### PR TITLE
Fix access to import CSV results in accountability

### DIFF
--- a/decidim-accountability/app/controllers/decidim/accountability/admin/import_results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/import_results_controller.rb
@@ -16,17 +16,7 @@ module Decidim
           Decidim::Accountability::Admin::ImportResultsCsvJob.perform_later(current_user, current_component, @csv_file.read.force_encoding("utf-8").encode("utf-8"))
 
           flash[:notice] = I18n.t("imports.create.success", scope: "decidim.accountability.admin")
-          redirect_to import_results_path(current_participatory_process, current_component)
-        end
-
-        private
-
-        def current_component
-          @current_component ||= current_participatory_process.components.find(params[:component_id])
-        end
-
-        def current_participatory_process
-          @current_participatory_process ||= ParticipatoryProcess.find_by(slug: params[:participatory_process_slug])
+          redirect_to import_results_path(current_participatory_space, current_component)
         end
       end
     end

--- a/decidim-accountability/app/views/decidim/accountability/admin/import_results/new.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/import_results/new.html.erb
@@ -17,6 +17,6 @@
     <%= submit_tag t(".import"), class: "button" %>
   </div>
   <div class="import-process-info">
-    <%= t(".info", link_new_status: new_status_path, link_new_result: new_result_path, link_export_csv: link_to(t(".link"), exports_path(@current_component, id: "results", format: "CSV"), method: :post)).try("html_safe") %>
+    <%= t(".info", link_new_status: new_status_path, link_new_result: new_result_path, link_export_csv: link_to(t(".link"), exports_path(current_component, id: "results", format: "CSV"), method: :post)).try("html_safe") %>
   </div>
 <% end %>

--- a/decidim-accountability/spec/controllers/decidim/accountability/admin/import_results_controller_spec.rb
+++ b/decidim-accountability/spec/controllers/decidim/accountability/admin/import_results_controller_spec.rb
@@ -10,14 +10,13 @@ module Decidim
 
         let(:organization) { create(:organization) }
         let(:current_user) { create(:user, :confirmed, :admin, organization: organization) }
-        let(:participatory_space) { create(:participatory_process, organization: organization) }
+        let(:params) { { participatory_process_slug: participatory_space.slug, component_id: component.id } }
         let!(:component) do
           create(
             :accountability_component,
             participatory_space: participatory_space
           )
         end
-        let(:params) { { participatory_process_slug: participatory_space.slug, component_id: component.id } }
 
         before do
           request.env["decidim.current_organization"] = organization
@@ -25,14 +24,28 @@ module Decidim
           sign_in current_user
         end
 
-        describe "GET the import result process new" do
-          before do
-            get :new, params: params
-          end
+        shared_examples "renders the import new result page" do
+          describe "GET the import result process new" do
+            before do
+              get :new, params: params
+            end
 
-          it "renders the import result form" do
-            expect(response).to render_template("decidim/accountability/admin/import_results/new")
+            it "renders the import result form" do
+              expect(response).to render_template("decidim/accountability/admin/import_results/new")
+            end
           end
+        end
+
+        describe "when in a participatory process" do
+          let(:participatory_space) { create(:participatory_process, organization: organization) }
+
+          it_behaves_like "renders the import new result page"
+        end
+
+        describe "when in an assembly" do
+          let(:participatory_space) { create(:assembly, organization: organization) }
+
+          it_behaves_like "renders the import new result page"
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
`decidim-accountability/app/controllers/decidim/accountability/admin/import_results_controller.rb` was incorrectly overriding the methods `current_component` & `current_participatory_process`, this PR removes this overrides. The override was not taking into account when accountability was in an assembly.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #8131 

#### Testing
Go to the accountability component of an assembly and click the "Import CSV" button.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*In an Assembly*
![imatge](https://user-images.githubusercontent.com/199462/121910926-914f9180-cd2f-11eb-8f05-fe9e3c6349ee.png)

*In a Participatory Process*
![imatge](https://user-images.githubusercontent.com/199462/121910956-9ad8f980-cd2f-11eb-91d0-107f5b71ed15.png)

:hearts: Thank you!
