### PR TITLE
Prevent registration error for followers

### DIFF
--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -109,6 +109,8 @@ module Decidim
       end
 
       def follow_meeting
+        return if already_following?
+        
         Decidim::CreateFollow.call(follow_form, user)
       end
 
@@ -124,6 +126,10 @@ module Decidim
 
       def questionnaire?
         registration_form.model_name == "Questionnaire"
+      end
+      
+      def already_following?
+        @meeting.follower_ids.include? @user.id
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Prevents the following error when a user is already following a meeting prior to registering for it:

```
ActiveRecord::RecordInvalid at /meetings/8/registration

Validation failed: User has already been taken
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist

- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.
