### PR TITLE
Fix broken test on meetings after merging PR without rebase

### DIFF
--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -211,7 +211,7 @@ describe "Meeting registrations", type: :system do
 
             expect(page).to have_content("successfully")
 
-            expect(page).to have_css(".button", text: "GOING")
+            expect(page).to have_text("You have signed up for this meeting")
             expect(page).to have_text("19 slots remaining")
             expect(page).to have_text("Stop following")
             expect(page).to have_text("ATTENDING PARTICIPANTS")


### PR DESCRIPTION
#### :tophat: What? Why?
After merging #7933 a broken test appeared because #7970 were merged before and the #7933 tests didn't run again with that changes. This PR fixes that.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #7933 and #7970
