### PR TITLE
Remove flaky test on meetings

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_index_admin.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_index_admin.html.erb
@@ -10,7 +10,7 @@
 
         <%= link_to t(".edit"), Decidim::EngineRouter.admin_proxy(meeting.component).edit_meeting_poll_path(meeting), target: "_blank", rel: "noopener noreferrer" %>
 
-        <div class="meeting-polls__admin-action">
+        <div class="meeting-polls__admin-action meeting-polls__admin-action-question">
           <div><%= t(".question") %></div>
           <div>
             <% if question.unpublished? %>
@@ -21,7 +21,7 @@
             <% end %>
           </div>
         </div>
-        <div class="meeting-polls__admin-action">
+        <div class="meeting-polls__admin-action meeting-polls__admin-action-results">
           <div><%= t(".results") %></div>
           <div>
             <% unless question.unpublished? %>

--- a/decidim-meetings/spec/system/live_meeting_admin_questions_spec.rb
+++ b/decidim-meetings/spec/system/live_meeting_admin_questions_spec.rb
@@ -83,10 +83,11 @@ describe "Meeting live event poll administration", type: :system do
     it "allows to publish an unpublished question" do
       open_first_question
 
-      click_button "Send"
-
-      expect(page).to have_content("Sent")
-      expect(page).to have_content("0 received answers")
+      within ".meeting-polls__admin-action-question" do
+        click_button "Send"
+        expect(page).to have_content("Sent")
+        expect(page).to have_content("0 received answers")
+      end
     end
   end
 
@@ -109,9 +110,10 @@ describe "Meeting live event poll administration", type: :system do
     it "allows to close a published question" do
       open_first_question
 
-      click_button "Send"
-
-      expect(page).to have_content("Sent")
+      within ".meeting-polls__admin-action-results" do
+        click_button "Send"
+        expect(page).to have_content("Sent")
+      end
 
       question_multiple_option.reload
       expect(question_multiple_option).to be_closed


### PR DESCRIPTION
#### :tophat: What? Why?
#8065 introduces polls during meetings, but one of the tests was flaky. It clicks on the "Send" button and [expects to find "Sent" in the page](https://github.com/decidim/decidim/pull/8065/files#diff-891f4db2a3dced7145ae1a8d9eb1ff159535974025ba9f35cba6095bd7ab7bc7R114). But the page already has a "Sent" text, so it doesn't wait the action to be processed and fails. This PR fixes that, using an additional class to scope the search for the "Send" and "Sent" texts.

#### :pushpin: Related Issues
- Related to #8065

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
