### PR TITLE
Remove obsolete rake webpack task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ task :uninstall_all do
 end
 
 desc "Pushes a new build for each gem."
-task release_all: [:update_versions, :check_locale_completeness, :webpack] do
+task release_all: [:update_versions, :check_locale_completeness] do
   Decidim::GemManager.run_all("rake release")
 end
 
@@ -73,11 +73,6 @@ task test_app: "decidim:generate_external_test_app"
 
 desc "Generates a development app."
 task development_app: "decidim:generate_external_development_app"
-
-desc "Build webpack bundle files"
-task :webpack do
-  sh "npm install && npm run build:prod"
-end
 
 desc "Bundle all Gemfiles"
 task :bundle do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR removes a rake task to build assets used before migrating to webpacker.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
