### PR TITLE
Fix user report notification reported user name

### DIFF
--- a/decidim-core/app/views/decidim/user_report_mailer/notify.html.erb
+++ b/decidim-core/app/views/decidim/user_report_mailer/notify.html.erb
@@ -1,6 +1,6 @@
 <p class="email-greeting"><%= t ".hello", admin: h(@admin.name) %></p>
 
-<p class="email-instructions"><%= t ".body_1", user: h(@user.name), token: h(@token.name) %></p>
+<p class="email-instructions"><%= t ".body_1", user: h(@user.user_name), token: h(@token.name) %></p>
 
 <p class="email-instructions"><%= t ".body_2", reason: h(@reason) %></p>
 

--- a/decidim-core/spec/mailers/user_report_mailer_spec.rb
+++ b/decidim-core/spec/mailers/user_report_mailer_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe UserReportMailer, type: :mailer do
+    let(:organization) { create(:organization, name: "Test Organization") }
+    let(:admin) { create(:user, :admin, organization: organization) }
+    let(:reporter) { create(:user, :confirmed, organization: organization) }
+    let(:user) { create(:user, :confirmed, organization: organization) }
+    let(:reason) { "spam" }
+
+    describe "#notify" do
+      let(:mail) { described_class.notify(admin, reporter, reason, user) }
+
+      describe "email body" do
+        it "includes the reported user name" do
+          expect(email_body(mail)).to include(user.name)
+        end
+
+        it "includes the reporter name" do
+          expect(email_body(mail)).to include(reporter.name)
+        end
+
+        it "includes the reason" do
+          expect(email_body(mail)).to include(reason)
+        end
+
+        context "when the user is already blocked" do
+          let(:user) { create(:user, :blocked, organization: organization) }
+
+          it "includes the reported user's original name" do
+            # The `user.name` is set to "Blocked user"
+            expect(email_body(mail)).not_to include(user.name)
+            expect(email_body(mail)).to include(user.user_name)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When a user is reported, a notification is sent to system administrators. This notification contains the user's name.

There can be delay for sending these emails due to the background processing having a long queue or the system having many administrators. If the user is already blocked when the mail is processed, the reported user's name will show up as "Blocked user" in the notification emails.

This changes the notification email to show the user's actual name instead of "Blocked user" also in this described case.

#### :pushpin: Related Issues
- Related to #6696

#### Testing
Send a user report notification to admin users for a user that is already blocked.

Or see the spec added in this PR.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.