### PR TITLE
Align UI groups filtering with the rest of decidim 

### DIFF
--- a/decidim-admin/app/controllers/concerns/decidim/admin/user_groups/filterable.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/user_groups/filterable.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Admin
+    module UserGroups
+      module Filterable
+        extend ActiveSupport::Concern
+
+        included do
+          include Decidim::Admin::Filterable
+
+          private
+
+          def base_query
+            collection
+          end
+
+          def search_field_predicate
+            :name_or_nickname_or_email_cont
+          end
+
+          def filters
+            [
+              :state_eq
+            ]
+          end
+
+          def filters_with_values
+            {
+              state_eq: user_groups_states
+            }
+          end
+
+          protected
+
+          def user_groups_states
+            %w(all pending rejected verified)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
@@ -54,14 +54,20 @@ module Decidim
 
       private
 
+      def filtered_collection
+        paginate(query.result)
+      end
+
       def base_query
         Decidim::Admin::UserGroupsEvaluation.for(collection, @query, @state)
       end
 
       def collection
         UserGroup
-          .includes(:memberships)
+          .left_outer_joins(:memberships)
+          .select("decidim_users.*, COUNT(decidim_user_group_memberships.decidim_user_group_id) as users_count")
           .where(decidim_user_group_memberships: { decidim_user_id: current_organization.users })
+          .group(Arel.sql("decidim_users.id"))
       end
     end
   end

--- a/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
@@ -6,6 +6,7 @@ module Decidim
     #
     class UserGroupsController < Decidim::Admin::ApplicationController
       include UserGroups
+      include Decidim::Admin::UserGroups::Filterable
 
       before_action :enforce_user_groups_enabled
 
@@ -13,11 +14,8 @@ module Decidim
 
       def index
         enforce_permission_to :index, :user_group
-        @query = params[:q]
-        @state = params[:state]
 
-        @user_groups = Decidim::Admin::UserGroupsEvaluation.for(collection, @query, @state)
-                                                           .page(params[:page]).per(15)
+        @user_groups = filtered_collection
       end
 
       def verify
@@ -55,6 +53,10 @@ module Decidim
       end
 
       private
+
+      def base_query
+        Decidim::Admin::UserGroupsEvaluation.for(collection, @query, @state)
+      end
 
       def collection
         UserGroup

--- a/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
@@ -1,41 +1,3 @@
-<div class="filters row">
-  <div class="column medium-3">
-    <span class="dropdown-menu-inverted_label"><%= t(".filter_by") %> :</span>
-    <ul class="dropdown menu dropdown-inverted" data-dropdown-menu data-close-on-click-inside="false">
-        <li class="is-dropdown-submenu-parent">
-          <a href="#">
-          <% if @state.present? %>
-            <%= t(".filter.#{@state}") %>
-          <% else %>
-            <%= t(".filter.all") %>
-          <% end %>
-          </a>
-          <ul class="menu is-dropdown-submenu">
-            <li><%= link_to t(".filter.pending"), url_for(state: "pending", q: @query) %></li>
-            <li><%= link_to t(".filter.rejected"), url_for(state: "rejected", q: @query) %></li>
-            <li><%= link_to t(".filter.verified"), url_for(state: "verified", q: @query) %></li>
-            <li><%= link_to t(".filter.all"), url_for(q: @query) %></li>
-          </ul>
-        </li>
-      </ul>
-  </div>
-  <div class="column medium-4">
-    <%= form_tag "", method: :get do %>
-      <div class="filters__search">
-        <div class="input-group">
-          <%= search_field_tag :q, @query,label: false, class: "input-group-field", placeholder: t(".search") %>
-          <%= hidden_field_tag :state, @state %>
-          <div class="input-group-button">
-            <button type="submit" class="button">
-              <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>
-            </button>
-          </div>
-        </div>
-      </div>
-    <% end %>
-  </div>
-</div>
-
 <div class="card" id='user-groups'>
   <div class="card-divider">
     <h2 class="card-title">
@@ -43,17 +5,19 @@
       <%= link_to t(".verify_via_csv"), new_user_groups_csv_verification_path, class: "button tiny button--title" %>
     </h2>
   </div>
+  <%= admin_filter_selector %>
+
   <div class="card-section">
     <div class="table-scroll">
       <table class="table-list">
         <thead>
           <tr>
-            <th><%= t("models.user_group.fields.name", scope: "decidim.admin") %></th>
-            <th><%= t("models.user_group.fields.document_number", scope: "decidim.admin") %></th>
-            <th><%= t("models.user_group.fields.phone", scope: "decidim.admin") %></th>
-            <th><%= t("models.user_group.fields.users_count", scope: "decidim.admin") %></th>
-            <th><%= t("models.user_group.fields.created_at", scope: "decidim.admin") %></th>
-            <th><%= t("models.user_group.fields.state", scope: "decidim.admin") %></th>
+            <th><%= sort_link(query, :name, t("models.user_group.fields.name", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :document_number, t("models.user_group.fields.document_number", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :phone, t("models.user_group.fields.phone", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :users_count, t("models.user_group.fields.users_count", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :created_at, t("models.user_group.fields.created_at", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :state, t("models.user_group.fields.state", scope: "decidim.admin"), default_order: :desc) %></th>
             <th><%= t("models.user_group.fields.actions", scope: "decidim.admin") %></th>
           </tr>
         </thead>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -406,6 +406,11 @@ en:
           user_name_or_user_email_cont: Search %{collection} by name or email.
         state_eq:
           label: State
+          values:
+            all: All
+            pending: Pending
+            rejected: Rejected
+            verified: Verified
       forms:
         file_help:
           import:
@@ -929,13 +934,6 @@ en:
           success: Group successfully verified
       user_groups:
         index:
-          filter:
-            all: All
-            pending: Pending
-            rejected: Rejected
-            verified: Verified
-          filter_by: Filter by
-          search: Search
           state:
             pending: Pending
             rejected: Rejected

--- a/decidim-admin/spec/system/admin_filters_user_groups_spec.rb
+++ b/decidim-admin/spec/system/admin_filters_user_groups_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+describe "Admin filters user_groups", type: :system do
+  let(:organization) { create(:organization) }
+  let!(:user) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:resource_controller) { Decidim::Admin::UserGroupsController }
+  let(:model_name) { Decidim::UserGroup.model_name }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin.user_groups_path
+  end
+
+  include_context "with filterable context"
+
+  context "when filtering by State" do
+    let!(:pending_ug) { create(:user_group, organization: organization, users: [user]) }
+    let!(:verified_ug) { create(:user_group, :verified, organization: organization, users: [user]) }
+    let!(:rejected_ug) { create(:user_group, :rejected, organization: organization, users: [user]) }
+
+    context "when pending" do
+      it_behaves_like "a filtered collection", options: "State", filter: "Pending" do
+        let(:in_filter) { pending_ug.name }
+        let(:not_in_filter) { verified_ug.name }
+      end
+
+      it_behaves_like "a filtered collection", options: "State", filter: "Pending" do
+        let(:in_filter) { pending_ug.name }
+        let(:not_in_filter) { rejected_ug.name }
+      end
+    end
+
+    context "when verified" do
+      it_behaves_like "a filtered collection", options: "State", filter: "Verified" do
+        let(:in_filter) { verified_ug.name }
+        let(:not_in_filter) { pending_ug.name }
+      end
+
+      it_behaves_like "a filtered collection", options: "State", filter: "Verified" do
+        let(:in_filter) { verified_ug.name }
+        let(:not_in_filter) { rejected_ug.name }
+      end
+    end
+
+    context "when rejected" do
+      it_behaves_like "a filtered collection", options: "State", filter: "Rejected" do
+        let(:in_filter) { rejected_ug.name }
+        let(:not_in_filter) { pending_ug.name }
+      end
+
+      it_behaves_like "a filtered collection", options: "State", filter: "Rejected" do
+        let(:in_filter) { rejected_ug.name }
+        let(:not_in_filter) { verified_ug.name }
+      end
+    end
+  end
+
+  context "when searching by ID or title" do
+    let!(:group) { create(:user_group, organization: organization, users: [user]) }
+
+    it "can be searched by nickname" do
+      search_by_text(group.nickname)
+
+      expect(page).to have_content(group.name)
+    end
+
+    it "can be searched by email" do
+      search_by_text(group.email)
+
+      expect(page).to have_content(group.name)
+    end
+
+    it "can be searched by name" do
+      search_by_text(group.name)
+
+      expect(page).to have_content(group.name)
+    end
+  end
+
+  context "when sorting" do
+    let!(:another_user) { create(:user, :admin, :confirmed, organization: organization) }
+    let!(:collection) { create_list(:user_group, 50, :verified, organization: organization, users: [user]) }
+    let!(:group) do
+      create(:user_group, organization: organization, users: [user, another_user],
+                          name: "ZZZupper group",
+                          document_number: "9999999999",
+                          phone: "999.999.9999").reload
+    end
+
+    context "with state desc" do
+      before { visit decidim_admin.user_groups_path(q: { s: "state desc" }) }
+
+      it "displays the result" do
+        expect(page).to have_content(group.name)
+      end
+    end
+
+    context "with state Asc" do
+      before { visit decidim_admin.user_groups_path(q: { s: "state asc" }) }
+
+      it "hides the result" do
+        expect(page).not_to have_content(group.name)
+      end
+    end
+
+    context "with participants count desc" do
+      before { visit decidim_admin.user_groups_path(q: { s: "users_count desc" }) }
+
+      it "displays the result" do
+        expect(group.users.size).to eq(2)
+        expect(page).to have_content(group.name)
+      end
+    end
+
+    context "with participants count asc" do
+      before { visit decidim_admin.user_groups_path(q: { s: "users_count asc" }) }
+
+      it "hides the result" do
+        expect(group.users.size).to eq(2)
+        expect(page).not_to have_content(group.name)
+      end
+    end
+
+    context "with phone desc" do
+      before { visit decidim_admin.user_groups_path(q: { s: "phone desc" }) }
+
+      it "displays the result" do
+        expect(group.users.size).to eq(2)
+        expect(page).to have_content(group.name)
+      end
+    end
+
+    context "with phone asc" do
+      before { visit decidim_admin.user_groups_path(q: { s: "phone asc" }) }
+
+      it "hides the result" do
+        expect(group.users.size).to eq(2)
+        expect(page).not_to have_content(group.name)
+      end
+    end
+
+    context "with document desc" do
+      before { visit decidim_admin.user_groups_path(q: { s: "document_number desc" }) }
+
+      it "displays the result" do
+        expect(group.users.size).to eq(2)
+        expect(page).to have_content(group.name)
+      end
+    end
+
+    context "with document asc" do
+      before { visit decidim_admin.user_groups_path(q: { s: "document_number asc" }) }
+
+      it "hides the result" do
+        expect(group.users.size).to eq(2)
+        expect(page).not_to have_content(group.name)
+      end
+    end
+
+    context "with name desc" do
+      before { visit decidim_admin.user_groups_path(q: { s: "name desc" }) }
+
+      it "displays the result" do
+        expect(group.users.size).to eq(2)
+        expect(page).to have_content(group.name)
+      end
+    end
+
+    context "with name asc" do
+      before { visit decidim_admin.user_groups_path(q: { s: "name asc" }) }
+
+      it "hides the result" do
+        expect(group.users.size).to eq(2)
+        expect(page).not_to have_content(group.name)
+      end
+    end
+  end
+
+  it_behaves_like "paginating a collection" do
+    let!(:collection) { create_list(:user_group, 50, organization: organization, users: [user]) }
+
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit decidim_admin.user_groups_path
+    end
+  end
+end

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -152,28 +152,36 @@ module Decidim
       [:state_eq]
     end
 
+    scope :sort_by_users_count_asc, lambda {
+      order("users_count ASC NULLS FIRST")
+    }
+
+    scope :sort_by_users_count_desc, lambda {
+      order("users_count DESC NULLS LAST")
+    }
+
     def self.sort_by_document_number_asc
-      order("extended_data->>'document_number' ASC")
+      order(Arel.sql("extended_data->>'document_number' ASC"))
     end
 
     def self.sort_by_document_number_desc
-      order("extended_data->>'document_number' DESC")
+      order(Arel.sql("extended_data->>'document_number' DESC"))
     end
 
     def self.sort_by_phone_asc
-      order("extended_data->>'phone' ASC")
+      order(Arel.sql("extended_data->>'phone' ASC"))
     end
 
     def self.sort_by_phone_desc
-      order("extended_data->>'phone' DESC")
+      order(Arel.sql("extended_data->>'phone' DESC"))
     end
 
     def self.sort_by_state_asc
-      order("extended_data->>'rejected_at' ASC, extended_data->>'verified_at' ASC, deleted_at ASC")
+      order(Arel.sql("extended_data->>'rejected_at' ASC, extended_data->>'verified_at' ASC, deleted_at ASC"))
     end
 
     def self.sort_by_state_desc
-      order("extended_data->>'rejected_at' DESC, extended_data->>'verified_at' DESC, deleted_at DESC")
+      order(Arel.sql("extended_data->>'rejected_at' DESC, extended_data->>'verified_at' DESC, deleted_at DESC"))
     end
 
     private

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -144,6 +144,38 @@ module Decidim
       @unread_messages_count_for[user.id] ||= Decidim::Messaging::Conversation.user_collection(self).unread_messages_by(user).count
     end
 
+    def self.state_eq(value)
+      send(value.to_sym) if %w(all pending rejected verified).include?(value)
+    end
+
+    def self.ransackable_scopes(_auth = nil)
+      [:state_eq]
+    end
+
+    def self.sort_by_document_number_asc
+      order("extended_data->>'document_number' ASC")
+    end
+
+    def self.sort_by_document_number_desc
+      order("extended_data->>'document_number' DESC")
+    end
+
+    def self.sort_by_phone_asc
+      order("extended_data->>'phone' ASC")
+    end
+
+    def self.sort_by_phone_desc
+      order("extended_data->>'phone' DESC")
+    end
+
+    def self.sort_by_state_asc
+      order("extended_data->>'rejected_at' ASC, extended_data->>'verified_at' ASC, deleted_at ASC")
+    end
+
+    def self.sort_by_state_desc
+      order("extended_data->>'rejected_at' DESC, extended_data->>'verified_at' DESC, deleted_at DESC")
+    end
+
     private
 
     # Private: Checks if the state user group is correct.


### PR DESCRIPTION
#### :tophat: What? Why?
Currently, the user groups page is displaying a one of a type filtering UI, and this PR aims to fix the issue, while adding also sorting options for groups module. 
It replaces the 
![image](https://user-images.githubusercontent.com/105683/125281537-00180e80-e31f-11eb-92b0-5445dbd6cd52.png)

with the following information: 

![image](https://user-images.githubusercontent.com/105683/120882312-7b2f2c00-c5df-11eb-936f-cd3bed5f9d8e.png)


#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![image](https://user-images.githubusercontent.com/105683/120882312-7b2f2c00-c5df-11eb-936f-cd3bed5f9d8e.png)

:hearts: Thank you!
