### PR TITLE
Fix user activity pagination when there are hidden items

### DIFF
--- a/decidim-core/app/controllers/decidim/user_activities_controller.rb
+++ b/decidim-core/app/controllers/decidim/user_activities_controller.rb
@@ -26,6 +26,7 @@ module Decidim
         ActivitySearch.new(
           organization: current_organization,
           user: user,
+          current_user: current_user,
           resource_type: "all",
           resource_name: filter.resource_type
         ).run

--- a/decidim-core/app/services/decidim/activity_search.rb
+++ b/decidim-core/app/services/decidim/activity_search.rb
@@ -29,7 +29,8 @@ module Decidim
       query = query.where(user: options[:user]) if options[:user]
       query = query.where(resource_type: options[:resource_name]) if options[:resource_name]
 
-      filter_follows(query)
+      query = filter_follows(query)
+      filter_hidden(query)
     end
 
     # Overwrites the default Searchlight run method since we want to return
@@ -118,6 +119,50 @@ module Decidim
       end
 
       query.where(chained_conditions)
+    end
+
+    def filter_hidden(query)
+      # Filter out the items that have been moderated.
+      query = query.joins(
+        <<~SQL.squish
+          LEFT JOIN decidim_moderations
+            ON decidim_moderations.decidim_reportable_type = decidim_action_logs.resource_type
+            AND decidim_moderations.decidim_reportable_id = decidim_action_logs.resource_id
+            AND decidim_moderations.hidden_at IS NOT NULL
+        SQL
+      ).where(decidim_moderations: { id: nil })
+
+      # Filter out the private space items that should not be visible for the
+      # current user.
+      current_user_id = options.fetch(:current_user, nil)&.id.to_i
+      Decidim.participatory_space_manifests.map do |manifest|
+        klass = manifest.model_class_name.constantize
+        next unless klass.include?(Decidim::HasPrivateUsers)
+
+        table = klass.table_name
+        query = query.joins(
+          Arel.sql(
+            <<~SQL.squish
+              LEFT JOIN #{table}
+                ON decidim_action_logs.participatory_space_type = '#{manifest.model_class_name}'
+                AND #{table}.id = decidim_action_logs.participatory_space_id
+              LEFT JOIN decidim_participatory_space_private_users AS #{manifest.name}_private_users
+                ON #{manifest.name}_private_users.privatable_to_type = '#{manifest.model_class_name}'
+                AND #{table}.id = #{manifest.name}_private_users.privatable_to_id
+            SQL
+          )
+        ).where(
+          Arel.sql(
+            <<~SQL.squish
+              #{table}.id IS NULL OR
+              #{table}.private_space = 'f' OR
+              #{manifest.name}_private_users.decidim_user_id = #{current_user_id}
+            SQL
+          )
+        )
+      end
+
+      query
     end
 
     def followed_users_conditions(follows)

--- a/decidim-core/spec/cells/decidim/user_activity_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/user_activity_cell_spec.rb
@@ -72,14 +72,6 @@ describe Decidim::UserActivityCell, type: :cell do
   end
 
   it "displays the latest items on the first page and a pagination" do
-    # The first five items should be on the second page
-    logs.first(5).each do |log|
-      root_link = Decidim::ResourceLocatorPresenter.new(log.resource.root_commentable).path
-      comment_link = "#{root_link}?commentId=#{log.resource.id}"
-      title = html_truncate(translated_attribute(log.resource.root_commentable.title), length: 80)
-
-      expect(subject).not_to have_link(title, href: comment_link)
-    end
     logs.last(10).each do |log|
       root_link = Decidim::ResourceLocatorPresenter.new(log.resource.root_commentable).path
       comment_link = "#{root_link}?commentId=#{log.resource.id}"

--- a/decidim-core/spec/cells/decidim/user_activity_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/user_activity_cell_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::UserActivityCell, type: :cell do
+  include Decidim::ApplicationHelper
+  include Decidim::TranslationsHelper
+
+  subject { my_cell.call }
+
+  let(:my_cell) do
+    cell(
+      "decidim/user_activity",
+      model,
+      context: {
+        activities: activities,
+        filter: filter,
+        resource_types: resource_types,
+        user: model
+      }
+    )
+  end
+  let(:model) { create(:user, :confirmed, organization: component.organization) }
+  let(:resource_types) do
+    %w(
+      Decidim::Proposals::CollaborativeDraft
+      Decidim::Comments::Comment
+      Decidim::Debates::Debate
+      Decidim::Initiative
+      Decidim::Meetings::Meeting
+      Decidim::Blogs::Post
+      Decidim::Proposals::Proposal
+      Decidim::Consultations::Question
+    )
+  end
+  let(:filter) { Decidim::FilterResource::Filter.new({ resource_type: resource_types }) }
+  let(:current_user) { nil }
+  let(:component) { create(:component, :published) }
+  let(:commentable) { create(:dummy_resource, component: component, published_at: Time.current) }
+  let(:comments) { create_list(:comment, 15, author: model, commentable: commentable) }
+  let(:activities) do
+    Decidim::ActivitySearch.new(
+      organization: component.organization,
+      user: model,
+      current_user: current_user,
+      resource_type: "all",
+      resource_name: filter.resource_type
+    ).run.page(0).per(10)
+  end
+  let!(:logs) do
+    comments.map do |comment|
+      create(
+        :action_log,
+        action: "publish",
+        visibility: "all",
+        user: model,
+        resource: comment,
+        organization: component.organization,
+        participatory_space: component.participatory_space
+      )
+    end
+  end
+  let(:controller) { double }
+
+  before do
+    allow(controller).to receive(:current_organization).and_return(component.organization)
+
+    allow(my_cell).to receive(:url_for).and_return("/")
+    allow(my_cell).to receive(:params).and_return({})
+    allow(my_cell).to receive(:controller).and_return(controller)
+  end
+
+  it "displays the latest items on the first page and a pagination" do
+    # The first five items should be on the second page
+    logs.first(5).each do |log|
+      root_link = Decidim::ResourceLocatorPresenter.new(log.resource.root_commentable).path
+      comment_link = "#{root_link}?commentId=#{log.resource.id}"
+      title = html_truncate(translated_attribute(log.resource.root_commentable.title), length: 80)
+
+      expect(subject).not_to have_link(title, href: comment_link)
+    end
+    logs.last(10).each do |log|
+      root_link = Decidim::ResourceLocatorPresenter.new(log.resource.root_commentable).path
+      comment_link = "#{root_link}?commentId=#{log.resource.id}"
+      title = html_truncate(translated_attribute(log.resource.root_commentable.title), length: 80)
+
+      expect(subject).to have_link(title, href: comment_link)
+    end
+
+    within "#decidim-paginate-container .pagination" do
+      expect(page).to have_selector("li.page.current", text: "1")
+      expect(page).to have_selector("li.page a", text: "2")
+      expect(page).not_to have_selector("li.page a", text: "3")
+    end
+  end
+
+  context "when there are moderated activity items that would span on the second page" do
+    before do
+      logs.first(5).each do |log|
+        create(
+          :moderation,
+          :hidden,
+          reportable: log.resource,
+          participatory_space: log.resource.commentable.participatory_space
+        )
+      end
+    end
+
+    it "displays only the non-moderated items on the first page without a pagination" do
+      # The first five items should be on the second page
+      logs.first(5).each do |log|
+        root_link = Decidim::ResourceLocatorPresenter.new(log.resource.root_commentable).path
+        comment_link = "#{root_link}?commentId=#{log.resource.id}"
+        title = html_truncate(translated_attribute(log.resource.root_commentable.title), length: 80)
+
+        expect(subject).not_to have_link(title, href: comment_link)
+      end
+      logs.last(10).each do |log|
+        root_link = Decidim::ResourceLocatorPresenter.new(log.resource.root_commentable).path
+        comment_link = "#{root_link}?commentId=#{log.resource.id}"
+        title = html_truncate(translated_attribute(log.resource.root_commentable.title), length: 80)
+
+        expect(subject).to have_link(title, href: comment_link)
+      end
+
+      expect(subject).not_to have_selector("#decidim-paginate-container .pagination")
+    end
+  end
+end

--- a/decidim-core/spec/cells/decidim/user_activity_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/user_activity_cell_spec.rb
@@ -119,7 +119,7 @@ describe Decidim::UserActivityCell, type: :cell do
     end
 
     it "displays only the non-moderated items on the first page without a pagination" do
-      # The first five items should be on the second page
+      # The first five items should be hidden through moderation
       logs.first(5).each do |log|
         root_link = Decidim::ResourceLocatorPresenter.new(log.resource.root_commentable).path
         comment_link = "#{root_link}?commentId=#{log.resource.id}"


### PR DESCRIPTION
#### :tophat: What? Why?
Right now if there are hidden items (e.g. private space items or moderated items) included in the user's activity page, they will mess up the pagination on that page.

This happens because rather than filtering out these items directly from the results, the activities cell will call `visible_for?` for each of the activity items individually:
https://github.com/decidim/decidim/blob/370ae76b5be6340d90448319e72650e6a946493c/decidim-core/app/cells/decidim/activities_cell.rb#L31

This is detached from the activity results which is used for the pagination:
https://github.com/decidim/decidim/blob/370ae76b5be6340d90448319e72650e6a946493c/decidim-core/app/cells/decidim/user_activity/show.erb#L28

This fixes the issue by directly filtering out these items from the activity query.

#### Testing
- Seed the development app
- Create comments in both participatory processes the seeds created
- Make one of these processes private
- Moderate one of the user's comments in the public process
- Go to the user's public profile activity view when logged out
- See that the pagination is not working correctly

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.