### PR TITLE
Let admins disable participatory space filters

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -56,7 +56,8 @@ module Decidim
           comments_max_length: form.comments_max_length,
           enable_machine_translations: form.enable_machine_translations,
           admin_terms_of_use_body: form.admin_terms_of_use_body,
-          rich_text_editor_in_public_views: form.rich_text_editor_in_public_views
+          rich_text_editor_in_public_views: form.rich_text_editor_in_public_views,
+          enable_participatory_space_filters: form.enable_participatory_space_filters
         }.merge(welcome_notification_attributes)
           .merge(machine_translation_attributes || {})
       end

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -25,6 +25,7 @@ module Decidim
       attribute :rich_text_editor_in_public_views, Boolean
       attribute :enable_machine_translations, Boolean
       attribute :machine_translation_display_priority, String
+      attribute :enable_participatory_space_filters, Boolean
 
       attribute :send_welcome_notification, Boolean
       attribute :customize_welcome_notification, Boolean

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -54,6 +54,12 @@
   </div>
 </div>
 
+<div class="row">
+  <div class="columns xlarge-6">
+    <%= form.check_box :enable_participatory_space_filters %>
+  </div>
+</div>
+
 <% if Decidim.config.enable_machine_translations %>
   <div class="row">
     <div class="columns xlarge-6">

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
         default_locale: Default locale
         description: Description
         enable_omnipresent_banner: Show omnipresent banner
+        enable_participatory_space_filters: Enable participatory space filters
         facebook_handler: Facebook handler
         favicon: Icon
         force_authentication: Force authentication

--- a/decidim-core/app/views/decidim/shared/participatory_space_filters/_show.html.erb
+++ b/decidim-core/app/views/decidim/shared/participatory_space_filters/_show.html.erb
@@ -1,4 +1,4 @@
-<% if Decidim.enable_participatory_space_filters %>
+<% if current_organization.enable_participatory_space_filters %>
   <div class="row" id="participatory-space-filters">
     <%= render partial: "decidim/shared/participatory_space_filters/filters_small_view" %>
     <div class="show-for-mediumlarge">

--- a/decidim-core/app/views/decidim/shared/participatory_space_filters/_show.html.erb
+++ b/decidim-core/app/views/decidim/shared/participatory_space_filters/_show.html.erb
@@ -1,7 +1,9 @@
-<div class="row" id="participatory-space-filters">
-  <%= render partial: "decidim/shared/participatory_space_filters/filters_small_view" %>
-  <div class="show-for-mediumlarge">
-    <%= render partial: "decidim/shared/participatory_space_filters/filters",
-        locals: { checkboxes_on_top: false } %>
+<% if Decidim.enable_participatory_space_filters %>
+  <div class="row" id="participatory-space-filters">
+    <%= render partial: "decidim/shared/participatory_space_filters/filters_small_view" %>
+    <div class="show-for-mediumlarge">
+      <%= render partial: "decidim/shared/participatory_space_filters/filters",
+          locals: { checkboxes_on_top: false } %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/decidim-core/db/migrate/20210412120115_add_enable_participatory_space_filters_to_organization.rb
+++ b/decidim-core/db/migrate/20210412120115_add_enable_participatory_space_filters_to_organization.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEnableParticipatorySpaceFiltersToOrganization < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_organizations, :enable_participatory_space_filters, :boolean, default: true
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -240,6 +240,11 @@ module Decidim
     true
   end
 
+  #  Show scope and area filters in /processes and /assemblies views.
+  config_accessor :enable_participatory_space_filters do
+    false
+  end
+
   # Allow organization's administrators to track newsletter links
   config_accessor :track_newsletter_links do
     true

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -242,7 +242,7 @@ module Decidim
 
   #  Show scope and area filters in /processes and /assemblies views.
   config_accessor :enable_participatory_space_filters do
-    false
+    true
   end
 
   # Allow organization's administrators to track newsletter links

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -240,11 +240,6 @@ module Decidim
     true
   end
 
-  #  Show scope and area filters in /processes and /assemblies views.
-  config_accessor :enable_participatory_space_filters do
-    true
-  end
-
   # Allow organization's administrators to track newsletter links
   config_accessor :track_newsletter_links do
     true

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -108,6 +108,7 @@ FactoryBot.define do
       }
     end
     file_upload_settings { Decidim::OrganizationSettings.default(:upload) }
+    enable_participatory_space_filters { true }
 
     trait :secure_context do
       host { "localhost" }

--- a/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
@@ -148,5 +148,20 @@ describe "Filter Participatory Processes", type: :system do
         expect(page).not_to have_content(translated(process_without_area.title))
       end
     end
+
+    context "when filters are disabled" do
+      let!(:process_with_area) { create(:participatory_process, area: create(:area, organization: organization), organization: organization) }
+      let!(:process_with_scope) { create(:participatory_process, scope: create(:scope, organization: organization), organization: organization) }
+
+      before do
+        allow(Decidim).to receive(:enable_participatory_space_filters).and_return(false)
+        visit decidim_participatory_processes.participatory_processes_path
+      end
+
+      it "doesnt show filters" do
+        expect(page).not_to have_css(".area_id_areas_select_filter")
+        expect(page).not_to have_css(".scope_id_scopes_picker_filter")
+      end
+    end
   end
 end

--- a/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
@@ -152,9 +152,9 @@ describe "Filter Participatory Processes", type: :system do
     context "when filters are disabled" do
       let!(:process_with_area) { create(:participatory_process, area: create(:area, organization: organization), organization: organization) }
       let!(:process_with_scope) { create(:participatory_process, scope: create(:scope, organization: organization), organization: organization) }
+      let(:organization) { create(:organization, enable_participatory_space_filters: false) }
 
       before do
-        allow(Decidim).to receive(:enable_participatory_space_filters).and_return(false)
         visit decidim_participatory_processes.participatory_processes_path
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
By default Decidim shows "Select a scope" and "Select an area" filters in /processes and /assemblies views. When there are just one or few processes these filters doesn't make much sense or if we just prefer to have views without them. This PR adds option to organization's settings to hide filters. 

#### :pushpin: Related Issues
https://meta.decidim.org/processes/roadmap/f/122/proposals/16325

#### Testing
1. Go to /admin/organization/edit
2. Toggle "Enable participatory space filters"
3. Go to /processes or /assemblies

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![admin_enable_participatory_space_filters](https://user-images.githubusercontent.com/19709320/114400773-fa3d5080-9baa-11eb-8649-6ca5961af55f.png)

![participatory_spaces_withtout_filters](https://user-images.githubusercontent.com/19709320/114151380-ba196c00-9925-11eb-98d3-12ac8cbd2b7e.png)

:hearts: Thank you!
