### PR TITLE
Fix "last comment by" with groups

### DIFF
--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -179,9 +179,15 @@ module Decidim
         comments_count = comments.not_hidden.not_deleted.count
         last_comment = comments.not_hidden.not_deleted.order("created_at DESC").first
 
+        if last_comment&.decidim_user_group_id
+          author_id = last_comment&.decidim_user_group_id
+        else 
+          author_id = last_comment&.decidim_author_id
+        end
+
         update_columns(
           last_comment_at: last_comment&.created_at,
-          last_comment_by_id: last_comment&.decidim_author_id,
+          last_comment_by_id: author_id,
           last_comment_by_type: last_comment&.decidim_author_type,
           comments_count: comments_count,
           updated_at: Time.current


### PR DESCRIPTION
#### :tophat: What? Why?
* When comment on a debate as a group  the "last comment by" box appears name instead of the group name.*

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #7431

#### Testing
*Write comment as group and see presenter with group name*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
**Before**
![Before](https://user-images.githubusercontent.com/72607737/108686787-2d8e2800-74f6-11eb-869b-5504a56d8ee2.png)
![Before2](https://user-images.githubusercontent.com/72607737/108687438-02f09f00-74f7-11eb-8f4e-596de8f8dbc9.png)
**After**
(right now not available)
:hearts: Thank you!
