### PR TITLE
Make surveys matrix tables to scroll when needed

### DIFF
--- a/decidim-forms/app/assets/stylesheets/decidim/forms/forms.scss
+++ b/decidim-forms/app/assets/stylesheets/decidim/forms/forms.scss
@@ -37,6 +37,9 @@
 }
 
 .questionnaire-question-matrix{
+  display: block;
+  overflow-x: auto;
+
   .collection-input{
     display: flex;
     align-items: center;


### PR DESCRIPTION
#### :tophat: What? Why?
When filling a survey with a matrix of answers, the table is not responsive. This PR makes the table to allow to scroll. I've tried to use a stacked table, but as the column headers are not shown is not very clear.

#### :pushpin: Related Issues
- Backports #8085 
