### PR TITLE
Fix branch name on generators

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -232,7 +232,7 @@ module Decidim
       def branch
         return if options[:path]
 
-        @branch ||= options[:edge] ? "7291-migrate-to-webpacker" : options[:branch].presence
+        @branch ||= options[:edge] ? "develop" : options[:branch].presence
       end
 
       def app_name

--- a/decidim-generators/spec/generators_spec.rb
+++ b/decidim-generators/spec/generators_spec.rb
@@ -109,7 +109,7 @@ module Decidim
       end
 
       context "with --branch flag" do
-        let(:default_branch) { "7291-migrate-to-webpacker" }
+        let(:default_branch) { "develop" }
         let(:command) { "decidim --branch #{default_branch} #{test_app}" }
 
         it_behaves_like "a new production application"


### PR DESCRIPTION
#### :tophat: What? Why?
After #7464, we need to fix the default branch name on generators specs. Similar to #7842, but for #7464.

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green.