### PR TITLE
Fix editor: shift+enter makes single br tag before link

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -150,6 +150,27 @@ describe "Admin manages organization", type: :system do
         end
       end
 
+      context "when the admin terms of use content has a link" do
+        let(:terms_content) do
+          <<~HTML
+            <p>foo<br><a href="https://www.decidim.org" rel="noopener noreferrer" target="_blank">link</a></p>
+          HTML
+        end
+        let(:organization) do
+          create(
+            :organization,
+            admin_terms_of_use_body: Decidim::Faker::Localized.localized { terms_content }
+          )
+        end
+
+        it "creates single br tag" do
+          find('div[contenteditable="true"].ql-editor').send_keys([:left, :left, :left, :left, :left], [:shift, :enter])
+          expect(find(
+            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+          )["innerHTML"]).to eq('<p>foo<br><br><a href="https://www.decidim.org" rel="noopener noreferrer" target="_blank">link</a></p>')
+        end
+      end
+
       context "when adding br tags to terms of use content" do
         let(:another_organization) { create(:organization) }
         let(:image) { create(:attachment, attached_to: another_organization) }

--- a/decidim-core/app/packs/src/decidim/editor/modified_enter.js
+++ b/decidim-core/app/packs/src/decidim/editor/modified_enter.js
@@ -39,17 +39,20 @@ const lineBreakHandler = (quill, range, context) => {
   const currentLeaf = quill.getLeaf(range.index)[0];
   const nextLeaf = quill.getLeaf(range.index + 1)[0];
   const previousChar = quill.getText(range.index - 1, 1);
+  const formats = quill.getFormat(range.index);
 
   quill.insertEmbed(range.index, "break", true, "user");
-  quill.formatText(range.index + 1, "bold", true)
-  if (nextLeaf === null || (currentLeaf.parent !== nextLeaf.parent)) {
+  if (nextLeaf === null || (currentLeaf.parent !== nextLeaf.parent &&
+      nextLeaf.parent.domNode.tagName !== "A")) {
     quill.insertEmbed(range.index, "break", true, "user");
   } else if (context.offset === 1 && previousChar === "\n") {
     const delta = new Delta().retain(range.index).insert("\n");
     quill.updateContents(delta, Quill.sources.USER);
   }
 
-  quill.format(name, context.format[name], Quill.sources.USER);
+  Object.keys(formats).forEach((format) => {
+    quill.format(format, context.format[format], Quill.sources.USER);
+  });
   quill.setSelection(range.index + 1, Quill.sources.SILENT);
 
   const lineFormats = getLineFormats(context);


### PR DESCRIPTION
#### :tophat: What? Why?
Editor creates double linebreak when pressing shift+enter between text and link.

#### Testing
1. find WYSIWYG editor, (for example: /admin/organization/edit)
2. clear all text 
3. write: foo<shift+enter>bar
4. select bar and make it a link
5. put cursor end of foo
6. you should have something like this:
![foo_bar](https://user-images.githubusercontent.com/19709320/115588813-d0390c00-a2d7-11eb-9f95-14e338572ab0.png)
7. press shift+enter

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
