### PR TITLE
Include the current component identifier to cache key when caching filters

### DIFF
--- a/decidim-core/app/helpers/decidim/filters_helper.rb
+++ b/decidim-core/app/helpers/decidim/filters_helper.rb
@@ -33,6 +33,7 @@ module Decidim
       hash = []
       hash << "decidim/proposals/filters"
       hash << type.to_s if type.present?
+      hash << current_component.id
       hash << Digest::MD5.hexdigest(filter.to_json)
 
       hash.join("/")

--- a/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
@@ -79,6 +79,12 @@ module Decidim
 
     describe "#filter_cache_hash" do
       let(:type) { :test }
+      let(:organization) { create(:organization) }
+      let(:proposal_component) { create(:proposal_component, organization: organization) }
+
+      before do
+        allow(helper).to receive(:current_component).and_return(proposal_component)
+      end
 
       it "generate a unique hash" do
         old_hash = helper.filter_cache_hash(filter, type)
@@ -102,6 +108,17 @@ module Decidim
         it "generate a different hash" do
           old_hash = helper.filter_cache_hash(filter, type)
           filter.test_attribute = "dummy-filter"
+
+          expect(helper.filter_cache_hash(filter, type)).not_to eq(old_hash)
+        end
+      end
+
+      context "when the component is different" do
+        let(:another_component) { create(:proposal_component, organization: organization) }
+
+        it "generate a different hash" do
+          old_hash = helper.filter_cache_hash(filter, type)
+          allow(helper).to receive(:current_component).and_return(another_component)
 
           expect(helper.filter_cache_hash(filter, type)).not_to eq(old_hash)
         end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the component id to the cache keys for the filters form to prevent to use the same URLs for different components. 

#### :pushpin: Related Issues
- Fixes #8003

#### Testing
Described in #8003