### PR TITLE
Move translations to the module they belong

### DIFF
--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -387,11 +387,6 @@ en:
         designated_on: Designated on
       index:
         title: Members
-    conferences:
-      pages:
-        home:
-          highlighted_conferences:
-            conferences_button_title: Link to the Conferences page displaying all the conferences
     events:
       assemblies:
         create_assembly_member:
@@ -424,17 +419,7 @@ en:
         description: Number of assemblies created
         object: assemblies
         title: Assemblies
-    pages:
-      home:
-        hero:
-          participate_title: Participate to the platform's processes
-        sub_hero:
-          register_title: Sign up to create an account
     participatory_processes:
-      pages:
-        home:
-          highlighted_processes:
-            processes_button_title: Link to the Processes page displaying all the processes
       show:
         related_assemblies: Related assemblies
     statistics:

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -502,6 +502,7 @@ en:
         home:
           highlighted_conferences:
             active_conferences: Active conferences
+            conferences_button_title: Link to the Conferences page displaying all the conferences
             see_all_conferences: See all conferences
       photo:
         image:

--- a/decidim-pages/config/locales/en.yml
+++ b/decidim-pages/config/locales/en.yml
@@ -29,3 +29,8 @@ en:
           update:
             invalid: There was a problem saving the page.
             success: Page successfully saved.
+      home:
+        hero:
+          participate_title: Participate to the platform's processes
+        sub_hero:
+          register_title: Sign up to create an account

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -404,6 +404,7 @@ en:
             more_information: More information
             participate: Participate
             participate_in: Participate in process %{resource_name}
+            processes_button_title: Link to the Processes page displaying all the processes
             see_all_processes: See all processes
       participatory_process_steps:
         index:


### PR DESCRIPTION
#### :tophat: What? Why?
I have found some translations outside the module to which they belong, this PR moves them to the module.

Removing `decidim-assemblies` gem from an app raised translation errors in the organization homepage.

#### :pushpin: Related Issues

- Related to none

#### Testing



#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
