### PR TITLE
Lock the `webpacker` gem to the beta release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ PATH
       social-share-button (~> 1.2, >= 1.2.1)
       truncato (~> 0.7)
       valid_email2 (~> 2.1)
-      webpacker (~> 6.0.0.beta.7)
+      webpacker (~> 6.0.0.beta.7, <= 6.0.0.c)
       wisper (~> 2.0)
     decidim-debates (0.25.0.dev)
       decidim-comments (= 0.25.0.dev)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ PATH
       social-share-button (~> 1.2, >= 1.2.1)
       truncato (~> 0.7)
       valid_email2 (~> 2.1)
-      webpacker (~> 6.0.0.beta.7, <= 6.0.0.c)
+      webpacker (~> 6.0.0.beta.7, < 6.0.0.c)
       wisper (~> 2.0)
     decidim-debates (0.25.0.dev)
       decidim-comments (= 0.25.0.dev)

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |s|
   s.add_dependency "social-share-button", "~> 1.2", ">= 1.2.1"
   s.add_dependency "truncato", "~> 0.7"
   s.add_dependency "valid_email2", "~> 2.1"
-  s.add_dependency "webpacker", "~> 6.0.0.beta.7"
+  s.add_dependency "webpacker", "~> 6.0.0.beta.7", "<= 6.0.0.c"
   s.add_dependency "wisper", "~> 2.0"
 
   s.add_dependency "decidim-api", Decidim::Core.version

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |s|
   s.add_dependency "social-share-button", "~> 1.2", ">= 1.2.1"
   s.add_dependency "truncato", "~> 0.7"
   s.add_dependency "valid_email2", "~> 2.1"
-  s.add_dependency "webpacker", "~> 6.0.0.beta.7", "<= 6.0.0.c"
+  s.add_dependency "webpacker", "~> 6.0.0.beta.7", "< 6.0.0.c"
   s.add_dependency "wisper", "~> 2.0"
 
   s.add_dependency "decidim-api", Decidim::Core.version

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -109,7 +109,7 @@ PATH
       social-share-button (~> 1.2, >= 1.2.1)
       truncato (~> 0.7)
       valid_email2 (~> 2.1)
-      webpacker (~> 6.0.0.beta.7, <= 6.0.0.c)
+      webpacker (~> 6.0.0.beta.7, < 6.0.0.c)
       wisper (~> 2.0)
     decidim-debates (0.25.0.dev)
       decidim-comments (= 0.25.0.dev)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -109,7 +109,7 @@ PATH
       social-share-button (~> 1.2, >= 1.2.1)
       truncato (~> 0.7)
       valid_email2 (~> 2.1)
-      webpacker (~> 6.0.0.beta.7)
+      webpacker (~> 6.0.0.beta.7, <= 6.0.0.c)
       wisper (~> 2.0)
     decidim-debates (0.25.0.dev)
       decidim-comments (= 0.25.0.dev)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -119,7 +119,7 @@ PATH
       social-share-button (~> 1.2, >= 1.2.1)
       truncato (~> 0.7)
       valid_email2 (~> 2.1)
-      webpacker (~> 6.0.0.beta.7)
+      webpacker (~> 6.0.0.beta.7, <= 6.0.0.c)
       wisper (~> 2.0)
     decidim-debates (0.25.0.dev)
       decidim-comments (= 0.25.0.dev)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -119,7 +119,7 @@ PATH
       social-share-button (~> 1.2, >= 1.2.1)
       truncato (~> 0.7)
       valid_email2 (~> 2.1)
-      webpacker (~> 6.0.0.beta.7, <= 6.0.0.c)
+      webpacker (~> 6.0.0.beta.7, < 6.0.0.c)
       wisper (~> 2.0)
     decidim-debates (0.25.0.dev)
       decidim-comments (= 0.25.0.dev)


### PR DESCRIPTION
#### :tophat: What? Why?
After #8181 bundler will install the `6.0.0.pre.x` version of the Webpacker gem unless you specifically lock the webpacker version in the application's `Gemfile`. This will break some Webpacker functionality because the `pre`-versions are older than the `beta` versions (see [the release history](https://rubygems.org/gems/webpacker/versions))

Why this happens is that alphabetically `6.0.0.pre.2` > `6.0.0.beta.7`.

The real issue is that the Webpacker gem hasn't released version `6.0.0` yet and also it has not released an RC version which would be higher in alphabetical order than `6.0.0.pre.2`.

This solves the issue by locking the `webpacker` dependency to the `beta` release until there is either an actual release or an RC release available.

#### :pushpin: Related Issues
- Related to #8181 rails/webpacker#3055

#### Testing
Upgrade some existing Decidim installation to `0.25.0.dev` following the upgrade guide.

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.