### PR TITLE
Show participants list in meetings

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -303,6 +303,7 @@ ignore_unused:
   - decidim.admin.forms.file_help.import.*
   - decidim.admin.menu.questions_submenu.attachments
   - decidim.admin.menu.questions_submenu.categories
+  - decidim.meetings.public_participants_list.hidden_participants_count.*
 
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:

--- a/decidim-core/app/cells/decidim/public_participation/show.erb
+++ b/decidim-core/app/cells/decidim/public_participation/show.erb
@@ -1,0 +1,4 @@
+<label class="represent-user-group">
+  <%= check_box_tag :public_participation %>
+  <%= checkbox_text %>
+</label>

--- a/decidim-core/app/cells/decidim/public_participation_cell.rb
+++ b/decidim-core/app/cells/decidim/public_participation_cell.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This cell is intended to be used on forms.
+  class PublicParticipationCell < Decidim::ViewModel
+    private
+
+    def checkbox_text
+      I18n.t("public_participation", scope: "decidim.shared.public_participation")
+    end
+  end
+end

--- a/decidim-core/app/packs/stylesheets/decidim/extras/_meeting-registrations.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/extras/_meeting-registrations.scss
@@ -15,6 +15,11 @@
   margin-bottom: .5em;
 }
 
+.public-participation{
+  margin-top: .5em;
+  margin-bottom: .5em;
+}
+
 .user-group-fields{
   margin-bottom: .5em;
 }

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1260,6 +1260,8 @@ en:
         filters:
           areas: Areas
           select_an_area: Select an area
+      public_participation:
+        public_participation: Show my attendance publicly
       reference:
         reference: 'Reference: %{reference}'
       represent_user_group:

--- a/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
@@ -8,6 +8,7 @@ module Decidim
       # important not to use the same word here to avoid querying all the entries, resulting in a high performance penalty
       attribute :responses, Array[AnswerForm]
       attribute :user_group_id, Integer
+      attribute :public_participation, Boolean, default: false
 
       attribute :tos_agreement, Boolean
 

--- a/decidim-forms/app/helpers/decidim/forms/application_helper.rb
+++ b/decidim-forms/app/helpers/decidim/forms/application_helper.rb
@@ -10,6 +10,7 @@ module Decidim
 
         permited_models.include?(model_name)
       end
+      alias show_public_participation? show_represent_user_group?
 
       def permited_models
         %(meeting)

--- a/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
@@ -99,6 +99,12 @@
                           </div>
                         <% end %>
 
+                        <% if show_public_participation? %>
+                          <div class="row column public-participation">
+                            <%= cell("decidim/public_participation", form) %>
+                          </div>
+                        <% end %>
+
                         <div class="row column tos-agreement">
                           <%= form.check_box :tos_agreement, label: t(".tos_agreement"), id: "questionnaire_tos_agreement", disabled: !current_participatory_space.can_participate?(current_user) %>
                           <div class="help-text">

--- a/decidim-meetings/app/cells/decidim/meetings/join_meeting_button/registration_confirm.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/join_meeting_button/registration_confirm.erb
@@ -7,6 +7,12 @@
     </div>
 
     <div class="row">
+      <div class="columns medium-10 medium-offset-1">
+        <%= cell("decidim/public_participation", form) %>
+      </div>
+    </div>
+
+    <div class="row">
       <div class="columns medium-10 medium-offset-1 help-text">
         <%= registration_terms_text %>
       </div>

--- a/decidim-meetings/app/cells/decidim/meetings/public_participants_list/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/public_participants_list/show.erb
@@ -1,0 +1,16 @@
+<div id="list-of-public-participants" class="section">
+  <div class="row">
+    <div class="columns large-12">
+      <h4 class="section-heading"><%= t("attending_participants", scope: "decidim.meetings.public_participants_list") %></h4>
+    </div>
+    <div class="columns large-12">
+      <%= cell(
+        "decidim/collapsible_list",
+        public_participants,
+        cell_name: "decidim/author",
+        cell_options: { extra_classes: ["author-data--small"] },
+        hidden_elements_count_i18n_key: "decidim.meetings.public_participants_list.hidden_participants_count"
+      ) %>
+    </div>
+  </div>
+</div>

--- a/decidim-meetings/app/cells/decidim/meetings/public_participants_list_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/public_participants_list_cell.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "cell/partial"
+
+module Decidim
+  module Meetings
+    # This cell renders the list of public participants of a meeting.
+    #
+    # Example:
+    #
+    #    cell("decidim/public_participants_list", meeting)
+    class PublicParticipantsListCell < Decidim::ViewModel
+      include ApplicationHelper
+
+      def show
+        return if public_participants.blank?
+
+        render
+      end
+
+      private
+
+      # Finds the public participants (as users) of meeting
+      #
+      # Returns an Array of presented Users
+      def public_participants
+        @public_participants ||= model.public_participants.map { |user| present(user) }
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -55,7 +55,8 @@ module Decidim
         @registration = Decidim::Meetings::Registration.create!(
           meeting: meeting,
           user: user,
-          user_group: user_group
+          user_group: user_group,
+          public_participation: registration_form.public_participation
         )
       end
 

--- a/decidim-meetings/app/forms/decidim/meetings/join_meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/join_meeting_form.rb
@@ -4,6 +4,7 @@ module Decidim
   module Meetings
     class JoinMeetingForm < Decidim::Form
       attribute :user_group_id, Integer
+      attribute :public_participation, Boolean, default: false
     end
   end
 end

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -34,6 +34,14 @@ module Decidim
       has_many :services, class_name: "Decidim::Meetings::Service", foreign_key: "decidim_meeting_id", dependent: :destroy
       has_one :minutes, class_name: "Decidim::Meetings::Minutes", foreign_key: "decidim_meeting_id", dependent: :destroy
       has_one :agenda, class_name: "Decidim::Meetings::Agenda", foreign_key: "decidim_meeting_id", dependent: :destroy
+      has_many(
+        :public_participants,
+        -> { merge(Registration.public_participant) },
+        through: :registrations,
+        class_name: "Decidim::User",
+        foreign_key: :decidim_user_id,
+        source: :user
+      )
 
       component_manifest_name "meetings"
 

--- a/decidim-meetings/app/models/decidim/meetings/registration.rb
+++ b/decidim-meetings/app/models/decidim/meetings/registration.rb
@@ -16,6 +16,8 @@ module Decidim
 
       before_validation :generate_code, on: :create
 
+      scope :public_participant, -> { where(decidim_user_group_id: nil, public_participation: true) }
+
       def self.user_collection(user)
         where(decidim_user_id: user.id)
       end

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -146,6 +146,8 @@ edit_link(
       <%= render "meeting_minutes" %>
     <% end %>
 
+    <%= cell "decidim/meetings/public_participants_list", meeting %>
+
     <% if !meeting.closed? && meeting.user_group_registrations.any? %>
       <% user_group_ids = meeting.user_group_registrations.user_group_ids %>
       <div class="section">

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -493,6 +493,11 @@ en:
             official_meeting: Official meeting
             start_time: Start date
             title: Title
+      public_participants_list:
+        attending_participants: Attending participants
+        hidden_participants_count:
+          one: and %{count} more person
+          other: and %{count} more people
       read_more: "(read more)"
       registration_mailer:
         confirmation:

--- a/decidim-meetings/db/migrate/20210430123416_add_public_participation_to_decidim_meetings_registrations.rb
+++ b/decidim-meetings/db/migrate/20210430123416_add_public_participation_to_decidim_meetings_registrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPublicParticipationToDecidimMeetingsRegistrations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :decidim_meetings_registrations, :public_participation, :boolean, default: false
+  end
+end

--- a/decidim-meetings/spec/commands/join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/join_meeting_spec.rb
@@ -53,11 +53,26 @@ module Decidim::Meetings
         expect { subject.call }.to broadcast(:ok)
       end
 
-      it "creates a registration for the meeting and the user" do
+      it "creates a registration for the meeting and the user no public participation" do
         expect { subject.call }.to change(Registration, :count).by(1)
         last_registration = Registration.last
         expect(last_registration.user).to eq(user)
         expect(last_registration.meeting).to eq(meeting)
+        expect(last_registration.public_participation).to be false
+      end
+
+      context "when the form has public_participation set to true" do
+        before do
+          registration_form.public_participation = true
+        end
+
+        it "creates a registration for the meeting and the user with public participation" do
+          expect { subject.call }.to change(Registration, :count).by(1)
+          last_registration = Registration.last
+          expect(last_registration.user).to eq(user)
+          expect(last_registration.meeting).to eq(meeting)
+          expect(last_registration.public_participation).to be true
+        end
       end
 
       context "when registration code is enabled" do
@@ -261,6 +276,30 @@ module Decidim::Meetings
           answer = Decidim::Forms::Answer.last
           expect(answer.user).to eq(user)
           expect(answer.body).to eq("My answer response")
+        end
+
+        it "creates a registration for the meeting and the user with no public participation" do
+          expect { subject.call }.to change(Registration, :count).by(1)
+          last_registration = Registration.last
+          expect(last_registration.user).to eq(user)
+          expect(last_registration.meeting).to eq(meeting)
+          expect(last_registration.public_participation).to be false
+        end
+
+        context "when the form has public_participation set to true" do
+          before do
+            registration_form.tos_agreement = true
+            registration_form.responses.first.body = "My answer response"
+            registration_form.public_participation = true
+          end
+
+          it "creates a registration for the meeting and the user with public participation" do
+            expect { subject.call }.to change(Registration, :count).by(1)
+            last_registration = Registration.last
+            expect(last_registration.user).to eq(user)
+            expect(last_registration.meeting).to eq(meeting)
+            expect(last_registration.public_participation).to be true
+          end
         end
       end
     end

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -178,6 +178,8 @@ describe "Meeting registrations", type: :system do
 
             within "#meeting-registration-confirm-#{meeting.id}" do
               expect(page).to have_content "A legal text"
+              expect(page).to have_content "Show my attendance publicly"
+              expect(page).to have_field("public_participation", checked: false)
               page.find(".button.expanded").click
             end
 
@@ -186,6 +188,33 @@ describe "Meeting registrations", type: :system do
             expect(page).to have_css(".button", text: "GOING")
             expect(page).to have_text("19 slots remaining")
             expect(page).to have_text("Stop following")
+            expect(page).to have_no_text("ATTENDING PARTICIPANTS")
+            expect(page).to have_no_css("#list-of-public-participants")
+          end
+
+          it "they can join the meeting and configure their participation to be shown publicly" do
+            visit_meeting
+
+            within ".card.extra" do
+              click_button "Join meeting"
+            end
+
+            within "#meeting-registration-confirm-#{meeting.id}" do
+              expect(page).to have_content "Show my attendance publicly"
+              expect(page).to have_field("public_participation", checked: false)
+              page.find("input#public_participation").click
+              page.find(".button.expanded").click
+            end
+
+            expect(page).to have_content("successfully")
+
+            expect(page).to have_css(".button", text: "GOING")
+            expect(page).to have_text("19 slots remaining")
+            expect(page).to have_text("Stop following")
+            expect(page).to have_text("ATTENDING PARTICIPANTS")
+            within "#list-of-public-participants" do
+              expect(page).to have_text(user.name)
+            end
           end
 
           it "they can join the meeting if they are already following it" do
@@ -199,6 +228,8 @@ describe "Meeting registrations", type: :system do
 
             within "#meeting-registration-confirm-#{meeting.id}" do
               expect(page).to have_content "A legal text"
+              expect(page).to have_content "Show my attendance publicly"
+              expect(page).to have_field("public_participation", checked: false)
               page.find(".button.expanded").click
             end
 
@@ -213,7 +244,7 @@ describe "Meeting registrations", type: :system do
         context "and they ARE part of a verified user group" do
           let!(:user_group) { create :user_group, :verified, users: [user], organization: organization }
 
-          it "they can join the meeting representing a group" do
+          it "they can join the meeting representing a group and appear in the attending organizations list" do
             visit_meeting
 
             within ".card.extra" do
@@ -222,8 +253,12 @@ describe "Meeting registrations", type: :system do
 
             within "#meeting-registration-confirm-#{meeting.id}" do
               expect(page).to have_content "I represent a group"
+              expect(page).to have_content "Show my attendance publicly"
+              expect(page).to have_field("public_participation", checked: false)
+              page.find("input#public_participation").click
               page.find("input#user_group").click
               select user_group.name, from: :join_meeting_user_group_id
+              page.find("input#public_participation").click
               page.find(".button.expanded").click
             end
 
@@ -234,6 +269,8 @@ describe "Meeting registrations", type: :system do
 
             expect(page).to have_text("ATTENDING ORGANIZATIONS")
             expect(page).to have_text(user_group.name)
+            expect(page).to have_no_text("ATTENDING PARTICIPANTS")
+            expect(page).to have_no_css("#list-of-public-participants")
           end
         end
       end
@@ -261,6 +298,8 @@ describe "Meeting registrations", type: :system do
 
           expect(page).to have_i18n_content(questionnaire.title, upcase: true)
           expect(page).to have_i18n_content(questionnaire.description)
+          expect(page).to have_content "Show my attendance publicly"
+          expect(page).to have_field("public_participation", checked: false)
 
           expect(page).to have_no_i18n_content(question.body)
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR:
* Adds a public_participation column to meetings registrations table, false by default
* Adds a checkbox on registrations form to set public participation both if the registration process has a questionnaire or not
* Displays a list of attending participants in meeting page when there is at least a user which has set their participation as public. This option is ignored when the user participates represented by a group. In this case the participation is always shown as organization in the attending organizations list as usual.
* Adds some tests in join meetings command and meeting registrations system specs

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #7297

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
