### PR TITLE
Remove deprecated Bootsnap warnings

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -136,8 +136,6 @@ module Decidim
             cache_dir: File.expand_path(File.join("..", "tmp", "cache"), __dir__),
             development_mode: env == "development",
             load_path_cache: true,
-            autoload_paths_cache: true,
-            disable_trace: false,
             compile_cache_iseq: !ENV["SIMPLECOV"],
             compile_cache_yaml: true
           )


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing #8010 I've seen two deprecations warnings:

> [DEPRECATED] Bootsnap's `autoload_paths_cache:` option is deprecated and will be removed. If you use Zeitwerk this option is useless, and if you are still using the classic autoloader upgrading is recommended.
> [DEPRECATED] Bootsnap's `disable_trace:` option is deprecated and will be removed. If you use Ruby 2.5 or newer this option is useless, if not upgrading is recommended.

I think it's safe to remove both options, as from Rails 6 migration (#7471) we're using Zeitweirk and for a couple of years we're using Ruby 2.5 (or newer, at the moment we're at 2.7.1)

#### :pushpin: Related Issues

- Related to #7471


#### Testing

Before this change:

1. `bin/rake development_app`
2. `cd development_app`
3. Execute any rails command, for instance, `bin/rails about`
4. See that you have the warning in the first few lines

After this change:

1. `bin/rake development_app`
2. `cd development_app`
3. Execute any rails command, for instance, `bin/rails about`
4. See that you don't have the warning

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
