### PR TITLE
Docs: Update the module webpacker migration guide

### DIFF
--- a/docs/modules/develop/pages/guide_migrate_webpacker_module.adoc
+++ b/docs/modules/develop/pages/guide_migrate_webpacker_module.adoc
@@ -35,14 +35,79 @@ For images, if they are in `app/packs/images` you could use `image_pack_tag`.
 
 == Asset compilation
 
-There's no specific or _Rails way_ to deal with assets compilation in engines, more than providing them as npm packages to be included.
+As all assets are now compiled using Webpacker without ever loading the Rails or Decidim environment, there are some new conventions how to tell Webpacker about the Decidim module's assets.
 
-In the community there are great examples of gems that have been adapted to Webpacker, such as https://github.com/activeadmin/activeadmin[ActiveAdmin]
+To begin with, create a new file named `config/assets.rb` inside your Decidim module.
 
-In ActiveAdmin:
+After this, add the following contents in that file, depending what kind of assets your module provides:
 
-- assets are defined in the package.json file, in an entry named `files:`
-- assets are precompiled using Rollup (a lightweigth Js compiler and packer)
-- a generator has been included to copy files to the Rails folder, do a `npm install` and install the npm package. See https://github.com/activeadmin/activeadmin/blob/master/lib/generators/active_admin/webpacker/webpacker_generator.rb[the generator]
+[source,ruby]
+----
+# frozen_string_literal: true
+# This file is located at `config/assets.rb` of your module.
 
-It's a good example to follow and get good practices
+# Define the base path of your module. Please note that `Rails.root` may not be
+# used because we are not inside the Rails environment when this file is loaded.
+base_path = File.expand_path("..", __dir__)
+
+# Register an additional load path for webpack. All the assets within these
+# directories will be available for inclusion within the Decidim assets. For
+# example, if you have `app/packs/src/decidim/foo.js`, you can include that file
+# in your JavaScript entrypoints (or other JavaScript files within Decidim)
+# using `import "src/decidim/foo"` after you have registered the additional path
+# as follows.
+Decidim::Webpacker.register_path("#{base_path}/app/packs")
+
+# Register the entrypoints for your module. These entrypoints can be included
+# within your application using `javascript_pack_tag` and if you include any
+# SCSS files within the entrypoints, they become available for inclusion using
+# `stylesheet_pack_tag`.
+Decidim::Webpacker.register_entrypoints(
+  decidim_foo: "#{base_path}/app/packs/entrypoints/decidim_foo.js",
+  decidim_foo_admin: "#{base_path}/app/packs/entrypoints/decidim_foo_admin.js"
+)
+
+# If you want to import some extra SCSS files in the Decidim main SCSS file
+# without adding any extra stylesheet inclusion tags, you can use the following
+# method to register the stylesheet import for the main application.
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/foo/app")
+
+# If you want to do the same but include the SCSS file for the admin panel's
+# main SCSS file, you can use the following method.
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/foo/admin", group: :admin)
+----
+
+== Component stylesheet migration
+
+In older Decidim versions your components could define their own stylesheet as follows:
+
+[source,ruby]
+----
+Decidim.register_component(:your_component) do |component|
+  component.engine = Decidim::YourComponent::Engine
+  component.stylesheet = "decidim/your_component/your_component"
+  component.admin_stylesheet = "decidim/your_component/your_component_admin"
+end
+----
+
+These were automatically included in the main application's stylesheet file and also in the admin panel's stylesheet file. These no longer work with Webpacker as the Decidim environment is not loaded when Webpacker compiles the assets.
+
+What you should do instead is to follow the asset compilation migration guide above and migrate these definitions into your application's `config/assets.rb` file as follows:
+
+[source,ruby]
+----
+# frozen_string_literal: true
+# This file is located at `config/assets.rb` of your module.
+
+base_path = File.expand_path("..", __dir__)
+
+# Register the additonal path for Webpacker in order to make the module's
+# stylesheets available for inclusion.
+Decidim::Webpacker.register_path("#{base_path}/app/packs")
+
+# Register the main application's stylesheet include statement:
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/your_component/your_component")
+
+# Register the admin panel's stylesheet include statement:
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/your_component/your_component_admin", group: :admin)
+----

--- a/docs/modules/develop/pages/guide_migrate_webpacker_module.adoc
+++ b/docs/modules/develop/pages/guide_migrate_webpacker_module.adoc
@@ -92,7 +92,7 @@ end
 
 These were automatically included in the main application's stylesheet file and also in the admin panel's stylesheet file. These no longer work with Webpacker as the Decidim environment is not loaded when Webpacker compiles the assets.
 
-What you should do instead is to follow the asset compilation migration guide above and migrate these definitions into your application's `config/assets.rb` file as follows:
+What you should do instead is to follow the asset compilation migration guide above and migrate these definitions into your module's `config/assets.rb` file as follows:
 
 [source,ruby]
 ----


### PR DESCRIPTION
#### :tophat: What? Why?
This updates the Webpacker migration guide for Decidim modules regarding the new conventions available in the module's assets configuration file (`config/assets.rb`).

#### :pushpin: Related Issues
- Related to #8066, #8115, #8154

#### Testing
Read the docs and see if you understand.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.