### PR TITLE
Fix fragment caching with multiple locales

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/devise_controllers.rb
+++ b/decidim-core/app/controllers/concerns/decidim/devise_controllers.rb
@@ -30,6 +30,7 @@ module Decidim
       helper Decidim::LayoutHelper
       helper Decidim::MenuHelper
       helper Decidim::OmniauthHelper
+      helper Decidim::CacheHelper
 
       layout "layouts/decidim/application"
 

--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -7,6 +7,7 @@ module Decidim
     include Decidim::ScopesHelper
     include Decidim::ContextualHelpHelper
     include Decidim::AmendmentsHelper
+    include Decidim::CacheHelper
 
     # Truncates a given text respecting its HTML tags.
     #

--- a/decidim-core/app/helpers/decidim/cache_helper.rb
+++ b/decidim-core/app/helpers/decidim/cache_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Helper overrides for the ActionView::Helpers::CacheHelper in order to take
+  # locale into account for fragment caching.
+  module CacheHelper
+    # See: https://git.io/J3ouj
+    def cache(name = {}, options = {}, &block)
+      name = Array(name) + [current_locale]
+
+      super(name, options, &block)
+    end
+  end
+end

--- a/decidim-core/app/helpers/decidim/filters_helper.rb
+++ b/decidim-core/app/helpers/decidim/filters_helper.rb
@@ -33,7 +33,6 @@ module Decidim
       hash = []
       hash << "decidim/proposals/filters"
       hash << type.to_s if type.present?
-      hash << I18n.locale.to_s
       hash << Digest::MD5.hexdigest(filter.to_json)
 
       hash.join("/")

--- a/decidim-core/spec/helpers/decidim/cache_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/cache_helper_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe CacheHelper do
+    describe "#cache" do
+      let(:helper) do
+        helper_class = described_class
+        parent_helper = parent
+
+        # Define the "original" cache method that is called through super.
+        # Normally this would be ActionView::Helpers::CacheHelper#cache but we
+        # override it to test what is actually received.
+        original = Module.new
+        original.define_method(:cache) do |name = {}, options = {}, &block|
+          parent_helper.send(:cache, name, options, &block)
+        end
+
+        # Define the final helper which is extended with the "original" helper
+        # and the helper class to be tested.
+        final = Class.new.tap do |v|
+          v.extend(original)
+          v.extend(helper_class)
+        end
+        allow(final).to receive(:current_locale).and_return(locale)
+
+        final
+      end
+      let(:parent) { double }
+      let(:name) { double }
+      let(:locale) { "en" }
+      let(:block) { -> {} }
+
+      it "calls the original method and with the locale added to the name" do
+        expect(parent).to receive(:cache) do |received_name, received_options, &received_block|
+          expect(received_name).to eq([name, locale])
+          expect(received_options).to eq({})
+          expect(received_block).to be(block)
+        end
+
+        helper.cache(name, &block)
+      end
+    end
+  end
+end

--- a/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
@@ -87,25 +87,14 @@ module Decidim
       end
 
       it "stores filter type" do
-        expect(helper.filter_cache_hash(filter, type)).to start_with("decidim/proposals/filters/test/en")
+        expect(helper.filter_cache_hash(filter, type)).to start_with("decidim/proposals/filters/test")
       end
 
       context "when no type is provided" do
         let(:type) { nil }
 
         it "doesn't stores filter type" do
-          expect(helper.filter_cache_hash(filter)).to start_with("decidim/proposals/filters/en")
-        end
-      end
-
-      context "when current locale changes" do
-        let(:alt_locale) { :ca }
-
-        it "generate a different hash" do
-          old_hash = helper.filter_cache_hash(filter, type)
-          allow(I18n).to receive(:locale).and_return(alt_locale)
-
-          expect(helper.filter_cache_hash(filter, type)).not_to eq(old_hash)
+          expect(helper.filter_cache_hash(filter)).to start_with("decidim/proposals/filters")
         end
       end
 

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -297,6 +297,17 @@ describe "Authentication", type: :system do
         expect(page).to have_content("Signed in successfully")
         expect(page).to have_content(user.name)
       end
+
+      it "caches the omniauth buttons correctly with different languages", :caching do
+        find(".sign-in-link").click
+        expect(page).to have_content("Sign in with Facebook")
+
+        within_language_menu do
+          click_link "Català"
+        end
+
+        expect(page).to have_content("Inicia sessió amb Facebook")
+      end
     end
 
     describe "Forgot password" do

--- a/decidim-core/spec/system/registration_spec.rb
+++ b/decidim-core/spec/system/registration_spec.rb
@@ -31,6 +31,18 @@ describe "Registration", type: :system do
         expect(page).to have_field("registration_user_newsletter", checked: false)
       end
     end
+
+    describe "on cached sight with a different language", :caching do
+      it "shows the omniauth buttons in correct locale" do
+        expect(page).to have_content("Sign in with Facebook")
+
+        within_language_menu do
+          click_link "Català"
+        end
+
+        expect(page).to have_content("Inicia sessió amb Facebook")
+      end
+    end
   end
 
   context "when newsletter checkbox is unchecked" do

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/caching.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/caching.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.around(:each, :caching) do |example|
+    caching = ActionController::Base.perform_caching
+    cache_store = ActionController::Base.cache_store
+    ActionController::Base.perform_caching = true
+    ActionController::Base.cache_store = ActiveSupport::Cache::MemoryStore.new
+
+    example.run
+
+    ActionController::Base.perform_caching = caching
+    ActionController::Base.cache_store = cache_store
+  end
+end

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -116,6 +116,33 @@ describe "Meeting registrations", type: :system do
           expect(page).to have_css("#loginModal", visible: :visible)
         end
 
+        context "and caching is enabled", :caching do
+          it "they have the option to sign in with different languages" do
+            visit_meeting
+
+            within ".card.extra" do
+              click_button "Join meeting"
+            end
+
+            within "#loginModal" do
+              expect(page).to have_content("Sign in with Facebook")
+              find(".close-button").click
+            end
+
+            within_language_menu do
+              click_link "Català"
+            end
+
+            within ".card.extra" do
+              click_button "Inscriu-te a la trobada"
+            end
+
+            within "#loginModal" do
+              expect(page).to have_content("Inicia sessió amb Facebook")
+            end
+          end
+        end
+
         context "and registration form is enabled" do
           let(:registration_form_enabled) { true }
 

--- a/decidim-proposals/spec/system/filter_proposals_spec.rb
+++ b/decidim-proposals/spec/system/filter_proposals_spec.rb
@@ -11,6 +11,26 @@ describe "Filter Proposals", :slow, type: :system do
   let!(:user) { create :user, :confirmed, organization: organization }
   let(:scoped_participatory_process) { create(:participatory_process, :with_steps, organization: organization, scope: scope) }
 
+  context "when caching is enabled", :caching do
+    before do
+      visit_component
+    end
+
+    it "displays the filter labels in correct locales" do
+      within "form.new_filter" do
+        expect(page).to have_content(/Status/i)
+      end
+
+      within_language_menu do
+        click_link "Català"
+      end
+
+      within "form.new_filter" do
+        expect(page).to have_content(/Estat/i)
+      end
+    end
+  end
+
   context "when filtering proposals by ORIGIN" do
     context "when official_proposals setting is enabled" do
       before do


### PR DESCRIPTION
#### :tophat: What? Why?
As described in #7937, the fragment caching is broken when the instance has multiple locales.

This fixes it by overriding the fragment cache method `ActionView::Helpers::CacheHelper#cache` and applying the locale to the fragment cache keys.

Credit is due where credit is due:
- Inspiration for the solution is from https://github.com/igorkasyanchuk/cache_with_locale but the solution is so simple, I thought adding it directly to the core
- Inspiration for the cache configurations during tests is from https://rossta.net/blog/how-to-test-features-with-rails-caching-in-rspec.html slightly modified. In addition to the example, I set up the `ActiveSupport::Cache::MemoryStore` as the cache store because the default `ActiveSupport::Cache::NullStore` would lose its records during reloads which are tested in system specs.

#### :pushpin: Related Issues
- Related to #6236
- Fixes #7937

#### Testing
- Enable caching in your instance (in development, run `bundle exec rails dev:cache`)
- Make sure your instance and organization has:
  * Multiple locales enabled
  * At least one omniauth sign in method enabled
- Go to the sign in page
- Change the locale to something else than you used before
- Take a look at the omniauth buttons which are not translated correctly

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.