### PR TITLE
Fix undetected broken tests because of missing dependencies

### DIFF
--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -14,6 +14,7 @@ on:
       - "decidim-admin/**"
       - "decidim-core/**"
       - "decidim-dev/**"
+      - "decidim-meetings/**"
       - "decidim-participatory_processes/**"
 
 env:

--- a/decidim-core/spec/services/decidim/open_data_exporter_spec.rb
+++ b/decidim-core/spec/services/decidim/open_data_exporter_spec.rb
@@ -135,7 +135,7 @@ describe Decidim::OpenDataExporter do
         let(:component) do
           create(:meeting_component, organization: organization, published_at: Time.current)
         end
-        let!(:meeting) { create(:meeting, component: component) }
+        let!(:meeting) { create(:meeting, :published, component: component) }
 
         before do
           subject.export

--- a/decidim-participatory_processes/decidim-participatory_processes.gemspec
+++ b/decidim-participatory_processes/decidim-participatory_processes.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "decidim-admin", Decidim::ParticipatoryProcesses.version
   s.add_development_dependency "decidim-dev", Decidim::ParticipatoryProcesses.version
+  s.add_development_dependency "decidim-meetings", Decidim::ParticipatoryProcesses.version
 end

--- a/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
@@ -257,8 +257,8 @@ describe "Participatory Process Groups", type: :system do
   context "when the meetings block is enabled" do
     let!(:meetings_component) { create(:component, :published, participatory_space: process, manifest_name: :meetings) }
     let!(:other_process_meetings_component) { create(:component, :published, participatory_space: other_process, manifest_name: :meetings) }
-    let!(:meeting_1) { create(:meeting, component: meetings_component, title: { en: "First awesome meeting!" }) }
-    let!(:meeting_2) { create(:meeting, component: other_process_meetings_component, title: { en: "Second fabulous meeting!" }) }
+    let!(:meeting_1) { create(:meeting, :published, component: meetings_component, title: { en: "First awesome meeting!" }) }
+    let!(:meeting_2) { create(:meeting, :published, component: other_process_meetings_component, title: { en: "Second fabulous meeting!" }) }
 
     before do
       create(
@@ -311,7 +311,7 @@ describe "Participatory Process Groups", type: :system do
       before do
         create_list(:proposal, 3, component: proposals_component)
         create_list(:proposal, 7, component: other_process_proposals_component)
-        create_list(:meeting, 4, component: other_process_meetings_component)
+        create_list(:meeting, 4, :published, component: other_process_meetings_component)
 
         # Set same coauthorships for all proposals
         Decidim::Proposals::Proposal.where(component: [proposals_component, other_process_proposals_component]).each do |proposal|


### PR DESCRIPTION
#### :tophat: What? Why?
After merging the PR #7893 two tests started to fail. This was because there were some missing dependencies between modules, so after some changes in the `decidim-meetings` module, not all the affected tests were executed.

On one hand, there is a dev dependency from `decidim-participatory_processes` to `decidim-meetings`. This problem was easily fixed adding the dependency to the `.gemspec` file.

The other dependency is a bit trickier. There is a dev dependency from `decidim-core` to many other modules (accountability, elections, meetings, proposals) to run [the open data tests](https://github.com/decidim/decidim/blob/develop/decidim-core/spec/services/decidim/open_data_exporter_spec.rb). In this case, add those dev dependencies to `decidim-core` would force all PRs to run almost all the tests. So, in this case, I just fixed the broken test, and we will have to move these tests to each module, to eliminate the need to add those dependencies.

#### :pushpin: Related Issues
- Related to #7893