### PR TITLE
Apply permissions system to comments

### DIFF
--- a/decidim-accountability/app/models/decidim/accountability/result.rb
+++ b/decidim-accountability/app/models/decidim/accountability/result.rb
@@ -12,7 +12,7 @@ module Decidim
       include Decidim::ScopableResource
       include Decidim::HasCategory
       include Decidim::HasReference
-      include Decidim::Comments::Commentable
+      include Decidim::Comments::CommentableWithComponent
       include Decidim::Traceable
       include Decidim::Loggable
       include Decidim::DataPortability
@@ -66,16 +66,6 @@ module Decidim
         save!
       end
 
-      # Public: Overrides the `commentable?` Commentable concern method.
-      def commentable?
-        component.settings.comments_enabled?
-      end
-
-      # Public: Overrides the `accepts_new_comments?` Commentable concern method.
-      def accepts_new_comments?
-        commentable? && !component.current_settings.comments_blocked
-      end
-
       # Public: Overrides the `comments_have_alignment?` Commentable concern method.
       def comments_have_alignment?
         true
@@ -84,11 +74,6 @@ module Decidim
       # Public: Overrides the `comments_have_votes?` Commentable concern method.
       def comments_have_votes?
         true
-      end
-
-      # Public: Whether the object can have new comments or not.
-      def user_allowed_to_comment?(user)
-        can_participate_in_space?(user)
       end
 
       ransacker :id_string do

--- a/decidim-accountability/app/models/decidim/accountability/result.rb
+++ b/decidim-accountability/app/models/decidim/accountability/result.rb
@@ -76,6 +76,11 @@ module Decidim
         true
       end
 
+      # Public: Overrides the `allow_resource_permissions?` Resourceable concern method.
+      def allow_resource_permissions?
+        true
+      end
+
       ransacker :id_string do
         Arel.sql(%{cast("decidim_accountability_results"."id" as text)})
       end

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
@@ -94,6 +94,8 @@
                   <%= icon_link_to "paperclip", result_attachments_path(result), t("actions.attachments", scope: "decidim.accountability"), class: "action-icon--attachments" %>
                 <% end %>
 
+                <%= resource_permissions_link(result) %>
+
                 <% if allowed_to? :destroy, :result, result: result %>
                   <%= icon_link_to "circle-x", result_path(result), t("actions.destroy", scope: "decidim.accountability"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.accountability", name: t("models.result.name", scope: "decidim.accountability.admin")) } %>
                 <% end %>

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -205,6 +205,8 @@ en:
             label: Status
     components:
       accountability:
+        actions:
+          comment: Comment
         name: Accountability
         settings:
           global:

--- a/decidim-accountability/lib/decidim/accountability/component.rb
+++ b/decidim-accountability/lib/decidim/accountability/component.rb
@@ -14,11 +14,15 @@ Decidim.register_component(:accountability) do |component|
     raise StandardError, "Can't remove this component" if Decidim::Accountability::Result.where(component: instance).any?
   end
 
+  # These actions permissions can be configured in the admin panel
+  component.actions = %w(comment)
+
   component.register_resource(:result) do |resource|
     resource.model_class_name = "Decidim::Accountability::Result"
     resource.template = "decidim/accountability/results/linked_results"
     resource.card = "decidim/accountability/result"
     resource.searchable = false
+    resource.actions = %w(comment)
   end
 
   component.settings(:global) do |settings|

--- a/decidim-blogs/app/models/decidim/blogs/post.rb
+++ b/decidim-blogs/app/models/decidim/blogs/post.rb
@@ -10,7 +10,7 @@ module Decidim
       include Decidim::HasAttachmentCollections
       include Decidim::HasComponent
       include Decidim::Authorable
-      include Decidim::Comments::Commentable
+      include Decidim::Comments::CommentableWithComponent
       include Decidim::Searchable
       include Decidim::Endorsable
       include Decidim::Followable
@@ -39,16 +39,6 @@ module Decidim
         participatory_space.try(:visible?) && component.try(:published?)
       end
 
-      # Public: Overrides the `commentable?` Commentable concern method.
-      def commentable?
-        component.settings.comments_enabled?
-      end
-
-      # Public: Overrides the `accepts_new_comments?` Commentable concern method.
-      def accepts_new_comments?
-        commentable? && !component.current_settings.comments_blocked
-      end
-
       # Public: Overrides the `comments_have_alignment?` Commentable concern method.
       def comments_have_alignment?
         true
@@ -61,11 +51,6 @@ module Decidim
 
       def official?
         author.nil?
-      end
-
-      # Public: Whether the object can have new comments or not.
-      def user_allowed_to_comment?(user)
-        can_participate_in_space?(user)
       end
 
       def users_to_notify_on_comment_created

--- a/decidim-blogs/app/models/decidim/blogs/post.rb
+++ b/decidim-blogs/app/models/decidim/blogs/post.rb
@@ -49,6 +49,11 @@ module Decidim
         true
       end
 
+      # Public: Overrides the `allow_resource_permissions?` Resourceable concern method.
+      def allow_resource_permissions?
+        true
+      end
+
       def official?
         author.nil?
       end

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
@@ -47,6 +47,8 @@
                   <%= icon_link_to "paperclip", post_attachments_path(post), t("actions.attachments", scope: "decidim.meetings"), class: "action-icon--attachments" %>
                 <% end %>
 
+                <%= resource_permissions_link(post) %>
+
                 <% if allowed_to? :destroy, :blogpost, blog_post: post %>
                   <%= icon_link_to "circle-x", post_path(post), t("actions.destroy", scope: "decidim.blogs"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.blogs") } %>
                 <% end %>

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -60,6 +60,8 @@ en:
       read_more: Read more
     components:
       blogs:
+        actions:
+          comment: Comment
         name: Blog
         settings:
           global:

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -61,7 +61,10 @@ en:
     components:
       blogs:
         actions:
+          amend: Amend
           comment: Comment
+          endorse: Endorse
+          vote: Vote
         name: Blog
         settings:
           global:

--- a/decidim-blogs/lib/decidim/blogs/component.rb
+++ b/decidim-blogs/lib/decidim/blogs/component.rb
@@ -18,7 +18,7 @@ Decidim.register_component(:blogs) do |component|
     Decidim::Blogs::Post.where(component: components).count
   end
 
-  component.actions = %w(endorse vote create withdraw amend)
+  component.actions = %w(endorse vote create withdraw amend comment)
 
   component.settings(:global) do |settings|
     settings.attribute :announcement, type: :text, translated: true, editor: true
@@ -36,7 +36,7 @@ Decidim.register_component(:blogs) do |component|
   component.register_resource(:blogpost) do |resource|
     resource.model_class_name = "Decidim::Blogs::Post"
     resource.card = "decidim/blogs/post"
-    resource.actions = %w(endorse vote amend)
+    resource.actions = %w(endorse vote amend comment)
     resource.searchable = true
   end
 

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -234,6 +234,7 @@ en:
     components:
       budgets:
         actions:
+          comment: Comment
           vote: Vote
         name: Budgets
         settings:

--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -16,7 +16,7 @@ Decidim.register_component(:budgets) do |component|
 
   component.query_type = "Decidim::Budgets::BudgetsType"
 
-  component.actions = %(vote)
+  component.actions = %w(vote comment)
 
   component.on(:before_destroy) do |instance|
     raise StandardError, "Can't remove this component" if Decidim::Budgets::Budget.where(component: instance).any?
@@ -32,7 +32,7 @@ Decidim.register_component(:budgets) do |component|
     resource.model_class_name = "Decidim::Budgets::Project"
     resource.template = "decidim/budgets/projects/linked_projects"
     resource.card = "decidim/budgets/project"
-    resource.actions = %(vote)
+    resource.actions = %w(vote comment)
     resource.searchable = true
   end
 

--- a/decidim-comments/app/cells/decidim/comments/comments_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comments_cell.rb
@@ -142,7 +142,12 @@ module Decidim
       end
 
       def blocked_comments_for_unauthorized_user_warning_link
-        action_authorized_link_to(:comment, commentable_path, { resource: model }) do
+        options = if current_component.present?
+                    { resource: model }
+                  else
+                    { resource: model, permissions_holder: model }
+                  end
+        action_authorized_link_to(:comment, commentable_path, options) do
           t("decidim.components.comments.blocked_comments_for_unauthorized_user_warning")
         end
       end

--- a/decidim-comments/lib/decidim/comments.rb
+++ b/decidim-comments/lib/decidim/comments.rb
@@ -12,6 +12,7 @@ module Decidim
   module Comments
     autoload :CommentsHelper, "decidim/comments/comments_helper"
     autoload :Commentable, "decidim/comments/commentable"
+    autoload :CommentableWithComponent, "decidim/comments/commentable_with_component"
     autoload :CommentSerializer, "decidim/comments/comment_serializer"
     autoload :CommentVoteSerializer, "decidim/comments/comment_vote_serializer"
     autoload :Export, "decidim/comments/export"

--- a/decidim-comments/lib/decidim/comments/commentable_with_component.rb
+++ b/decidim-comments/lib/decidim/comments/commentable_with_component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Comments
+    # Commentable overriding some methods to include settings and
+    # authorizations given by a component the resource belongs to
+    module CommentableWithComponent
+      extend ActiveSupport::Concern
+      include Decidim::Comments::Commentable
+
+      included do
+        # Public: Overrides the `commentable?` Commentable concern method.
+        def commentable?
+          component.settings.comments_enabled?
+        end
+
+        # Public: Overrides the `accepts_new_comments?` Commentable concern method.
+        def accepts_new_comments?
+          commentable? && !component.current_settings.comments_blocked
+        end
+
+        # Public: Whether the object can have new comments or not.
+        def user_allowed_to_comment?(user)
+          return unless can_participate?(user)
+
+          ActionAuthorizer.new(user, "comment", component, self).authorize.ok?
+        end
+      end
+    end
+  end
+end

--- a/decidim-consultations/app/models/decidim/consultations/question.rb
+++ b/decidim-consultations/app/models/decidim/consultations/question.rb
@@ -201,6 +201,14 @@ module Decidim
         true
       end
 
+      def user_allowed_to_comment?(user)
+        ActionAuthorizer.new(user, "comment", self, nil).authorize.ok?
+      end
+
+      def component
+        nil
+      end
+
       def attachment_context
         :admin
       end

--- a/decidim-consultations/config/locales/en.yml
+++ b/decidim-consultations/config/locales/en.yml
@@ -360,6 +360,7 @@ en:
     resources:
       consultations:
         actions:
+          comment: Comment
           vote: Vote
     statistics:
       consultations_count: Consultations

--- a/decidim-consultations/lib/decidim/consultations/participatory_space.rb
+++ b/decidim-consultations/lib/decidim/consultations/participatory_space.rb
@@ -31,7 +31,7 @@ Decidim.register_participatory_space(:consultations) do |participatory_space|
 
   participatory_space.register_resource(:question) do |resource|
     resource.model_class_name = "Decidim::Consultations::Question"
-    resource.actions = %w(vote)
+    resource.actions = %w(vote comment)
   end
 
   participatory_space.seeds do

--- a/decidim-core/app/controllers/decidim/free_resource_authorization_modals_controller.rb
+++ b/decidim-core/app/controllers/decidim/free_resource_authorization_modals_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  class FreeResourceAuthorizationModalsController < Decidim::ApplicationController
+    helper_method :authorizations, :authorize_action_path
+    layout false
+
+    def show
+      render template: "decidim/authorization_modals/show"
+    end
+
+    private
+
+    def resource
+      @resource ||= if params[:resource_name] && params[:resource_id]
+                      manifest = Decidim.find_resource_manifest(params[:resource_name])
+                      manifest&.model_class&.find_by(id: params[:resource_id])
+                    end
+    end
+
+    def authorization_action
+      @authorization_action ||= params[:authorization_action]
+    end
+
+    def authorize_action_path(handler_name)
+      authorizations.status_for(handler_name).current_path(redirect_url: URI(request.referer).path)
+    end
+
+    def authorizations
+      @authorizations ||= action_authorized_to(authorization_action, resource: nil, permissions_holder: resource)
+    end
+  end
+end

--- a/decidim-core/app/helpers/decidim/action_authorization_helper.rb
+++ b/decidim-core/app/helpers/decidim/action_authorization_helper.rb
@@ -64,13 +64,14 @@ module Decidim
 
       html_options ||= {}
       resource = html_options.delete(:resource)
+      permissions_holder = html_options.delete(:permissions_holder)
 
       if !current_user
         html_options = clean_authorized_to_data_open(html_options)
 
         html_options["data-open"] = "loginModal"
         url = "#"
-      elsif action && !action_authorized_to(action, resource: resource).ok?
+      elsif action && !action_authorized_to(action, resource: resource, permissions_holder: permissions_holder).ok?
         html_options = clean_authorized_to_data_open(html_options)
 
         html_options["data-open"] = "authorizationModal"

--- a/decidim-core/app/helpers/decidim/action_authorization_helper.rb
+++ b/decidim-core/app/helpers/decidim/action_authorization_helper.rb
@@ -95,7 +95,11 @@ module Decidim
                         else
                           {}
                         end
-      decidim.authorization_modal_path(authorization_action: action, component_id: current_component.id, **resource_params)
+      if current_component.present?
+        decidim.authorization_modal_path(authorization_action: action, component_id: current_component&.id, **resource_params)
+      else
+        decidim.free_resource_authorization_modal_path(authorization_action: action, **resource_params)
+      end
     end
 
     def clean_authorized_to_data_open(html_options)

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -70,6 +70,11 @@ Decidim::Core::Engine.routes.draw do
     resource :user_interests, only: [:show, :update]
 
     get "/authorization_modals/:authorization_action/f/:component_id(/:resource_name/:resource_id)", to: "authorization_modals#show", as: :authorization_modal
+    get(
+      "/free_resource_authorization_modals/:authorization_action/f/:resource_name/:resource_id",
+      to: "free_resource_authorization_modals#show",
+      as: :free_resource_authorization_modal
+    )
 
     resources :groups, except: [:destroy, :index, :show] do
       resources :join_requests, only: [:create, :update, :destroy], controller: "user_group_join_requests"

--- a/decidim-core/lib/decidim/action_authorization.rb
+++ b/decidim-core/lib/decidim/action_authorization.rb
@@ -23,7 +23,7 @@ module Decidim
 
     def action_authorization_cache_key(action, resource, permissions_holder = nil)
       if resource && !resource.permissions.nil?
-        "#{action}-#{resource.component.id}-#{resource.resource_manifest.name}-#{resource.id}"
+        "#{action}-#{resource.component&.id}-#{resource.resource_manifest.name}-#{resource.id}"
       elsif resource && permissions_holder
         "#{action}-#{permissions_holder.class.name}-#{permissions_holder.id}-#{resource.resource_manifest.name}-#{resource.id}"
       elsif permissions_holder

--- a/decidim-core/lib/decidim/resource_manifest.rb
+++ b/decidim-core/lib/decidim/resource_manifest.rb
@@ -53,6 +53,10 @@ module Decidim
     # as well that allows checking for those permissions.
     attribute :actions, Array[String]
 
+    # The name of the class that handles the permissions for this resource. It will
+    # probably have the form of `Decidim::<MyComponent>::Permissions`.
+    attribute :permissions_class_name, String, default: "Decidim::DefaultPermissions"
+
     validates :model_class_name, :route_name, :name, presence: true
 
     # Finds an ActiveRecord::Relation of the resource `model_class`, scoped to the
@@ -78,6 +82,15 @@ module Decidim
     # Returns a class.
     def model_class
       model_class_name.constantize
+    end
+
+    # Public: Finds the permission class from its name, using the
+    # `permissions_class_name` attribute. If the class does not exist,
+    # it raises an exception. If the class name is not set, it returns nil.
+    #
+    # Returns a Class.
+    def permissions_class
+      permissions_class_name&.constantize
     end
 
     # The name of the named Rails route to create the url to the resource.

--- a/decidim-core/spec/helpers/decidim/action_authorization_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/action_authorization_helper_spec.rb
@@ -6,6 +6,7 @@ module Decidim
   describe ActionAuthorizationHelper do
     let(:component) { create(:component) }
     let(:resource) { nil }
+    let(:permissions_holder) { nil }
     let(:user) { create(:user) }
     let(:action) { "foo" }
     let(:status) { double(ok?: authorized) }
@@ -17,7 +18,7 @@ module Decidim
     before do
       allow(helper).to receive(:current_component).and_return(component)
       allow(helper).to receive(:current_user).and_return(user)
-      allow(helper).to receive(:action_authorized_to).with(action, resource: resource).and_return(status)
+      allow(helper).to receive(:action_authorized_to).with(action, resource: resource, permissions_holder: permissions_holder).and_return(status)
     end
 
     shared_examples "an action authorization widget helper" do |params|

--- a/decidim-core/spec/helpers/decidim/action_authorization_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/action_authorization_helper_spec.rb
@@ -43,6 +43,19 @@ module Decidim
               expect(subject).to include(*params[:widget_parts])
             end
           end
+
+          context "when called with no component and permissions_holder" do
+            let(:component) { nil }
+            let(:resource) { create(:dummy_resource) }
+            let(:permissions_holder) { resource }
+
+            it "renders a widget toggling the authorization modal of free resources not related with a component" do
+              expect(subject).not_to include(path)
+              expect(subject).to include('data-open="authorizationModal"')
+              expect(subject).to include("data-open-url=\"/free_resource_authorization_modals/#{action}/f/#{resource.resource_manifest.name}/#{resource.id}\"")
+              expect(subject).to include(*params[:widget_parts])
+            end
+          end
         end
 
       else
@@ -70,13 +83,13 @@ module Decidim
 
     describe "action_authorized_link_to" do
       context "when called with text" do
-        subject(:rendered) { helper.action_authorized_link_to(action, widget_text, path, resource: resource) }
+        subject(:rendered) { helper.action_authorized_link_to(action, widget_text, path, resource: resource, permissions_holder: permissions_holder) }
 
         it_behaves_like "an action authorization widget helper", has_action: true, widget_parts: %w(<a)
       end
 
       context "when called with a block" do
-        subject(:rendered) { helper.action_authorized_link_to(action, path, resource: resource) { widget_text } }
+        subject(:rendered) { helper.action_authorized_link_to(action, path, resource: resource, permissions_holder: permissions_holder) { widget_text } }
 
         it_behaves_like "an action authorization widget helper", has_action: true, widget_parts: %w(<a)
       end
@@ -84,13 +97,13 @@ module Decidim
 
     describe "action_authorized_button_to" do
       context "when called with text" do
-        subject(:rendered) { helper.action_authorized_button_to(action, widget_text, path, resource: resource) }
+        subject(:rendered) { helper.action_authorized_button_to(action, widget_text, path, resource: resource, permissions_holder: permissions_holder) }
 
         it_behaves_like "an action authorization widget helper", has_action: true, widget_parts: %w(<input type="submit")
       end
 
       context "when called with a block" do
-        subject(:rendered) { helper.action_authorized_button_to(action, path, resource: resource) { widget_text } }
+        subject(:rendered) { helper.action_authorized_button_to(action, path, resource: resource, permissions_holder: permissions_holder) { widget_text } }
 
         it_behaves_like "an action authorization widget helper", has_action: true, widget_parts: %w(<button type="submit")
       end

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -10,7 +10,7 @@ module Decidim
       include Decidim::HasCategory
       include Decidim::Resourceable
       include Decidim::Followable
-      include Decidim::Comments::Commentable
+      include Decidim::Comments::CommentableWithComponent
       include Decidim::ScopableResource
       include Decidim::Authorable
       include Decidim::Reportable
@@ -96,11 +96,6 @@ module Decidim
         (ama? && open_ama?) || !ama?
       end
 
-      # Public: Overrides the `commentable?` Commentable concern method.
-      def commentable?
-        component.settings.comments_enabled?
-      end
-
       # Public: Overrides the `accepts_new_comments?` Commentable concern method.
       def accepts_new_comments?
         return false unless open?
@@ -133,11 +128,6 @@ module Decidim
 
       def self.export_serializer
         Decidim::Debates::DataPortabilityDebateSerializer
-      end
-
-      # Public: Whether the object can have new comments or not.
-      def user_allowed_to_comment?(user)
-        can_participate_in_space?(user)
       end
 
       def self.newsletter_participant_ids(component)

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -126,6 +126,11 @@ module Decidim
         followers
       end
 
+      # Public: Overrides the `allow_resource_permissions?` Resourceable concern method.
+      def allow_resource_permissions?
+        true
+      end
+
       def self.export_serializer
         Decidim::Debates::DataPortabilityDebateSerializer
       end

--- a/decidim-debates/app/views/decidim/debates/admin/debates/index.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/index.html.erb
@@ -51,6 +51,8 @@
                   <span class="action-space icon"></span>
                 <% end %>
 
+                <%= resource_permissions_link(debate) %>
+
                 <% if allowed_to? :delete, :debate, debate: debate %>
                   <%= icon_link_to "circle-x", debate_path(debate), t("actions.destroy", scope: "decidim.debates"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.debates") } %>
                 <% else %>

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
     components:
       debates:
         actions:
+          comment: Comment
           create: Create
           endorse: Endorse
         name: Debates

--- a/decidim-debates/lib/decidim/debates/component.rb
+++ b/decidim-debates/lib/decidim/debates/component.rb
@@ -52,10 +52,10 @@ Decidim.register_component(:debates) do |component|
     resource.card = "decidim/debates/debate"
     resource.reported_content_cell = "decidim/debates/reported_content"
     resource.searchable = true
-    resource.actions = %w(create endorse)
+    resource.actions = %w(create endorse comment)
   end
 
-  component.actions = %w(create endorse)
+  component.actions = %w(create endorse comment)
 
   component.exports :comments do |exports|
     exports.collection do |component_instance|

--- a/decidim-initiatives/app/controllers/concerns/decidim/initiatives/admin/initiative_admin.rb
+++ b/decidim-initiatives/app/controllers/concerns/decidim/initiatives/admin/initiative_admin.rb
@@ -19,6 +19,13 @@ module Decidim
           participatory_space_admin_layout
 
           alias_method :current_participatory_space, :current_initiative
+          alias_method :current_participatory_space_manifest, :initiatives_manifest
+        end
+
+        private
+
+        def initiatives_manifest
+          @initiatives_manifest ||= Decidim.find_participatory_space_manifest(:initiatives)
         end
       end
     end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -12,6 +12,7 @@ module Decidim
         include Decidim::Initiatives::TypeSelectorOptions
         include Decidim::Initiatives::Admin::Filterable
 
+        helper ::Decidim::Admin::ResourcePermissionsHelper
         helper Decidim::Initiatives::InitiativeHelper
         helper Decidim::Initiatives::CreateInitiativeHelper
 

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_permissions_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_permissions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      # Controller that allows managing initiatives
+      # permissions in the admin panel.
+      class InitiativesPermissionsController < Decidim::Admin::ResourcePermissionsController
+        include Decidim::Initiatives::NeedsInitiative
+
+        layout "decidim/admin/initiatives"
+
+        register_permissions(::Decidim::Initiatives::Admin::InitiativesPermissionsController,
+                             ::Decidim::Initiatives::Permissions,
+                             ::Decidim::Admin::Permissions)
+
+        def resource
+          current_initiative
+        end
+
+        def permission_class_chain
+          ::Decidim.permissions_registry.chain_for(::Decidim::Initiatives::Admin::InitiativesPermissionsController)
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -114,6 +114,10 @@ module Decidim
         @current_participatory_space ||= Initiative.find_by(id: id_from_slug(params[:slug]))
       end
 
+      def current_participatory_space_manifest
+        @current_participatory_space_manifest ||= Decidim.find_participatory_space_manifest(:initiatives)
+      end
+
       def initiatives
         @initiatives = search.results.includes(:scoped_type)
         @initiatives = reorder(@initiatives)

--- a/decidim-initiatives/app/controllers/decidim/initiatives/versions_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/versions_controller.rb
@@ -15,6 +15,12 @@ module Decidim
       def versioned_resource
         current_initiative
       end
+
+      private
+
+      def current_participatory_space_manifest
+        @current_participatory_space_manifest ||= Decidim.find_participatory_space_manifest(:initiatives)
+      end
     end
   end
 end

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -434,6 +434,14 @@ module Decidim
       true
     end
 
+    def user_allowed_to_comment?(user)
+      ActionAuthorizer.new(user, "comment", self, nil).authorize.ok?
+    end
+
+    def component
+      nil
+    end
+
     private
 
     # Private: This is just an alias because the naming on InitiativeTypeScope

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -21,6 +21,7 @@ module Decidim
     include Decidim::Searchable
     include Decidim::Initiatives::HasArea
     include Decidim::TranslatableResource
+    include Decidim::HasResourcePermission
 
     translatable_fields :title, :description, :answer
 
@@ -426,6 +427,11 @@ module Decidim
     # implement this interface.
     def user_role_config_for(_user, _role_name)
       Decidim::ParticipatorySpaceRoleConfig::Base.new(:empty_role_name)
+    end
+
+    # Public: Overrides the `allow_resource_permissions?` Resourceable concern method.
+    def allow_resource_permissions?
+      true
     end
 
     private

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -74,6 +74,7 @@
               <% else %>
                 <span class="action-space icon"></span>
               <% end %>
+              <%= free_resource_permissions_link(initiative) || content_tag(:span, nil, class: "action-space icon") %>
             </td>
         <% end %>
         </tbody>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -580,6 +580,9 @@ en:
     menu:
       initiatives: Initiatives
     resources:
+      initiative:
+        actions:
+          comment: Comment
       initiatives_type:
         actions:
           title: Actions

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -44,6 +44,8 @@ module Decidim
             end
           end
 
+          resource :permissions, controller: "initiatives_permissions"
+
           resource :answer, only: [:edit, :update]
         end
 

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -21,6 +21,7 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
   participatory_space.query_type = "Decidim::Initiatives::InitiativeType"
 
   participatory_space.register_resource(:initiative) do |resource|
+    resource.actions = %w(comment)
     resource.model_class_name = "Decidim::Initiative"
     resource.card = "decidim/initiatives/initiative"
     resource.searchable = true

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -22,6 +22,7 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
 
   participatory_space.register_resource(:initiative) do |resource|
     resource.actions = %w(comment)
+    resource.permissions_class_name = "Decidim::Initiatives::Permissions"
     resource.model_class_name = "Decidim::Initiative"
     resource.card = "decidim/initiatives/initiative"
     resource.searchable = true

--- a/decidim-initiatives/spec/shared/manage_resource_permissions_examples.rb
+++ b/decidim-initiatives/spec/shared/manage_resource_permissions_examples.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+shared_examples "manage resource permissions" do
+  context "when managing resource permissions" do
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit edit_resource_permissions_path
+    end
+
+    it "shows the resource permissions settings" do
+      expect(page).to have_content(translated(resource.title))
+    end
+
+    context "when setting permissions" do
+      it "saves permission settings for the resource" do
+        within "form.new_component_permissions" do
+          within ".#{action}-permission" do
+            check "Example authorization (Direct)"
+            fill_in "Allowed postal codes", with: "08002"
+          end
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("Permissions updated successfully.")
+
+        expect(resource.reload.permissions[action]).to(
+          include(
+            "authorization_handlers" => {
+              "dummy_authorization_handler" => {
+                "options" => { "allowed_postal_codes" => "08002" }
+              }
+            }
+          )
+        )
+      end
+    end
+
+    context "when unsetting permissions" do
+      before do
+        resource.create_resource_permission(
+          permissions: {
+            action => {
+              "authorization_handlers" => {
+                "dummy_authorization_handler" => {
+                  "options" => { "allowed_postal_codes" => "08002" }
+                }
+              }
+            }
+          }
+        )
+
+        visit edit_resource_permissions_path
+      end
+
+      it "removes the action from the permissions hash" do
+        within "form.new_component_permissions" do
+          within ".#{action}-permission" do
+            uncheck "Example authorization (Direct)"
+            uncheck "Another example authorization (Direct)"
+          end
+
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("Permissions updated successfully.")
+
+        expect(resource.reload.permissions[action]).to be_nil
+      end
+    end
+
+    context "when changing existing permissions" do
+      before do
+        resource.create_resource_permission(
+          permissions: {
+            action => {
+              "authorization_handlers" => {
+                "dummy_authorization_handler" => {
+                  "options" => { "allowed_postal_codes" => "08002" }
+                }
+              }
+            }
+          }
+        )
+
+        visit edit_resource_permissions_path
+      end
+
+      it "changes the configured action in the resource permissions hash" do
+        within "form.new_component_permissions" do
+          within ".#{action}-permission" do
+            uncheck "Example authorization (Direct)"
+            check "Another example authorization (Direct)"
+            fill_in "Passport number", with: "AXXXXXXXX"
+          end
+
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("Permissions updated successfully.")
+
+        expect(resource.reload.permissions[action]).to(
+          include(
+            "authorization_handlers" => {
+              "another_dummy_authorization_handler" => {
+                "options" => { "passport_number" => "AXXXXXXXX" }
+              }
+            }
+          )
+        )
+      end
+
+      it "adds an authorization to the configured action in the resource permissions hash" do
+        within "form.new_component_permissions" do
+          within ".#{action}-permission" do
+            check "Another example authorization (Direct)"
+            fill_in "Passport number", with: "AXXXXXXXX"
+          end
+
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("Permissions updated successfully.")
+
+        expect(resource.reload.permissions[action]).to(
+          include(
+            "authorization_handlers" => {
+              "dummy_authorization_handler" => {
+                "options" => { "allowed_postal_codes" => "08002" }
+              },
+              "another_dummy_authorization_handler" => {
+                "options" => { "passport_number" => "AXXXXXXXX" }
+              }
+            }
+          )
+        )
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_permissions_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_permissions_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+# require "decidim/admin/test/manage_component_permissions_examples"
+
+# We should ideally be using the shared_context for this, but it assumes the
+# resource belongs to a component, which is not the case.
+describe "Admin manages initiative permissions", type: :system do
+  let(:organization) do
+    create(
+      :organization,
+      available_authorizations: %w(dummy_authorization_handler another_dummy_authorization_handler)
+    )
+  end
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:participatory_space_engine) { decidim_admin_initiatives }
+  let!(:initiative_type) { create(:initiatives_type, :online_signature_enabled, organization: organization) }
+  let!(:scoped_type) { create(:initiatives_type_scope, type: initiative_type) }
+  let(:initiative) { create(:initiative, :published, author: author, scoped_type: scoped_type, organization: organization) }
+  let!(:author) { create(:user, :confirmed, organization: organization) }
+
+  let(:action) { "comment" }
+
+  let(:index_path) do
+    participatory_space_engine.initiatives_path
+  end
+  let(:edit_resource_permissions_path) do
+    participatory_space_engine
+      .edit_initiative_permissions_path(
+        initiative,
+        resource_name: initiative.resource_manifest.name
+      )
+  end
+  let(:index_class_selector) { ".initiative-#{initiative.id}" }
+  let(:resource) { initiative }
+
+  it_behaves_like "manage resource permissions"
+end

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_type_permissions_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_type_permissions_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "decidim/admin/test/manage_component_permissions_examples"
 
 # We should ideally be using the shared_context for this, but it assumes the
 # resource belongs to a component, which is not the case.
@@ -21,150 +20,15 @@ describe "Admin manages initiative type permissions", type: :system do
   let(:index_path) do
     participatory_space_engine.initiatives_types_path
   end
-  let(:index_class_selector) { ".initiative-type-#{initiative_type.id}" }
-
-  context "when managing resource permissions" do
-    let(:edit_resource_permissions_path) do
-      participatory_space_engine
-        .edit_initiatives_type_permissions_path(
-          initiative_type.id,
-          resource_name: initiative_type.resource_manifest.name
-        )
-    end
-
-    before do
-      switch_to_host(organization.host)
-      login_as user, scope: :user
-      visit edit_resource_permissions_path
-    end
-
-    it "shows the resource permissions settings" do
-      expect(page).to have_content(translated(initiative_type.title))
-    end
-
-    context "when setting permissions" do
-      it "saves permission settings for the resource" do
-        within "form.new_component_permissions" do
-          within ".#{action}-permission" do
-            check "Example authorization (Direct)"
-            fill_in "Allowed postal codes", with: "08002"
-          end
-          find("*[type=submit]").click
-        end
-
-        expect(page).to have_content("Permissions updated successfully.")
-
-        expect(initiative_type.reload.permissions[action]).to(
-          include(
-            "authorization_handlers" => {
-              "dummy_authorization_handler" => {
-                "options" => { "allowed_postal_codes" => "08002" }
-              }
-            }
-          )
-        )
-      end
-    end
-
-    context "when unsetting permissions" do
-      before do
-        initiative_type.create_resource_permission(
-          permissions: {
-            action => {
-              "authorization_handlers" => {
-                "dummy_authorization_handler" => {
-                  "options" => { "allowed_postal_codes" => "08002" }
-                }
-              }
-            }
-          }
-        )
-
-        visit edit_resource_permissions_path
-      end
-
-      it "removes the action from the permissions hash" do
-        within "form.new_component_permissions" do
-          within ".#{action}-permission" do
-            uncheck "Example authorization (Direct)"
-            uncheck "Another example authorization (Direct)"
-          end
-
-          find("*[type=submit]").click
-        end
-
-        expect(page).to have_content("Permissions updated successfully.")
-
-        expect(initiative_type.reload.permissions[action]).to be_nil
-      end
-    end
-
-    context "when changing existing permissions" do
-      before do
-        initiative_type.create_resource_permission(
-          permissions: {
-            action => {
-              "authorization_handlers" => {
-                "dummy_authorization_handler" => {
-                  "options" => { "allowed_postal_codes" => "08002" }
-                }
-              }
-            }
-          }
-        )
-
-        visit edit_resource_permissions_path
-      end
-
-      it "changes the configured action in the resource permissions hash" do
-        within "form.new_component_permissions" do
-          within ".#{action}-permission" do
-            uncheck "Example authorization (Direct)"
-            check "Another example authorization (Direct)"
-            fill_in "Passport number", with: "AXXXXXXXX"
-          end
-
-          find("*[type=submit]").click
-        end
-
-        expect(page).to have_content("Permissions updated successfully.")
-
-        expect(initiative_type.reload.permissions[action]).to(
-          include(
-            "authorization_handlers" => {
-              "another_dummy_authorization_handler" => {
-                "options" => { "passport_number" => "AXXXXXXXX" }
-              }
-            }
-          )
-        )
-      end
-
-      it "adds an authorization to the configured action in the resource permissions hash" do
-        within "form.new_component_permissions" do
-          within ".#{action}-permission" do
-            check "Another example authorization (Direct)"
-            fill_in "Passport number", with: "AXXXXXXXX"
-          end
-
-          find("*[type=submit]").click
-        end
-
-        expect(page).to have_content("Permissions updated successfully.")
-
-        expect(initiative_type.reload.permissions[action]).to(
-          include(
-            "authorization_handlers" => {
-              "dummy_authorization_handler" => {
-                "options" => { "allowed_postal_codes" => "08002" }
-              },
-              "another_dummy_authorization_handler" => {
-                "options" => { "passport_number" => "AXXXXXXXX" }
-              }
-            }
-          )
-        )
-      end
-    end
+  let(:edit_resource_permissions_path) do
+    participatory_space_engine
+      .edit_initiatives_type_permissions_path(
+        initiative_type.id,
+        resource_name: initiative_type.resource_manifest.name
+      )
   end
+  let(:index_class_selector) { ".initiative-type-#{initiative_type.id}" }
+  let(:resource) { initiative_type }
+
+  it_behaves_like "manage resource permissions"
 end

--- a/decidim-initiatives/spec/system/authorized_comments_spec.rb
+++ b/decidim-initiatives/spec/system/authorized_comments_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Authorized comments", type: :system do
+  let!(:initiative_type) { create(:initiatives_type, :online_signature_enabled, organization: organization) }
+  let!(:scoped_type) { create(:initiatives_type_scope, type: initiative_type) }
+  let(:commentable) { create(:initiative, :published, author: author, scoped_type: scoped_type, organization: organization) }
+  let!(:author) { create(:user, :confirmed, organization: organization) }
+  let!(:user) { create(:user, :confirmed, organization: organization) }
+  let!(:comments) { create_list(:comment, 3, commentable: commentable) }
+  let!(:authorization_handler_name) { "dummy_authorization_handler" }
+  let!(:organization) { create(:organization, available_authorizations: available_authorizations) }
+  let!(:available_authorizations) { [authorization_handler_name] }
+
+  let(:resource_path) { resource_locator(commentable).path }
+
+  after do
+    expect_no_js_errors
+  end
+
+  before do
+    switch_to_host(organization.host)
+    sign_in user
+  end
+
+  shared_examples_for "allowed to comment" do
+    it do
+      expect(page).to have_no_content("You need to be verified to comment at this moment")
+      expect(page).to have_selector("form.new_comment")
+    end
+  end
+
+  shared_examples_for "not allowed to comment" do
+    it do
+      expect(page).to have_content("You need to be verified to comment at this moment")
+      click_link("You need to be verified to comment at this moment")
+      expect(page).to have_content("Authorization required")
+      expect(page).to have_link("Authorize with \"Example authorization\"")
+      click_link("Authorize with \"Example authorization\"")
+      expect(page).to have_content("Verify with Example authorization")
+    end
+  end
+
+  context "when the initiative has no restriction on commenting" do
+    before do
+      visit resource_path
+    end
+
+    it_behaves_like "allowed to comment"
+  end
+
+  context "when the initiative has restrictions on commenting" do
+    let!(:resource_permission) { commentable.create_resource_permission(permissions: permissions) }
+    let(:comment_permission) do
+      { comment: authorization_handlers }
+    end
+    let(:authorization_handlers) do
+      { authorization_handlers: { authorization_handler_name => { "options" => {} } } }
+    end
+
+    before do
+      authorization
+      visit resource_path
+    end
+
+    context "and user is not verified" do
+      let(:authorization) { nil }
+
+      describe "restricted comment action" do
+        let(:permissions) { comment_permission }
+
+        it_behaves_like "not allowed to comment"
+      end
+    end
+
+    context "and user is verified" do
+      let(:authorization) { create(:authorization, user: user, name: "dummy_authorization_handler") }
+
+      describe "restricted comment action" do
+        let(:permissions) { comment_permission }
+
+        it_behaves_like "allowed to comment"
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -13,7 +13,7 @@ module Decidim
       include Decidim::ScopableResource
       include Decidim::HasCategory
       include Decidim::Followable
-      include Decidim::Comments::Commentable
+      include Decidim::Comments::CommentableWithComponent
       include Decidim::Searchable
       include Decidim::Traceable
       include Decidim::Loggable
@@ -171,16 +171,6 @@ module Decidim
         component.settings.maps_enabled?
       end
 
-      # Public: Overrides the `commentable?` Commentable concern method.
-      def commentable?
-        component.settings.comments_enabled?
-      end
-
-      # Public: Overrides the `accepts_new_comments?` Commentable concern method.
-      def accepts_new_comments?
-        commentable? && !component.current_settings.comments_blocked
-      end
-
       # Public: Overrides the `allow_resource_permissions?` Resourceable concern method.
       def allow_resource_permissions?
         component.settings.resources_permissions_enabled
@@ -199,11 +189,6 @@ module Decidim
       # Public: Override Commentable concern method `users_to_notify_on_comment_created`
       def users_to_notify_on_comment_created
         followers
-      end
-
-      # Public: Whether the object can have new comments or not.
-      def user_allowed_to_comment?(user)
-        can_participate?(user)
       end
 
       def can_participate?(user)

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -81,6 +81,7 @@ en:
     components:
       meetings:
         actions:
+          comment: Comment
           join: Join
         name: Meetings
         settings:

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -20,7 +20,7 @@ Decidim.register_component(:meetings) do |component|
     resource.template = "decidim/meetings/meetings/linked_meetings"
     resource.card = "decidim/meetings/meeting"
     resource.reported_content_cell = "decidim/meetings/reported_content"
-    resource.actions = %w(join)
+    resource.actions = %w(join comment)
     resource.searchable = true
   end
 
@@ -76,7 +76,7 @@ Decidim.register_component(:meetings) do |component|
     exports.serializer Decidim::Meetings::UserAnswersSerializer
   end
 
-  component.actions = %w(join)
+  component.actions = %w(join comment)
 
   component.settings(:global) do |settings|
     settings.attribute :scopes_enabled, type: :boolean, default: false

--- a/decidim-proposals/lib/decidim/proposals/commentable_proposal.rb
+++ b/decidim-proposals/lib/decidim/proposals/commentable_proposal.rb
@@ -5,19 +5,9 @@ module Decidim
     # The data store for a Proposal in the Decidim::Proposals component.
     module CommentableProposal
       extend ActiveSupport::Concern
-      include Decidim::Comments::Commentable
+      include Decidim::Comments::CommentableWithComponent
 
       included do
-        # Public: Overrides the `commentable?` Commentable concern method.
-        def commentable?
-          component.settings.comments_enabled?
-        end
-
-        # Public: Overrides the `accepts_new_comments?` Commentable concern method.
-        def accepts_new_comments?
-          commentable? && !component.current_settings.comments_blocked
-        end
-
         # Public: Overrides the `comments_have_alignment?` Commentable concern method.
         def comments_have_alignment?
           true
@@ -33,12 +23,6 @@ module Decidim
           return (followers | component.participatory_space.admins).uniq if official?
 
           followers
-        end
-
-        def user_allowed_to_comment?(user)
-          return unless can_participate_in_space?(user)
-
-          ActionAuthorizer.new(user, "comment", component, self).authorize.ok?
         end
 
         def user_allowed_to_vote_comment?(user)

--- a/decidim-sortitions/app/models/decidim/sortitions/sortition.rb
+++ b/decidim-sortitions/app/models/decidim/sortitions/sortition.rb
@@ -11,7 +11,7 @@ module Decidim
       include Decidim::HasReference
       include Decidim::Traceable
       include Decidim::Loggable
-      include Decidim::Comments::Commentable
+      include Decidim::Comments::CommentableWithComponent
       include Decidim::Randomable
       include Decidim::TranslatableResource
 
@@ -58,11 +58,6 @@ module Decidim
         cancelled_on.present?
       end
 
-      # Public: Overrides the `commentable?` Commentable concern method.
-      def commentable?
-        component.settings.comments_enabled?
-      end
-
       # Public: Overrides the `accepts_new_comments?` Commentable concern method.
       def accepts_new_comments?
         commentable?
@@ -76,11 +71,6 @@ module Decidim
       # Public: Overrides the `comments_have_votes?` Commentable concern method.
       def comments_have_votes?
         true
-      end
-
-      # Public: Whether the object can have new comments or not.
-      def user_allowed_to_comment?(user)
-        can_participate_in_space?(user)
       end
     end
   end

--- a/decidim-sortitions/app/models/decidim/sortitions/sortition.rb
+++ b/decidim-sortitions/app/models/decidim/sortitions/sortition.rb
@@ -72,6 +72,11 @@ module Decidim
       def comments_have_votes?
         true
       end
+
+      # Public: Overrides the `allow_resource_permissions?` Resourceable concern method.
+      def allow_resource_permissions?
+        true
+      end
     end
   end
 end

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
@@ -42,6 +42,8 @@
                 <span class="action-space icon"></span>
               <% end %>
 
+              <%= resource_permissions_link(sortition) %>
+
               <% if allowed_to? :destroy, :sortition, sortition: sortition %>
                 <%= icon_link_to "circle-x",
                                  confirm_destroy_sortition_path(sortition),

--- a/decidim-sortitions/config/locales/en.yml
+++ b/decidim-sortitions/config/locales/en.yml
@@ -20,6 +20,8 @@ en:
   decidim:
     components:
       sortitions:
+        actions:
+          comment: Comment
         name: Sortitions
         settings:
           global:

--- a/decidim-sortitions/lib/decidim/sortitions/component.rb
+++ b/decidim-sortitions/lib/decidim/sortitions/component.rb
@@ -13,7 +13,7 @@ Decidim.register_component(:sortitions) do |component|
   end
 
   # These actions permissions can be configured in the admin panel
-  component.actions = %w()
+  component.actions = %w(comment)
 
   component.settings(:global) do |settings|
     settings.attribute :comments_enabled, type: :boolean, default: true
@@ -25,6 +25,7 @@ Decidim.register_component(:sortitions) do |component|
     resource.model_class_name = "Decidim::Sortitions::Sortition"
     resource.template = "decidim/sortitions/sortitions/linked_sortitions"
     resource.card = "decidim/sortitions/sortition"
+    resource.actions = %w(comment)
   end
 
   component.register_stat :sortitions_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, start_at, end_at|


### PR DESCRIPTION
#### :tophat: What? Why?

This PR extends authorizations permissions system to comments on all commentable resources:
* For the commentable resources linked to components some of the logic has been extracted to a `CommentableWithComponent` concern and the comment action has been declared in their resource manifests.
* There are 2 other commentable resources not linked to components: `Decidim::Initiative` and `Decidim::Consultations::Question`. For them:
  * The PR creates the controller to manage permissions from admin for initiatives (on questions already exists)
  * Adds an authorization modal for resources not linked to components
  * Adapts ActionAuthorizationHelper to accept a permissions_holder argument which is used on resources without component and to return the previously defined modal path when component is not present
  * Defines a component method on initiatives and question models which returns a blank response to establish that they are resources not related to any component.
  * Overrides `current_participatory_space_manifest` used in some controllers of initiatives to return the participatory space manifest instead of a resource manifest
  * Allow definition of `permissions_class_name` in resources manifests as it is done in the manifests of the participatory spaces manifests.
* Adds tests

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #7726

#### Testing

From admin visit accountability, blogs, budgets, debates, meetings and sortitions components of a participatory space. The permissions icon should appear and the permissions for comment action should be available in the permissions modal.
The same from initiatives and questions of a consultation indexes.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

<img width="1164" alt="Screen Shot 2021-07-08 at 16 18 31" src="https://user-images.githubusercontent.com/446459/124938217-668fea80-e008-11eb-96e3-aa5e9dbd4766.png">
<img width="1154" alt="Screen Shot 2021-07-08 at 16 18 46" src="https://user-images.githubusercontent.com/446459/124938231-6a237180-e008-11eb-8d08-adcf5fd01239.png">
<img width="1161" alt="Screen Shot 2021-07-08 at 16 18 55" src="https://user-images.githubusercontent.com/446459/124938237-6b549e80-e008-11eb-9e56-df33dd82a76a.png">
<img width="1161" alt="Screen Shot 2021-07-08 at 16 19 06" src="https://user-images.githubusercontent.com/446459/124938241-6c85cb80-e008-11eb-80b6-93f29df5ca9b.png">
<img width="889" alt="Screen Shot 2021-07-08 at 16 19 21" src="https://user-images.githubusercontent.com/446459/124938252-6ee82580-e008-11eb-9756-b58d2f80886f.png">
<img width="876" alt="Screen Shot 2021-07-08 at 16 19 28" src="https://user-images.githubusercontent.com/446459/124938261-70b1e900-e008-11eb-8662-578cadf9338e.png">

:hearts: Thank you!
