### PR TITLE
Hide moderated meetings and proposals from admin lists

### DIFF
--- a/decidim-meetings/app/controllers/decidim/meetings/admin/application_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/application_controller.rb
@@ -13,7 +13,7 @@ module Decidim
         helper_method :meetings, :meeting
 
         def meetings
-          @meetings ||= Meeting.where(component: current_component).order(start_time: :desc).page(params[:page]).per(15)
+          @meetings ||= Meeting.not_hidden.where(component: current_component).order(start_time: :desc).page(params[:page]).per(15)
         end
 
         def meeting

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -147,7 +147,7 @@ module Decidim
         private
 
         def collection
-          @collection ||= Proposal.where(component: current_component).published
+          @collection ||= Proposal.where(component: current_component).not_hidden.published
         end
 
         def proposals


### PR DESCRIPTION
#### :tophat: What? Why?
When a meeting or a proposal is being hidden, the specific resources are still being displayed in the admin section. This Pr aims to hide them from the resource admin section . This PR adds the functionality only for Proposals and Meeting, letting other components untouched.


Need to add test for the scenario

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #7429 

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
