### PR TITLE
Show missing election component callout also for in-person votings

### DIFF
--- a/decidim-elections/app/models/decidim/votings/voting.rb
+++ b/decidim-elections/app/models/decidim/votings/voting.rb
@@ -121,10 +121,6 @@ module Decidim
         true
       end
 
-      def needs_elections?
-        !in_person_voting? && !has_elections?
-      end
-
       def polling_stations_with_missing_officers?
         !online_voting? && polling_stations.any?(&:missing_officers?)
       end
@@ -134,8 +130,6 @@ module Decidim
           .where(presided_polling_station_id: nil)
           .where(managed_polling_station_id: nil)
       end
-
-      private
 
       def has_elections?
         components.where(manifest_name: :elections).any? do |component|

--- a/decidim-elections/app/views/layouts/decidim/admin/voting.html.erb
+++ b/decidim-elections/app/views/layouts/decidim/admin/voting.html.erb
@@ -12,7 +12,7 @@
   </div>
 
   <div class="voting-content">
-    <% if current_participatory_space.needs_elections? %>
+    <% if !current_participatory_space.has_elections? %>
       <%= cell("decidim/announcement", t("votings.edit.add_election_component", scope: "decidim.votings.admin"), callout_class: "alert") %>
     <% end %>
     <% if current_participatory_space.polling_stations_with_missing_officers? %>


### PR DESCRIPTION
#### :tophat: What? Why?
In https://github.com/decidim/decidim/pull/7217, we added a callout to warn the admin when an `online`/`hybrid` voting does not have any Election component.
We actually want to show the callout also for `in_person` votings (basically for all kinds).

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/5033945/113892724-97247600-97c6-11eb-875a-555bfceff6cd.png)


:hearts: Thank you!
