### PR TITLE
Backport "Add missing translation for authorization_modals" to 0.24

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -314,6 +314,8 @@ en:
           authorize: Authorize with "%{authorization}"
           explanation: In order to perform this action, you need to be authorized with "%{authorization}".
           title: Authorization required
+        ok:
+          title: You've been authorized while in this page. Please, reload the page to perform your action
         pending:
           explanation: In order to perform this action, you need to be authorized with "%{authorization}", but your authorization is still in progress
           resume: Check your "%{authorization}" authorization progress


### PR DESCRIPTION
#### :tophat: What? Why?
This PR backports the fix in #8129 to the `release/0.24-stable` branch.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #8129 
