### PR TITLE
Fix some explore budgets specs

### DIFF
--- a/decidim-budgets/spec/system/explore_budgets_spec.rb
+++ b/decidim-budgets/spec/system/explore_budgets_spec.rb
@@ -25,7 +25,7 @@ describe "Explore Budgets", :slow, type: :system do
 
   context "with many budgets" do
     let!(:budgets) do
-      1.upto(6).to_a.map { |x| create(:budget, component: component, total_budget: x * 10_000_000, description: { en: "This is budget #{x}" }) }
+      1.upto(6).to_a.map { |x| create(:budget, component: component, weight: x, total_budget: x * 10_000_000, description: { en: "This is budget #{x}" }) }
     end
 
     before do
@@ -37,8 +37,9 @@ describe "Explore Budgets", :slow, type: :system do
 
       budgets.each do |budget|
         expect(page).to have_content(translated(budget.title))
-        expect(page).to have_content("This is budget 1")
-        expect(page).to have_content("€10,000,000")
+        1.upto(6).each do |x|
+          expect(page).to have_content("€#{x * 10},000,000")
+        end
       end
     end
 

--- a/decidim-budgets/spec/system/explore_budgets_spec.rb
+++ b/decidim-budgets/spec/system/explore_budgets_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe "Explore Budgets", :slow, type: :system do
+  include ActionView::Helpers::NumberHelper
+
   include_context "with a component"
   let(:manifest_name) { "budgets" }
 
@@ -37,9 +39,7 @@ describe "Explore Budgets", :slow, type: :system do
 
       budgets.each do |budget|
         expect(page).to have_content(translated(budget.title))
-        1.upto(6).each do |x|
-          expect(page).to have_content("€#{x * 10},000,000")
-        end
+        expect(page).to have_content(number_to_currency(budget.total_budget, unit: Decidim.currency_unit, precision: 0))
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
There seems to be problem with the explore budgets specs according to this test run at #8293:
https://github.com/decidim/decidim/pull/8293/checks?check_run_id=3523981561

I think the problem is because the budgets can be ordered "randomly" in some occasions in case the budget weight is not defined. This should make sure the budgets are always in expected order.

Another issue I noticed at the same time was that the budget amounts were not checked properly. It was checking the first budget's amount for all budgets.

#### :pushpin: Related Issues
- Related to #8293

#### Testing
I am not sure how to replicate this, but see the failed test run.

I am also not sure if this is the answer but I think it is.

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.