### PR TITLE
Fix attachment title migration generating possibly invalid values

### DIFF
--- a/decidim-participatory_processes/db/migrate/20201006072346_fix_attachments_titles.rb
+++ b/decidim-participatory_processes/db/migrate/20201006072346_fix_attachments_titles.rb
@@ -15,14 +15,11 @@ class FixAttachmentsTitles < ActiveRecord::Migration[5.2]
                  Decidim.default_locale
 
         # rubocop:disable Rails/SkipsModelValidations
-        attachment.update_columns(
-          title: {
-            locale => attachment.title
-          },
-          description: {
-            locale => attachment.description
-          }
-        )
+        values = {}
+        values[:title] = { locale => attachment.title } unless attachment.title.is_a?(Hash)
+        values[:description] = { locale => attachment.description } unless attachment.description.is_a?(Hash)
+
+        attachment.update_columns(values)
         # rubocop:enable Rails/SkipsModelValidations
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the fix from #8020 to 0.24.

#### :pushpin: Related Issues
- Related to #8020

#### Testing
See #8020

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.