### PR TITLE
Evote bugfixing

### DIFF
--- a/decidim-elections/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-in-person-vote.js
+++ b/decidim-elections/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-in-person-vote.js
@@ -1,0 +1,1 @@
+import "src/decidim/votings/polling_officer_zone/in-person-vote";

--- a/decidim-elections/app/packs/src/decidim/votings/polling_officer_zone/in-person-vote.js
+++ b/decidim-elections/app/packs/src/decidim/votings/polling_officer_zone/in-person-vote.js
@@ -1,0 +1,5 @@
+$(() => {
+  $("#person_voted_checkbox").on("change", (event) => {
+    $("#submit_complete_voting").toggleClass("disabled", !$(event.target).is(":checked"));
+  });
+});

--- a/decidim-elections/app/views/decidim/elections/elections/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/show.html.erb
@@ -27,6 +27,9 @@ edit_link(
     <h1 class="heading3">
       <%== present(election).title %>
     </h1>
+    <div class="card__callout">
+      <%= cell "decidim/elections/remaining_time_callout", election %>
+    </div>
     <p>
       <%= t(".voting_period_status.#{election.voting_period_status}",
             start_time: "<strong>#{l election.start_time, format: :long}</strong>",

--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/in_person_votes/_complete_voting.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/in_person_votes/_complete_voting.html.erb
@@ -33,8 +33,8 @@
             <%= decidim_form_for(in_person_vote_form, url: polling_officer_election_in_person_votes_path(polling_officer, election)) do |f| %>
               <%= f.hidden_field :voter_token %>
               <%= f.hidden_field :voter_id %>
-              <%= f.check_box :voted, label: t(".voted") %>
-              <%= f.submit t(".complete_voting"), class: "button button--sc expanded mt-sm mb-none" %>
+              <%= f.check_box :voted, label: t(".voted"), id: "person_voted_checkbox", label_options: { for: nil } %>
+              <%= f.submit t(".complete_voting"), class: "button button--sc expanded mt-sm mb-none disabled", id: "submit_complete_voting" %>
             <% end %>
           </div>
         </div>
@@ -55,3 +55,5 @@
     <% end %>
   </div>
 </div>
+
+<%= javascript_pack_tag "decidim_votings_voting_polling_officer_zone_in_person_vote" %>

--- a/decidim-elections/app/views/decidim/votings/votings/check_census.html.erb
+++ b/decidim-elections/app/views/decidim/votings/votings/check_census.html.erb
@@ -26,7 +26,9 @@ edit_link(
             </button>
           </p>
         </div>
-        <%= render partial: "access_code_modal", locals: { datum: datum, email: datum.email.gsub!(/.{4}(?=@)/,"****"), sms: datum.mobile_phone_number ? datum.mobile_phone_number.gsub!(/.{3}\d$/,"***") : "" } %>
+        <% if datum.email.present? || datum.mobile_phone_number.present? %>
+          <%= render partial: "access_code_modal", locals: { datum: datum, email: datum.email ? datum.email.gsub!(/.{4}(?=@)/,"****") : "", sms: datum.mobile_phone_number ? datum.mobile_phone_number.gsub!(/.{3}\d$/,"***") : "" } %>
+        <% end %>
       <% elsif not_found %>
         <div class="verify-census-error callout alert mt-s">
           <h5><%= t("decidim.votings.votings.check_census.error.title") %></h5>

--- a/decidim-elections/config/assets.rb
+++ b/decidim-elections/config/assets.rb
@@ -21,6 +21,7 @@ Decidim::Webpacker.register_entrypoints(
   decidim_votings_admin_monitoring_committee_members_form: "#{base_path}/app/packs/entrypoints/decidim_votings_admin_monitoring_committee_members_form.js",
   decidim_votings_admin_polling_officers_form: "#{base_path}/app/packs/entrypoints/decidim_votings_admin_polling_officers_form.js",
   decidim_votings_admin_polling_officers_picker: "#{base_path}/app/packs/entrypoints/decidim_votings_admin_polling_officers_picker.js",
+  decidim_votings_voting_polling_officer_zone_in_person_vote: "#{base_path}/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-in-person-vote.js",
   decidim_votings_voting_polling_officer_zone_new_closure: "#{base_path}/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-new-closure.js",
   decidim_votings_voting_polling_officer_zone_edit_closure: "#{base_path}/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-edit-closure.js",
   decidim_votings_voting_polling_officer_zone_sign_closure: "#{base_path}/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-sign-closure.js",


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes several bugs found during evote QA.
Specifically:
1. 81a6c80: Voting public area - Only show "recover access code" modal when at least one of the email and the phone number are in the census;
2. ded5a2b: Voting public area - Add "remaining time to vote" on election show view (previously only present in the index view);
3. a5404e8: Polling Officer Zone - Disable the "Complete voting" button when a voter is not marked as 'voted' - also, makes the checkbox clickable on the label; (https://app.clickup.com/t/nxdtem)

### :camera: Screenshots
2. ![remaining time](https://user-images.githubusercontent.com/5033945/126302539-77ae140a-d59a-4611-aca6-2e4e87c05d5a.png)

3.  https://user-images.githubusercontent.com/5033945/126303307-530bdef1-91e5-4e55-9e5b-9893441a1076.mov






:hearts: Thank you!
