### PR TITLE
Fix dont allow budget exceeding in project view

### DIFF
--- a/decidim-budgets/app/packs/stylesheets/decidim/budgets/budget/_budget-list.scss
+++ b/decidim-budgets/app/packs/stylesheets/decidim/budgets/budget/_budget-list.scss
@@ -161,4 +161,8 @@
       pointer-events: none;
     }
   }
+
+  &__nocircle{
+    border-radius: 4px;
+  }
 }

--- a/decidim-budgets/app/views/decidim/budgets/projects/_project_budget_button.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_project_budget_button.html.erb
@@ -8,7 +8,7 @@
           remote: true,
           data: {
             disable: true,
-            budget: project.budget_amount,
+            allocation: project.budget_amount,
             "redirect-url": budget_project_path(budget, project)
           },
           disabled: !can_have_order? || current_order_checked_out?,
@@ -24,12 +24,12 @@
           remote: true,
           data: {
             disable: true,
-            budget: project.budget_amount,
+            allocation: project.budget_amount,
             add: true,
             "redirect-url": budget_project_path(budget, project)
           },
           disabled: !can_have_order? || current_order_checked_out?,
-          class: "button expanded button--sc",
+          class: "budget-list__action budget-list__nocircle button expanded button--sc",
           "aria-label": t(".add_descriptive", resource_name: translated_attribute(project.title))
         ) %>
   <% else %>

--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -342,6 +342,20 @@ describe "Orders", type: :system do
         end
       end
 
+      context "and in project show page cant exceed the budget" do
+        let!(:expensive_project) { create(:project, budget: budget, budget_amount: 250_000_000) }
+
+        it "cannot add the project" do
+          page.visit Decidim::EngineRouter.main_proxy(component).budget_project_path(budget, expensive_project)
+
+          within "#project-#{expensive_project.id}-budget-button" do
+            page.find("button").click
+          end
+
+          expect(page).to have_css("#budget-excess", visible: :visible)
+        end
+      end
+
       context "and add another project exceeding vote threshold" do
         let!(:other_project) { create(:project, budget: budget, budget_amount: 50_000_000) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
It is possible to exceed budget when adding project in project (show) view.

#### Testing
1. Login
2. Go to budgets component
3. Click project title (which would exceed budget)
4. Click "Add to your vote"
5. "Maximum budget exceeded modal" should appear!

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
