### PR TITLE
Display meetings count in directory page

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
@@ -2,7 +2,9 @@
 
 <div class="wrapper">
   <div class="row">
-    <h1 class="section-heading"><%= t(".meetings") %></h1>
+    <h1 class="section-heading" id="meetings-count">
+      <%= render partial: "decidim/meetings/meetings/count" %>
+    </h1>
 
     <%= cell "decidim/meetings/meetings_map", search.results %>
 

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.js.erb
@@ -1,6 +1,8 @@
 var $meetings = $('#meetings');
+var $meetingsCount = $('#meetings-count');
 
 $meetings.html('<%= j(render partial: "meetings").strip.html_safe %>');
+$meetingsCount.html('<%= j(render partial: "decidim/meetings/meetings/count").strip.html_safe %>');
 
 var $dropdownMenu = $('.dropdown.menu', $meetings);
 $dropdownMenu.foundation();

--- a/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
+++ b/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
@@ -25,6 +25,8 @@ describe "Explore meeting directory", type: :system do
     within "#meetings" do
       expect(page).to have_css(".card--meeting", count: 6)
     end
+
+    expect(page).to have_css("#meetings-count", text: "6 MEETINGS")
   end
 
   context "when there's a past meeting" do
@@ -38,6 +40,7 @@ describe "Explore meeting directory", type: :system do
       end
 
       expect(page).to have_content(past_meeting.title["en"])
+      expect(page).to have_css("#meetings-count", text: "1 MEETING")
     end
   end
 
@@ -76,6 +79,7 @@ describe "Explore meeting directory", type: :system do
 
       expect(page).to have_content(assembly_meeting.title["en"])
       expect(page).to have_css(".card--meeting", count: 1)
+      expect(page).to have_css("#meetings-count", text: "1 MEETING")
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds the number of total meetings visible in global /meetings page

#### :pushpin: Related Issues

- Fixes #7725

#### Testing

- Go to /meetings and check the number of meetings is visible
- Play with filters and see how this number changes, and should match with the number of listed meetings
- 
#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

List with future events:

![Screenshot from 2021-05-10 05-32-51](https://user-images.githubusercontent.com/17616/117602542-3d122a00-b151-11eb-9cce-f125c0d40280.png)

List with past events:

![Screenshot from 2021-05-10 05-32-57](https://user-images.githubusercontent.com/17616/117602545-3e435700-b151-11eb-8e59-4560f97baff1.png)

:hearts: Thank you!
