### PR TITLE
Include resources on maps only when the geocoding got valid coords

### DIFF
--- a/decidim-core/app/helpers/decidim/map_helper.rb
+++ b/decidim-core/app/helpers/decidim/map_helper.rb
@@ -10,7 +10,7 @@ module Decidim
     # options - An optional hash of options (default: { zoom: 17 })
     #           * zoom: A number to represent the zoom value of the map
     def static_map_link(resource, options = {}, map_html_options = {}, &block)
-      return unless resource.geocoded?
+      return unless resource.geocoded_and_valid?
       return unless map_utility_static || map_utility_dynamic
 
       address_text = resource.try(:address)

--- a/decidim-core/lib/decidim/geocodable.rb
+++ b/decidim-core/lib/decidim/geocodable.rb
@@ -27,6 +27,10 @@ module Decidim
     included do
       include Geocoder::Store::ActiveRecord
 
+      def geocoded_and_valid?
+        geocoded? && to_coordinates.none?(&:nan?)
+      end
+
       private
 
       # rubocop:disable Style/OptionalBooleanParameter

--- a/decidim-core/spec/lib/geocodable_spec.rb
+++ b/decidim-core/spec/lib/geocodable_spec.rb
@@ -38,11 +38,29 @@ module Decidim
       expect(subject.latitude).to eq(latitude)
       expect(subject.longitude).to eq(longitude)
 
+      expect(subject).to be_geocoded
+      expect(subject).to be_geocoded_and_valid
+
       # Check that the calculations are correctly passed to the
       # `Geocoder::Calculations` module.
       expect(
         subject.distance_to([60.169857, 24.938379], :km)
       ).to eq(2728.962159915394)
+    end
+
+    context "when the address is invalid" do
+      let(:address) { "aaa" }
+      let(:latitude) { Float::NAN }
+      let(:longitude) { Float::NAN }
+
+      it "calls the Decidim geocoding utility and try to geocode the resource, but the result is [NaN,NaN]" do
+        subject.geocode
+        expect(subject.latitude).to be_nan
+        expect(subject.longitude).to be_nan
+
+        expect(subject).to be_geocoded
+        expect(subject).not_to be_geocoded_and_valid
+      end
     end
   end
 end

--- a/decidim-meetings/app/cells/decidim/meetings/meetings_map_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meetings_map_cell.rb
@@ -15,7 +15,7 @@ module Decidim
       end
 
       def geocoded_meetings
-        @geocoded_meetings ||= meetings.select(&:geocoded?)
+        @geocoded_meetings ||= meetings.select(&:geocoded_and_valid?)
       end
 
       def meetings

--- a/decidim-meetings/app/helpers/decidim/meetings/map_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/map_helper.rb
@@ -9,7 +9,7 @@ module Decidim
       #
       # meetings - A collection of meetings
       def meetings_data_for_map(meetings)
-        geocoded_meetings = meetings.select(&:geocoded?)
+        geocoded_meetings = meetings.select(&:geocoded_and_valid?)
         geocoded_meetings.map do |meeting|
           meeting.slice(:latitude, :longitude, :address).merge(title: translated_attribute(meeting.title),
                                                                description: html_truncate(translated_attribute(meeting.description), length: 200),

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
@@ -7,7 +7,7 @@ $meetingsCount.html('<%= j(render partial: "count").strip.html_safe %>');
 var $dropdownMenu = $('.dropdown.menu', $meetings);
 $dropdownMenu.foundation();
 
-var markerData = JSON.parse('<%= escape_javascript meetings_data_for_map(search.results.select(&:geocoded?)).to_json.html_safe %>');
+var markerData = JSON.parse('<%= escape_javascript meetings_data_for_map(search.results.select(&:geocoded_and_valid?)).to_json.html_safe %>');
 
 var $map = $("#map");
 var controller = $map.data("map-controller");

--- a/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
@@ -134,7 +134,7 @@ module Decidim
       end
 
       def geocoded_collaborative_draft
-        @geocoded_collaborative_draft ||= search.results.not_hidden.select(&:geocoded?)
+        @geocoded_collaborative_draft ||= search.results.not_hidden.select(&:geocoded_and_valid?)
       end
 
       def search_klass


### PR DESCRIPTION
#### :tophat: What? Why?
For in-person meetings, it is not allowed to leave the `address` field empty, or with a value that can't be located in the geocoding service database. But online meetings allow admins to leave it empty, and in that case the geocoding library stores `NaN` for the `longitude` and `latitude` fields. As these values are not `nil` or `false`, the `geocoded?` method returns `true`, even when those values are not valid. This results in the meetings map to raise a JS error and to appear completely empty, as explained in #7983.

This PR adds a new method `geocoded_and_valid?` that is used to avoid trying to paint the online meetings on the map. I didn't override the `geocoded?` method because it could be used by the library to try to geocode the meeting again if it returns `false`.

#### :pushpin: Related Issues
- Fixes #7983

#### Testing
1. Configure the maps service for Decidim
2. Add an in-person meeting and an online meeting to a `meetings` component
3. Go to the meetings component front page and check that the map shows the in-person meeting properly
