### PR TITLE
Fix performance issue in notification settings page

### DIFF
--- a/decidim-assemblies/app/queries/decidim/assemblies/admin/admin_users.rb
+++ b/decidim-assemblies/app/queries/decidim/assemblies/admin/admin_users.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Assemblies
     module Admin
-      # A class used to find the admins for an assembly.
+      # A class used to find the admins for an assembly or an organization assemblies.
       class AdminUsers < Rectify::Query
         # Syntactic sugar to initialize the class and return the queried objects.
         #
@@ -12,33 +12,46 @@ module Decidim
           new(assembly).query
         end
 
+        # Syntactic sugar to initialize the class and return the queried objects.
+        #
+        # organization - an organization that needs to find its assembly admins
+        def self.for_organization(organization)
+          new(nil, organization).query
+        end
+
         # Initializes the class.
         #
         # assembly - an assembly that needs to find its assembly admins
-        def initialize(assembly)
+        # organization - an organization that needs to find its assembly admins
+        def initialize(assembly, organization = nil)
           @assembly = assembly
+          @organization = assembly&.organization || organization
         end
 
         # Finds organization admins and the users with role admin for the given assembly.
         #
         # Returns an ActiveRecord::Relation.
         def query
-          Decidim::User.where(id: organization_admins).or(assembly_user_admins)
+          organization.admins.or(assemblies_user_admins)
         end
 
         private
 
-        attr_reader :assembly
+        attr_reader :assembly, :organization
 
-        def organization_admins
-          assembly.organization.admins
+        def assemblies_user_admins
+          Decidim::User.where(
+            id: Decidim::AssemblyUserRole.where(assembly: assemblies, role: :admin)
+                                         .select(:decidim_user_id)
+          )
         end
 
-        def assembly_user_admins
-          assembly_user_admin_ids = Decidim::AssemblyUserRole
-                                    .where(assembly: assembly, role: :admin)
-                                    .pluck(:decidim_user_id)
-          Decidim::User.where(id: assembly_user_admin_ids)
+        def assemblies
+          if assembly
+            [assembly]
+          else
+            Decidim::Assembly.where(organization: organization)
+          end
         end
       end
     end

--- a/decidim-assemblies/spec/queries/admin/assembly_admins_spec.rb
+++ b/decidim-assemblies/spec/queries/admin/assembly_admins_spec.rb
@@ -2,19 +2,30 @@
 
 require "spec_helper"
 
-module Decidim::Assemblies
-  describe Admin::AdminUsers do
+module Decidim::Assemblies::Admin
+  describe AdminUsers do
     subject { described_class.new(assembly) }
 
     let(:organization) { create :organization }
-    let(:assembly) { create :assembly, organization: organization }
+    let!(:assembly) { create :assembly, organization: organization }
     let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
-    let!(:assembly_admin) do
-      create(:user, :admin, :confirmed, organization: organization)
-    end
+    let!(:assembly_admin_role) { create(:assembly_user_role, assembly: assembly, user: assembly_admin) }
+    let(:assembly_admin) { create(:user, organization: organization) }
+    let!(:other_assembly_admin_role) { create(:assembly_user_role, user: other_assembly_admin) }
+    let(:other_assembly_admin) { create(:user, organization: organization) }
+    let!(:normal_user) { create(:user, :confirmed, organization: organization) }
+    let!(:other_organization_user) { create(:user, :confirmed) }
 
     it "returns the organization admins and assembly admins" do
       expect(subject.query).to match_array([admin, assembly_admin])
+    end
+
+    context "when asking for organization admin users" do
+      subject { described_class.new(nil, organization) }
+
+      it "returns all the organization admins and assembly admins" do
+        expect(subject.query).to match_array([admin, assembly_admin, other_assembly_admin])
+      end
     end
   end
 end

--- a/decidim-conferences/app/queries/decidim/conferences/admin/admin_users.rb
+++ b/decidim-conferences/app/queries/decidim/conferences/admin/admin_users.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Conferences
     module Admin
-      # A class used to find the admins for an conference.
+      # A class used to find the admins for an conference or an organization conferences.
       class AdminUsers < Rectify::Query
         # Syntactic sugar to initialize the class and return the queried objects.
         #
@@ -12,33 +12,46 @@ module Decidim
           new(conference).query
         end
 
+        # Syntactic sugar to initialize the class and return the queried objects.
+        #
+        # organization - an organization that needs to find its conference admins
+        def self.for_organization(organization)
+          new(nil, organization).query
+        end
+
         # Initializes the class.
         #
         # conference - an conference that needs to find its conference admins
-        def initialize(conference)
+        # organization - an organization that needs to find its conference admins
+        def initialize(conference, organization = nil)
           @conference = conference
+          @organization = conference&.organization || organization
         end
 
         # Finds organization admins and the users with role admin for the given conference.
         #
         # Returns an ActiveRecord::Relation.
         def query
-          Decidim::User.where(id: organization_admins).or(conference_user_admins)
+          organization.admins.or(conferences_user_admins)
         end
 
         private
 
-        attr_reader :conference
+        attr_reader :conference, :organization
 
-        def organization_admins
-          conference.organization.admins
+        def conferences_user_admins
+          Decidim::User.where(
+            id: Decidim::ConferenceUserRole.where(conference: conferences, role: :admin)
+                                           .select(:decidim_user_id)
+          )
         end
 
-        def conference_user_admins
-          conference_user_admin_ids = Decidim::ConferenceUserRole
-                                      .where(conference: conference, role: :admin)
-                                      .pluck(:decidim_user_id)
-          Decidim::User.where(id: conference_user_admin_ids)
+        def conferences
+          if conference
+            [conference]
+          else
+            Decidim::Conference.where(organization: organization)
+          end
         end
       end
     end

--- a/decidim-conferences/spec/queries/admin/conference_admins_spec.rb
+++ b/decidim-conferences/spec/queries/admin/conference_admins_spec.rb
@@ -7,14 +7,25 @@ module Decidim::Conferences
     subject { described_class.new(conference) }
 
     let(:organization) { create :organization }
-    let(:conference) { create :conference, organization: organization }
+    let!(:conference) { create :conference, organization: organization }
     let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
-    let!(:conference_admin) do
-      create(:user, :admin, :confirmed, organization: organization)
-    end
+    let!(:conference_admin_role) { create(:conference_user_role, conference: conference, user: conference_admin) }
+    let(:conference_admin) { create(:user, organization: organization) }
+    let!(:other_conference_admin_role) { create(:conference_user_role, user: other_conference_admin) }
+    let(:other_conference_admin) { create(:user, organization: organization) }
+    let!(:normal_user) { create(:user, :confirmed, organization: organization) }
+    let!(:other_organization_user) { create(:user, :confirmed) }
 
     it "returns the organization admins and conference admins" do
       expect(subject.query).to match_array([admin, conference_admin])
+    end
+
+    context "when asking for organization admin users" do
+      subject { described_class.new(nil, organization) }
+
+      it "returns all the organization admins and conference admins" do
+        expect(subject.query).to match_array([admin, conference_admin, other_conference_admin])
+      end
     end
   end
 end

--- a/decidim-consultations/app/queries/decidim/consultations/admin/admin_users.rb
+++ b/decidim-consultations/app/queries/decidim/consultations/admin/admin_users.rb
@@ -3,37 +3,41 @@
 module Decidim
   module Consultations
     module Admin
-      # A class used to find the admins for a participatory process including
-      # organization admins.
+      # A class used to find the admins for a consultation or an organization consultations.
       class AdminUsers < Rectify::Query
         # Syntactic sugar to initialize the class and return the queried objects.
         #
-        # consultation - a process that needs to find its process admins
+        # consultation - a consultation that needs to find its consultation admins
         def self.for(consultation)
           new(consultation).query
         end
 
-        # Initializes the class.
+        # Syntactic sugar to initialize the class and return the queried objects.
         #
-        # consultation - a consultation that needs to find its process admins
-        def initialize(consultation)
-          @consultation = consultation
+        # organization - an organization that needs to find its consultation admins
+        def self.for_organization(organization)
+          new(nil, organization).query
         end
 
-        # Finds organization admins and the users with role admin for the given process.
+        # Initializes the class.
+        #
+        # consultation - a consultation that needs to find its consultation admins
+        # organization - an organization that needs to find its consultation admins
+        def initialize(consultation, organization = nil)
+          @consultation = consultation
+          @organization = consultation&.organization || organization
+        end
+
+        # Finds organization admins and the users with role admin for the given consultation.
         #
         # Returns an ActiveRecord::Relation.
         def query
-          Decidim::User.where(id: organization_admins)
+          organization.admins
         end
 
         private
 
-        attr_reader :consultation
-
-        def organization_admins
-          consultation.organization.admins
-        end
+        attr_reader :organization
       end
     end
   end

--- a/decidim-consultations/spec/queries/decidim/consultations/admin/process_admins_spec.rb
+++ b/decidim-consultations/spec/queries/decidim/consultations/admin/process_admins_spec.rb
@@ -7,8 +7,10 @@ module Decidim::Consultations
     subject { described_class.new(consultation) }
 
     let(:organization) { create :organization }
-    let(:consultation) { create :consultation, organization: organization }
+    let!(:consultation) { create :consultation, organization: organization }
     let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+    let!(:normal_user) { create(:user, :confirmed, organization: organization) }
+    let!(:other_organization_user) { create(:user, :confirmed) }
 
     it "returns the organization admins" do
       expect(subject.query).to match_array([admin])

--- a/decidim-core/app/forms/decidim/notifications_settings_form.rb
+++ b/decidim-core/app/forms/decidim/notifications_settings_form.rb
@@ -43,22 +43,11 @@ module Decidim
     end
 
     def user_is_moderator?(user)
-      participatory_space_types.each do |participatory_space_type|
-        participatory_space_type.constantize.all.each do |participatory_space|
-          return true if participatory_space.moderators.include?(user)
-        end
+      Decidim.participatory_space_manifests.map do |manifest|
+        participatory_space_type = manifest.model_class_name.constantize
+        return true if participatory_space_type.moderators(user.organization).exists?(id: user.id)
       end
       false
-    end
-
-    private
-
-    def participatory_space_types
-      participatory_space_types = []
-      Decidim.participatory_space_manifests.each do |manifest|
-        participatory_space_types << manifest.model_class_name.to_s
-      end
-      participatory_space_types
     end
   end
 end

--- a/decidim-core/lib/decidim/participable.rb
+++ b/decidim-core/lib/decidim/participable.rb
@@ -8,45 +8,15 @@ module Decidim
     extend ActiveSupport::Concern
 
     included do
-      def demodulized_name
-        @demodulized_name ||= self.class.name.demodulize
-      end
-
-      delegate :foreign_key, to: :demodulized_name
-
-      def module_name
-        "Decidim::#{demodulized_name.pluralize}"
-      end
-
-      def admin_module_name
-        "#{module_name}::Admin"
-      end
-
-      def underscored_name
-        demodulized_name.underscore
-      end
-
-      def mounted_engine
-        "decidim_#{underscored_name.pluralize}"
-      end
-
-      def mounted_admin_engine
-        "decidim_admin_#{underscored_name.pluralize}"
-      end
+      delegate :demodulized_name, :foreign_key, :module_name, :admin_module_name, :underscored_name,
+               :mounted_engine, :mounted_admin_engine, :admin_extension_module, :admins_query,
+               to: :class
 
       def mounted_params
         {
           host: organization.host,
           "#{underscored_name}_slug".to_sym => slug
         }
-      end
-
-      def admin_extension_module
-        "#{admin_module_name}::#{demodulized_name}Context".constantize
-      end
-
-      def admins_query
-        "#{admin_module_name}::AdminUsers".constantize
       end
 
       def admins
@@ -94,6 +64,44 @@ module Decidim
     end
 
     class_methods do
+      def demodulized_name
+        @demodulized_name ||= self.name.demodulize
+      end
+
+      delegate :foreign_key, to: :demodulized_name
+
+      def module_name
+        "Decidim::#{demodulized_name.pluralize}"
+      end
+
+      def admin_module_name
+        "#{module_name}::Admin"
+      end
+
+      def underscored_name
+        demodulized_name.underscore
+      end
+
+      def mounted_engine
+        "decidim_#{underscored_name.pluralize}"
+      end
+
+      def mounted_admin_engine
+        "decidim_admin_#{underscored_name.pluralize}"
+      end
+
+      def admin_extension_module
+        "#{admin_module_name}::#{demodulized_name}Context".constantize
+      end
+
+      def admins_query
+        "#{admin_module_name}::AdminUsers".constantize
+      end
+
+      def moderators(organization)
+        admins_query.for_organization(organization)
+      end
+
       def slug_format
         /\A[a-zA-Z]+[a-zA-Z0-9\-]+\z/
       end

--- a/decidim-core/lib/decidim/participable.rb
+++ b/decidim-core/lib/decidim/participable.rb
@@ -65,7 +65,7 @@ module Decidim
 
     class_methods do
       def demodulized_name
-        @demodulized_name ||= self.name.demodulize
+        @demodulized_name ||= name.demodulize
       end
 
       delegate :foreign_key, to: :demodulized_name

--- a/decidim-elections/app/queries/decidim/votings/admin/admin_users.rb
+++ b/decidim-elections/app/queries/decidim/votings/admin/admin_users.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Votings
     module Admin
-      # A class used to find the admins for a voting including organization admins.
+      # A class used to find the admins for a voting or an organization votings.
       class AdminUsers < Rectify::Query
         # Syntactic sugar to initialize the class and return the queried objects.
         #
@@ -12,27 +12,32 @@ module Decidim
           new(voting).query
         end
 
-        # Initializes the class.
+        # Syntactic sugar to initialize the class and return the queried objects.
         #
-        # voting - a voting that needs to find its process admins
-        def initialize(voting)
-          @voting = voting
+        # organization - an organization that needs to find its voting admins
+        def self.for_organization(organization)
+          new(nil, organization).query
         end
 
-        # Finds organization admins and the users with role admin for the given process.
+        # Initializes the class.
+        #
+        # voting - a voting that needs to find its voting admins
+        # organization - an organization that needs to find its voting admins
+        def initialize(voting, organization = nil)
+          @voting = voting
+          @organization = voting&.organization || organization
+        end
+
+        # Finds organization admins and the users with role admin for the given voting.
         #
         # Returns an ActiveRecord::Relation.
         def query
-          Decidim::User.where(id: organization_admins)
+          organization.admins
         end
 
         private
 
-        attr_reader :voting
-
-        def organization_admins
-          voting.organization.admins
-        end
+        attr_reader :voting, :organization
       end
     end
   end

--- a/decidim-elections/spec/queries/decidim/votings/admin/admin_users_spec.rb
+++ b/decidim-elections/spec/queries/decidim/votings/admin/admin_users_spec.rb
@@ -9,7 +9,7 @@ module Decidim
         subject { described_class.new(voting) }
 
         let(:organization) { create :organization }
-        let(:voting) { create :voting, organization: organization }
+        let!(:voting) { create :voting, organization: organization }
         let!(:admins) { create_list(:user, 3, :admin, :confirmed, organization: organization) }
         let!(:normal_user) { create(:user, :confirmed, organization: organization) }
         let!(:other_organization_user) { create(:user, :confirmed) }

--- a/decidim-initiatives/app/queries/decidim/initiatives/admin/admin_users.rb
+++ b/decidim-initiatives/app/queries/decidim/initiatives/admin/admin_users.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Initiatives
     module Admin
-      # A class used to find the admins for an initiative.
+      # A class used to find the admins for an initiative or an organization initiatives.
       class AdminUsers < Rectify::Query
         # Syntactic sugar to initialize the class and return the queried objects.
         #
@@ -12,27 +12,32 @@ module Decidim
           new(initiative).query
         end
 
+        # Syntactic sugar to initialize the class and return the queried objects.
+        #
+        # organization - an organization that needs to find its initiative admins
+        def self.for_organization(organization)
+          new(nil, organization).query
+        end
+
         # Initializes the class.
         #
         # initiative - Decidim::Initiative
-        def initialize(initiative)
+        # organization - an organization that needs to find its initiative admins
+        def initialize(initiative, organization = nil)
           @initiative = initiative
+          @organization = initiative&.organization || organization
         end
 
         # Finds organization admins and the users with role admin for the given initiative.
         #
         # Returns an ActiveRecord::Relation.
         def query
-          Decidim::User.where(id: organization_admins)
+          organization.admins
         end
 
         private
 
-        attr_reader :initiative
-
-        def organization_admins
-          initiative.organization.admins
-        end
+        attr_reader :initiative, :organization
       end
     end
   end

--- a/decidim-initiatives/spec/queries/decidim/initiatives/admin/admin_users_spec.rb
+++ b/decidim-initiatives/spec/queries/decidim/initiatives/admin/admin_users_spec.rb
@@ -7,14 +7,13 @@ module Decidim::Initiatives
     subject { described_class.new(initiative) }
 
     let(:organization) { create :organization }
-    let(:initiative) { create :initiative, :published, organization: organization }
+    let!(:initiative) { create :initiative, :published, organization: organization }
     let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
-    let!(:initiative_admin) do
-      create(:user, :admin, :confirmed, organization: organization)
-    end
+    let!(:normal_user) { create(:user, :confirmed, organization: organization) }
+    let!(:other_organization_user) { create(:user, :confirmed) }
 
-    it "returns the organization admins and initiative admins" do
-      expect(subject.query).to match_array([admin, initiative_admin])
+    it "returns the organization admins" do
+      expect(subject.query).to match_array([admin])
     end
   end
 end

--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -156,9 +156,13 @@ module Decidim
       slug
     end
 
-    # Overrides the method from `Participable`.
+    # Overrides the moderators methods from `Participable`.
     def moderators
       "#{admin_module_name}::Moderators".constantize.for(self)
+    end
+
+    def self.moderators(organization)
+      "#{admin_module_name}::Moderators".constantize.for_organization(organization)
     end
 
     def user_roles(role_name = nil)

--- a/decidim-participatory_processes/app/queries/decidim/participatory_processes/admin/admin_users.rb
+++ b/decidim-participatory_processes/app/queries/decidim/participatory_processes/admin/admin_users.rb
@@ -42,7 +42,7 @@ module Decidim
 
         def processes_user_admins
           Decidim::User.where(
-            id: Decidim::ParticipatoryProcessUserRole.where(participatory_process: processes,role: :admin)
+            id: Decidim::ParticipatoryProcessUserRole.where(participatory_process: processes, role: :admin)
                                                      .select(:decidim_user_id)
           )
         end

--- a/decidim-participatory_processes/app/queries/decidim/participatory_processes/admin/admin_users.rb
+++ b/decidim-participatory_processes/app/queries/decidim/participatory_processes/admin/admin_users.rb
@@ -26,7 +26,7 @@ module Decidim
         # organization - an organization that needs to find its process admins
         def initialize(process, organization = nil)
           @process = process
-          @organization = assembly&.organization || organization
+          @organization = process&.organization || organization
         end
 
         # Finds organization admins and the users with role admin for the given process.

--- a/decidim-participatory_processes/app/queries/decidim/participatory_processes/admin/admin_users.rb
+++ b/decidim-participatory_processes/app/queries/decidim/participatory_processes/admin/admin_users.rb
@@ -13,33 +13,46 @@ module Decidim
           new(process).query
         end
 
+        # Syntactic sugar to initialize the class and return the queried objects.
+        #
+        # organization - an organization that needs to find its process admins
+        def self.for_organization(organization)
+          new(nil, organization).query
+        end
+
         # Initializes the class.
         #
         # process - a process that needs to find its process admins
-        def initialize(process)
+        # organization - an organization that needs to find its process admins
+        def initialize(process, organization = nil)
           @process = process
+          @organization = assembly&.organization || organization
         end
 
         # Finds organization admins and the users with role admin for the given process.
         #
         # Returns an ActiveRecord::Relation.
         def query
-          Decidim::User.where(id: organization_admins).or(process_user_admins)
+          organization.admins.or(processes_user_admins)
         end
 
         private
 
-        attr_reader :process
+        attr_reader :process, :organization
 
-        def organization_admins
-          process.organization.admins
+        def processes_user_admins
+          Decidim::User.where(
+            id: Decidim::ParticipatoryProcessUserRole.where(participatory_process: processes,role: :admin)
+                                                     .select(:decidim_user_id)
+          )
         end
 
-        def process_user_admins
-          process_user_admin_ids = Decidim::ParticipatoryProcessUserRole
-                                   .where(participatory_process: process, role: :admin)
-                                   .pluck(:decidim_user_id)
-          Decidim::User.where(id: process_user_admin_ids)
+        def processes
+          if process
+            [process]
+          else
+            Decidim::ParticipatoryProcess.where(organization: organization)
+          end
         end
       end
     end

--- a/decidim-participatory_processes/spec/queries/admin/admin_users_spec.rb
+++ b/decidim-participatory_processes/spec/queries/admin/admin_users_spec.rb
@@ -7,14 +7,25 @@ module Decidim::ParticipatoryProcesses
     subject { described_class.new(participatory_process) }
 
     let(:organization) { create :organization }
-    let(:participatory_process) { create :participatory_process, organization: organization }
+    let!(:participatory_process) { create :participatory_process, organization: organization }
     let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
-    let!(:participatory_process_admin) do
-      create(:process_admin, participatory_process: participatory_process)
-    end
+    let!(:participatory_process_admin_role) { create(:participatory_process_user_role, participatory_process: participatory_process, user: participatory_process_admin) }
+    let(:participatory_process_admin) { create(:user, organization: organization) }
+    let!(:other_participatory_process_admin_role) { create(:participatory_process_user_role, user: other_participatory_process_admin) }
+    let(:other_participatory_process_admin) { create(:user, organization: organization) }
+    let!(:normal_user) { create(:user, :confirmed, organization: organization) }
+    let!(:other_organization_user) { create(:user, :confirmed) }
 
     it "returns the organization admins and participatory process admins" do
       expect(subject.query).to match_array([admin, participatory_process_admin])
+    end
+
+    context "when asking for organization admin users" do
+      subject { described_class.new(nil, organization) }
+
+      it "returns all the organization admins and participatory process admins" do
+        expect(subject.query).to match_array([admin, participatory_process_admin, other_participatory_process_admin])
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
If you visit https://www.decidim.barcelona/notifications_settings with a non admin user you will get a server error page. This occurs because the page needs to know if the current user is a moderator or not to show an additional setting, and that is done browsing all the participatory spaces and checking if the user is in the moderators list. This was implemented in #7328.

This PR adds to all participatory spaces the ability to ask for all the moderators for an organization. With that, the queries needed to know if a user is a moderator or not decreases dramatically.

#### :pushpin: Related Issues
- Related to #7328

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
