### PR TITLE
Remove "Allow card image" setting from Proposals

### DIFF
--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -118,7 +118,7 @@ module Decidim
       end
 
       def has_image?
-        @has_image ||= model.component.settings.allow_card_image && model.attachments.find_by("content_type like '%image%'").present?
+        @has_image ||= model.attachments.find_by("content_type like '%image%'").present?
       end
 
       def resource_image_path

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -126,7 +126,6 @@ en:
         name: Proposals
         settings:
           global:
-            allow_card_image: Allow card image
             amendments_enabled: Amendments enabled
             amendments_enabled_help: If active, configure Amendment features for each step.
             amendments_wizard_help_text: Amendments Wizard help text

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -39,7 +39,6 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :comments_max_length, type: :integer, required: false
     settings.attribute :geocoding_enabled, type: :boolean, default: false
     settings.attribute :attachments_allowed, type: :boolean, default: false
-    settings.attribute :allow_card_image, type: :boolean, default: false
     settings.attribute :resources_permissions_enabled, type: :boolean, default: true
     settings.attribute :collaborative_drafts_enabled, type: :boolean, default: false
     settings.attribute :participatory_texts_enabled,

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -214,14 +214,6 @@ FactoryBot.define do
       end
     end
 
-    trait :with_card_image_allowed do
-      settings do
-        {
-          allow_card_image: true
-        }
-      end
-    end
-
     trait :with_extra_hashtags do
       transient do
         automatic_hashtags { "AutoHashtag AnotherAutoHashtag" }

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
@@ -12,7 +12,7 @@ module Decidim::Proposals
     let(:cell_html) { my_cell.call }
     let(:created_at) { Time.current - 1.month }
     let(:published_at) { Time.current }
-    let(:component) { create(:proposal_component, :with_attachments_allowed, :with_card_image_allowed) }
+    let(:component) { create(:proposal_component, :with_attachments_allowed) }
     let!(:proposal) { create(:proposal, component: component, created_at: created_at, published_at: published_at) }
     let(:model) { proposal }
     let(:user) { create :user, organization: proposal.participatory_space.organization }

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -126,10 +126,9 @@ describe "Proposals", type: :system do
       it_behaves_like "rendering unsafe content", ".columns.mediumlarge-8.large-9"
     end
 
-    context "when it is a proposal with card image enabled" do
+    context "when it is a proposal with image" do
       let!(:component) do
         create(:proposal_component,
-               :with_card_image_allowed,
                manifest: manifest,
                participatory_space: participatory_process)
       end


### PR DESCRIPTION
#### :tophat: What? Why?

There's a setting in the proposals component called "Allow card image" that, well, shows the proposal card image when there are attachments. This PR drops this setting as that's just too granular even for Decidim standards 😄  

#### :pushpin: Related Issues

- Originally implemented in  #5640
- Related to #8276 - I was having doubts if we should implement that setting in those cases but then I thought better and say "let's drop it" 

#### Testing

1. Sign in as admin
2. Go to a proposals component settings in a participatory process
3. See that you don't have the "Allow card image" setting anymore
4. Check "Allow attachments"
5. Create a new proposal with an image
6. See in the proposals listing that you have the card image

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

(As it's removing a setting is difficult to show, but pic is related to the feature)

![imatge](https://user-images.githubusercontent.com/717367/131819851-471c1a00-587c-4f95-9d26-41b0320c4c40.png)


:hearts: Thank you!
