### PR TITLE
Fix JS errors in the admin panel

### DIFF
--- a/decidim-admin/app/packs/entrypoints/decidim_admin.js
+++ b/decidim-admin/app/packs/entrypoints/decidim_admin.js
@@ -37,7 +37,7 @@ import managedUsersForm from "../src/decidim/admin/managed_users"
 
 window.Decidim.managedUsersForm = managedUsersForm
 window.Decidim.config = new Configuration()
-window.Decidim.InputCharacterCounter = InputCharacterCounter;
+window.Decidim.InputCharacterCounter = InputCharacterCounter
 
 // This needs to be loaded after confirm dialog to bind properly
 import Rails from "@rails/ujs"

--- a/decidim-admin/app/packs/entrypoints/decidim_admin.js
+++ b/decidim-admin/app/packs/entrypoints/decidim_admin.js
@@ -29,12 +29,15 @@ import "../../../../decidim-core/app/packs/src/decidim/input_mentions"
 import "../../../../decidim-core/app/packs/src/decidim/vizzs"
 import "../../../../decidim-core/app/packs/src/decidim/ajax_modals"
 import "../src/decidim/admin/officializations"
-import "../../../../decidim-core/app/packs/src/decidim/input_character_counter"
+import InputCharacterCounter from "../../../../decidim-core/app/packs/src/decidim/input_character_counter"
 import "../../../../decidim-core/app/packs/src/decidim/session_timeouter"
 import "../../../../decidim-core/app/packs/src/decidim/slug_form"
-import "../../../../decidim-core/app/packs/src/decidim/configuration"
+import Configuration from "../../../../decidim-core/app/packs/src/decidim/configuration"
 import managedUsersForm from "../src/decidim/admin/managed_users"
+
 window.Decidim.managedUsersForm = managedUsersForm
+window.Decidim.config = new Configuration()
+window.Decidim.InputCharacterCounter = InputCharacterCounter;
 
 // This needs to be loaded after confirm dialog to bind properly
 import Rails from "@rails/ujs"


### PR DESCRIPTION
#### :tophat: What? Why?
Right now there are some JS errors in the admin panel due to missing global Decidim objects.

This fixes those issues.

#### :pushpin: Related Issues
- Related to #7464

#### Testing
- Go to admin panel
- See the JS console

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Admin panel JS errors](https://user-images.githubusercontent.com/864340/116375230-c2bfdc80-a817-11eb-90d6-6702eab8b02d.png)