### PR TITLE
Revert "Fix single initiative type"

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
@@ -19,37 +19,27 @@
                   { disabled: !@form.state_updatable? } %>
 </div>
 
-<% if single_initiative_type? %>
-  <%= form.select :type_id,
-                  initiative_type_options,
-                  {},
-                  {
-                    disabled: !@form.signature_type_updatable?,
-                    "data-scope-selector": "initiative_decidim_scope_id",
-                    "data-scope-id": form.object.scope_id.to_s,
-                    "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url,
-                    "data-signature-types-selector": "initiative_signature_type",
-                    "data-signature-type": current_initiative.signature_type,
-                    "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url
-                  } %>
-<% else %>
-  <%= form.hidden_field :type_id,
-                        {
-                          disabled: !@form.signature_type_updatable?,
-                          "data-scope-selector": "initiative_decidim_scope_id",
-                          "data-scope-id": form.object.scope_id.to_s,
-                          "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url,
-                          "data-signature-types-selector": "initiative_signature_type",
-                          "data-signature-type": current_initiative.signature_type,
-                          "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url,
-                          value: current_initiative.signature_type
-                        } %>
+<% unless single_initiative_type? %>
+  <div class="field">
+    <%= form.select :type_id,
+                    initiative_type_options,
+                    {},
+                    {
+                      disabled: !@form.signature_type_updatable?,
+                      "data-scope-selector": "initiative_decidim_scope_id",
+                      "data-scope-id": form.object.scope_id.to_s,
+                      "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url,
+                      "data-signature-types-selector": "initiative_signature_type",
+                      "data-signature-type": current_initiative.signature_type,
+                      "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url
+                    } %>
+  </div>
 <% end %>
 
 <div class="field">
   <%= form.select :scope_id,
-                  @form.available_scopes.map { |scope| [translated_attribute(scope.scope_name), scope&.scope&.id] },
-                  { disabled: !@form.state_updatable? } %>
+                @form.available_scopes.map { |scope| [translated_attribute(scope.scope_name), scope&.scope&.id] },
+                { disabled: !@form.state_updatable? } %>
 </div>
 
 <% if can_edit_custom_signature_end_date?(current_initiative) %>

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -420,31 +420,6 @@ describe "Initiative", type: :system do
 
           it_behaves_like "initiatives path redirection"
         end
-
-        context "when there is a single initiative type" do
-          let!(:other_initiative_type) { create(:initiatives_type, organization: organization) }
-          let!(:other_initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
-
-          before do
-            find_link("Continue").click
-          end
-
-          it "finish view is shown" do
-            expect(page).to have_content("Finish")
-          end
-
-          it "Offers contextual help" do
-            within ".callout.secondary" do
-              expect(page).to have_content("Congratulations! Your initiative has been successfully created.")
-            end
-          end
-
-          it "displays an edit link" do
-            within ".actions" do
-              expect(page).to have_link("Edit my initiative")
-            end
-          end
-        end
       end
     end
   end

--- a/decidim-initiatives/spec/system/edit_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/edit_initiative_spec.rb
@@ -44,13 +44,6 @@ describe "Edit initiative", type: :system do
 
     it_behaves_like "manage update"
 
-    context "when there is a single initiative" do
-      let!(:other_initiative_type) { nil }
-      let!(:other_scoped_type) { nil }
-
-      it_behaves_like "manage update"
-    end
-
     context "when initiative is published" do
       let(:initiative) { create(:initiative, author: user, scoped_type: scoped_type, organization: organization) }
 


### PR DESCRIPTION
Reverts decidim/decidim#7667.

As discussed in the original PR, I merged this too early and tests were failing. I thought they were failing due to the PR not being up-to-date with `develop`, but the reason was another one.

Really sorry for the troubles caused!