### PR TITLE
Fix flaky test on initiatives

### DIFF
--- a/decidim-initiatives/app/jobs/decidim/initiatives/export_initiatives_job.rb
+++ b/decidim-initiatives/app/jobs/decidim/initiatives/export_initiatives_job.rb
@@ -21,7 +21,7 @@ module Decidim
 
         collection = collection.where(id: ids) if ids.present?
 
-        collection
+        collection.order(id: :asc)
       end
 
       def serializer

--- a/decidim-initiatives/spec/jobs/decidim/initiatives/export_initiatives_job_spec.rb
+++ b/decidim-initiatives/spec/jobs/decidim/initiatives/export_initiatives_job_spec.rb
@@ -18,7 +18,7 @@ module Decidim
       it "sends an email with the result of the export" do
         expect(Decidim::Exporters.find_exporter(format)).to receive(:new)
           .with(
-            initiatives,
+            initiatives.sort_by(&:id),
             Decidim::Initiatives::InitiativeSerializer
           ).and_call_original
 
@@ -31,13 +31,13 @@ module Decidim
         expect(email.body.encoded).to match("Please find attached a zipped version of your export.")
       end
 
-      context "when a collection of ids is passed as a parameter" do
-        let(:collection_ids) { [initiatives.first.id] }
+      context "when a collection of ids is passed as a parameter using an odd ordering" do
+        let(:collection_ids) { [initiatives.last.id, initiatives.first.id] }
 
         it "sends an email with the result of the export" do
           expect(Decidim::Exporters.find_exporter(format)).to receive(:new)
             .with(
-              [initiatives.first],
+              [initiatives.first, initiatives.last],
               Decidim::Initiatives::InitiativeSerializer
             ).and_call_original
 


### PR DESCRIPTION
#### :tophat: What? Why?
After merging #8033 I started to see some flaky tests related to the initiatives exporting job. It seems that the problem is that sometimes the initiatives are not received in the same order than they are created, and the existing tests check their order too.

First, I've just changed the tests to ignore the order. But then I thought that maybe it could be useful to retrieve the exported initiatives always in the same order. Then I modified the exporter job to output the initiatives ordered by ID and added a test to verify that this is being done.

@decidim/product I think this is not a big deal, but it could be interesting for you to know it 🙂  

#### :pushpin: Related Issues
- Related to #8033

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
