### PR TITLE
Allow Frontend user to add attendees count information

### DIFF
--- a/decidim-meetings/app/commands/decidim/meetings/close_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/close_meeting.rb
@@ -41,7 +41,9 @@ module Decidim
           form.current_user
         ) do
           meeting.update!(
+            attendees_count: form.attendees_count,
             closed_at: form.closed_at,
+            closing_visible: true,
             closing_report: { I18n.locale => parsed_closing_report }
           )
         end

--- a/decidim-meetings/app/forms/decidim/meetings/close_meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/close_meeting_form.rb
@@ -8,8 +8,12 @@ module Decidim
       attribute :proposal_ids, Array[Integer]
       attribute :proposals
       attribute :closed_at, Decidim::Attributes::TimeWithZone, default: ->(_form, _attribute) { Time.current }
+      attribute :attendees_count, Integer, default: 0
 
       validates :closing_report, presence: true
+      validates :attendees_count,
+                presence: true,
+                numericality: { greater_than_or_equal_to: 0, only_integer: true }
 
       # Private: Gets the proposals from the meeting and injects them to the form.
       #

--- a/decidim-meetings/app/views/decidim/meetings/meeting_closes/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meeting_closes/_form.html.erb
@@ -2,6 +2,11 @@
   <%= text_editor_for(form, :closing_report, hashtaggable: true) %>
 </div>
 
+<div class="field hashtags__container">
+  <%= form.number_field :attendees_count, min: 0 %>
+  <div class="help-text help-text-form-required-fields"><%= t("decidim.forms.meetings.attendees_count_help_text") %></div>
+</div>
+
 <% if Decidim::Meetings.enable_proposal_linking %>
   <div class="field hashtags__container">
     <%= proposals_picker(form, :proposals, proposals_picker_meeting_meeting_closes_path(meeting)) %>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -148,6 +148,9 @@ en:
           email_outro: You have received this notification because you are following the "%{resource_title}" meeting. You can unfollow it from the previous link.
           email_subject: The "%{resource_title}" meeting will start in less than 48h.
           notification_title: The <a href="%{resource_path}">%{resource_title}</a> meeting will start in less than 48h.
+    forms:
+      meetings:
+        attendees_count_help_text: Don’t forget to include the total number of participants at your event. Whether in person, hybrid, or online, it’s important that we know how many people are involved.
     gamification:
       badges:
         attended_meetings:

--- a/decidim-meetings/spec/commands/close_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/close_meeting_spec.rb
@@ -15,6 +15,7 @@ module Decidim::Meetings
         closed_at: Time.current,
         proposal_ids: proposal_ids,
         current_user: user,
+        attendees_count: 10,
         current_organization: meeting.organization
       )
     end

--- a/decidim-meetings/spec/forms/close_meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/close_meeting_form_spec.rb
@@ -8,8 +8,10 @@ module Decidim::Meetings
 
     let(:meeting) { create(:meeting, component: component) }
     let(:component) { create(:meeting_component) }
+    let(:attendees_count) { 5 }
     let(:attributes) do
       {
+        attendees_count: attendees_count,
         closing_report: closing_report
       }
     end
@@ -32,6 +34,18 @@ module Decidim::Meetings
 
     describe "when closing_report is missing" do
       let(:closing_report) { nil }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    describe "when attendees_count is missing" do
+      let(:attendees_count) { nil }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    describe "when attendees_count is invalid" do
+      let(:attendees_count) { "a" }
 
       it { is_expected.not_to be_valid }
     end

--- a/decidim-meetings/spec/system/user_close_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_close_meeting_spec.rb
@@ -47,13 +47,13 @@ describe "User edit meeting", type: :system do
         expect(page).to have_content "Choose proposals"
 
         fill_in :close_meeting_closing_report, with: closing_report
+        fill_in :close_meeting_attendees_count, with: 10
 
         click_button "Close meeting"
       end
 
       expect(page).to have_content(closing_report)
       expect(page).not_to have_content "Close meeting"
-      expect(page).not_to have_content "ATTENDEES COUNT"
       expect(page).not_to have_content "ATTENDING ORGANIZATIONS"
       expect(meeting.reload.closed_at).not_to be nil
     end


### PR DESCRIPTION
#### :tophat: What? Why?
As a user who created a meeting when closing it I’d like to be able to indicate the number of participants.

#### :pushpin: Related Issues
- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/16397

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Screen shot](https://ajbcn-meta-decidim.s3.amazonaws.com/uploads/decidim/attachment/file/3092/big_Capture_d_e%CC%81cran_2021-06-08_a%CC%80_14.46.18.png)

:hearts: Thank you!
