### PR TITLE
Remove unnecessary spacer from external link indicator

### DIFF
--- a/decidim-core/app/packs/src/decidim/external_link.js
+++ b/decidim-core/app/packs/src/decidim/external_link.js
@@ -37,7 +37,12 @@ export default class ExternalLink {
     }
 
     this.$link.addClass("external-link-container");
-    this.$link.append(`&nbsp;${this.generateElement()}`);
+    let spacer = "&nbsp;";
+    if (this.$link.text().trim().length < 1) {
+      // Fixes image links extra space
+      spacer = "";
+    }
+    this.$link.append(`${spacer}${this.generateElement()}`);
   }
 
   generateElement() {


### PR DESCRIPTION
#### :tophat: What? Why?
When there is no text within the link, do not add the extra non-breaking spacer.

See the screenshots for a better explanation.

#### :pushpin: Related Issues
- Related to #6253

#### Testing
Run the development app and hover one of the external image links that have no text inside them.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

#### Before

![Before](https://user-images.githubusercontent.com/864340/131896190-fb1f192b-27eb-457f-a0ae-e337a97334e3.png)

#### After

![After](https://user-images.githubusercontent.com/864340/131896219-f7024471-8e7b-4cb5-bcff-9eef04b1d192.png)