### PR TITLE
Add the map module to the admin styles

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_decidim.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_decidim.scss
@@ -13,6 +13,7 @@
 @import "stylesheets/decidim/admin/utils/flex";
 @import "stylesheets/decidim/admin/plugins/foundation-datepicker";
 @import "stylesheets/decidim/modules/data-picker";
+@import "stylesheets/decidim/modules/map";
 @import "stylesheets/decidim/admin/modules/modules";
 @import "stylesheets/decidim/admin/plugins/jquery.auto-complete";
 @import "stylesheets/decidim/admin/components/accordion";


### PR DESCRIPTION
#### :tophat: What? Why?
When static maps are displayed through Leaflet (which is the case when static maps are not available), the map squares in the admin panel are invisible.

This adds the map CSS to the admin panel to fix the issue.

#### :pushpin: Related Issues
- Related to #6340

#### Testing
- Enable maps
- Disable static maps service as described in the [maps configuration documentation](https://github.com/decidim/decidim/blob/develop/docs/modules/services/pages/maps.adoc#disabling-some-of-the-map-services)
- Go to the admin panel to see some record with a map position
- See that the map is not displayed

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Static map replacement in the admin panel](https://user-images.githubusercontent.com/864340/119353167-3afcaf00-bcab-11eb-95f5-d9329d7ee137.png)
