### PR TITLE
Fix regex that parses users and groups references inside content.

### DIFF
--- a/decidim-core/lib/decidim/content_renderers/user_group_renderer.rb
+++ b/decidim-core/lib/decidim/content_renderers/user_group_renderer.rb
@@ -10,7 +10,7 @@ module Decidim
     # @see BaseRenderer Examples of how to use a content renderer
     class UserGroupRenderer < BaseRenderer
       # Matches a global id representing a Decidim::UserGroup
-      GLOBAL_ID_REGEX = %r{gid://\S+/Decidim::UserGroup/\d+}.freeze
+      GLOBAL_ID_REGEX = %r{gid://[\w-]+/Decidim::UserGroup/\d+}.freeze
 
       # Replaces found Global IDs matching an existing user with
       # a link to their profile. The Global IDs representing an

--- a/decidim-core/lib/decidim/content_renderers/user_renderer.rb
+++ b/decidim-core/lib/decidim/content_renderers/user_renderer.rb
@@ -10,7 +10,7 @@ module Decidim
     # @see BaseRenderer Examples of how to use a content renderer
     class UserRenderer < BaseRenderer
       # Matches a global id representing a Decidim::User
-      GLOBAL_ID_REGEX = %r{gid://\S+/Decidim::User/\d+}.freeze
+      GLOBAL_ID_REGEX = %r{gid://[\w-]+/Decidim::User/\d+}.freeze
 
       # Replaces found Global IDs matching an existing user with
       # a link to their profile. The Global IDs representing an

--- a/decidim-core/spec/content_renderers/decidim/user_group_renderer_spec.rb
+++ b/decidim-core/spec/content_renderers/decidim/user_group_renderer_spec.rb
@@ -48,5 +48,15 @@ module Decidim
         expect { renderer.render }.not_to raise_error
       end
     end
+
+    context "when markdown is rendered " do
+      let(:content) { "<p>#{user_group.to_global_id}</p><p>#{user_group.to_global_id}</p>" }
+
+      it "ensure regex does not match across multiple gids" do
+        rendered = renderer.render
+        mention = %(<a class="user-mention" href="#{profile_url}">@#{user_group.nickname}</a>)
+        expect(rendered.scan(mention).length).to eq(2)
+      end
+    end
   end
 end

--- a/decidim-core/spec/content_renderers/decidim/user_renderer_spec.rb
+++ b/decidim-core/spec/content_renderers/decidim/user_renderer_spec.rb
@@ -48,5 +48,15 @@ module Decidim
         expect { renderer.render }.not_to raise_error
       end
     end
+
+    context "when markdown is rendered " do
+      let(:content) { "<p>#{user.to_global_id}</p><p>#{user.to_global_id}</p>" }
+
+      it "ensure regex does not match across multiple gids" do
+        rendered = renderer.render
+        mention = %(<a class="user-mention" href="#{profile_url}">@#{user.nickname}</a>)
+        expect(rendered.scan(mention).length).to eq(2)
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently there is a possibility that after applying markdown a string is generated, that will match more than it should:
```
body = '<p>gid://test/Decidim::Hashtag/9/13</p><p>gid://test/Decidim::User/3</p>'
old_regex = %r{gid://\S+/Decidim::User/\d+}
new_regex = %r{gid://[\w-]+/Decidim::User/\d+}
body.match(old_regex)[0]
# => "gid://test/Decidim::Hashtag/9/13</p><p>gid://test/Decidim::User/3"
body.match(new_regex)[0]
# => "gid://test/Decidim::User/3"
```

#### Testing
Before PR:
```
Decidim::ContentProcessor.render('<p>gid://test/Decidim::Hashtag/123</p><p>gid://test/Decidim::UserGroup/456</p>')
# NoMethodError: undefined method `nickname' for nil:NilClass
# from /code/pz/decidim-zuerich/vendor/bundle/ruby/2.7.0/gems/decidim-core-0.24.3/app/presenters/decidim/user_presenter.rb:16:in `nickname'
```

After PR:
```
Decidim::ContentProcessor.render('<p>gid://test/Decidim::Hashtag/123</p><p>gid://test/Decidim::UserGroup/456</p>')
#=> "<p><p></p><p></p></p>"
```

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.



:hearts: Thank you!
