### PR TITLE
Make accountability functional without the proposals module

### DIFF
--- a/decidim-accountability/app/controllers/decidim/accountability/admin/results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/results_controller.rb
@@ -7,7 +7,7 @@ module Decidim
       class ResultsController < Admin::ApplicationController
         include Decidim::ApplicationHelper
         include Decidim::SanitizeHelper
-        include Decidim::Proposals::Admin::Picker
+        include Decidim::Proposals::Admin::Picker if Decidim::Accountability.enable_proposal_linking
         include Decidim::Accountability::Admin::Filterable
 
         helper_method :results, :parent_result, :parent_results, :statuses, :present

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/_form.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/_form.html.erb
@@ -52,9 +52,11 @@
       </div>
     </div>
 
-    <div class="row column">
-      <%= proposals_picker(form, :proposals, proposals_picker_results_path) %>
-    </div>
+    <% if Decidim::Accountability.enable_proposal_linking %>
+      <div class="row column">
+        <%= proposals_picker(form, :proposals, proposals_picker_results_path) %>
+      </div>
+    <% end %>
 
     <div class="row column">
       <% if @form.projects %>

--- a/decidim-accountability/lib/decidim/accountability.rb
+++ b/decidim-accountability/lib/decidim/accountability.rb
@@ -10,5 +10,12 @@ module Decidim
   # Base module for this engine.
   module Accountability
     autoload :ResultSerializer, "decidim/accountability/result_serializer"
+
+    include ActiveSupport::Configurable
+
+    # Public Setting that defines whether proposals can be linked to meetings
+    config_accessor :enable_proposal_linking do
+      Decidim.const_defined?("Proposals")
+    end
   end
 end

--- a/decidim-accountability/spec/controllers/decidim/accountability/admin/results_controller_spec.rb
+++ b/decidim-accountability/spec/controllers/decidim/accountability/admin/results_controller_spec.rb
@@ -66,22 +66,12 @@ module Decidim
             allow(Decidim::Accountability).to receive(:enable_proposal_linking).and_return(false)
           end
 
-          after do
-            # Re-enable proposal linking before reloading the class
-            allow(Decidim::Accountability).to receive(:enable_proposal_linking).and_return(true)
-
-            # Reload the class with proposal linking enabled
-            Decidim::Accountability::Admin.send(:remove_const, :ResultsController)
-            load "#{Decidim::Accountability::Engine.root}/app/controllers/decidim/accountability/admin/results_controller.rb"
-          end
-
           it "does not load the proposals admin picker concern" do
-            Decidim::Accountability::Admin.send(:remove_const, :ResultsController)
-            load "#{Decidim::Accountability::Engine.root}/app/controllers/decidim/accountability/admin/results_controller.rb"
+            expect(Decidim::Accountability::Admin::ResultsController).not_to receive(:include).with(
+              Decidim::Proposals::Admin::Picker
+            )
 
-            expect(
-              Decidim::Accountability::Admin::ResultsController.include?(Decidim::Proposals::Admin::Picker)
-            ).to be(false)
+            load "#{Decidim::Accountability::Engine.root}/app/controllers/decidim/accountability/admin/results_controller.rb"
           end
         end
       end

--- a/decidim-accountability/spec/controllers/decidim/accountability/admin/results_controller_spec.rb
+++ b/decidim-accountability/spec/controllers/decidim/accountability/admin/results_controller_spec.rb
@@ -60,6 +60,30 @@ module Decidim
             end
           end
         end
+
+        context "when proposal linking is not enabled" do
+          before do
+            allow(Decidim::Accountability).to receive(:enable_proposal_linking).and_return(false)
+          end
+
+          after do
+            # Re-enable proposal linking before reloading the class
+            allow(Decidim::Accountability).to receive(:enable_proposal_linking).and_return(true)
+
+            # Reload the class with proposal linking enabled
+            Decidim::Accountability::Admin.send(:remove_const, :ResultsController)
+            load "#{Decidim::Accountability::Engine.root}/app/controllers/decidim/accountability/admin/results_controller.rb"
+          end
+
+          it "does not load the proposals admin picker concern" do
+            Decidim::Accountability::Admin.send(:remove_const, :ResultsController)
+            load "#{Decidim::Accountability::Engine.root}/app/controllers/decidim/accountability/admin/results_controller.rb"
+
+            expect(
+              Decidim::Accountability::Admin::ResultsController.include?(Decidim::Proposals::Admin::Picker)
+            ).to be(false)
+          end
+        end
       end
     end
   end

--- a/decidim-accountability/spec/shared/manage_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_examples.rb
@@ -7,6 +7,23 @@ shared_examples "manage results" do
     before { click_on "New Result", match: :first }
 
     it_behaves_like "having a rich text editor", "new_result", "full"
+
+    it "displays the proposals picker" do
+      expect(page).to have_content("Choose proposals")
+    end
+
+    context "when proposal linking is disabled" do
+      before do
+        allow(Decidim::Accountability).to receive(:enable_proposal_linking).and_return(false)
+
+        # Reload the page with the updated settings
+        visit current_path
+      end
+
+      it "does not display the proposal picker" do
+        expect(page).not_to have_content "Choose proposals"
+      end
+    end
   end
 
   context "when having existing proposals" do


### PR DESCRIPTION
#### :tophat: What? Why?
Same fix as #7784 but for the accountability module.

#### :pushpin: Related Issues
- Related to #7784

#### Testing
See #7784

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.