### PR TITLE
Backport "Fix Luxembourgish locale" to v0.24

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -29,6 +29,7 @@ files:
         it: it
         ja: ja
         ko: ko
+        lb: lb
         lt: lt
         lv: lv
         mt: mt

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -152,7 +152,7 @@ module Decidim
 
   # Exposes a configuration option: The application available locales.
   config_accessor :available_locales do
-    %w(en bg ar ca cs da de el eo es es-MX es-PY et eu fi-pl fi fr fr-CA ga gl hr hu id is it ja ko lt lv mt nl no pl pt pt-BR ro ru sk sl sr sv tr uk vi zh-CN zh-TW)
+    %w(en bg ar ca cs da de el eo es es-MX es-PY et eu fi-pl fi fr fr-CA ga gl hr hu id is it ja ko lb lt lv mt nl no pl pt pt-BR ro ru sk sl sr sv tr uk vi zh-CN zh-TW)
   end
 
   # Exposes a configuration option: The application default locale.

--- a/decidim-core/spec/lib/available_locales_spec.rb
+++ b/decidim-core/spec/lib/available_locales_spec.rb
@@ -12,7 +12,7 @@ end
 
 describe "available locales", type: :system do
   let(:languages) do
-    %w(en bg ar ca cs da de el eo es es-MX es-PY et eu fi-pl fi fr fr-CA ga gl hr hu id is it ja ko lt lv mt nl no pl pt pt-BR ro ru sk sl sr sv tr uk vi zh-CN zh-TW)
+    %w(en bg ar ca cs da de el eo es es-MX es-PY et eu fi-pl fi fr fr-CA ga gl hr hu id is it ja ko lb lt lv mt nl no pl pt pt-BR ro ru sk sl sr sv tr uk vi zh-CN zh-TW)
   end
   let(:datepicker_file) do
     lambda { |lang|

--- a/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.lb.js
+++ b/decidim-core/vendor/assets/javascripts/datepicker-locales/foundation-datepicker.lb.js
@@ -1,0 +1,13 @@
+/**
+ * Luxembourgish localisation
+ */
+;(function($){
+	$.fn.fdatepicker.dates['lb'] = {
+		days: ["Sonndeg", "Méindeg", "Dënschdeg", "Mëttwoch", "Donneschdeg", "Freideg", "Samschdeg", "Sonndeg"],
+		daysShort: ["Son", "Méi", "Dën", "Mët", "Don", "Fre", "Sam", "Son"],
+		daysMin: ["So", "Mé", "Dë", "Më", "Do", "Fr", "Sa", "So"],
+		months: ["Januar", "Februar", "Mäerz", "Abrëll", "Mee", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"], 
+		monthsShort: ["Jan", "Febr", "Mrz", "Abr", "Mee", "Jun", "Jul", "Aug", "Sept", "Okt", "Nov", "Dez"],
+		today: "Haut"
+	};
+}(jQuery));


### PR DESCRIPTION
#### :tophat: What? Why?
This PR backports the Luxembourgish locale fixes to v0.24

Mind that in this case as we didn't use webpacker yet we had the datepicker locales in `decidim-core/vendor/assets/javascripts/datepicker-locales/`

#### :pushpin: Related Issues

- Related to #8270 
- Related to #8282 
