### PR TITLE
Fix editor when formatting starts with a linebreak

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -178,6 +178,34 @@ describe "Admin manages organization", type: :system do
         end
       end
 
+      context "when the admin terms of use content has linebreaks inside different formattings" do
+        let(:terms_content) do
+          <<~HTML
+            <p>foo</p>
+            <h1><br></h1>
+            <p><strong><br></strong></p>
+            <p><u><br></u></p>
+            <p><em><br></em></p>
+          HTML
+        end
+
+        let(:organization) do
+          create(
+            :organization,
+            admin_terms_of_use_body: Decidim::Faker::Localized.localized { terms_content }
+          )
+        end
+
+        it "is still editable" do
+          find('div[contenteditable="true"].ql-editor').send_keys(Array.new(15) { :backspace }, "bar baz")
+          click_button "Update"
+          expect(page).to have_content("Organization updated successfully")
+          expect(find(
+            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+          )["innerHTML"]).to eq("<p>bar baz</p>")
+        end
+      end
+
       context "when adding br tags to terms of use content" do
         let(:another_organization) { create(:organization) }
         let(:image) { create(:attachment, attached_to: another_organization) }

--- a/decidim-core/app/packs/src/decidim/editor/linebreak_module.js
+++ b/decidim-core/app/packs/src/decidim/editor/linebreak_module.js
@@ -12,6 +12,8 @@ Quill.debug("error");
 const Delta = Quill.import("delta");
 const Break = Quill.import("blots/break");
 const Embed = Quill.import("blots/embed");
+const Scroll = Quill.import("blots/scroll");
+const Parchment = Quill.import("parchment");
 Quill.register({"modules/history": HistoryOverride}, true);
 let icons = Quill.import("ui/icons");
 icons.linebreak = "⏎";
@@ -31,6 +33,101 @@ class SmartBreak extends Break {
   }
 }
 Quill.register(SmartBreak);
+
+class ScrollOvderride extends Scroll {
+  optimize(mutations = [], context = {}) {
+    if (this.batch === true) {
+      return;
+    }
+
+    this.parchmentOptimize(mutations, context);
+
+    if (mutations.length > 0) {
+      this.emitter.emit("scroll-optimize", mutations, context);
+    }
+  }
+
+  parchmentOptimize(mutations = [], context = {}) {
+    // super.optimize(context);
+    Reflect.apply(Parchment.Container.prototype.optimize, this, [context]);
+
+    // We must modify mutations directly, cannot make copy and then modify
+    // let records = [].slice.call(this.observer.takeRecords());
+    let records = [...this.observer.takeRecords()];
+    // Array.push currently seems to be implemented by a non-tail recursive function
+    // so we cannot just mutations.push.apply(mutations, this.observer.takeRecords());
+    while (records.length > 0) {
+      mutations.push(records.pop());
+    }
+    let mark = (blot, markParent) => {
+      if (!blot || blot === this) {
+        return;
+      }
+      if (!blot.domNode.parentNode) {
+        return;
+      }
+      if (blot.domNode.__blot && blot.domNode.__blot.mutations === null) {
+        blot.domNode.__blot.mutations = [];
+      }
+      if (markParent) {
+        mark(blot.parent);
+      }
+    };
+    let optimize = (blot) => {
+      // Post-order traversal
+      if (
+        blot.domNode.__blot === null &&
+        blot.domNode.__blot.mutations === null
+      ) {
+        return;
+      }
+      if (blot instanceof Parchment.Container) {
+        blot.children.forEach(optimize);
+      }
+      blot.optimize(context);
+    };
+    let remaining = mutations;
+    for (let ind = 0; remaining.length > 0; ind += 1) {
+      // MAX_OPTIMIZE_ITERATIONS = 100
+      if (ind >= 100) {
+        throw new Error("[Parchment] Maximum optimize iterations reached");
+      }
+      remaining.forEach((mutation) => {
+        let blot = Parchment.find(mutation.target, true);
+        if (!blot) {
+          return;
+        }
+        if (blot.domNode === mutation.target) {
+          if (mutation.type === "childList") {
+            mark(Parchment.find(mutation.previousSibling, false));
+
+            mutation.addedNodes.forEach((node) => {
+              let child = Parchment.find(node, false);
+              mark(child, false);
+              if (child instanceof Parchment.Container) {
+                child.children.forEach(function(grandChild) {
+                  mark(grandChild, false);
+                });
+              }
+            });
+          } else if (mutation.type === "attributes") {
+            mark(blot.prev);
+          }
+        }
+        mark(blot);
+      });
+      this.children.forEach(optimize);
+      remaining = [...this.observer.takeRecords()];
+      records = remaining.slice();
+      while (records.length > 0) {
+        mutations.push(records.pop());
+      }
+    }
+  }
+};
+Quill.register("blots/scroll", ScrollOvderride, true);
+Parchment.register(ScrollOvderride);
+
 
 export default function lineBreakButtonHandler(quill) {
   let range = quill.selection.getRange()[0];

--- a/decidim-core/app/packs/src/decidim/editor/linebreak_module.js
+++ b/decidim-core/app/packs/src/decidim/editor/linebreak_module.js
@@ -81,6 +81,7 @@ class ScrollOvderride extends Scroll {
       if (!blot.domNode.__blot) {
         return;
       }
+
       if (blot instanceof Parchment.Container) {
         blot.children.forEach(optimize);
       }

--- a/decidim-core/app/packs/src/decidim/editor/linebreak_module.js
+++ b/decidim-core/app/packs/src/decidim/editor/linebreak_module.js
@@ -34,6 +34,7 @@ class SmartBreak extends Break {
 }
 Quill.register(SmartBreak);
 
+// Override quill/blots/scroll.js
 class ScrollOvderride extends Scroll {
   optimize(mutations = [], context = {}) {
     if (this.batch === true) {
@@ -43,10 +44,12 @@ class ScrollOvderride extends Scroll {
     this.parchmentOptimize(mutations, context);
 
     if (mutations.length > 0) {
+      // quill/core/emitter.js, Emitter.events.SCROLL_OPTIMIZE = "scroll-optimize"
       this.emitter.emit("scroll-optimize", mutations, context);
     }
   }
 
+  // Override parchment/src/blot/scroll.ts
   parchmentOptimize(mutations = [], context = {}) {
     // super.optimize(context);
     Reflect.apply(Parchment.Container.prototype.optimize, this, [context]);
@@ -75,10 +78,7 @@ class ScrollOvderride extends Scroll {
     };
     let optimize = (blot) => {
       // Post-order traversal
-      if (
-        blot.domNode.__blot === null &&
-        blot.domNode.__blot.mutations === null
-      ) {
+      if (!blot.domNode.__blot) {
         return;
       }
       if (blot instanceof Parchment.Container) {


### PR DESCRIPTION
#### :tophat: What? Why?
Currently editor crashes when formatting start with a linebreak, for example
`` <strong><br>foo</strong> ``, or `` <em><br>bar</em>``. This pull request fixes this and adds test.

#### :pushpin: Related Issues
#7896 @alecslupu 's comment
https://github.com/quilljs/parchment/issues/87

#### Testing
1. In console:
```
Decidim::Organization.first.update(admin_terms_of_use_body: { "en" => "<p>something</p><h1><br
></h1><p><strong><br></strong></p><p><u><br></u></p><p><em><br></em></p>" })
```
2. Go to: admin/organization/edit
3. Editor content is editable

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
