### PR TITLE
Make meeting report editable by the author in front-end

### DIFF
--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -82,7 +82,6 @@ module Decidim
       def can_close_meeting?
         component_settings&.creation_enabled_for_participants? &&
           meeting.authored_by?(user) &&
-          !meeting.closed? &&
           meeting.past?
       end
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -37,7 +37,8 @@ edit_link(
     <% end %>
 
     <% if allowed_to?(:close, :meeting, meeting: meeting) %>
-      <%= link_to t(".close_meeting"), edit_meeting_meeting_close_path(meeting_id: meeting.id, id: meeting.id), class: "button hollow expanded button-sc button--icon follow-button" %>
+      <% caption =  meeting.closed? ? t(".edit_close_meeting") : t(".close_meeting") %>
+      <%= link_to caption, edit_meeting_meeting_close_path(meeting_id: meeting.id, id: meeting.id), class: "button hollow expanded button-sc button--icon follow-button" %>
     <% end %>
 
     <div class="card extra">

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -503,6 +503,7 @@ en:
           close_meeting: Close meeting
           contributions: Contributions count
           date: Date
+          edit_close_meeting: Edit meeting report
           edit_meeting: Edit meeting
           going: You have signed up for this meeting
           join: Join meeting


### PR DESCRIPTION
#### :tophat: What? Why?
As a user who created a meeting and published a meeting report I'm frustrated I cannot edit that meeting report. This is often necessary to correct typos or add complementary information.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/16415

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![image](https://user-images.githubusercontent.com/105683/126058462-732a5e98-734d-4392-9e55-31fdf04a5b2f.png)
![image](https://user-images.githubusercontent.com/105683/126058467-51c9e64b-3b65-4f8e-b81c-ab88a2166f49.png)

:hearts: Thank you!
