### PR TITLE
Online meetings iframe visibility with time

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/meeting_url/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_url/show.erb
@@ -6,11 +6,12 @@
     <li class="card-data__item">
       <div class="text-left">
         <div class="card__icondata--address">
-          <% if has_meeting_url? %>
-            <span><%= link_to(live_event_url, live_event_url, target: "_blank") %></span><br>
-            <span><%= translated_attribute model.location_hints %></span>
-          <% else %>
+          <% if future? %>
             <span><%= t("link_available_soon", scope: "decidim.meetings.meetings.show") %></span>
+          <% elsif live? %>
+            <span><%= link_to(t("join", scope: "decidim.meetings.meetings.show"), live_event_url, target: "_blank") %></span><br>
+          <% else %>
+            <span><%= link_to(t("visit_finished", scope: "decidim.meetings.meetings.show"), live_event_url, target: "_blank") %></span><br>
           <% end %>
         </div>
       </div>

--- a/decidim-meetings/app/cells/decidim/meetings/online_meeting_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/online_meeting_cell.rb
@@ -11,14 +11,19 @@ module Decidim
         @embedder ||= MeetingIframeEmbedder.new(model.online_meeting_url)
       end
 
+      delegate :live?, to: :model
       delegate :embeddable?, to: :embedder
 
       def live_event_url
-        if !model.show_embedded_iframe? && embeddable?
+        if embeddable?
           Decidim::EngineRouter.main_proxy(model.component).meeting_live_event_path(meeting_id: model.id)
         else
           model.online_meeting_url
         end
+      end
+
+      def future?
+        Time.current <= model.start_time && !live?
       end
     end
   end

--- a/decidim-meetings/app/cells/decidim/meetings/online_meeting_link/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/online_meeting_link/show.erb
@@ -15,11 +15,11 @@
         <% end %>
 
         <% if show_embed? %>
-          <div class="margin-top-3 absolutes aspect-ratio-16-9">
+          <div class="<%= "margin-top-3" if live? %> absolutes aspect-ratio-16-9">
             <%== embed_code(request.host) %>
           </div>
         <% elsif live? || future? %>
-          <div class="margin-top-3 absolutes">
+          <div class="absolutes">
             <% if live? %>
               <%= link_to t("join", scope: "decidim.meetings.meetings.show"), live_event_url, target: "_blank", class: "button button--sc" %>
             <% elsif future? %>

--- a/decidim-meetings/app/cells/decidim/meetings/online_meeting_link_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/online_meeting_link_cell.rb
@@ -22,6 +22,13 @@ module Decidim
       def show_embed?
         model.show_embedded_iframe? && embedder.embeddable?
       end
+
+      def live?
+        model.start_time &&
+          model.end_time &&
+          Time.current >= (model.start_time - 10.minutes) &&
+          Time.current <= model.end_time
+      end
     end
   end
 end

--- a/decidim-meetings/app/cells/decidim/meetings/online_meeting_link_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/online_meeting_link_cell.rb
@@ -15,14 +15,9 @@ module Decidim
         model.online_meeting_url.present?
       end
 
-      delegate :live?, to: :model
       delegate :embed_code, to: :embedder
 
       private
-
-      def future?
-        Time.current <= model.start_time && !live?
-      end
 
       def show_embed?
         model.show_embedded_iframe? && embedder.embeddable?

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -280,10 +280,6 @@ module Decidim
         !!attendees_count && attendees_count.positive?
       end
 
-      def live?
-        start_time && end_time && Time.current >= start_time && Time.current <= end_time
-      end
-
       def self.sort_by_translated_title_asc
         field = Arel::Nodes::InfixOperation.new("->>", arel_table[:title], Arel::Nodes.build_quoted(I18n.locale))
         order(Arel::Nodes::InfixOperation.new("", field, Arel.sql("ASC")))

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -523,6 +523,7 @@ en:
             one: "%{count} slot remaining"
             other: "%{count} slots remaining"
           view: View
+          visit_finished: View past meeting
         update:
           invalid: There was a problem updating the meeting.
           success: You have updated the meeting successfully.

--- a/decidim-meetings/spec/system/live_meeting_access_spec.rb
+++ b/decidim-meetings/spec/system/live_meeting_access_spec.rb
@@ -86,4 +86,52 @@ describe "Meeting live event access", type: :system do
       expect(page).to have_css("iframe")
     end
   end
+
+  describe "live meeting access" do
+    let(:meeting) { create :meeting, :published, :online, component: component }
+    let(:start_time) { meeting.start_time }
+    let(:end_time) { meeting.end_time }
+
+    around do |example|
+      travel_to current_time do
+        example.run
+      end
+    end
+
+    before do
+      visit_meeting
+    end
+
+    context "when current time is further than 10 minutes from the start time" do
+      let(:current_time) { start_time - 20.minutes }
+
+      it "is not live" do
+        expect(page).to have_no_content("This meeting is happening right now")
+      end
+    end
+
+    context "when current time is lesser than 10 minutes from the start time" do
+      let(:current_time) { start_time - 5.minutes }
+
+      it "is live" do
+        expect(page).to have_content("This meeting is happening right now")
+      end
+    end
+
+    context "when current time in between the start and the end time" do
+      let(:current_time) { start_time + 1.minute }
+
+      it "is live" do
+        expect(page).to have_content("This meeting is happening right now")
+      end
+    end
+
+    context "when current time has passed the end time" do
+      let(:current_time) { end_time + 5.minutes }
+
+      it "is not live" do
+        expect(page).to have_no_content("This meeting is happening right now")
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

⚠️ based on #8096

This PR updates the time window an online meeting is displaying the join to meeting CTA to a range of `[start_date - 10 minutes, end_date]` 

#### :pushpin: Related Issues

- Fixes #7722

#### Testing

Play with the start_time of the meeting and the current time and see that when the current time is in between the range of time, users are able to see the join to meeting CTA.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

_This PR changes the internal logic of a method, but there are no changes in the UI_

:hearts: Thank you!
