### PR TITLE
Fix meeting registrations questionnaire free text choice answers export

### DIFF
--- a/decidim-meetings/app/serializers/decidim/meetings/registration_serializer.rb
+++ b/decidim-meetings/app/serializers/decidim/meetings/registration_serializer.rb
@@ -21,18 +21,9 @@ module Decidim
       private
 
       def serialize_answers
-        questions = resource.meeting.questionnaire.questions
-        answers = resource.meeting.questionnaire.answers.where(user: resource.user)
-        questions.each_with_index.inject({}) do |serialized, (question, idx)|
-          answer = answers.find_by(question: question)
-          serialized.update("#{idx + 1}. #{translated_attribute(question.body)}" => normalize_body(answer))
-        end
-      end
-
-      def normalize_body(answer)
-        return "" unless answer
-
-        answer.body || answer.choices.pluck(:body)
+        Decidim::Forms::UserAnswersSerializer.new(
+          resource.meeting.questionnaire.answers.where(user: resource.user)
+        ).serialize
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
When the meeting registrations form has a question with single or multiple choices and they have the `free_text` option defined for them, those free text answers won't be exported.

This fixes the issue by utilizing the `Decidim::Forms::UserAnswersSerializer` serializer to export the registration form answers.

#### Testing
- Create a meeting with a registration form
- Add a question to the form with the single choice or multiple choice types
- For one of the answer options, enable the "free text" option
- Submit an answer to the form with a free text choice answer
- Export the meeting registrations from the admin panel
- See that the free text answers are not exported correctly

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.