### PR TITLE
Improve dialog accessibility

### DIFF
--- a/decidim-core/app/packs/src/decidim/dialog_mode.js
+++ b/decidim-core/app/packs/src/decidim/dialog_mode.js
@@ -1,0 +1,143 @@
+const focusGuardClass = "focusguard";
+const focusableNodes = ["A", "IFRAME", "OBJECT", "EMBED"];
+const focusableDisableableNodes = ["BUTTON", "INPUT", "TEXTAREA", "SELECT"];
+
+const isFocusGuard = (element) => {
+  return element.classList.contains(focusGuardClass);
+}
+
+const isFocusable = (element) => {
+  if (focusableNodes.indexOf(element.nodeName) > -1) {
+    return true;
+  }
+  if (focusableDisableableNodes.indexOf(element.nodeName) > -1 || element.getAttribute("contenteditable")) {
+    if (element.getAttribute("disabled")) {
+      return false;
+    }
+    return true;
+  }
+
+  const tabindex = parseInt(element.getAttribute("tabindex"), 10);
+  if (!isNaN(tabindex) && tabindex >= 0) {
+    return true;
+  }
+
+  return false;
+}
+
+const createFocusGuard = (position) => {
+  return $(`<div class="${focusGuardClass}" data-position="${position}" tabindex="0" aria-hidden="true"></div>`);
+};
+
+const handleContainerFocus = ($container, $guard) => {
+  const $reveal = $(".reveal:visible:last", $container);
+  if ($reveal.length > 0) {
+    handleContainerFocus($reveal, $guard);
+    return;
+  }
+
+  const $nodes = $("*:visible", $container);
+  let $target = null;
+
+  if ($guard.data("position") === "start") {
+    // Focus at the start guard, so focus the first focusable element after that
+    for (let ind = 0; ind < $nodes.length; ind += 1) {
+      if (!isFocusGuard($nodes[ind]) && isFocusable($nodes[ind])) {
+        $target = $($nodes[ind]);
+        break;
+      }
+    }
+  } else {
+    // Focus at the end guard, so focus the first focusable element after that
+    for (let ind = $nodes.length - 1; ind >= 0; ind -= 1) {
+      if (!isFocusGuard($nodes[ind]) && isFocusable($nodes[ind])) {
+        $target = $($nodes[ind]);
+        break;
+      }
+    }
+  }
+
+  if ($target) {
+    $target.trigger("focus");
+  } else {
+    // If no focusable element was found, blur the guard focus
+    $guard.blur();
+  }
+};
+
+/**
+ * A method to enable the dialog mode for the given dialog(s).
+ *
+ * This should be called when the dialog is opened. It implements two things for
+ * the dialog:
+ * 1. It places the focus to the title element making sure the screen reader
+ *    focuses in the correct position of the document. Otherwise some screen
+ *    readers continue reading outside of the document.
+ * 2. Document "tab guards" that force the keyboard focus within the modal when
+ *    the user is using keyboard or keyboard emulating devices for browsing the
+ *    document.
+ *
+ * The "tab guards" are added at the top and bottom of the document to keep the
+ * user's focus within the dialog if they accidentally or intentionally place
+ * the focus outside of the document, e.g. in different window or in the browser
+ * address bar. They guard the focus on both sides of the document returning
+ * focus back to the first or last focusable element within the dialog.
+ *
+ * @param {jQuery} $dialogs The jQuery element(s) to apply the mode for.
+ * @return {Void} Nothing
+ */
+export default ($dialogs) => {
+  $dialogs.each((_i, dialog) => {
+    const $dialog = $(dialog);
+
+    const $container = $("body");
+    const $title = $(".reveal__title:first", $dialog);
+
+    if ($title.length > 0) {
+      // Focus on the title to make the screen reader to start reading the
+      // content within the modal.
+      $title.attr("tabindex", $title.attr("tabindex") || -1);
+      $title.trigger("focus");
+    }
+
+    // Once the final modal closes, remove the focus guards from the container
+    $dialog.off("closed.zf.reveal.focusguard").on("closed.zf.reveal.focusguard", () => {
+      $dialog.off("closed.zf.reveal.focusguard");
+
+      // After the last dialog is closed, the tab guards should be removed.
+      // Note that there may be multiple dialogs open on top of each other at
+      // the same time.
+      if ($(".reveal:visible", $container).length < 1) {
+        $(`> .${focusGuardClass}`, $container).remove();
+      }
+    });
+
+    // Check if the guards already exists due to some other dialog
+    const $guards = $(`> .${focusGuardClass}`, $container);
+    if ($guards.length > 0) {
+      // Make sure the guards are the first and last element as there have
+      // been changes in the DOM.
+      $guards.each((_j, guard) => {
+        const $guard = $(guard);
+        if ($guard.data("position") === "start") {
+          $container.prepend($guard);
+        } else {
+          $container.append($guard);
+        }
+      });
+
+      return;
+    }
+
+    // Add guards at the start and end of the document and attach their focus
+    // listeners
+    const $startGuard = createFocusGuard("start");
+    const $endGuard = createFocusGuard("end");
+
+    $container.prepend($startGuard);
+    $container.append($endGuard);
+
+    $startGuard.on("focus", () => handleContainerFocus($container, $startGuard));
+    $endGuard.on("focus", () => handleContainerFocus($container, $endGuard));
+  });
+};

--- a/decidim-core/app/packs/src/decidim/dialog_mode.test.js
+++ b/decidim-core/app/packs/src/decidim/dialog_mode.test.js
@@ -1,0 +1,168 @@
+/* global jest, global */
+
+// Mock jQuery because the visibility indicator works differently within jest.
+// This fixes jQuery reporting $(".element").is(":visible") correctly during the
+// tests and within foundation, too.
+jest.mock("jquery", () => {
+  const jq = jest.requireActual("jquery");
+
+  jq.expr.pseudos.visible = (elem) => {
+    const display = global.window.getComputedStyle(elem).display;
+    return ["inline", "block", "inline-block"].includes(display);
+  };
+
+  return jq;
+});
+
+import $ from "jquery"; // eslint-disable-line id-length
+import "foundation-sites";
+
+import dialogMode from "./dialog_mode.js";
+
+describe("dialogMode", () => {
+  const content = `
+    <div class="reveal" id="test-modal" data-reveal aria-modal="true" aria-labelledby="test-modal-label">
+      <div class="reveal__header">
+        <h3 id="test-modal-label" class="reveal__title">Testing modal</h3>
+        <button class="close-button" data-close aria-label="Close window"
+          type="button">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="row">
+        <div class="columns medium-4 medium-centered">
+          <p>Here is some content within the modal.</p>
+          <button type="button" id="test-modal-button">Button at the bottom</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="reveal" id="test-modal-2" data-reveal aria-modal="true" aria-labelledby="test-modal-2-label">
+      <div class="reveal__header">
+        <h3 id="test-modal-2-label" class="reveal__title">Other testing modal</h3>
+        <button class="close-button" data-close aria-label="Close window"
+          type="button">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="row">
+        <div class="columns medium-4 medium-centered">
+          <p>Here is some content within the other modal.</p>
+          <button type="button" id="test-modal-2-button">Button at the bottom</button>
+        </div>
+      </div>
+    </div>
+  `;
+
+  beforeEach(() => {
+    $("body").html(content);
+
+    $(document).foundation();
+
+    // Make sure all reveals are hidden by default so that their visibility is
+    // correctly reported always.
+    $(".reveal").css("display", "none");
+
+    $(document).on("open.zf.reveal", (ev) => {
+      dialogMode($(ev.target));
+    });
+  });
+
+  it("focuses the title", () => {
+    $("#test-modal").foundation("open");
+
+    const $focused = $(document.activeElement);
+    expect($focused.is($("#test-modal-label"))).toBe(true);
+  });
+
+  it("adds the tab guads on both sides of the document", () => {
+    $("#test-modal").foundation("open");
+
+    const $first = $("body *:first");
+    const $last = $("body *:last");
+
+    expect($first[0].outerHTML).toEqual(
+      '<div class="focusguard" data-position="start" tabindex="0" aria-hidden="true"></div>'
+    );
+    expect($last[0].outerHTML).toEqual(
+      '<div class="focusguard" data-position="end" tabindex="0" aria-hidden="true"></div>'
+    );
+  });
+
+  it("removes the tab guards when the modal is closed", () => {
+    const $modal = $("#test-modal");
+    $modal.foundation("open");
+    $modal.foundation("close");
+
+    expect($(".focusguard").length).toEqual(0);
+  });
+
+  it("focuses the first focusable element when the start tab guard gets focus", () => {
+    const $modal = $("#test-modal");
+    $modal.foundation("open");
+
+    $(".focusguard[data-position='start']").trigger("focus");
+
+    const $focused = $(document.activeElement);
+    expect($focused.is($("#test-modal .close-button"))).toBe(true);
+  });
+
+  it("focuses the last focusable element when the end tab guard gets focus", () => {
+    const $modal = $("#test-modal");
+    $modal.foundation("open");
+
+    $(".focusguard[data-position='end']").trigger("focus");
+
+    const $focused = $(document.activeElement);
+    expect($focused.is($("#test-modal-button"))).toBe(true);
+  });
+
+  describe("when multiple modals are opened", () => {
+    it("adds the tab guads only once", () => {
+      $("#test-modal").foundation("open");
+      $("#test-modal-2").foundation("open");
+
+      expect($(".focusguard[data-position='start']").length).toEqual(1);
+      expect($(".focusguard[data-position='end']").length).toEqual(1);
+    });
+
+    it("does not remove the tab guards when modal is closed but there is still another modal open", () => {
+      $("#test-modal").foundation("open");
+      $("#test-modal-2").foundation("open");
+      $("#test-modal-2").foundation("close");
+
+      expect($(".focusguard[data-position='start']").length).toEqual(1);
+      expect($(".focusguard[data-position='end']").length).toEqual(1);
+    });
+
+    it("removes the tab guards when the last modal is closed", () => {
+      $("#test-modal").foundation("open");
+      $("#test-modal-2").foundation("open");
+      $("#test-modal-2").foundation("close");
+      $("#test-modal").foundation("close");
+
+      expect($(".focusguard").length).toEqual(0);
+    });
+
+    describe("within the active modal", () => {
+      beforeEach(() => {
+        $("#test-modal").foundation("open");
+        $("#test-modal-2").foundation("open");
+      });
+
+      it("focuses the first focusable element when the start tab guard gets focus", () => {
+        $(".focusguard[data-position='start']").trigger("focus");
+
+        const $focused = $(document.activeElement);
+        expect($focused.is($("#test-modal-2 .close-button"))).toBe(true);
+      });
+
+      it("focuses the last focusable element when the end tab guard gets focus", () => {
+        $(".focusguard[data-position='end']").trigger("focus");
+
+        const $focused = $(document.activeElement);
+        expect($focused.is($("#test-modal-2-button"))).toBe(true);
+      });
+    });
+  });
+});

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -13,6 +13,7 @@ import CommentsComponent from "src/decidim/comments/comments.component"
 import DataPicker from "src/decidim/data_picker"
 import FormFilterComponent from "src/decidim/form_filter"
 import addInputEmoji from "src/decidim/input_emoji"
+import dialogMode from "src/decidim/dialog_mode"
 
 window.Decidim = window.Decidim || {};
 window.Decidim.config = new Configuration()
@@ -27,6 +28,9 @@ $(() => {
   window.theDataPicker = new DataPicker($(".data-picker"));
 
   $(document).foundation();
+  $(document).on("open.zf.reveal", (ev) => {
+    dialogMode($(ev.target));
+  });
 
   fixDropdownMenus();
 


### PR DESCRIPTION
#### :tophat: What? Why?
In a recent accessibility audit, we got some accessibility violation reports from the modal functionality. This fixes these issues.

1. It places the focus **INSIDE** the modal (to the title element) in order to get most screen readers focus within the modal. Otherwise the screen reader may focus somewhere else and start reading completely irrelevant information. By default, foundation focuses the modal element which does not work for all screen readers.
2. It implements "tab guards" on both sides of the document "guarding" the user focus within the modal. The focus may be lost outside the modal e.g. if the user places the focus outside of the document, e.g. in the browser address bar or within a different window. Now when they return to the document, the focus is guarded within the modal.

#### Testing
- For the focus indicator, use some screen reader and open modal, e.g. click "New proposal" when logged out
- For the tab guard, open the modal and then place the focus in the browser address bar. Now, start pressing the TAB key to re-enter the document and notice that the focus is placed within the modal again. For the ending guard, start browsing with SHIFT+TAB when you are in the address bar.

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.