### PR TITLE
Dynamic stylesheet includes with Webpacker

### DIFF
--- a/decidim-accountability/config/assets.rb
+++ b/decidim-accountability/config/assets.rb
@@ -7,3 +7,4 @@ Decidim::Webpacker.register_entrypoints(
   decidim_accountability: "#{base_path}/app/packs/entrypoints/decidim_accountability.js",
   decidim_accountability_admin: "#{base_path}/app/packs/entrypoints/decidim_accountability_admin.js"
 )
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/accountability/accountability")

--- a/decidim-budgets/config/assets.rb
+++ b/decidim-budgets/config/assets.rb
@@ -6,3 +6,4 @@ Decidim::Webpacker.register_path("#{base_path}/app/packs")
 Decidim::Webpacker.register_entrypoints(
   decidim_budgets: "#{base_path}/app/packs/entrypoints/decidim_budgets.js"
 )
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/budgets/budgets")

--- a/decidim-conferences/config/assets.rb
+++ b/decidim-conferences/config/assets.rb
@@ -6,3 +6,4 @@ Decidim::Webpacker.register_path("#{base_path}/app/packs")
 Decidim::Webpacker.register_entrypoints(
   decidim_conferences_admin: "#{base_path}/app/packs/entrypoints/decidim_conferences_admin.js"
 )
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/conferences/conferences")

--- a/decidim-consultations/config/assets.rb
+++ b/decidim-consultations/config/assets.rb
@@ -6,3 +6,4 @@ Decidim::Webpacker.register_path("#{base_path}/app/packs")
 Decidim::Webpacker.register_entrypoints(
   decidim_consultations: "#{base_path}/app/packs/entrypoints/decidim_consultations.js"
 )
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/consultations/consultations")

--- a/decidim-core/app/packs/stylesheets/decidim/application.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/application.scss
@@ -1,14 +1,8 @@
 @import "stylesheets/decidim/editor";
 @import "stylesheets/decidim/decidim";
 
-@import "stylesheets/decidim/accountability/accountability";
-@import "stylesheets/decidim/budgets/budgets";
-@import "stylesheets/decidim/conferences/conferences";
-@import "stylesheets/decidim/consultations/consultations";
-@import "stylesheets/decidim/initiatives/initiatives";
-@import "stylesheets/decidim/elections/elections";
-@import "stylesheets/decidim/votings/votings";
-@import "stylesheets/decidim/proposals/proposals";
-@import "stylesheets/decidim/surveys/surveys";
+// This imports all the Decidim module stylesheet imports registered at
+// `config/assets.rb` of the module.
+@import "!decidim-style-imports";
 
 @import "stylesheets/decidim/decidim_application";

--- a/decidim-core/lib/decidim/webpacker.rb
+++ b/decidim-core/lib/decidim/webpacker.rb
@@ -20,5 +20,9 @@ module Decidim
     def self.register_entrypoints(entrypoints)
       configuration.entrypoints.merge!(entrypoints.stringify_keys)
     end
+
+    def self.register_stylesheet_import(import)
+      configuration.stylesheet_imports.push(import)
+    end
   end
 end

--- a/decidim-core/lib/decidim/webpacker/configuration.rb
+++ b/decidim-core/lib/decidim/webpacker/configuration.rb
@@ -3,11 +3,12 @@
 module Decidim
   module Webpacker
     class Configuration
-      attr_reader :additional_paths, :entrypoints
+      attr_reader :additional_paths, :entrypoints, :stylesheet_imports
 
       def initialize
         @additional_paths = []
         @entrypoints = {}
+        @stylesheet_imports = []
       end
 
       def configuration_file
@@ -23,12 +24,15 @@ module Decidim
         default = config["default"] || {}
         all_additional_paths = default["additional_paths"] || []
         all_additional_paths += additional_paths
+        all_stylesheet_imports = default["stylesheet_imports"] || []
+        all_stylesheet_imports += stylesheet_imports
         all_entrypoints = default["entrypoints"] || {}
         all_entrypoints.merge!(entrypoints)
         config.each do |environment, env_config|
           config[environment] = env_config.merge(
             "additional_paths" => all_additional_paths,
-            "entrypoints" => all_entrypoints
+            "entrypoints" => all_entrypoints,
+            "stylesheet_imports" => all_stylesheet_imports
           )
         end
 

--- a/decidim-core/lib/decidim/webpacker/webpack/base.js
+++ b/decidim-core/lib/decidim/webpacker/webpack/base.js
@@ -27,9 +27,7 @@ const overrideSassRule = (modifyConfig) => {
         return null
       }
 
-      const statements = imports.map((style) => {
-        return `@import "${style}";`
-      })
+      const statements = imports.map((style) => `@import "${style}";`)
 
       return { contents: statements.join("\n") }
     }

--- a/decidim-core/lib/decidim/webpacker/webpack/base.js
+++ b/decidim-core/lib/decidim/webpacker/webpack/base.js
@@ -1,6 +1,45 @@
 /* eslint-disable */
 
-const { webpackConfig, merge } = require("@rails/webpacker")
+const { webpackConfig, merge, config } = require("@rails/webpacker")
 const customConfig = require("./custom")
 
-module.exports = merge(webpackConfig, customConfig)
+const overrideSassRule = (modifyConfig) => {
+  const sassRule = modifyConfig.module.rules.find((rule) => rule.test.toString() === "/\\.(scss|sass)(\\.erb)?$/i")
+  if (!sassRule) {
+    return modifyConfig
+  }
+
+  const sassLoader = sassRule.use.find(use => use.loader.match(/sass-loader/))
+  if (!sassLoader) {
+    return modifyConfig
+  }
+
+  const imports = config.stylesheet_imports
+  if (!Array.isArray(imports)) {
+    return modifyConfig
+  }
+
+  // Add the extra importer to the sass-loader to load the import statements for
+  // Decidim modules.
+  sassLoader.options.sassOptions.importer = [
+    (url, _prev) => {
+      if (url !== "!decidim-style-imports") {
+        return null
+      }
+
+      const statements = imports.map((style) => {
+        return `@import "${style}";`
+      })
+
+      return { contents: statements.join("\n") }
+    }
+  ]
+
+  return modifyConfig
+}
+
+const overrideConfig = (originalConfig) => {
+  return overrideSassRule(originalConfig)
+}
+
+module.exports = merge(overrideConfig(webpackConfig), customConfig)

--- a/decidim-core/spec/lib/webpacker/configuration_spec.rb
+++ b/decidim-core/spec/lib/webpacker/configuration_spec.rb
@@ -46,6 +46,20 @@ module Decidim
             "decidim_widget" => "#{core_path}/app/packs/entrypoints/decidim_widget.js"
           )
         end
+
+        it "adds the stylesheet imports to the webpacker runtime configuration" do
+          expect(runtime_config["default"]["stylesheet_imports"]).to include(
+            "stylesheets/decidim/accountability/accountability",
+            "stylesheets/decidim/budgets/budgets",
+            "stylesheets/decidim/proposals/proposals",
+            "stylesheets/decidim/surveys/surveys",
+            "stylesheets/decidim/conferences/conferences",
+            "stylesheets/decidim/consultations/consultations",
+            "stylesheets/decidim/elections/elections",
+            "stylesheets/decidim/votings/votings",
+            "stylesheets/decidim/initiatives/initiatives"
+          )
+        end
       end
     end
   end

--- a/decidim-core/spec/lib/webpacker/runner_spec.rb
+++ b/decidim-core/spec/lib/webpacker/runner_spec.rb
@@ -42,6 +42,17 @@ module Webpacker
           "decidim_map_provider_here" => "#{core_path}/app/packs/entrypoints/decidim_map_provider_here.js",
           "decidim_widget" => "#{core_path}/app/packs/entrypoints/decidim_widget.js"
         )
+        expect(runtime_config["default"]["stylesheet_imports"]).to include(
+          "stylesheets/decidim/accountability/accountability",
+          "stylesheets/decidim/budgets/budgets",
+          "stylesheets/decidim/proposals/proposals",
+          "stylesheets/decidim/surveys/surveys",
+          "stylesheets/decidim/conferences/conferences",
+          "stylesheets/decidim/consultations/consultations",
+          "stylesheets/decidim/elections/elections",
+          "stylesheets/decidim/votings/votings",
+          "stylesheets/decidim/initiatives/initiatives"
+        )
       end
     end
 

--- a/decidim-core/spec/lib/webpacker_spec.rb
+++ b/decidim-core/spec/lib/webpacker_spec.rb
@@ -5,6 +5,13 @@ require "decidim/webpacker"
 
 module Decidim
   describe Webpacker do
+    before do
+      # Use a local configuration object for easier testing
+      allow(subject).to receive(:configuration).and_return(
+        Decidim::Webpacker::Configuration.new
+      )
+    end
+
     describe ".configuration" do
       it "returns the configuration object" do
         expect(subject.configuration).to be_a(Decidim::Webpacker::Configuration)
@@ -49,6 +56,23 @@ module Decidim
         expect(described_class.configuration.entrypoints).to eq(
           "test_entry" => "entrypath",
           "other_entry" => "otherpath"
+        )
+      end
+    end
+
+    describe ".register_stylesheet_import" do
+      after do
+        described_class.configuration.stylesheet_imports.slice!(
+          0,
+          described_class.configuration.stylesheet_imports.length
+        )
+      end
+
+      it "registers the defined entrypoints" do
+        described_class.register_stylesheet_import("stylesheets/decidim/test")
+
+        expect(described_class.configuration.stylesheet_imports).to eq(
+          %w(stylesheets/decidim/test)
         )
       end
     end

--- a/decidim-elections/config/assets.rb
+++ b/decidim-elections/config/assets.rb
@@ -30,3 +30,5 @@ Decidim::Webpacker.register_entrypoints(
   decidim_votings_in_person_vote: "#{base_path}/app/packs/entrypoints/decidim_votings_in-person-vote.js",
   decidim_votings_admin_votings: "#{base_path}/app/packs/entrypoints/decidim_votings_admin_votings.js"
 )
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/elections/elections")
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/votings/votings")

--- a/decidim-initiatives/config/assets.rb
+++ b/decidim-initiatives/config/assets.rb
@@ -9,3 +9,4 @@ Decidim::Webpacker.register_entrypoints(
   decidim_initiatives_print: "#{base_path}/app/packs/entrypoints/decidim_initiatives_print.js",
   decidim_initiatives_initiatives_votes: "#{base_path}/app/packs/entrypoints/decidim_initiatives_initiatives_votes.js"
 )
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/initiatives/initiatives")

--- a/decidim-proposals/config/assets.rb
+++ b/decidim-proposals/config/assets.rb
@@ -7,3 +7,4 @@ Decidim::Webpacker.register_entrypoints(
   decidim_proposals: "#{base_path}/app/packs/entrypoints/decidim_proposals.js",
   decidim_proposals_admin: "#{base_path}/app/packs/entrypoints/decidim_proposals_admin.js"
 )
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/proposals/proposals")

--- a/decidim-surveys/config/assets.rb
+++ b/decidim-surveys/config/assets.rb
@@ -3,3 +3,4 @@
 base_path = File.expand_path("..", __dir__)
 
 Decidim::Webpacker.register_path("#{base_path}/app/packs")
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/surveys/surveys")


### PR DESCRIPTION
#### :tophat: What? Why?
The Decidim asset compilation will fail if all Decidim gems are not available in the bundle because the `application.scss` assumes all these gems are available:
https://github.com/decidim/decidim/blob/6bd8053edf7ada63f27df4daf4bff6ea356a6fcd/decidim-core/app/packs/stylesheets/decidim/application.scss#L4-L12

This works fine when Decidim is installed from GitHub (because they are all available in the repository) but it fails when it is installed e.g. through RubyGems in the future.

See further explanations from #8109.

This PR proposes a solution to this problem by moving the stylesheet import configurations to the module's `assets.rb`.

#### :pushpin: Related Issues
- Fixes #8109

#### Testing
See #8109

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.