### PR TITLE
Add groups as assembly members

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/organization_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_controller.rb
@@ -30,10 +30,15 @@ module Decidim
       end
 
       def users
+        user_entities(current_organization.users)
+      end
+
+      def user_entities(relation = nil)
+        relation ||= current_organization.user_entities
         respond_to do |format|
           format.json do
             if (term = params[:term].to_s).present?
-              query = current_organization.users.order(name: :asc)
+              query = relation.order(name: :asc)
               query = if term.start_with?("@")
                         query.where("nickname ILIKE ?", "#{term.delete("@")}%")
                       else

--- a/decidim-admin/app/controllers/decidim/admin/organization_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_controller.rb
@@ -30,11 +30,16 @@ module Decidim
       end
 
       def users
-        user_entities(current_organization.users)
+        search(current_organization.users)
       end
 
-      def user_entities(relation = nil)
-        relation ||= current_organization.user_entities
+      def user_entities
+        search(current_organization.user_entities)
+      end
+
+      private
+
+      def search(relation)
         respond_to do |format|
           format.json do
             if (term = params[:term].to_s).present?

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -10,6 +10,7 @@ Decidim::Admin::Engine.routes.draw do
 
       member do
         get :users
+        get :user_entities
       end
     end
 

--- a/decidim-admin/spec/controllers/organizations_contoller_spec.rb
+++ b/decidim-admin/spec/controllers/organizations_contoller_spec.rb
@@ -15,9 +15,63 @@ module Decidim
         sign_in current_user, scope: :user
       end
 
+      describe "GET users and user groups in json format" do
+        let!(:user) { create(:user, name: "Daisy Miller", nickname: "daisy_m", organization: organization, email: "d.mail@example.org") }
+        let!(:other_user) { create(:user, name: "Daisy O'connor", nickname: "daisy_o", email: "d.mail.o@example.org") }
+        let!(:user_group) do
+          create(
+            :user_group,
+            :verified,
+            name: "Daisy Organization",
+            nickname: "daisy_org",
+            email: "d.mail.org@example.org",
+            users: [user],
+            organization: organization
+          )
+        end
+        let(:parsed_response) { JSON.parse(response.body).map(&:symbolize_keys) }
+
+        context "when searching by name" do
+          it "returns the id, name, email and nickname for filtered users and user groups" do
+            get :user_entities, format: :json, params: { term: "daisy" }
+            expect(parsed_response).to include({ value: user.id, label: "#{user.name} (@#{user.nickname}) #{user.email}" })
+            expect(parsed_response).to include({ value: user_group.id, label: "#{user_group.name} (@#{user_group.nickname}) #{user_group.email}" })
+            expect(parsed_response).not_to include({ value: other_user.id, label: "#{other_user.name} (@#{other_user.nickname}) #{other_user.email}" })
+          end
+        end
+
+        context "when searching by nickname" do
+          it "returns the id, name, email and nickname for filtered users and user groups" do
+            get :user_entities, format: :json, params: { term: "@daisy" }
+            expect(parsed_response).to include({ value: user.id, label: "#{user.name} (@#{user.nickname}) #{user.email}" })
+            expect(parsed_response).to include({ value: user_group.id, label: "#{user_group.name} (@#{user_group.nickname}) #{user_group.email}" })
+            expect(parsed_response).not_to include({ value: other_user.id, label: "#{other_user.name} (@#{other_user.nickname}) #{other_user.email}" })
+          end
+        end
+
+        context "when searching by email" do
+          it "returns the id, name, email and nickname for filtered users and user groups" do
+            get :user_entities, format: :json, params: { term: "d.mail" }
+            expect(parsed_response).to include({ value: user.id, label: "#{user.name} (@#{user.nickname}) #{user.email}" })
+            expect(parsed_response).to include({ value: user_group.id, label: "#{user_group.name} (@#{user_group.nickname}) #{user_group.email}" })
+            expect(parsed_response).not_to include({ value: other_user.id, label: "#{other_user.name} (@#{other_user.nickname}) #{other_user.email}" })
+          end
+        end
+      end
+
       describe "GET users in json format" do
         let!(:user) { create(:user, name: "Daisy Miller", nickname: "daisy_m", organization: organization) }
         let!(:other_user) { create(:user, name: "Daisy O'connor", nickname: "daisy_o") }
+        let!(:user_group) do
+          create(
+            :user_group,
+            :verified,
+            name: "Daisy Organization",
+            nickname: "daysy_org",
+            users: [user],
+            organization: organization
+          )
+        end
 
         let(:parsed_response) { JSON.parse(response.body).map(&:symbolize_keys) }
 

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly_member.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly_member.rb
@@ -67,12 +67,16 @@ module Decidim
           )
         end
 
+        def followers
+          form.user.is_a?(Decidim::UserGroup) ? form.user.users : [form.user]
+        end
+
         def notify_assembly_member_about_new_membership
           data = {
             event: "decidim.events.assemblies.create_assembly_member",
             event_class: Decidim::Assemblies::CreateAssemblyMemberEvent,
             resource: assembly,
-            followers: [form.user]
+            followers: followers
           }
           Decidim::EventsManager.publish(data)
         end

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
@@ -34,7 +34,7 @@ module Decidim
         end
 
         def user
-          @user ||= current_organization.users.find_by(id: user_id)
+          @user ||= current_organization.user_entities.find_by(id: user_id)
         end
 
         def positions_for_select

--- a/decidim-assemblies/app/models/decidim/assembly_member.rb
+++ b/decidim-assemblies/app/models/decidim/assembly_member.rb
@@ -9,7 +9,7 @@ module Decidim
 
     POSITIONS = %w(president vice_president secretary other).freeze
 
-    belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User", optional: true
+    belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::UserBaseEntity", optional: true
     belongs_to :assembly, foreign_key: "decidim_assembly_id", class_name: "Decidim::Assembly"
     alias participatory_space assembly
 

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/_form.html.erb
@@ -16,7 +16,7 @@
       </div>
 
       <div class="row column user-fields--user-picker">
-        <% prompt_options = { url: decidim_admin.users_organization_url, placeholder: t(".select_user") } %>
+        <% prompt_options = { url: decidim_admin.user_entities_organization_url, placeholder: t(".select_user") } %>
         <%= form.autocomplete_select(:user_id, form.object.user.presence,  { multiple: false }, prompt_options) do |user|
           { value: user.id, label: "#{user.name} (@#{user.nickname})" }
         end %>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -64,7 +64,7 @@ en:
         full_name: Full name
         gender: Gender
         position: Position
-        user_id: User
+        user_id: User or group
       assembly_user_role:
         email: Email
         name: Name

--- a/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
@@ -64,6 +64,33 @@ shared_examples "manage assembly members examples" do
     end
   end
 
+  context "with existing user group" do
+    let!(:member_organization) { create :user_group, :verified, organization: assembly.organization }
+
+    it "creates a new assembly member" do
+      find(".card-title a.new").click
+
+      execute_script("$('#assembly_member_designation_date').focus()")
+      find(".datepicker-days .active").click
+
+      within ".new_assembly_member" do
+        select "Existing participant", from: :assembly_member_existing_user
+        autocomplete_select "#{member_organization.name} (@#{member_organization.nickname})", from: :user_id
+
+        select "President", from: :assembly_member_position
+
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_admin_callout("successfully")
+      expect(page).to have_current_path decidim_admin_assemblies.assembly_members_path(assembly)
+
+      within "#assembly_members table" do
+        expect(page).to have_content("#{member_organization.name} (@#{member_organization.nickname})")
+      end
+    end
+  end
+
   describe "when managing other assembly members" do
     let!(:assembly_member) { create(:assembly_member, assembly: assembly) }
 

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -29,6 +29,7 @@ module Decidim
     has_many :admins, -> { where(admin: true) }, foreign_key: "decidim_organization_id", class_name: "Decidim::User"
     has_many :users_with_any_role, -> { where.not(roles: []) }, foreign_key: "decidim_organization_id", class_name: "Decidim::User"
     has_many :users, foreign_key: "decidim_organization_id", class_name: "Decidim::User", dependent: :destroy
+    has_many :user_entities, foreign_key: "decidim_organization_id", class_name: "Decidim::UserBaseEntity", dependent: :destroy
     has_many :oauth_applications, foreign_key: "decidim_organization_id", class_name: "Decidim::OAuthApplication", inverse_of: :organization, dependent: :destroy
     has_many :hashtags, foreign_key: "decidim_organization_id", class_name: "Decidim::Hashtag", dependent: :destroy
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR allows the addition of user groups as members of assemblies. To do this:
* Adds a has_many association of Organization with UserBaseEntity
* Changes the organization admin API endpoint to query for user users and groups
* Changes assemblies members management to include groups
* Changes notification of CreateAssemblyMember command to notify group users if membership is for a group

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #7294 

#### Testing

From admin panel visit an assembly and go to the members section. Click on new member, choose "Existing participant" in "Participant type" and start writing the name of a group in "User or group". The group should appear in the options, and the membership created.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
