### PR TITLE
Fix ARIA roles for dialogs and tooltips

### DIFF
--- a/decidim-admin/app/views/decidim/admin/moderated_users/_report.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderated_users/_report.html.erb
@@ -3,7 +3,6 @@
 <% else %>
   <span
     data-tooltip
-    aria-haspopup="true"
     title="<%= report.details&.truncate(250) %>">
       <%= t(".reasons.#{report.reason}") %>
   </span>

--- a/decidim-admin/app/views/decidim/admin/moderations/_report.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/_report.html.erb
@@ -3,7 +3,6 @@
 <% else %>
   <span
     data-tooltip
-    aria-haspopup="true"
     title="<%= report.details&.truncate(250) %>">
       <%= t(".reasons.#{report.reason}") %>
   </span>

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -49,7 +49,7 @@
               </td>
               <td>
                 <%=
-                  link_to t("models.moderation.fields.visit_url", scope: "decidim.moderations"), moderation.reportable.reported_content_url, data: { tooltip: true }, aria: { haspopup: true }, title: strip_tags(reported_content_excerpt_for(moderation.reportable, limit: 250))
+                  link_to t("models.moderation.fields.visit_url", scope: "decidim.moderations"), moderation.reportable.reported_content_url, data: { tooltip: true }, title: strip_tags(reported_content_excerpt_for(moderation.reportable, limit: 250))
                 %>
               </td>
               <td>

--- a/decidim-admin/app/views/layouts/decidim/admin/_title_bar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_title_bar.html.erb
@@ -17,7 +17,7 @@
           data-close-on-click="true"
           tabindex="-1">
           <li class="is-dropdown-submenu-parent" tabindex="-1">
-            <%= link_to t("name", scope: "locale"), "#", id: "admin-user-menu-control", "aria-controls": "admin-user-menu", "aria-haspopup": "true" %>
+            <%= link_to t("name", scope: "locale"), "#", id: "admin-user-menu-control", "aria-controls": "admin-user-menu", "aria-haspopup": "menu" %>
             <ul class="menu is-dropdown-submenu" id="admin-user-menu" role="menu" aria-labelledby="admin-user-menu-control" tabindex="-1">
               <% (available_locales - [I18n.locale.to_s]).each do |locale| %>
                 <li><%= link_to(locale_name(locale), decidim.locale_path(locale: locale), method: :post, tabindex: "-1") %></li>
@@ -36,7 +36,7 @@
         data-close-on-click="true"
         tabindex="-1">
         <li class="is-dropdown-submenu-parent" tabindex="-1">
-          <%= link_to current_user.email, "#", id: "admin-language-menu-control", "aria-controls": "admin-language-menu", "aria-haspopup": "true", "aria-label": t("layouts.decidim.user_menu.account", name: current_user.email) %>
+          <%= link_to current_user.email, "#", id: "admin-language-menu-control", "aria-controls": "admin-language-menu", "aria-haspopup": "menu", "aria-label": t("layouts.decidim.user_menu.account", name: current_user.email) %>
           <ul class="menu is-dropdown-submenu" id="admin-language-menu" role="menu" aria-labelledby="admin-language-menu-control" tabindex="-1">
             <li><%= link_to(t("layouts.decidim.user_menu.sign_out"), decidim.destroy_user_session_path, method: :delete, tabindex: "-1") %></li>
           </ul>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -48,7 +48,7 @@
             <tr>
               <td>
                 <% if assembly.promoted? %>
-                  <span data-tooltip class="icon-state icon-highlight" aria-haspopup="true" data-disable-hover="false" title="<%= t("models.assembly.fields.promoted", scope: "decidim.admin") %>">
+                  <span data-tooltip class="icon-state icon-highlight" data-disable-hover="false" title="<%= t("models.assembly.fields.promoted", scope: "decidim.admin") %>">
                     <%= icon "star", role: "img", "aria-hidden": true %>
                   </span>
                 <% end %>

--- a/decidim-budgets/app/cells/decidim/budgets/budget_information_modal/show.erb
+++ b/decidim-budgets/app/cells/decidim/budgets/budget_information_modal/show.erb
@@ -1,10 +1,10 @@
-<button class="link" data-open="budget-modal-info" aria-controls="budget-modal-info" aria-haspopup="true" tabindex="0">
+<button class="link" data-open="budget-modal-info" aria-controls="budget-modal-info" aria-haspopup="dialog" tabindex="0">
   <%= t(:more_information, scope: i18n_scope) %>
 </button>
 
-<div class="reveal" data-reveal id="budget-modal-info">
+<div class="reveal" data-reveal id="budget-modal-info" aria-modal="true" aria-labelledby="budget-modal-info-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= decidim_sanitize(component_name) %></h3>
+    <h3 id="budget-modal-info-label" class="reveal__title"><%= decidim_sanitize(component_name) %></h3>
     <button class="close-button" data-close aria-label="<%= t(:close_modal, scope: i18n_scope) %>" type="button">
       <span aria-hidden="true">×</span>
     </button>

--- a/decidim-budgets/app/views/decidim/budgets/projects/_filters_small_view.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_filters_small_view.html.erb
@@ -1,13 +1,13 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     <%= t ".filter" %>
     <%= icon "caret-bottom", class: "icon--small float-right", aria_label: t(".unfold"), role: "img" %>
   </button>
 </div>
 
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t ".filter_by" %>:</h3>
+    <h3 id="filter-box-label" class="reveal__title"><%= t ".filter_by" %>:</h3>
     <button class="close-button" data-close aria-label="<%= t(".close_modal") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-comments/app/cells/decidim/comments/comment/utilities.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/utilities.erb
@@ -4,7 +4,7 @@
   </label>
   <ul id="<%= context_menu_id %>" data-dropdown data-close-on-click="true" data-position="left" data-alignment="top" class="card dropdown-pane comment__header__context-menu__content">
     <li>
-      <button type="button" class="link-alt comment__header__context-menu__content-item" data-open="<%= current_user.present? ? "flagModalComment#{model.id}" : "loginModal" %>" title="<%= t("decidim.components.comment.report.title") %>" aria-controls="<%= current_user.present? ? "flagModalComment#{model.id}" : "loginModal" %>" aria-haspopup="true" tabindex="0">
+      <button type="button" class="link-alt comment__header__context-menu__content-item" data-open="<%= current_user.present? ? "flagModalComment#{model.id}" : "loginModal" %>" title="<%= t("decidim.components.comment.report.title") %>" aria-controls="<%= current_user.present? ? "flagModalComment#{model.id}" : "loginModal" %>" aria-haspopup="dialog" tabindex="0">
         <%= icon "flag", class: "icon--small", aria_label: t("decidim.components.comment.report.title") %>
         <span><%= t("decidim.components.comment.report.action") %></span>
       </button>
@@ -17,7 +17,7 @@
     </li>
     <% if model.authored_by?(current_user) %>
       <li>
-      <button type="button" class="link-alt comment__header__context-menu__content-item" data-open="<%= "editCommentModal#{model.id}" %>" title="<%= t("decidim.components.comment.edit") %>" aria-controls="<%= "editCommentModal#{model.id}" %>" aria-haspopup="true" tabindex="0">
+      <button type="button" class="link-alt comment__header__context-menu__content-item" data-open="<%= "editCommentModal#{model.id}" %>" title="<%= t("decidim.components.comment.edit") %>" aria-controls="<%= "editCommentModal#{model.id}" %>" aria-haspopup="dialog" tabindex="0">
           <%= icon "pencil", class: "icon--small", aria_label: t("decidim.components.comment.edit") %>
           <span><%= t("decidim.components.comment.edit") %></span>
       </button>

--- a/decidim-comments/app/cells/decidim/comments/comments/order_control.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/order_control.erb
@@ -12,7 +12,7 @@
       <a href="#" id="comments-order-menu-control"
         aria-label="<%= t("decidim.components.comment_order_selector.title") %>"
         aria-controls="comments-order-menu"
-        aria-haspopup="true"
+        aria-haspopup="menu"
         role="menuitem"><%= t("decidim.components.comment_order_selector.order.#{order}") %></a>
       <ul class="menu is-dropdown-submenu submenu first-sub vertical"
         id="comments-order-chooser-menu"

--- a/decidim-comments/app/cells/decidim/comments/edit_comment_modal_form/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/edit_comment_modal_form/show.erb
@@ -1,6 +1,6 @@
-<div class="reveal edit-comment-modal" id="<%= "editCommentModal#{model.id}" %>" data-reveal>
+<div class="reveal edit-comment-modal" id="<%= "editCommentModal#{model.id}" %>" data-reveal role="dialog" aria-modal="true" aria-labelledby="<%= "editCommentModal#{model.id}" %>-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t("decidim.components.edit_comment_modal_form.title") %></h3>
+    <h3 id="<%= "editCommentModal#{model.id}" %>-label" class="reveal__title"><%= t("decidim.components.edit_comment_modal_form.title") %></h3>
     <button class="close-button" data-close aria-label="<%= t("decidim.components.edit_comment_modal_form.close") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
@@ -114,7 +114,6 @@ describe("CommentsComponent", () => {
                   data-tooltip="true"
                   data-disable-hover="false"
                   data-keep-on-hover="true"
-                  aria-haspopup="true"
                   class="label-required has-tip"
               >
                 <span aria-hidden="true">*</span><span class="show-for-sr">Required field</span>
@@ -170,7 +169,7 @@ describe("CommentsComponent", () => {
               </span>
             </div>
             <div class="author-data__extra">
-                <button type="button" class="link-alt" data-open="flagModalComment${commentId}" title="Report inappropriate content" aria-controls="flagModalComment${commentId}" aria-haspopup="true" tabindex="0">
+                <button type="button" class="link-alt" data-open="flagModalComment${commentId}" title="Report inappropriate content" aria-controls="flagModalComment${commentId}" aria-haspopup="dialog" tabindex="0">
                   <svg role="img" aria-hidden="true" class="icon--flag icon icon--small">
                     <title></title>
                     <use href="/assets/decidim/icons-123.svg#icon-flag"></use>
@@ -261,7 +260,7 @@ describe("CommentsComponent", () => {
     let orderSelector = `
       <ul id="comments-order-menu" class="dropdown menu" data-dropdown-menu="data-dropdown-menu" data-autoclose="false" data-disable-hover="true" data-click-open="true" data-close-on-click="true" tabindex="-1" role="menubar">
         <li class="is-dropdown-submenu-parent opens-right" tabindex="-1" role="none">
-          <a href="#" id="comments-order-menu-control" aria-label="Order by:" aria-controls="comments-order-menu" aria-haspopup="true" role="menuitem">Older</a>
+          <a href="#" id="comments-order-menu-control" aria-label="Order by:" aria-controls="comments-order-menu" aria-haspopup="menu" role="menuitem">Older</a>
           <ul class="menu is-dropdown-submenu submenu first-sub vertical" id="comments-order-chooser-menu" role="menu" aria-labelledby="comments-order-menu-control" tabindex="-1" data-submenu="">
             <li role="none" class="is-submenu-item is-dropdown-submenu-item">
               <a tabindex="-1" role="menuitem" data-remote="true" href="/comments?commentable_gid=commentable-gid&amp;order=best_rated&amp;reload=1">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/index.html.erb
@@ -22,7 +22,7 @@
             <tr>
               <td>
                 <% if conference.promoted? %>
-                  <span data-tooltip class="icon-state icon-highlight" aria-haspopup="true" data-disable-hover="false" title="<%= t("models.conference.fields.promoted", scope: "decidim.admin") %>">
+                  <span data-tooltip class="icon-state icon-highlight" data-disable-hover="false" title="<%= t("models.conference.fields.promoted", scope: "decidim.admin") %>">
                     <%= icon "star", aria_label: t("models.conference.fields.promoted", scope: "decidim.admin"), role: "img" %>
                   </span>
                 <% end %>

--- a/decidim-consultations/app/views/decidim/consultations/consultations/_filters_small_view.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/consultations/_filters_small_view.html.erb
@@ -1,5 +1,5 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     <%= t "consultations.filters_small_view.filter", scope: "decidim" %>
     <%= icon "caret-bottom",
              class: "icon--small float-right",
@@ -8,9 +8,9 @@
   </button>
 </div>
 
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t "consultations.filters_small_view.filter_by", scope: "decidim" %>:</h3>
+    <h3 id="filter-box-label" class="reveal__title"><%= t "consultations.filters_small_view.filter_by", scope: "decidim" %>:</h3>
     <button class="close-button" data-close
             aria-label="<%= t("consultations.filters_small_view.close_modal", scope: "decidim") %>"
             type="button">

--- a/decidim-core/app/cells/decidim/author/flag_user.erb
+++ b/decidim-core/app/cells/decidim/author/flag_user.erb
@@ -1,5 +1,5 @@
 <% if user_flaggable? && model.try(:id) != current_user.try(:id) %>
-  <button type="button" class="link-alt" data-open="<%= current_user.present? ? "flagUserModal" : "loginModal" %>" title="<%= t("report", scope: "decidim.proposals.proposals.show") %>" aria-controls="<%= current_user.present? ? "flagUserModal" : "loginModal" %>" aria-haspopup="true" tabindex="0">
+  <button type="button" class="link-alt" data-open="<%= current_user.present? ? "flagUserModal" : "loginModal" %>" title="<%= t("report", scope: "decidim.proposals.proposals.show") %>" aria-controls="<%= current_user.present? ? "flagUserModal" : "loginModal" %>" aria-haspopup="dialog" tabindex="0">
     <%= icon "flag", aria_hidden: true, class: "icon--small", role: "img", "aria-hidden": true %>
     <span class="show-for-sr">
         <%= t("report", scope: "decidim.proposals.proposals.show") %>

--- a/decidim-core/app/cells/decidim/flag_modal/flag_user.erb
+++ b/decidim-core/app/cells/decidim/flag_modal/flag_user.erb
@@ -1,6 +1,6 @@
-<div class="reveal flag-modal" id="flagUserModal" data-reveal>
+<div class="reveal flag-modal" id="flagUserModal" data-reveal role="dialog" aria-modal="true" aria-labelledby="flagUserModal-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t("decidim.shared.flag_user_modal.title") %></h3>
+    <h3 id="flagUserModal-label" class="reveal__title"><%= t("decidim.shared.flag_user_modal.title") %></h3>
     <button class="close-button" data-close aria-label="<%= t("decidim.shared.flag_user_modal.close") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-core/app/cells/decidim/flag_modal/show.erb
+++ b/decidim-core/app/cells/decidim/flag_modal/show.erb
@@ -1,6 +1,6 @@
-<div class="reveal flag-modal" id="<%= modal_id %>" data-reveal>
+<div class="reveal flag-modal" id="<%= modal_id %>" data-reveal role="dialog" aria-modal="true" aria-labelledby="<%= modal_id %>-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t("decidim.shared.flag_modal.title") %></h3>
+    <h3 id="<%= modal_id %>-label" class="reveal__title"><%= t("decidim.shared.flag_modal.title") %></h3>
     <button class="close-button" data-close aria-label="<%= t("decidim.shared.flag_modal.close") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-core/app/views/decidim/searches/_filters_small_view.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters_small_view.html.erb
@@ -1,13 +1,13 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     <%= t ".filter" %>
     <%= icon "caret-bottom", class: "icon--small float-right", aria_label: t(".unfold"), role: "img" %>
   </button>
 </div>
 
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t ".filter_by" %>:</h3>
+    <h3 id="filter-box-label" class="reveal__title"><%= t ".filter_by" %>:</h3>
     <button class="close-button" data-close aria-label="<%= t(".close_modal") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-core/app/views/decidim/shared/_login_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_login_modal.html.erb
@@ -1,6 +1,6 @@
-<div class="reveal" id="loginModal" data-reveal>
+<div class="reveal" id="loginModal" data-reveal role="dialog" aria-modal="true" aria-labelledby="loginModal-label">
   <div class="reveal__header">
-    <h2 class="reveal__title"><%= t(".please_sign_in") %></h2>
+    <h2 id="loginModal-label" class="reveal__title"><%= t(".please_sign_in") %></h2>
     <button class="close-button" data-close aria-label="<%= t(".close_modal") %>"
       type="button">
       <span aria-hidden="true">&times;</span>

--- a/decidim-core/app/views/decidim/shared/_orders.html.erb
+++ b/decidim-core/app/views/decidim/shared/_orders.html.erb
@@ -9,7 +9,7 @@
       data-close-on-click="true"
       role="menubar">
       <li class="is-dropdown-submenu-parent" role="presentation">
-        <a href="#" id="<%= menu_id %>-control" aria-controls="<%= menu_id %>" aria-haspopup="true" title="<%= t("#{i18n_scope}.label") %>" role="menuitem"><%= t("#{i18n_scope}.#{order}") %></a>
+        <a href="#" id="<%= menu_id %>-control" aria-controls="<%= menu_id %>" aria-haspopup="menu" title="<%= t("#{i18n_scope}.label") %>" role="menuitem"><%= t("#{i18n_scope}.#{order}") %></a>
 
         <ul id="<%= menu_id %>" class="menu" role="menu" aria-labelledby="<%= menu_id %>-control">
           <% orders.each do |order_name| %>

--- a/decidim-core/app/views/decidim/shared/_results_per_page.html.erb
+++ b/decidim-core/app/views/decidim/shared/_results_per_page.html.erb
@@ -9,7 +9,7 @@
       data-close-on-click="true"
       role="menubar">
       <li class="is-dropdown-submenu-parent" role="presentation">
-        <a href="#" id="<%= menu_id %>-control" aria-controls="<%= menu_id %>" aria-haspopup="true" title="<%= t("decidim.shared.results_per_page.title") %>" role="menuitem"><%= per_page %></a>
+        <a href="#" id="<%= menu_id %>-control" aria-controls="<%= menu_id %>" aria-haspopup="menu" title="<%= t("decidim.shared.results_per_page.title") %>" role="menuitem"><%= per_page %></a>
         <ul id="<%= menu_id %>" class="menu" role="menu" aria-labelledby="<%= menu_id %>-control">
           <% Decidim::Paginable::OPTIONS.each do |per_page_option| %>
             <li role="presentation">

--- a/decidim-core/app/views/decidim/shared/participatory_space_filters/_filters_small_view.html.erb
+++ b/decidim-core/app/views/decidim/shared/participatory_space_filters/_filters_small_view.html.erb
@@ -1,13 +1,13 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     <%= t("filter", scope: "decidim.searches.filters_small_view") %>
     <%= icon "caret-bottom", class: "icon--small float-right", aria_label: t("unfold", scope: "decidim.searches.filters_small_view"), role: "img" %>
   </button>
 </div>
 
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t("filter_by", scope: "decidim.searches.filters_small_view") %>:</h3>
+    <h3 id="filter-box-label" class="reveal__title"><%= t("filter_by", scope: "decidim.searches.filters_small_view") %>:</h3>
     <button class="close-button" data-close aria-label="<%= 't("close_modal", scope: "decidim.searches.filters_small_view")' %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-core/app/views/layouts/decidim/_language_chooser.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_language_chooser.html.erb
@@ -7,7 +7,7 @@
       data-close-on-click="true"
       role="menubar">
       <li class="is-dropdown-submenu-parent" role="presentation">
-        <%= link_to t("name", scope: "locale"), "#language-chooser-menu", id: "language-chooser-control", "aria-label": t("layouts.decidim.language_chooser.choose_language"), "aria-controls": "language-chooser-menu", "aria-haspopup": "true", role: "menuitem" %>
+        <%= link_to t("name", scope: "locale"), "#language-chooser-menu", id: "language-chooser-control", "aria-label": t("layouts.decidim.language_chooser.choose_language"), "aria-controls": "language-chooser-menu", "aria-haspopup": "menu", role: "menuitem" %>
         <ul class="menu is-dropdown-submenu" id="language-chooser-menu" role="menu" aria-labelledby="language-chooser-control">
           <% (available_locales - [I18n.locale.to_s]).each do |locale| %>
             <li lang="<%= locale %>" role="presentation"><%= link_to locale_name(locale), decidim.locale_path(locale: locale), method: :post, role: "menuitem" %></li>

--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -66,7 +66,7 @@ end
                     data-close-on-click="true"
                     role="menubar">
                     <li class="is-dropdown-submenu-parent show-for-medium" role="presentation">
-                      <%= link_to current_user.name, decidim.account_path, id: "user-menu-control", "aria-controls": "user-menu", "aria-haspopup": "true", "aria-label": t("layouts.decidim.user_menu.account", name: current_user.name), "role": "menuitem" %>
+                      <%= link_to current_user.name, decidim.account_path, id: "user-menu-control", "aria-controls": "user-menu", "aria-haspopup": "menu", "aria-label": t("layouts.decidim.user_menu.account", name: current_user.name), "role": "menuitem" %>
                       <ul class="menu is-dropdown-submenu" id="user-menu" role="menu" aria-labelledby="user-menu-control">
                         <%= render partial: "layouts/decidim/user_menu" %>
                       </ul>

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -780,7 +780,6 @@ module Decidim
           visible_title + screenreader_title,
           title: I18n.t("required", scope: "forms"),
           data: { tooltip: true, disable_hover: false, keep_on_hover: true },
-          "aria-haspopup": true,
           class: "label-required"
         ).html_safe
       end

--- a/decidim-debates/app/views/decidim/debates/debates/_close_debate_modal.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_close_debate_modal.html.erb
@@ -1,6 +1,6 @@
-<div class="reveal close-debate-modal" id="closeDebateModal" data-reveal>
+<div class="reveal close-debate-modal" id="closeDebateModal" data-reveal role="dialog" aria-modal="true" aria-labelledby="closeDebateModal-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t("decidim.debates.debates.show.close_debate") %></h3>
+    <h3 id="closeDebateModal-label" class="reveal__title"><%= t("decidim.debates.debates.show.close_debate") %></h3>
     <button class="close-button" data-close aria-label="<%= t(".close") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-debates/app/views/decidim/debates/debates/_filters_small_view.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_filters_small_view.html.erb
@@ -1,13 +1,13 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     <%= t ".filter" %>
     <%= icon "caret-bottom", class: "icon--small float-right", aria_label: t(".unfold"), role: "img" %>
   </button>
 </div>
 
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t ".filter_by" %>:</h3>
+    <h3 id="filter-box-label" class="reveal__title"><%= t ".filter_by" %>:</h3>
     <button class="close-button" data-close aria-label="<%= t(".close_modal") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -37,7 +37,7 @@ edit_link(
     <% end %>
     <% close_debate_action_text = (debate.closed? ? ".edit_conclusions" : ".close_debate" ) %>
     <% if allowed_to?(:close, :debate, debate: debate) %>
-      <button type="button" data-open="closeDebateModal" title="<%= t(close_debate_action_text) %>" aria-controls="closeDebateModal" aria-haspopup="true" tabindex="0" class="button hollow expanded button-sc button--icon follow-button">
+      <button type="button" data-open="closeDebateModal" title="<%= t(close_debate_action_text) %>" aria-controls="closeDebateModal" aria-haspopup="dialog" tabindex="0" class="button hollow expanded button-sc button--icon follow-button">
         <%= t(close_debate_action_text) %>
       </button>
     <% elsif admin_allowed_to?(:close, :debate, debate: debate) %>

--- a/decidim-elections/app/views/decidim/elections/elections/_filters_small_view.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/_filters_small_view.html.erb
@@ -1,13 +1,13 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     <%= t ".filter" %>
     <%= icon "caret-bottom", class: "icon--small float-right", aria_label: t(".unfold"), role: "img" %>
   </button>
 </div>
 
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t ".filter_by" %>:</h3>
+    <h3 id="filter-box-label" class="reveal__title"><%= t ".filter_by" %>:</h3>
     <button class="close-button" data-close aria-label="<%= t(".close_modal") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-elections/app/views/decidim/votings/admin/votings/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/votings/index.html.erb
@@ -26,7 +26,7 @@
             <tr>
               <td>
                 <% if voting.promoted? %>
-                  <span data-tooltip class="icon-state icon-highlight" aria-haspopup="true" data-disable-hover="false" title="<%= t("models.voting.fields.promoted", scope: "decidim.votings.admin") %>">
+                  <span data-tooltip class="icon-state icon-highlight" data-disable-hover="false" title="<%= t("models.voting.fields.promoted", scope: "decidim.votings.admin") %>">
                     <%= icon "star" %>
                   </span>
                 <% end %>

--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/_modal_ballots_count_error.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/_modal_ballots_count_error.html.erb
@@ -1,9 +1,10 @@
 <div id="wrapper-modal-closure-count-error">
-  <div class="reveal" data-reveal id="modal-closure-count-error" data-append-to="div#wrapper-modal-closure-count-error">
+  <div class="reveal" data-reveal id="modal-closure-count-error" data-append-to="div#wrapper-modal-closure-count-error" role="dialog" aria-modal="true" aria-labelledby="modal-closure-count-error-label">
     <div class="reveal__header">
       <%= content_tag :h3,
                       t("title", scope: "decidim.votings.polling_officer_zone.closures.new.modal_ballots_count_error"),
-                      class: "reveal__title" %>
+                      class: "reveal__title",
+                      id: "modal-closure-count-error-label" %>
 
       <button class="close-button" data-close aria-label="<%= t("close_modal", scope: "decidim.votings.polling_officer_zone.closures.new.modal_ballots_count_error") %>" type="button">
         <span aria-hidden="true">×</span>

--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/_modal_ballots_results_count_error.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/_modal_ballots_results_count_error.html.erb
@@ -1,8 +1,9 @@
-<div class="reveal" data-reveal id="modal-closure-results-count-error">
+<div class="reveal" data-reveal id="modal-closure-results-count-error" role="dialog" aria-modal="true" aria-labelledby="modal-closure-results-count-error-label">
   <div class="reveal__header">
     <%= content_tag :h3,
                     t("title", scope: "decidim.votings.polling_officer_zone.closures.edit.modal_ballots_results_count_error"),
-                    class: "reveal__title" %>
+                    class: "reveal__title",
+                    id: "modal-closure-results-count-error-label" %>
 
     <button class="close-button" data-close aria-label="<%= t("close_modal", scope: "decidim.votings.polling_officer_zone.closures.edit.modal_ballots_results_count_error") %>" type="button">
       <span aria-hidden="true">×</span>

--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/_sign_form.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/_sign_form.html.erb
@@ -15,17 +15,18 @@
                   data: { open: "modal-closure-sign" },
                   aria: {
                     controls: "modal-closure-sign",
-                    haspopup: true
+                    haspopup: "dialog"
                   },
                   disabled: true,
                   tabindex: "0" %>
 
   <div id="wrapper-modal-closure-sign">
-    <div class="reveal" data-reveal id="modal-closure-sign" data-append-to="div#wrapper-modal-closure-sign">
+    <div class="reveal" data-reveal id="modal-closure-sign" data-append-to="div#wrapper-modal-closure-sign" role="dialog" aria-modal="true" aria-labelledby="modal-closure-sign-label">
       <div class="reveal__header">
         <%= content_tag :h3,
                         t("title", scope: "decidim.votings.polling_officer_zone.closures.sign"),
-                        class: "reveal__title" %>
+                        class: "reveal__title",
+                        id: "modal-closure-sign-label" %>
 
         <button class="close-button" data-close aria-label="<%= t("close_modal", scope: "decidim.votings.polling_officer_zone.closures.sign") %>" type="button">
           <span aria-hidden="true">×</span>

--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/edit.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/edit.html.erb
@@ -39,7 +39,7 @@
                   data: { open: "modal-closure-results-count-error" },
                   aria: {
                           controls:"modal-closure-results-count-error",
-                          haspopup: "true"
+                          haspopup: "dialog"
                         } %>
 <% end %>
 

--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/new.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/closures/new.html.erb
@@ -48,7 +48,7 @@
 
               <%= render "modal_ballots_count_error", form: form %>
 
-              <button id="btn-modal-closure-count-error" class="button button--sc expanded mt-sm mb-none hide" data-open="modal-closure-count-error" aria-controls="modal-closure-count-error" aria-haspopup="true" tabindex="0">
+              <button id="btn-modal-closure-count-error" class="button button--sc expanded mt-sm mb-none hide" data-open="modal-closure-count-error" aria-controls="modal-closure-count-error" aria-haspopup="dialog" tabindex="0">
                 <%= t(".submit") %>
               </button>
             <% end %>

--- a/decidim-elections/app/views/decidim/votings/votings/_filters_small_view.html.erb
+++ b/decidim-elections/app/views/decidim/votings/votings/_filters_small_view.html.erb
@@ -1,5 +1,5 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     <%= t ".filter" %>
     <%= icon "caret-bottom",
              class: "icon--small float-right",
@@ -8,9 +8,9 @@
   </button>
 </div>
 
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t ".filter_by" %>:</h3>
+    <h3 id="filter-box-label" class="reveal__title"><%= t ".filter_by" %>:</h3>
     <button class="close-button" data-close
             aria-label="<%= t(".close_modal") %>"
             type="button">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_filters_small_view.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_filters_small_view.html.erb
@@ -1,13 +1,13 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     <%= t ".filter" %>
     <%= icon "caret-bottom", class: "icon--small float-right", aria_label: t(".unfold"), role: "img" %>
   </button>
 </div>
 
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t ".filter_by" %>:</h3>
+    <h3 id="filter-box-label" class="reveal__title"><%= t ".filter_by" %>:</h3>
     <button class="close-button" data-close aria-label="<%= t(".close_modal") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_index_header.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_index_header.html.erb
@@ -9,13 +9,13 @@
         <%= icon "plus", role: "img", "aria-hidden": true %>
       <% end %>
     <% elsif current_user %>
-      <button type="button" class="title-action__action button small" data-open="not-authorized-modal" aria-controls="not-authorized-modal" aria-haspopup="true" tabindex="0">
+      <button type="button" class="title-action__action button small" data-open="not-authorized-modal" aria-controls="not-authorized-modal" aria-haspopup="dialog" tabindex="0">
         <%= t(".new_initiative") %>
         <%= icon "plus", role: "img", "aria-hidden": true %>
       </button>
     <% else %>
       <% content_for(:redirect_after_login) { create_initiative_url(:select_initiative_type) } %>
-      <button type="button" class="title-action__action button small" data-open="loginModal" aria-controls="loginModal" aria-haspopup="true" tabindex="0">
+      <button type="button" class="title-action__action button small" data-open="loginModal" aria-controls="loginModal" aria-haspopup="dialog" tabindex="0">
         <%= t(".new_initiative") %>
         <%= icon "plus", role: "img", "aria-hidden": true %>
       </button>
@@ -23,7 +23,7 @@
   <% end %>
 </div>
 
-<div class="reveal not-authorized-reveal" id="not-authorized-modal" aria-hidden="true" role="dialog" aria-labelledby="not-authorized-modal-title" data-reveal data-multiple-opened="true">
+<div class="reveal not-authorized-reveal" id="not-authorized-modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="not-authorized-modal-title" data-reveal data-multiple-opened="true">
   <div class="reveal__header">
     <h2 class="reveal__title" id="not-authorized-modal-title"><%= t(".not_authorized.title") %></h2>
     <button class="close-button" data-close aria-label="<%= t(".not_authorized.close") %>"

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters_small_view.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters_small_view.html.erb
@@ -1,13 +1,13 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     <%= t ".filter" %>
     <%= icon "caret-bottom", class: "icon--small float-right", aria_label: t(".unfold"), role: "img" %>
   </button>
 </div>
 
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t ".filter_by" %>:</h3>
+    <h3 id="filter-box-label" class="reveal__title"><%= t ".filter_by" %>:</h3>
     <button class="close-button" data-close aria-label="<%= t(".close_modal") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/highlighted_participatory_processes/filters_small_view.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/highlighted_participatory_processes/filters_small_view.erb
@@ -1,13 +1,13 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     <%= t("filter", scope: "decidim.searches.filters_small_view") %>
     <%= icon "caret-bottom", class: "icon--small float-right", aria_label: t("unfold", scope: "decidim.searches.filters_small_view"), role: "img" %>
   </button>
 </div>
 
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t("filter_by", scope: "decidim.searches.filters_small_view") %>:</h3>
+    <h3 id="filter-box-label" class="reveal__title"><%= t("filter_by", scope: "decidim.searches.filters_small_view") %>:</h3>
     <button class="close-button" data-close aria-label="<%= 't("close_modal", scope: "decidim.searches.filters_small_view")' %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/index.html.erb
@@ -29,7 +29,7 @@
             <tr>
               <td>
                 <% if group.promoted? %>
-                  <span data-tooltip class="icon-state icon-highlight" aria-haspopup="true" data-disable-hover="false" title="<%= t("models.participatory_process.fields.promoted", scope: "decidim.admin") %>">
+                  <span data-tooltip class="icon-state icon-highlight" data-disable-hover="false" title="<%= t("models.participatory_process.fields.promoted", scope: "decidim.admin") %>">
                     <%= icon "star" %>
                   </span>
                 <% end %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
@@ -70,7 +70,7 @@
             <tr>
               <td>
                 <% if process.promoted? %>
-                  <span data-tooltip class="icon-state icon-highlight" aria-haspopup="true" data-disable-hover="false" title="<%= t("models.participatory_process.fields.promoted", scope: "decidim.admin") %>">
+                  <span data-tooltip class="icon-state icon-highlight" data-disable-hover="false" title="<%= t("models.participatory_process.fields.promoted", scope: "decidim.admin") %>">
                     <%= icon "star" %>
                   </span>
                 <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_filters_small_view.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_filters_small_view.html.erb
@@ -1,13 +1,13 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     <%= t ".filter" %>
     <%= icon "caret-bottom", class: "icon--small float-right", aria_label: t(".unfold"), role: "img" %>
   </button>
 </div>
 
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t ".filter_by" %>:</h3>
+    <h3 id="filter-box-label" class="reveal__title"><%= t ".filter_by" %>:</h3>
     <button class="close-button" data-close aria-label="<%= t(".close_modal") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters_small_view.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters_small_view.html.erb
@@ -1,13 +1,13 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     <%= t ".filter" %>
     <%= icon "caret-bottom", class: "icon--small float-right", aria_label: t(".unfold"), role: "img" %>
   </button>
 </div>
 
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t ".filter_by" %>:</h3>
+    <h3 id="filter-box-label" class="reveal__title"><%= t ".filter_by" %>:</h3>
     <button class="close-button" data-close aria-label="<%= t(".close_modal") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/_filters_small_view.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/_filters_small_view.html.erb
@@ -1,13 +1,13 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     <%= t ".filter" %>
     <%= icon "caret-bottom", class: "icon--small float-right", aria_label: t(".unfold"), role: "img" %>
   </button>
 </div>
 
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title"><%= t ".filter_by" %>:</h3>
+    <h3 id="filter-box-label" class="reveal__title"><%= t ".filter_by" %>:</h3>
     <button class="close-button" data-close aria-label="<%= t(".close_modal") %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/decidim_app-design/app/views/admin/component-meetings.html.erb
+++ b/decidim_app-design/app/views/admin/component-meetings.html.erb
@@ -35,9 +35,9 @@
                   20/02/17
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
             </tbody>

--- a/decidim_app-design/app/views/admin/old/component-proposals.html.erb
+++ b/decidim_app-design/app/views/admin/old/component-proposals.html.erb
@@ -37,8 +37,8 @@
                   <a href="#" class="button tiny">Responder</a>
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
                 </td>
               </tr>
               <tr>
@@ -51,8 +51,8 @@
                   <strong class="text-success">Aprobado</strong>
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
                 </td>
               </tr>
               <tr>
@@ -65,8 +65,8 @@
                   <strong class="text-alert">Rechazado</strong>
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
                 </td>
               </tr>
             </tbody>

--- a/decidim_app-design/app/views/admin/pages.html.erb
+++ b/decidim_app-design/app/views/admin/pages.html.erb
@@ -28,9 +28,9 @@
                   Información FAQ
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
               <tr>
@@ -38,9 +38,9 @@
                   Información Términos y Condiciones
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
               <tr>
@@ -48,9 +48,9 @@
                   Información Accesibilidad
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
             </tbody>

--- a/decidim_app-design/app/views/admin/process-admin.html.erb
+++ b/decidim_app-design/app/views/admin/process-admin.html.erb
@@ -34,8 +34,8 @@
                   lorena@decidim.org
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
             </tbody>

--- a/decidim_app-design/app/views/admin/process-categories.html.erb
+++ b/decidim_app-design/app/views/admin/process-categories.html.erb
@@ -31,8 +31,8 @@
                   Categoría 1
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
               <tr>
@@ -40,8 +40,8 @@
                   Categoría 2
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
             </tbody>

--- a/decidim_app-design/app/views/admin/process-docs.html.erb
+++ b/decidim_app-design/app/views/admin/process-docs.html.erb
@@ -35,8 +35,8 @@
                   PDF
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
               <tr>
@@ -47,8 +47,8 @@
                   JPG
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
             </tbody>

--- a/decidim_app-design/app/views/admin/process-moderations.html.erb
+++ b/decidim_app-design/app/views/admin/process-moderations.html.erb
@@ -40,8 +40,8 @@
                 <td>1</td>
 
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Cancelar denuncia" class="action-icon"><%= icon "action-undo" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Esconder" class="action-icon action-icon--hide"><%= icon "eye" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Cancelar denuncia" class="action-icon"><%= icon "action-undo" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Esconder" class="action-icon action-icon--hide"><%= icon "eye" %></a>
                 </td>
               </tr>
             </tbody>

--- a/decidim_app-design/app/views/admin/process-pages.html.erb
+++ b/decidim_app-design/app/views/admin/process-pages.html.erb
@@ -30,9 +30,9 @@
                   Información de la votación
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Ver" class="action-icon"><%= icon "eye" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
             </tbody>

--- a/decidim_app-design/app/views/admin/process-steps.html.erb
+++ b/decidim_app-design/app/views/admin/process-steps.html.erb
@@ -39,13 +39,13 @@
                   15/01/17
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
               <tr>
                 <td>
-                  <span data-tooltip aria-haspopup="true" data-disable-hover="false" title="Fase activa">
+                  <span data-tooltip data-disable-hover="false" title="Fase activa">
                     <span class="icon-active"></span>
                   </span>
                   <a href="#">Fase 2: Recogida de propuestas</a>
@@ -57,8 +57,8 @@
                   08/06/17
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
               <tr>
@@ -72,8 +72,8 @@
                   12/09/17
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Editar" class="action-icon"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
             </tbody>

--- a/decidim_app-design/app/views/admin/processes.html.erb
+++ b/decidim_app-design/app/views/admin/processes.html.erb
@@ -26,7 +26,7 @@
             <tbody>
               <tr>
                 <td>
-                  <span data-tooltip class="icon-state icon-highlight" aria-haspopup="true" data-disable-hover="false" title="Destacado"><%= icon "star" %></span>
+                  <span data-tooltip class="icon-state icon-highlight" data-disable-hover="false" title="Destacado"><%= icon "star" %></span>
                   <%= link_to page_path("process-info") do %>
                     Proposa, prioritza i decideix sobre el pressupost del districte de l’Eixample
                   <% end %>
@@ -35,8 +35,8 @@
                   <strong class="text-success">Publicado</strong>
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" class="action-icon" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar"><%= icon "pencil" %></a>
-                  <a href="#" class="action-icon" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Previsualizar"><%= icon "eye" %></a>
+                  <a href="#" class="action-icon" data-tooltip data-disable-hover="false" title="Editar"><%= icon "pencil" %></a>
+                  <a href="#" class="action-icon" data-tooltip data-disable-hover="false" title="Previsualizar"><%= icon "eye" %></a>
                 </td>
               </tr>
               <tr>
@@ -49,8 +49,8 @@
                   <strong class="text-alert">Sin publicar</strong>
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" class="action-icon" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar"><%= icon "pencil" %></a>
-                  <a href="#" class="action-icon" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Previsualizar"><%= icon "eye" %></a>
+                  <a href="#" class="action-icon" data-tooltip data-disable-hover="false" title="Editar"><%= icon "pencil" %></a>
+                  <a href="#" class="action-icon" data-tooltip data-disable-hover="false" title="Previsualizar"><%= icon "eye" %></a>
                 </td>
               </tr>
               <tr>
@@ -63,8 +63,8 @@
                   <strong class="text-muted">Borrador</strong>
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" class="action-icon" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar"><%= icon "pencil" %></a>
-                  <a href="#" class="action-icon" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Previsualizar"><%= icon "eye" %></a>
+                  <a href="#" class="action-icon" data-tooltip data-disable-hover="false" title="Editar"><%= icon "pencil" %></a>
+                  <a href="#" class="action-icon" data-tooltip data-disable-hover="false" title="Previsualizar"><%= icon "eye" %></a>
                 </td>
               </tr>
               <tr>
@@ -77,8 +77,8 @@
                   <strong class="text-success">Publicado</strong>
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" class="action-icon" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar"><%= icon "pencil" %></a>
-                  <a href="#" class="action-icon" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Previsualizar"><%= icon "eye" %></a>
+                  <a href="#" class="action-icon" data-tooltip data-disable-hover="false" title="Editar"><%= icon "pencil" %></a>
+                  <a href="#" class="action-icon" data-tooltip data-disable-hover="false" title="Previsualizar"><%= icon "eye" %></a>
                 </td>
               </tr>
             </tbody>

--- a/decidim_app-design/app/views/admin/scope-browse.html.erb
+++ b/decidim_app-design/app/views/admin/scope-browse.html.erb
@@ -34,7 +34,7 @@
                 </td>
                 <td class="table-list__actions">
                   <%= link_to page_path("scope-edit"), class: "action-icon", data: { :tooltip => true, :haspopup => true, :'disable-hover' => false }, title: "Editar" do %><%= icon "pencil" %><% end %>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                   </td>
               </tr>
             </tbody>

--- a/decidim_app-design/app/views/admin/scope-sub-browse.html.erb
+++ b/decidim_app-design/app/views/admin/scope-sub-browse.html.erb
@@ -35,8 +35,8 @@
                   subdistrito
                 </td>
                 <td class="table-list__actions">
-                  <%= link_to page_path("scope-edit"), class: "action-icon", data: { :tooltip => true, :'aria-haspopup' => "true", :'disable-hover' => "false" }, title: "Editar" do %><%= icon "pencil" %><% end %>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
+                  <%= link_to page_path("scope-edit"), class: "action-icon", data: { :tooltip => true, :'disable-hover' => "false" }, title: "Editar" do %><%= icon "pencil" %><% end %>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
               </tr>
               <tr>
                 <td>
@@ -47,7 +47,7 @@
                 </td>
                 <td class="table-list__actions">
                   <%= link_to page_path("scope-edit"), class: "action-icon", data: { :tooltip => true, :haspopup => true, :'disable-hover' => false }, title: "Editar" do %><%= icon "pencil" %><% end %>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
               </tr>
             </tbody>
           </table>

--- a/decidim_app-design/app/views/admin/settings-scope-types.html.erb
+++ b/decidim_app-design/app/views/admin/settings-scope-types.html.erb
@@ -33,8 +33,8 @@
                   provincias
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" class="action-icon" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
+                  <a href="#" class="action-icon" data-tooltip data-disable-hover="false" title="Editar"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
               </tr>
               <tr>
                 <td>
@@ -44,8 +44,8 @@
                   distritos
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" class="action-icon" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Editar"><%= icon "pencil" %></a>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
+                  <a href="#" class="action-icon" data-tooltip data-disable-hover="false" title="Editar"><%= icon "pencil" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
               </tr>
             </tbody>
           </table>

--- a/decidim_app-design/app/views/admin/settings-scopes.html.erb
+++ b/decidim_app-design/app/views/admin/settings-scopes.html.erb
@@ -34,7 +34,7 @@
                 </td>
                 <td class="table-list__actions">
                   <%= link_to page_path("scope-edit"), class: "action-icon", data: { :tooltip => true, :haspopup => true, :'disable-hover' => false }, title: "Editar" do %><%= icon "pencil" %><% end %>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
               </tr>
               <tr>
                 <td>
@@ -45,7 +45,7 @@
                 </td>
                 <td class="table-list__actions">
                   <%= link_to page_path("scope-edit"), class: "action-icon", data: { :tooltip => true, :haspopup => true, :'disable-hover' => false }, title: "Editar" do %><%= icon "pencil" %><% end %>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
               </tr>
               <tr>
                 <td>
@@ -56,7 +56,7 @@
                 </td>
                 <td class="table-list__actions">
                   <%= link_to page_path("scope-edit"), class: "action-icon", data: { :tooltip => true, :haspopup => true, :'disable-hover' => false }, title: "Editar" do %><%= icon "pencil" %><% end %>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
               </tr>
               <tr>
                 <td>
@@ -67,7 +67,7 @@
                 </td>
                 <td class="table-list__actions">
                   <%= link_to page_path("scope-edit"), class: "action-icon", data: { :tooltip => true, :haspopup => true, :'disable-hover' => false }, title: "Editar" do %><%= icon "pencil" %><% end %>
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>                </td>
               </tr>
             </tbody>
           </table>

--- a/decidim_app-design/app/views/admin/users.html.erb
+++ b/decidim_app-design/app/views/admin/users.html.erb
@@ -37,7 +37,7 @@
                   12/01/17
                 </td>
                 <td class="table-list__actions">
-                  <a href="#" data-tooltip aria-haspopup="true" data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
+                  <a href="#" data-tooltip data-disable-hover="false" title="Eliminar" class="action-icon action-icon--remove"><%= icon "circle-x" %></a>
                 </td>
               </tr>
             </tbody>

--- a/decidim_app-design/app/views/public/partials/_filters_small_view.html.erb
+++ b/decidim_app-design/app/views/public/partials/_filters_small_view.html.erb
@@ -1,12 +1,12 @@
 <div class="filters-controls hide-for-mediumlarge">
-  <button data-open="filter-box" class="filters-controls__trigger">
+  <button data-open="filter-box" class="filters-controls__trigger" aria-controls="filter-box" aria-haspopup="dialog">
     Filtrar
     <%= icon "caret-bottom", class: "icon--small float-right", aria_label: "Desplegar", role: "img" %>
   </button>
 </div>
-<div class="reveal" id="filter-box" data-reveal>
+<div class="reveal" id="filter-box" data-reveal role="dialog" aria-modal="true" aria-labelledby="filter-box-label">
   <div class="reveal__header">
-    <h3 class="reveal__title">Filtrar por:</h3>
+    <h3 id="filter-box-label" class="reveal__title">Filtrar por:</h3>
     <button class="close-button" data-close aria-label="Close modal" type="button">
       <span aria-hidden="true">&times;</span>
     </button>


### PR DESCRIPTION
#### :tophat: What? Why?
There are several places where dialog controls and tooltip controls have incorrect ARIA roles. Also, the dialogs themselves do not have all ARIA attributes defined for them. This PR fixes those.

This also marks the ARIA role `menu` for the menu controls which is currently the suggested role for those elements, although it is technically the same as `aria-role="true"`. This clarifies these elements for further use.

https://www.w3.org/TR/wai-aria-1.1/#dialog
https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup

> A popup element usually appears as a block of content that is on top of other content. Authors MUST ensure that the role of the element that serves as the container for the popup content is menu, listbox, tree, grid, or dialog, and that the value of aria-haspopup matches the role of the popup container.

Regarding tooltips, there is no `aria-haspopup` role defined at the official documentation.

According to this, tooltips should not have the `aria-haspopup` attribute:
https://sarahmhigley.com/writing/tooltips-in-wcag-21/

> `aria-haspopup`: although a tooltip may visually look like a popup, this attribute is for more interactive popups -- specifically only menus, listboxes, trees, grids, and dialogs are allowed in conjunction with `aria-haspopup`. Using a generic value of `aria-haspopup="true"` will be interpreted as if it were `aria-haspopup="menu"`. Since tooltips are not intended to be interacted with or navigated to, `aria-haspopup` should not be used to indicate a tooltip.

#### :pushpin: Related Issues

- Related to #6253, #6246, #5684

#### Testing
Read the W3C docs.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.