### PR TITLE
Show confirmation modal when leaving a meeting

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/join_meeting_button/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/join_meeting_button/show.erb
@@ -1,16 +1,18 @@
 <% if model.can_be_joined_by?(current_user) %>
   <% if model.has_registration_for? current_user %>
+    <span>
+      <%= icon("check", class: "icon--small") %>
+      <%= t("going", scope: "decidim.meetings.meetings.show") %>
+    </span>
     <%= action_authorized_button_to(
       :join,
+      t("leave", scope: "decidim.meetings.meetings.show"),
       meeting_registration_path(model),
       resource: model,
       method: :delete,
-      class: "#{button_classes} active",
-      data: { disable: true }
-    ) do %>
-      <%= icon("check", class: "icon--small") %>
-      <%= t("going", scope: "decidim.meetings.meetings.show") %>
-    <% end %>
+      class: button_classes,
+      data: { disable: true, confirm: t("leave_confirmation", scope: "decidim.meetings.meetings.show") }
+    ) %>
   <% else %>
     <% if model.registration_form_enabled? %>
       <%= action_authorized_link_to(

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -456,8 +456,10 @@ en:
           contributions: Contributions count
           date: Date
           edit_meeting: Edit meeting
-          going: Going
+          going: You have signed up for this meeting
           join: Join meeting
+          leave: Cancel your registration
+          leave_confirmation: Are you sure you want to cancel your registration for this meeting?
           meeting_report: Meeting report
           no_slots_available: No slots available
           organizations: Attending organizations

--- a/decidim-meetings/spec/shared/manage_invites_examples.rb
+++ b/decidim-meetings/spec/shared/manage_invites_examples.rb
@@ -83,7 +83,7 @@ shared_examples "manage invites" do
           end
 
           expect(page).to have_content "successfully"
-          expect(page).to have_css(".button", text: "GOING")
+          expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
         end
 
         it "the invited user sign up into the application and declines the invitation" do
@@ -116,7 +116,7 @@ shared_examples "manage invites" do
 
           visit last_email_link
 
-          expect(page).to have_css(".button", text: "GOING")
+          expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
         end
 
         it "the invited user declines the invitation" do
@@ -140,7 +140,7 @@ shared_examples "manage invites" do
 
           visit last_email_link
 
-          expect(page).to have_css(".button", text: "GOING")
+          expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
         end
 
         it "the invited user declines the invitation" do

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -181,8 +181,11 @@ describe "Meeting registrations", type: :system do
               page.find(".button.expanded").click
             end
 
-            expect(page).to have_content("successfully")
+            within_flash_messages do
+              expect(page).to have_content("successfully")
+            end
 
+            expect(page).to have_text("You have signed up for this meeting")
             expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
             expect(page).to have_text("19 slots remaining")
             expect(page).to have_text("Stop following")
@@ -202,8 +205,11 @@ describe "Meeting registrations", type: :system do
               page.find(".button.expanded").click
             end
 
-            expect(page).to have_content("successfully")
+            within_flash_messages do
+              expect(page).to have_content("successfully")
+            end
 
+            expect(page).to have_text("You have signed up for this meeting")
             expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
             expect(page).to have_text("19 slots remaining")
             expect(page).to have_text("Stop following")
@@ -227,8 +233,11 @@ describe "Meeting registrations", type: :system do
               page.find(".button.expanded").click
             end
 
-            expect(page).to have_content("successfully")
+            within_flash_messages do
+              expect(page).to have_content("successfully")
+            end
 
+            expect(page).to have_text("You have signed up for this meeting")
             expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
             expect(page).to have_text("19 slots remaining")
 
@@ -279,6 +288,7 @@ describe "Meeting registrations", type: :system do
 
       it "shows the confirmation modal when leaving the meeting" do
         visit_meeting
+
         click_button "Cancel your registration"
 
         within ".confirm-modal-content" do
@@ -289,12 +299,11 @@ describe "Meeting registrations", type: :system do
       it "they can leave the meeting" do
         visit_meeting
 
-        expect(page).to have_text("You have signed up for this meeting")
-
         accept_confirm { click_button "Cancel your registration" }
 
-        expect(page).to have_content("successfully")
-        expect(questionnaire.answers.where(user: user).empty?).to be(true)
+        within_flash_messages do
+          expect(page).to have_content("successfully")
+        end
 
         expect(page).to have_css(".button", text: "JOIN MEETING")
         expect(page).to have_text("20 slots remaining")

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -183,7 +183,7 @@ describe "Meeting registrations", type: :system do
 
             expect(page).to have_content("successfully")
 
-            expect(page).to have_css(".button", text: "GOING")
+            expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
             expect(page).to have_text("19 slots remaining")
             expect(page).to have_text("Stop following")
           end
@@ -204,7 +204,7 @@ describe "Meeting registrations", type: :system do
 
             expect(page).to have_content("successfully")
 
-            expect(page).to have_css(".button", text: "GOING")
+            expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
             expect(page).to have_text("19 slots remaining")
             expect(page).to have_text("Stop following")
           end
@@ -229,7 +229,7 @@ describe "Meeting registrations", type: :system do
 
             expect(page).to have_content("successfully")
 
-            expect(page).to have_css(".button", text: "GOING")
+            expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
             expect(page).to have_text("19 slots remaining")
 
             expect(page).to have_text("ATTENDING ORGANIZATIONS")
@@ -275,6 +275,29 @@ describe "Meeting registrations", type: :system do
 
       before do
         login_as user, scope: :user
+      end
+
+      it "shows the confirmation modal when leaving the meeting" do
+        visit_meeting
+        click_button "Cancel your registration"
+
+        within ".confirm-modal-content" do
+          expect(page).to have_content("Are you sure you want to cancel your registration for this meeting?")
+        end
+      end
+
+      it "they can leave the meeting" do
+        visit_meeting
+
+        expect(page).to have_text("You have signed up for this meeting")
+
+        accept_confirm { click_button "Cancel your registration" }
+
+        expect(page).to have_content("successfully")
+        expect(questionnaire.answers.where(user: user).empty?).to be(true)
+
+        expect(page).to have_css(".button", text: "JOIN MEETING")
+        expect(page).to have_text("20 slots remaining")
       end
 
       context "when registration code is enabled" do
@@ -355,17 +378,6 @@ describe "Meeting registrations", type: :system do
           expect(registration.validated_at).not_to be(nil)
           expect(page).to have_no_content("VALIDATED")
         end
-      end
-
-      it "they can leave the meeting" do
-        visit_meeting
-        click_button "Going"
-
-        expect(page).to have_content("successfully")
-        expect(questionnaire.answers.where(user: user).empty?).to be(true)
-
-        expect(page).to have_css(".button", text: "JOIN MEETING")
-        expect(page).to have_text("20 slots remaining")
       end
 
       context "and registration form is enabled" do

--- a/decidim-meetings/spec/system/private_meetings_spec.rb
+++ b/decidim-meetings/spec/system/private_meetings_spec.rb
@@ -112,7 +112,7 @@ describe "Private meetings", type: :system do
 
             expect(page).to have_current_path resource_locator(private_meeting).path
             expect(page).to have_content "Private"
-            expect(page).to have_css(".button", text: "GOING")
+            expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

>In the process of registering the meeting in Decidim, a button is generated where the user has the option to join. If you click the same button again, the user desjoin from the meeting. Because only one click is required, users sometimes inadvertently withdraw their registration.

#### :pushpin: Related Issues

- https://meta.decidim.org/processes/roadmap/f/122/proposals/16340


#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

https://user-images.githubusercontent.com/40306853/117547746-95520a80-b031-11eb-96f8-74438abb0372.mp4

:hearts: Thank you!
