### PR TITLE
Fix "last comment by" when commenter is a user group

### DIFF
--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -174,9 +174,15 @@ module Decidim
         comments_count = comments.not_hidden.not_deleted.count
         last_comment = comments.not_hidden.not_deleted.order("created_at DESC").first
 
+        if last_comment&.decidim_user_group_id
+          author_id = last_comment&.decidim_user_group_id
+        else 
+          author_id = last_comment&.decidim_author_id
+        end
+
         update_columns(
           last_comment_at: last_comment&.created_at,
-          last_comment_by_id: last_comment&.decidim_author_id,
+          last_comment_by_id: author_id,
           last_comment_by_type: last_comment&.decidim_author_type,
           comments_count: comments_count,
           updated_at: Time.current

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -174,15 +174,9 @@ module Decidim
         comments_count = comments.not_hidden.not_deleted.count
         last_comment = comments.not_hidden.not_deleted.order("created_at DESC").first
 
-        if last_comment&.decidim_user_group_id
-          author_id = last_comment&.decidim_user_group_id
-        else 
-          author_id = last_comment&.decidim_author_id
-        end
-
         update_columns(
           last_comment_at: last_comment&.created_at,
-          last_comment_by_id: author_id,
+          last_comment_by_id: last_comment&.decidim_user_group_id || last_comment&.decidim_author_id,
           last_comment_by_type: last_comment&.decidim_author_type,
           comments_count: comments_count,
           updated_at: Time.current

--- a/decidim-debates/spec/system/show_spec.rb
+++ b/decidim-debates/spec/system/show_spec.rb
@@ -47,6 +47,17 @@ describe "show", type: :system do
         end
       end
 
+      it "shows the last comment author when it's a user group" do
+        group = create(:user_group, organization: debate.organization)
+        create(:comment, commentable: debate, author: group)
+
+        visit current_url
+
+        within ".definition-data" do
+          expect(page).to have_content(group.name)
+        end
+      end
+
       it "shows the number of participants" do
         within ".definition-data" do
           expect(page).to have_content("PARTICIPANTS\n1")


### PR DESCRIPTION
#### :tophat: What? Why?

This PR supersedes #8163, made by @cf17jeremy. Thanks a lot!

*When comment on a debate as a group  the "last comment by" box appears name instead of the group name.*

I'm only adding a couple of things:

1. Applying [feedback](https://github.com/decidim/decidim/pull/8163/files#r661370121) from @leio10 
2. Adding [requested spec](https://github.com/decidim/decidim/pull/8163#pullrequestreview-696015087)
3. Merging with develop so it's easier to work with 

⚠️ this fix will only be available to new comments, as the bug was in what was saved in the DB

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #7431

#### Testing
*Write comment as group and see presenter with group name*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
**Before**

![Selecció_1461](https://user-images.githubusercontent.com/717367/131805637-cbaa5b44-d009-44a3-88aa-94593820ddbc.png)
![Selecció_1462](https://user-images.githubusercontent.com/717367/131805661-9f467e2d-b9c8-447b-a99c-9b4b6eee0b11.png)


**After**

![Selecció_1463](https://user-images.githubusercontent.com/717367/131805686-8f933983-e7ab-421a-940e-3daa06077d57.png)
![Selecció_1464](https://user-images.githubusercontent.com/717367/131805695-1bdb075e-87f1-41de-be17-f640e76d0f64.png)



:hearts: Thank you!
