### PR TITLE
Redirect unauthenticated users to sign in page for unauthorized views

### DIFF
--- a/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
@@ -97,10 +97,24 @@ module Decidim
 
       describe "GET show" do
         context "when the assembly is unpublished" do
-          it "redirects to root path" do
+          it "redirects to sign in path" do
             get :show, params: { slug: unpublished_assembly.slug }
 
-            expect(response).to redirect_to("/")
+            expect(response).to redirect_to("/users/sign_in")
+          end
+
+          context "with signed in user" do
+            let!(:user) { create(:user, :confirmed, organization: organization) }
+
+            before do
+              sign_in user, scope: :user
+            end
+
+            it "redirects to root path" do
+              get :show, params: { slug: unpublished_assembly.slug }
+
+              expect(response).to redirect_to("/")
+            end
           end
         end
       end

--- a/decidim-conferences/spec/controllers/conferences_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/conferences_controller_spec.rb
@@ -52,10 +52,24 @@ module Decidim
 
       describe "GET show" do
         context "when the conference is unpublished" do
-          it "redirects to root path" do
+          it "redirects to sign in path" do
             get :show, params: { slug: unpublished_conference.slug }
 
-            expect(response).to redirect_to("/")
+            expect(response).to redirect_to("/users/sign_in")
+          end
+
+          context "with signed in user" do
+            let!(:user) { create(:user, :confirmed, organization: organization) }
+
+            before do
+              sign_in user, scope: :user
+            end
+
+            it "redirects to root path" do
+              get :show, params: { slug: unpublished_conference.slug }
+
+              expect(response).to redirect_to("/")
+            end
           end
         end
       end

--- a/decidim-consultations/spec/system/consultation_spec.rb
+++ b/decidim-consultations/spec/system/consultation_spec.rb
@@ -33,11 +33,24 @@ describe "Consultation", type: :system do
 
       before do
         switch_to_host(organization.host)
-        visit decidim_consultations.consultation_path(consultation)
       end
 
-      it "redirects to root path" do
-        expect(page).to have_current_path("/")
+      it "redirects to sign in path" do
+        visit decidim_consultations.consultation_path(consultation)
+        expect(page).to have_current_path("/users/sign_in")
+      end
+
+      context "with signed in user" do
+        let!(:user) { create(:user, :confirmed, organization: organization) }
+
+        before do
+          sign_in user, scope: :user
+        end
+
+        it "redirects to root path" do
+          visit decidim_consultations.consultation_path(consultation)
+          expect(page).to have_current_path("/")
+        end
       end
     end
 

--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -112,6 +112,8 @@ module Decidim
     end
 
     def user_has_no_permission_path
+      return decidim.new_user_session_path unless user_signed_in?
+
       decidim.root_path
     end
 

--- a/decidim-core/spec/controllers/application_controller_spec.rb
+++ b/decidim-core/spec/controllers/application_controller_spec.rb
@@ -203,6 +203,18 @@ module Decidim
 
         expect(response).to redirect_to("/users/sign_in")
       end
+
+      context "when authenticated" do
+        before do
+          sign_in user
+        end
+
+        it "redirects the user to root path" do
+          get :unauthorized
+
+          expect(response).to redirect_to("/")
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/controllers/application_controller_spec.rb
+++ b/decidim-core/spec/controllers/application_controller_spec.rb
@@ -16,6 +16,10 @@ module Decidim
       def tos
         render plain: "Terms"
       end
+
+      def unauthorized
+        enforce_permission_to :foo, :bar
+      end
     end
 
     before do
@@ -23,6 +27,7 @@ module Decidim
       routes.draw do
         get "show" => "decidim/application#show"
         get "pages/terms-and-conditions" => "decidim/application#tos"
+        get "unauthorized" => "decidim/application#unauthorized"
       end
     end
 
@@ -189,6 +194,14 @@ module Decidim
             expect(flash[:warning]).to include("Please, login with your account before access")
           end
         end
+      end
+    end
+
+    describe "#unauthorized" do
+      it "redirects the user to the sign in page" do
+        get :unauthorized
+
+        expect(response).to redirect_to("/users/sign_in")
       end
     end
   end

--- a/decidim-elections/spec/system/voting_spec.rb
+++ b/decidim-elections/spec/system/voting_spec.rb
@@ -32,11 +32,24 @@ describe "Voting", type: :system do
 
       before do
         switch_to_host(organization.host)
-        visit decidim_votings.voting_path(voting)
       end
 
-      it "redirects to root path" do
-        expect(page).to have_current_path("/")
+      it "redirects to sign in path" do
+        visit decidim_votings.voting_path(voting)
+        expect(page).to have_current_path("/users/sign_in")
+      end
+
+      context "with signed in user" do
+        let!(:user) { create(:user, :confirmed, organization: organization) }
+
+        before do
+          sign_in user, scope: :user
+        end
+
+        it "redirects to root path" do
+          visit decidim_votings.voting_path(voting)
+          expect(page).to have_current_path("/")
+        end
       end
     end
 

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -29,6 +29,13 @@ describe "User creates meeting", type: :system do
     let(:user) { create :user, :confirmed, organization: organization }
     let!(:category) { create :category, participatory_space: participatory_space }
 
+    context "when the user is not logged in" do
+      it "redirects the user to the sign in page" do
+        page.visit Decidim::EngineRouter.main_proxy(component).new_meeting_path
+        expect(page).to have_current_path("/users/sign_in")
+      end
+    end
+
     context "when the user is logged in" do
       before do
         login_as user, scope: :user

--- a/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
@@ -107,10 +107,24 @@ module Decidim
 
       describe "GET show" do
         context "when the process is unpublished" do
-          it "redirects to root path" do
+          it "redirects to sign in path" do
             get :show, params: { slug: unpublished_process.slug }
 
-            expect(response).to redirect_to("/")
+            expect(response).to redirect_to("/users/sign_in")
+          end
+
+          context "with signed in user" do
+            let!(:user) { create(:user, :confirmed, organization: organization) }
+
+            before do
+              sign_in user, scope: :user
+            end
+
+            it "redirects to root path" do
+              get :show, params: { slug: unpublished_process.slug }
+
+              expect(response).to redirect_to("/")
+            end
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
When the user is unauthorized to do something (e.g. create a new meeting) and there is a direct link to the new meeting page, the user will be redirected to the root of the application.

More sensible would be to ask the user to authenticate themselves.

#### Testing
- Create an instance with a meetings component and meetings creation enabled for participants
- Write the new meeting path (`.../meetings/new`) directly to the browser
- See where the user is redirected to

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.