### PR TITLE
Fix editor: shift+enter makes single br tag before link and remove br tags from inside a tags

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -150,6 +150,34 @@ describe "Admin manages organization", type: :system do
         end
       end
 
+      context "when the admin terms of use content has a link" do
+        let(:terms_content) do
+          <<~HTML
+            <p>foo<br><a href="https://www.decidim.org" rel="noopener noreferrer" target="_blank">link</a></p>
+          HTML
+        end
+        let(:organization) do
+          create(
+            :organization,
+            admin_terms_of_use_body: Decidim::Faker::Localized.localized { terms_content }
+          )
+        end
+
+        it "creates single br tag" do
+          find('div[contenteditable="true"].ql-editor').send_keys([:left, :left, :left, :left, :left], [:shift, :enter])
+          expect(find(
+            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+          )["innerHTML"]).to eq('<p>foo<br><br><a href="https://www.decidim.org" rel="noopener noreferrer" target="_blank">link</a></p>')
+        end
+
+        it "doesnt create br tag inside a tag" do
+          find('div[contenteditable="true"].ql-editor').send_keys([:left, :left, :left, :left], [:shift, :enter])
+          expect(find(
+            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+          )["innerHTML"]).to eq('<p>foo<br><br><a href="https://www.decidim.org" rel="noopener noreferrer" target="_blank">link</a></p>')
+        end
+      end
+
       context "when adding br tags to terms of use content" do
         let(:another_organization) { create(:organization) }
         let(:image) { create(:attachment, attached_to: another_organization) }

--- a/decidim-core/app/assets/javascripts/decidim/editor/linebreak_module.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/editor/linebreak_module.js.es6
@@ -11,7 +11,7 @@
   const Break = Quill.import("blots/break");
   const Embed = Quill.import("blots/embed");
   const { HistoryOverride } = exports.Decidim.Editor
-  Quill.register({"modules/history": HistoryOverride}, true)
+  Quill.register({ "modules/history": HistoryOverride }, true)
   let icons = Quill.import("ui/icons");
   icons.linebreak = "⏎";
 
@@ -70,6 +70,13 @@
       if (text === "\n\n") {
         quill.deleteText(quill.getLength() - 2, 2);
       }
+    });
+
+    quill.clipboard.addMatcher("BR", (node) => {
+      if (node?.parentNode?.tagName === "A") {
+        return new Delta().insert("\n");
+      }
+      return new Delta().insert({ "break": "" });
     });
 
     addEnterBindings(quill);

--- a/decidim-core/app/assets/javascripts/decidim/editor/modified_enter.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/editor/modified_enter.js.es6
@@ -40,17 +40,26 @@
     const currentLeaf = quill.getLeaf(range.index)[0];
     const nextLeaf = quill.getLeaf(range.index + 1)[0];
     const previousChar = quill.getText(range.index - 1, 1);
+    const formats = quill.getFormat(range.index);
+
+    if (currentLeaf?.next?.domNode?.tagName === "A" || nextLeaf?.parent?.domNode?.tagName === "A") {
+      quill.insertEmbed(range.index, "break", true, "user");
+      quill.removeFormat(range.index, 1, Quill.sources.SILENT)
+    } else {
+      quill.insertEmbed(range.index, "break", true, "user");
+    }
 
     quill.insertEmbed(range.index, "break", true, "user");
-    quill.formatText(range.index + 1, "bold", true)
-    if (nextLeaf === null || (currentLeaf.parent !== nextLeaf.parent)) {
+    if (nextLeaf === null) {
       quill.insertEmbed(range.index, "break", true, "user");
     } else if (context.offset === 1 && previousChar === "\n") {
       const delta = new Delta().retain(range.index).insert("\n");
       quill.updateContents(delta, Quill.sources.USER);
     }
 
-    quill.format(name, context.format[name], Quill.sources.USER);
+    Object.keys(formats).forEach((format) => {
+      quill.format(format, context.format[format], Quill.sources.USER);
+    });
     quill.setSelection(range.index + 1, Quill.sources.SILENT);
 
     const lineFormats = getLineFormats(context);
@@ -58,12 +67,6 @@
   };
 
   const addEnterBindings = (quill) => {
-    quill.clipboard.addMatcher("BR", () => {
-      let newDelta = new Delta();
-      newDelta.insert({"break": ""});
-      return newDelta;
-    });
-
     quill.keyboard.addBinding({
       key: 13,
       shiftKey: true


### PR DESCRIPTION
#### :tophat: What? Why?
This PR backports #7877 and #7901 to 0.24.

#### :pushpin: Related Issues
See #7896

#### Testing
Ensure CI is green.