### PR TITLE
Remove the relative paths from the fontface file

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/utils/_fontface.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/utils/_fontface.scss
@@ -3,9 +3,9 @@
   font-style: normal;
   font-weight: 400;
   src:
-    url('../../../../decidim-core/app/packs/fonts/decidim/Source_Sans_Pro_400.woff2') format('woff2'),
-    url('../../../../decidim-core/app/packs/fonts/decidim/Source_Sans_Pro_400.woff') format('woff'),
-    url('../../../../decidim-core/app/packs/fonts/decidim/Source_Sans_Pro_400.ttf') format('truetype');
+    url('fonts/decidim/Source_Sans_Pro_400.woff2') format('woff2'),
+    url('fonts/decidim/Source_Sans_Pro_400.woff') format('woff'),
+    url('fonts/decidim/Source_Sans_Pro_400.ttf') format('truetype');
 }
 
 @font-face{
@@ -13,9 +13,9 @@
   font-style: normal;
   font-weight: 600;
   src:
-    url('../../../../decidim-core/app/packs/fonts/decidim/Source_Sans_Pro_600.woff2') format('woff2'),
-    url('../../../../decidim-core/app/packs/fonts/decidim/Source_Sans_Pro_600.woff') format('woff'),
-    url('../../../../decidim-core/app/packs/fonts/decidim/Source_Sans_Pro_600.ttf') format('truetype');
+    url('fonts/decidim/Source_Sans_Pro_600.woff2') format('woff2'),
+    url('fonts/decidim/Source_Sans_Pro_600.woff') format('woff'),
+    url('fonts/decidim/Source_Sans_Pro_600.ttf') format('truetype');
 }
 
 @font-face{
@@ -23,7 +23,7 @@
   font-style: normal;
   font-weight: 900;
   src:
-    url('../../../../decidim-core/app/packs/fonts/decidim/Source_Sans_Pro_900.woff2') format('woff2'),
-    url('../../../../decidim-core/app/packs/fonts/decidim/Source_Sans_Pro_900.woff') format('woff'),
-    url('../../../../decidim-core/app/packs/fonts/decidim/Source_Sans_Pro_900.ttf') format('truetype');
-  }
+    url('fonts/decidim/Source_Sans_Pro_900.woff2') format('woff2'),
+    url('fonts/decidim/Source_Sans_Pro_900.woff') format('woff'),
+    url('fonts/decidim/Source_Sans_Pro_900.ttf') format('truetype');
+}


### PR DESCRIPTION
#### :tophat: What? Why?
The fontface file refers to the fonts through relative paths. This seems to work within the core repo but when you build the gems and try to compile the assets, the `decidim-system` entrypoint stylesheet fails to find these font files.

#### :pushpin: Related Issues
- Related to #7464, #7733

#### Testing
Build the gems, install the gems and try compiling the assets.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.