### PR TITLE
Make meetings functional without the proposals module

### DIFF
--- a/decidim-meetings/app/commands/decidim/meetings/admin/destroy_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/destroy_meeting.rb
@@ -40,6 +40,8 @@ module Decidim
         end
 
         def proposals
+          return [] unless Decidim::Meetings.enable_proposal_linking
+
           @proposals ||= meeting.authored_proposals.load
         end
       end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meeting_closes_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meeting_closes_controller.rb
@@ -5,7 +5,7 @@ module Decidim
     module Admin
       # This controller allows an admin to manage meetings from a Participatory Process
       class MeetingClosesController < Admin::ApplicationController
-        include Decidim::Proposals::Admin::Picker
+        include Decidim::Proposals::Admin::Picker if Decidim::Meetings.enable_proposal_linking
 
         helper_method :meeting
 

--- a/decidim-meetings/app/controllers/decidim/meetings/meeting_closes_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meeting_closes_controller.rb
@@ -4,7 +4,7 @@ module Decidim
   module Meetings
     # This controller allows a participant to update the closing_report and the linked proposals of a closed meeting
     class MeetingClosesController < Decidim::Meetings::ApplicationController
-      include Decidim::Proposals::Admin::Picker
+      include Decidim::Proposals::Admin::Picker if Decidim::Meetings.enable_proposal_linking
       include FormFactory
 
       helper_method :meeting

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -216,6 +216,8 @@ module Decidim
       end
 
       def authored_proposals
+        return [] unless Decidim::Meetings.enable_proposal_linking
+
         Decidim::Proposals::Proposal
           .joins(:coauthorships)
           .where(

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -108,6 +108,7 @@ module Decidim
       end
 
       def proposals
+        return unless Decidim::Meetings.enable_proposal_linking
         return unless meeting
 
         @proposals ||= meeting.authored_proposals.load

--- a/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
@@ -11,7 +11,7 @@ module Decidim
       # Public: Initializes the service.
       # component     - A Decidim::Component to get the meetings from.
       # page        - The page number to paginate the results.
-      # per_page    - The number of proposals to return per page.
+      # per_page    - The number of meetings to return per page.
       def initialize(options = {})
         scope = options.fetch(:scope, Meeting.all)
         super(scope, options)

--- a/decidim-meetings/app/views/decidim/meetings/admin/meeting_closes/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meeting_closes/_form.html.erb
@@ -21,8 +21,11 @@
         <%= form.number_field :contributions_count, min: 0 %>
       </div>
     </div>
-    <div class="row column">
-      <%= proposals_picker(form, :proposals, proposals_picker_meeting_meeting_closes_path(meeting)) %>
-    </div>
+
+    <% if Decidim::Meetings.enable_proposal_linking %>
+      <div class="row column">
+        <%= proposals_picker(form, :proposals, proposals_picker_meeting_meeting_closes_path(meeting)) %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/meeting_closes/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meeting_closes/_form.html.erb
@@ -2,6 +2,8 @@
   <%= text_editor_for(form, :closing_report, hashtaggable: true) %>
 </div>
 
-<div class="field hashtags__container">
-  <%= proposals_picker(form, :proposals, proposals_picker_meeting_meeting_closes_path(meeting)) %>
-</div>
+<% if Decidim::Meetings.enable_proposal_linking %>
+  <div class="field hashtags__container">
+    <%= proposals_picker(form, :proposals, proposals_picker_meeting_meeting_closes_path(meeting)) %>
+  </div>
+<% end %>

--- a/decidim-meetings/lib/decidim/api/linked_resources_interface.rb
+++ b/decidim-meetings/lib/decidim/api/linked_resources_interface.rb
@@ -8,7 +8,14 @@ module Decidim
       graphql_name "MeetinsLinkedResourcewInterface"
       description "An interface that can be used with Resourceable models."
 
-      field :proposals_from_meeting, [Decidim::Proposals::ProposalType, { null: true }], "Proposals created in this meeting", null: false
+      if Decidim::Meetings.enable_proposal_linking
+        field(
+          :proposals_from_meeting,
+          [Decidim::Proposals::ProposalType, { null: true }],
+          "Proposals created in this meeting",
+          null: false
+        )
+      end
 
       def proposals_from_meeting
         object.linked_resources(:proposals, :proposals_from_meeting)

--- a/decidim-meetings/lib/decidim/meetings.rb
+++ b/decidim-meetings/lib/decidim/meetings.rb
@@ -13,5 +13,13 @@ module Decidim
   module Meetings
     autoload :Registrations, "decidim/meetings/registrations"
     autoload :MeetingSerializer, "decidim/meetings/meeting_serializer"
+
+    include ActiveSupport::Configurable
+
+    # Public Setting that defines whether proposals can be linked to meetings
+    config_accessor :enable_proposal_linking do
+      # Decidim.const_defined?("Proposals")
+      false
+    end
   end
 end

--- a/decidim-meetings/lib/decidim/meetings.rb
+++ b/decidim-meetings/lib/decidim/meetings.rb
@@ -18,8 +18,7 @@ module Decidim
 
     # Public Setting that defines whether proposals can be linked to meetings
     config_accessor :enable_proposal_linking do
-      # Decidim.const_defined?("Proposals")
-      false
+      Decidim.const_defined?("Proposals")
     end
   end
 end

--- a/decidim-meetings/spec/commands/admin/destroy_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/destroy_meeting_spec.rb
@@ -53,5 +53,19 @@ module Decidim::Meetings
         expect { meeting.reload }.not_to raise_error
       end
     end
+
+    context "when proposal linking is disabled for meetings" do
+      before do
+        allow(Decidim::Meetings).to receive(:enable_proposal_linking).and_return(false)
+      end
+
+      it "destroys the meeting and does not call authored_proposals on the meeting" do
+        expect(meeting).not_to receive(:authored_proposals)
+
+        subject.call
+
+        expect { meeting.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 end

--- a/decidim-meetings/spec/controllers/decidim/meetings/admin/meeting_closes_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/admin/meeting_closes_controller_spec.rb
@@ -8,22 +8,12 @@ describe Decidim::Meetings::Admin::MeetingClosesController, type: :controller do
       allow(Decidim::Meetings).to receive(:enable_proposal_linking).and_return(false)
     end
 
-    after do
-      # Re-enable proposal linking before reloading the class
-      allow(Decidim::Meetings).to receive(:enable_proposal_linking).and_return(true)
-
-      # Reload the class with proposal linking enabled
-      Decidim::Meetings::Admin.send(:remove_const, :MeetingClosesController)
-      load "#{Decidim::Meetings::Engine.root}/app/controllers/decidim/meetings/admin/meeting_closes_controller.rb"
-    end
-
     it "does not load the proposals admin picker concern" do
-      Decidim::Meetings::Admin.send(:remove_const, :MeetingClosesController)
-      load "#{Decidim::Meetings::Engine.root}/app/controllers/decidim/meetings/admin/meeting_closes_controller.rb"
+      expect(Decidim::Meetings::Admin::MeetingClosesController).not_to receive(:include).with(
+        Decidim::Proposals::Admin::Picker
+      )
 
-      expect(
-        Decidim::Meetings::Admin::MeetingClosesController.include?(Decidim::Proposals::Admin::Picker)
-      ).to be(false)
+      load "#{Decidim::Meetings::Engine.root}/app/controllers/decidim/meetings/admin/meeting_closes_controller.rb"
     end
   end
 end

--- a/decidim-meetings/spec/controllers/decidim/meetings/admin/meeting_closes_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/admin/meeting_closes_controller_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Meetings::Admin::MeetingClosesController, type: :controller do
+  context "when proposal linking is not enabled" do
+    before do
+      allow(Decidim::Meetings).to receive(:enable_proposal_linking).and_return(false)
+    end
+
+    after do
+      # Re-enable proposal linking before reloading the class
+      allow(Decidim::Meetings).to receive(:enable_proposal_linking).and_return(true)
+
+      # Reload the class with proposal linking enabled
+      Decidim::Meetings::Admin.send(:remove_const, :MeetingClosesController)
+      load "#{Decidim::Meetings::Engine.root}/app/controllers/decidim/meetings/admin/meeting_closes_controller.rb"
+    end
+
+    it "does not load the proposals admin picker concern" do
+      Decidim::Meetings::Admin.send(:remove_const, :MeetingClosesController)
+      load "#{Decidim::Meetings::Engine.root}/app/controllers/decidim/meetings/admin/meeting_closes_controller.rb"
+
+      expect(
+        Decidim::Meetings::Admin::MeetingClosesController.include?(Decidim::Proposals::Admin::Picker)
+      ).to be(false)
+    end
+  end
+end

--- a/decidim-meetings/spec/controllers/decidim/meetings/meeting_closes_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/meeting_closes_controller_spec.rb
@@ -8,24 +8,12 @@ describe Decidim::Meetings::MeetingClosesController, type: :controller do
       allow(Decidim::Meetings).to receive(:enable_proposal_linking).and_return(false)
     end
 
-    after do
-      # Re-enable proposal linking before reloading the class
-      allow(Decidim::Meetings).to receive(:enable_proposal_linking).and_return(true)
-
-      # Reload the class with proposal linking enabled
-      Decidim::Meetings.send(:remove_const, :MeetingClosesController)
-      load "#{Decidim::Meetings::Engine.root}/app/controllers/decidim/meetings/meeting_closes_controller.rb"
-    end
-
     it "does not load the proposals admin picker concern" do
-      Decidim::Meetings.send(:remove_const, :MeetingClosesController)
-      load "#{Decidim::Meetings::Engine.root}/app/controllers/decidim/meetings/meeting_closes_controller.rb"
+      expect(Decidim::Meetings::MeetingClosesController).not_to receive(:include).with(
+        Decidim::Proposals::Admin::Picker
+      )
 
-      # Do not use `described_class` here because it is referring to the
-      # previously defined class.
-      expect(
-        Decidim::Meetings::MeetingClosesController.include?(Decidim::Proposals::Admin::Picker)
-      ).to be(false)
+      load "#{Decidim::Meetings::Engine.root}/app/controllers/decidim/meetings/admin/meeting_closes_controller.rb"
     end
   end
 end

--- a/decidim-meetings/spec/controllers/decidim/meetings/meeting_closes_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/meeting_closes_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Meetings::MeetingClosesController, type: :controller do
+  context "when proposal linking is not enabled" do
+    before do
+      allow(Decidim::Meetings).to receive(:enable_proposal_linking).and_return(false)
+    end
+
+    after do
+      # Re-enable proposal linking before reloading the class
+      allow(Decidim::Meetings).to receive(:enable_proposal_linking).and_return(true)
+
+      # Reload the class with proposal linking enabled
+      Decidim::Meetings.send(:remove_const, :MeetingClosesController)
+      load "#{Decidim::Meetings::Engine.root}/app/controllers/decidim/meetings/meeting_closes_controller.rb"
+    end
+
+    it "does not load the proposals admin picker concern" do
+      Decidim::Meetings.send(:remove_const, :MeetingClosesController)
+      load "#{Decidim::Meetings::Engine.root}/app/controllers/decidim/meetings/meeting_closes_controller.rb"
+
+      # Do not use `described_class` here because it is referring to the
+      # previously defined class.
+      expect(
+        Decidim::Meetings::MeetingClosesController.include?(Decidim::Proposals::Admin::Picker)
+      ).to be(false)
+    end
+  end
+end

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -385,7 +385,7 @@ module Decidim::Meetings
 
       it "returns the proposals authored in the meeting" do
         expect(subject.authored_proposals.count).to eq(5)
-        expect(subject.authored_proposals.map(&:id)).to eq(proposals.map(&:id))
+        expect(subject.authored_proposals.map(&:id)).to match_array(proposals.map(&:id))
       end
 
       context "when proposal linking is disabled" do

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -367,5 +367,37 @@ module Decidim::Meetings
         end
       end
     end
+
+    describe "#authored_proposals" do
+      let(:meeting) { create(:meeting, address: address, component: meeting_component) }
+      let(:meeting_component) { create(:meeting_component) }
+      let(:proposal_component) { create(:proposal_component, participatory_space: meeting_component.participatory_space) }
+      let!(:proposals) do
+        proposals = build_list(:proposal, 5, component: proposal_component)
+        proposals.each do |proposal|
+          proposal.coauthorships.clear
+          proposal.coauthorships.build(author: meeting)
+          proposal.save!
+        end
+        proposals
+      end
+      let!(:proposals_outside_meeting) { create_list(:proposal, 5, component: proposal_component) }
+
+      it "returns the proposals authored in the meeting" do
+        expect(subject.authored_proposals.count).to eq(5)
+        expect(subject.authored_proposals.map(&:id)).to eq(proposals.map(&:id))
+      end
+
+      context "when proposal linking is disabled" do
+        before do
+          allow(Decidim::Meetings).to receive(:enable_proposal_linking).and_return(false)
+        end
+
+        it "returns an empty array and does not call authored_proposals" do
+          expect(Decidim::Proposals::Proposal).not_to receive(:where)
+          expect(subject.authored_proposals).to eq([])
+        end
+      end
+    end
   end
 end

--- a/decidim-meetings/spec/presenters/decidim/meetings/meeting_presenter_spec.rb
+++ b/decidim-meetings/spec/presenters/decidim/meetings/meeting_presenter_spec.rb
@@ -31,6 +31,17 @@ module Decidim::Meetings
       it "has at least one proposal" do
         expect(subject.size.positive?).to be true
       end
+
+      context "when proposal linking is disabled" do
+        before do
+          allow(Decidim::Meetings).to receive(:enable_proposal_linking).and_return(false)
+        end
+
+        it "returns an empty array and does not call authored_proposals" do
+          expect(meeting).not_to receive(:authored_proposals)
+          expect(subject).to be nil
+        end
+      end
     end
 
     describe "#formatted_proposals_titles" do

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -523,6 +523,8 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
       end
 
       within ".edit_close_meeting" do
+        expect(page).to have_content "Choose proposals"
+
         fill_in_i18n_editor(
           :close_meeting_closing_report,
           "#close_meeting-closing_report-tabs",
@@ -558,6 +560,24 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
         end
 
         expect(page).to have_admin_callout("Meeting successfully closed")
+      end
+    end
+
+    context "when proposal linking is disabled" do
+      before do
+        allow(Decidim::Meetings).to receive(:enable_proposal_linking).and_return(false)
+      end
+
+      it "does not display the proposal picker" do
+        within find("tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title) do
+          page.click_link "Close"
+        end
+
+        expect(page).to have_content "Close meeting"
+
+        within "form.edit_close_meeting" do
+          expect(page).not_to have_content "Choose proposals"
+        end
       end
     end
   end

--- a/decidim-meetings/spec/system/user_close_meeting.rb
+++ b/decidim-meetings/spec/system/user_close_meeting.rb
@@ -43,6 +43,8 @@ describe "User edit meeting", type: :system do
       expect(page).to have_content "CLOSE MEETING"
 
       within "form.edit_close_meeting" do
+        expect(page).to have_content "Choose proposals"
+
         fill_in :close_meeting_closing_report, with: closing_report
 
         click_button "Close meeting"
@@ -53,6 +55,25 @@ describe "User edit meeting", type: :system do
       expect(page).not_to have_content "ATTENDEES COUNT"
       expect(page).not_to have_content "ATTENDING ORGANIZATIONS"
       expect(meeting.reload.closed_at).not_to be nil
+    end
+
+    context "when proposal linking is disabled" do
+      before do
+        allow(Decidim::Meetings).to receive(:enable_proposal_linking).and_return(false)
+      end
+
+      it "does not display the proposal picker" do
+        visit_component
+
+        click_link translated(meeting.title)
+        click_link "Close meeting"
+
+        expect(page).to have_content "CLOSE MEETING"
+
+        within "form.edit_close_meeting" do
+          expect(page).not_to have_content "Choose proposals"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Right now the meetings component has a hard requirement for the proposals module. The instance won't boot with the meetings module when you configure the instance to preload the classes with `Rails.application.config.eager_load = true` as is usually the default in production/staging instances.

This decouples the hard requirement on the proposals module from the meetings module. It provides a new module configuration option `enable_proposal_linking` that will be disabled when the proposals module is not available.

There are also other parts of the module where this needs to be considered, such as when closing the proposals, do not load the concern dependencies from the proposals module and do not display the proposals picker.

#### :pushpin: Related Issues
- Related to #7690

#### Testing
Try installing decidim by manually defining the gems that you need (e.g. `decidim.core`, `decidim-admin`, etc.) and run that code in an environment that preloads the class definitions (`Rails.application.config.eager_load = true`) which is generally the default for production/staging/etc.

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.