### PR TITLE
Skip version generation on touch events

### DIFF
--- a/decidim-core/lib/decidim/traceable.rb
+++ b/decidim-core/lib/decidim/traceable.rb
@@ -16,7 +16,7 @@ module Decidim
     extend ActiveSupport::Concern
 
     included do
-      has_paper_trail
+      has_paper_trail on: [:create, :destroy, :update]
 
       delegate :count, to: :versions, prefix: true
 


### PR DESCRIPTION
#### :tophat: What? Why?
Adding a comment to a meeting generates a new version of the meeting. This is not correct, a new version should only be generated when the meeting is updated.

This PR is disabling the PaperTrail callback for touch event, the root cause of the issue. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #7889

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
