### PR TITLE
Backport "Fix joining a meetings that the user already follows" to 0.24

### DIFF
--- a/decidim-core/app/commands/decidim/create_follow.rb
+++ b/decidim-core/app/commands/decidim/create_follow.rb
@@ -32,7 +32,10 @@ module Decidim
     attr_reader :follow, :form, :current_user
 
     def create_follow!
-      @follow = Follow.create!(
+      @follow = Follow.find_by(
+        followable: form.followable,
+        user: current_user
+      ) || Follow.create!(
         followable: form.followable,
         user: current_user
       )

--- a/decidim-core/spec/commands/decidim/create_follow_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_follow_spec.rb
@@ -22,5 +22,15 @@ module Decidim
       expect(Decidim::Gamification.status_for(user1, :followers).score).to eq(0)
       expect(Decidim::Gamification.status_for(user2, :followers).score).to eq(1)
     end
+
+    context "when the user is already following the item" do
+      let!(:follow) { create(:follow, followable: user2, user: user1) }
+
+      it "does not raise a validation error" do
+        expect { described_class.new(form, user1).call }.to broadcast(:ok)
+        expect(user2.reload.followers).to include(user1)
+        expect(user2.follows_count).to eq(1)
+      end
+    end
   end
 end

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -187,6 +187,27 @@ describe "Meeting registrations", type: :system do
             expect(page).to have_text("19 slots remaining")
             expect(page).to have_text("Stop following")
           end
+
+          it "they can join the meeting if they are already following it" do
+            create(:follow, followable: meeting, user: user)
+
+            visit_meeting
+
+            within ".card.extra" do
+              click_button "Join meeting"
+            end
+
+            within "#meeting-registration-confirm-#{meeting.id}" do
+              expect(page).to have_content "A legal text"
+              page.find(".button.expanded").click
+            end
+
+            expect(page).to have_content("successfully")
+
+            expect(page).to have_css(".button", text: "GOING")
+            expect(page).to have_text("19 slots remaining")
+            expect(page).to have_text("Stop following")
+          end
         end
 
         context "and they ARE part of a verified user group" do
@@ -222,6 +243,12 @@ describe "Meeting registrations", type: :system do
       let(:registration_form_enabled) { true }
 
       it_behaves_like "has questionnaire"
+
+      context "when the user is following the meeting" do
+        let!(:follow) { create(:follow, followable: meeting, user: user) }
+
+        it_behaves_like "has questionnaire"
+      end
 
       context "when the registration form has no questions" do
         before do


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the fix from #7854 to 0.24.

#### :pushpin: Related Issues
- Related to #7854

#### Testing
See #7854.

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.