### PR TITLE
Downgrade postscss version to 2.1.1

### DIFF
--- a/decidim_app-design/package-lock.json
+++ b/decidim_app-design/package-lock.json
@@ -13545,17 +13545,6 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
-    "node_modules/nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -15852,38 +15841,6 @@
         "postcss": "^7.0.21"
       }
     },
-    "node_modules/postcss-scss": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-3.0.5.tgz",
-      "integrity": "sha512-3e0qYk87eczfzg5P73ZVuuxEGCBfatRhPze6KrSaIbEKVtmnFI1RYp1Fv+AyZi+w8kcNRSPeNX6ap4b65zEkiA==",
-      "dependencies": {
-        "postcss": "^8.2.7"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/postcss-scss/node_modules/postcss": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.2.tgz",
-      "integrity": "sha512-y1FK/AWdZlBF5lusS5j5l4/vF67+vQZt1SXPVJ32y1kRGDQyrs1zk32hG1cInRTu14P0V+orPz+ifwW/7rR4bg==",
-      "dependencies": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
-        "source-map-js": "^0.6.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
     "node_modules/postcss-selector-matches": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
@@ -18122,14 +18079,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21864,7 +21813,7 @@
         "postcss-import": "^12.0.1",
         "postcss-loader": "^5.2.0",
         "postcss-preset-env": "^6.7.0",
-        "postcss-scss": "^3.0.5",
+        "postcss-scss": "^2.1.1",
         "sass": "^1.32.8",
         "sass-loader": "^11.0.1",
         "source-map-loader": "^0.2.4",
@@ -21878,6 +21827,17 @@
       "engines": {
         "node": "^15.14.0",
         "npm": "^7.7.2"
+      }
+    },
+    "packages/webpacker/node_modules/postcss-scss": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.1.1.tgz",
+      "integrity": "sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==",
+      "dependencies": {
+        "postcss": "^7.0.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     }
   },
@@ -23153,7 +23113,7 @@
         "postcss-import": "^12.0.1",
         "postcss-loader": "^5.2.0",
         "postcss-preset-env": "^6.7.0",
-        "postcss-scss": "^3.0.5",
+        "postcss-scss": "^2.1.1",
         "sass": "^1.32.8",
         "sass-loader": "^11.0.1",
         "source-map-loader": "^0.2.4",
@@ -23163,6 +23123,16 @@
         "webpack-cli": "^4.2.0",
         "webpack-config-utils": "^2.3.1",
         "webpack-dev-server": "^3.11.2"
+      },
+      "dependencies": {
+        "postcss-scss": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.1.1.tgz",
+          "integrity": "sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==",
+          "requires": {
+            "postcss": "^7.0.6"
+          }
+        }
       }
     },
     "@discoveryjs/json-ext": {
@@ -32308,11 +32278,6 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
-    "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -34155,26 +34120,6 @@
         "postcss": "^7.0.21"
       }
     },
-    "postcss-scss": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-3.0.5.tgz",
-      "integrity": "sha512-3e0qYk87eczfzg5P73ZVuuxEGCBfatRhPze6KrSaIbEKVtmnFI1RYp1Fv+AyZi+w8kcNRSPeNX6ap4b65zEkiA==",
-      "requires": {
-        "postcss": "^8.2.7"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.2.tgz",
-          "integrity": "sha512-y1FK/AWdZlBF5lusS5j5l4/vF67+vQZt1SXPVJ32y1kRGDQyrs1zk32hG1cInRTu14P0V+orPz+ifwW/7rR4bg==",
-          "requires": {
-            "colorette": "^1.2.2",
-            "nanoid": "^3.1.23",
-            "source-map-js": "^0.6.2"
-          }
-        }
-      }
-    },
     "postcss-selector-matches": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
@@ -35952,11 +35897,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-    },
-    "source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
     },
     "source-map-loader": {
       "version": "0.2.4",

--- a/decidim_app-design/packages/webpacker/package.json
+++ b/decidim_app-design/packages/webpacker/package.json
@@ -40,7 +40,7 @@
     "postcss-import": "^12.0.1",
     "postcss-loader": "^5.2.0",
     "postcss-preset-env": "^6.7.0",
-    "postcss-scss": "^3.0.5",
+    "postcss-scss": "^2.1.1",
     "sass": "^1.32.8",
     "sass-loader": "^11.0.1",
     "source-map-loader": "^0.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13545,17 +13545,6 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
-    "node_modules/nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -15852,38 +15841,6 @@
         "postcss": "^7.0.21"
       }
     },
-    "node_modules/postcss-scss": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-3.0.5.tgz",
-      "integrity": "sha512-3e0qYk87eczfzg5P73ZVuuxEGCBfatRhPze6KrSaIbEKVtmnFI1RYp1Fv+AyZi+w8kcNRSPeNX6ap4b65zEkiA==",
-      "dependencies": {
-        "postcss": "^8.2.7"
-      },
-      "engines": {
-        "node": ">=10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/postcss-scss/node_modules/postcss": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.2.tgz",
-      "integrity": "sha512-y1FK/AWdZlBF5lusS5j5l4/vF67+vQZt1SXPVJ32y1kRGDQyrs1zk32hG1cInRTu14P0V+orPz+ifwW/7rR4bg==",
-      "dependencies": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
-        "source-map-js": "^0.6.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
     "node_modules/postcss-selector-matches": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
@@ -18122,14 +18079,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21864,7 +21813,7 @@
         "postcss-import": "^12.0.1",
         "postcss-loader": "^5.2.0",
         "postcss-preset-env": "^6.7.0",
-        "postcss-scss": "^3.0.5",
+        "postcss-scss": "^2.1.1",
         "sass": "^1.32.8",
         "sass-loader": "^11.0.1",
         "source-map-loader": "^0.2.4",
@@ -21878,6 +21827,17 @@
       "engines": {
         "node": "^15.14.0",
         "npm": "^7.7.2"
+      }
+    },
+    "packages/webpacker/node_modules/postcss-scss": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.1.1.tgz",
+      "integrity": "sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==",
+      "dependencies": {
+        "postcss": "^7.0.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     }
   },
@@ -23153,7 +23113,7 @@
         "postcss-import": "^12.0.1",
         "postcss-loader": "^5.2.0",
         "postcss-preset-env": "^6.7.0",
-        "postcss-scss": "^3.0.5",
+        "postcss-scss": "^2.1.1",
         "sass": "^1.32.8",
         "sass-loader": "^11.0.1",
         "source-map-loader": "^0.2.4",
@@ -23163,6 +23123,16 @@
         "webpack-cli": "^4.2.0",
         "webpack-config-utils": "^2.3.1",
         "webpack-dev-server": "^3.11.2"
+      },
+      "dependencies": {
+        "postcss-scss": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.1.1.tgz",
+          "integrity": "sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==",
+          "requires": {
+            "postcss": "^7.0.6"
+          }
+        }
       }
     },
     "@discoveryjs/json-ext": {
@@ -32308,11 +32278,6 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
-    "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -34155,26 +34120,6 @@
         "postcss": "^7.0.21"
       }
     },
-    "postcss-scss": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-3.0.5.tgz",
-      "integrity": "sha512-3e0qYk87eczfzg5P73ZVuuxEGCBfatRhPze6KrSaIbEKVtmnFI1RYp1Fv+AyZi+w8kcNRSPeNX6ap4b65zEkiA==",
-      "requires": {
-        "postcss": "^8.2.7"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.2.tgz",
-          "integrity": "sha512-y1FK/AWdZlBF5lusS5j5l4/vF67+vQZt1SXPVJ32y1kRGDQyrs1zk32hG1cInRTu14P0V+orPz+ifwW/7rR4bg==",
-          "requires": {
-            "colorette": "^1.2.2",
-            "nanoid": "^3.1.23",
-            "source-map-js": "^0.6.2"
-          }
-        }
-      }
-    },
     "postcss-selector-matches": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
@@ -35952,11 +35897,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-    },
-    "source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
     },
     "source-map-loader": {
       "version": "0.2.4",

--- a/packages/webpacker/package.json
+++ b/packages/webpacker/package.json
@@ -41,7 +41,7 @@
     "postcss-import": "^12.0.1",
     "postcss-loader": "^5.2.0",
     "postcss-preset-env": "^6.7.0",
-    "postcss-scss": "^3.0.5",
+    "postcss-scss": "^2.1.1",
     "sass": "^1.32.8",
     "sass-loader": "^11.0.1",
     "source-map-loader": "^0.2.4",


### PR DESCRIPTION
#### :tophat: What? Why?

This PR forces postcss-scss version to 2.1.1 to avoid the compilation errors described in #8167 

The other alternative, which was removed postscss-preset-env was not an option because the autoprefixer plugin is need to make CSSs compatible with browsers. Notice that autoprefixer was available in Sprockets version (see #8183)

#### :pushpin: Related Issues

- Fixes #8167

#### Testing

- you should be able to compile assets

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

No


:hearts: Thank you!
