### PR TITLE
Disable unconfirmed access by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,18 @@
 
 ## [Unreleased](https://github.com/decidim/decidim/tree/HEAD)
 
+#### Unconfirmed access disabled by default
+As per [\#8233](https://github.com/decidim/decidim/pull/8233), by default all participants must confirm their email account to sign in. Implementors can change this setting as a [initializer configuration](https://docs.decidim.org/en/configure/initializer/#_unconfirmed_access_for_users):
+
+```ruby
+Decidim.configure do |config|
+  config.unconfirmed_access_for = 2.days
+end
+```
+
 ### Added
-* [#8012](https://github.com/decidim/decidim/pull/8012) Participatory space to comments, to fix the statistics. Use 
-`rake decidim_comments:update_participatory_process_in_comments` to migrate existing comments to the new structure.    
+* [#8012](https://github.com/decidim/decidim/pull/8012) Participatory space to comments, to fix the statistics. Use
+`rake decidim_comments:update_participatory_process_in_comments` to migrate existing comments to the new structure.
 
 ### Changed
 

--- a/decidim-admin/spec/controllers/conflicts_controller_spec.rb
+++ b/decidim-admin/spec/controllers/conflicts_controller_spec.rb
@@ -30,7 +30,7 @@ module Decidim
 
       context "when updating a conflict" do
         let(:organization) { create :organization }
-        let(:current_user) { create :user, :admin, organization: organization }
+        let(:current_user) { create :user, :confirmed, :admin, organization: organization }
         let(:new_user) { create :user, :admin, organization: organization, email: "user@test.com" }
         let(:managed_user) { create :user, managed: true, organization: organization }
         let(:conflict) do

--- a/decidim-assemblies/spec/system/admin/valuator_checks_components_spec.rb
+++ b/decidim-assemblies/spec/system/admin/valuator_checks_components_spec.rb
@@ -10,7 +10,7 @@ describe "Valuator checks components", type: :system do
     decidim_admin_assemblies.components_path(assembly)
   end
   let(:components_path) { participatory_space_path }
-  let!(:user) { create :user, organization: organization }
+  let!(:user) { create :user, :confirmed, organization: organization }
   let!(:valuator_role) { create :assembly_user_role, role: :valuator, user: user, assembly: assembly }
   let(:another_component) { create :component, participatory_space: assembly }
 

--- a/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
+++ b/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
   let!(:component) { create(:budgets_component) }
   let(:organization) { component.organization }
-  let!(:current_user) { create(:user, :admin, organization: organization) }
+  let!(:current_user) { create(:user, :confirmed, :admin, organization: organization) }
 
   describe "on update" do
     let(:manifest) { component.manifest }

--- a/decidim-conferences/spec/system/admin/valuator_checks_components_spec.rb
+++ b/decidim-conferences/spec/system/admin/valuator_checks_components_spec.rb
@@ -10,7 +10,7 @@ describe "Valuator checks components", type: :system do
     decidim_admin_conferences.components_path(conference)
   end
   let(:components_path) { participatory_space_path }
-  let!(:user) { create :user, organization: organization }
+  let!(:user) { create :user, :confirmed, organization: organization }
   let!(:valuator_role) { create :conference_user_role, role: :valuator, user: user, conference: conference }
   let(:another_component) { create :component, participatory_space: conference }
 

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -267,7 +267,7 @@ module Decidim
 
   # Time window were users can access the website even if their email is not confirmed.
   config_accessor :unconfirmed_access_for do
-    2.days
+    0.days
   end
 
   # Allow machine translations

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -248,7 +248,7 @@ FactoryBot.define do
   end
 
   factory :user_group_membership, class: "Decidim::UserGroupMembership" do
-    user
+    user { create(:user, :confirmed, organization: user_group.organization) }
     role { :creator }
     user_group
   end

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -27,7 +27,7 @@ describe "Authentication", type: :system do
           find("*[type=submit]").click
         end
 
-        expect(page).to have_content("You have signed up successfully")
+        expect(page).to have_content("confirmation link")
       end
     end
 
@@ -52,7 +52,7 @@ describe "Authentication", type: :system do
           find("*[type=submit]").click
         end
 
-        expect(page).to have_content("¡Bienvenida! Te has registrado con éxito.")
+        expect(page).to have_content("Se ha enviado un mensaje con un enlace de confirmación")
         expect(last_user.locale).to eq("es")
       end
     end
@@ -73,7 +73,7 @@ describe "Authentication", type: :system do
           find("*[type=submit]").click
         end
 
-        expect(page).not_to have_content("You have signed up successfully")
+        expect(page).not_to have_content("confirmation link")
       end
     end
 
@@ -539,7 +539,7 @@ describe "Authentication", type: :system do
             find("*[type=submit]").click
           end
 
-          expect(page).to have_content("You have signed up successfully")
+          expect(page).to have_content("confirmation link")
         end
       end
     end

--- a/decidim-core/spec/system/session_timeout_spec.rb
+++ b/decidim-core/spec/system/session_timeout_spec.rb
@@ -6,7 +6,7 @@ describe "Session timeout", type: :system do
   include ActiveSupport::Testing::TimeHelpers
 
   let(:organization) { create(:organization) }
-  let(:current_user) { create :user, organization: organization }
+  let(:current_user) { create :user, :confirmed, organization: organization }
 
   context "when session is about to timeout" do
     before do

--- a/decidim-core/spec/system/user_timeline_spec.rb
+++ b/decidim-core/spec/system/user_timeline_spec.rb
@@ -14,7 +14,7 @@ describe "User timeline", type: :system do
 
   let(:organization) { create(:organization) }
   let(:comment) { create(:comment) }
-  let(:user) { create(:user, organization: organization) }
+  let(:user) { create(:user, :confirmed, organization: organization) }
   let(:user2) { create(:user, organization: organization) }
 
   let(:component) do

--- a/decidim-elections/lib/decidim/elections/test/factories.rb
+++ b/decidim-elections/lib/decidim/elections/test/factories.rb
@@ -315,7 +315,7 @@ FactoryBot.define do
     end
 
     public_key { nil }
-    user { build(:user, organization: organization) }
+    user { build(:user, :confirmed, organization: organization) }
     organization { create(:organization) }
 
     trait :considered do

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
@@ -6,7 +6,7 @@ describe "Admin manages initiatives", type: :system do
   STATES = Decidim::Initiative.states.keys.map(&:to_sym)
 
   let(:organization) { create(:organization) }
-  let(:user) { create(:user, :admin, organization: organization) }
+  let(:user) { create(:user, :confirmed, :admin, organization: organization) }
   let(:model_name) { Decidim::Initiative.model_name }
   let(:resource_controller) { Decidim::Initiatives::Admin::InitiativesController }
   let(:type1) { create :initiatives_type, organization: organization }

--- a/decidim-initiatives/spec/system/edit_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/edit_initiative_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe "Edit initiative", type: :system do
   let(:organization) { create(:organization) }
-  let(:user) { create(:user, organization: organization) }
+  let(:user) { create(:user, :confirmed, organization: organization) }
   let(:initiative_title) { translated(initiative.title) }
   let(:new_title) { "This is my initiative new title" }
 
@@ -70,7 +70,7 @@ describe "Edit initiative", type: :system do
   end
 
   describe "when user is admin" do
-    let(:user) { create(:user, :admin, organization: organization) }
+    let(:user) { create(:user, :confirmed, :admin, organization: organization) }
     let(:initiative) { create(:initiative, :created, scoped_type: scoped_type, organization: organization) }
 
     it_behaves_like "manage update"

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -297,7 +297,7 @@ FactoryBot.define do
       proposal.body = Decidim::ContentProcessor.parse_with_processor(:hashtag, proposal.body, current_organization: proposal.organization).rewrite
 
       if proposal.component
-        users = evaluator.users || [create(:user, organization: proposal.component.participatory_space.organization)]
+        users = evaluator.users || [create(:user, :confirmed, organization: proposal.component.participatory_space.organization)]
         users.each_with_index do |user, idx|
           user_group = evaluator.user_groups[idx]
           proposal.coauthorships.build(author: user, user_group: user_group)

--- a/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -218,7 +218,7 @@ module Decidim
         end
 
         describe "when current user is NOT the author of the proposal" do
-          let(:current_user) { create(:user, organization: component.organization) }
+          let(:current_user) { create(:user, :confirmed, organization: component.organization) }
           let(:proposal) { create(:proposal, component: component, users: [current_user]) }
 
           context "and the proposal has no supports" do

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
   let!(:component) { create(:proposal_component) }
   let(:organization) { component.organization }
-  let!(:current_user) { create(:user, :admin, organization: organization) }
+  let!(:current_user) { create(:user, :confirmed, :admin, organization: organization) }
 
   describe "on destroy" do
     context "when there are no proposals for the component" do

--- a/decidim-templates/spec/system/admin/admin_manages_questionnaire_templates_spec.rb
+++ b/decidim-templates/spec/system/admin/admin_manages_questionnaire_templates_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe "Admin manages questionnaire templates", type: :system do
   let!(:organization) { create :organization }
-  let!(:user) { create :user, organization: organization }
+  let!(:user) { create :user, :confirmed, organization: organization }
 
   before do
     switch_to_host(organization.host)


### PR DESCRIPTION
#### :tophat: What? Why?
Change the default behavior of the unconfirmed access configuration, to disabled by default. If implementors want to activate that setting can do this still by changing the configuration in the initializer. 

We're receiving lots of spam accounts in Decidim Barcelona and Metadecidim. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #4269

#### Testing
Try to sign up, you'll don't get signed in. 

#### Screenshots

![Selecció_1493](https://user-images.githubusercontent.com/717367/132870631-395e03ce-e668-47f8-8244-2ad0597b06a6.png)

:hearts: Thank you!
