### PR TITLE
Backport "Fix accountability notifications proposal title" to v0.24

### DIFF
--- a/decidim-accountability/app/events/decidim/accountability/proposal_linked_event.rb
+++ b/decidim-accountability/app/events/decidim/accountability/proposal_linked_event.rb
@@ -10,7 +10,7 @@ module Decidim
       end
 
       def proposal_title
-        @proposal_title ||= proposal.title
+        @proposal_title ||= translated_attribute(proposal.title)
       end
 
       def proposal

--- a/decidim-accountability/app/events/decidim/accountability/result_progress_updated_event.rb
+++ b/decidim-accountability/app/events/decidim/accountability/result_progress_updated_event.rb
@@ -10,7 +10,7 @@ module Decidim
       end
 
       def proposal_title
-        @proposal_title ||= proposal.title
+        @proposal_title ||= translated_attribute(proposal.title)
       end
 
       def proposal

--- a/decidim-accountability/spec/events/decidim/accountability/proposal_linked_event_spec.rb
+++ b/decidim-accountability/spec/events/decidim/accountability/proposal_linked_event_spec.rb
@@ -13,7 +13,7 @@ describe Decidim::Accountability::ProposalLinkedEvent do
   let(:proposal) { create :proposal, component: proposal_component, title: { en: "My super proposal" } }
   let(:extra) { { proposal_id: proposal.id } }
   let(:proposal_path) { resource_locator(proposal).path }
-  let(:proposal_title) { proposal.title }
+  let(:proposal_title) { translated(proposal.title) }
 
   before do
     resource.link_resources([proposal], "included_proposals")
@@ -42,18 +42,21 @@ describe Decidim::Accountability::ProposalLinkedEvent do
   describe "email_subject" do
     it "is generated correctly" do
       expect(subject.email_subject).to eq("An update to #{proposal_title}")
+      expect(subject.email_subject).not_to include(proposal.title.to_s)
     end
   end
 
   describe "email_outro" do
     it "is generated correctly" do
       expect(subject.email_outro).to eq("You have received this notification because you are following \"#{proposal_title}\". You can stop receiving notifications following the previous link.")
+      expect(subject.email_outro).not_to include(proposal.title.to_s)
     end
   end
 
   describe "email_intro" do
     it "is generated correctly" do
       expect(subject.email_intro).to eq("The proposal \"#{proposal_title}\" has been included in a result. You can see it from this page:")
+      expect(subject.email_intro).not_to include(proposal.title.to_s)
     end
   end
 

--- a/decidim-accountability/spec/events/decidim/accountability/result_progress_updated_event_spec.rb
+++ b/decidim-accountability/spec/events/decidim/accountability/result_progress_updated_event_spec.rb
@@ -13,7 +13,7 @@ describe Decidim::Accountability::ResultProgressUpdatedEvent do
   let(:proposal) { create :proposal, component: proposal_component, title: { en: "My super proposal" } }
   let(:extra) { { proposal_id: proposal.id, progress: 95 } }
   let(:proposal_path) { resource_locator(proposal).path }
-  let(:proposal_title) { proposal.title }
+  let(:proposal_title) { translated(proposal.title) }
 
   before do
     resource.link_resources([proposal], "included_proposals")
@@ -48,12 +48,14 @@ describe Decidim::Accountability::ResultProgressUpdatedEvent do
   describe "email_outro" do
     it "is generated correctly" do
       expect(subject.email_outro).to eq("You have received this notification because you are following \"#{proposal_title}\", and this proposal is included in the result \"#{translated resource.title}\". You can stop receiving notifications following the previous link.")
+      expect(subject.email_outro).not_to include(proposal.title.to_s)
     end
   end
 
   describe "email_intro" do
     it "is generated correctly" do
       expect(subject.email_intro).to eq("The result \"#{translated resource.title}\", which includes the proposal \"#{proposal_title}\", is now 95% complete. You can see it from this page:")
+      expect(subject.email_intro).not_to include(proposal.title.to_s)
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the fix from #8240 to 0.24.

#### :pushpin: Related Issues
- Related to #8240

#### Testing
See #8240.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.