### PR TITLE
Fix NOT "Enable rich text editor for participants" + Proposal with template

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -48,7 +48,8 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :amendments_enabled, type: :boolean, default: false
     settings.attribute :amendments_wizard_help_text, type: :text, translated: true, editor: true, required: false
     settings.attribute :announcement, type: :text, translated: true, editor: true
-    settings.attribute :new_proposal_body_template, type: :text, translated: true, editor: true, required: false
+    settings.attribute :new_proposal_body_template, type: :text, translated: true, required: false,
+                       editor: ->(context) { context[:component].organization.rich_text_editor_in_public_views? }
     settings.attribute :new_proposal_help_text, type: :text, translated: true, editor: true
     settings.attribute :proposal_wizard_step_1_help_text, type: :text, translated: true, editor: true
     settings.attribute :proposal_wizard_step_2_help_text, type: :text, translated: true, editor: true


### PR DESCRIPTION
#### :tophat: What? Why?
When I have disabled "Enable rich text editor for participants" option, proposal template is displayed with html tags.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #7034

#### Testing
Enable rich text editor and create/edit template then create new proposal and all work fine

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
**Before**
![Before](https://user-images.githubusercontent.com/72607737/109334141-9a8c1f80-7860-11eb-9518-561c2d02ae09.png)
![Before](https://user-images.githubusercontent.com/72607737/109333219-754ae180-785f-11eb-8989-0cfe7fe304fc.png)
**After**
![After](https://user-images.githubusercontent.com/43346616/121860449-24210980-ccf9-11eb-8bae-3bbc96a4a62d.png)
![After](https://user-images.githubusercontent.com/43346616/121860526-38fd9d00-ccf9-11eb-8954-333e291c6792.png)

:hearts: Thank you!
