### PR TITLE
Fix missing icons after CORS

### DIFF
--- a/decidim-admin/app/views/layouts/decidim/admin/_js_configuration.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_js_configuration.html.erb
@@ -1,7 +1,6 @@
 <%
 js_configs = {
-  cors_enabled: Decidim.cors_enabled,
-  icons_path: asset_pack_path("media/images/icons.svg"),
+  icons_path: Decidim.cors_enabled ? "" : asset_pack_path("media/images/icons.svg"),
   messages: {
     "selfxssWarning": {
       title: t("decidim.security.selfxss_warning.title"),

--- a/decidim-core/app/packs/src/decidim/icon.js
+++ b/decidim-core/app/packs/src/decidim/icon.js
@@ -13,7 +13,6 @@ const DEFAULT_ATTRIBUTES = {
  */
 export default function icon(iconKey, attributes = {}) {
   const iconAttributes = $.extend(DEFAULT_ATTRIBUTES, attributes);
-  const corsMode = window.Decidim.config.get("cors_enabled");
   const title = iconAttributes.title || iconAttributes.ariaLabel;
   Reflect.deleteProperty(iconAttributes, "title");
 
@@ -30,11 +29,7 @@ export default function icon(iconKey, attributes = {}) {
     }
   });
 
-  let iconsPath =  ""
-  if (corsMode === true) {
-    iconsPath = window.Decidim.config.get("icons_path");
-  }
-
+  const iconsPath =  window.Decidim.config.get("icons_path");
   const elHtml = `<svg><use href="${iconsPath}#icon-${iconKey}"></use></svg>`;
   const $el = $(elHtml);
   if (title) {

--- a/decidim-core/app/packs/src/decidim/input_mentions.js
+++ b/decidim-core/app/packs/src/decidim/input_mentions.js
@@ -110,12 +110,7 @@ $(() => {
     menuItemTemplate: function(item) {
       let svg = "";
       if (window.Decidim && item.original.__typename === "UserGroup") {
-        let corsMode = window.Decidim.config.get("cors_enabled");
-
-        let iconsPath =  ""
-        if (corsMode === true) {
-          iconsPath = window.Decidim.config.get("icons_path");
-        }
+        const iconsPath =  window.Decidim.config.get("icons_path");
 
         svg = `<span class="is-group">${item.original.membersCount}x <svg class="icon--members icon"><use href="${iconsPath}#icon-members"/></svg></span>`;
       }

--- a/decidim-core/app/packs/src/decidim/input_multiple_mentions.js
+++ b/decidim-core/app/packs/src/decidim/input_multiple_mentions.js
@@ -121,8 +121,7 @@ $(() => {
       let enabled = item.original.directMessagesEnabled === "true";
       if (window.Decidim && item.original.__typename === "UserGroup") {
         enabled = true;
-        let corsMode = window.Decidim.config.get("cors_enabled");
-        let iconsPath = corsMode ? "" : window.Decidim.config.get("icons_path");
+        const iconsPath = window.Decidim.config.get("icons_path");
         svg = `<span class="is-group">${item.original.membersCount}x <svg class="icon--members icon"><use href="${iconsPath}#icon-members"/></svg></span>`;
       }
       let disabledElementClass = enabled ? "" : "disabled-tribute-element";

--- a/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
@@ -1,7 +1,6 @@
 <%
 js_configs = {
-  cors_enabled: Decidim.cors_enabled,
-  icons_path: asset_pack_path("media/images/icons.svg"),
+  icons_path: Decidim.cors_enabled ? "" : asset_pack_path("media/images/icons.svg"),
   messages: {
     "selfxssWarning": {
       title: t("decidim.security.selfxss_warning.title"),
@@ -33,12 +32,4 @@ validator_messages = {
   Decidim.InputCharacterCounter.configureMessages(<%== character_messages.to_json %>);
   Decidim.ExternalLink.configureMessages(<%== external_link_messages.to_json %>);
   Decidim.FormValidator.configureMessages(<%== validator_messages.to_json %>);
-  DecidimComments = {
-    assets: {
-      'icons.svg': "<%= asset_pack_path "media/images/icons.svg" %>"
-    }
-  }
-  Decidim.assets = {
-    'icons.svg': "<%= asset_pack_path "media/images/icons.svg" %>"
-  }
 </script>

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -387,6 +387,27 @@ describe "Homepage", type: :system do
         end
       end
 
+      describe "decidim link with external icon" do
+        before { visit current_path }
+
+        let(:webpacker_helper) do
+          Class.new do
+            include ActionView::Helpers::AssetUrlHelper
+            include Webpacker::Helper
+          end.new
+        end
+
+        it "displays the decidim link with external link indicator" do
+          within ".footer .mini-footer" do
+            expect(page).to have_selector("a[target='_blank'][href='https://github.com/decidim/decidim']")
+
+            within "a[target='_blank'][href='https://github.com/decidim/decidim']" do
+              expect(page).to have_selector("svg.icon use[href='#{webpacker_helper.asset_pack_path("media/images/icons.svg")}#icon-external-link']")
+            end
+          end
+        end
+      end
+
       context "and has highlighted content banner enabled" do
         let(:organization) do
           create(:organization,

--- a/decidim-dev/spec/system/accessibility_tool_spec.rb
+++ b/decidim-dev/spec/system/accessibility_tool_spec.rb
@@ -25,9 +25,9 @@ describe "Accessibility tool", type: :system do
         <head>
           <title>Accessibility Test</title>
           #{stylesheet_pack_tag "decidim_core"}
-          #{javascript_pack_tag "decidim_core"}
+          #{javascript_pack_tag "decidim_core", defer: false}
           #{stylesheet_pack_tag "decidim_dev"}
-          #{javascript_pack_tag "decidim_dev"}
+          #{javascript_pack_tag "decidim_dev", defer: false}
         </head>
         <body>
           #{document_inner}

--- a/decidim-system/app/views/layouts/decidim/system/_js_configuration.html.erb
+++ b/decidim-system/app/views/layouts/decidim/system/_js_configuration.html.erb
@@ -1,7 +1,6 @@
 <%
 js_configs = {
-  cors_enabled: Decidim.cors_enabled,
-  icons_path: asset_pack_path("media/images/icons.svg")
+  icons_path: Decidim.cors_enabled ? "" : asset_pack_path("media/images/icons.svg")
 }
 %>
 


### PR DESCRIPTION
#### :tophat: What? Why?
After #8019 was merged, the frontend displayed icons got broken.

This fixes the issue.

#### :pushpin: Related Issues
- Related to #8019

#### Testing
- Run the development app and take a look at the footer of the page.
- See that there is now an icon displayed at the external link ("Website made with")

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.