### PR TITLE
Backport "Fix ordering of question matrix_rows in templates" to 0.24

### DIFF
--- a/decidim-forms/app/assets/javascripts/decidim/forms/admin/forms.js.es6
+++ b/decidim-forms/app/assets/javascripts/decidim/forms/admin/forms.js.es6
@@ -59,7 +59,7 @@
     listSelector: ".questionnaire-question:not(.hidden)",
     labelSelector: ".card-title span:first",
     onPositionComputed: (el, idx) => {
-      $(el).find("input[name$=\\[position\\]]").val(idx);
+      $(el).find("input[name$=\\[position\\]]:not([name*=\\[matrix_rows\\]])").val(idx);
 
       autoButtonsByPosition.run();
 

--- a/decidim-forms/app/commands/decidim/forms/admin/update_questionnaire.rb
+++ b/decidim-forms/app/commands/decidim/forms/admin/update_questionnaire.rb
@@ -78,9 +78,10 @@ module Decidim
               update_nested_model(form_display_condition, display_condition_attributes, question.display_conditions)
             end
 
-            form_question.matrix_rows.each do |form_matrix_row|
+            form_question.matrix_rows_by_position.each_with_index do |form_matrix_row, idx|
               matrix_row_attributes = {
-                body: form_matrix_row.body
+                body: form_matrix_row.body,
+                position: form_matrix_row.position || idx
               }
 
               update_nested_model(form_matrix_row, matrix_row_attributes, question.matrix_rows)

--- a/decidim-forms/app/forms/decidim/forms/admin/question_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/admin/question_form.rb
@@ -42,6 +42,20 @@ module Decidim
           question_type == Decidim::Forms::Question::SEPARATOR_TYPE
         end
 
+        def matrix_rows_by_position
+          matrix_rows.sort do |a, b|
+            if a.position && b.position
+              a.position <=> b.position
+            elsif a.position
+              -1
+            elsif b.position
+              1
+            else
+              0
+            end
+          end
+        end
+
         private
 
         def matrix?

--- a/decidim-forms/app/forms/decidim/forms/admin/question_matrix_row_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/admin/question_matrix_row_form.rb
@@ -7,12 +7,12 @@ module Decidim
       class QuestionMatrixRowForm < Decidim::Form
         include TranslatableAttributes
 
-        attribute :position, Integer, default: 0
+        attribute :position, Integer
         attribute :deleted, Boolean, default: false
 
         translatable_attribute :body, String
 
-        validates :position, numericality: { greater_than_or_equal_to: 0 }
+        validates :position, numericality: { greater_than_or_equal_to: 0 }, if: -> { position.present? }
         validates :body, translatable_presence: true, unless: :deleted
 
         def to_param

--- a/decidim-forms/app/models/decidim/forms/question_matrix_row.rb
+++ b/decidim-forms/app/models/decidim/forms/question_matrix_row.rb
@@ -10,6 +10,9 @@ module Decidim
       belongs_to :question, class_name: "Question", foreign_key: "decidim_question_id"
 
       delegate :answer_options, :mandatory, :max_choices, to: :question
+
+      scope :by_position, -> { order(:position) }
+      default_scope { by_position }
     end
   end
 end

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_matrix_row.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_matrix_row.html.erb
@@ -28,6 +28,7 @@
 
   <% if matrix_row.persisted? %>
     <%= form.hidden_field :id, disabled: !editable %>
+    <%= form.hidden_field :position, disabled: !editable %>
   <% end %>
 
   <%= form.hidden_field :deleted, disabled: !editable %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_question.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_question.html.erb
@@ -104,7 +104,7 @@
 
     <div class="questionnaire-question-matrix-rows" data-template="<%= matrix_row_template_selector %>">
       <div class="questionnaire-question-matrix-rows-list">
-        <% question.matrix_rows.each do |matrix_row| %>
+        <% question.matrix_rows_by_position.each do |matrix_row| %>
           <%= fields_for "questionnaire[questions][#{question.to_param}][matrix_rows][]", matrix_row do |matrix_row_form| %>
             <%= render "decidim/forms/admin/questionnaires/matrix_row", form: matrix_row_form, question: question, editable: editable %>
           <% end %>

--- a/decidim-forms/app/views/decidim/forms/questionnaires/answers/_matrix_multiple.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/answers/_matrix_multiple.html.erb
@@ -8,7 +8,7 @@
     </tr>
   </thead>
   <tbody>
-    <% answer.question.matrix_rows.each_with_index do |row, row_idx| %>
+    <% answer.question.matrix_rows.by_position.each_with_index do |row, row_idx| %>
       <tr class="check-box-collection">
         <td><%= translated_attribute row.body %></td>
         <% answer.question.answer_options.each_with_index do |answer_option, idx| %>

--- a/decidim-forms/app/views/decidim/forms/questionnaires/answers/_matrix_single.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/answers/_matrix_single.html.erb
@@ -8,7 +8,7 @@
     </tr>
   </thead>
   <tbody>
-    <% answer.question.matrix_rows.each_with_index do |row, row_idx| %>
+    <% answer.question.matrix_rows.by_position.each_with_index do |row, row_idx| %>
       <tr class="radio-button-collection">
         <td><%= translated_attribute row.body %></td>
         <% answer.question.answer_options.each_with_index do |answer_option, idx| %>

--- a/decidim-forms/db/migrate/20210616153042_set_position_to_question_matrix_rows.rb
+++ b/decidim-forms/db/migrate/20210616153042_set_position_to_question_matrix_rows.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SetPositionToQuestionMatrixRows < ActiveRecord::Migration[5.2]
+  def up
+    execute "UPDATE decidim_forms_question_matrix_rows SET position = id"
+  end
+
+  def down
+    execute "UPDATE decidim_forms_question_matrix_rows SET position = NULL"
+  end
+end

--- a/decidim-forms/lib/decidim/forms/test/factories.rb
+++ b/decidim-forms/lib/decidim/forms/test/factories.rb
@@ -63,9 +63,10 @@ FactoryBot.define do
       end
 
       if question.matrix_rows.empty?
-        evaluator.rows.each do |row|
+        evaluator.rows.each_with_index do |row, idx|
           question.matrix_rows.build(
-            body: row["body"]
+            body: row["body"],
+            position: idx
           )
         end
       end

--- a/decidim-forms/spec/commands/decidim/forms/admin/update_questionnaire_spec.rb
+++ b/decidim-forms/spec/commands/decidim/forms/admin/update_questionnaire_spec.rb
@@ -255,7 +255,10 @@ module Decidim
 
             expect(questionnaire.questions[4].question_type).to eq("matrix_single")
             expect(questionnaire.questions[4].answer_options[0].free_text).to eq(true)
-            expect(questionnaire.questions[4].matrix_rows[0].body["en"]).to eq(form_params["questions"]["4"]["matrix_rows"]["0"]["body"]["en"])
+            (0..1).each do |idx|
+              expect(questionnaire.questions[4].matrix_rows[idx].body["en"]).to eq(form_params["questions"]["4"]["matrix_rows"][idx.to_s]["body"]["en"])
+              expect(questionnaire.questions[4].matrix_rows[idx].position).to eq(idx)
+            end
 
             expect(questionnaire.questions[5].question_type).to eq("matrix_multiple")
             expect(questionnaire.questions[5].answer_options[0].free_text).to eq(true)

--- a/decidim-forms/spec/forms/decidim/forms/admin/question_form_spec.rb
+++ b/decidim-forms/spec/forms/decidim/forms/admin/question_form_spec.rb
@@ -135,6 +135,79 @@ module Decidim
         end
 
         it_behaves_like "form to param", default_id: "questionnaire-question-id"
+
+        describe "#matrix_rows_by_position" do
+          let!(:question_type) { "single_option" }
+          let(:matrix_rows) do
+            {
+              "1" => { "body" => { "en" => "Matrix row 1" }, "deleted" => "false" },
+              "2" => { "body" => { "en" => "Matrix row 2" }, "deleted" => "false" },
+              "3" => { "body" => { "en" => "Matrix row 3" }, "deleted" => "false" }
+            }
+          end
+
+          before do
+            attributes.merge!("matrix_rows" => matrix_rows)
+          end
+
+          context "when all rows are new" do
+            it "positions are setted by order of reception" do
+              matrix_rows_by_position = subject.matrix_rows_by_position
+              (1..3).each do |idx|
+                question_matrix_row_form = matrix_rows_by_position[idx - 1]
+                expect(question_matrix_row_form.body[:en]).to eq(matrix_rows[idx.to_s]["body"]["en"])
+              end
+            end
+          end
+
+          context "when all rows already existed" do
+            before do
+              matrix_rows.each_pair do |key, row|
+                row["id"] = key
+                row["position"] = key
+              end
+            end
+
+            it "keeps positions even when in different by order of reception" do
+              matrix_rows_by_position = subject.matrix_rows_by_position
+              (0..2).each do |idx|
+                question_matrix_row_form = matrix_rows_by_position[idx]
+                expect(question_matrix_row_form.body[:en]).to eq(matrix_rows[(idx + 1).to_s]["body"]["en"])
+                expect(question_matrix_row_form.position).to eq(matrix_rows[(idx + 1).to_s]["position"].to_i)
+              end
+            end
+          end
+
+          context "when mixing existing and new rows" do
+            before do
+              matrix_rows.merge!({
+                                   "4" => { "body" => { "en" => "Matrix row 4" }, "position" => "2", "deleted" => "false" },
+                                   "5" => { "body" => { "en" => "Matrix row 5" }, "position" => "3", "deleted" => "false" },
+                                   "7" => { "body" => { "en" => "Matrix row 7" }, "position" => "5", "deleted" => "false" },
+                                   "6" => { "body" => { "en" => "Matrix row 6" }, "position" => "4", "deleted" => "false" },
+                                   "8" => { "body" => { "en" => "Matrix row 8" }, "position" => "1", "deleted" => "false" }
+                                 })
+            end
+
+            it "keeps positions of existing rows and moves all new rows to the end of the array" do
+              matrix_rows_by_position = subject.matrix_rows_by_position
+
+              # first five rows are the already existing ordered by position
+              %w(8 4 5 6 7).each_with_index do |key, idx|
+                question_matrix_row_form = matrix_rows_by_position[idx]
+                expect(question_matrix_row_form.body[:en]).to eq(matrix_rows[key]["body"]["en"])
+                expect(question_matrix_row_form.position).to eq(matrix_rows[key]["position"].to_i)
+              end
+
+              # at the end the new rows (no position attribute) by order of reception
+              (5..7).each do |idx|
+                question_matrix_row_form = matrix_rows_by_position[idx]
+                expect(question_matrix_row_form.body[:en]).to eq(matrix_rows[(idx - 4).to_s]["body"]["en"])
+                expect(question_matrix_row_form.position).to be_nil
+              end
+            end
+          end
+        end
       end
     end
   end

--- a/decidim-forms/spec/forms/decidim/forms/admin/question_matrix_row_form_spec.rb
+++ b/decidim-forms/spec/forms/decidim/forms/admin/question_matrix_row_form_spec.rb
@@ -35,7 +35,7 @@ module Decidim
         context "when the position is not present" do
           let!(:position) { nil }
 
-          it { is_expected.not_to be_valid }
+          it { is_expected.to be_valid }
         end
 
         context "when the body is missing a locale translation" do

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -161,9 +161,9 @@ Decidim.register_component(:surveys) do |component|
         position: index
       )
 
-      3.times do
+      3.times do |position|
         question.answer_options.create!(body: Decidim::Faker::Localized.sentence)
-        question.matrix_rows.create!(body: Decidim::Faker::Localized.sentence)
+        question.matrix_rows.create!(body: Decidim::Faker::Localized.sentence, position: position)
       end
     end
   end

--- a/decidim-templates/db/seeds.rb
+++ b/decidim-templates/db/seeds.rb
@@ -69,9 +69,9 @@ if !Rails.env.production? || ENV["SEED"]
       question_type: matrix_question_type
     )
 
-    3.times do
+    3.times do |idx|
       question.answer_options.create!(body: Decidim::Faker::Localized.sentence)
-      question.matrix_rows.create!(body: Decidim::Faker::Localized.sentence)
+      question.matrix_rows.create!(body: Decidim::Faker::Localized.sentence, position: idx)
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*
This PR backports #8143 to `release/0.24-stable`.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #8143
