### PR TITLE
Fix question preview when no questions are published

### DIFF
--- a/decidim-consultations/app/controllers/concerns/decidim/consultations/needs_question.rb
+++ b/decidim-consultations/app/controllers/concerns/decidim/consultations/needs_question.rb
@@ -112,7 +112,7 @@ module Decidim
         end
 
         def current_published_question_index
-          current_consultation_published_questions.find_index(current_question)
+          current_consultation_published_questions.find_index(current_question) || -1
         end
       end
     end

--- a/decidim-consultations/spec/system/question_spec.rb
+++ b/decidim-consultations/spec/system/question_spec.rb
@@ -70,6 +70,24 @@ describe "Question", type: :system do
     end
   end
 
+  context "when no question is published" do
+    let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+    let(:previous_question) { create :question, :unpublished, consultation: consultation }
+    let(:question) { create :question, :unpublished, consultation: consultation }
+    let(:next_question) { create :question, :unpublished, consultation: consultation }
+
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit decidim_consultations.question_path(question)
+    end
+
+    it "hides the previous/next question button" do
+      expect(page).not_to have_content("Previous question")
+      expect(page).not_to have_content("Next question")
+    end
+  end
+
   context "when next question is published" do
     before do
       question.publish!


### PR DESCRIPTION
#### :tophat: What? Why?

Previewing a question from /admin/consultations resulted in a 500 when none of the questions were published. 

`#current_published_question_index` was returning nil and this was causing an ``undefined method `-' for nil:NilClass`` on `#previous_published_question`. See below.

![Peek 2021-05-21 16-16](https://user-images.githubusercontent.com/762088/119151806-07721880-ba50-11eb-8cd8-5404b626afe3.gif)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
