### PR TITLE
Fix webpacker asset configs for external apps

### DIFF
--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -2,9 +2,6 @@
 
 $LOAD_PATH.push File.expand_path("lib", __dir__)
 
-# Unshift the webpacker to give priority for the Decidim webpacker override.
-$LOAD_PATH.unshift File.expand_path("lib/gem_overrides", __dir__)
-
 # Maintain your gem's version:
 require "decidim/core/version"
 

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -45,6 +45,9 @@ require "social-share-button"
 require "ransack"
 require "searchlight"
 
+# Needed for the assets:precompile task, for configuring webpacker instance
+require "decidim/webpacker"
+
 require "decidim/api"
 require "decidim/middleware/strip_x_forwarded_host"
 require "decidim/middleware/current_organization"

--- a/decidim-core/lib/decidim/webpacker/configuration.rb
+++ b/decidim-core/lib/decidim/webpacker/configuration.rb
@@ -3,11 +3,82 @@
 module Decidim
   module Webpacker
     class Configuration
-      attr_accessor :additional_paths, :entrypoints
+      attr_reader :additional_paths, :entrypoints
 
       def initialize
         @additional_paths = []
         @entrypoints = {}
+      end
+
+      def configuration_file
+        # Before webpacker is installed, the original configuration file may not
+        # be available yet.
+        return unless File.exist?(original_configuration_file_path)
+        return configuration_file_path if configurations_loaded?
+
+        load_asset_configurations
+
+        # Read the original configuration and append the paths
+        config = YAML.load_file(original_configuration_file_path)
+        default = config["default"] || {}
+        all_additional_paths = default["additional_paths"] || []
+        all_additional_paths += additional_paths
+        all_entrypoints = default["entrypoints"] || {}
+        all_entrypoints.merge!(entrypoints)
+        config.each do |environment, env_config|
+          config[environment] = env_config.merge(
+            "additional_paths" => all_additional_paths,
+            "entrypoints" => all_entrypoints
+          )
+        end
+
+        # Write the runtime configuration and override the configuration
+        File.write(configuration_file_path, config.to_yaml)
+
+        self.configurations_loaded = true
+
+        configuration_file_path
+      end
+
+      private
+
+      attr_writer :configurations_loaded
+
+      def configurations_loaded?
+        @configurations_loaded == true
+      end
+
+      def app_path
+        @app_path ||=
+          if defined?(Rails)
+            Rails.application.root
+          else
+            # This is used when Rails is not available from the webpacker binstubs
+            File.expand_path(".", Dir.pwd)
+          end
+      end
+
+      def configuration_file_path
+        @configuration_file_path ||= File.join(app_path, "tmp/webpacker_runtime.yml")
+      end
+
+      def original_configuration_file_path
+        @original_configuration_file_path = File.join(app_path, "config/webpacker.yml")
+      end
+
+      def load_asset_configurations
+        # Decidim gem assets
+        decidim_gems = Bundler.load.specs.select { |spec| spec.name =~ /^decidim-/ }
+        decidim_gems.each do |gem|
+          asset_config_path = File.join(gem.full_gem_path, "config/assets.rb")
+          next unless File.exist?(asset_config_path)
+
+          load asset_config_path
+        end
+
+        # Application assets
+        asset_config_path = File.join(app_path, "config/assets.rb")
+        load asset_config_path if File.exist?(asset_config_path)
       end
     end
   end

--- a/decidim-core/lib/decidim/webpacker/runner.rb
+++ b/decidim-core/lib/decidim/webpacker/runner.rb
@@ -16,36 +16,8 @@ module Decidim
       private
 
       def decidim_initialize(_argv)
-        # Decidim gem assets
-        decidim_gems = Bundler.load.specs.select { |spec| spec.name =~ /^decidim-/ }
-        decidim_gems.each do |gem|
-          asset_config_path = File.join(gem.full_gem_path, "config/assets.rb")
-          next unless File.exist?(asset_config_path)
-
-          load asset_config_path
-        end
-
-        # Application assets
-        asset_config_path = File.join(@app_path, "config/assets.rb")
-        load asset_config_path if File.exist?(asset_config_path)
-
-        # Read the original configuration and append the paths
-        config = YAML.load_file(@webpacker_config)
-        default = config["default"] || {}
-        additional_paths = default["additional_paths"] || []
-        additional_paths += Decidim::Webpacker.configuration.additional_paths
-        entrypoints = default["entrypoints"] || {}
-        entrypoints.merge!(Decidim::Webpacker.configuration.entrypoints)
-        config.each do |environment, env_config|
-          config[environment] = env_config.merge(
-            "additional_paths" => additional_paths,
-            "entrypoints" => entrypoints
-          )
-        end
-
         # Write the runtime configuration and override the configuration
-        @webpacker_config = File.join(@app_path, "tmp/webpacker_runtime.yml")
-        File.write(@webpacker_config, config.to_yaml)
+        @webpacker_config = Decidim::Webpacker.configuration.configuration_file
       end
     end
   end

--- a/decidim-core/lib/tasks/decidim_webpacker_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_webpacker_tasks.rake
@@ -52,6 +52,11 @@ namespace :decidim do
     def add_binstub_load_path(binstub_path)
       file = rails_app_path.join(binstub_path)
 
+      # Skip if the load path is already added
+      return if File.readlines(file).grep(
+        %r{^\$LOAD_PATH.unshift "#\{Gem.loaded_specs\["decidim-core"\].full_gem_path\}/lib/gem_overrides"$}
+      ).size.positive?
+
       contents = ""
       File.readlines(file).each do |line|
         contents += line

--- a/decidim-core/lib/tasks/decidim_webpacker_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_webpacker_tasks.rake
@@ -51,14 +51,15 @@ namespace :decidim do
 
     def add_binstub_load_path(binstub_path)
       file = rails_app_path.join(binstub_path)
+      lines = File.readlines(file)
 
       # Skip if the load path is already added
-      return if File.readlines(file).grep(
+      return if lines.grep(
         %r{^\$LOAD_PATH.unshift "#\{Gem.loaded_specs\["decidim-core"\].full_gem_path\}/lib/gem_overrides"$}
       ).size.positive?
 
       contents = ""
-      File.readlines(file).each do |line|
+      lines.each do |line|
         contents += line
         next unless line =~ %r{^require "bundler/setup"$}
 

--- a/decidim-core/spec/lib/webpacker/configuration_spec.rb
+++ b/decidim-core/spec/lib/webpacker/configuration_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gem_overrides/webpacker/runner"
+
+module Decidim
+  module Webpacker
+    describe Configuration do
+      before do
+        # When the asset configurations are called through Decidim::Webpacker,
+        # return always the subject being tested.
+        allow(Decidim::Webpacker).to receive(:configuration).and_return(subject)
+      end
+
+      describe "#configuration_file" do
+        let(:runtime_config_path) do
+          Rails.application.root.join("tmp/webpacker_runtime.yml")
+        end
+        let(:runtime_config) { YAML.load_file(runtime_config_path) }
+        let(:core_path) do
+          core_gem = Bundler.load.specs.find { |spec| spec.name == "decidim-core" }
+          core_gem.full_gem_path
+        end
+        let!(:config_file) { subject.configuration_file }
+
+        it "returns the runtime configuration path" do
+          expect(config_file).to eq(runtime_config_path.to_s)
+        end
+
+        it "adds the core additional paths to the webpacker runtime configuration" do
+          expect(runtime_config["default"]["additional_paths"]).to include("node_modules")
+          expect(runtime_config["default"]["additional_paths"]).to include("app/packs")
+          expect(runtime_config["default"]["additional_paths"]).to include("#{core_path}/app/packs")
+        end
+
+        it "adds the core entrypoints to the webpacker runtime configuration" do
+          expect(runtime_config["default"]["entrypoints"]).to include(
+            "decidim_core" => "#{core_path}/app/packs/entrypoints/decidim_core.js",
+            "decidim_conference_diploma" => "#{core_path}/app/packs/entrypoints/decidim_conference_diploma.js",
+            "decidim_email" => "#{core_path}/app/packs/entrypoints/decidim_email.js",
+            "decidim_map" => "#{core_path}/app/packs/entrypoints/decidim_map.js",
+            "decidim_geocoding_provider_photon" => "#{core_path}/app/packs/entrypoints/decidim_geocoding_provider_photon.js",
+            "decidim_geocoding_provider_here" => "#{core_path}/app/packs/entrypoints/decidim_geocoding_provider_here.js",
+            "decidim_map_provider_default" => "#{core_path}/app/packs/entrypoints/decidim_map_provider_default.js",
+            "decidim_map_provider_here" => "#{core_path}/app/packs/entrypoints/decidim_map_provider_here.js",
+            "decidim_widget" => "#{core_path}/app/packs/entrypoints/decidim_widget.js"
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
As described at #8103, the asset configurations do not work for external apps outside of the Decidim main repo.

This is an oversight in the original implementation (#8066) where the webpacker override load path was added through the core gemspec. Obviously, this gemspec is not loaded in the actual applications.

This fixes the issue by applying the override load path directly to the webpacker binstubs during the webpacker install command, as that is the only place where this can be done. In addition, this change broke the `assets:precompile` task in some occasions which also needs to know the watch paths (additional paths) from the overridden configuration in order to calculate the asset hash to decide whether the assets need to be recompiled or not.

#### :pushpin: Related Issues
- Fixes #8103

#### Testing
See #8066 + try out the `assets:precompile` task which should be already in the CI.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.