### PR TITLE
Fix proposal form attachment errors

### DIFF
--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -107,12 +107,15 @@ module Decidim
 
       private
 
-      # This method will add an error to the `attachment` field only if there's
-      # any error in any other field. This is needed because when the form has
-      # an error, the attachment is lost, so we need a way to inform the user of
+      # This method will add an error to the `add_photos` and/or "add_documents" fields
+      # only if there's any error in any other field. This is needed because when the
+      # form has an error, the attachment is lost, so we need a way to inform the user of
       # this problem.
       def notify_missing_attachment_if_errored
-        errors.add(:attachment, :needs_to_be_reattached) if errors.any? && attachment.present?
+        if errors.any?
+          errors.add(:add_photos, :needs_to_be_reattached) if add_photos.present?
+          errors.add(:add_documents, :needs_to_be_reattached) if add_documents.present?
+        end
       end
 
       def ordered_hashtag_list(string)

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -48,6 +48,10 @@ en:
               invalid_document_type: 'Invalid document type. Accepted formats are: %{valid_mime_types}'
         proposal:
           attributes:
+            add_documents:
+              needs_to_be_reattached: Needs to be reattached
+            add_photos:
+              needs_to_be_reattached: Needs to be reattached
             attachment:
               needs_to_be_reattached: Needs to be reattached
             body:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -52,8 +52,6 @@ en:
               needs_to_be_reattached: Needs to be reattached
             add_photos:
               needs_to_be_reattached: Needs to be reattached
-            attachment:
-              needs_to_be_reattached: Needs to be reattached
             body:
               cant_be_equal_to_template: cannot be equal to the template
               identical: AND title cannot be identical

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -265,10 +265,18 @@ shared_examples "a proposal form" do |options|
   end
 
   context "when the attachment is present" do
-    let(:attachment_params) do
+    let(:params) do
       {
-        title: "My attachment",
-        file: Decidim::Dev.test_file("city.jpeg", "image/jpeg")
+        title: title,
+        body: body,
+        author: author,
+        category_id: category_id,
+        scope_id: scope_id,
+        address: address,
+        has_address: has_address,
+        meeting_as_author: meeting_as_author,
+        suggested_hashtags: suggested_hashtags,
+        add_photos: [Decidim::Dev.test_file("city.jpeg", "image/jpeg")]
       }
     end
 
@@ -281,11 +289,11 @@ shared_examples "a proposal form" do |options|
         expect(subject).not_to be_valid
 
         if options[:i18n]
-          expect(subject.errors.full_messages).to match_array(["Title en can't be blank", "Attachment Needs to be reattached"])
-          expect(subject.errors.keys).to match_array([:title_en, :attachment])
+          expect(subject.errors.full_messages).to match_array(["Title en can't be blank", "Add photos Needs to be reattached"])
+          expect(subject.errors.keys).to match_array([:title_en, :add_photos])
         else
-          expect(subject.errors.full_messages).to match_array(["Title can't be blank", "Title is too short (under 15 characters)", "Attachment Needs to be reattached"])
-          expect(subject.errors.keys).to match_array([:title, :attachment])
+          expect(subject.errors.full_messages).to match_array(["Title can't be blank", "Title is too short (under 15 characters)", "Add photos Needs to be reattached"])
+          expect(subject.errors.keys).to match_array([:title, :add_photos])
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
When creating new proposal: the file fields do not display an error, they should show "needs to be reattached".

#### Testing
Inside a proposals component with attachments and card images enabled:
1. Create a new proposal
2. Write the title with the first letter being in lowercase
3. Add both image and attachment files to the proposal
4. Submit the form
5. See an error

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![needs_to_be_reattached](https://user-images.githubusercontent.com/19709320/115229523-d2ef0200-a11b-11eb-9250-1527f86b1d1e.png)

:hearts: Thank you!
