### PR TITLE
When deleting an user, the information submitted is not being saved. 

### DIFF
--- a/decidim-core/app/views/decidim/account/delete.html.erb
+++ b/decidim-core/app/views/decidim/account/delete.html.erb
@@ -7,7 +7,7 @@
       <p><%= t(".alert") %></p>
     </div>
     <p><%= t(".explanation") %></p>
-    <%= decidim_form_for(@form, url: account_path, method: :delete, namespace: "delete_user", html: { class: "user-form delete-account" }) do |f| %>
+    <%= decidim_form_for(@form, url: account_path, method: :delete, html: { class: "user-form delete-account" }) do |f| %>
       <div>
         <label>
           <span class="user-form__label"><%= t("activemodel.attributes.account.delete_reason") %></span>
@@ -17,7 +17,7 @@
       <button class="button open-modal-button"><%= t(".confirm.title") %></button>
     <% end %>
     <div class="tiny reveal" id="deleteConfirm" data-reveal>
-      <%= decidim_form_for(@form, url: account_path, method: :delete, namespace: "delete_user_confirm", html: { class: "user-form delete-account-modal" }) do |f| %>
+      <%= decidim_form_for(@form, url: account_path, method: :delete, html: { class: "user-form delete-account-modal" }) do |f| %>
         <%= f.hidden_field :delete_reason %>
 
         <p><%= t(".confirm.question") %></p>


### PR DESCRIPTION
#### :tophat: What? Why?
Currently, when an user chooses to delete it's account, he is being prompted to provide some details regarding his decision. The submitted information is not being saved to the user data. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
