### PR TITLE
Make the `webpacker` gem a core dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,6 @@ gem "uglifier", "~> 4.1"
 
 gem "faker", "~> 2.14"
 
-gem "webpacker", "6.0.0.beta.7"
-
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ PATH
       truncato (~> 0.7)
       uglifier (~> 4.1)
       valid_email2 (~> 2.1)
+      webpacker (~> 6.0.0.beta.7)
       wisper (~> 2.0)
     decidim-debates (0.25.0.dev)
       decidim-comments (= 0.25.0.dev)
@@ -870,7 +871,6 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0)
   uglifier (~> 4.1)
   web-console (= 4.0.4)
-  webpacker (= 6.0.0.beta.7)
 
 RUBY VERSION
    ruby 2.7.1p83

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -73,6 +73,7 @@ Gem::Specification.new do |s|
   s.add_dependency "truncato", "~> 0.7"
   s.add_dependency "uglifier", "~> 4.1"
   s.add_dependency "valid_email2", "~> 2.1"
+  s.add_dependency "webpacker", "~> 6.0.0.beta.7"
   s.add_dependency "wisper", "~> 2.0"
 
   s.add_dependency "decidim-api", Decidim::Core.version

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -44,6 +44,7 @@ require "anchored"
 require "social-share-button"
 require "ransack"
 require "searchlight"
+require "webpacker"
 
 # Needed for the assets:precompile task, for configuring webpacker instance
 require "decidim/webpacker"

--- a/decidim-generators/Gemfile
+++ b/decidim-generators/Gemfile
@@ -20,8 +20,6 @@ gem "faker", "~> 2.14"
 
 gem "wicked_pdf", "~> 2.1"
 
-gem "webpacker", "6.0.0.beta.7"
-
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
 

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -114,6 +114,7 @@ PATH
       truncato (~> 0.7)
       uglifier (~> 4.1)
       valid_email2 (~> 2.1)
+      webpacker (~> 6.0.0.beta.7)
       wisper (~> 2.0)
     decidim-debates (0.25.0.dev)
       decidim-comments (= 0.25.0.dev)
@@ -859,7 +860,6 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0)
   uglifier (~> 4.1)
   web-console (~> 4.0)
-  webpacker (= 6.0.0.beta.7)
   wicked_pdf (~> 2.1)
 
 RUBY VERSION

--- a/decidim-generators/lib/decidim/generators/component_templates/Gemfile.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/Gemfile.erb
@@ -11,8 +11,6 @@ gem "puma", ">= 4.3"
 gem "bootsnap", "~> 1.4"
 gem "uglifier", "~> 4.1"
 
-gem "webpacker", "6.0.0.beta.7"
-
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
 

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -124,6 +124,7 @@ PATH
       truncato (~> 0.7)
       uglifier (~> 4.1)
       valid_email2 (~> 2.1)
+      webpacker (~> 6.0.0.beta.7)
       wisper (~> 2.0)
     decidim-debates (0.25.0.dev)
       decidim-comments (= 0.25.0.dev)
@@ -870,7 +871,6 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0)
   uglifier (~> 4.1)
   web-console (= 4.0.4)
-  webpacker (= 6.0.0.beta.7)
 
 RUBY VERSION
    ruby 2.7.1p83

--- a/docs/modules/develop/pages/guide_migrate_webpacker_app.adoc
+++ b/docs/modules/develop/pages/guide_migrate_webpacker_app.adoc
@@ -22,19 +22,10 @@ Before starting the migration, please check you have the following dependencies 
 
 Follow the steps descibed https://github.com/rails/webpacker#installation[here]
 
-* Add it to your Gemfile
-
-[source, console]
-----
-# Gemfile
-gem "webpacker", "6.0.0.beta.7"
-----
-
 - Install it
 
 [source,console]
 ----
-bundle install
 bundle exec rails webpacker:install
 ----
 
@@ -47,7 +38,7 @@ bundle exec rails decidim:webpacker:install
 
 This task do a few steps to allow the Rails instance to have a webpacker instance sharing the code between itself and Decidim gem.
 
-This task should be performed everytime decidim has been updated, to get the latest assets dependencies and Webpack configuration, and is run in the `decidim:upgrade` task.
+This task is automatically performed everytime decidim is updated, to get the latest Webpack configuration. This happens when you run the `decidim:upgrade` task.
 
 == Copy Decidim custom CSS and Javascript
 
@@ -66,7 +57,7 @@ If it's not the case you must create it. Then, copy Decidim customizable assets
 
 * Copy the file https://github.com/decidim/decidim/blob/develop/decidim-generators/lib/decidim/generators/app_templates/decidim_application.js[decidim_application.js] to `app/packs/src/decidim/decidim_application.js`
 * Copy the file https://github.com/decidim/decidim/blob/develop/decidim-generators/lib/decidim/generators/app_templates/decidim_application.scss[decidim_application.scss] to `app/packs/stylesheets/decidim/decidim_application.scss`
-* Copy the file https://github.com/decidim/decidim/blob/develop/decidim-generators/lib/decidim/generators/app_templates/decidim-settings.scss[_decidim-settings.scss] to `app/packs/stylesheets/decidim/_decidim-settings.scss`
+* Copy the file https://github.com/decidim/decidim/blob/develop/decidim-core/app/packs/stylesheets/decidim/_decidim-settings.scss[_decidim-settings.scss] to `app/packs/stylesheets/decidim/_decidim-settings.scss`
 
 These files are hooked into Decidim packs (specifically into decidim-core pack) and will be automatically included inside that pack when compiled.
 
@@ -80,7 +71,7 @@ Existing stylesheets should be moved from `app/assets/stylesheets` to `app/packs
 
 If that CSS file is replacing a Decidim file, there's no need to add it to `decidim_application.scss`.
 
-If any of the CSS is re-defining CSS vars should be renamed to `_decidim-settings.scss`.
+If any of the CSS is re-defining CSS vars add them to `_decidim-settings.scss`.
 
 == Migrate javascripts
 
@@ -99,7 +90,32 @@ For images, if they are in `app/packs/images` you could use `image_pack_tag`.
 Sometimes assets are included in `vendor/assets/` folder or imported from gems. For each specific one you should check:
 
 1. if the asset is a javascript that is available as npm package the recommendation is to add it to package.json with `npm install`. If it's not available you might want to copy it to `app/packs/src` and import it.
-2. if the asset is a stylesheet it should be copied to `app/packs/stylesheets` and imported with `@import...` from `decidim-settings.scss`
+2. if the asset is a stylesheet it should be copied to `app/packs/stylesheets` and imported with `@import...` from `_decidim-settings.scss`. Alternatively you can use the optional asset includes as described below to include these in the Decidim main SCSS files.
+
+== Optional asset includes
+
+Decidim Webpacker provides a new configuration convention that allows you to add extra configurations for webpacker using a configuration file named `config/assets.rb`. Within this file, you have the following API methods available:
+
+[source,ruby]
+----
+# frozen_string_literal: true
+# This file is located at `config/assets.rb` of your module.
+
+# Define the base path of your module. Please note that `Rails.root` may not be
+# used because we are not inside the Rails environment when this file is loaded.
+base_path = File.expand_path("..", __dir__)
+
+# If you want to import some extra SCSS files in the Decidim main SCSS file
+# without adding any extra stylesheet inclusion tags, you can use the following
+# method to register the stylesheet import for the main application. This would
+# include an SCSS file at `app/packs/stylesheets/your_app_extensions.scss` into
+# the Decidim's main SCSS file.
+Decidim::Webpacker.register_stylesheet_import("stylesheets/your_app_extensions")
+
+# If you want to do the same but include the SCSS file for the admin panel's
+# main SCSS file, you can use the following method.
+Decidim::Webpacker.register_stylesheet_import("stylesheets/your_app_admin_extensions", group: :admin)
+----
 
 == Remove Sprockets references
 
@@ -110,14 +126,14 @@ The completely remove Sprockets references from your application:
 * Remove `app/assets` folder
 * In `config/application.rb` replace:
 
-[source,console]
+[source,ruby]
 ----
 require 'rails/all'
 ----
 
 with:
 
-[source,console]
+[source,ruby]
 ----
 require "rails"
 # Pick the frameworks you want:
@@ -143,7 +159,7 @@ The deployment needs to be updated to manually run `npm install` before assets a
 
 In the case of Capistrano this can be done with a before hook:
 
-[source,console]
+[source,ruby]
 ----
 namespace :deploy do
   desc "Decidim webpacker configuration"

--- a/docs/modules/develop/pages/guide_migrate_webpacker_app.adoc
+++ b/docs/modules/develop/pages/guide_migrate_webpacker_app.adoc
@@ -38,7 +38,7 @@ bundle exec rails decidim:webpacker:install
 
 This task do a few steps to allow the Rails instance to have a webpacker instance sharing the code between itself and Decidim gem.
 
-This task is automatically performed everytime decidim is updated, to get the latest Webpack configuration. This happens when you run the `decidim:upgrade` task.
+This task is automatically performed every time decidim is updated, to get the latest Webpack configuration. This happens when you run the `decidim:upgrade` task.
 
 == Copy Decidim custom CSS and Javascript
 

--- a/docs/modules/develop/pages/guide_migrate_webpacker_app.adoc
+++ b/docs/modules/develop/pages/guide_migrate_webpacker_app.adoc
@@ -57,7 +57,7 @@ If it's not the case you must create it. Then, copy Decidim customizable assets
 
 * Copy the file https://github.com/decidim/decidim/blob/develop/decidim-generators/lib/decidim/generators/app_templates/decidim_application.js[decidim_application.js] to `app/packs/src/decidim/decidim_application.js`
 * Copy the file https://github.com/decidim/decidim/blob/develop/decidim-generators/lib/decidim/generators/app_templates/decidim_application.scss[decidim_application.scss] to `app/packs/stylesheets/decidim/decidim_application.scss`
-* Copy the file https://github.com/decidim/decidim/blob/develop/decidim-core/app/packs/stylesheets/decidim/_decidim-settings.scss[_decidim-settings.scss] to `app/packs/stylesheets/decidim/_decidim-settings.scss`
+* Copy the file https://github.com/decidim/decidim/blob/develop/decidim-generators/lib/decidim/generators/app_templates/_decidim-settings.scss[_decidim-settings.scss] to `app/packs/stylesheets/decidim/_decidim-settings.scss`
 
 These files are hooked into Decidim packs (specifically into decidim-core pack) and will be automatically included inside that pack when compiled.
 

--- a/docs/modules/develop/pages/guide_migrate_webpacker_app.adoc
+++ b/docs/modules/develop/pages/guide_migrate_webpacker_app.adoc
@@ -20,7 +20,7 @@ Before starting the migration, please check you have the following dependencies 
 
 == Add Webpacker to the application
 
-Follow the steps descibed https://github.com/rails/webpacker#installation[here]
+Follow the steps described https://github.com/rails/webpacker#installation[here]
 
 - Install it
 


### PR DESCRIPTION
#### :tophat: What? Why?
Decidim won't run without the `webpacker` gem anymore.

Shouldn't it be a core dependency then rather than requiring everyone to add it manually as a dependency?

I also updated the app migration guide with some relevant parts as I went through it after #8180.

#### :pushpin: Related Issues
- Related to #7464, #7733, #7942, #8180

#### Testing
- Re-create the development app
- See that webpacker is working

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.