### PR TITLE
Update bundle for security reasons

### DIFF
--- a/Dockerfile.design
+++ b/Dockerfile.design
@@ -17,7 +17,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
 
 RUN npm install -g npm@6.3.0
 
-RUN gem install bundler --version '>= 2.1.4'
+RUN gem install bundler --version '>= 2.2.18'
 
 WORKDIR /code
 COPY . .

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -919,4 +919,4 @@ RUBY VERSION
    ruby 2.7.1p83
 
 BUNDLED WITH
-   2.1.4
+   2.2.18

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -909,4 +909,4 @@ RUBY VERSION
    ruby 2.7.1p83
 
 BUNDLED WITH
-   2.1.4
+   2.2.18

--- a/decidim.gemspec
+++ b/decidim.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-templates", Decidim.version
   s.add_dependency "decidim-verifications", Decidim.version
 
-  s.add_development_dependency "bundler", "~> 2.1.2"
+  s.add_development_dependency "bundler", "~> 2.2", ">= 2.2.18"
   s.add_development_dependency "rake", "~> 12.0"
   s.add_development_dependency "rspec", "~> 3.0"
 end

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -919,4 +919,4 @@ RUBY VERSION
    ruby 2.7.1p83
 
 BUNDLED WITH
-   2.1.4
+   2.2.18

--- a/docs/modules/install/pages/update.adoc
+++ b/docs/modules/install/pages/update.adoc
@@ -43,7 +43,7 @@ In theory, that would be all. However, you need to be careful in certain situati
 
 == From git repositories
 
-For managing the gems we use the standard Rails gem called Bundler, where you can also point to https://bundler.io/v2.1/guides/git.html[git repositories and branches]. This is specially useful if you want to try an unreleased version, then you can do so by pointing to the release branch.
+For managing the gems we use the standard Rails gem called Bundler, where you can also point to https://bundler.io/v2.2/guides/git.html[git repositories and branches]. This is specially useful if you want to try an unreleased version, then you can do so by pointing to the release branch.
 
 [source,ruby]
 ----


### PR DESCRIPTION
#### :tophat: What? Why?
Updates bundle version to address [this issue](https://bundler.io/blog/2021/02/15/a-more-secure-bundler-we-fixed-our-source-priorities.html), even when it shouldn't affect Decidim.

