### PR TITLE
Webpacker: Do not override the application's package.json

### DIFF
--- a/decidim-core/lib/tasks/decidim_webpacker_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_webpacker_tasks.rake
@@ -23,7 +23,7 @@ namespace :decidim do
       system! "npm i decidim/decidim#develop"
 
       # Remove the webpacker dependencies as they come through Decidim dependencies.
-      # This ensures we can control their versions from Decidim dependencies and avoid version conflicts.
+      # This ensures we can control their versions from Decidim dependencies to avoid version conflicts.
       webpacker_packages = %w(
         @rails/actioncable
         @rails/activestorage

--- a/decidim-core/lib/tasks/decidim_webpacker_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_webpacker_tasks.rake
@@ -12,9 +12,6 @@ namespace :decidim do
       remove_file_from_application "bin/yarn"
       # Babel config
       copy_file_to_application "babel.config.json"
-      # Npm packagesj
-      copy_file_to_application "package.json"
-      copy_file_to_application "package-lock.json"
       # PostCSS configuration
       copy_file_to_application "decidim-core/lib/decidim/webpacker/postcss.config.js", "postcss.config.js"
       # Webpacker configuration
@@ -23,7 +20,22 @@ namespace :decidim do
       copy_folder_to_application "decidim-core/lib/decidim/webpacker/webpack", "config"
 
       # Install JS dependencies
-      system! "npm ci"
+      system! "npm i decidim/decidim#develop"
+
+      # Remove the webpacker dependencies as they come through Decidim dependencies.
+      # This ensures we can control their versions from Decidim dependencies and avoid version conflicts.
+      webpacker_packages = %w(
+        @rails/actioncable
+        @rails/activestorage
+        @rails/ujs
+        @rails/webpacker
+        turbolinks
+        webpack
+        webpack-cli
+        @webpack-cli/serve
+        webpack-dev-server
+      )
+      system! "npm uninstall #{webpacker_packages.join(" ")}"
     end
 
     def decidim_path


### PR DESCRIPTION
#### :tophat: What? Why?
Follow up for #8066 (see the related discussion in that issue).

This proposes a solution for the `package.json` override in the webpacker installation task (`decidim:webpacker:install`).

This is not ideal because it is very slow as it clones the whole Decidim git repository to `node_modules`.

This is, however, how it should be solved. What needs to be done after:

- Create a new NPM package that ships with the dependencies listed in Decidim's `package.json`
- Mark the `devDependencies` correctly to that file as all the dependencies are now listed within `dependencies`. The `devDependencies` are those NPM packages that are not necessarily relevant for the Decidim application (jest related, etc. see https://github.com/decidim/decidim/pull/8066#issuecomment-852906678)
- Release that package to NPM, e.g. with name `@decidim/essentials`
- Replace the line `system! "npm i decidim/decidim#develop"` with `system! "npm i @decidim/essentials"`

#### :pushpin: Related Issues
- Related to #7464, #7733

#### Testing
Run the development app with the webpack-dev-server.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.