### PR TITLE
Backport "Fix invalid i18n values for diff changeset" to v0.24

### DIFF
--- a/decidim-core/app/services/decidim/log/diff_changeset_calculator.rb
+++ b/decidim-core/app/services/decidim/log/diff_changeset_calculator.rb
@@ -75,9 +75,14 @@ module Decidim
       #
       # Returns an array of hashes.
       def generate_i18n_changeset(attribute, values, type)
-        values.map! { |value| value.is_a?(String) ? JSON.parse(value) : value }
+        values.map! do |value|
+          value = value.is_a?(String) ? JSON.parse(value) : value
+          value.is_a?(Hash) ? value : { I18n.default_locale.to_s => value }
+        rescue JSON::ParserError
+          { I18n.default_locale.to_s => value }
+        end
 
-        locales = values[0].to_h.keys | values[1].to_h.keys
+        locales = values[0].keys | values[1].keys
         locales.flat_map do |locale|
           previous_value = values.first.try(:[], locale)
           new_value = values.last.try(:[], locale)

--- a/decidim-core/spec/services/decidim/log/diff_changeset_calculator_spec.rb
+++ b/decidim-core/spec/services/decidim/log/diff_changeset_calculator_spec.rb
@@ -129,6 +129,72 @@ describe Decidim::Log::DiffChangesetCalculator do
           ]
         end
       end
+
+      context "when the i18n values are strings" do
+        let(:changeset) do
+          {
+            field: %w(Foo Bar)
+          }
+        end
+
+        it "calculates the changeset for the default locale" do
+          expect(subject).to eq [
+            {
+              attribute_name: :field,
+              label: "My field (English)",
+              previous_value: "Foo",
+              new_value: "Bar",
+              type: :i18n
+            }
+          ]
+        end
+      end
+
+      context "when the i18n values are JSON formatted strings" do
+        let(:changeset) do
+          {
+            field: [
+              '"Foo"',
+              '"Bar"'
+            ]
+          }
+        end
+
+        it "calculates the changeset for the default locale" do
+          expect(subject).to eq [
+            {
+              attribute_name: :field,
+              label: "My field (English)",
+              previous_value: "Foo",
+              new_value: "Bar",
+              type: :i18n
+            }
+          ]
+        end
+      end
+
+      context "when the i18n values are symbols" do
+        let(:changeset) do
+          {
+            field: [
+              :foo,
+              :bar
+            ]
+          }
+        end
+
+        it "calculates the changeset for the default locale" do
+          expect(subject).to eq [
+            {
+              attribute_name: :field,
+              label: "My field (English)",
+              previous_value: :foo,
+              new_value: :bar,
+              type: :i18n
+            }
+          ]
+        end
+      end
     end
 
     context "when fields mapping is empty" do


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the fix from #8299 to 0.24.

#### :pushpin: Related Issues
- Related to #8299

#### Testing
See #8299.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.