### PR TITLE
Validate nickname using correct regexp

### DIFF
--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -20,7 +20,7 @@ module Decidim
 
     validates :name, presence: true
     validates :email, presence: true, 'valid_email_2/email': { disposable: true }
-    validates :nickname, presence: true, format: Decidim::UserBaseEntity::REGEXP_NICKNAME
+    validates :nickname, presence: true, format: Decidim::User::REGEXP_NICKNAME
 
     validates :nickname, length: { maximum: Decidim::User.nickname_max_length, allow_blank: true }
     validates :password, confirmation: true

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -20,7 +20,7 @@ module Decidim
 
     validates :name, presence: true
     validates :email, presence: true, 'valid_email_2/email': { disposable: true }
-    validates :nickname, presence: true, format: /\A[\w\-]+\z/
+    validates :nickname, presence: true, format: Decidim::UserBaseEntity::REGEXP_NICKNAME
 
     validates :nickname, length: { maximum: Decidim::User.nickname_max_length, allow_blank: true }
     validates :password, confirmation: true

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -13,6 +13,8 @@ module Decidim
     include Decidim::UserReportable
     include Decidim::Traceable
 
+    REGEXP_NICKNAME = /\A[\w\-]+\z/.freeze
+
     class Roles
       def self.all
         Decidim.config.user_roles
@@ -35,7 +37,11 @@ module Decidim
     has_one :blocking, class_name: "Decidim::UserBlock", foreign_key: :id, primary_key: :block_id, dependent: :destroy
 
     validates :name, presence: true, unless: -> { deleted? }
-    validates :nickname, presence: true, unless: -> { deleted? || managed? }, length: { maximum: Decidim::User.nickname_max_length }
+    validates :nickname,
+              presence: true,
+              format: { with: REGEXP_NICKNAME },
+              length: { maximum: Decidim::User.nickname_max_length },
+              unless: -> { deleted? || managed? }
     validates :locale, inclusion: { in: :available_locales }, allow_blank: true
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
     validates :tos_agreement, acceptance: true, if: :user_invited?

--- a/decidim-core/app/models/decidim/user_base_entity.rb
+++ b/decidim-core/app/models/decidim/user_base_entity.rb
@@ -19,11 +19,13 @@ module Decidim
 
     # Regex for name & nickname format validations
     REGEXP_NAME = /\A(?!.*[<>?%&\^*#@()\[\]=+:;"{}\\|])/.freeze
+    REGEXP_NICKNAME = /\A[\w\-]+\z/.freeze
 
     validates_avatar
     mount_uploader :avatar, Decidim::AvatarUploader
 
-    validates :name, :nickname, format: { with: REGEXP_NAME }
+    validates :name, format: { with: REGEXP_NAME }
+    validates :nickname, format: { with: REGEXP_NICKNAME }
 
     # Public: Returns a collection with all the entities this user is following.
     #

--- a/decidim-core/app/models/decidim/user_base_entity.rb
+++ b/decidim-core/app/models/decidim/user_base_entity.rb
@@ -19,13 +19,11 @@ module Decidim
 
     # Regex for name & nickname format validations
     REGEXP_NAME = /\A(?!.*[<>?%&\^*#@()\[\]=+:;"{}\\|])/.freeze
-    REGEXP_NICKNAME = /\A[\w\-]+\z/.freeze
 
     validates_avatar
     mount_uploader :avatar, Decidim::AvatarUploader
 
     validates :name, format: { with: REGEXP_NAME }
-    validates :nickname, format: { with: REGEXP_NICKNAME }
 
     # Public: Returns a collection with all the entities this user is following.
     #

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -74,7 +74,7 @@ module Decidim
 
         it "is not valid" do
           expect(user).not_to be_valid
-          expect(user.errors[:nickname].length).to eq(1)
+          expect(user.errors[:nickname]).to include("can't be blank")
         end
 
         it "can't be empty backed by an index" do


### PR DESCRIPTION
#### :tophat: What? Why?
In a Decidim installation we found some users having an invalid nickname. This caused errors when trying to list those users.

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green.