### PR TITLE
Fix status search on projects page

### DIFF
--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -28,6 +28,9 @@ module Decidim
 
       delegate :organization, :participatory_space, to: :component
 
+      scope :selected, -> { where.not(selected_at: nil) }
+      scope :not_selected, -> { where(selected_at: nil) }
+
       searchable_fields(
         scope_id: :decidim_scope_id,
         participatory_space: { component: :participatory_space },

--- a/decidim-budgets/app/services/decidim/budgets/project_search.rb
+++ b/decidim-budgets/app/services/decidim/budgets/project_search.rb
@@ -27,6 +27,12 @@ module Decidim
         Project.where(id: super.pluck(:id)).includes([:scope, :component, :attachments, :category])
       end
 
+      def search_status
+        return query if status.member?("all")
+
+        apply_scopes(%w(selected not_selected), status)
+      end
+
       private
 
       # Private: Since budget is not used by a search method we need

--- a/decidim-budgets/spec/services/project_search_spec.rb
+++ b/decidim-budgets/spec/services/project_search_spec.rb
@@ -35,6 +35,28 @@ module Decidim::Budgets
           expect(subject).to eq [resource_without_scope]
         end
       end
+
+      context "when votes are finished" do
+        let(:component) { create(:budgets_component, :with_voting_finished) }
+        let!(:resource_selected) { create(:project, :selected, budget: budget) }
+        let!(:resource_not_selected) { create(:project, budget: budget) }
+
+        context "and the user doesn't filter by status" do
+          it { expect(subject).to match_array([resource_selected, resource_not_selected]) }
+        end
+
+        context "and the user filters selected projects" do
+          let(:params) { default_params.merge(status: ["selected"]) }
+
+          it { expect(subject).to eq [resource_selected] }
+        end
+
+        context "and the user filters not selected projects" do
+          let(:params) { default_params.merge(status: ["not_selected"]) }
+
+          it { expect(subject).to eq [resource_not_selected] }
+        end
+      end
     end
   end
 end

--- a/decidim-budgets/spec/system/explore_projects_spec.rb
+++ b/decidim-budgets/spec/system/explore_projects_spec.rb
@@ -79,9 +79,9 @@ describe "Explore projects", :slow, type: :system do
       context "and votes are finished" do
         let!(:component) do
           create(:budgets_component,
-                :with_voting_finished,
-                manifest: manifest,
-                participatory_space: participatory_process)
+                 :with_voting_finished,
+                 manifest: manifest,
+                 participatory_space: participatory_process)
         end
 
         it "allows filtering by status" do

--- a/decidim-budgets/spec/system/explore_projects_spec.rb
+++ b/decidim-budgets/spec/system/explore_projects_spec.rb
@@ -75,6 +75,31 @@ describe "Explore projects", :slow, type: :system do
           expect(page).to have_content(translated(project.title))
         end
       end
+
+      context "and votes are finished" do
+        let!(:component) do
+          create(:budgets_component,
+                :with_voting_finished,
+                manifest: manifest,
+                participatory_space: participatory_process)
+        end
+
+        it "allows filtering by status" do
+          project.selected_at = Time.current
+          project.save
+
+          visit_budget
+
+          within ".status_check_boxes_tree_filter" do
+            uncheck "Selected"
+          end
+
+          within "#projects" do
+            expect(page).to have_css(".budget-list__item", count: 1)
+            expect(page).to have_content(translated(project.title))
+          end
+        end
+      end
     end
 
     context "when directly accessing from URL with an invalid budget id" do


### PR DESCRIPTION
#### :tophat: What? Why?
The projects search by status is not working. It stopped working after #6438 and there were no tests for that. This PR fixes this issue and adds the missing tests.

#### :pushpin: Related Issues
- Related to #6438

#### Testing
1. Create a budgets component, with a budget item and some projects.
2. Mark some projects as selected and configure the active participatory step as "Voting finished".
3. Go to the budget page and filter projects by status. 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
