### PR TITLE
Backport "Fix don't require inactive authorization handlers" to 0.24

### DIFF
--- a/decidim-core/app/services/decidim/action_authorizer.rb
+++ b/decidim-core/app/services/decidim/action_authorizer.rb
@@ -37,11 +37,12 @@ module Decidim
     attr_reader :user, :component, :resource, :action
 
     def authorization_handlers
-      if permission&.has_key?("authorization_handler_name")
+      available_authorizations = component.organization.available_authorizations
+      if permission&.has_key?("authorization_handler_name") && available_authorizations.include?(permission["authorization_handler_name"])
         options = permission["options"]
         { permission["authorization_handler_name"] => options.present? ? { "options" => options } : {} }
       else
-        permission&.fetch("authorization_handlers", {})
+        permission&.fetch("authorization_handlers", {})&.slice(*available_authorizations)
       end
     end
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -85,6 +85,7 @@ FactoryBot.define do
     favicon { Decidim::Dev.test_file("icon.png", "image/png") }
     default_locale { Decidim.default_locale }
     available_locales { Decidim.available_locales }
+    available_authorizations { %w(dummy_authorization_handler) }
     users_registration_mode { :enabled }
     official_img_header { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
     official_img_footer { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }

--- a/decidim-core/spec/controllers/sessions_controller_spec.rb
+++ b/decidim-core/spec/controllers/sessions_controller_spec.rb
@@ -31,8 +31,8 @@ module Decidim
 
               context "when there are authorization handlers" do
                 before do
-                  user.organization.available_authorizations = ["dummy_authorization_handler"]
-                  user.organization.save
+                  allow(user.organization).to receive(:available_authorizations)
+                    .and_return(["dummy_authorization_handler"])
                 end
 
                 it { is_expected.to eq("/authorizations/first_login") }
@@ -71,6 +71,10 @@ module Decidim
               end
 
               context "and otherwise", with_authorization_workflows: [] do
+                before do
+                  allow(user.organization).to receive(:available_authorizations).and_return([])
+                end
+
                 it { is_expected.to eq("/") }
               end
             end


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the fix from #8122 to 0.24.

#### :pushpin: Related Issues
- Related to #8122

#### Testing
See #8122

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.