### PR TITLE
Fix admin stylesheet dynamic imports

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/application.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/application.scss
@@ -17,3 +17,6 @@
 @import "stylesheets/decidim/admin/extra/sort";
 @import "stylesheets/decidim/admin/extra/title_bar";
 
+// This imports all the Decidim module stylesheet imports registered at
+// `config/assets.rb` of the module for the "admin" group.
+@import "!decidim-style-imports[admin]";

--- a/decidim-core/app/packs/stylesheets/decidim/application.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/application.scss
@@ -2,7 +2,7 @@
 @import "stylesheets/decidim/decidim";
 
 // This imports all the Decidim module stylesheet imports registered at
-// `config/assets.rb` of the module.
-@import "!decidim-style-imports";
+// `config/assets.rb` of the module for the "app" group.
+@import "!decidim-style-imports[app]";
 
 @import "stylesheets/decidim/decidim_application";

--- a/decidim-core/lib/decidim/webpacker.rb
+++ b/decidim-core/lib/decidim/webpacker.rb
@@ -21,8 +21,10 @@ module Decidim
       configuration.entrypoints.merge!(entrypoints.stringify_keys)
     end
 
-    def self.register_stylesheet_import(import)
-      configuration.stylesheet_imports.push(import)
+    def self.register_stylesheet_import(import, group: :app)
+      key = group.to_s
+      configuration.stylesheet_imports[key] ||= []
+      configuration.stylesheet_imports[key].push(import)
     end
   end
 end

--- a/decidim-core/lib/decidim/webpacker/configuration.rb
+++ b/decidim-core/lib/decidim/webpacker/configuration.rb
@@ -8,7 +8,7 @@ module Decidim
       def initialize
         @additional_paths = []
         @entrypoints = {}
-        @stylesheet_imports = []
+        @stylesheet_imports = {}
       end
 
       def configuration_file
@@ -24,8 +24,8 @@ module Decidim
         default = config["default"] || {}
         all_additional_paths = default["additional_paths"] || []
         all_additional_paths += additional_paths
-        all_stylesheet_imports = default["stylesheet_imports"] || []
-        all_stylesheet_imports += stylesheet_imports
+        all_stylesheet_imports = default["stylesheet_imports"] || {}
+        all_stylesheet_imports.merge!(stylesheet_imports)
         all_entrypoints = default["entrypoints"] || {}
         all_entrypoints.merge!(entrypoints)
         config.each do |environment, env_config|

--- a/decidim-core/lib/decidim/webpacker/webpack/base.js
+++ b/decidim-core/lib/decidim/webpacker/webpack/base.js
@@ -15,7 +15,7 @@ const overrideSassRule = (modifyConfig) => {
   }
 
   const imports = config.stylesheet_imports
-  if (!Array.isArray(imports)) {
+  if (!imports) {
     return modifyConfig
   }
 
@@ -23,11 +23,20 @@ const overrideSassRule = (modifyConfig) => {
   // Decidim modules.
   sassLoader.options.sassOptions.importer = [
     (url, _prev) => {
-      if (url !== "!decidim-style-imports") {
+      const matches = url.match(/^\!decidim-style-imports\[([^\]]+)\]$/);
+      if (!matches) {
         return null
       }
 
-      const statements = imports.map((style) => `@import "${style}";`)
+      const group = matches[1]
+      if (!imports[group]) {
+        // If the group is not defined, return an empty configuration because
+        // otherwise the importer would continue finding the asset through
+        // paths which obviously fails.
+        return { contents: "" }
+      }
+
+      const statements = imports[group].map((style) => `@import "${style}";`)
 
       return { contents: statements.join("\n") }
     }

--- a/decidim-core/spec/lib/webpacker/configuration_spec.rb
+++ b/decidim-core/spec/lib/webpacker/configuration_spec.rb
@@ -48,7 +48,8 @@ module Decidim
         end
 
         it "adds the stylesheet imports to the webpacker runtime configuration" do
-          expect(runtime_config["default"]["stylesheet_imports"]).to include(
+          expect(runtime_config["default"]["stylesheet_imports"].keys).to include("app")
+          expect(runtime_config["default"]["stylesheet_imports"]["app"]).to include(
             "stylesheets/decidim/accountability/accountability",
             "stylesheets/decidim/budgets/budgets",
             "stylesheets/decidim/proposals/proposals",

--- a/decidim-core/spec/lib/webpacker/runner_spec.rb
+++ b/decidim-core/spec/lib/webpacker/runner_spec.rb
@@ -42,7 +42,8 @@ module Webpacker
           "decidim_map_provider_here" => "#{core_path}/app/packs/entrypoints/decidim_map_provider_here.js",
           "decidim_widget" => "#{core_path}/app/packs/entrypoints/decidim_widget.js"
         )
-        expect(runtime_config["default"]["stylesheet_imports"]).to include(
+        expect(runtime_config["default"]["stylesheet_imports"].keys).to include("app")
+        expect(runtime_config["default"]["stylesheet_imports"]["app"]).to include(
           "stylesheets/decidim/accountability/accountability",
           "stylesheets/decidim/budgets/budgets",
           "stylesheets/decidim/proposals/proposals",

--- a/decidim-core/spec/lib/webpacker_spec.rb
+++ b/decidim-core/spec/lib/webpacker_spec.rb
@@ -62,18 +62,25 @@ module Decidim
 
     describe ".register_stylesheet_import" do
       after do
-        described_class.configuration.stylesheet_imports.slice!(
-          0,
-          described_class.configuration.stylesheet_imports.length
+        described_class.configuration.stylesheet_imports.clear
+      end
+
+      it "registers the defined entrypoints for the 'app' group by default" do
+        described_class.register_stylesheet_import("stylesheets/decidim/test")
+
+        expect(described_class.configuration.stylesheet_imports["app"]).to eq(
+          %w(stylesheets/decidim/test)
         )
       end
 
-      it "registers the defined entrypoints" do
-        described_class.register_stylesheet_import("stylesheets/decidim/test")
+      context "with a group provided" do
+        it "registers the defined entrypoints for the defined group" do
+          described_class.register_stylesheet_import("stylesheets/decidim/test", group: :admin)
 
-        expect(described_class.configuration.stylesheet_imports).to eq(
-          %w(stylesheets/decidim/test)
-        )
+          expect(described_class.configuration.stylesheet_imports["admin"]).to eq(
+            %w(stylesheets/decidim/test)
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
As described at #8153, it was possible before to define admin stylesheet imports from the components.

After the webpacker migration this is no longer possible.

This PR adds this feature back by extending the implementation of #8115. This PR adds stylesheet import "groups" which can be then included separately for the `app` and `admin` groups.

#### :pushpin: Related Issues
- Fixes #8153

#### Testing
Define a component with an admin stylesheet:

```ruby
Decidim.register_component(:foo) do |component|
  component.admin_stylesheet = "decidim/foo/admin"
end
```

Expect to see a difference in the admin styles. You won't see after the webpacker migration.

Note that the method above will not work after this is merged either, but this adds an alternative way to get the same functionality back with Webpacker.

Same with webpacker would be (after this PR):

```ruby
# Inside decidim-foo module
# config/assets.rb
Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/foo/admin", group: :admin)
```

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.
