### PR TITLE
Backport "Update foundation-sites to 6.7.0 for better Dart Sass compatibility" to v0.25

### DIFF
--- a/decidim_app-design/package-lock.json
+++ b/decidim_app-design/package-lock.json
@@ -8444,11 +8444,11 @@
       "integrity": "sha1-bciR8/ZCICghn3QoTRaEVIqMpL8="
     },
     "node_modules/foundation-sites": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.6.3.tgz",
-      "integrity": "sha512-8X93wUAmUg1HhVv8uWMWnwoBLSQWSmFImJencneIZDctswn724Bq/MV1cbPZN/GFWGOB/9ngoQHztfzd4+ovCg==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.7.1.tgz",
+      "integrity": "sha512-Qr+9oQUItVInQG4wK2PKL53RwPe1eyx1irmgTkTGfm1CM0snQuenCRl7OtD8MfMykqw4NOU9JQGDLgV8oz0jxg==",
       "engines": {
-        "node": ">=8.4.0"
+        "node": ">=12.0"
       },
       "peerDependencies": {
         "jquery": ">=2.2.0",
@@ -21100,7 +21100,7 @@
         "d3": "5.4.0",
         "diff": "^5.0.0",
         "foundation-datepicker": "1.5.6",
-        "foundation-sites": "^6.6.3",
+        "foundation-sites": "^6.7.0",
         "graphiql": "^1.4.2",
         "graphql-docs": "https://github.com/decidim/graphql-docs/raw/master/graphql-docs-0.2.1.tgz",
         "html5sortable": "0.10.0",
@@ -22437,7 +22437,7 @@
         "d3": "5.4.0",
         "diff": "^5.0.0",
         "foundation-datepicker": "1.5.6",
-        "foundation-sites": "^6.6.3",
+        "foundation-sites": "^6.7.0",
         "graphiql": "^1.4.2",
         "graphql-docs": "https://github.com/decidim/graphql-docs/raw/master/graphql-docs-0.2.1.tgz",
         "html5sortable": "0.10.0",
@@ -27822,9 +27822,9 @@
       "integrity": "sha1-bciR8/ZCICghn3QoTRaEVIqMpL8="
     },
     "foundation-sites": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.6.3.tgz",
-      "integrity": "sha512-8X93wUAmUg1HhVv8uWMWnwoBLSQWSmFImJencneIZDctswn724Bq/MV1cbPZN/GFWGOB/9ngoQHztfzd4+ovCg==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.7.1.tgz",
+      "integrity": "sha512-Qr+9oQUItVInQG4wK2PKL53RwPe1eyx1irmgTkTGfm1CM0snQuenCRl7OtD8MfMykqw4NOU9JQGDLgV8oz0jxg==",
       "requires": {}
     },
     "fragment-cache": {

--- a/decidim_app-design/packages/core/package.json
+++ b/decidim_app-design/packages/core/package.json
@@ -22,7 +22,7 @@
     "d3": "5.4.0",
     "diff": "^5.0.0",
     "foundation-datepicker": "1.5.6",
-    "foundation-sites": "^6.6.3",
+    "foundation-sites": "^6.7.0",
     "graphiql": "^1.4.2",
     "graphql-docs": "https://github.com/decidim/graphql-docs/raw/master/graphql-docs-0.2.1.tgz",
     "html5sortable": "0.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8444,11 +8444,11 @@
       "integrity": "sha1-bciR8/ZCICghn3QoTRaEVIqMpL8="
     },
     "node_modules/foundation-sites": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.6.3.tgz",
-      "integrity": "sha512-8X93wUAmUg1HhVv8uWMWnwoBLSQWSmFImJencneIZDctswn724Bq/MV1cbPZN/GFWGOB/9ngoQHztfzd4+ovCg==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.7.1.tgz",
+      "integrity": "sha512-Qr+9oQUItVInQG4wK2PKL53RwPe1eyx1irmgTkTGfm1CM0snQuenCRl7OtD8MfMykqw4NOU9JQGDLgV8oz0jxg==",
       "engines": {
-        "node": ">=8.4.0"
+        "node": ">=12.0"
       },
       "peerDependencies": {
         "jquery": ">=2.2.0",
@@ -21100,7 +21100,7 @@
         "d3": "5.4.0",
         "diff": "^5.0.0",
         "foundation-datepicker": "1.5.6",
-        "foundation-sites": "^6.6.3",
+        "foundation-sites": "^6.7.0",
         "graphiql": "^1.4.2",
         "graphql-docs": "https://github.com/decidim/graphql-docs/raw/master/graphql-docs-0.2.1.tgz",
         "html5sortable": "0.10.0",
@@ -22437,7 +22437,7 @@
         "d3": "5.4.0",
         "diff": "^5.0.0",
         "foundation-datepicker": "1.5.6",
-        "foundation-sites": "^6.6.3",
+        "foundation-sites": "^6.7.0",
         "graphiql": "^1.4.2",
         "graphql-docs": "https://github.com/decidim/graphql-docs/raw/master/graphql-docs-0.2.1.tgz",
         "html5sortable": "0.10.0",
@@ -27822,9 +27822,9 @@
       "integrity": "sha1-bciR8/ZCICghn3QoTRaEVIqMpL8="
     },
     "foundation-sites": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.6.3.tgz",
-      "integrity": "sha512-8X93wUAmUg1HhVv8uWMWnwoBLSQWSmFImJencneIZDctswn724Bq/MV1cbPZN/GFWGOB/9ngoQHztfzd4+ovCg==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.7.1.tgz",
+      "integrity": "sha512-Qr+9oQUItVInQG4wK2PKL53RwPe1eyx1irmgTkTGfm1CM0snQuenCRl7OtD8MfMykqw4NOU9JQGDLgV8oz0jxg==",
       "requires": {}
     },
     "fragment-cache": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
     "d3": "5.4.0",
     "diff": "^5.0.0",
     "foundation-datepicker": "1.5.6",
-    "foundation-sites": "^6.6.3",
+    "foundation-sites": "^6.7.0",
     "graphiql": "^1.4.2",
     "graphql-docs": "https://github.com/decidim/graphql-docs/raw/master/graphql-docs-0.2.1.tgz",
     "html5sortable": "0.10.0",


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the fix from #8273 to 0.25.

**Note:** this updates the locked version actually to 6.7.1 as it has been released 2021-09-02. But the Decidim apps can still choose between 6.7.0 and 6.7.1. There shouldn't be any major changes between the two:
https://github.com/foundation/foundation-sites/releases/tag/v6.7.1

#### :pushpin: Related Issues
- Related to #8273

#### Testing
See #8273.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.