### PR TITLE
Fix not signed in needs permission redirect for internal links

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/needs_permission.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_permission.rb
@@ -25,6 +25,7 @@ module Decidim
       end
 
       def user_has_no_permission_referer
+        return unless user_signed_in?
         return if request.referer == request.original_url
 
         request.referer

--- a/decidim-core/spec/controllers/concerns/needs_permission_spec.rb
+++ b/decidim-core/spec/controllers/concerns/needs_permission_spec.rb
@@ -71,6 +71,16 @@ module Decidim
           expect(response).to redirect_to("/you-need-permissions")
         end
       end
+
+      context "and the user is not signed in" do
+        let(:user) { nil }
+
+        it "redirects the user to the user_has_no_permissions_path" do
+          get :show
+
+          expect(response).to redirect_to("/you-need-permissions")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
#7852 fixed the unauthenticated redirects to the sign in page for requests that do not have a referer (e.g. in email links).

But the requests still fail to redirect to the sign in page if the referer is defined (e.g. links/buttons within the site).

This fixes the unauthenticated user redirects to any resources that need permissions to the sign in page.

#### :pushpin: Related Issues
- Related to #7852

#### Testing
- Create an instance with a meetings component and meetings creation enabled for participants
- Create a link on the process front page to the new meeting path (.../meetings/new) or use the step CTAs
- See where the user is redirected to

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.