### PR TITLE
Move the webpacker config override to @decidim/webpacker

### DIFF
--- a/decidim-core/lib/decidim/webpacker/webpack/base.js
+++ b/decidim-core/lib/decidim/webpacker/webpack/base.js
@@ -1,52 +1,6 @@
 /* eslint-disable */
 
-const { webpackConfig, merge, config } = require("@rails/webpacker")
+const { webpackConfig, merge } = require("@decidim/webpacker")
 const customConfig = require("./custom")
 
-const overrideSassRule = (modifyConfig) => {
-  const sassRule = modifyConfig.module.rules.find((rule) => rule.test.toString() === "/\\.(scss|sass)(\\.erb)?$/i")
-  if (!sassRule) {
-    return modifyConfig
-  }
-
-  const sassLoader = sassRule.use.find(use => use.loader.match(/sass-loader/))
-  if (!sassLoader) {
-    return modifyConfig
-  }
-
-  const imports = config.stylesheet_imports
-  if (!imports) {
-    return modifyConfig
-  }
-
-  // Add the extra importer to the sass-loader to load the import statements for
-  // Decidim modules.
-  sassLoader.options.sassOptions.importer = [
-    (url, _prev) => {
-      const matches = url.match(/^\!decidim-style-imports\[([^\]]+)\]$/);
-      if (!matches) {
-        return null
-      }
-
-      const group = matches[1]
-      if (!imports[group]) {
-        // If the group is not defined, return an empty configuration because
-        // otherwise the importer would continue finding the asset through
-        // paths which obviously fails.
-        return { contents: "" }
-      }
-
-      const statements = imports[group].map((style) => `@import "${style}";`)
-
-      return { contents: statements.join("\n") }
-    }
-  ]
-
-  return modifyConfig
-}
-
-const overrideConfig = (originalConfig) => {
-  return overrideSassRule(originalConfig)
-}
-
-module.exports = merge(overrideConfig(webpackConfig), customConfig)
+module.exports = merge(webpackConfig, customConfig)

--- a/packages/webpacker/index.js
+++ b/packages/webpacker/index.js
@@ -1,0 +1,6 @@
+const webpacker = require("@rails/webpacker");
+const overrideConfig = require("./src/override-config");
+
+module.exports = Object.assign(webpacker, {
+  webpackConfig: overrideConfig(webpacker.webpackConfig)
+});

--- a/packages/webpacker/package.json
+++ b/packages/webpacker/package.json
@@ -13,6 +13,7 @@
     "node": "^15.14.0",
     "npm": "^7.7.2"
   },
+  "main": "index.js",
   "dependencies": {
     "@babel/core": "^7.13.13",
     "@babel/eslint-parser": "^7.13.14",

--- a/packages/webpacker/src/override-config.js
+++ b/packages/webpacker/src/override-config.js
@@ -1,0 +1,49 @@
+const { config } = require("@rails/webpacker");
+
+const overrideSassRule = (modifyConfig) => {
+  const sassRule = modifyConfig.module.rules.find(
+    (rule) => rule.test.toString() === "/\\.(scss|sass)(\\.erb)?$/i"
+  );
+  if (!sassRule) {
+    return modifyConfig;
+  }
+
+  const sassLoader = sassRule.use.find(use => use.loader.match(/sass-loader/));
+  if (!sassLoader) {
+    return modifyConfig;
+  }
+
+  const imports = config.stylesheet_imports;
+  if (!imports) {
+    return modifyConfig;
+  }
+
+  // Add the extra importer to the sass-loader to load the import statements for
+  // Decidim modules.
+  sassLoader.options.sassOptions.importer = [
+    (url, _prev) => {
+      const matches = url.match(/^\!decidim-style-imports\[([^\]]+)\]$/);
+      if (!matches) {
+        return null;
+      }
+
+      const group = matches[1];
+      if (!imports[group]) {
+        // If the group is not defined, return an empty configuration because
+        // otherwise the importer would continue finding the asset through
+        // paths which obviously fails.
+        return { contents: "" };
+      }
+
+      const statements = imports[group].map((style) => `@import "${style}";`);
+
+      return { contents: statements.join("\n") };
+    }
+  ];
+
+  return modifyConfig;
+}
+
+module.exports = (originalConfig) => {
+  return overrideSassRule(originalConfig);
+};


### PR DESCRIPTION
#### :tophat: What? Why?
This moves the configuration override for dynamic stylesheet includes implemented at #8115 to the `@decidim/webpacker` package.

This idea came from @ferblape's comment at https://github.com/decidim/decidim/pull/8115#discussion_r647973320 where he mentioned this file might change during upgrades. At that point it wasn't possible to do but after #8121 was merged it is now possible to move these to the Decidim NPM packages.

We still need to override the import at `base.js` file but this decouples the configuration overrides from that file to the `@decidim/webpacker` NPM package, so the changes needed at `base.js` are much more minimal.

#### :pushpin: Related Issues
- Related to #8115, #8154, #8121

#### Testing
- Re-create the development app
- Run `./bin/webpack-dev-server` at the development app
- Go to the help page of the development instance
- Make a change at some dynamically included stylesheet, e.g. `decidim-budgets/app/packs/stylesheets/decidim/budgets/_budgets.scss` -> add `p{ color: #f00; }`
- Wait for webpacker to recompile the stylesheet
- Take a look at the help page whether you can see the change

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.