### PR TITLE
Register to meeting via email

### DIFF
--- a/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
+++ b/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
@@ -2,6 +2,12 @@
 
 <p class="email-instructions"><%= @event_instance.email_intro %></p>
 
+<% if @event_instance.resource_path.present? && @event_instance.resource_title.present? %>
+  <p class="email-button email-button__cta">
+    <%= link_to @event_instance.resource_title, @event_instance.resource_url %>
+  </p>
+<% end %>
+
 <% if @event_instance.try(:safe_resource_text).present? %>
   <blockquote>
     <p>
@@ -10,10 +16,21 @@
   </blockquote>
 <% end %>
 
-<% if @event_instance.resource_path.present? && @event_instance.resource_title.present? %>
-  <p class="email-button email-button__cta">
-    <%= link_to @event_instance.resource_title, @event_instance.resource_url %>
-  </p>
+<% if @event_instance.has_button? %>
+  <table class="button expanded radius">
+    <tr>
+      <td>
+        <table>
+          <tr>
+            <td>
+              <%= link_to @event_instance.button_text, @event_instance.button_url, target: :blank %>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+
 <% end %>
 
 <p class="email-closing"><%= @event_instance.email_outro %></p>

--- a/decidim-core/lib/decidim/events/email_event.rb
+++ b/decidim-core/lib/decidim/events/email_event.rb
@@ -33,6 +33,18 @@ module Decidim
         def email_outro
           I18n.t("decidim.events.email_event.email_outro", resource_title: resource_title)
         end
+
+        def has_button?
+          button_text.present? && button_url.present?
+        end
+
+        def button_text
+          nil
+        end
+
+        def button_url
+          nil
+        end
       end
     end
   end

--- a/decidim-core/spec/lib/events/email_event_spec.rb
+++ b/decidim-core/spec/lib/events/email_event_spec.rb
@@ -15,5 +15,33 @@ module Decidim
         expect(subject.types).to include :email
       end
     end
+
+    context "when the event behaves like email event" do
+      subject do
+        TestEvent.new(resource: resource, event_name: "test", user: user)
+      end
+
+      let(:organization) { create(:organization, name: "O'Connor") }
+      let(:user) { create(:user, name: "Sarah Connor", organization: organization) }
+      let(:resource) { user }
+
+      describe ".button_url" do
+        it "responds and returns nil" do
+          expect(subject.button_url).to be_nil
+        end
+      end
+
+      describe ".button_text" do
+        it "responds and returns nil" do
+          expect(subject.button_text).to be_nil
+        end
+      end
+
+      describe ".has_button?" do
+        it "responds and returns false" do
+          expect(subject).not_to have_button
+        end
+      end
+    end
   end
 end

--- a/decidim-core/spec/mailers/notification_mailer_spec.rb
+++ b/decidim-core/spec/mailers/notification_mailer_spec.rb
@@ -54,6 +54,26 @@ module Decidim
       end
 
       include_examples "email with logo"
+
+      context "when the event defines buttons" do
+        class Decidim::ProfileUpdatedEvent
+          def button_text
+            "BUTTON TEXT"
+          end
+
+          def button_url
+            "http://button.link"
+          end
+        end
+
+        it "includes the button text" do
+          expect(mail.body).to include(event_instance.button_text)
+        end
+
+        it "includes the button url" do
+          expect(mail.body).to include(event_instance.button_url)
+        end
+      end
     end
   end
 end

--- a/decidim-meetings/app/events/decidim/meetings/create_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/create_meeting_event.rb
@@ -3,8 +3,18 @@
 module Decidim
   module Meetings
     class CreateMeetingEvent < Decidim::Events::SimpleEvent
+      delegate :organization, to: :user, prefix: false
+
       def resource_text
         translated_attribute(resource.description)
+      end
+
+      def button_text
+        I18n.t("meeting_created.button_text", scope: "decidim.events.meetings") if resource.can_be_joined_by?(user)
+      end
+
+      def button_url
+        Decidim::EngineRouter.main_proxy(component).join_meeting_registration_url(meeting_id: resource.id, host: organization.host) if resource.can_be_joined_by?(user)
       end
     end
   end

--- a/decidim-meetings/app/events/decidim/meetings/create_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/create_meeting_event.rb
@@ -14,7 +14,13 @@ module Decidim
       end
 
       def button_url
-        Decidim::EngineRouter.main_proxy(component).join_meeting_registration_url(meeting_id: resource.id, host: organization.host) if resource.can_be_joined_by?(user)
+        if resource.can_be_joined_by?(user)
+          if resource.registration_form_enabled?
+            Decidim::EngineRouter.main_proxy(component).join_meeting_registration_url(meeting_id: resource.id, host: organization.host)
+          else
+            Decidim::EngineRouter.main_proxy(component).meeting_url(id: resource.id, host: organization.host)
+          end
+        end
       end
     end
   end

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -115,6 +115,7 @@ en:
             email_subject: The "%{resource_title}" meeting was closed
             notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting was closed.
         meeting_created:
+          button_text: Register to the meeting
           email_intro: The meeting "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
           email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
           email_subject: New meeting added to %{participatory_space_title}

--- a/decidim-meetings/spec/events/decidim/meetings/create_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/create_meeting_event_spec.rb
@@ -40,4 +40,50 @@ describe Decidim::Meetings::CreateMeetingEvent do
       expect(subject.resource_text).to eq translated(resource.description)
     end
   end
+
+  describe "button text" do
+    it "returns the nil" do
+      expect(subject.button_text).to be_nil
+    end
+  end
+
+  describe "button url" do
+    it "returns the nil" do
+      expect(subject.button_url).to be_nil
+    end
+  end
+
+  context "when registration is enabled" do
+    let(:organization) { create :organization }
+    let(:participatory_process) { create :participatory_process, organization: organization }
+    let(:component) { create :component, manifest_name: :meetings, participatory_space: participatory_process }
+
+    let(:registrations_enabled) { true }
+    let(:available_slots) { 10 }
+    let(:questionnaire) { nil }
+
+    let(:resource) do
+      create(:meeting,
+             component: component,
+             registrations_enabled: registrations_enabled,
+             available_slots: available_slots,
+             questionnaire: questionnaire)
+    end
+
+    let(:user) { create :user, :confirmed, organization: organization, email_on_notification: false }
+
+    let(:registration_form) { Decidim::Meetings::JoinMeetingForm.new }
+
+    describe "button text" do
+      it "returns a register to meeting call to action" do
+        expect(subject.button_text).to eq("Register to the meeting")
+      end
+    end
+
+    describe "button url" do
+      it "returns the link to join the meeting" do
+        expect(subject.button_url).to eq(Decidim::EngineRouter.main_proxy(component).join_meeting_registration_url(meeting_id: resource.id, host: organization.host))
+      end
+    end
+  end
 end

--- a/decidim-meetings/spec/events/decidim/meetings/create_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/create_meeting_event_spec.rb
@@ -5,6 +5,8 @@ require "spec_helper"
 describe Decidim::Meetings::CreateMeetingEvent do
   let(:resource) { create :meeting }
   let(:event_name) { "decidim.events.meetings.meeting_created" }
+  let(:available_slots) { 10 }
+  let(:questionnaire) { nil }
 
   include_context "when a simple event"
   it_behaves_like "a simple event"
@@ -53,36 +55,49 @@ describe Decidim::Meetings::CreateMeetingEvent do
     end
   end
 
-  context "when registration is enabled" do
+  context "when in a participatory space and the registration is enabled" do
     let(:organization) { create :organization }
     let(:participatory_process) { create :participatory_process, organization: organization }
     let(:component) { create :component, manifest_name: :meetings, participatory_space: participatory_process }
-
     let(:registrations_enabled) { true }
-    let(:available_slots) { 10 }
-    let(:questionnaire) { nil }
-
     let(:resource) do
       create(:meeting,
              component: component,
              registrations_enabled: registrations_enabled,
+             registration_form_enabled: registration_form_enabled,
              available_slots: available_slots,
              questionnaire: questionnaire)
     end
 
-    let(:user) { create :user, :confirmed, organization: organization, email_on_notification: false }
+    context "when registration form is enabled" do
+      let(:registration_form_enabled) { true }
 
-    let(:registration_form) { Decidim::Meetings::JoinMeetingForm.new }
+      describe "button text" do
+        it "returns a register to meeting call to action" do
+          expect(subject.button_text).to eq("Register to the meeting")
+        end
+      end
 
-    describe "button text" do
-      it "returns a register to meeting call to action" do
-        expect(subject.button_text).to eq("Register to the meeting")
+      describe "button url" do
+        it "returns the link to join the meeting" do
+          expect(subject.button_url).to eq(Decidim::EngineRouter.main_proxy(component).join_meeting_registration_url(meeting_id: resource.id, host: organization.host))
+        end
       end
     end
 
-    describe "button url" do
-      it "returns the link to join the meeting" do
-        expect(subject.button_url).to eq(Decidim::EngineRouter.main_proxy(component).join_meeting_registration_url(meeting_id: resource.id, host: organization.host))
+    context "when registration form is disabled" do
+      let(:registration_form_enabled) { false }
+
+      describe "button text" do
+        it "returns a register to meeting call to action" do
+          expect(subject.button_text).to eq("Register to the meeting")
+        end
+      end
+
+      describe "button url" do
+        it "returns the link to the meeting" do
+          expect(subject.button_url).to eq(Decidim::EngineRouter.main_proxy(component).meeting_url(id: resource.id, host: organization.host))
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds a link to the join meeting page in the notification email received by the user when a meeting is published in a space she follows.

#### :pushpin: Related Issues

- Fixes #7727

#### Testing

Two scenarios:

###### Scenario 1

As a  user:
- enable email notifications
- follow a space

As an admin:
- publish a meeting with registration enabled

The user should receive an email notification that includes a button to register in the meeting, and when clicking she'll be redirected to the registration form.

###### Scenario 2

As a  user:
- enable email notifications
- follow a space

As an admin:
- publish a meeting with registration disabled

The user should receive an email notification that **doesn't** include  a button to register in the meeting

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

![Screenshot from 2021-05-18 11-17-02](https://user-images.githubusercontent.com/17616/118625793-9a018600-b7ca-11eb-867a-2e39594c8197.png)


:hearts: Thank you!
