### PR TITLE
Improve control of comments in meetings and debates

### DIFF
--- a/decidim-comments/app/views/decidim/comments/admin/shared/_availability_fields.html.erb
+++ b/decidim-comments/app/views/decidim/comments/admin/shared/_availability_fields.html.erb
@@ -1,0 +1,15 @@
+<div class="row column">
+  <%= form.check_box :comments_enabled, label: t(".enabled"), :"data-toggle" => "customize_comments_times-div" %>
+</div>
+
+<div id="customize_comments_times-div" data-toggler=".hide" class="row column <%= @form.comments_enabled ? nil : "hide" %>">
+  <div class="row">
+    <div class="columns xlarge-6">
+      <%= form.datetime_field :comments_start_time, label: t(".start_time") %>
+    </div>
+
+    <div class="columns xlarge-6">
+      <%= form.datetime_field :comments_end_time, label: t(".end_time") %>
+    </div>
+  </div>
+</div>

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -17,6 +17,12 @@ en:
         other: Votes
   decidim:
     comments:
+      admin:
+        shared:
+          availability_fields:
+            enabled: Comments enabled
+            end_time: Comments enabled until
+            start_time: Comments enabled from
       comments:
         create:
           error: There was a problem creating the comment.

--- a/decidim-comments/lib/decidim/comments.rb
+++ b/decidim-comments/lib/decidim/comments.rb
@@ -13,6 +13,7 @@ module Decidim
     autoload :CommentsHelper, "decidim/comments/comments_helper"
     autoload :Commentable, "decidim/comments/commentable"
     autoload :CommentableWithComponent, "decidim/comments/commentable_with_component"
+    autoload :HasAvailabilityAttributes, "decidim/comments/has_availability_attributes"
     autoload :CommentSerializer, "decidim/comments/comment_serializer"
     autoload :CommentVoteSerializer, "decidim/comments/comment_vote_serializer"
     autoload :Export, "decidim/comments/export"

--- a/decidim-comments/lib/decidim/comments/has_availability_attributes.rb
+++ b/decidim-comments/lib/decidim/comments/has_availability_attributes.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Comments
+    # Shared behaviour for commentable models with enabled, start_time and
+    # end_time attributes for comments.
+    module HasAvailabilityAttributes
+      extend ActiveSupport::Concern
+
+      included do
+        # Public: Whether the object has comments allowed based on availability
+        # attributes
+        def comments_allowed?
+          (!comments_enabled.nil? && comments_enabled) &&
+            (comments_start_time.blank? || comments_start_time <= Time.current) &&
+            (comments_end_time.blank? || comments_end_time > Time.current)
+        end
+      end
+    end
+  end
+end

--- a/decidim-comments/lib/decidim/comments/test.rb
+++ b/decidim-comments/lib/decidim/comments/test.rb
@@ -3,3 +3,4 @@
 require "decidim/comments/test/shared_examples/create_comment_context"
 require "decidim/comments/test/shared_examples/comment_event"
 require "decidim/comments/test/shared_examples/comment_voted_event"
+require "decidim/comments/test/shared_examples/has_comments_availability_attributes"

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/has_comments_availability_attributes.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/has_comments_availability_attributes.rb
@@ -4,14 +4,19 @@ shared_examples_for "has comments availability attributes" do
   let(:comments_enabled) { nil }
   let(:comments_start_time) { nil }
   let(:comments_end_time) { nil }
+  let(:updates) do
+    { comments_enabled: comments_enabled }.merge(
+      if subject.is_a?(Decidim::Debates::Debate)
+        { start_time: comments_start_time, end_time: comments_end_time }
+      else
+        { comments_start_time: comments_start_time, comments_end_time: comments_end_time }
+      end
+    )
+  end
 
   describe "#comments_allowed?" do
     before do
-      subject.update(
-        comments_enabled: comments_enabled,
-        comments_start_time: comments_start_time,
-        comments_end_time: comments_end_time
-      )
+      subject.update(updates)
     end
 
     context "when all attributes are blank" do

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/has_comments_availability_attributes.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/has_comments_availability_attributes.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+shared_examples_for "has comments availability attributes" do
+  let(:comments_enabled) { nil }
+  let(:comments_start_time) { nil }
+  let(:comments_end_time) { nil }
+
+  describe "#comments_allowed?" do
+    before do
+      subject.update(
+        comments_enabled: comments_enabled,
+        comments_start_time: comments_start_time,
+        comments_end_time: comments_end_time
+      )
+    end
+
+    context "when all attributes are blank" do
+      it { expect(subject.comments_allowed?).to be false }
+    end
+
+    context "when comments_enabled is false" do
+      let(:comments_enabled) { false }
+
+      context "and start time is in the past and end time in the future" do
+        let(:comments_start_time) { 1.day.ago }
+        let(:comments_end_time) { 2.days.from_now }
+
+        it { expect(subject.comments_allowed?).to be false }
+      end
+    end
+
+    context "when comments_enabled is true" do
+      let(:comments_enabled) { true }
+
+      context "and start and end time are blank" do
+        it { expect(subject.comments_allowed?).to be true }
+      end
+
+      context "and start time is present and in the past" do
+        let(:comments_start_time) { 1.day.ago }
+
+        it { expect(subject.comments_allowed?).to be true }
+      end
+
+      context "and start time is present and in the future" do
+        let(:comments_start_time) { 1.day.from_now }
+
+        it { expect(subject.comments_allowed?).to be false }
+      end
+
+      context "and end time is present and in the future" do
+        let(:comments_end_time) { 2.days.from_now }
+
+        it { expect(subject.comments_allowed?).to be true }
+      end
+
+      context "and end time is present and in the past" do
+        let(:comments_end_time) { 1.day.ago }
+
+        it { expect(subject.comments_allowed?).to be false }
+      end
+
+      context "and start time is in the past and end time in the future" do
+        let(:comments_start_time) { 1.day.ago }
+        let(:comments_end_time) { 2.days.from_now }
+
+        it { expect(subject.comments_allowed?).to be true }
+      end
+    end
+  end
+end

--- a/decidim-debates/app/commands/decidim/debates/admin/create_debate.rb
+++ b/decidim-debates/app/commands/decidim/debates/admin/create_debate.rb
@@ -40,7 +40,8 @@ module Decidim
             start_time: (form.start_time if form.finite),
             scope: form.scope,
             component: form.current_component,
-            author: form.current_organization
+            author: form.current_organization,
+            comments_enabled: form.comments_enabled
           }
 
           @debate = Decidim.traceability.create!(

--- a/decidim-debates/app/commands/decidim/debates/admin/update_debate.rb
+++ b/decidim-debates/app/commands/decidim/debates/admin/update_debate.rb
@@ -43,7 +43,8 @@ module Decidim
             instructions: form.instructions,
             end_time: form.end_time,
             start_time: form.start_time,
-            scope: form.scope
+            scope: form.scope,
+            comments_enabled: form.comments_enabled
           )
         end
       end

--- a/decidim-debates/app/forms/decidim/debates/admin/debate_form.rb
+++ b/decidim-debates/app/forms/decidim/debates/admin/debate_form.rb
@@ -16,6 +16,7 @@ module Decidim
         attribute :decidim_category_id, Integer
         attribute :finite, Boolean, default: true
         attribute :scope_id, Integer
+        attribute :comments_enabled, Boolean, default: true
 
         validates :title, translatable_presence: true
         validates :description, translatable_presence: true

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -11,6 +11,7 @@ module Decidim
       include Decidim::Resourceable
       include Decidim::Followable
       include Decidim::Comments::CommentableWithComponent
+      include Decidim::Comments::HasAvailabilityAttributes
       include Decidim::ScopableResource
       include Decidim::Authorable
       include Decidim::Reportable
@@ -57,6 +58,14 @@ module Decidim
         Decidim::Debates::AdminLog::DebatePresenter
       end
 
+      def comments_start_time
+        start_time
+      end
+
+      def comments_end_time
+        end_time
+      end
+
       # Public: Overrides the `reported_content_url` Reportable concern method.
       def reported_content_url
         ResourceLocatorPresenter.new(self).url
@@ -96,12 +105,12 @@ module Decidim
         (ama? && open_ama?) || !ama?
       end
 
-      # Public: Overrides the `accepts_new_comments?` Commentable concern method.
+      # Public: Overrides the `accepts_new_comments?` CommentableWithComponent concern method.
       def accepts_new_comments?
         return false unless open?
         return false if closed?
 
-        commentable? && !comments_blocked?
+        commentable? && !comments_blocked? && comments_allowed?
       end
 
       # Public: Overrides the `comments_have_alignment?` Commentable concern method.

--- a/decidim-debates/app/views/decidim/debates/admin/debates/_form.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/_form.html.erb
@@ -43,6 +43,10 @@
     <div class="row column">
       <%= form.categories_select :decidim_category_id, current_participatory_space.categories, include_blank: "", disable_parents: false %>
     </div>
+
+    <div class="row column">
+      <%= form.check_box :comments_enabled, label: t("enabled", scope: "decidim.comments.admin.shared.availability_fields") %>
+    </div>
   </div>
 </div>
 

--- a/decidim-debates/db/migrate/20210519201932_add_comments_availability_columns_to_debates_table.rb
+++ b/decidim-debates/db/migrate/20210519201932_add_comments_availability_columns_to_debates_table.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddCommentsAvailabilityColumnsToDebatesTable < ActiveRecord::Migration[6.0]
+  def change
+    add_column :decidim_debates_debates, :comments_enabled, :boolean, default: true
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE decidim_debates_debates set comments_enabled = true"
+      end
+    end
+  end
+end

--- a/decidim-debates/spec/commands/decidim/debates/admin/create_debate_spec.rb
+++ b/decidim-debates/spec/commands/decidim/debates/admin/create_debate_spec.rb
@@ -25,7 +25,8 @@ describe Decidim::Debates::Admin::CreateDebate do
       current_user: user,
       current_component: current_component,
       current_organization: organization,
-      finite: finite
+      finite: finite,
+      comments_enabled: true
     )
   end
   let(:finite) { true }

--- a/decidim-debates/spec/commands/decidim/debates/admin/update_debate_spec.rb
+++ b/decidim-debates/spec/commands/decidim/debates/admin/update_debate_spec.rb
@@ -22,7 +22,8 @@ describe Decidim::Debates::Admin::UpdateDebate do
       end_time: 1.day.from_now + 1.hour,
       scope: scope,
       category: category,
-      current_organization: organization
+      current_organization: organization,
+      comments_enabled: true
     )
   end
   let(:invalid) { false }

--- a/decidim-debates/spec/models/decidim/debates/debate_spec.rb
+++ b/decidim-debates/spec/models/decidim/debates/debate_spec.rb
@@ -14,6 +14,7 @@ describe Decidim::Debates::Debate do
   include_examples "has component"
   include_examples "has category"
   include_examples "resourceable"
+  include_examples "has comments availability attributes"
 
   describe "newsletter participants" do
     subject { Decidim::Debates::Debate.newsletter_participant_ids(debate.component) }

--- a/decidim-debates/spec/spec_helper.rb
+++ b/decidim-debates/spec/spec_helper.rb
@@ -7,3 +7,4 @@ ENV["ENGINE_ROOT"] = File.dirname(__dir__)
 Decidim::Dev.dummy_app_path = File.expand_path(File.join("..", "spec", "decidim_dummy_app"))
 
 require "decidim/dev/test/base_spec_helper"
+require "decidim/comments/test"

--- a/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
@@ -56,7 +56,10 @@ module Decidim
             questionnaire: Decidim::Forms::Questionnaire.new,
             customize_registration_email: form.customize_registration_email,
             registration_email_custom_content: form.registration_email_custom_content,
-            show_embedded_iframe: form.show_embedded_iframe
+            show_embedded_iframe: form.show_embedded_iframe,
+            comments_enabled: form.comments_enabled,
+            comments_start_time: form.comments_start_time,
+            comments_end_time: form.comments_end_time
           }
 
           @meeting = Decidim.traceability.create!(

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
@@ -62,7 +62,10 @@ module Decidim
             transparent: form.transparent,
             customize_registration_email: form.customize_registration_email,
             registration_email_custom_content: form.registration_email_custom_content,
-            show_embedded_iframe: form.show_embedded_iframe
+            show_embedded_iframe: form.show_embedded_iframe,
+            comments_enabled: form.comments_enabled,
+            comments_start_time: form.comments_start_time,
+            comments_end_time: form.comments_end_time
           )
         end
 

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -24,6 +24,9 @@ module Decidim
         attribute :available_slots, Integer, default: 0
         attribute :customize_registration_email, Boolean
         attribute :show_embedded_iframe, Boolean, default: false
+        attribute :comments_enabled, Boolean, default: true
+        attribute :comments_start_time, Decidim::Attributes::TimeWithZone
+        attribute :comments_end_time, Decidim::Attributes::TimeWithZone
 
         translatable_attribute :title, String
         translatable_attribute :description, String
@@ -44,6 +47,8 @@ module Decidim
         validates :online_meeting_url, url: true, if: ->(form) { form.online_meeting? || form.hybrid_meeting? }
         validates :start_time, presence: true, date: { before: :end_time }
         validates :end_time, presence: true, date: { after: :start_time }
+        validates :comments_start_time, date: { before: :comments_end_time, allow_blank: true, if: proc { |obj| obj.comments_end_time.present? } }
+        validates :comments_end_time, date: { after: :comments_start_time, allow_blank: true, if: proc { |obj| obj.comments_start_time.present? } }
 
         validates :current_component, presence: true
         validates :category, presence: true, if: ->(form) { form.decidim_category_id.present? }

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -14,6 +14,7 @@ module Decidim
       include Decidim::HasCategory
       include Decidim::Followable
       include Decidim::Comments::CommentableWithComponent
+      include Decidim::Comments::HasAvailabilityAttributes
       include Decidim::Searchable
       include Decidim::Traceable
       include Decidim::Loggable
@@ -169,6 +170,11 @@ module Decidim
 
       def maps_enabled?
         component.settings.maps_enabled?
+      end
+
+      # Public: Overrides the `accepts_new_comments?` CommentableWithComponent concern method.
+      def accepts_new_comments?
+        commentable? && !component.current_settings.comments_blocked && comments_allowed?
       end
 
       # Public: Overrides the `allow_resource_permissions?` Resourceable concern method.

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -99,6 +99,7 @@
       <p class="help-text"><%= t(".registration_email_help") %></p>
     </div>
 
+    <%= render partial: "decidim/comments/admin/shared/availability_fields", locals: { form: form } %>
   </div>
 </div>
 

--- a/decidim-meetings/db/migrate/20210519133705_add_comments_availability_columns_to_meetings_table.rb
+++ b/decidim-meetings/db/migrate/20210519133705_add_comments_availability_columns_to_meetings_table.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddCommentsAvailabilityColumnsToMeetingsTable < ActiveRecord::Migration[6.0]
+  def change
+    add_column :decidim_meetings_meetings, :comments_enabled, :boolean, default: true
+    add_column :decidim_meetings_meetings, :comments_start_time, :datetime
+    add_column :decidim_meetings_meetings, :comments_end_time, :datetime
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE decidim_meetings_meetings set comments_enabled = true"
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/commands/admin/create_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/create_meeting_spec.rb
@@ -71,7 +71,10 @@ module Decidim::Meetings
         online_meeting_url: online_meeting_url,
         customize_registration_email: customize_registration_email,
         registration_email_custom_content: registration_email_custom_content,
-        show_embedded_iframe: show_embedded_iframe
+        show_embedded_iframe: show_embedded_iframe,
+        comments_enabled: true,
+        comments_start_time: nil,
+        comments_end_time: nil
       )
     end
 

--- a/decidim-meetings/spec/commands/admin/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/update_meeting_spec.rb
@@ -59,7 +59,10 @@ module Decidim::Meetings
         online_meeting_url: online_meeting_url,
         customize_registration_email: customize_registration_email,
         registration_email_custom_content: registration_email_custom_content,
-        show_embedded_iframe: show_embedded_iframe
+        show_embedded_iframe: show_embedded_iframe,
+        comments_enabled: true,
+        comments_start_time: nil,
+        comments_end_time: nil
       )
     end
 
@@ -156,7 +159,10 @@ module Decidim::Meetings
             online_meeting_url: online_meeting_url,
             customize_registration_email: customize_registration_email,
             registration_email_custom_content: registration_email_custom_content,
-            show_embedded_iframe: show_embedded_iframe
+            show_embedded_iframe: show_embedded_iframe,
+            comments_enabled: true,
+            comments_start_time: nil,
+            comments_end_time: nil
           )
         end
 

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -18,6 +18,7 @@ module Decidim::Meetings
     include_examples "has reference"
     include_examples "resourceable"
     include_examples "reportable"
+    include_examples "has comments availability attributes"
 
     it "has an association with one agenda" do
       subject.agenda = build_stubbed(:agenda)

--- a/decidim-meetings/spec/spec_helper.rb
+++ b/decidim-meetings/spec/spec_helper.rb
@@ -9,3 +9,4 @@ Decidim::Dev.dummy_app_path = File.expand_path(File.join("..", "spec", "decidim_
 require "decidim/dev/test/base_spec_helper"
 
 require "decidim/forms/test"
+require "decidim/comments/test"


### PR DESCRIPTION
#### :tophat: What? Why?
This PR:

* Adds a migration to include a `comments_enabled` column in debates and meeting tables, true by default, and 2 datetime columns to meetings table named `comments_start_time` and `comments_end_time`
* Allows admins to enable/disable new comments on individual debates and meetings from their edition form and when comments are enabled set an start and/or end time for which comments are available. When comments are disabled the users can see previously existing comments
* Adds some tests

#### :pushpin: Related Issues

- Fixes #7287
- Fixes #7904

#### Testing

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
