### PR TITLE
Remove creation date from meeting card

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/meeting_m_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_m_cell.rb
@@ -64,6 +64,10 @@ module Decidim
       def show_footer_actions?
         options[:show_footer_actions]
       end
+
+      def statuses
+        [:follow, :comments_count]
+      end
     end
   end
 end

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
@@ -6,7 +6,7 @@ module Decidim::Meetings
   describe MeetingMCell, type: :cell do
     controller Decidim::Meetings::MeetingsController
 
-    let!(:meeting) { create(:meeting) }
+    let!(:meeting) { create(:meeting, created_at: "2001-01-01") }
     let(:model) { meeting }
     let(:the_cell) { cell("decidim/meetings/meeting_m", meeting, context: { show_space: show_space }) }
     let(:cell_html) { the_cell.call }
@@ -18,6 +18,11 @@ module Decidim::Meetings
 
       it "renders the card" do
         expect(cell_html).to have_css(".card--meeting")
+      end
+
+      it "doesn't show creation date" do
+        expect(cell_html).to have_no_content("Created at")
+        expect(cell_html).to have_no_content(I18n.l(meeting.created_at.to_date, format: :decidim_short))
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR removes default created_at item in statuses section of meetings m card to not show it. Also adds a test in cells

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #7292

#### Testing

Visit the meetings index of a participatory space The "Created at" shouldn't be present

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

<img width="413" alt="Screen Shot 2021-04-29 at 17 49 55" src="https://user-images.githubusercontent.com/446459/116580248-79ed4e00-a913-11eb-9a17-eaf827fefe11.png">


:hearts: Thank you!
