### PR TITLE
Polling station closure attach the physical electoral closure certificate

### DIFF
--- a/decidim-elections/app/cells/decidim/votings/polling_station_closure_certificate/show.erb
+++ b/decidim-elections/app/cells/decidim/votings/polling_station_closure_certificate/show.erb
@@ -1,0 +1,9 @@
+<% if has_images? %>
+  <div class="row column">
+    <% model.photos.each do |image| %>
+      <a href="<%= image.url %>" target="_blank">
+        <img class="thumbnail" src="<%= image.thumbnail_url %>" alt="<%= translated_attribute(image.title) %>">
+      </a>
+    <% end %>
+  </div>
+<% end %>

--- a/decidim-elections/app/cells/decidim/votings/polling_station_closure_certificate_cell.rb
+++ b/decidim-elections/app/cells/decidim/votings/polling_station_closure_certificate_cell.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    # This cell renders the image of the physical certificate of a Polling Station Closure
+    class PollingStationClosureCertificateCell < Decidim::ViewModel
+      def has_images?
+        model.photos.present?
+      end
+    end
+  end
+end

--- a/decidim-elections/app/commands/decidim/votings/certify_polling_station_closure.rb
+++ b/decidim-elections/app/commands/decidim/votings/certify_polling_station_closure.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    # A command with all the business logic when signing a closure of a polling station
+    class CertifyPollingStationClosure < Rectify::Command
+      include ::Decidim::AttachmentMethods
+      include ::Decidim::GalleryMethods
+      # Public: Initializes the command.
+      #
+      # form - A form object with the params.
+      # closure - A closure object.
+      def initialize(form, closure)
+        @form = form
+        @closure = closure
+        @attached_to = closure
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if form.invalid?
+
+        if process_gallery?
+          build_gallery
+          return broadcast(:invalid) if gallery_invalid?
+        end
+
+        transaction do
+          create_gallery if process_gallery?
+          closure.update!(phase: :signature)
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :form, :closure, :attachment
+    end
+  end
+end

--- a/decidim-elections/app/commands/decidim/votings/create_polling_station_results.rb
+++ b/decidim-elections/app/commands/decidim/votings/create_polling_station_results.rb
@@ -35,7 +35,7 @@ module Decidim
             create_question_result_for!(question_result)
           end
 
-          closure.signature_phase!
+          closure.certificate_phase!
         end
 
         broadcast(:ok)

--- a/decidim-elections/app/forms/decidim/votings/closure_certify_form.rb
+++ b/decidim-elections/app/forms/decidim/votings/closure_certify_form.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    class ClosureCertifyForm < Decidim::Form
+      include Decidim::AttachmentAttributes
+      attribute :attachment, AttachmentForm
+      attachments_attribute :photos
+
+      validates :add_photos, presence: true
+      validate :closure_phase
+
+      private
+
+      def closure_phase
+        errors.add(:base, :not_in_certificate_phase) unless context.closure.certificate_phase?
+      end
+    end
+  end
+end

--- a/decidim-elections/app/models/decidim/votings/polling_station_closure.rb
+++ b/decidim-elections/app/models/decidim/votings/polling_station_closure.rb
@@ -4,6 +4,7 @@ module Decidim
   module Votings
     # The data store for an Election Closure.
     class PollingStationClosure < ApplicationRecord
+      include Decidim::HasAttachments
       enum phase: [:count, :results, :certificate, :signature, :complete], _suffix: true
 
       belongs_to :election,
@@ -21,6 +22,8 @@ module Decidim
                class_name: "Decidim::Elections::Result",
                dependent: :destroy,
                as: :closurable
+
+      delegate :organization, to: :election
 
       # Public: Checks if the closure has been signed by the polling officer or not.
       #

--- a/decidim-elections/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-sign-closure.js
+++ b/decidim-elections/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-sign-closure.js
@@ -1,1 +1,1 @@
-import "../src/decidim/votings/polling_officer_zone/sign-closure";
+import "src/decidim/votings/polling_officer_zone/sign-closure";

--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/_certify_form.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/_certify_form.html.erb
@@ -1,0 +1,15 @@
+<%= decidim_form_for(@form,
+                     url: certify_polling_officer_election_closure_path(polling_officer, election),
+                     html: { multipart: true, class: "form certify_closure" }) do |form| %>
+
+  <div class="row column gallery__container">
+    <fieldset>
+      <legend><%= t("form_legend", scope: "decidim.votings.polling_officer_zone.closures.certify") %></legend>
+      <div class="row column">
+        <%= form.file_field :add_photos, multiple: true, label: t("add_images", scope: "decidim.votings.polling_officer_zone.closures.certify") %>
+      </div>
+    </fieldset>
+  </div>
+
+  <%= form.submit t("submit", scope: "decidim.votings.polling_officer_zone.closures.certify"), class: "button button--sc mt-sm mb-none" %>
+<% end %>

--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/show.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/show.html.erb
@@ -4,16 +4,31 @@
     <%= t("back_to_polling_stations", scope: "decidim.votings.polling_officer_zone.closures") %>
   <% end %>
 </div>
-<% heading = if closure.signature_phase?
+
+<%= content_tag :h2, if closure.certificate_phase?
+               t("heading", scope: "decidim.votings.polling_officer_zone.closures.certify")
+             elsif closure.signature_phase?
                t("heading", scope: "decidim.votings.polling_officer_zone.closures.sign")
              else
                t("heading", scope: "decidim.votings.polling_officer_zone.closures.show")
              end %>
-<%= content_tag :h2, heading %>
+
+<%= content_tag :p,
+                if closure.certificate_phase?
+                  t("info_text", scope: "decidim.votings.polling_officer_zone.closures.certify")
+                elsif closure.signature_phase?
+                  t("info_text", scope: "decidim.votings.polling_officer_zone.closures.sign")
+                else
+                  t("info_text", scope: "decidim.votings.polling_officer_zone.closures.show")
+                end %>
 
 <div class="row mt-sm">
   <div class="columns">
     <%= cell("decidim/votings/polling_station_closure_recount", closure) %>
+
+    <%= cell("decidim/votings/polling_station_closure_certificate", closure) %>
+
+    <%= render "certify_form" if closure.certificate_phase? %>
 
     <%= render "sign_form" if closure.signature_phase? && !closure.signed? %>
   </div>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -1020,6 +1020,14 @@ en:
       polling_officer_zone:
         closures:
           back_to_polling_stations: Back to polling stations
+          certify:
+            add_images: Add images
+            error: An error occurred attaching the certificate, please try again.
+            form_legend: Upload a picture of the Electoral Closure Certificate
+            heading: Vote recount - Upload certificate
+            info_text: Please upload a picture of the Electoral Closure Certificate.
+            submit: Upload the certificate
+            success: Certificate uploaded successfully.
           create:
             error: An error occurred creating the closure, please try again later.
             success: Closure successfully created.
@@ -1055,6 +1063,7 @@ en:
             total_ballots_count: Number of ballots
           show:
             heading: Vote recount
+            info_text: Polling station electoral closure.
           sign:
             cancel: Cancel
             check_box: I've reviewed this and is the same as the physical electoral closure certificate

--- a/decidim-elections/lib/decidim/votings/polling_officer_zone_engine.rb
+++ b/decidim-elections/lib/decidim/votings/polling_officer_zone_engine.rb
@@ -14,7 +14,10 @@ module Decidim
         resources :polling_officers, path: "/", only: [:index] do
           resources :elections, only: [:index] do
             resource :closure do
-              post :sign, on: :member
+              member do
+                post :certify
+                post :sign
+              end
             end
             resources :in_person_votes, only: [:new, :create, :show, :update]
           end

--- a/decidim-elections/spec/commands/decidim/votings/certify_polling_station_closure_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/certify_polling_station_closure_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Votings
+  describe CertifyPollingStationClosure do
+    subject { described_class.new(form, closure) }
+
+    let(:closure) { create :ps_closure, :with_results, phase: :certificate }
+    let(:add_photos) { [Decidim::Dev.test_file("city.jpeg", "image/jpeg")] }
+
+    let(:form) { ClosureCertifyForm.from_params(add_photos: add_photos).with_context(closure: closure) }
+
+    before do
+      Decidim::AttachmentUploader.enable_processing = true
+    end
+
+    it "saves the attachment" do
+      expect { subject.call }.to change(Decidim::Attachment, :count).by(1)
+      expect(closure.photos.first).to be_present
+      expect(closure.photos.first).to be_kind_of(Decidim::Attachment)
+    end
+
+    it "changes to signature phase" do
+      subject.call
+
+      expect(closure.signature_phase?).to be true
+    end
+  end
+end

--- a/decidim-elections/spec/commands/decidim/votings/create_polling_station_results_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/create_polling_station_results_spec.rb
@@ -69,10 +69,10 @@ module Decidim::Votings
         expect(subject.call).to broadcast(:ok)
       end
 
-      it "changes to signature phase" do
+      it "changes to certificate phase" do
         subject.call
 
-        expect(closure.signature_phase?).to be true
+        expect(closure.certificate_phase?).to be true
       end
     end
   end

--- a/decidim-elections/spec/forms/decidim/votings/closure_certify_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/votings/closure_certify_form_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Votings::ClosureCertifyForm do
+  subject { described_class.from_params(params).with_context(closure: closure) }
+
+  let(:closure) { create :ps_closure, :with_results, phase: phase }
+  let(:phase) { :certificate }
+  let(:add_photos) { [Decidim::Dev.test_file("city.jpeg", "image/jpeg")] }
+  let(:params) do
+    {
+      add_photos: add_photos
+    }
+  end
+
+  it { is_expected.to be_valid }
+
+  describe "when attachment is missing" do
+    let(:add_photos) { nil }
+
+    it { is_expected.to be_invalid }
+  end
+
+  describe "when closure is not in certificate phase" do
+    let(:phase) { :results }
+
+    it { is_expected.to be_invalid }
+  end
+end

--- a/decidim-elections/spec/system/polling_officer_zone_spec.rb
+++ b/decidim-elections/spec/system/polling_officer_zone_spec.rb
@@ -104,8 +104,28 @@ describe "Polling Officer zone", type: :system do
       end
     end
 
+    describe "when attaching the physical certificate image to the closure", processing_uploads_for: Decidim::AttachmentUploader do
+      let!(:closure) { create(:ps_closure, :with_results, phase: :certificate, election: election, polling_station: polling_station) }
+
+      before do
+        visit decidim_votings_polling_officer_zone.polling_officer_election_closure_path(assigned_polling_officer, election)
+      end
+
+      it "can attach images to the closure" do
+        expect(page).to have_content("Vote recount - Upload certificate")
+
+        within ".form.certify_closure" do
+          attach_file :closure_certify_add_photos, Decidim::Dev.asset("city.jpeg")
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("Certificate uploaded successfully.")
+        expect(page.html).to include("city.jpeg")
+      end
+    end
+
     describe "when signing the closure" do
-      let!(:closure) { create(:ps_closure, :with_results, election: election, polling_station: polling_station) }
+      let!(:closure) { create(:ps_closure, :with_results, phase: :signature, election: election, polling_station: polling_station) }
 
       before do
         visit decidim_votings_polling_officer_zone.polling_officer_election_closure_path(assigned_polling_officer, election)


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds the ability to the polling officer to attach an image(s) of the physical closure to the polling station closure.

#### :pushpin: Related Issues

- Fixes #7130

#### Testing

- Go to the polling officer zone, fill in all the ballot/vote recount.
- in the next step you can attach the closure images.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

- ![Screenshot 2021-04-30 at 18-20-41 MacGyver-Leffler](https://user-images.githubusercontent.com/210216/116724557-1a5d7400-a9e1-11eb-9221-6f2eadf4267d.png)
- ![Screenshot 2021-04-30 at 18-21-20 MacGyver-Leffler](https://user-images.githubusercontent.com/210216/116724581-20ebeb80-a9e1-11eb-8e80-ac87e07f402b.png)


:hearts: Thank you!
