### PR TITLE
Allow to create online meetings without an URL

### DIFF
--- a/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
@@ -52,7 +52,7 @@ module Decidim
                 :logo,
                 passthru: { to: Decidim::Organization }
 
-      validates :highlighted_content_banner_action_url, presence: true, if: :highlighted_content_banner_enabled?
+      validates :highlighted_content_banner_action_url, url: true, presence: true, if: :highlighted_content_banner_enabled?
       validates :highlighted_content_banner_image,
                 presence: true,
                 passthru: { to: Decidim::Organization },
@@ -70,7 +70,7 @@ module Decidim
                 translatable_presence: true,
                 if: :highlighted_content_banner_enabled?
 
-      validates :omnipresent_banner_url, presence: true, if: :enable_omnipresent_banner?
+      validates :omnipresent_banner_url, url: true, presence: true, if: :enable_omnipresent_banner?
       validates :omnipresent_banner_title, translatable_presence: true, if: :enable_omnipresent_banner?
       validates :omnipresent_banner_short_description, translatable_presence: true, if: :enable_omnipresent_banner?
 

--- a/decidim-consultations/app/forms/decidim/consultations/admin/question_form.rb
+++ b/decidim-consultations/app/forms/decidim/consultations/admin/question_form.rb
@@ -37,7 +37,7 @@ module Decidim
         validates :banner_image, passthru: { to: Decidim::Consultations::Question }
         validate :slug_uniqueness
         validates :origin_scope, :origin_title, translatable_presence: true, if: :has_origin_data?
-        validates :i_frame_url, presence: true, if: :external_voting
+        validates :i_frame_url, url: true, presence: true, if: :external_voting
         validates :order, numericality: { only_integer: true, allow_nil: true, allow_blank: true }
 
         alias organization current_organization

--- a/decidim-core/app/forms/url_validator.rb
+++ b/decidim-core/app/forms/url_validator.rb
@@ -12,6 +12,8 @@ class UrlValidator < ActiveModel::EachValidator
   # a URL may be technically well-formed but may
   # not actually be valid, so this checks for both.
   def url_valid?(url)
+    return true unless url.present?
+
     url = URI.parse(url)
     (url.is_a?(URI::HTTP) || url.is_a?(URI::HTTPS)) && url.host.present?
   rescue URI::InvalidURIError

--- a/decidim-core/app/forms/url_validator.rb
+++ b/decidim-core/app/forms/url_validator.rb
@@ -12,7 +12,7 @@ class UrlValidator < ActiveModel::EachValidator
   # a URL may be technically well-formed but may
   # not actually be valid, so this checks for both.
   def url_valid?(url)
-    return true unless url.present?
+    return true if url.blank?
 
     url = URI.parse(url)
     (url.is_a?(URI::HTTP) || url.is_a?(URI::HTTPS)) && url.host.present?

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_url/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_url/show.erb
@@ -6,8 +6,12 @@
     <li class="card-data__item">
       <div class="text-left">
         <div class="card__icondata--address">
-          <span><%= link_to(model.online_meeting_url, model.online_meeting_url, target: "_blank") %></span><br>
-          <span><%= translated_attribute model.location_hints %></span>
+          <% if has_meeting_url? %>
+            <span><%= link_to(model.online_meeting_url, model.online_meeting_url, target: "_blank") %></span><br>
+            <span><%= translated_attribute model.location_hints %></span>
+          <% else %>
+            <span><%= t("decidim.meetings.meetings.online_meeting_link.link_available_soon") %></span>
+          <% end %>
         </div>
       </div>
     </li>

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_url_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_url_cell.rb
@@ -10,7 +10,19 @@ module Decidim
       private
 
       def resource_icon
-        icon "video", class: "icon--big", role: "img", "aria-hidden": true
+        icon icon_name, class: "icon--big", role: "img", "aria-hidden": true
+      end
+
+      def icon_name
+        if has_meeting_url?
+          "video"
+        else
+          "timer"
+        end
+      end
+
+      def has_meeting_url?
+        @has_meeting_url ||= model.online_meeting_url.present?
       end
     end
   end

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -40,7 +40,7 @@ module Decidim
 
         validates :address, presence: true, if: ->(form) { form.needs_address? }
         validates :address, geocoding: true, if: ->(form) { form.has_address? && !form.geocoded? && form.needs_address? }
-        validates :online_meeting_url, presence: true, url: true, if: ->(form) { form.online_meeting? || form.hybrid_meeting? }
+        validates :online_meeting_url, url: true, if: ->(form) { form.online_meeting? || form.hybrid_meeting? }
         validates :start_time, presence: true, date: { before: :end_time }
         validates :end_time, presence: true, date: { after: :start_time }
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_online_meeting_link.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_online_meeting_link.html.erb
@@ -16,11 +16,18 @@
 <div class="card card--secondary">
   <div class="card__content address">
     <div class="address__info">
-      <%= icon "video", role: "img", "aria-hidden": true, remove_icon_class: true, width: 40, height: 70 %>
-      <div class="address__details">
-        <span><%= link_to(meeting.online_meeting_url, meeting.online_meeting_url, target: "_blank") %></span><br>
-        <span><%= translated_attribute meeting.location_hints %></span>
-      </div>
+      <% if meeting.online_meeting_url.present? %>
+        <%= icon "video", role: "img", "aria-hidden": true, remove_icon_class: true, width: 40, height: 70 %>
+        <div class="address__details">
+          <span><%= link_to(meeting.online_meeting_url, meeting.online_meeting_url, target: "_blank") %></span><br>
+          <span><%= translated_attribute meeting.location_hints %></span>
+        </div>
+      <% else %>
+        <%= icon "timer", role: "img", "aria-hidden": true, remove_icon_class: true, width: 40, height: 70 %>
+        <div class="address__details">
+          <span><%= t(".link_available_soon") %></span>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -457,6 +457,7 @@ en:
         online_meeting_link:
           join: Join the meeting
           live_event: This meeting is happening right now
+          link_available_soon: Link available soon
         registration_confirm:
           cancel: Cancel
           confirm: Confirm

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -456,8 +456,8 @@ en:
           title: Create Your Meeting
         online_meeting_link:
           join: Join the meeting
-          live_event: This meeting is happening right now
           link_available_soon: Link available soon
+          live_event: This meeting is happening right now
         registration_confirm:
           cancel: Cancel
           confirm: Confirm

--- a/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
@@ -189,9 +189,16 @@ module Decidim::Meetings
       it { is_expected.to eq(services.size) }
     end
 
-    describe "when online meeting link is missing and type of meeting is online" do
+    describe "when type of meeting is online and online meeting link is missing" do
       let(:type_of_meeting) { "online" }
       let(:online_meeting_url) { nil }
+
+      it { is_expected.to be_valid }
+    end
+
+    describe "when type of meeting is online and online meeting link is not a URL" do
+      let(:type_of_meeting) { "online" }
+      let(:online_meeting_url) { "potato" }
 
       it { is_expected.not_to be_valid }
     end

--- a/decidim-system/app/forms/decidim/system/oauth_application_form.rb
+++ b/decidim-system/app/forms/decidim/system/oauth_application_form.rb
@@ -16,6 +16,7 @@ module Decidim
       attribute :redirect_uri, String
 
       validates :name, :redirect_uri, :decidim_organization_id, :organization_name, :organization_url, :organization_logo, presence: true
+      validates :redirect_uri, :organization_url, url: true
       validates :organization_logo, passthru: { to: Decidim::OAuthApplication }
       validate :redirect_uri_is_ssl
 


### PR DESCRIPTION
#### :tophat: What? Why?
When creating an online meeting, sometimes the admin doesn't have the meeting URL. This PR allows to create the meeting without requiring to fill the URL field. In this case, the platform will show a "Link available soon" message instead of a link.

This PR also adds some validation for other URL fields in the project.
 
#### :pushpin: Related Issues

#### Testing
* Create an online meeting without an URL
* Visit the meeting page and check the message shown.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Uploading imagen.png…]()

:hearts: Thank you!
