### PR TITLE
Evote bug fixing

### DIFF
--- a/decidim-elections/app/cells/decidim/elections/remaining_time_callout_cell.rb
+++ b/decidim-elections/app/cells/decidim/elections/remaining_time_callout_cell.rb
@@ -8,7 +8,7 @@ module Decidim
       private
 
       def needs_to_show_remaining_time?
-        model.end_time > Time.current && model.end_time < 12.hours.from_now
+        model.ongoing? && model.end_time < 12.hours.from_now
       end
 
       def remaining_time

--- a/decidim-elections/app/commands/decidim/elections/trustee_zone/update_election_bulletin_board_status.rb
+++ b/decidim-elections/app/commands/decidim/elections/trustee_zone/update_election_bulletin_board_status.rb
@@ -78,9 +78,13 @@ module Decidim
 
         def store_verifiable_results
           election.update!(
-            verifiable_results_file_url: verifiable_results[:url],
+            verifiable_results_file_url: verifiable_results_file_url,
             verifiable_results_file_hash: verifiable_results[:hash]
           )
+        end
+
+        def verifiable_results_file_url
+          URI.join(Decidim::Elections.bulletin_board.bulletin_board_server, verifiable_results[:url])
         end
 
         def update_election_status!

--- a/decidim-elections/app/forms/decidim/elections/admin/question_form.rb
+++ b/decidim-elections/app/forms/decidim/elections/admin/question_form.rb
@@ -16,7 +16,7 @@ module Decidim
 
         validates :title, translatable_presence: true
         validates :description, translatable_presence: true
-        validates :max_selections, presence: true, numericality: { greater_than_or_equal_to: 0 }
+        validates :max_selections, presence: true, numericality: { greater_than_or_equal_to: 1 }
 
         def election
           @election ||= context[:election]

--- a/decidim-elections/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-in-person-vote.js
+++ b/decidim-elections/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-in-person-vote.js
@@ -1,0 +1,1 @@
+import "src/decidim/votings/polling_officer_zone/in-person-vote";

--- a/decidim-elections/app/packs/src/decidim/votings/polling_officer_zone/in-person-vote.js
+++ b/decidim-elections/app/packs/src/decidim/votings/polling_officer_zone/in-person-vote.js
@@ -1,0 +1,5 @@
+$(() => {
+  $("#person_voted_checkbox").on("change", (event) => {
+    $("#submit_complete_voting").toggleClass("disabled", !$(event.target).is(":checked"));
+  });
+});

--- a/decidim-elections/app/views/decidim/elections/elections/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/show.html.erb
@@ -27,6 +27,9 @@ edit_link(
     <h1 class="heading3">
       <%== present(election).title %>
     </h1>
+    <div class="card__callout">
+      <%= cell "decidim/elections/remaining_time_callout", election %>
+    </div>
     <p>
       <%= t(".voting_period_status.#{election.voting_period_status}",
             start_time: "<strong>#{l election.start_time, format: :long}</strong>",

--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/in_person_votes/_complete_voting.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/in_person_votes/_complete_voting.html.erb
@@ -33,8 +33,8 @@
             <%= decidim_form_for(in_person_vote_form, url: polling_officer_election_in_person_votes_path(polling_officer, election)) do |f| %>
               <%= f.hidden_field :voter_token %>
               <%= f.hidden_field :voter_id %>
-              <%= f.check_box :voted, label: t(".voted") %>
-              <%= f.submit t(".complete_voting"), class: "button button--sc expanded mt-sm mb-none" %>
+              <%= f.check_box :voted, label: t(".voted"), id: "person_voted_checkbox", label_options: { for: nil } %>
+              <%= f.submit t(".complete_voting"), class: "button button--sc expanded mt-sm mb-none disabled", id: "submit_complete_voting" %>
             <% end %>
           </div>
         </div>
@@ -55,3 +55,5 @@
     <% end %>
   </div>
 </div>
+
+<%= javascript_pack_tag "decidim_votings_voting_polling_officer_zone_in_person_vote" %>

--- a/decidim-elections/app/views/decidim/votings/votings/check_census.html.erb
+++ b/decidim-elections/app/views/decidim/votings/votings/check_census.html.erb
@@ -26,7 +26,9 @@ edit_link(
             </button>
           </p>
         </div>
-        <%= render partial: "access_code_modal", locals: { datum: datum, email: datum.email.gsub!(/.{4}(?=@)/,"****"), sms: datum.mobile_phone_number ? datum.mobile_phone_number.gsub!(/.{3}\d$/,"***") : "" } %>
+        <% if datum.email.present? || datum.mobile_phone_number.present? %>
+          <%= render partial: "access_code_modal", locals: { datum: datum, email: datum.email ? datum.email.gsub!(/.{4}(?=@)/,"****") : "", sms: datum.mobile_phone_number ? datum.mobile_phone_number.gsub!(/.{3}\d$/,"***") : "" } %>
+        <% end %>
       <% elsif not_found %>
         <div class="verify-census-error callout alert mt-s">
           <h5><%= t("decidim.votings.votings.check_census.error.title") %></h5>

--- a/decidim-elections/config/assets.rb
+++ b/decidim-elections/config/assets.rb
@@ -21,6 +21,7 @@ Decidim::Webpacker.register_entrypoints(
   decidim_votings_admin_monitoring_committee_members_form: "#{base_path}/app/packs/entrypoints/decidim_votings_admin_monitoring_committee_members_form.js",
   decidim_votings_admin_polling_officers_form: "#{base_path}/app/packs/entrypoints/decidim_votings_admin_polling_officers_form.js",
   decidim_votings_admin_polling_officers_picker: "#{base_path}/app/packs/entrypoints/decidim_votings_admin_polling_officers_picker.js",
+  decidim_votings_voting_polling_officer_zone_in_person_vote: "#{base_path}/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-in-person-vote.js",
   decidim_votings_voting_polling_officer_zone_new_closure: "#{base_path}/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-new-closure.js",
   decidim_votings_voting_polling_officer_zone_edit_closure: "#{base_path}/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-edit-closure.js",
   decidim_votings_voting_polling_officer_zone_sign_closure: "#{base_path}/app/packs/entrypoints/decidim_votings_voting_polling_officer_zone-sign-closure.js",

--- a/decidim-elections/spec/commands/decidim/elections/trustee_zone/update_election_bulletin_board_status_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/trustee_zone/update_election_bulletin_board_status_spec.rb
@@ -40,6 +40,7 @@ describe Decidim::Elections::TrusteeZone::UpdateElectionBulletinBoardStatus do
     let(:election) { create :election, :complete, bb_status: required_status }
     let(:required_status) { :tally }
     let(:new_status) { :tally_ended }
+    let(:bullettin_board_server) { "https://my-bb.com" }
     let(:election_results_response) do
       {
         election_results: {
@@ -59,13 +60,14 @@ describe Decidim::Elections::TrusteeZone::UpdateElectionBulletinBoardStatus do
 
     before do
       allow(Decidim::Elections.bulletin_board).to receive(:get_election_results).and_return(election_results_response)
+      allow(Decidim::Elections.bulletin_board).to receive(:bulletin_board_server).and_return(bullettin_board_server)
     end
 
     it "updates the election verifiable results data" do
       subject.call
       election.reload
 
-      expect(election.verifiable_results_file_url).to eq "some-url"
+      expect(election.verifiable_results_file_url).to eq "https://my-bb.com/some-url"
       expect(election.verifiable_results_file_hash).to eq "some-hash"
     end
 

--- a/decidim-elections/spec/forms/decidim/elections/admin/question_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/question_form_spec.rb
@@ -56,4 +56,10 @@ describe Decidim::Elections::Admin::QuestionForm do
 
     it { is_expected.not_to be_valid }
   end
+
+  describe "when max_selections is zero" do
+    let(:max_selections) { 0 }
+
+    it { is_expected.not_to be_valid }
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes several bugs found during evote QA.
Specifically:
1. 83b6bd9: Voting public area - Only show "recover access code" modal when at least one of the email and the phone number are in the census;
2. 1f3c701: Voting public area - Add "remaining time to vote" on election show view (previously only present in the index view);
3. eee518a: Polling Officer Zone - Disable the "Complete voting" button when a voter is not marked as 'voted' - also, makes the checkbox clickable on the label (https://app.clickup.com/t/nxdtem);
4. f4cbcf0: Election creation: limit question max selection parameter to min 1 (https://app.clickup.com/t/nxdrx6);
5. 10d64c5: Voting public area - Don't show "remaining time to vote" BEFORE the election voting time starts (https://app.clickup.com/t/nxejkt);
5. 1d3dcd5: Monitoring Committee Zone - verifiable election file URL pointing to BB
### :camera: Screenshots
2. ![remaining time](https://user-images.githubusercontent.com/5033945/126302539-77ae140a-d59a-4611-aca6-2e4e87c05d5a.png)

3. https://user-images.githubusercontent.com/5033945/126303307-530bdef1-91e5-4e55-9e5b-9893441a1076.mov