### PR TITLE
Add 'Lint PR title' workflow to CI

### DIFF
--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -1,4 +1,4 @@
-name: "[CI] Lint"
+name: "[CI] Lint code"
 on:
   push:
     branches:

--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -1,0 +1,27 @@
+name: "[CI] Lint PR format"
+on:
+  push:
+    branches:
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check_title:
+    name: Check PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rokroskar/workflow-run-cleanup-action@v0.3.2
+        if: "github.ref != 'refs/heads/develop'"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: deepakputhraya/action-pr-title@master
+        with:
+          disallowed_prefixes: "feat,chore,build,ci,refactor,docs,wip"
+          prefix_case_sensitive: false
+          min_length: 5
+          max_length: 100


### PR DESCRIPTION
#### :tophat: What? Why?

This adds a new linter, for checking that the PR title has the right format. 

Decidim has more than 100 contributors and if everyone uses their own nomenclature for PRs (like adding JIRA numbers, GH issues numbers, using conventional commits for PR titles, etc) then this would make the git history really difficult to work with. By starting to check these kinds of things in the CI we'd hopefully have a more consistent git/GitHub history. <sub><sup>Also, that really rustles my jimmies.</sup></sub>

It uses https://github.com/deepakputhraya/action-pr-title - the same that's [already implemented in decidim-bulletin-board](https://github.com/decidim/decidim-bulletin-board/blob/e22d7156356c38d4fa9508ff66849a4000ea56d0/.github/workflows/pull-request-best-practises-workflow.yml)

#### :pushpin: Related Issues

- Related to #8277 (just as the last example of a title that breaks the title conventions)

:hearts: Thank you!
