### PR TITLE
NoMethodError raised when voting comments from threads

### DIFF
--- a/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
@@ -8,6 +8,11 @@ module Decidim
       i18n_attributes :upvotes
       i18n_attributes :downvotes
 
+      def initialize(resource:, event_name:, user:, user_role: nil, extra: nil)
+        resource = target_resource(resource)
+        super
+      end
+
       def upvotes
         extra[:upvotes]
       end
@@ -20,10 +25,6 @@ module Decidim
 
       def resource_url_params
         { anchor: "comment_#{comment.id}" }
-      end
-
-      def resource
-        target_resource(@resource)
       end
 
       def target_resource(t_resource)

--- a/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
@@ -27,7 +27,7 @@ module Decidim
       end
 
       def target_resource(t_resource)
-        t_resource.is_a?(Decidim::Comments::Comment) ? target_resource(t_resource.commentable): t_resource
+        t_resource.is_a?(Decidim::Comments::Comment) ? target_resource(t_resource.commentable) : t_resource
       end
     end
   end

--- a/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
@@ -28,7 +28,7 @@ module Decidim
       end
 
       def target_resource(t_resource)
-        t_resource.is_a?(Decidim::Comments::Comment) ? target_resource(t_resource.commentable) : t_resource
+        t_resource.is_a?(Decidim::Comments::Comment) ? t_resource.root_commentable : t_resource
       end
     end
   end

--- a/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_voted_event.rb
@@ -21,6 +21,14 @@ module Decidim
       def resource_url_params
         { anchor: "comment_#{comment.id}" }
       end
+
+      def resource
+        target_resource(@resource)
+      end
+
+      def target_resource(t_resource)
+        t_resource.is_a?(Decidim::Comments::Comment) ? target_resource(t_resource.commentable): t_resource
+      end
     end
   end
 end

--- a/decidim-comments/spec/events/decidim/comments/comment_downvoted_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_downvoted_event_spec.rb
@@ -6,5 +6,20 @@ describe Decidim::Comments::CommentDownvotedEvent do
   let(:event_name) { "decidim.events.comments.comment_downvoted" }
   let(:weight) { -1 }
 
-  it_behaves_like "a comment voted event"
+  context "with leaf comment" do
+    it_behaves_like "a comment voted event" do
+      let(:parent_comment) { create(:comment) }
+      let(:comment) { create :comment, commentable: parent_comment, root_commentable: parent_comment.root_commentable }
+      let(:resource_title) { decidim_html_escape(translated(resource.commentable.title)) }
+      let(:resource_path) { resource_locator(resource.commentable).path }
+    end
+  end
+
+  context "with root comment" do
+    it_behaves_like "a comment voted event" do
+      let(:resource) { comment.commentable }
+      let(:comment) { create :comment }
+      let(:resource_title) { decidim_html_escape(translated(resource.title)) }
+    end
+  end
 end

--- a/decidim-comments/spec/events/decidim/comments/comment_upvoted_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_upvoted_event_spec.rb
@@ -6,5 +6,20 @@ describe Decidim::Comments::CommentUpvotedEvent do
   let(:event_name) { "decidim.events.comments.comment_upvoted" }
   let(:weight) { 1 }
 
-  it_behaves_like "a comment voted event"
+  context "with leaf comment" do
+    it_behaves_like "a comment voted event" do
+      let(:parent_comment) { create(:comment) }
+      let(:comment) { create :comment, commentable: parent_comment, root_commentable: parent_comment.root_commentable }
+      let(:resource_title) { decidim_html_escape(translated(resource.commentable.title)) }
+      let(:resource_path) { resource_locator(resource.commentable).path }
+    end
+  end
+
+  context "with root comment" do
+    it_behaves_like "a comment voted event" do
+      let(:resource) { comment.commentable }
+      let(:comment) { create :comment }
+      let(:resource_title) { decidim_html_escape(translated(resource.title)) }
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When a comment is added you can up-vote or down-vote it and this will trigger a notification in which is included the link to the resource. For the comments from threads this action will raise an error:

> NoMethodErrorSidekiq/ActionMailer::MailDeliveryJob
> error
> undefined method `route_name' for nil:NilClass

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
- Add a reply to a comment.
- Vote that comment from the reply.
- Go to the notifications page
- Error is displayed

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Screenshot from 2021-04-22 10-04-42](https://user-images.githubusercontent.com/66411127/115670608-467a5480-a352-11eb-9129-5aef792e98c4.png)


:hearts: Thank you!
