### PR TITLE
Fix broken autopublishing of Docker images

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -9,15 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-    - name: Send dispatch for Github Container Registry build
-      run: |
-        curl --fail --show-error \
-        --request POST \
-        --user "decidim-bot:${{ secrets.DOCKER_WORKFLOW_PAT }}" \
-        --header "Accept: application/vnd.github.everest-preview+json" \
-        --header "Content-Type: application/json" \
-        https://api.github.com/repos/decidim/docker/actions/workflows/github_registry.yml/dispatches \
-        --data '{"ref": "master"}'
     - name: Send dispatch for Docker Hub build
       run: |
         curl --fail --show-error \


### PR DESCRIPTION
#### :tophat: What? Why?
decidim/docker#86 unifies two workflows into one, but this repo was still trying to execute both workflows after each release. This PR removes the call to the removed workflow.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to decidim/docker#86

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
