### PR TITLE
Add missing translation for authorization_modals

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -321,6 +321,8 @@ en:
           authorize: Authorize with "%{authorization}"
           explanation: In order to perform this action, you need to be authorized with "%{authorization}".
           title: Authorization required
+        ok:
+          title: You've been authorized while in this page. Please, reload the page to perform your action
         pending:
           explanation: In order to perform this action, you need to be authorized with "%{authorization}", but your authorization is still in progress
           resume: Check your "%{authorization}" authorization progress


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the missing translation for the `authorization_modals_controller` view.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #8123

#### Testing
Follow the steps to reproduce in the issue but at the end you should receive a modal with the text "You've been authorized while in this page. Please, reload the page to perform your action" instead of the internal server error.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![imatge](https://user-images.githubusercontent.com/199462/121905910-e4731580-cd2a-11eb-869e-c44d841d57e8.png)

:hearts: Thank you!
