### PR TITLE
Fix proposal map for on release/0.24-stable

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
@@ -33,7 +33,8 @@
         <%= decidim_form_for(@form, url: update_draft_proposal_path(@form), html: { method: :patch }) do |form| %>
           <%= form.hidden_field :title, value: form_presenter.title %>
           <%= form.hidden_field :body, value: form_presenter.body %>
-          <%= form.hidden_field :address %>
+          <%= form.hidden_field :has_address, value: true %>
+          <%= form.hidden_field :address, value: form_presenter.address %>
           <%= form.hidden_field :latitude, data: { type: "latitude" } %>
           <%= form.hidden_field :longitude, data: { type: "longitude" } %>
           <div class="preview--form__hidden">

--- a/decidim-proposals/spec/shared/proposals_wizards_examples.rb
+++ b/decidim-proposals/spec/shared/proposals_wizards_examples.rb
@@ -299,6 +299,7 @@ shared_examples "proposals wizards" do |options|
         within "#edit_proposal_#{proposal_draft.id}" do
           expect(page).to have_field("proposal_title", type: :hidden, with: proposal_title)
           expect(page).to have_field("proposal_body", type: :hidden, with: proposal_body)
+          expect(page).to have_field("proposal_has_address", type: :hidden, with: true)
           expect(page).to have_field("proposal_address", type: :hidden, with: address)
           expect(page).to have_field("proposal_longitude", type: :hidden, with: longitude)
           expect(page).to have_field("proposal_latitude", type: :hidden, with: latitude)


### PR DESCRIPTION
#### :tophat: What? Why?
Hi, 

Since the proposal map form is broken on `release/0.24-stable`, I propose a light fix that allows users to drag cursor on map for updating the coordinates.

A previous PR was merged on `develop` with a light UX enhancement. 

#### :pushpin: Related Issues
- Related to #8088, #6291

#### Testing
1. Enable geocoding
1. Allow proposal to be geocoded
1. Create a new proposal
1. On the preview step, drag the cursor on map and click on button 'Update coordinate'.
1. The map should be displayed and the coordinates should be updated

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
