### PR TITLE
Fix birthday attribute type in Assembly Members

### DIFF
--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_member_form.rb
@@ -11,7 +11,7 @@ module Decidim
         attribute :weight, Integer, default: 0
         attribute :full_name, String
         attribute :gender, String
-        attribute :birthday, Decidim::Attributes::TimeWithZone
+        attribute :birthday, Decidim::Attributes::LocalizedDate
         attribute :birthplace, String
         attribute :ceased_date, Decidim::Attributes::LocalizedDate
         attribute :designation_date, Decidim::Attributes::LocalizedDate


### PR DESCRIPTION
#### :tophat: What? Why?

While I was working in #8310 I found out that the birthday field had the wrong attribute type, this PR fixes it. 

It shouldn't make any difference, as far as I see in this context it didn't matter, but I think it just added noise -- "why this field has this type? is there something else that I'm not seeing?"

#### :pushpin: Related Issues

- Related to #3724 

#### Testing

It shouldn't make any difference for the end user.

:hearts: Thank you!
