### PR TITLE
Show initiative image in homepage

### DIFF
--- a/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives/show.erb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives/show.erb
@@ -6,6 +6,8 @@
         <% highlighted_initiatives.each do |initiative| %>
           <div class="column">
             <%= link_to decidim_initiatives.initiative_path(initiative), class: "card card--initiative card--mini" do %>
+              <div aria-hidden="true" class="card__image-top"
+                style="background-image:url(<%= initiative.banner_image.url %>)"></div>
               <span class="show-for-sr"><%= translated_attribute initiative.title %></span>
               <div class="card__content">
                 <span class="card__title card__link"><%= decidim_html_escape(translated_attribute(initiative.title)) %></span>


### PR DESCRIPTION
#### :tophat: What? Why?
Adds the image to initiative cards on the homepage

#### :pushpin: Related Issues
- Fixes #6687 

#### Testing
I don't know if you test layouts in the project? If someone points me to a similar test I can add one to check the image for the initiative is rendered.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
<img width="1143" alt="Screenshot 2021-04-09 at 23 53 20" src="https://user-images.githubusercontent.com/3627301/114248132-c685df00-998e-11eb-8c5b-cb15cf87db66.png">

First commit, bullied into it by @oliverbarnes.
