### PR TITLE
Fix proposal picker remove using "×"

### DIFF
--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -173,7 +173,7 @@ shared_examples "manage projects" do
       end
     end
 
-    it "removes proposals from project" do
+    it "removes proposals from project", :slow do
       project.link_resources(proposals, "included_proposals")
       expect(project.linked_resources(:proposals, "included_proposals").count).to eq(5)
 

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -173,6 +173,33 @@ shared_examples "manage projects" do
       end
     end
 
+    it "removes proposals from project" do
+      project.link_resources(proposals, "included_proposals")
+      expect(project.linked_resources(:proposals, "included_proposals").count).to eq(5)
+
+      within find("tr", text: translated(project.title)) do
+        click_link "Edit"
+      end
+
+      within ".edit_project" do
+        fill_in_i18n(
+          :project_title,
+          "#project-title-tabs",
+          en: "My new title",
+          es: "Mi nuevo título",
+          ca: "El meu nou títol"
+        )
+
+        page.execute_script "window.scrollBy(0,10000)"
+        proposals_remove(select_data_picker(:project_proposals, multiple: true), proposals.last(4))
+
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_admin_callout("successfully")
+      expect(project.linked_resources(:proposals, "included_proposals").count).to eq(1)
+    end
+
     it "creates a new project", :slow do
       find(".card-title a.button.new").click
 

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -175,6 +175,7 @@ shared_examples "manage projects" do
 
     it "removes proposals from project", :slow do
       project.link_resources(proposals, "included_proposals")
+      not_removed_projects_title = project.linked_resources(:proposals, "included_proposals").first.title
       expect(project.linked_resources(:proposals, "included_proposals").count).to eq(5)
 
       within find("tr", text: translated(project.title)) do
@@ -189,6 +190,7 @@ shared_examples "manage projects" do
 
       expect(page).to have_admin_callout("successfully")
       expect(project.linked_resources(:proposals, "included_proposals").count).to eq(1)
+      expect(project.linked_resources(:proposals, "included_proposals").first.title).to eq(not_removed_projects_title)
     end
 
     it "creates a new project", :slow do

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -182,15 +182,6 @@ shared_examples "manage projects" do
       end
 
       within ".edit_project" do
-        fill_in_i18n(
-          :project_title,
-          "#project-title-tabs",
-          en: "My new title",
-          es: "Mi nuevo título",
-          ca: "El meu nou títol"
-        )
-
-        page.execute_script "window.scrollBy(0,10000)"
         proposals_remove(select_data_picker(:project_proposals, multiple: true), proposals.last(4))
 
         find("*[type=submit]").click

--- a/decidim-core/app/packs/src/decidim/data_picker.js
+++ b/decidim-core/app/packs/src/decidim/data_picker.js
@@ -237,10 +237,8 @@ export default class DataPicker {
   _removeValue($picker, target) {
     if (target) {
       this._setCurrentPicker($picker, target);
-      this.current.target.fadeOut(100, () => {
-        this.current.target.remove();
-        this.current.target = null;
-      });
+      this.current.target.remove();
+      this.current.target = null;
     }
   }
 

--- a/decidim-core/app/packs/src/decidim/data_picker.js
+++ b/decidim-core/app/packs/src/decidim/data_picker.js
@@ -36,6 +36,8 @@ export default class DataPicker {
 
       if ($(this._targetFromEvent(event)).hasClass("picker-prompt") || !isMultiPicker) {
         this._openPicker($picker, this._targetFromEvent(event));
+      }  else if (this._targetFromEvent(event).tagName === "A") {
+        this._removeValue($picker, this._targetFromEvent(event).parentNode);
       } else {
         this._removeValue($picker, this._targetFromEvent(event));
       }

--- a/decidim-core/app/packs/src/decidim/data_picker.js
+++ b/decidim-core/app/packs/src/decidim/data_picker.js
@@ -237,7 +237,7 @@ export default class DataPicker {
   _removeValue($picker, target) {
     if (target) {
       this._setCurrentPicker($picker, target);
-      this.current.target.fadeOut(500, () => {
+      this.current.target.fadeOut(100, () => {
         this.current.target.remove();
         this.current.target = null;
       });

--- a/decidim-core/app/packs/src/decidim/data_picker.js
+++ b/decidim-core/app/packs/src/decidim/data_picker.js
@@ -238,7 +238,10 @@ export default class DataPicker {
     if (target) {
       this._setCurrentPicker($picker, target);
       // Fadeout (with time) doesn't work in system tests
-      const fadeoutTime = navigator?.webdriver ? 0 : 500;
+      let fadeoutTime = 500;
+      if (navigator && navigator.webdriver) {
+        fadeoutTime = 0;
+      }
       this.current.target.fadeOut(fadeoutTime, () => {
         this.current.target.remove();
         this.current.target = null;

--- a/decidim-core/app/packs/src/decidim/data_picker.js
+++ b/decidim-core/app/packs/src/decidim/data_picker.js
@@ -237,8 +237,12 @@ export default class DataPicker {
   _removeValue($picker, target) {
     if (target) {
       this._setCurrentPicker($picker, target);
-      this.current.target.remove();
-      this.current.target = null;
+      // Fadeout (with time) doesn't work in system tests
+      const fadeoutTime = navigator?.webdriver ? 0 : 500;
+      this.current.target.fadeOut(fadeoutTime, () => {
+        this.current.target.remove();
+        this.current.target = null;
+      });
     }
   }
 

--- a/decidim-proposals/lib/decidim/proposals/test/capybara_proposals_picker.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/capybara_proposals_picker.rb
@@ -41,6 +41,16 @@ module Capybara
 
       expect(proposals_picker).to have_proposals_picked(proposals)
     end
+
+    def proposals_remove(proposals_picker, proposals)
+      data_picker = proposals_picker.data_picker
+
+      proposals.each do |proposal|
+        data_picker.find("a", text: proposal.title["en"]).find("span").click
+      end
+
+      expect(proposals_picker).to have_proposals_not_picked(proposals)
+    end
   end
 end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Pressing "×"  within proposal picker doesn't remove linked proposal from project or result. It removes link yes, but hidden input field stays and so proposal stays linked to project in database.  I had to remove fadeout, because couldn't write system tests when element was fading (element didn't fade out even with wait or sleep, it just got hidden).

#### Testing
1. Go to admin
2. Edit project with linked proposals
3. Click "×" before some linked proposal
4. Update
5. Go to Edit project view again
6. Proposal SHOULD NOT be linked anymore.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/122764317-0844d700-d2a8-11eb-9370-374f164aa7ff.png)

:hearts: Thank you!
