### PR TITLE
Fix don't require inactive authorization handlers

### DIFF
--- a/decidim-core/app/services/decidim/action_authorizer.rb
+++ b/decidim-core/app/services/decidim/action_authorizer.rb
@@ -38,7 +38,7 @@ module Decidim
 
     def authorization_handlers
       available_authorizations = component.organization.available_authorizations
-      if permission&.has_key?("authorization_handler_name")
+      if permission&.has_key?("authorization_handler_name") && available_authorizations.include?(permission["authorization_handler_name"])
         options = permission["options"]
         { permission["authorization_handler_name"] => options.present? ? { "options" => options } : {} }
       else

--- a/decidim-core/app/services/decidim/action_authorizer.rb
+++ b/decidim-core/app/services/decidim/action_authorizer.rb
@@ -37,11 +37,12 @@ module Decidim
     attr_reader :user, :component, :resource, :action
 
     def authorization_handlers
+      available_authorizations = component.organization.available_authorizations
       if permission&.has_key?("authorization_handler_name")
         options = permission["options"]
         { permission["authorization_handler_name"] => options.present? ? { "options" => options } : {} }
       else
-        permission&.fetch("authorization_handlers", {})
+        permission&.fetch("authorization_handlers", {})&.slice(*available_authorizations)
       end
     end
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -85,6 +85,7 @@ FactoryBot.define do
     favicon { Decidim::Dev.test_file("icon.png", "image/png") }
     default_locale { Decidim.default_locale }
     available_locales { Decidim.available_locales }
+    available_authorizations { [] }
     users_registration_mode { :enabled }
     official_img_header { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
     official_img_footer { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -85,7 +85,7 @@ FactoryBot.define do
     favicon { Decidim::Dev.test_file("icon.png", "image/png") }
     default_locale { Decidim.default_locale }
     available_locales { Decidim.available_locales }
-    available_authorizations { [] }
+    available_authorizations { %w(dummy_authorization_handler) }
     users_registration_mode { :enabled }
     official_img_header { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
     official_img_footer { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }

--- a/decidim-core/spec/controllers/sessions_controller_spec.rb
+++ b/decidim-core/spec/controllers/sessions_controller_spec.rb
@@ -31,8 +31,8 @@ module Decidim
 
               context "when there are authorization handlers" do
                 before do
-                  user.organization.available_authorizations = ["dummy_authorization_handler"]
-                  user.organization.save
+                  allow(user.organization).to receive(:available_authorizations)
+                    .and_return(["dummy_authorization_handler"])
                 end
 
                 it { is_expected.to eq("/authorizations/first_login") }
@@ -71,6 +71,10 @@ module Decidim
               end
 
               context "and otherwise", with_authorization_workflows: [] do
+                before do
+                  allow(user.organization).to receive(:available_authorizations).and_return([])
+                end
+
                 it { is_expected.to eq("/") }
               end
             end

--- a/decidim-core/spec/services/decidim/action_authorizer_spec.rb
+++ b/decidim-core/spec/services/decidim/action_authorizer_spec.rb
@@ -6,9 +6,9 @@ module Decidim
   describe ActionAuthorizer do
     subject { authorizer }
 
-    let(:organization) { create :organization }
+    let(:organization) { create(:organization, available_authorizations: %w(dummy_authorization_handler another_dummy_authorization_handler)) }
     let(:user) { create(:user, organization: organization) }
-    let(:component) { create(:component, permissions: permissions) }
+    let(:component) { create(:component, permissions: permissions, organization: organization) }
     let(:resource) { nil }
     let(:action) { "vote" }
     let(:permissions) { { action => permission } }
@@ -86,6 +86,21 @@ module Decidim
               expect(response.codes).to include(:unauthorized)
             end
           end
+        end
+      end
+
+      context "when organization doesnt have authorization handler available" do
+        let(:permission) do
+          {
+            "authorization_handlers" => {
+              "disabled_authorization_handler" => {}
+            }
+          }
+        end
+
+        it "doesn't require it" do
+          expect(response).to be_ok
+          expect(response.statuses.count).to eq(0)
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Currently when we change "Available authorizations" from system admin panel, it doesn't affect to component's permissions. So for example if we edit permissions from component, enable some authorization and after that we disable it from system admin, component still requires it.

#### Testing
1. Basic decidim installation with seed data (e.g. decidim GitHub development_app)
2. Go to /system
3. Enable all available authorization options
4. Go to /admin
5. Configure both authorizations as required for a budgeting component
6. Go to vote, you should see the authorization modal with two authorization options
7. Go to /system
8. Disable the other authorization from the organization
9. Go to vote, you SHOULD see only the available authorization but you are seeing both options that you previously configured for the component

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/121383267-fda54c00-c94f-11eb-999f-50171832ccee.png)

![image](https://user-images.githubusercontent.com/19709320/121382806-a1422c80-c94f-11eb-9ee8-f5e0ad7249b5.png)

:hearts: Thank you!
