### PR TITLE
Cast proposal and collaborative drafts titles to text

### DIFF
--- a/decidim-proposals/app/cells/decidim/proposals/proposals_picker_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposals_picker_cell.rb
@@ -50,7 +50,7 @@ module Decidim
 
       def filtered_proposals
         @filtered_proposals ||= if filtered?
-                                  proposals.where("title ILIKE ?", "%#{search_text}%")
+                                  proposals.where("title::text ILIKE ?", "%#{search_text}%")
                                            .or(proposals.where("reference ILIKE ?", "%#{search_text}%"))
                                            .or(proposals.where("id::text ILIKE ?", "%#{search_text}%"))
                                 else

--- a/decidim-proposals/app/services/decidim/proposals/collaborative_draft_search.rb
+++ b/decidim-proposals/app/services/decidim/proposals/collaborative_draft_search.rb
@@ -21,7 +21,7 @@ module Decidim
       # translated.
       def search_search_text
         query
-          .where("title ILIKE ?", "%#{search_text}%")
+          .where("title::text ILIKE ?", "%#{search_text}%")
           .or(query.where("body ILIKE ?", "%#{search_text}%"))
       end
 

--- a/decidim-proposals/spec/services/decidim/proposals/collaborative_draft_search_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/collaborative_draft_search_spec.rb
@@ -26,8 +26,8 @@ module Decidim
 
           it "returns the drafts containing the search in the title or the body" do
             create_list(:collaborative_draft, 3, component: component)
-            create(:collaborative_draft, title: "A giraffe", component: component)
-            create(:collaborative_draft, body: "There is a giraffe in the office", component: component)
+            create(:collaborative_draft, title: { en: "A giraffe" }, component: component)
+            create(:collaborative_draft, body: { en: "There is a giraffe in the office" }, component: component)
 
             expect(subject.size).to eq(2)
           end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the proposal picker and the collaborative draft search by casting the title to text so that PostgreSQL can search their titles.

#### :pushpin: Related Issues
None

#### Testing
Ensure CI is green.