### PR TITLE
Dynamically get all participatory space role tables for the `visible_meeting_for` query

### DIFF
--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -47,34 +47,45 @@ module Decidim
       scope :visible_meeting_for, lambda { |user|
         (all.distinct if user&.admin?) ||
           if user.present?
-            spaces = %w(assembly participatory_process)
-            spaces << "conference" if defined?(Decidim::Conference)
-            user_role_queries = spaces.map do |participatory_space_name|
+            spaces = Decidim.participatory_space_registry.manifests.map do |manifest|
+              {
+                name: manifest.model_class_name.constantize.table_name.singularize,
+                class_name: manifest.model_class_name
+              }
+            end
+            user_role_queries = spaces.map do |space|
+              roles_table = "#{space[:name]}_user_roles"
+              next unless connection.table_exists?(roles_table)
+
               "SELECT decidim_components.id FROM decidim_components
               WHERE CONCAT(decidim_components.participatory_space_id, '-', decidim_components.participatory_space_type)
               IN
-              (SELECT CONCAT(decidim_#{participatory_space_name}_user_roles.decidim_#{participatory_space_name}_id, '-Decidim::#{participatory_space_name.classify}')
-              FROM decidim_#{participatory_space_name}_user_roles WHERE decidim_#{participatory_space_name}_user_roles.decidim_user_id = ?)
+              (SELECT CONCAT(#{roles_table}.#{space[:name]}_id, '-#{space[:class_name]}')
+              FROM #{roles_table} WHERE #{roles_table}.decidim_user_id = ?)
               "
             end
 
-            where("decidim_meetings_meetings.private_meeting = ?
-            OR decidim_meetings_meetings.transparent = ?
-            OR decidim_meetings_meetings.id IN
-              (SELECT decidim_meetings_registrations.decidim_meeting_id FROM decidim_meetings_registrations WHERE decidim_meetings_registrations.decidim_user_id = ?)
-            OR decidim_meetings_meetings.decidim_component_id IN
-              (SELECT decidim_components.id FROM decidim_components
+            query = "
+              decidim_meetings_meetings.private_meeting = ?
+              OR decidim_meetings_meetings.transparent = ?
+              OR decidim_meetings_meetings.id IN (
+                SELECT decidim_meetings_registrations.decidim_meeting_id FROM decidim_meetings_registrations WHERE decidim_meetings_registrations.decidim_user_id = ?
+              )
+              OR decidim_meetings_meetings.decidim_component_id IN (
+                SELECT decidim_components.id FROM decidim_components
                 WHERE CONCAT(decidim_components.participatory_space_id, '-', decidim_components.participatory_space_type)
                 IN
                   (SELECT CONCAT(decidim_participatory_space_private_users.privatable_to_id, '-', decidim_participatory_space_private_users.privatable_to_type)
                   FROM decidim_participatory_space_private_users WHERE decidim_participatory_space_private_users.decidim_user_id = ?)
               )
-            OR decidim_meetings_meetings.decidim_component_id IN
-              (
-                #{user_role_queries.compact.join(" UNION ")}
-              )
-            ", false, true, user.id, user.id, *user_role_queries.compact.map { user.id })
-              .distinct
+            "
+            if user_role_queries.any?
+              query = "#{query} OR decidim_meetings_meetings.decidim_component_id IN
+                (#{user_role_queries.compact.join(" UNION ")})
+              "
+            end
+
+            where(query, false, true, user.id, user.id, *user_role_queries.compact.map { user.id }).distinct
           else
             visible
           end


### PR DESCRIPTION
#### :tophat: What? Why?
Right now the meetings component is broken if one of the hard coded participatory spaces is not available. In this particular case, we are not using the `assemblies` gem at all, when this query is broken.

#### Testing
- Install decidim without the `decidim-assemblies` gem
- Enable the meetings component for some space (e.g. processes)
- Try to visit any of the meeting pages

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.