### PR TITLE
Fix verification route issues

### DIFF
--- a/decidim-verifications/spec/lib/decidim/verifications/adapter_spec.rb
+++ b/decidim-verifications/spec/lib/decidim/verifications/adapter_spec.rb
@@ -43,4 +43,109 @@ describe Decidim::Verifications::Adapter do
       expect(wrappers.map(&:type)).to eq(%w(direct multistep))
     end
   end
+
+  describe "#resume_authorization_path", with_authorization_workflows: %w(dummy_authorization_handler dummy_authorization_workflow) do
+    let(:handler) { "dummy_authorization_workflow" }
+    let(:wrapper) { described_class.from_element(handler) }
+
+    it "returns the edit authorization path for the workflow engine" do
+      expect(wrapper.resume_authorization_path).to eq("/dummy_authorization_workflow/edit_authorization")
+    end
+
+    context "when the main engine is not defined" do
+      it "raises a MissingEngine error" do
+        expect(wrapper).to receive(:respond_to?).with("decidim_#{handler}").and_return(false)
+
+        expect { wrapper.resume_authorization_path }.to raise_error(
+          Decidim::Verifications::MissingEngine
+        )
+      end
+    end
+
+    context "when the edit_authorization_path is not defined for the engine" do
+      it "raises a MissingVerificationRoute error" do
+        allow(wrapper).to receive(:decidim_dummy_authorization_workflow).and_return(double)
+
+        expect { wrapper.resume_authorization_path }.to raise_error(
+          Decidim::Verifications::MissingVerificationRoute
+        )
+      end
+    end
+
+    context "with direct verification" do
+      let(:handler) { "dummy_authorization_handler" }
+
+      it "raises an InvalidVerificationRoute error" do
+        expect { wrapper.resume_authorization_path }.to raise_error(
+          Decidim::Verifications::InvalidVerificationRoute
+        )
+      end
+    end
+  end
+
+  describe "#renew_path", with_authorization_workflows: %w(dummy_authorization_handler dummy_authorization_workflow) do
+    let(:handler) { "dummy_authorization_workflow" }
+    let(:wrapper) { described_class.from_element(handler) }
+
+    it "returns the renew authorization path for the workflow engine" do
+      expect(wrapper.renew_path).to eq("/dummy_authorization_workflow/renew_authorization")
+    end
+
+    context "when the main engine is not defined" do
+      it "raises a MissingEngine error" do
+        expect(wrapper).to receive(:respond_to?).with("decidim_#{handler}").and_return(false)
+
+        expect { wrapper.renew_path }.to raise_error(
+          Decidim::Verifications::MissingEngine
+        )
+      end
+    end
+
+    context "when the edit_authorization_path is not defined for the engine" do
+      it "raises a MissingVerificationRoute error" do
+        allow(wrapper).to receive(:decidim_dummy_authorization_workflow).and_return(double)
+
+        expect { wrapper.renew_path }.to raise_error(
+          Decidim::Verifications::MissingVerificationRoute
+        )
+      end
+    end
+
+    context "with direct verification" do
+      let(:handler) { "dummy_authorization_handler" }
+
+      it "returns the general renew authorization path" do
+        expect(wrapper.renew_path).to eq("/authorizations/renew?handler=dummy_authorization_handler")
+      end
+    end
+  end
+
+  describe "#admin_root_path", with_authorization_workflows: %w(dummy_authorization_handler dummy_authorization_workflow id_documents) do
+    let(:handler) { "id_documents" }
+    let(:wrapper) { described_class.from_element(handler) }
+
+    it "returns the renew authorization path for the workflow engine" do
+      expect(wrapper.admin_root_path).to eq("/admin/id_documents/")
+    end
+
+    context "when the admin engine is not defined" do
+      let(:handler) { "dummy_authorization_workflow" }
+
+      it "raises a MissingEngine error" do
+        expect { wrapper.admin_root_path }.to raise_error(
+          Decidim::Verifications::MissingEngine
+        )
+      end
+    end
+
+    context "with direct verification" do
+      let(:handler) { "dummy_authorization_handler" }
+
+      it "raises an InvalidVerificationRoute error" do
+        expect { wrapper.admin_root_path }.to raise_error(
+          Decidim::Verifications::InvalidVerificationRoute
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
There are some situations when the verification adapter raises very obfuscated error messages, such as:
- The admin or main engine have not been defined for the verification workflow
- The verification workflow is missing some of the routes assumed for "multi step" workflows (although it's not really necessary)
- When trying to call these route methods for direct verification types as reported at #8145

This improves the exceptions in these situations to better identify the problem with the workflow. This also adds specs for these cases.

#### :pushpin: Related Issues
- Fixes #8145

#### Testing
- Create a multi-step workflow and define both main and admin engine for it
- Do **NOT** define the "edit" and "renew" routes for the workflow
- Configure an action where this workflow is required (e.g. voting)
- Manually create an authorization for the current user in the database for this workflow but leave the `granted_at` field `nil`
- Try to vote, you will see a very non-descriptive error message with non-descriptive stack trace in the console

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
This is what the user sees in these situations:
![Obfuscated user error](https://user-images.githubusercontent.com/864340/122571768-befd4900-d055-11eb-9530-456f14c8d328.png)

It does not really matter as it should never happen when the workflow is configured accordingly to the database data.

But the stacktrace exceptions are now improved in order to identify what causes this issue.