### PR TITLE
Exclude blocked and deleted users from participants stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 
+#### Statistics change 
+As per [\#8147](https://github.com/decidim/decidim/pull/8147), the participants stats will not take into account deleted and blocked users.   
+
 #### Webpacker migration
 As per [#7464](https://github.com/decidim/decidim/pull/7464), [#7733](https://github.com/decidim/decidim/pull/7733) Decidim has been upgraded to use Webpacker to manage its assets. It's a huge change that requires some updates in your applications. Please refer to the guide [Migrate to Webpacker an instance app](https://github.com/decidim/decidim/blob/develop/docs/modules/develop/pages/guide_migrate_webpacker_app.adoc) and follow the steps described.
 

--- a/decidim-core/app/queries/decidim/stats_users_count.rb
+++ b/decidim-core/app/queries/decidim/stats_users_count.rb
@@ -15,10 +15,9 @@ module Decidim
     end
 
     def query
-      users = Decidim::User.where(organization: @organization)
+      users = Decidim::User.where(organization: @organization).not_deleted.not_blocked.confirmed
       users = users.where("created_at >= ?", @start_at) if @start_at.present?
       users = users.where("created_at <= ?", @end_at) if @end_at.present?
-      users = users.where.not(confirmed_at: nil)
       users.count
     end
   end

--- a/decidim-core/spec/queries/decidim/stats_users_count_spec.rb
+++ b/decidim-core/spec/queries/decidim/stats_users_count_spec.rb
@@ -40,4 +40,14 @@ describe Decidim::StatsUsersCount do
       expect(subject.query).to eq(1)
     end
   end
+
+  context "with blocked and deleted users" do
+    it "will exclude all the users blocked or with deleted account" do
+      create(:user, :confirmed, organization: organization, blocked: true)
+      create(:user, :confirmed, organization: organization, deleted_at: Time.current - 1.day)
+      create(:user, :confirmed, organization: organization)
+
+      expect(subject.query).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
On the currents state of the application all the users are being added to the participant count, regardless the user is banned or deleted. This PR aims to fix the issue. 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
