### PR TITLE
Non participant assembly members avatar

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -306,6 +306,8 @@ ignore_unused:
   - decidim.meetings.public_participants_list.hidden_participants_count.*
   - decidim.budgets.budgets_list.*
   - decidim.budgets.projects.project_budget_button.*
+  - decidim.assemblies.admin.assembly_members.form.explanation
+  - decidim.assemblies.admin.assembly_members.form.image_guide
 
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -308,6 +308,7 @@ ignore_unused:
   - decidim.budgets.projects.project_budget_button.*
   - decidim.assemblies.admin.assembly_members.form.explanation
   - decidim.assemblies.admin.assembly_members.form.image_guide
+  - decidim.assemblies.admin.assembly_members.form.non_user_avatar_help
 
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:

--- a/decidim-assemblies/app/cells/decidim/assemblies/assembly_member/show.erb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/assembly_member/show.erb
@@ -24,7 +24,7 @@
                   <% end %>
                 </div>
               <% else %>
-                <div class="author__avatar"><%= image_tag model.not_user_avatar_path, alt: "member-avatar" %></div>
+                <div class="author__avatar"><%= image_tag model.non_user_avatar_path, alt: "member-avatar" %></div>
                 <div>
                   <div class="author__name--container">
                     <div class="author__name">

--- a/decidim-assemblies/app/cells/decidim/assemblies/assembly_member/show.erb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/assembly_member/show.erb
@@ -24,7 +24,7 @@
                   <% end %>
                 </div>
               <% else %>
-                <div class="author__avatar"><%= image_tag asset_pack_path("media/images/default-avatar.svg"), alt: "member-avatar" %></div>
+                <div class="author__avatar"><%= image_tag model.not_user_avatar_path, alt: "member-avatar" %></div>
                 <div>
                   <div class="author__name--container">
                     <div class="author__name">

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly_member.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly_member.rb
@@ -33,10 +33,10 @@ module Decidim
 
             broadcast(:ok)
           else
-            if assembly_member_with_attributes.errors.include? :not_user_avatar
+            if assembly_member_with_attributes.errors.include? :non_user_avatar
               form.errors.add(
-                :not_user_avatar,
-                assembly_member_with_attributes.errors[:not_user_avatar]
+                :non_user_avatar,
+                assembly_member_with_attributes.errors[:non_user_avatar]
               )
             end
             broadcast(:invalid)
@@ -67,7 +67,7 @@ module Decidim
             assembly: assembly,
             user: form.user
           ).merge(
-            attachment_attributes(:not_user_avatar)
+            attachment_attributes(:non_user_avatar)
           )
         end
 

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly_member.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly_member.rb
@@ -6,6 +6,8 @@ module Decidim
       # A command with all the business logic when creating a new assembly
       # member in the system.
       class CreateAssemblyMember < Rectify::Command
+        include ::Decidim::AttachmentAttributesMethods
+
         # Public: Initializes the command.
         #
         # form - A form object with the params.
@@ -25,15 +27,49 @@ module Decidim
         def call
           return broadcast(:invalid) if form.invalid?
 
-          create_assembly_member!
-          notify_assembly_member_about_new_membership
+          if assembly_member_with_attributes.valid?
+            create_assembly_member!
+            notify_assembly_member_about_new_membership
 
-          broadcast(:ok)
+            broadcast(:ok)
+          else
+            if assembly_member_with_attributes.errors.include? :not_user_avatar
+              form.errors.add(
+                :not_user_avatar,
+                assembly_member_with_attributes.errors[:not_user_avatar]
+              )
+            end
+            broadcast(:invalid)
+          end
         end
 
         private
 
         attr_reader :form, :assembly, :current_user
+
+        def assembly_member_with_attributes
+          @assembly_member_with_attributes ||= Decidim::AssemblyMember.new(assembly_member_attributes)
+        end
+
+        def assembly_member_attributes
+          form.attributes.slice(
+            :full_name,
+            :gender,
+            :birthday,
+            :birthplace,
+            :ceased_date,
+            :designation_date,
+            :designation_mode,
+            :position,
+            :position_other,
+            :weight
+          ).merge(
+            assembly: assembly,
+            user: form.user
+          ).merge(
+            attachment_attributes(:not_user_avatar)
+          )
+        end
 
         def create_assembly_member!
           log_info = {
@@ -48,21 +84,7 @@ module Decidim
           @assembly_member = Decidim.traceability.create!(
             Decidim::AssemblyMember,
             current_user,
-            form.attributes.slice(
-              :full_name,
-              :gender,
-              :birthday,
-              :birthplace,
-              :ceased_date,
-              :designation_date,
-              :designation_mode,
-              :position,
-              :position_other,
-              :weight
-            ).merge(
-              assembly: assembly,
-              user: form.user
-            ),
+            assembly_member_attributes,
             log_info
           )
         end

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly_member.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly_member.rb
@@ -6,6 +6,8 @@ module Decidim
       # A command with all the business logic when updating an assembly
       # member in the system.
       class UpdateAssemblyMember < Rectify::Command
+        include ::Decidim::AttachmentAttributesMethods
+
         # Public: Initializes the command.
         #
         # form - A form object with the params.
@@ -25,13 +27,46 @@ module Decidim
           return broadcast(:invalid) if form.invalid?
           return broadcast(:invalid) unless assembly_member
 
-          update_assembly_member!
-          broadcast(:ok)
+          assembly_member.assign_attributes(attributes)
+
+          if assembly_member.valid?
+            assembly_member.reload
+            update_assembly_member!
+            broadcast(:ok)
+          else
+            if assembly_member.errors.include? :not_user_avatar
+              form.errors.add(
+                :not_user_avatar,
+                assembly_member.errors[:not_user_avatar]
+              )
+            end
+
+            broadcast(:invalid)
+          end
         end
 
         private
 
         attr_reader :form, :assembly_member
+
+        def attributes
+          form.attributes.slice(
+            :full_name,
+            :gender,
+            :birthday,
+            :birthplace,
+            :ceased_date,
+            :designation_date,
+            :designation_mode,
+            :position,
+            :position_other,
+            :weight
+          ).merge(
+            user: form.user
+          ).merge(
+            attachment_attributes(:not_user_avatar)
+          )
+        end
 
         def update_assembly_member!
           log_info = {
@@ -46,20 +81,7 @@ module Decidim
           Decidim.traceability.update!(
             assembly_member,
             form.current_user,
-            form.attributes.slice(
-              :full_name,
-              :gender,
-              :birthday,
-              :birthplace,
-              :ceased_date,
-              :designation_date,
-              :designation_mode,
-              :position,
-              :position_other,
-              :weight
-            ).merge(
-              user: form.user
-            ),
+            attributes,
             log_info
           )
         end

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly_member.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly_member.rb
@@ -34,10 +34,10 @@ module Decidim
             update_assembly_member!
             broadcast(:ok)
           else
-            if assembly_member.errors.include? :not_user_avatar
+            if assembly_member.errors.include? :non_user_avatar
               form.errors.add(
-                :not_user_avatar,
-                assembly_member.errors[:not_user_avatar]
+                :non_user_avatar,
+                assembly_member.errors[:non_user_avatar]
               )
             end
 
@@ -64,7 +64,7 @@ module Decidim
           ).merge(
             user: form.user
           ).merge(
-            attachment_attributes(:not_user_avatar)
+            attachment_attributes(:non_user_avatar)
           )
         end
 

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
@@ -25,6 +25,18 @@ module Decidim
 
         validates :designation_date, presence: true
         validates :full_name, presence: true, unless: proc { |object| object.existing_user }
+        validates :not_user_avatar, passthru: {
+          to: Decidim::AssemblyMember,
+          with: {
+            # The member gets its organization context through the assembly
+            # object which is why we need to create a dummy assembly in order
+            # to pass the correct organization context to the file upload
+            # validators.
+            assembly: lambda do |form|
+              Decidim::Assembly.new(organization: form.current_organization)
+            end
+          }
+        }
         validates :position, presence: true, inclusion: { in: Decidim::AssemblyMember::POSITIONS }
         validates :position_other, presence: true, if: ->(form) { form.position == "other" }
         validates :ceased_date, date: { after: :designation_date, allow_blank: true }

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
@@ -10,8 +10,8 @@ module Decidim
 
         attribute :weight, Integer, default: 0
         attribute :full_name, String
-        attribute :not_user_avatar
-        attribute :remove_not_user_avatar, Boolean, default: false
+        attribute :non_user_avatar
+        attribute :remove_non_user_avatar, Boolean, default: false
         attribute :gender, String
         attribute :birthday, Decidim::Attributes::TimeWithZone
         attribute :birthplace, String
@@ -25,7 +25,7 @@ module Decidim
 
         validates :designation_date, presence: true
         validates :full_name, presence: true, unless: proc { |object| object.existing_user }
-        validates :not_user_avatar, passthru: {
+        validates :non_user_avatar, passthru: {
           to: Decidim::AssemblyMember,
           with: {
             # The member gets its organization context through the assembly

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
@@ -10,6 +10,8 @@ module Decidim
 
         attribute :weight, Integer, default: 0
         attribute :full_name, String
+        attribute :not_user_avatar
+        attribute :remove_not_user_avatar, Boolean, default: false
         attribute :gender, String
         attribute :birthday, Decidim::Attributes::TimeWithZone
         attribute :birthplace, String

--- a/decidim-assemblies/app/models/decidim/assembly_member.rb
+++ b/decidim-assemblies/app/models/decidim/assembly_member.rb
@@ -14,8 +14,8 @@ module Decidim
     belongs_to :assembly, foreign_key: "decidim_assembly_id", class_name: "Decidim::Assembly"
     alias participatory_space assembly
 
-    has_one_attached :not_user_avatar
-    validates_avatar :not_user_avatar, uploader: Decidim::AvatarUploader
+    has_one_attached :non_user_avatar
+    validates_avatar :non_user_avatar, uploader: Decidim::AvatarUploader
 
     delegate :organization, to: :assembly
 
@@ -27,7 +27,7 @@ module Decidim
       Decidim::Assemblies::AdminLog::AssemblyMemberPresenter
     end
 
-    def remove_not_user_avatar
+    def remove_non_user_avatar
       false
     end
   end

--- a/decidim-assemblies/app/models/decidim/assembly_member.rb
+++ b/decidim-assemblies/app/models/decidim/assembly_member.rb
@@ -6,12 +6,16 @@ module Decidim
   class AssemblyMember < ApplicationRecord
     include Decidim::Traceable
     include Decidim::Loggable
+    include Decidim::HasUploadValidations
 
     POSITIONS = %w(president vice_president secretary other).freeze
 
     belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::UserBaseEntity", optional: true
     belongs_to :assembly, foreign_key: "decidim_assembly_id", class_name: "Decidim::Assembly"
     alias participatory_space assembly
+
+    has_one_attached :not_user_avatar
+    validates_avatar :not_user_avatar, uploader: Decidim::AvatarUploader
 
     default_scope { order(weight: :asc, created_at: :asc) }
 

--- a/decidim-assemblies/app/models/decidim/assembly_member.rb
+++ b/decidim-assemblies/app/models/decidim/assembly_member.rb
@@ -26,5 +26,9 @@ module Decidim
     def self.log_presenter_class_for(_log)
       Decidim::Assemblies::AdminLog::AssemblyMemberPresenter
     end
+
+    def remove_not_user_avatar
+      false
+    end
   end
 end

--- a/decidim-assemblies/app/models/decidim/assembly_member.rb
+++ b/decidim-assemblies/app/models/decidim/assembly_member.rb
@@ -17,6 +17,8 @@ module Decidim
     has_one_attached :not_user_avatar
     validates_avatar :not_user_avatar, uploader: Decidim::AvatarUploader
 
+    delegate :organization, to: :assembly
+
     default_scope { order(weight: :asc, created_at: :asc) }
 
     scope :not_ceased, -> { where("ceased_date >= ? OR ceased_date IS NULL", Time.zone.today) }

--- a/decidim-assemblies/app/packs/src/decidim/assemblies/admin/assembly_members.js
+++ b/decidim-assemblies/app/packs/src/decidim/assemblies/admin/assembly_members.js
@@ -16,6 +16,16 @@ $(() => {
   createFieldDependentInputs({
     controllerField: $assemblyMemberType,
     wrapperSelector: ".user-fields",
+    dependentFieldsSelector: ".user-fields--not-user-avatar",
+    dependentInputSelector: "input",
+    enablingCondition: ($field) => {
+      return $field.val() === "false"
+    }
+  });
+
+  createFieldDependentInputs({
+    controllerField: $assemblyMemberType,
+    wrapperSelector: ".user-fields",
     dependentFieldsSelector: ".user-fields--user-picker",
     dependentInputSelector: "input",
     enablingCondition: ($field) => {

--- a/decidim-assemblies/app/packs/src/decidim/assemblies/admin/assembly_members.js
+++ b/decidim-assemblies/app/packs/src/decidim/assemblies/admin/assembly_members.js
@@ -16,7 +16,7 @@ $(() => {
   createFieldDependentInputs({
     controllerField: $assemblyMemberType,
     wrapperSelector: ".user-fields",
-    dependentFieldsSelector: ".user-fields--not-user-avatar",
+    dependentFieldsSelector: ".user-fields--non-user-avatar",
     dependentInputSelector: "input",
     enablingCondition: ($field) => {
       return $field.val() === "false"

--- a/decidim-assemblies/app/presenters/decidim/assembly_member_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assembly_member_presenter.rb
@@ -33,6 +33,16 @@ module Decidim
       I18n.t(__getobj__.position, scope: "decidim.admin.models.assembly_member.positions", default: "")
     end
 
+    def not_user_avatar_path
+      return not_user_avatar.default_url unless not_user_avatar.attached?
+
+      not_user_avatar.path
+    end
+
+    def not_user_avatar
+      attached_uploader(:not_user_avatar)
+    end
+
     private
 
     def user

--- a/decidim-assemblies/app/presenters/decidim/assembly_member_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assembly_member_presenter.rb
@@ -33,14 +33,14 @@ module Decidim
       I18n.t(__getobj__.position, scope: "decidim.admin.models.assembly_member.positions", default: "")
     end
 
-    def not_user_avatar_path
-      return not_user_avatar.default_url unless not_user_avatar.attached?
+    def non_user_avatar_path
+      return non_user_avatar.default_url unless non_user_avatar.attached?
 
-      not_user_avatar.path
+      non_user_avatar.path
     end
 
-    def not_user_avatar
-      attached_uploader(:not_user_avatar)
+    def non_user_avatar
+      attached_uploader(:non_user_avatar)
     end
 
     private

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/_form.html.erb
@@ -15,6 +15,10 @@
         <%= form.text_field :full_name, autofocus: true %>
       </div>
 
+      <div class="row column user-fields--not-user-avatar">
+        <%= form.upload :not_user_avatar %>
+      </div>
+
       <div class="row column user-fields--user-picker">
         <% prompt_options = { url: decidim_admin.user_entities_organization_url, placeholder: t(".select_user") } %>
         <%= form.autocomplete_select(:user_id, form.object.user.presence,  { multiple: false }, prompt_options) do |user|

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/_form.html.erb
@@ -18,9 +18,6 @@
       <div class="row column user-fields--non-user-avatar">
         <%= form.upload :non_user_avatar, help_i18n_messages: ["non_user_avatar_help", "image_guide"], help_i18n_scope: "decidim.assemblies.admin.assembly_members.form" %>
       </div>
-        <p class="help-text">
-          <%= t(".non_user_avatar_help") %>
-        </p>
 
       <div class="row column user-fields--user-picker">
         <% prompt_options = { url: decidim_admin.user_entities_organization_url, placeholder: t(".select_user") } %>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/_form.html.erb
@@ -16,8 +16,11 @@
       </div>
 
       <div class="row column user-fields--not-user-avatar">
-        <%= form.upload :not_user_avatar %>
+        <%= form.upload :not_user_avatar, help_i18n_messages: ["non_user_avatar_help", "image_guide"], help_i18n_scope: "decidim.assemblies.admin.assembly_members.form" %>
       </div>
+        <p class="help-text">
+          <%= t(".non_user_avatar_help") %>
+        </p>
 
       <div class="row column user-fields--user-picker">
         <% prompt_options = { url: decidim_admin.user_entities_organization_url, placeholder: t(".select_user") } %>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/_form.html.erb
@@ -15,8 +15,8 @@
         <%= form.text_field :full_name, autofocus: true %>
       </div>
 
-      <div class="row column user-fields--not-user-avatar">
-        <%= form.upload :not_user_avatar, help_i18n_messages: ["non_user_avatar_help", "image_guide"], help_i18n_scope: "decidim.assemblies.admin.assembly_members.form" %>
+      <div class="row column user-fields--non-user-avatar">
+        <%= form.upload :non_user_avatar, help_i18n_messages: ["non_user_avatar_help", "image_guide"], help_i18n_scope: "decidim.assemblies.admin.assembly_members.form" %>
       </div>
         <p class="help-text">
           <%= t(".non_user_avatar_help") %>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -298,7 +298,10 @@ en:
         assembly_members:
           form:
             existing_user: Existing participant
+            explanation: 'Guidance for image:'
+            image_guide: Preferrably a portrait image that does not have any text.
             non_user: Non participant
+            non_user_avatar_help: You should get the consent of the persons before publishing them as a member.
             select_a_position: Select a position
             select_user: Select a participant
             user_type: Participant type

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -63,7 +63,7 @@ en:
         designation_mode: Designation mode
         full_name: Full name
         gender: Gender
-        not_user_avatar: Avatar
+        non_user_avatar: Avatar
         position: Position
         user_id: User or group
       assembly_user_role:

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -63,6 +63,7 @@ en:
         designation_mode: Designation mode
         full_name: Full name
         gender: Gender
+        not_user_avatar: Avatar
         position: Position
         user_id: User or group
       assembly_user_role:

--- a/decidim-assemblies/spec/commands/create_assembly_member_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_member_spec.rb
@@ -10,7 +10,7 @@ module Decidim::Assemblies
     let(:user_entity) { nil }
     let!(:current_user) { create :user, :confirmed, organization: assembly.organization }
     let(:existing_user) { false }
-    let(:not_user_avatar) do
+    let(:non_user_avatar) do
       ActiveStorage::Blob.create_after_upload!(
         io: File.open(Decidim::Dev.asset("avatar.jpg")),
         filename: "avatar.jpeg",
@@ -32,7 +32,7 @@ module Decidim::Assemblies
           position: Decidim::AssemblyMember::POSITIONS.sample,
           position_other: "other",
           existing_user: existing_user,
-          not_user_avatar: not_user_avatar,
+          non_user_avatar: non_user_avatar,
           user_id: user_entity&.id
         }
       }
@@ -55,7 +55,7 @@ module Decidim::Assemblies
 
       context "when image is invalid" do
         let(:existing_user) { false }
-        let(:not_user_avatar) do
+        let(:non_user_avatar) do
           ActiveStorage::Blob.create_after_upload!(
             io: File.open(Decidim::Dev.asset("invalid.jpeg")),
             filename: "avatar.jpeg",

--- a/decidim-assemblies/spec/commands/create_assembly_member_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_member_spec.rb
@@ -9,13 +9,18 @@ module Decidim::Assemblies
     let(:assembly) { create(:assembly) }
     let(:user_entity) { nil }
     let!(:current_user) { create :user, :confirmed, organization: assembly.organization }
-    let(:form) do
-      instance_double(
-        Admin::AssemblyMemberForm,
-        invalid?: invalid,
-        full_name: "Full name",
-        user: user_entity,
-        attributes: {
+    let(:existing_user) { false }
+    let(:not_user_avatar) do
+      ActiveStorage::Blob.create_after_upload!(
+        io: File.open(Decidim::Dev.asset("avatar.jpg")),
+        filename: "avatar.jpeg",
+        content_type: "image/jpeg"
+      )
+    end
+    let(:form_klass) { Admin::AssemblyMemberForm }
+    let(:form_params) do
+      {
+        assembly_member: {
           weight: 0,
           full_name: "Full name",
           gender: Faker::Lorem.word,
@@ -25,17 +30,43 @@ module Decidim::Assemblies
           designation_date: Time.current,
           designation_mode: "designation mode",
           position: Decidim::AssemblyMember::POSITIONS.sample,
-          position_other: "other"
+          position_other: "other",
+          existing_user: existing_user,
+          not_user_avatar: not_user_avatar,
+          user_id: user_entity&.id
         }
+      }
+    end
+    let(:form) do
+      form_klass.from_params(
+        form_params
+      ).with_context(
+        current_user: current_user,
+        current_organization: assembly.organization
       )
     end
-    let(:invalid) { false }
 
     context "when the form is not valid" do
-      let(:invalid) { true }
+      let(:existing_user) { true }
 
       it "is not valid" do
         expect { subject.call }.to broadcast(:invalid)
+      end
+
+      context "when image is invalid" do
+        let(:existing_user) { false }
+        let(:not_user_avatar) do
+          ActiveStorage::Blob.create_after_upload!(
+            io: File.open(Decidim::Dev.asset("invalid.jpeg")),
+            filename: "avatar.jpeg",
+            content_type: "image/jpeg"
+          )
+        end
+
+        it "prevents uploading" do
+          expect { subject.call }.not_to raise_error
+          expect { subject.call }.to broadcast(:invalid)
+        end
       end
     end
 
@@ -68,6 +99,7 @@ module Decidim::Assemblies
 
       context "with an existing user in the platform" do
         let!(:user_entity) { create(:user, organization: assembly.organization) }
+        let(:existing_user) { true }
 
         it "sets the user" do
           subject.call
@@ -94,6 +126,7 @@ module Decidim::Assemblies
         let!(:member1) { create(:user, organization: assembly.organization) }
         let!(:member2) { create(:user, organization: assembly.organization) }
         let!(:user_entity) { create(:user_group, :verified, users: [member1, member2], organization: assembly.organization) }
+        let(:existing_user) { true }
 
         it "sets the group" do
           subject.call

--- a/decidim-assemblies/spec/commands/update_assembly_member_spec.rb
+++ b/decidim-assemblies/spec/commands/update_assembly_member_spec.rb
@@ -11,7 +11,7 @@ module Decidim::Assemblies
     let!(:current_user) { create :user, :confirmed, organization: assembly.organization }
     let(:user) { nil }
     let(:existing_user) { false }
-    let(:not_user_avatar) do
+    let(:non_user_avatar) do
       ActiveStorage::Blob.create_after_upload!(
         io: File.open(Decidim::Dev.asset("avatar.jpg")),
         filename: "avatar.jpeg",
@@ -33,7 +33,7 @@ module Decidim::Assemblies
           position: Decidim::AssemblyMember::POSITIONS.sample,
           position_other: "",
           existing_user: existing_user,
-          not_user_avatar: not_user_avatar,
+          non_user_avatar: non_user_avatar,
           user_id: user&.id
         }
       }
@@ -56,7 +56,7 @@ module Decidim::Assemblies
 
       context "when image is invalid" do
         let(:existing_user) { false }
-        let(:not_user_avatar) do
+        let(:non_user_avatar) do
           ActiveStorage::Blob.create_after_upload!(
             io: File.open(Decidim::Dev.asset("invalid.jpeg")),
             filename: "avatar.jpeg",

--- a/decidim-assemblies/spec/forms/assembly_member_form_spec.rb
+++ b/decidim-assemblies/spec/forms/assembly_member_form_spec.rb
@@ -20,7 +20,7 @@ module Decidim
         let(:gender) { ::Faker::Lorem.word }
         let(:position) { Decidim::AssemblyMember::POSITIONS.first }
         let(:existing_user) { false }
-        let(:not_user_avatar) { fixture_file_upload(File.open(Decidim::Dev.asset("city.jpeg")), "image/jpeg") }
+        let(:non_user_avatar) { fixture_file_upload(File.open(Decidim::Dev.asset("city.jpeg")), "image/jpeg") }
         let(:user_id) { nil }
 
         let(:attributes) do
@@ -32,7 +32,7 @@ module Decidim
               "position" => position,
               "birthday" => Time.current,
               "existing_user" => existing_user,
-              "not_user_avatar" => not_user_avatar,
+              "non_user_avatar" => non_user_avatar,
               "user_id" => user_id
             }
           }

--- a/decidim-assemblies/spec/forms/assembly_member_form_spec.rb
+++ b/decidim-assemblies/spec/forms/assembly_member_form_spec.rb
@@ -20,6 +20,7 @@ module Decidim
         let(:gender) { ::Faker::Lorem.word }
         let(:position) { Decidim::AssemblyMember::POSITIONS.first }
         let(:existing_user) { false }
+        let(:not_user_avatar) { fixture_file_upload(File.open(Decidim::Dev.asset("city.jpeg")), "image/jpeg") }
         let(:user_id) { nil }
 
         let(:attributes) do
@@ -31,6 +32,7 @@ module Decidim
               "position" => position,
               "birthday" => Time.current,
               "existing_user" => existing_user,
+              "not_user_avatar" => not_user_avatar,
               "user_id" => user_id
             }
           }

--- a/decidim-assemblies/spec/presenters/decidim/assembly_member_presenter_spec.rb
+++ b/decidim-assemblies/spec/presenters/decidim/assembly_member_presenter_spec.rb
@@ -8,9 +8,10 @@ module Decidim
     let(:day_offset) { 0 }
     let(:today) { ::Time.zone.today }
     let(:birthday) { Time.zone.today - age.years + day_offset.days }
+    let(:non_user_avatar) { nil }
 
     let(:assembly_member) do
-      build(:assembly_member, full_name: "Full name", birthday: birthday)
+      build(:assembly_member, full_name: "Full name", birthday: birthday, non_user_avatar: non_user_avatar)
     end
 
     describe "name" do
@@ -108,6 +109,27 @@ module Decidim
         it "show the custom position value" do
           expect(subject).to eq("Custom position")
         end
+      end
+    end
+
+    describe "non_user_avatar_path" do
+      subject { described_class.new(assembly_member).non_user_avatar_path }
+
+      context "when no image is attached" do
+        it { is_expected.to include "default-avatar" }
+      end
+
+      context "when a image is attached" do
+        let(:non_user_avatar) do
+          ActiveStorage::Blob.create_after_upload!(
+            io: File.open(Decidim::Dev.asset("avatar.jpg")),
+            filename: "avatar.jpeg",
+            content_type: "image/jpeg"
+          )
+        end
+        let(:avatar_path) { Rails.application.routes.url_helpers.rails_blob_url(non_user_avatar, only_path: true) }
+
+        it { is_expected.to eq avatar_path }
       end
     end
   end

--- a/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
@@ -18,10 +18,14 @@ shared_examples "manage assembly members examples" do
       find(".datepicker-days .active").click
 
       within ".new_assembly_member" do
+        expect(page).to have_content("You should get the consent of the persons before publishing them as a member")
+
         fill_in(
           :assembly_member_full_name,
           with: "Daisy O'connor"
         )
+
+        attach_file "Avatar", Decidim::Dev.asset("avatar.jpg")
 
         select "President", from: :assembly_member_position
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR allows adding an avatar image to assembly members not related with a user.
If an existing member with an avatar of this type is associated with an existing user then the user avatar is used and the other one is ignored 

#### :pushpin: Related Issues

- Fixes #7293

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
