### PR TITLE
Remove proposals filters cache

### DIFF
--- a/decidim-core/app/helpers/decidim/filters_helper.rb
+++ b/decidim-core/app/helpers/decidim/filters_helper.rb
@@ -29,15 +29,6 @@ module Decidim
       end
     end
 
-    def filter_cache_hash(filter, type = nil)
-      hash = []
-      hash << "decidim/proposals/filters"
-      hash << type.to_s if type.present?
-      hash << Digest::MD5.hexdigest(filter.to_json)
-
-      hash.join("/")
-    end
-
     private
 
     # Creates a unique namespace for a filter form to prevent dupliacte IDs in

--- a/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
@@ -76,36 +76,5 @@ module Decidim
         end
       end
     end
-
-    describe "#filter_cache_hash" do
-      let(:type) { :test }
-
-      it "generate a unique hash" do
-        old_hash = helper.filter_cache_hash(filter, type)
-
-        expect(helper.filter_cache_hash(filter, type)).to eq(old_hash)
-      end
-
-      it "stores filter type" do
-        expect(helper.filter_cache_hash(filter, type)).to start_with("decidim/proposals/filters/test")
-      end
-
-      context "when no type is provided" do
-        let(:type) { nil }
-
-        it "doesn't stores filter type" do
-          expect(helper.filter_cache_hash(filter)).to start_with("decidim/proposals/filters")
-        end
-      end
-
-      context "when filter is different" do
-        it "generate a different hash" do
-          old_hash = helper.filter_cache_hash(filter, type)
-          filter.test_attribute = "dummy-filter"
-
-          expect(helper.filter_cache_hash(filter, type)).not_to eq(old_hash)
-        end
-      end
-    end
   end
 end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -1,48 +1,46 @@
 <%= render partial: "decidim/shared/filter_form_help", locals: { skip_to_id: "proposals" } %>
 
-<% cache filter_cache_hash(filter, defined?(type) ? type : nil) do %>
-  <%= filter_form_for filter do |form| %>
-    <div class="filters__section">
-      <div class="filters__search">
-        <div class="input-group">
-          <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), "aria-label": t(".search"), data: { disable_dynamic_change: true } %>
-          <div class="input-group-button">
-            <button type="submit" class="button" aria-controls="proposals">
-              <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>
-            </button>
-          </div>
+<%= filter_form_for filter do |form| %>
+  <div class="filters__section">
+    <div class="filters__search">
+      <div class="input-group">
+        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), "aria-label": t(".search"), data: { disable_dynamic_change: true } %>
+        <div class="input-group-button">
+          <button type="submit" class="button" aria-controls="proposals">
+            <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>
+          </button>
         </div>
       </div>
     </div>
+  </div>
 
-    <% if component_settings.proposal_answering_enabled && current_settings.proposal_answering_enabled %>
-      <%= form.check_boxes_tree :state, filter_proposals_state_values, legend_title: t(".state"), "aria-controls": "proposals" %>
-    <% end %>
-
-    <% if current_component.has_subscopes? %>
-      <%= form.check_boxes_tree :scope_id, filter_scopes_values, legend_title: t(".scope"), "aria-controls": "proposals" %>
-    <% end %>
-
-    <% if current_component.categories.any? %>
-      <%= form.check_boxes_tree :category_id, filter_categories_values, legend_title: t(".category"), "aria-controls": "proposals" %>
-    <% end %>
-
-    <% if component_settings.official_proposals_enabled %>
-      <%= form.check_boxes_tree :origin, filter_origin_values, legend_title: t(".origin"), "aria-controls": "proposals" %>
-    <% end %>
-
-    <% if current_user %>
-      <%= form.collection_radio_buttons :activity, activity_filter_values, :first, :last, { legend_title: t(".activity") }, "aria-controls": "proposals" %>
-    <% end %>
-
-    <% if @proposals.only_emendations.any? %>
-      <%= form.collection_radio_buttons :type, filter_type_values, :first, :last, { legend_title: t(".amendment_type") }, "aria-controls": "proposals" %>
-    <% end %>
-
-    <% if linked_classes_for(Decidim::Proposals::Proposal).any? %>
-      <%= form.collection_radio_buttons :related_to, linked_classes_filter_values_for(Decidim::Proposals::Proposal), :first, :last, { legend_title: t(".related_to") }, "aria-controls": "proposals" %>
-    <% end %>
-
-    <%= hidden_field_tag :order, order, id: nil, class: "order_filter" %>
+  <% if component_settings.proposal_answering_enabled && current_settings.proposal_answering_enabled %>
+    <%= form.check_boxes_tree :state, filter_proposals_state_values, legend_title: t(".state"), "aria-controls": "proposals" %>
   <% end %>
+
+  <% if current_component.has_subscopes? %>
+    <%= form.check_boxes_tree :scope_id, filter_scopes_values, legend_title: t(".scope"), "aria-controls": "proposals" %>
+  <% end %>
+
+  <% if current_component.categories.any? %>
+    <%= form.check_boxes_tree :category_id, filter_categories_values, legend_title: t(".category"), "aria-controls": "proposals" %>
+  <% end %>
+
+  <% if component_settings.official_proposals_enabled %>
+    <%= form.check_boxes_tree :origin, filter_origin_values, legend_title: t(".origin"), "aria-controls": "proposals" %>
+  <% end %>
+
+  <% if current_user %>
+    <%= form.collection_radio_buttons :activity, activity_filter_values, :first, :last, { legend_title: t(".activity") }, "aria-controls": "proposals" %>
+  <% end %>
+
+  <% if @proposals.only_emendations.any? %>
+    <%= form.collection_radio_buttons :type, filter_type_values, :first, :last, { legend_title: t(".amendment_type") }, "aria-controls": "proposals" %>
+  <% end %>
+
+  <% if linked_classes_for(Decidim::Proposals::Proposal).any? %>
+    <%= form.collection_radio_buttons :related_to, linked_classes_filter_values_for(Decidim::Proposals::Proposal), :first, :last, { legend_title: t(".related_to") }, "aria-controls": "proposals" %>
+  <% end %>
+
+  <%= hidden_field_tag :order, order, id: nil, class: "order_filter" %>
 <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters_small_view.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters_small_view.html.erb
@@ -13,6 +13,6 @@
     </button>
   </div>
   <div class="filters">
-    <%= render partial: "filters", locals: { type: :small } %>
+    <%= render partial: "filters" %>
   </div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?

We've found some issues related to proposals filters caused by the cache introduced in #6808. It is caching too much, as it's not taking into account the component (reported in #8003) nor changes in the scopes (#8023). 

My first approach to fix these issues was to add those elements to the cache key (as in #8029), but then I realized there are many resources that should invalidate the filters cache when changing (the current user and component, the space current step settings, the organization scopes and categories, the component proposals and their linked resources, etc). 

We could try to add all of them to the cache key or add some and force a cache invalidation when changing scopes or categories, but in any case it seems to be a big effort and complexity increase and it's not very clear the performance improvement that will be obtained from these changes.

So, I think it's better to remove the filters cache at this moment, and evaluate better how to improve the performance of this part. 

#### :pushpin: Related Issues
- Related to #6808 and #8029
- Fixes #8003 and #8023

#### Testing
This only removes the cache feature, so issues #8003 and #8023 should be fixed.
