### PR TITLE
Fully copy question's display_conditions from template

### DIFF
--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_display_condition.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_display_condition.html.erb
@@ -44,10 +44,10 @@
       <%=
         form.select(
           :decidim_answer_option_id,
-          options_from_collection_for_select(display_condition.answer_options, :id, :translated_body, display_condition.answer_option),
+          options_from_collection_for_select(display_condition.answer_options, :id, :translated_body, selected: display_condition.decidim_answer_option_id),
           { prompt: t(".select_answer_option"), label: t(".answer_option") },
           disabled: !editable,
-          data: { selected: display_condition.answer_option&.id }
+          data: { selected: display_condition.decidim_answer_option_id }
         )
       %>
     </div>

--- a/decidim-forms/lib/decidim/forms/test/factories.rb
+++ b/decidim-forms/lib/decidim/forms/test/factories.rb
@@ -28,6 +28,42 @@ FactoryBot.define do
       end
     end
 
+    trait :with_all_questions do
+      questions do
+        position = 0
+        qs = %w(short_answer long_answer).collect do |text_question_type|
+          q = build(:questionnaire_question, question_type: text_question_type, position: position)
+          position += 1
+          q
+        end
+
+        %w(single_option multiple_option).each do |option_question_type|
+          q = build(:questionnaire_question, :with_answer_options, question_type: option_question_type, position: position)
+          position += 1
+          qs << q
+          q.display_conditions.build(
+            condition_question: qs[q.position - 2],
+            question: q,
+            condition_type: :answered,
+            mandatory: true
+          )
+        end
+
+        %w(matrix_single matrix_multiple).collect do |matrix_question_type|
+          q = build(:questionnaire_question, :with_answer_options, question_type: matrix_question_type, position: position, body: generate_localized_title)
+          position += 1
+          qs << q
+          q.display_conditions.build(
+            condition_question: qs[q.position - 2],
+            question: q,
+            condition_type: :answered,
+            mandatory: true
+          )
+        end
+        qs
+      end
+    end
+
     trait :empty do
       title { {} }
       description { {} }

--- a/decidim-forms/spec/commands/decidim/forms/admin/update_questionnaire_spec.rb
+++ b/decidim-forms/spec/commands/decidim/forms/admin/update_questionnaire_spec.rb
@@ -307,6 +307,7 @@ module Decidim
 
         describe "when the questionnaire has existing questions" do
           let!(:questions) { 0.upto(3).to_a.map { |x| create(:questionnaire_question, questionnaire: questionnaire, position: x) } }
+          let!(:question_2_answer_options) { create_list(:answer_option, 3, question: questions.second) }
 
           context "and display conditions are to be created" do
             let(:form_params) do
@@ -337,7 +338,10 @@ module Decidim
                     "id" => questions[1].id,
                     "body" => questions[1].body,
                     "position" => 1,
-                    "question_type" => "short_answer"
+                    "question_type" => "single_option",
+                    "answer_options" => Hash[question_2_answer_options.map do |answer_option|
+                      [answer_option.id.to_s, { "id" => answer_option.id, "body" => answer_option.body, "free_text" => answer_option.free_text, "deleted" => false }]
+                    end]
                   },
                   "3" => {
                     "id" => questions[2].id,
@@ -350,6 +354,12 @@ module Decidim
                         "decidim_condition_question_id" => questions[0].id,
                         "decidim_question_id" => questions[2].id,
                         "condition_type" => "answered"
+                      },
+                      "2" => {
+                        "decidim_condition_question_id" => questions[1].id,
+                        "decidim_question_id" => questions[2].id,
+                        "condition_type" => "equal",
+                        "decidim_answer_option_id" => question_2_answer_options.first.id
                       }
                     }
                   }
@@ -363,6 +373,8 @@ module Decidim
 
               expect(questionnaire.questions[2].display_conditions).not_to be_empty
               expect(questionnaire.questions[2].display_conditions.first.condition_type).to eq("answered")
+              expect(questionnaire.questions[2].display_conditions.second.condition_type).to eq("equal")
+              expect(questionnaire.questions[2].display_conditions.second.decidim_answer_option_id).to eq(question_2_answer_options.first.id)
             end
           end
         end

--- a/decidim-templates/app/commands/decidim/templates/admin/apply_questionnaire_template.rb
+++ b/decidim-templates/app/commands/decidim/templates/admin/apply_questionnaire_template.rb
@@ -5,6 +5,8 @@ module Decidim
     # A command with all the business logic when duplicating a questionnaire template
     module Admin
       class ApplyQuestionnaireTemplate < Rectify::Command
+        include Decidim::Templates::Admin::QuestionnaireCopier
+
         # Public: Initializes the command.
         #
         # template - The template we want to apply
@@ -21,7 +23,7 @@ module Decidim
         #
         # Returns nothing.
         def call
-          return broadcast(:invalid) unless @template.valid?
+          return broadcast(:invalid) unless @template && @template.valid?
 
           Template.transaction do
             apply_template
@@ -41,32 +43,6 @@ module Decidim
             description: @template.templatable.description,
             tos: @template.templatable.tos
           )
-        end
-
-        def copy_questionnaire_questions(original_questionnaire, new_questionnaire)
-          original_questionnaire.questions.each do |original_question|
-            new_question = original_question.dup
-            new_question.questionnaire = new_questionnaire
-            new_question.save!
-            copy_questionnaire_answer_options(original_question, new_question)
-            copy_questionnaire_matrix_rows(original_question, new_question)
-          end
-        end
-
-        def copy_questionnaire_answer_options(original_question, new_question)
-          original_question.answer_options.each do |original_answer_option|
-            new_answer_option = original_answer_option.dup
-            new_answer_option.question = new_question
-            new_answer_option.save!
-          end
-        end
-
-        def copy_questionnaire_matrix_rows(original_question, new_question)
-          original_question.matrix_rows.each do |original_matrix_row|
-            new_matrix_row = original_matrix_row.dup
-            new_matrix_row.question = new_question
-            new_matrix_row.save!
-          end
         end
       end
     end

--- a/decidim-templates/app/commands/decidim/templates/admin/copy_questionnaire_template.rb
+++ b/decidim-templates/app/commands/decidim/templates/admin/copy_questionnaire_template.rb
@@ -5,6 +5,8 @@ module Decidim
     # A command with all the business logic when duplicating a questionnaire template
     module Admin
       class CopyQuestionnaireTemplate < Rectify::Command
+        include Decidim::Templates::Admin::QuestionnaireCopier
+
         # Public: Initializes the command.
         #
         # template - A template we want to duplicate
@@ -46,32 +48,6 @@ module Decidim
           )
 
           @copied_template.update!(templatable: @resource)
-        end
-
-        def copy_questionnaire_questions(original_questionnaire, new_questionnaire)
-          original_questionnaire.questions.each do |original_question|
-            new_question = original_question.dup
-            new_question.questionnaire = new_questionnaire
-            new_question.save!
-            copy_questionnaire_answer_options(original_question, new_question)
-            copy_questionnaire_matrix_rows(original_question, new_question)
-          end
-        end
-
-        def copy_questionnaire_answer_options(original_question, new_question)
-          original_question.answer_options.each do |original_answer_option|
-            new_answer_option = original_answer_option.dup
-            new_answer_option.question = new_question
-            new_answer_option.save!
-          end
-        end
-
-        def copy_questionnaire_matrix_rows(original_question, new_question)
-          original_question.matrix_rows.each do |original_matrix_row|
-            new_matrix_row = original_matrix_row.dup
-            new_matrix_row.question = new_question
-            new_matrix_row.save!
-          end
         end
       end
     end

--- a/decidim-templates/app/commands/decidim/templates/admin/questionnaire_copier.rb
+++ b/decidim-templates/app/commands/decidim/templates/admin/questionnaire_copier.rb
@@ -7,6 +7,7 @@ module Decidim
       module QuestionnaireCopier
         def copy_questionnaire_questions(original_questionnaire, new_questionnaire)
           # start by copying the questions so that they already exist when cross referencing them in the conditions
+          original_questionnaire.questions.includes(:answer_options, :matrix_rows, :display_conditions).load
           original_questionnaire.questions.each do |original_question|
             new_question = original_question.dup
             new_question.questionnaire = new_questionnaire
@@ -14,7 +15,8 @@ module Decidim
             copy_questionnaire_answer_options(original_question, new_question)
             copy_questionnaire_matrix_rows(original_question, new_question)
           end
-          original_questionnaire.questions.zip(new_questionnaire.questions).each do |original_question, new_question|
+          # once all questions are copied, copy display conditions
+          original_questionnaire.questions.zip(new_questionnaire.questions.load).each do |original_question, new_question|
             copy_question_display_conditions(original_question, new_question)
           end
         end

--- a/decidim-templates/app/commands/decidim/templates/admin/questionnaire_copier.rb
+++ b/decidim-templates/app/commands/decidim/templates/admin/questionnaire_copier.rb
@@ -41,13 +41,23 @@ module Decidim
           original_question.display_conditions.each do |original_display_condition|
             new_display_condition = original_display_condition.dup
             new_display_condition.question = destination_question
-            destination_question_to_be_checked = destination_question.questionnaire.questions.find_by(position: original_display_condition.condition_question.position)
+
+            destination_question_to_be_checked = find_question_by_position(destination_question.questionnaire.questions, original_display_condition.condition_question.position)
             new_display_condition.condition_question = destination_question_to_be_checked
+
             if original_display_condition.answer_option
-              new_display_condition.answer_option = destination_question_to_be_checked.answer_options.find_by(body: original_display_condition.answer_option.body)
+              new_display_condition.answer_option = find_answer_option_by_body(destination_question_to_be_checked.answer_options, original_display_condition.answer_option.body)
             end
             new_display_condition.save!
           end
+        end
+
+        def find_question_by_position(questions, position)
+          questions.to_a.find { |q| q.position == position }
+        end
+
+        def find_answer_option_by_body(answer_options, body)
+          answer_options.to_a.find { |ao| ao.body == body }
         end
       end
     end

--- a/decidim-templates/app/commands/decidim/templates/admin/questionnaire_copier.rb
+++ b/decidim-templates/app/commands/decidim/templates/admin/questionnaire_copier.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Templates
+    # All the business logic to duplicate a questionnaire
+    module Admin
+      module QuestionnaireCopier
+        def copy_questionnaire_questions(original_questionnaire, new_questionnaire)
+          # start by copying the questions so that they already exist when cross referencing them in the conditions
+          original_questionnaire.questions.each do |original_question|
+            new_question = original_question.dup
+            new_question.questionnaire = new_questionnaire
+            new_question.save!
+            copy_questionnaire_answer_options(original_question, new_question)
+            copy_questionnaire_matrix_rows(original_question, new_question)
+          end
+          original_questionnaire.questions.zip(new_questionnaire.questions).each do |original_question, new_question|
+            copy_question_display_conditions(original_question, new_question)
+          end
+        end
+
+        def copy_questionnaire_answer_options(original_question, new_question)
+          original_question.answer_options.each do |original_answer_option|
+            new_answer_option = original_answer_option.dup
+            new_answer_option.question = new_question
+            new_answer_option.save!
+          end
+        end
+
+        def copy_questionnaire_matrix_rows(original_question, new_question)
+          original_question.matrix_rows.each do |original_matrix_row|
+            new_matrix_row = original_matrix_row.dup
+            new_matrix_row.question = new_question
+            new_matrix_row.save!
+          end
+        end
+
+        def copy_question_display_conditions(original_question, destination_question)
+          original_question.display_conditions.each do |original_display_condition|
+            new_display_condition = original_display_condition.dup
+            new_display_condition.question = destination_question
+            destination_question_to_be_checked = destination_question.questionnaire.questions.find_by(position: original_display_condition.condition_question.position)
+            new_display_condition.condition_question = destination_question_to_be_checked
+            if original_display_condition.answer_option
+              new_display_condition.answer_option = destination_question_to_be_checked.answer_options.find_by(body: original_display_condition.answer_option.body)
+            end
+            new_display_condition.save!
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-templates/lib/decidim/templates/test/factories.rb
+++ b/decidim-templates/lib/decidim/templates/test/factories.rb
@@ -18,6 +18,13 @@ FactoryBot.define do
         end
       end
 
+      trait :with_all_questions do
+        after(:create) do |template|
+          template.templatable = create(:questionnaire, :with_all_questions, questionnaire_for: template)
+          template.save!
+        end
+      end
+
       after(:create) do |template|
         template.templatable = create(:questionnaire, questionnaire_for: template)
         template.save!

--- a/decidim-templates/lib/decidim/templates/test/shared_examples/copies_all_questionnaire_contents_examples.rb
+++ b/decidim-templates/lib/decidim/templates/test/shared_examples/copies_all_questionnaire_contents_examples.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples_for "copies all questionnaire contents" do
+  describe "when the questionnaire has all contents" do
+    it "copies all template contents to the questionnaire" do
+      destination_questionnaire.reload
+
+      check_copy_questionnaire_questions(template.templatable, destination_questionnaire)
+    end
+
+    def check_copy_questionnaire_questions(source_questionnaire, new_questionnaire)
+      expect(source_questionnaire.questions.size).to eq(new_questionnaire.questions.size)
+
+      source_questionnaire.questions.each_with_index do |source_question, idx|
+        new_question = new_questionnaire.questions[idx]
+
+        expect(source_question.position).to eq(new_question.position)
+        expect(source_question.question_type).to eq(new_question.question_type)
+        expect(source_question.mandatory).to eq(new_question.mandatory)
+        expect(source_question.body).to eq(new_question.body)
+        expect(source_question.description).to eq(new_question.description)
+        expect(source_question.max_choices).to eq(new_question.max_choices)
+
+        check_answer_options(source_question, new_question)
+        check_matrix_rows(source_question, new_question)
+        check_display_conditions(source_question.display_conditions, new_question.display_conditions)
+        check_display_conditions(source_question.display_conditions_for_other_questions, new_question.display_conditions_for_other_questions)
+      end
+    end
+
+    def check_answer_options(source_question, new_question)
+      expect(source_question.answer_options.size).to eq(new_question.answer_options.size)
+
+      source_question.answer_options.each_with_index do |source_answer_option, idx|
+        new_answer_option = new_question.answer_options[idx]
+
+        expect(source_answer_option.body).to eq(new_answer_option.body)
+      end
+    end
+
+    def check_matrix_rows(source_question, new_question)
+      expect(source_question.matrix_rows.size).to eq(new_question.matrix_rows.size)
+
+      source_question.matrix_rows.each_with_index do |source_matrix_row, idx|
+        new_matrix_row = new_question.matrix_rows[idx]
+
+        expect(source_matrix_row.body).to eq(new_matrix_row.body)
+        expect(source_matrix_row.position).to eq(new_matrix_row.position)
+      end
+    end
+
+    def check_display_conditions(source_display_conditions, new_display_conditions)
+      expect(source_display_conditions.size).to eq(new_display_conditions.size)
+
+      source_display_conditions.each_with_index do |source_matrix_row, idx|
+        new_matrix_row = new_display_conditions[idx]
+
+        expect(source_matrix_row.condition_type).to eq(new_matrix_row.condition_type)
+        expect(source_matrix_row.condition_value).to eq(new_matrix_row.condition_value)
+        expect(source_matrix_row.mandatory).to eq(new_matrix_row.mandatory)
+        expect(new_matrix_row).to be_persisted
+      end
+    end
+  end
+end

--- a/decidim-templates/spec/commands/decidim/templates/admin/apply_questionnaire_template_spec.rb
+++ b/decidim-templates/spec/commands/decidim/templates/admin/apply_questionnaire_template_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/templates/test/shared_examples/copies_all_questionnaire_contents_examples"
+
+module Decidim
+  module Templates
+    module Admin
+      describe ApplyQuestionnaireTemplate do
+        let(:template) { create(:questionnaire_template) }
+        let(:destination_questionnaire) { create(:questionnaire, questionnaire_for: template) }
+        let(:command) { described_class.new(destination_questionnaire, template) }
+
+        describe "when the template is nil" do
+          let(:command) { described_class.new(destination_questionnaire, nil) }
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+        end
+
+        describe "when the template is valid" do
+          before do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "applies template attributes to the questionnaire" do
+            destination_questionnaire.reload
+            expect(destination_questionnaire.title).to eq(template.templatable.title)
+            expect(destination_questionnaire.description).to eq(template.templatable.description)
+            expect(destination_questionnaire.tos).to eq(template.templatable.tos)
+          end
+
+          context "when the questionnaire has all question types and display conditions" do
+            let(:template) { create(:questionnaire_template, :with_all_questions) }
+
+            it_behaves_like "copies all questionnaire contents"
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-templates/spec/commands/decidim/templates/admin/copy_questionnaire_template_spec.rb
+++ b/decidim-templates/spec/commands/decidim/templates/admin/copy_questionnaire_template_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/templates/test/shared_examples/copies_all_questionnaire_contents_examples"
+
+module Decidim
+  module Templates
+    module Admin
+      describe CopyQuestionnaireTemplate do
+        let(:template) { create(:questionnaire_template) }
+
+        describe "when the template is invalid" do
+          before do
+            template.update(name: nil)
+          end
+
+          it "broadcasts invalid" do
+            expect { described_class.call(template) }.to broadcast(:invalid)
+          end
+        end
+
+        describe "when the template is valid" do
+          let(:destination_questionnaire) do
+            events = described_class.call(template)
+            # events => { :ok => copied_template }
+            expect(events).to have_key(:ok)
+            events[:ok].templatable
+          end
+
+          it "applies template attributes to the questionnaire" do
+            expect(destination_questionnaire.title).to eq(template.templatable.title)
+            expect(destination_questionnaire.description).to eq(template.templatable.description)
+            expect(destination_questionnaire.tos).to eq(template.templatable.tos)
+          end
+
+          context "when the questionnaire has all question types and display conditions" do
+            let!(:template) { create(:questionnaire_template, :with_all_questions) }
+
+            it_behaves_like "copies all questionnaire contents"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When a template questionnaire question has display conditions, these conditions are ignored when the template is applied or copied.
This PR fixes this incorrect behavior by also copying the display_conditions.

As a bonus, another bug has been fixed when rendering `display_conditions` of type "equal". The problem was that the form input was not rendered with the previously selected answer option. The first option of the list was pre-selected instead, and if the user doesn't change the interface and clicks "Save" the display condition answer option changes.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?

#### Testing
*Describe the best way to test or validate your PR.*
1. Create a template with questions that have display conditions
2. go to a process or an assembly and add a surveys component
3. create the questionnaire from the template created in step 1
4. questions that should have display conditions are missing them

Second bug:
1. In the template, create a question with display condition of type equal and with an answer option that is not the first.
2. save
3. edit the questionnaire again
4. see that the display condition in step 1 shows the first answer option of the list, not the one selected in step 1
5. check the database and see that the display condition was correctly saved and points to the answer option selected in step 1

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
