### PR TITLE
W3C does not yet allow svg being loaded via CORS

### DIFF
--- a/decidim-admin/app/views/layouts/decidim/admin/_application.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_application.html.erb
@@ -28,5 +28,6 @@
     <%= render partial: "layouts/decidim/admin/template_bottom" %>
     <%= render partial: "decidim/shared/confirm_modal" %>
     <%= render partial: "layouts/decidim/admin/js_configuration" %>
+    <%= render partial: "layouts/decidim/cors" if Decidim.cors_enabled %>
   </body>
 </html>

--- a/decidim-admin/app/views/layouts/decidim/admin/_js_configuration.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_js_configuration.html.erb
@@ -1,5 +1,6 @@
 <%
 js_configs = {
+  cors_enabled: Decidim.cors_enabled,
   icons_path: asset_pack_path("media/images/icons.svg"),
   messages: {
     "selfxssWarning": {

--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -53,9 +53,11 @@ module Decidim
         html_properties["aria-hidden"] = true
       end
 
+      href = Decidim.cors_enabled ? "" : asset_pack_path("media/images/icons.svg")
+
       content_tag :svg, html_properties do
         inner = content_tag :title, title
-        inner += content_tag :use, nil, "href" => "#{asset_pack_path("media/images/icons.svg")}#icon-#{name}"
+        inner += content_tag :use, nil, "href" => "#{href}#icon-#{name}"
 
         inner
       end
@@ -73,11 +75,18 @@ module Decidim
 
       if path.split(".").last == "svg"
         attributes = { class: classes.join(" ") }.merge(options)
-        asset = File.read(Rails.root.join("public#{asset_pack_path(path)}"))
+        asset = File.read(application_path(path))
         asset.gsub("<svg ", "<svg#{tag_builder.tag_options(attributes)} ").html_safe
       else
         image_pack_tag(path, class: classes.join(" "), style: "display: none")
       end
+    end
+
+    def application_path(path)
+      asset_host = Rails.application.config.action_controller.asset_host
+      img_path = asset_pack_path(path)
+      img_path.gsub!(asset_host , "") if asset_host.present?
+      Rails.root.join("public/#{img_path}")
     end
 
     # Allows to create role attribute according to accessibility rules

--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -83,9 +83,8 @@ module Decidim
     end
 
     def application_path(path)
-      asset_host = Rails.application.config.action_controller.asset_host
       img_path = asset_pack_path(path)
-      img_path.gsub!(asset_host , "") if asset_host.present?
+      img_path = URI(img_path).path if Decidim.cors_enabled
       Rails.root.join("public/#{img_path}")
     end
 

--- a/decidim-core/app/packs/src/decidim/icon.js
+++ b/decidim-core/app/packs/src/decidim/icon.js
@@ -13,6 +13,7 @@ const DEFAULT_ATTRIBUTES = {
  */
 export default function icon(iconKey, attributes = {}) {
   const iconAttributes = $.extend(DEFAULT_ATTRIBUTES, attributes);
+  const corsMode = window.Decidim.config.get("cors_enabled");
   const title = iconAttributes.title || iconAttributes.ariaLabel;
   Reflect.deleteProperty(iconAttributes, "title");
 
@@ -29,7 +30,11 @@ export default function icon(iconKey, attributes = {}) {
     }
   });
 
-  const iconsPath = window.Decidim.config.get("icons_path");
+  let iconsPath =  ""
+  if (corsMode === true) {
+    iconsPath = window.Decidim.config.get("icons_path");
+  }
+
   const elHtml = `<svg><use href="${iconsPath}#icon-${iconKey}"></use></svg>`;
   const $el = $(elHtml);
   if (title) {

--- a/decidim-core/app/packs/src/decidim/input_mentions.js
+++ b/decidim-core/app/packs/src/decidim/input_mentions.js
@@ -110,8 +110,14 @@ $(() => {
     menuItemTemplate: function(item) {
       let svg = "";
       if (window.Decidim && item.original.__typename === "UserGroup") {
-        let icons = window.Decidim.assets["icons.svg"];
-        svg = `<span class="is-group">${item.original.membersCount}x <svg class="icon--members icon"><use xlink:href="${icons}#icon-members"/></svg></span>`;
+        let corsMode = window.Decidim.config.get("cors_enabled");
+
+        let iconsPath =  ""
+        if (corsMode === true) {
+          iconsPath = window.Decidim.config.get("icons_path");
+        }
+
+        svg = `<span class="is-group">${item.original.membersCount}x <svg class="icon--members icon"><use href="${iconsPath}#icon-members"/></svg></span>`;
       }
       return `<div class="tribute-item ${item.original.__typename}">
       <span class="author__avatar"><img src="${item.original.avatarUrl}" alt="author-avatar"></span>

--- a/decidim-core/app/packs/src/decidim/input_multiple_mentions.js
+++ b/decidim-core/app/packs/src/decidim/input_multiple_mentions.js
@@ -121,8 +121,9 @@ $(() => {
       let enabled = item.original.directMessagesEnabled === "true";
       if (window.Decidim && item.original.__typename === "UserGroup") {
         enabled = true;
-        let icons = window.Decidim.assets["icons.svg"];
-        svg = `<span class="is-group">${item.original.membersCount}x <svg class="icon--members icon"><use xlink:href="${icons}#icon-members"/></svg></span>`;
+        let corsMode = window.Decidim.config.get("cors_enabled");
+        let iconsPath = corsMode ? "" : window.Decidim.config.get("icons_path");
+        svg = `<span class="is-group">${item.original.membersCount}x <svg class="icon--members icon"><use href="${iconsPath}#icon-members"/></svg></span>`;
       }
       let disabledElementClass = enabled ? "" : "disabled-tribute-element";
       let disabledElementMessage = enabled ? "" : `&nbsp;<span class="disabled-tribute-element-info">${directMessageDisabled}</span>`;

--- a/decidim-core/app/views/layouts/decidim/_application.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_application.html.erb
@@ -31,5 +31,6 @@
     <%= render partial: "decidim/shared/login_modal" unless current_user %>
     <%= render partial: "decidim/shared/authorization_modal" %>
     <%= render partial: "layouts/decidim/js_configuration" %>
+    <%= render partial: "layouts/decidim/cors" if Decidim.cors_enabled %>
   </body>
 </html>

--- a/decidim-core/app/views/layouts/decidim/_cors.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_cors.html.erb
@@ -1,0 +1,8 @@
+<div id="svg-cors-container" style="display: none"></div>
+<script type="text/javascript">
+  $.get(window.Decidim.config.get("icons_path"), function(data) {
+    var div = document.getElementById("svg-cors-container");
+    div.innerHTML = new XMLSerializer().serializeToString(data.documentElement);
+    document.body.insertBefore(div, document.body.childNodes[0]);
+  });
+</script>

--- a/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
@@ -1,5 +1,6 @@
 <%
 js_configs = {
+  cors_enabled: Decidim.cors_enabled,
   icons_path: asset_pack_path("media/images/icons.svg"),
   messages: {
     "selfxssWarning": {

--- a/decidim-core/app/views/layouts/decidim/widget.html.erb
+++ b/decidim-core/app/views/layouts/decidim/widget.html.erb
@@ -29,5 +29,6 @@
 
     <%= javascript_pack_tag "decidim_widget" %>
     <%= render partial: "layouts/decidim/js_configuration" %>
+    <%= render partial: "layouts/decidim/cors" if Decidim.cors_enabled %>
   </body>
 </html>

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -149,7 +149,7 @@ module Decidim
     true
   end
 
-  # Setting that
+  # Having this on true will change the way the svg assets are being served.
   config_accessor :cors_enabled do
     false
   end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -149,6 +149,11 @@ module Decidim
     true
   end
 
+  # Setting that
+  config_accessor :cors_enabled do
+    false
+  end
+
   # Exposes a configuration option: The application available locales.
   config_accessor :available_locales do
     %w(en bg ar ca cs da de el eo es es-MX es-PY et eu fi-pl fi fr fr-CA ga gl hr hu id is it ja ko lt lv mt nl no pl pt pt-BR ro ru sk sl sr sv tr uk vi zh-CN zh-TW)

--- a/decidim-system/app/views/layouts/decidim/system/_js_configuration.html.erb
+++ b/decidim-system/app/views/layouts/decidim/system/_js_configuration.html.erb
@@ -1,5 +1,6 @@
 <%
 js_configs = {
+  cors_enabled: Decidim.cors_enabled,
   icons_path: asset_pack_path("media/images/icons.svg")
 }
 %>

--- a/decidim-system/app/views/layouts/decidim/system/application.html.erb
+++ b/decidim-system/app/views/layouts/decidim/system/application.html.erb
@@ -38,5 +38,6 @@
   </div>
   <%= render partial: "decidim/shared/confirm_modal" %>
   <%= render partial: "layouts/decidim/system/js_configuration" %>
+  <%= render partial: "layouts/decidim/cors" if Decidim.cors_enabled %>
 </body>
 </html>

--- a/docs/modules/configure/pages/initializer.adoc
+++ b/docs/modules/configure/pages/initializer.adoc
@@ -79,6 +79,22 @@ Whether SSL should be enabled or not. Recommended for extra security.
   config.force_ssl = true
 ....
 
+== CORS enabled
+
+The SVG do not support CORS. When using custom asset host different than root url, set this value to `true`, in order to activate the available workaround.
+
+Please refer to:
+
+- https://github.com/w3c/svgwg/issues/707
+- https://stackoverflow.com/questions/65811142/how-to-allow-external-images-referenced-within-embedded-svg
+- https://groups.google.com/a/chromium.org/g/blink-dev/c/qemQwRpe2so/m/THi81oodSDgJ.
+- https://www.w3.org/Graphics/SVG/WG/track/actions/3781
+
+[source,ruby]
+....
+  config.cors_enabled = true
+....
+
 == Geocoder configuration
 
 Allows to make geographical mapping in some components, like Proposals or Meetings. It must be configured against a OpenStreetMap provider. See xref:services:geocoder.adoc[Geocoder service documentation].


### PR DESCRIPTION
#### :tophat: What? Why?
When setting asset host on a rails application, different than current domain, all the icons used by the application will be blocked by the browser, therefore, this PR adds a workaround to the issue. 

This PR introduces a new Decidim setting named cors_enabled. If the value of this variable is set to false, then the default decidim behavior is used. 
When the value of the setting is set to true, all the svg references will be switched to local id reference, as the cors partial has a small javascript which will fetch the icons.svg using ajax from the external domain, then populate a hidden div with the content of the svg file for later use. 

I have not tried to render the svg directly to the page that is requested to keep the page size small, and take advantage of the asset caching. 


Additional resources on the matter: 
- https://github.com/w3c/svgwg/issues/707
- https://stackoverflow.com/questions/65811142/how-to-allow-external-images-referenced-within-embedded-svg
- https://groups.google.com/a/chromium.org/g/blink-dev/c/qemQwRpe2so/m/THi81oodSDgJ.
- https://www.w3.org/Graphics/SVG/WG/track/actions/3781

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
