### PR TITLE
Attempt to fix puffing-billy runtime error

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/puffing_billy.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/puffing_billy.rb
@@ -34,10 +34,13 @@ end
 # https://github.com/oesmith/puffing-billy/issues/253#issuecomment-539710620
 module BillyProxyPatch
   def stop
+    return if EM.stopped?
     return unless EM.reactor_running?
 
     super
   rescue Timeout::Error
+    nil
+  rescue RuntimeError
     nil
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/puffing_billy.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/puffing_billy.rb
@@ -34,7 +34,6 @@ end
 # https://github.com/oesmith/puffing-billy/issues/253#issuecomment-539710620
 module BillyProxyPatch
   def stop
-    return if EM.stopped?
     return unless EM.reactor_running?
 
     super


### PR DESCRIPTION
#### :tophat: What? Why?
Puffing billy is still failing in occasional test runs. This is an attempt for a further fix it based on the stack trace. There's been already a few attempts before (see the related issues).

Example test run that failed:
https://github.com/decidim/decidim/runs/2370653474?check_suite_focus=true

Stack trace from the failed spec:

```
An error occurred in an `after(:suite)` hook.
Failure/Error: Socket.unpack_sockaddr_in(EM.get_sockname(@signature)).first

RuntimeError:
  eventmachine not initialized: evma_get_sockname
# /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/puffing_billy.rb:39:in `stop'
# ------------------
# --- Caused by: ---
# Timeout::Error:
#   execution expired
#   /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/puffing_billy.rb:39:in `stop'
```

#### :pushpin: Related Issues
- Related to #7672, #7364

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.