### PR TITLE
Add missing tests for scope types admin page

### DIFF
--- a/decidim-admin/app/views/decidim/admin/scope_types/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scope_types/index.html.erb
@@ -1,7 +1,7 @@
-<div class="card">
+<div class="card" id="scope-types">
   <div class="card-divider">
     <% if allowed_to? :creste, :scope_type %>
-      <h2 class="card-title"><%= t "decidim.admin.titles.scope_types" %> <%= link_to t("actions.add", scope: "decidim.admin"), [:new, :scope_type], class: "button tiny button--title" %></h2>
+      <h2 class="card-title"><%= t "decidim.admin.titles.scope_types" %> <%= link_to t("actions.add", scope: "decidim.admin"), [:new, :scope_type], class: "button tiny button--title new" %></h2>
     <% end %>
   </div>
   <div class="card-section">

--- a/decidim-admin/spec/system/admin_manages_organization_scope_types_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_scope_types_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages scope types", type: :system do
+  let(:admin) { create :user, :admin, :confirmed }
+  let(:organization) { admin.organization }
+
+  before do
+    switch_to_host(organization.host)
+    login_as admin, scope: :user
+    visit decidim_admin.root_path
+    click_link "Settings"
+    click_link "Scope types"
+  end
+
+  it "can create new scope types" do
+    within ".card" do
+      find(".new").click
+    end
+
+    within ".new_scope_type" do
+      fill_in_i18n(
+        :scope_type_name,
+        "#scope_type-name-tabs",
+        en: "Territorial en",
+        es: "Territorial es",
+        ca: "Territorial ca"
+      )
+
+      fill_in_i18n(
+        :scope_type_plural,
+        "#scope_type-plural-tabs",
+        en: "Territorials en",
+        es: "Territoriales es",
+        ca: "Territorials ca"
+      )
+
+      find("*[type=submit]").click
+    end
+
+    expect(page).to have_admin_callout("successfully")
+
+    within "table" do
+      expect(page).to have_content("Territorial en")
+    end
+  end
+
+  context "with existing scope_types" do
+    let!(:scope_type) { create(:scope_type, organization: organization) }
+
+    before do
+      visit current_path
+    end
+
+    it "lists all the scope types for the organization" do
+      within "#scope-types table" do
+        expect(page).to have_content(translated(scope_type.name, locale: :en))
+      end
+    end
+
+    it "can edit them" do
+      within find("tr", text: translated(scope_type.name)) do
+        click_link "Edit"
+      end
+
+      within ".edit_scope_type" do
+        fill_in_i18n(
+          :scope_type_name,
+          "#scope_type-name-tabs",
+          en: "Not Territorial en"
+        )
+
+        fill_in_i18n(
+          :scope_type_plural,
+          "#scope_type-plural-tabs",
+          en: "This is the new pluarl"
+        )
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      within "table" do
+        expect(page).to have_content("Not Territorial en")
+      end
+    end
+
+    it "can delete them" do
+      within find("tr", text: translated(scope_type.name)) do
+        accept_confirm { click_link "Delete" }
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      within "table" do
+        expect(page).to have_no_content(translated(scope_type.name))
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
In #8021 we detected that the "Scope types" page in the admin zone didn't was not tested. So, after merging the fix for it this PR adds the missing tests, that are heavily based on the "Area types" tests, because this page was a copy of the "Scope types" page.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #8021 and #8052

