### PR TITLE
Make it possible to define SCSS settings overrides from modules

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/utils/_settings.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/utils/_settings.scss
@@ -876,3 +876,7 @@ $grid-padding-gutters: $grid-margin-gutters;
 $grid-container-padding: $grid-padding-gutters;
 $grid-container-max: $global-width;
 $xy-block-grid-max: 8;
+
+// This imports all the Decidim module stylesheet configs registered at
+// `config/assets.rb` of the module for the "admin" group.
+@import "!decidim-style-settings[admin]";

--- a/decidim-core/app/packs/stylesheets/decidim/utils/_settings.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/utils/_settings.scss
@@ -880,4 +880,10 @@ $grid-container-padding: $grid-padding-gutters;
 $grid-container-max: $global-width;
 $xy-block-grid-max: 8;
 
+// This imports all the Decidim module stylesheet configs registered at
+// `config/assets.rb` of the module for the "app" group.
+@import "!decidim-style-settings[app]";
+
+// Import the application specific settings which will overrule the registered
+// imports.
 @import "stylesheets/decidim/decidim-settings";

--- a/decidim-core/lib/decidim/webpacker.rb
+++ b/decidim-core/lib/decidim/webpacker.rb
@@ -21,10 +21,12 @@ module Decidim
       configuration.entrypoints.merge!(entrypoints.stringify_keys)
     end
 
-    def self.register_stylesheet_import(import, group: :app)
+    def self.register_stylesheet_import(import, type: :imports, group: :app)
+      type = type.to_s
       key = group.to_s
-      configuration.stylesheet_imports[key] ||= []
-      configuration.stylesheet_imports[key].push(import)
+      configuration.stylesheet_imports[type] ||= {}
+      configuration.stylesheet_imports[type][key] ||= []
+      configuration.stylesheet_imports[type][key].push(import)
     end
   end
 end

--- a/decidim-core/spec/lib/webpacker/configuration_spec.rb
+++ b/decidim-core/spec/lib/webpacker/configuration_spec.rb
@@ -48,8 +48,9 @@ module Decidim
         end
 
         it "adds the stylesheet imports to the webpacker runtime configuration" do
-          expect(runtime_config["default"]["stylesheet_imports"].keys).to include("app")
-          expect(runtime_config["default"]["stylesheet_imports"]["app"]).to include(
+          expect(runtime_config["default"]["stylesheet_imports"].keys).to include("imports")
+          expect(runtime_config["default"]["stylesheet_imports"]["imports"].keys).to include("app")
+          expect(runtime_config["default"]["stylesheet_imports"]["imports"]["app"]).to include(
             "stylesheets/decidim/accountability/accountability",
             "stylesheets/decidim/budgets/budgets",
             "stylesheets/decidim/proposals/proposals",

--- a/decidim-core/spec/lib/webpacker/runner_spec.rb
+++ b/decidim-core/spec/lib/webpacker/runner_spec.rb
@@ -42,8 +42,9 @@ module Webpacker
           "decidim_map_provider_here" => "#{core_path}/app/packs/entrypoints/decidim_map_provider_here.js",
           "decidim_widget" => "#{core_path}/app/packs/entrypoints/decidim_widget.js"
         )
-        expect(runtime_config["default"]["stylesheet_imports"].keys).to include("app")
-        expect(runtime_config["default"]["stylesheet_imports"]["app"]).to include(
+        expect(runtime_config["default"]["stylesheet_imports"].keys).to include("imports")
+        expect(runtime_config["default"]["stylesheet_imports"]["imports"].keys).to include("app")
+        expect(runtime_config["default"]["stylesheet_imports"]["imports"]["app"]).to include(
           "stylesheets/decidim/accountability/accountability",
           "stylesheets/decidim/budgets/budgets",
           "stylesheets/decidim/proposals/proposals",

--- a/decidim-core/spec/lib/webpacker_spec.rb
+++ b/decidim-core/spec/lib/webpacker_spec.rb
@@ -68,7 +68,7 @@ module Decidim
       it "registers the defined entrypoints for the 'app' group by default" do
         described_class.register_stylesheet_import("stylesheets/decidim/test")
 
-        expect(described_class.configuration.stylesheet_imports["app"]).to eq(
+        expect(described_class.configuration.stylesheet_imports["imports"]["app"]).to eq(
           %w(stylesheets/decidim/test)
         )
       end
@@ -77,7 +77,27 @@ module Decidim
         it "registers the defined entrypoints for the defined group" do
           described_class.register_stylesheet_import("stylesheets/decidim/test", group: :admin)
 
-          expect(described_class.configuration.stylesheet_imports["admin"]).to eq(
+          expect(described_class.configuration.stylesheet_imports["imports"]["admin"]).to eq(
+            %w(stylesheets/decidim/test)
+          )
+        end
+      end
+
+      context "with a type provided" do
+        it "registers the defined entrypoints for the defined type and 'app' group by default" do
+          described_class.register_stylesheet_import("stylesheets/decidim/test", type: :settings)
+
+          expect(described_class.configuration.stylesheet_imports["settings"]["app"]).to eq(
+            %w(stylesheets/decidim/test)
+          )
+        end
+      end
+
+      context "with a type and a group provided" do
+        it "registers the defined entrypoints for the defined type and group" do
+          described_class.register_stylesheet_import("stylesheets/decidim/test", type: :settings, group: :admin)
+
+          expect(described_class.configuration.stylesheet_imports["settings"]["admin"]).to eq(
             %w(stylesheets/decidim/test)
           )
         end

--- a/docs/modules/develop/pages/guide_migrate_webpacker_module.adoc
+++ b/docs/modules/develop/pages/guide_migrate_webpacker_module.adoc
@@ -75,6 +75,14 @@ Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/foo/app")
 # If you want to do the same but include the SCSS file for the admin panel's
 # main SCSS file, you can use the following method.
 Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/foo/admin", group: :admin)
+
+# If you want to override some SCSS variables/settings for Foundation from the
+# module, you can add the following registered import.
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/foo/settings", type: :settings)
+
+# If you want to do the same but override the SCSS variables of the admin
+# panel's styles, you can use the following method.
+Decidim::Webpacker.register_stylesheet_import("stylesheets/decidim/foo/admin_settings", type: :settings, group: :admin)
 ----
 
 == Component stylesheet migration

--- a/packages/webpacker/index.js
+++ b/packages/webpacker/index.js
@@ -1,6 +1,6 @@
 const webpacker = require("@rails/webpacker");
 const overrideConfig = require("./src/override-config");
 
-module.exports = Object.assign(webpacker, {
+module.exports = Object.assign(webpacker, { // eslint-disable-line
   webpackConfig: overrideConfig(webpacker.webpackConfig)
 });

--- a/packages/webpacker/src/override-config.js
+++ b/packages/webpacker/src/override-config.js
@@ -8,7 +8,7 @@ const overrideSassRule = (modifyConfig) => {
     return modifyConfig;
   }
 
-  const sassLoader = sassRule.use.find(use => use.loader.match(/sass-loader/));
+  const sassLoader = sassRule.use.find((use) => use.loader.match(/sass-loader/));
   if (!sassLoader) {
     return modifyConfig;
   }
@@ -21,21 +21,22 @@ const overrideSassRule = (modifyConfig) => {
   // Add the extra importer to the sass-loader to load the import statements for
   // Decidim modules.
   sassLoader.options.sassOptions.importer = [
-    (url, _prev) => {
-      const matches = url.match(/^\!decidim-style-imports\[([^\]]+)\]$/);
+    (url) => {
+      const matches = url.match(/^!decidim-style-([^[]+)\[([^\]]+)\]$/);
       if (!matches) {
         return null;
       }
 
-      const group = matches[1];
-      if (!imports[group]) {
+      const type = matches[1];
+      const group = matches[2];
+      if (!imports[type] || !imports[type][group]) {
         // If the group is not defined, return an empty configuration because
         // otherwise the importer would continue finding the asset through
         // paths which obviously fails.
         return { contents: "" };
       }
 
-      const statements = imports[group].map((style) => `@import "${style}";`);
+      const statements = imports[type][group].map((style) => `@import "${style}";`);
 
       return { contents: statements.join("\n") };
     }
@@ -44,6 +45,6 @@ const overrideSassRule = (modifyConfig) => {
   return modifyConfig;
 }
 
-module.exports = (originalConfig) => {
+module.exports = (originalConfig) => { // eslint-disable-line
   return overrideSassRule(originalConfig);
 };


### PR DESCRIPTION
#### :tophat: What? Why?
Right now it is possible to add extra SCSS to the main and admin SCSS from modules as of #8115 and #8154.

But it is not possible to override any Foundation/Decidim SCSS settings variables from modules.

This adds this possibility in order to make it easier to do theming directly from modules.

#### :pushpin: Related Issues
- Related to #8115, #8154

#### Testing
- Override some SCSS variable from a module of your choice by following the added documentation, e.g. `$anchor-color: #f00;`
- See whether your change was applied

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.