### PR TITLE
Use correct newsletter cell for web view

### DIFF
--- a/decidim-core/app/views/decidim/newsletters/show.html.erb
+++ b/decidim-core/app/views/decidim/newsletters/show.html.erb
@@ -1,5 +1,5 @@
 <% @cell = cell(
-  "decidim/newsletter_templates/basic_only_text",
+  "decidim/newsletter_templates/#{newsletter.template.manifest_name}",
   newsletter.template,
   organization: @organization,
   newsletter: newsletter,

--- a/decidim-core/spec/system/newsletter_spec.rb
+++ b/decidim-core/spec/system/newsletter_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Newsletters (view in web)", type: :system do
+  let(:organization) { newsletter.organization }
+  let!(:newsletter) { create :newsletter, :sent }
+  let!(:content_block) do
+    content_block = Decidim::ContentBlock.find_by(organization: organization, scope_name: :newsletter_template, scoped_resource_id: newsletter.id)
+    content_block.destroy!
+    content_block = create(
+      :content_block,
+      :newsletter_template,
+      organization: organization,
+      scoped_resource_id: newsletter.id,
+      manifest_name: "image_text_cta",
+      settings: {
+        body: Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title },
+        introduction: Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title },
+        cta_text: Decidim::Faker::Localized.word,
+        cta_url: I18n.available_locales.index_with { |_locale| Faker::Internet.url }
+      }
+    )
+    content_block
+  end
+
+  before do
+    switch_to_host organization.host
+  end
+
+  describe "accessing the newsletter page" do
+    before do
+      page.visit decidim.newsletter_path(newsletter)
+    end
+
+    it "renders the correct template" do
+      within ".content" do
+        byebug
+        expect(page).to have_link(translated(content_block.settings.cta_text), href: translated(content_block.settings.cta_url))
+      end
+    end
+  end
+end

--- a/decidim-core/spec/system/newsletter_spec.rb
+++ b/decidim-core/spec/system/newsletter_spec.rb
@@ -35,7 +35,6 @@ describe "Newsletters (view in web)", type: :system do
 
     it "renders the correct template" do
       within ".content" do
-        byebug
         expect(page).to have_link(translated(content_block.settings.cta_text), href: translated(content_block.settings.cta_url))
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes "view in website" for newsletters. It was always using the `basic_only_text` cell, therefore never rendering the image nor the `introduction` text. 

#### Testing
- [x] [./decidim-core/spec/system/newsletter_spec.rb](./decidim-core/spec/system/newsletter_spec.rb)

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
