### PR TITLE
Fix flaky test on proposals splitting

### DIFF
--- a/decidim-proposals/spec/shared/split_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/split_proposals_examples.rb
@@ -24,7 +24,7 @@ shared_examples "split proposals" do
     context "when split into a new one is selected from the actions dropdown" do
       before do
         page.find("#proposals_bulk.js-check-all").set(false)
-        page.first(".js-proposal-list-check").set(true)
+        page.find(".js-proposal-id-#{proposals.first.id}").set(true)
 
         click_button "Actions"
         click_button "Split proposals"


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the flaky test introduced in #8193. It tries to split a proposal and get an error message, but it takes the first created proposal, and sometimes this is not the proposal created for this test, but a proposal created within the component. This PR forces the test to use the right proposal.

#### :pushpin: Related Issues
- Related to #8193

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
