### PR TITLE
Make surveys matrix tables to scroll when needed

### DIFF
--- a/decidim-forms/app/packs/stylesheets/decidim/forms/forms.scss
+++ b/decidim-forms/app/packs/stylesheets/decidim/forms/forms.scss
@@ -37,6 +37,9 @@
 }
 
 .questionnaire-question-matrix{
+  display: block;
+  overflow-x: auto;
+
   .collection-input{
     display: flex;
     align-items: center;


### PR DESCRIPTION
#### :tophat: What? Why?
When filling a survey with a matrix of answers, the table is not responsive. This PR makes the table to allow to scroll. I've tried to use a [stacked table](https://get.foundation/sites/docs/table.html#table-stack), but as the column headers are not shown is not very clear.

#### :pushpin: Related Issues
- Fixes #7969

#### Testing
* Create a survey with a question with a big matrix of answers.
* Access to the survey with a mobile phone.

### :camera: Screenshots
![imagen](https://user-images.githubusercontent.com/453545/120311017-4c5f4000-c2d7-11eb-91ae-1c23659d6932.png)

:hearts: Thank you!
