### PR TITLE
Fix "Edit" and "View public page" in Assembly Members

### DIFF
--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_members_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_members_controller.rb
@@ -7,6 +7,7 @@ module Decidim
       #
       class AssemblyMembersController < Decidim::Assemblies::Admin::ApplicationController
         include Concerns::AssemblyAdmin
+        layout "decidim/admin/assembly_members"
 
         def index
           enforce_permission_to :index, :assembly_member

--- a/decidim-assemblies/app/views/decidim/assemblies/assembly_members/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assembly_members/index.html.erb
@@ -1,5 +1,14 @@
 <% add_decidim_meta_tags(title: t("assembly_members.index.title", scope: "decidim")) %>
 
+<%
+edit_link(
+  decidim_admin_assemblies.assembly_members_path(current_participatory_space.slug),
+  :update,
+  :assembly,
+  assembly: current_participatory_space
+)
+%>
+
 <div class="section row column">
   <div class="flex--sbe">
     <h3 class="section-heading"><%= t(".members") %> <span class="text-muted">(<%= collection.size %>)</span></h3>

--- a/decidim-assemblies/app/views/layouts/decidim/admin/assembly_members.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/admin/assembly_members.html.erb
@@ -1,0 +1,18 @@
+<% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
+<% content_for :sidebar_menu_nav do %>
+  <%= sidebar_menu(:admin_assembly_menu).render do
+    public_page_link decidim_assemblies.assembly_assembly_members_path(current_participatory_space)
+  end %>
+<% end %>
+
+<%= render "layouts/decidim/admin/application" do %>
+  <div class="process-title">
+    <div class="process-title-content">
+      <%= link_to translated_attribute(current_participatory_space.title), decidim_assemblies.assembly_path(current_participatory_space), target: "_blank" %>
+    </div>
+  </div>
+
+  <div class="process-content">
+    <%= yield %>
+  </div>
+<% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

While working in #8310, in Assembly Members pages I wanted to be able to go back and forth between admin and public view and both pointed to Assembly. This PR fixes that. 

#### Testing

##### Edit link

1. Sign in as admin
2. Go to an assembly member public page
3. Click on "Edit" link in the header
4. See that you're in the assembly members listing in admin 

##### View public page link

1. Sign in as admin
2. Go to an assembly member admin page
3. Click on "View public pae" link in the sidebar
4. See that you're in the assembly members public page 

:hearts: Thank you!
