### PR TITLE
Do not block registered users with InviteUserAgain

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_participatory_space_admin_user_actions.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_space_admin_user_actions.rb
@@ -49,13 +49,9 @@ module Decidim
           organization: @participatory_space.organization
         )
 
-        InviteUserAgain.call(@existing_user, invitation_instructions) if @existing_user && invitation_pending?(@existing_user)
+        InviteUserAgain.call(@existing_user, invitation_instructions) if @existing_user&.invitation_pending?
 
         @existing_user
-      end
-
-      def invitation_pending?(user)
-        user.invited_to_sign_up? && !user.invitation_accepted?
       end
 
       def new_user

--- a/decidim-admin/app/commands/decidim/admin/create_participatory_space_private_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_space_private_user.rb
@@ -66,7 +66,7 @@ module Decidim
           organization: private_user_to.organization
         )
 
-        InviteUserAgain.call(@existing_user, invitation_instructions) if @existing_user && !@existing_user.invitation_accepted?
+        InviteUserAgain.call(@existing_user, invitation_instructions) if @existing_user&.invitation_pending?
 
         @existing_user
       end

--- a/decidim-admin/spec/commands/create_participatory_space_private_user_spec.rb
+++ b/decidim-admin/spec/commands/create_participatory_space_private_user_spec.rb
@@ -76,6 +76,13 @@ module Decidim::Admin
         end
       end
 
+      it "don't invite the user again" do
+        subject.call
+        user.reload
+
+        expect(user.invited_to_sign_up?).not_to be true
+      end
+
       context "when there is no user with the given email" do
         let(:email) { "does_not_exist@example.com" }
 

--- a/decidim-conferences/app/commands/decidim/conferences/admin/create_conference_admin.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/create_conference_admin.rb
@@ -68,7 +68,7 @@ module Decidim
             organization: conference.organization
           )
 
-          InviteUserAgain.call(@existing_user, invitation_instructions) if @existing_user && !@existing_user.invitation_accepted?
+          InviteUserAgain.call(@existing_user, invitation_instructions) if @existing_user&.invitation_pending?
 
           @existing_user
         end

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -107,6 +107,10 @@ module Decidim
     # Returns a String.
     attr_accessor :invitation_instructions
 
+    def invitation_pending?
+      invited_to_sign_up? && !invitation_accepted?
+    end
+
     # Returns the user corresponding to the given +email+ if it exists and has pending invitations,
     #   otherwise returns nil.
     def self.has_pending_invitations?(organization_id, email)

--- a/decidim-elections/app/commands/decidim/votings/admin/create_monitoring_committee_member.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/create_monitoring_committee_member.rb
@@ -67,7 +67,7 @@ module Decidim
               organization: voting.organization
             )
 
-            InviteUserAgain.call(tentative_user, invitation_instructions) if tentative_user && !tentative_user.invitation_accepted?
+            InviteUserAgain.call(tentative_user, invitation_instructions) if tentative_user&.invitation_pending?
 
             tentative_user
           end

--- a/decidim-elections/app/commands/decidim/votings/admin/create_polling_officer.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/create_polling_officer.rb
@@ -67,7 +67,7 @@ module Decidim
               organization: voting.organization
             )
 
-            InviteUserAgain.call(tentative_user, invitation_instructions) if tentative_user && !tentative_user.invitation_accepted?
+            InviteUserAgain.call(tentative_user, invitation_instructions) if tentative_user&.invitation_pending?
 
             tentative_user
           end


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*
This PR is a continuation of bugfix #7392. It has now been found that the problem described in https://github.com/decidim/decidim/issues/6966 extends to

- inviting private users
- inviting conference admins
- inviting monitoring committee members
- inviting polling officers

To solve the problems `user&.invitation_pending?` has been extracted and used everywhere to be sure when the user has invitations pending.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/decidim/decidim/issues/6966
- Related to #7392

#### Testing
*Describe the best way to test or validate your PR.*
Invite an already registered user and check that it can still login.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
