### PR TITLE
Fix content type delegation to blank attachments

### DIFF
--- a/decidim-core/app/models/decidim/attachment.rb
+++ b/decidim-core/app/models/decidim/attachment.rb
@@ -50,6 +50,7 @@ module Decidim
     def photo?
       @photo ||= file.attached? && file.image?
     end
+    alias image? photo?
 
     # Whether this attachment is a document or not.
     #

--- a/decidim-elections/app/views/decidim/elections/elections/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/show.html.erb
@@ -35,7 +35,7 @@ edit_link(
   </div>
 </div>
 <div class="row section">
-  <% if election.attachments.first.present? && election.attachments.first.file.content_type.start_with?("image") %>
+  <% if election.attachments.first.present? && election.attachments.first.image? %>
     <div class="columns medium-4 mediumlarge-5">
       <img src="<%= election.attachments.first.url %>" alt="">
     </div>

--- a/decidim-initiatives/app/cells/decidim/initiatives/initiative_m_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/initiative_m_cell.rb
@@ -65,9 +65,7 @@ module Decidim
       end
 
       def image
-        @image ||= model.attachments.find do |attachment|
-          attachment.file.content_type.start_with?("image")
-        end
+        @image ||= model.attachments.find(&:image?)
       end
 
       def resource_image_path

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -101,6 +101,29 @@ describe "Initiatives", type: :system do
       end
     end
 
+    context "when requesting the initiatives path and initiatives have attachments but the file is not present" do
+      let!(:base_initiative) { create(:initiative, :with_photos, organization: organization) }
+
+      before do
+        initiative.attachments.each do |attachment|
+          attachment.file.purge
+        end
+        visit decidim_initiatives.initiatives_path
+      end
+
+      it "lists all the initiatives without errors" do
+        within "#initiatives-count" do
+          expect(page).to have_content("1")
+        end
+
+        within "#initiatives" do
+          expect(page).to have_content(translated(initiative.title, locale: :en))
+          expect(page).to have_content(initiative.author_name, count: 1)
+          expect(page).not_to have_content(translated(unpublished_initiative.title, locale: :en))
+        end
+      end
+    end
+
     context "when it is an initiative with card image enabled" do
       before do
         initiative.type.attachments_enabled = true


### PR DESCRIPTION
#### :tophat: What? Why?

This PR avoids some errors produced when a `Decidim::Attachment` exists but its associated attached file is not present

#### :pushpin: Related Issues
- Fixes #8227

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
