### PR TITLE
Backport "Use comments counter cache instead of additional query" to 0.24

### DIFF
--- a/decidim-budgets/lib/decidim/budgets/project_serializer.rb
+++ b/decidim-budgets/lib/decidim/budgets/project_serializer.rb
@@ -34,7 +34,7 @@ module Decidim
           budget: { id: project.budget.id },
           budget_amount: project.budget_amount,
           confirmed_votes: project.confirmed_orders_count,
-          comments: project.comments.count,
+          comments: project.comments_count,
           created_at: project.created_at,
           url: project.polymorphic_resource_url({}),
           related_proposals: related_proposals,

--- a/decidim-comments/app/cells/decidim/comments/comments_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comments_cell.rb
@@ -51,7 +51,7 @@ module Decidim
       end
 
       def comments_count
-        model.comments.count
+        model.comments_count
       end
 
       def root_depth

--- a/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
+++ b/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
@@ -21,7 +21,7 @@ module Decidim
           order_by: order,
           after: params.fetch(:after, 0).to_i
         )
-        @comments_count = commentable.comments.count
+        @comments_count = commentable.comments_count
 
         respond_to do |format|
           format.js do
@@ -80,9 +80,9 @@ module Decidim
         @comments_count = begin
           case commentable
           when Decidim::Comments::Comment
-            commentable.root_commentable.comments.count
+            commentable.root_commentable.comments_count
           else
-            commentable.comments.count
+            commentable.comments_count
           end
         end
       end

--- a/decidim-core/app/cells/decidim/author/comments.erb
+++ b/decidim-core/app/cells/decidim/author/comments.erb
@@ -1,6 +1,6 @@
 <% if commentable? %>
-  <%= link_to "#{resource_locator(from_context).path}#comments", title: t("decidim.author.comments", count: from_context.comments.count) do %>
+  <%= link_to "#{resource_locator(from_context).path}#comments", title: t("decidim.author.comments", count: from_context.comments_count) do %>
     <%= icon "comment-square", class: "icon--small", role: "img", "aria-hidden": true %>
-    <%= from_context.comments.count %> <%= t("decidim.author.comments", count: from_context.comments.count) %>
+    <%= from_context.comments_count %> <%= t("decidim.author.comments", count: from_context.comments_count) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
Backports #7627 to 0.24.

It was supposed to be a performance fix but as a side effect it also fixed the comments counter when there are moderated comments on the page. Right now 0.24 includes the moderated comments amount in the total amount of comments.

#### Testing
- Create a commentable resource
- Add two comments on it
- Moderate the comment currently visible
- Reload the page
- See the comments counter

#### :clipboard: Checklist
- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.