### PR TITLE
Metric is not shown when value is zero for blocked and reported users

### DIFF
--- a/decidim-core/app/queries/decidim/metric_manage.rb
+++ b/decidim-core/app/queries/decidim/metric_manage.rb
@@ -28,7 +28,7 @@ module Decidim
     def save
       return @registry if @registry
 
-      return if cumulative.zero? && !['blocked_users', 'reported_users', 'user_reports'].include?(@metric_name)
+      return if cumulative.zero? && %w(blocked_users reported_users user_reports).exclude?(@metric_name)
 
       @registry = Decidim::Metric.find_or_initialize_by(day: @day.to_s, metric_type: @metric_name, organization: @organization)
       @registry.assign_attributes(cumulative: cumulative, quantity: quantity)

--- a/decidim-core/app/queries/decidim/metric_manage.rb
+++ b/decidim-core/app/queries/decidim/metric_manage.rb
@@ -28,7 +28,7 @@ module Decidim
     def save
       return @registry if @registry
 
-      return if cumulative.zero?
+      return if cumulative.zero? && !['blocked_users', 'reported_users', 'user_reports'].include?(@metric_name)
 
       @registry = Decidim::Metric.find_or_initialize_by(day: @day.to_s, metric_type: @metric_name, organization: @organization)
       @registry.assign_attributes(cumulative: cumulative, quantity: quantity)


### PR DESCRIPTION
#### :tophat: What? Why?
When a given metric has the value zero, then it’s not shown in the Dashboard Metrics section.When no users are blocked and the metric job has started, the "Blocked users" box is not displayed.

#### :pushpin: Related Issues
Issue : https://github.com/decidim/decidim/issues/8116

#### Testing
Unblock all users
Check metrics from Dashboard
No metric displayed for blocked users

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
