### PR TITLE
Open attachments in new tab

### DIFF
--- a/decidim-core/app/views/decidim/application/_document.html.erb
+++ b/decidim-core/app/views/decidim/application/_document.html.erb
@@ -1,7 +1,7 @@
 <div class="card--list__item">
   <div class="card--list__text">
     <div>
-      <a href="<%= document.url %>" class="card__link">
+      <a href="<%= document.url %>" class="card__link" target="_blank">
         <h4 class="card--list__heading heading6">
           <%= attachment_title(document) %> <small><%= document.file_type %> <%= number_to_human_size(document.file_size) %></small>
         </h4>


### PR DESCRIPTION
#### :tophat: What? Why?
When opening attachments by clicking the attachment name, they open in the same tab, but if you click on the download icon they open in another tab. 

This PR unifies the behavior by making all attachments opening in new tabs.

#### :pushpin: Related Issues
Reported by Decidim.Barcelona

#### Testing
Ensure CI is green.