### PR TITLE
Fix visible moderated single comment

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comments_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comments_cell.rb
@@ -113,7 +113,7 @@ module Decidim
       def single_comment
         return if options[:single_comment].blank?
 
-        @single_comment ||= model.comments.find_by(id: options[:single_comment])
+        @single_comment ||= SortedComments.for(model, id: options[:single_comment], order_by: order).first
       end
 
       def machine_translations_toggled?

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -35,7 +35,7 @@ module Decidim::Comments
 
       context "with the single comment defined" do
         let(:my_cell) { cell("decidim/comments/comments", comment.commentable, single_comment: comment.id) }
-        let(:other_comments) { create_list(:comment, 10, commentable: commentable) }
+        let!(:other_comments) { create_list(:comment, 10, commentable: commentable) }
 
         it "renders only the single comment" do
           expect(subject).to have_css(".section-heading", text: "Comment details")
@@ -49,6 +49,29 @@ module Decidim::Comments
         it "renders the single comment warning" do
           expect(subject).to have_css(".callout.secondary", text: "You are seeing a single comment")
           expect(subject).to have_css(".callout.secondary", text: "You can check the rest of the comments here.")
+        end
+
+        context "with the single comment being moderated" do
+          before do
+            Decidim::Moderation.create!(
+              reportable: comment,
+              participatory_space: commentable.participatory_space,
+              hidden_at: 1.day.ago
+            )
+          end
+
+          it "renders the thread" do
+            expect(subject).to have_css(".section-heading", text: "10 comments")
+            expect(subject).to have_css(".callout.primary.loading-comments p", text: "Loading comments ...")
+            expect(subject).not_to have_content(comment.body.values.first)
+            expect(subject).to have_css(".add-comment")
+            expect(subject).to have_content("Sign in with your account or sign up to add your comment.")
+          end
+
+          it "does not render the single comment warning" do
+            expect(subject).not_to have_css(".callout.secondary", text: "You are seeing a single comment")
+            expect(subject).not_to have_css(".callout.secondary", text: "You can check the rest of the comments here.")
+          end
         end
       end
 

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -53,10 +53,11 @@ module Decidim::Comments
 
         context "with the single comment being moderated" do
           before do
-            Decidim::Moderation.create!(
+            create(
+              :moderation,
+              :hidden,
               reportable: comment,
-              participatory_space: commentable.participatory_space,
-              hidden_at: 1.day.ago
+              participatory_space: commentable.participatory_space
             )
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?
If you know the single comment ID that has been moderated, you can get it visible by adding the comment ID on the commentable page to the URL.

This fixes the issue.

#### Testing
- Create a commentable resource
- Add two comments on it
- Get a direct link to the first one
- Moderate the comment currently visible
- See if you can still see the comment

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.