### PR TITLE
Filter participants admin

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/users_controller.rb
@@ -5,9 +5,11 @@ module Decidim
     # Controller that allows managing all admins at the admin panel.
     #
     class UsersController < Decidim::Admin::ApplicationController
+      include Decidim::Admin::Officializations::Filterable
+
       def index
         enforce_permission_to :read, :admin_user
-        @users = collection.page(params[:page]).per(15)
+        @users = filtered_collection
       end
 
       def new
@@ -79,6 +81,10 @@ module Decidim
 
       def collection
         @collection ||= current_organization.admins.or(current_organization.users_with_any_role)
+      end
+
+      def filters
+        [:invitation_accepted_at_present, :last_sign_in_at_present]
       end
     end
   end

--- a/decidim-admin/app/views/decidim/admin/users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/index.html.erb
@@ -7,18 +7,19 @@
       <% end %>
     </h2>
   </div>
+  <%= admin_filter_selector %>
   <div class="card-section">
     <div class="table-scroll">
       <table class="table-list">
         <thead>
           <tr>
-            <th><%= t("models.user.fields.role", scope: "decidim.admin") %></th>
-            <th><%= t("models.user.fields.name", scope: "decidim.admin") %></th>
-            <th><%= t("models.user.fields.email", scope: "decidim.admin") %></th>
-            <th><%= t("models.user.fields.invitation_sent_at", scope: "decidim.admin") %></th>
-            <th><%= t("models.user.fields.invitation_accepted_at", scope: "decidim.admin") %></th>
-            <th><%= t("models.user.fields.last_sign_in_at", scope: "decidim.admin") %></th>
-            <th><%= t("models.user.fields.created_at", scope: "decidim.admin") %></th>
+            <th><%= sort_link(query, :role, t("models.user.fields.role", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :name, t("models.user.fields.name", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :email, t("models.user.fields.email", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :invitation_sent_at, t("models.user.fields.invitation_sent_at", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :invitation_accepted_at, t("models.user.fields.invitation_accepted_at", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :last_sign_in_at, t("models.user.fields.last_sign_in_at", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :created_at, t("models.user.fields.created_at", scope: "decidim.admin"), default_order: :desc) %></th>
             <th></th>
           </tr>
         </thead>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -356,6 +356,16 @@ en:
         category_id_eq:
           label: Category
         filter_label: Filter
+        invitation_accepted_at_present:
+          label: Invite accepted
+          values:
+            'false': 'No'
+            'true': 'Yes'
+        last_sign_in_at_present:
+          label: Ever logged in
+          values:
+            'false': 'No'
+            'true': 'Yes'
         moderations:
           reportable_type_string_eq:
             label: Type

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -256,6 +256,14 @@ module Decidim
       save!
     end
 
+    ransacker :invitation_accepted_at do
+      Arel.sql(%{("decidim_users"."invitation_accepted_at")::text})
+    end
+
+    ransacker :last_sign_in_at do
+      Arel.sql(%{("decidim_users"."last_sign_in_at")::text})
+    end
+
     protected
 
     # Overrides devise email required validation.


### PR DESCRIPTION
#### :tophat: What? Why?
As an administrator I would like to be able to sort the content of the columns in the "Participants" section (back office) with ransak as it is possible to do in other participatory spaces. 

The content can be sorted in ascending or descending order by date or alphabetically. This is useful when there are many administrators.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Metaproposal: https://meta.decidim.org/processes/roadmap/f/122/proposals/16326

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
