### PR TITLE
Fix dont save timeout path to session

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
+++ b/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
@@ -22,7 +22,6 @@ module Decidim
       # Next stop: Let's check whether auth is ok
       unless user_signed_in?
         flash[:warning] = t("actions.login_before_access", scope: "decidim.core")
-        store_location_for(:user, request.path)
         redirect_to decidim.new_user_session_path
       end
     end

--- a/decidim-core/app/controllers/decidim/timeouts_controller.rb
+++ b/decidim-core/app/controllers/decidim/timeouts_controller.rb
@@ -10,10 +10,6 @@ module Decidim
 
     prepend_before_action :skip_timeout, only: :seconds_until_timeout
 
-    def skip_timeout
-      request.env["devise.skip_timeoutable"] = true
-    end
-
     def seconds_until_timeout
       time_remaining = current_user ? ::Devise.timeout_in - (Time.current - Time.zone.at(user_session["last_request_at"])) : 0
       respond_to do |format|
@@ -26,6 +22,12 @@ module Decidim
       respond_to do |format|
         format.js
       end
+    end
+
+    private
+
+    def skip_timeout
+      request.env["devise.skip_timeoutable"] = true
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/timeouts_controller.rb
+++ b/decidim-core/app/controllers/decidim/timeouts_controller.rb
@@ -5,6 +5,9 @@ require "active_support/concern"
 module Decidim
   # Tells/Extends time before inactivity warning or automatic logout.
   class TimeoutsController < Decidim::ApplicationController
+    # Skip these methods because they can call Devise's store_location_for, which can save timeouts path to session.
+    skip_before_action :store_current_location, :ensure_authenticated!
+
     prepend_before_action :skip_timeout, only: :seconds_until_timeout
 
     def skip_timeout

--- a/decidim-core/app/controllers/decidim/timeouts_controller.rb
+++ b/decidim-core/app/controllers/decidim/timeouts_controller.rb
@@ -6,7 +6,7 @@ module Decidim
   # Tells/Extends time before inactivity warning or automatic logout.
   class TimeoutsController < Decidim::ApplicationController
     # Skip these methods because they can call Devise's store_location_for, which can save timeouts path to session.
-    skip_before_action :store_current_location, :ensure_authenticated!
+    skip_before_action :store_current_location
 
     prepend_before_action :skip_timeout, only: :seconds_until_timeout
 

--- a/decidim-core/spec/controllers/decidim/timeouts_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/timeouts_controller_spec.rb
@@ -32,7 +32,6 @@ module Decidim
 
         it "returns seconds until timeout" do
           expect(controller).not_to receive(:store_current_location)
-          expect(controller).not_to receive(:ensure_authenticated!)
 
           get :seconds_until_timeout, format: :json, params: params
 

--- a/decidim-core/spec/controllers/decidim/timeouts_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/timeouts_controller_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe TimeoutsController, type: :controller do
+    routes { Decidim::Core::Engine.routes }
+
+    let(:current_user) { create(:user, :confirmed, organization: organization) }
+    let(:timeout_time) { 30.minutes }
+    let(:last_request) { (Time.current - time_since_last_request).to_i }
+    let(:user_session) { { "last_request_at" => last_request } }
+    let(:time_since_last_request) { 1.minute }
+    let(:params) { {} }
+    let(:max_delay) { 5 }
+
+    before do
+      allow(Devise).to receive(:timeout_in).and_return(timeout_time)
+      allow(controller).to receive(:user_session).and_return(user_session)
+    end
+
+    describe "#seconds_until_timeout" do
+      let(:parsed_response) { JSON.parse(response.body) }
+
+      context "when forcing users to authenticate before access organization" do
+        let(:organization) { create(:organization, force_users_to_authenticate_before_access_organization: true) }
+
+        before do
+          request.env["decidim.current_organization"] = organization
+          sign_in current_user, scope: :user
+        end
+
+        it "returns seconds until timeout" do
+          expect(controller).not_to receive(:store_current_location)
+          expect(controller).not_to receive(:ensure_authenticated!)
+
+          get :seconds_until_timeout, format: :json, params: params
+
+          expect(response.status).to eq(200)
+          expect(parsed_response["seconds_remaining"])
+            .to be_between(timeout_time.to_i - time_since_last_request.to_i - max_delay, timeout_time.to_i - time_since_last_request.to_i)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When "Force users to authenticate before access organization" is set from system panel, automatic session timeout isn't working as expected: it's not always singing out in all tabs and stores /timeouts/seconds_until_timeout location (as redirect path) to user's session. This is because ensure_authenticated! method calls store_location_for which stores /timeouts/seconds_until_timeout location to session. 

#### Testing
0. *OPTIONAL*: config.timeout_in = 2.minutes @ devise.rb
1. Go to system panel and set "Force users to authenticate before access organization"
2. Sign in
3. Open two tabs (e.g. /processes and /assemblies)
4. Wait for timeout modal to popup 
5. Click "Continue session" in one tab
6. Wait for automatic sign out (don't press anything when timeout modal appears)
7. All tabs SHOULD have location /users/sign_in (without timeout modal)
8. When signing in again SHOULD NOT see error (screenshot below)

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/122197576-00002c80-cea1-11eb-8bcf-e2f505d833dc.png)

:hearts: Thank you!
