### PR TITLE
Fix "View all comments" link in single comment page

### DIFF
--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -94,7 +94,7 @@ en:
         blocked_comments_warning: Comments are disabled at this time, but you can read the previous ones.
         comment_details_title: Comment details
         loading: Loading comments ...
-        single_comment_warning: You can check the rest of the comments <a href="%{url}">here</a>.
+        single_comment_warning: <a href="%{url}">View all comments</a>
         single_comment_warning_title: You are seeing a single comment
         title:
           one: "%{count} comment"

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -48,7 +48,7 @@ module Decidim::Comments
 
         it "renders the single comment warning" do
           expect(subject).to have_css(".callout.secondary", text: "You are seeing a single comment")
-          expect(subject).to have_css(".callout.secondary", text: "You can check the rest of the comments here.")
+          expect(subject).to have_css(".callout.secondary", text: "View all comments")
         end
 
         context "with the single comment being moderated" do
@@ -71,7 +71,7 @@ module Decidim::Comments
 
           it "does not render the single comment warning" do
             expect(subject).not_to have_css(".callout.secondary", text: "You are seeing a single comment")
-            expect(subject).not_to have_css(".callout.secondary", text: "You can check the rest of the comments here.")
+            expect(subject).not_to have_css(".callout.secondary", text: "View all comments")
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

When reviewing #8251 with @carolromero, she mentioned that we already have a "here" link in single comment page. This fixes that.

#### :pushpin: Related Issues

- Related to #8251
- See also https://uxmovement.com/content/why-your-links-should-never-say-click-here/ 

#### Testing

1. Go to a single comment page
2. See change in link 

### :camera: Screenshots

How it's done in Reddit: 
![imatge](https://user-images.githubusercontent.com/717367/132301539-abef7432-8cc4-41b2-a7b4-0165f7bb111a.png)


#### Before

![imatge](https://user-images.githubusercontent.com/717367/132301381-adc2c3b8-69df-44e1-9625-bd01019c9996.png)

#### After
![imatge](https://user-images.githubusercontent.com/717367/132301512-814a949b-4857-4bc3-a175-e5578c89f7a4.png)


:hearts: Thank you!
