### PR TITLE
Fix TypeError in newsletters

### DIFF
--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -160,6 +160,8 @@ module Decidim
                                     .where(decidim_commentable_id: resources.pluck(:id))
                                     .where(decidim_commentable_type: commentable_type)
                                     .where("decidim_author_type" => "Decidim::UserBaseEntity").pluck(:decidim_author_id)
+        else
+          []
         end
       end
 

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -254,6 +254,13 @@ module Decidim
       end
 
       describe "#user_commentators_ids_in" do
+        context "when passing a non-commentable resource" do
+          it "returns the autors of the resources' comments" do
+            ids = Decidim::Comments::Comment.user_commentators_ids_in([commentable.component.participatory_space])
+            expect(ids).to match_array([])
+          end
+        end
+
         context "when commentors belong to the given resources" do
           it "returns the autors of the resources' comments" do
             ids = Decidim::Comments::Comment.user_commentators_ids_in(Decidim::DummyResources::DummyResource.where(component: commentable.component))

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -277,16 +277,6 @@ module Decidim
             expect(ids).to match_array([author.id])
           end
         end
-
-        context "when resource is not commentable" do
-          let(:other_component) { create(:dummy_component) }
-          let!(:non_commentable) { create(:coauthorable_dummy_resource, component: other_component) }
-
-          it "returns nil" do
-            ids = Decidim::Comments::Comment.user_commentators_ids_in(Decidim::DummyResources::CoauthorableDummyResource.where(component: other_component))
-            expect(ids).to be_nil
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Sometimes, when sending a newsletter, a `TypeError` exception is raised. This is due to a method returning `nil` instead of an empty list.

This PR fixes the problem. Bug seems to be introduced in #7046 and related backports.

Error example: https://sentry.io/share/issue/7bcc9e62a01b44519d6a525ea9a4a447/

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green.