### PR TITLE
Fix updating blog post author group

### DIFF
--- a/decidim-blogs/app/commands/decidim/blogs/admin/update_post.rb
+++ b/decidim-blogs/app/commands/decidim/blogs/admin/update_post.rb
@@ -35,7 +35,8 @@ module Decidim
         def update_post!
           post.update!(
             title: form.title,
-            body: form.body
+            body: form.body,
+            author: form.author
           )
         end
       end

--- a/decidim-blogs/app/forms/decidim/blogs/admin/post_form.rb
+++ b/decidim-blogs/app/forms/decidim/blogs/admin/post_form.rb
@@ -15,6 +15,10 @@ module Decidim
         validates :title, translatable_presence: true
         validates :body, translatable_presence: true
 
+        def map_model(post)
+          self.user_group_id = post.author.id if post.author.is_a?(Decidim::UserGroup)
+        end
+
         def user_group
           @user_group ||= Decidim::UserGroup.find_by(
             organization: current_organization,

--- a/decidim-blogs/spec/commands/decidim/blogs/admin/create_post_spec.rb
+++ b/decidim-blogs/spec/commands/decidim/blogs/admin/create_post_spec.rb
@@ -97,6 +97,24 @@ module Decidim
             expect(action_log.version).to be_present
             expect(action_log.version.event).to eq "create"
           end
+
+          context "with a group author" do
+            let(:group) { create(:user_group, :verified, organization: organization) }
+            let(:form) do
+              double(
+                invalid?: invalid,
+                title: { en: title },
+                body: { en: body },
+                current_component: current_component,
+                author: group
+              )
+            end
+
+            it "sets the group as the author" do
+              subject.call
+              expect(post.author).to eq(group)
+            end
+          end
         end
       end
     end

--- a/decidim-blogs/spec/commands/decidim/blogs/admin/update_post_spec.rb
+++ b/decidim-blogs/spec/commands/decidim/blogs/admin/update_post_spec.rb
@@ -22,7 +22,7 @@ module Decidim
             title: { en: title },
             body: { en: body },
             current_component: current_component,
-            decidim_author_id: current_user.id
+            author: current_user
           )
         end
 
@@ -59,6 +59,24 @@ module Decidim
 
           it "creates a searchable resource" do
             expect { subject.call }.to change(Decidim::SearchableResource, :count).by_at_least(1)
+          end
+
+          context "with a group author" do
+            let(:group) { create(:user_group, :verified, organization: organization) }
+            let(:form) do
+              double(
+                invalid?: invalid,
+                title: { en: title },
+                body: { en: body },
+                current_component: current_component,
+                author: group
+              )
+            end
+
+            it "sets the group as the author" do
+              subject.call
+              expect(post.author).to eq(group)
+            end
           end
         end
       end

--- a/decidim-blogs/spec/forms/decidim/blogs/admin/post_form_spec.rb
+++ b/decidim-blogs/spec/forms/decidim/blogs/admin/post_form_spec.rb
@@ -42,6 +42,28 @@ module Decidim
         context "when everything is OK" do
           it { is_expected.to be_valid }
         end
+
+        describe "map_model" do
+          let(:component) { create(:post_component, organization: current_organization) }
+          let(:post) { create(:post, component: component, author: author) }
+          let(:author) { create(:user, organization: current_organization) }
+
+          before do
+            subject.map_model(post)
+          end
+
+          it "does not assign the user group for normal users" do
+            expect(subject.user_group_id).to be_nil
+          end
+
+          context "when the author is a group" do
+            let(:author) { create(:user_group, :verified, organization: current_organization) }
+
+            it "assigns the user group ID to the form" do
+              expect(subject.user_group_id).to eq(author.id)
+            end
+          end
+        end
       end
     end
   end

--- a/decidim-blogs/spec/shared/manage_posts_examples.rb
+++ b/decidim-blogs/spec/shared/manage_posts_examples.rb
@@ -122,5 +122,22 @@ shared_examples "manage posts" do
         expect(page).to have_content("Post title 2")
       end
     end
+
+    it "can update the user group as the post author" do
+      within find("tr", text: translated(post1.title)) do
+        click_link "Edit"
+      end
+
+      within ".edit_post" do
+        select user_group.name, from: "post_user_group_id"
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      within find("tr", text: translated(post1.title)) do
+        expect(page).to have_content(user_group.name)
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When you try to update the blog post author, the change is not saved. Also in the editing form, the group is not assigned automatically as the author in the author dropdown.

This fixes those issues and adds some tests for these.

#### :pushpin: Related Issues
- Related to #7425

#### Testing
- Go to admin panel blogs component with existing articles
- Make sure your user belongs to at least one group
- Go to edit one of the posts
- Try to update the posts's author
- For posts that already have a group author, open the edit form and see that the group is not automatically assigned as author

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.