### PR TITLE
Add sorting to private participants in a participatory space

### DIFF
--- a/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
@@ -15,10 +15,18 @@
         <table class="stack">
           <thead>
             <tr>
-              <th><%= t("models.assembly_user_role.fields.name", scope: "decidim.admin") %></th>
-              <th><%= t("models.assembly_user_role.fields.email", scope: "decidim.admin") %></th>
-              <th><%= t("models.user.fields.invitation_sent_at", scope: "decidim.admin") %></th>
-              <th><%= t("models.user.fields.invitation_accepted_at", scope: "decidim.admin") %></th>
+              <th>
+               <%= sort_link(query, :name, t("models.user.fields.name", scope: "decidim.admin"), default_order: :desc ) %>
+              </th>
+              <th>
+                <%= sort_link(query, :email, t("models.user.fields.email", scope: "decidim.admin"), default_order: :desc ) %>
+              </th>
+              <th>
+                <%= sort_link(query, :invitation_sent_at, t("models.user.fields.invitation_sent_at", scope: "decidim.admin"), default_order: :desc ) %>
+              </th>
+              <th>
+                <%= sort_link(query, :invitation_accepted_at, t("models.user.fields.invitation_accepted_at", scope: "decidim.admin"), default_order: :desc ) %>
+              </th>
               <th class="actions"></th>
             </tr>
           </thead>

--- a/decidim-core/app/models/decidim/participatory_space_private_user.rb
+++ b/decidim-core/app/models/decidim/participatory_space_private_user.rb
@@ -22,6 +22,22 @@ module Decidim
       Decidim::AdminLog::ParticipatorySpacePrivateUserPresenter
     end
 
+    ransacker :name do
+      Arel.sql(%{("decidim_users"."name")::text})
+    end
+
+    ransacker :email do
+      Arel.sql(%{("decidim_users"."email")::text})
+    end
+
+    ransacker :invitation_sent_at do
+      Arel.sql(%{("invitation_sent_at")::text})
+    end
+
+    ransacker :invitation_accepted_at do
+      Arel.sql(%{("invitation_accepted_at")::text})
+    end
+
     private
 
     # Private: check if the participatory space and the user have the same organization


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds sorting to private participants in a participatory space. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #6922. Merging this PR we could also close that one. Mind that filtering was already added in #7817 
- Closes #6020 

#### Testing

1. Sign in as admin
2. Go to the private participants of a participatory space 
3. Click on the columns name

### :camera: Screenshots

https://user-images.githubusercontent.com/717367/127342630-ddb26e5c-c752-4e61-9240-7724a5e52dc2.mp4

:hearts: Thank you!
