### PR TITLE
Set current_component as commentable when commentable is a participatory space

### DIFF
--- a/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
+++ b/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
@@ -69,7 +69,7 @@ module Decidim
           params.merge(commentable: commentable)
         ).with_context(
           current_organization: current_organization,
-          current_component: commentable.try(:component) || commentable.participatory_space
+          current_component: current_component
         )
         Decidim::Comments::CreateComment.call(form, current_user) do
           on(:ok) do |comment|
@@ -86,6 +86,12 @@ module Decidim
             end
           end
         end
+      end
+
+      def current_component
+        return commentable.component if commentable.respond_to?(:component)
+        return commentable.participatory_space if commentable.respond_to?(:participatory_space)
+        return commentable if Decidim.participatory_space_manifests.find { |manifest| manifest.model_class_name == commentable.class.name }
       end
 
       def destroy

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -121,13 +121,15 @@ shared_examples "comments" do
         end
       end
 
-      context "when component has a default comments length params" do
+      context "when component is present and has a default comments length params" do
         it "displays the numbers of characters left" do
-          component.update!(settings: { comments_max_length: 3000 })
-          visit current_path
+          if component.present?
+            component.update!(settings: { comments_max_length: 3000 })
+            visit current_path
 
-          within ".add-comment form" do
-            expect(page).to have_content("3000 characters left")
+            within ".add-comment form" do
+              expect(page).to have_content("3000 characters left")
+            end
           end
         end
       end

--- a/decidim-core/lib/decidim/resourceable.rb
+++ b/decidim-core/lib/decidim/resourceable.rb
@@ -93,6 +93,8 @@ module Decidim
       # - the visibility of its participatory space.
       # - the visibility of the resource itself.
       def visible?
+        return resource_visible? if participatory_space?
+
         component.participatory_space.try(:visible?) && component.published? && resource_visible?
       end
 
@@ -107,6 +109,12 @@ module Decidim
         return !hidden? if respond_to?(:hidden?)
 
         true
+      end
+
+      def participatory_space?
+        return if component.present?
+
+        Decidim.participatory_space_manifests.find { |manifest| manifest.model_class_name == self.class.name }
       end
 
       # Public: Whether the permissions for this object actions can be set at resource level.

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -410,6 +410,10 @@ module Decidim
       committee_members.approved.count >= minimum_committee_members
     end
 
+    def component
+      nil
+    end
+
     # PUBLIC
     #
     # Checks if the type the initiative belongs to enables SMS code

--- a/decidim-initiatives/spec/system/comments_spec.rb
+++ b/decidim-initiatives/spec/system/comments_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Comments", type: :system do
+  let(:organization) { create(:organization) }
+  let!(:initiative_type) { create(:initiatives_type, :online_signature_enabled, organization: organization) }
+  let!(:scoped_type) { create(:initiatives_type_scope, type: initiative_type) }
+  let(:commentable) { create(:initiative, :published, author: user, scoped_type: scoped_type, organization: organization) }
+  let!(:participatory_space) { commentable }
+  let(:component) { nil }
+  let(:resource_path) { resource_locator(commentable).path }
+
+  include_examples "comments"
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR:

 * Allows to set commentable as current_component on CommentForm when commentable does't respond to component or participatory_space and there is a manifest declaring the commentable class as participatory space.
 * Adapts the `Decidim::Resourceable` concern to work with resources that don't belong to a component, like `Decidim::Initiative`
 * Adds the shared comment examples to initiatives and changes an example which doesn't make sense in the context of an initiative.

#### :pushpin: Related Issues

- Related to #7726
- Fixes #8064

#### Testing

As signed in user visit a published initiative. The user should be able to add new comments

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
