### PR TITLE
CSV exporter should take into account locales from all resources

### DIFF
--- a/decidim-core/lib/decidim/exporters/csv.rb
+++ b/decidim-core/lib/decidim/exporters/csv.rb
@@ -43,7 +43,7 @@ module Decidim
       def headers
         return [] if processed_collection.empty?
 
-        processed_collection.first.keys
+        processed_collection.inject([]) { |keys, resource| keys | resource.keys }
       end
 
       def processed_collection

--- a/decidim-core/spec/lib/exporters/csv_spec.rb
+++ b/decidim-core/spec/lib/exporters/csv_spec.rb
@@ -40,6 +40,26 @@ module Decidim
         data = CSV.parse(exported, headers: true, col_sep: ";").map(&:to_h)
         expect(data[0]["serialized_name/ca"]).to eq("foocat")
       end
+
+      context "with items in heterogeneous locales" do
+        let(:collection) do
+          [
+            OpenStruct.new(id: 1, name: { ca: "name cat" }, body: { ca: "body cat" }),
+            OpenStruct.new(id: 2, name: { es: "name es" }, body: { es: "body es" }),
+            OpenStruct.new(id: 3, name: { en: "name en" }, ids: { en: "body en" })
+          ]
+        end
+
+        it "exports all locales" do
+          exported = subject.export.read
+          data = CSV.parse(exported, headers: true, col_sep: ";").map(&:to_h)
+          3.times do |idx|
+            expect(data[idx]).to have_key("serialized_name/ca")
+            expect(data[idx]).to have_key("serialized_name/en")
+            expect(data[idx]).to have_key("serialized_name/es")
+          end
+        end
+      end
     end
 
     describe "export sanitizer" do


### PR DESCRIPTION
#### :tophat: What? Why?
Until now only the locales of the first resource were taken into account.
This affected the export of Proposals which may have been created in many locales and each proposal only have the key for the locale it has been created with. For example, in the same component, one proposal may have have the title `{"ca"=>"TEST title CA"}` and another proposal have the title `{"en"=>"TEST title EN"}`.
Until the moment the CSV exporter extracts the headers from the first item, thus if the title or body of the first Proposal is in `:en` then the rest of proposals will be exported only with the title and body in `:en`.

This problem does not happen when exporting to JSON.

This fix solves the issue by merging the headers of all the collection items. This does not guarantee that the headers for the same field but different language appear together. Instead they are appended at the end of the header. I've thought about sorting the columns after all the merges but then all fields are re-ordered ant the ID, for example, appears in the middle of the header instead of being the first column.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

1. Create a proposal in one language (A)
2. Create another proposal in a different language (B)
3. Go to the admin panel and export the proposals as CSV
4. Go to the email and open the attached zip
5. Check that the CSV contains both the title and body in language A and in language B

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
