### PR TITLE
Fix issues with dynamic comments polling

### DIFF
--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -37,12 +37,7 @@ export default class CommentsComponent {
       this.mounted = true;
       this._initializeComments(this.$element);
 
-      $(".order-by__dropdown .is-submenu-item a", this.$element).on(
-        "click.decidim-comments",
-        () => {
-          this._onInitOrder();
-        }
-      );
+      $(".order-by__dropdown .is-submenu-item a", this.$element).on("click.decidim-comments", () => this._onInitOrder());
     }
   }
 
@@ -68,14 +63,16 @@ export default class CommentsComponent {
    * Adds a new thread to the comments section.
    * @public
    * @param {String} threadHtml - The HTML content for the thread.
+   * @param {Boolean} fromCurrentUser - A boolean indicating whether the user
+   *   herself was the author of the new thread. Defaults to false.
    * @returns {Void} - Returns nothing
    */
-  addThread(threadHtml) {
+  addThread(threadHtml, fromCurrentUser = false) {
     const $parent = $(".comments:first", this.$element);
     const $comment = $(threadHtml);
     const $threads = $(".comment-threads", this.$element);
     this._addComment($threads, $comment);
-    this._finalizeCommentCreation($parent);
+    this._finalizeCommentCreation($parent, fromCurrentUser);
   }
 
   /**
@@ -84,15 +81,17 @@ export default class CommentsComponent {
    * @param {Number} commentId - The ID of the comment for which to add the
    *   reply to.
    * @param {String} replyHtml - The HTML content for the reply.
+   * @param {Boolean} fromCurrentUser - A boolean indicating whether the user
+   *   herself was the author of the new reply. Defaults to false.
    * @returns {Void} - Returns nothing
    */
-  addReply(commentId, replyHtml) {
+  addReply(commentId, replyHtml, fromCurrentUser = false) {
     const $parent = $(`#comment_${commentId}`);
     const $comment = $(replyHtml);
     const $replies = $(`#comment-${commentId}-replies`);
     this._addComment($replies, $comment);
     $replies.siblings(".comment__additionalreply").removeClass("hide");
-    this._finalizeCommentCreation($parent);
+    this._finalizeCommentCreation($parent, fromCurrentUser);
   }
 
   /**
@@ -170,18 +169,22 @@ export default class CommentsComponent {
    * successfully.
    * @private
    * @param {jQuery} $parent - The parent comment element to finalize.
+   * @param {Boolean} fromCurrentUser - A boolean indicating whether the user
+   *   herself was the author of the new comment.
    * @returns {Void} - Returns nothing
    */
-  _finalizeCommentCreation($parent) {
-    const $add = $("> .add-comment", $parent);
-    const $text = $("textarea", $add);
-    const characterCounter = $text.data("remaining-characters-counter");
-    $text.val("");
-    if (characterCounter) {
-      characterCounter.updateStatus();
-    }
-    if (!$add.parent().is(".comments")) {
-      $add.addClass("hide");
+  _finalizeCommentCreation($parent, fromCurrentUser) {
+    if (fromCurrentUser) {
+      const $add = $("> .add-comment", $parent);
+      const $text = $("textarea", $add);
+      const characterCounter = $text.data("remaining-characters-counter");
+      $text.val("");
+      if (characterCounter) {
+        characterCounter.updateStatus();
+      }
+      if (!$add.parent().is(".comments")) {
+        $add.addClass("hide");
+      }
     }
 
     // Restart the polling
@@ -207,9 +210,7 @@ export default class CommentsComponent {
           order: this.order,
           after: this.lastCommentId
         }
-      }).done(() => {
-        this._pollComments();
-      });
+      }).done(() => this._pollComments());
     }, this.pollingInterval);
   }
 

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
@@ -558,16 +558,81 @@ describe("CommentsComponent", () => {
           "This is a dynamically added comment"
         ));
       });
+
+      it("does not clear the comment form text area", () => {
+        const commentSection = addComment[addComment.length - 1];
+        const textArea = $("textarea", commentSection);
+        textArea.val("I am writing a new comment...");
+
+        const newThread = generateCommentThread(999, "This is a dynamically added comment");
+        subject.addThread(newThread);
+
+        expect(textArea.val()).toEqual("I am writing a new comment...");
+      });
+
+      describe("as the current user", () => {
+        it("clears the comment form text area", () => {
+          const commentSection = addComment[addComment.length - 1];
+          const textArea = $("textarea", commentSection);
+          textArea.val("I am writing a new comment...");
+
+          const newThread = generateCommentThread(999, "This is a dynamically added comment");
+          subject.addThread(newThread, true);
+
+          expect(textArea.val()).toEqual("");
+        });
+      });
     });
 
     describe("addReply", () => {
+      const newReply = generateSingleComment(999, "This is a dynamically added reply");
+
       it("adds a new reply to an existing thread", () => {
-        const newThread = generateSingleComment(999, "This is a dynamically added reply");
-        subject.addReply(450, newThread);
+        subject.addReply(450, newReply);
 
         expect(subject.$element.html()).toEqual(expect.stringContaining(
           "This is a dynamically added reply"
         ));
+      });
+
+      it("does not clear the reply comment form text area", () => {
+        const commentSection = $("#comment450-reply", subject.$element);
+        const textArea = $("textarea", commentSection);
+        textArea.val("I am writing a new comment...");
+
+        subject.addReply(450, newReply);
+
+        expect(textArea.val()).toEqual("I am writing a new comment...");
+      });
+
+      it("does not hide the reply form", () => {
+        const commentSection = $("#comment450-reply", subject.$element);
+        commentSection.removeClass("hide");
+
+        subject.addReply(450, newReply);
+
+        expect(commentSection.hasClass("hide")).toBeFalsy();
+      });
+
+      describe("as the current user", () => {
+        it("clears the comment form text area", () => {
+          const commentSection = $("#comment450-reply", subject.$element);
+          const textArea = $("textarea", commentSection);
+          textArea.val("I am writing a new comment...");
+
+          subject.addReply(450, newReply, true);
+
+          expect(textArea.val()).toEqual("");
+        });
+
+        it("hides the reply form", () => {
+          const commentSection = $("#comment450-reply", subject.$element);
+          commentSection.removeClass("hide");
+
+          subject.addReply(450, newReply, true);
+
+          expect(commentSection.hasClass("hide")).toBeTruthy();
+        });
       });
     });
   });

--- a/decidim-comments/app/queries/decidim/comments/sorted_comments.rb
+++ b/decidim-comments/app/queries/decidim/comments/sorted_comments.rb
@@ -33,12 +33,6 @@ module Decidim
         scope = base_scope
                 .not_hidden
                 .includes(:author, :user_group, :up_votes, :down_votes)
-        if @options[:after]
-          scope = scope.where(
-            "decidim_comments_comments.id > ?",
-            @options[:after]
-          )
-        end
 
         case @options[:order_by]
         when "older"
@@ -59,6 +53,14 @@ module Decidim
       def base_scope
         id = @options[:id]
         return Comment.where(root_commentable: commentable, id: id) if id.present?
+
+        after = @options[:after]
+        if after.present?
+          return Comment.where(root_commentable: commentable).where(
+            "decidim_comments_comments.id > ?",
+            after
+          )
+        end
 
         Comment.where(commentable: commentable)
       end

--- a/decidim-comments/app/views/decidim/comments/comments/create.js.erb
+++ b/decidim-comments/app/views/decidim/comments/comments/create.js.erb
@@ -6,9 +6,9 @@
   var $comments = $("#" + rootCommentableId);
   var component = $comments.data("comments");
   if (inReplyTo) {
-    component.addReply(inReplyTo, commentHtml);
+    component.addReply(inReplyTo, commentHtml, true);
   } else {
-    component.addThread(commentHtml);
+    component.addThread(commentHtml, true);
   }
 
   // Update the comments count

--- a/decidim-comments/spec/queries/sorted_comments_spec.rb
+++ b/decidim-comments/spec/queries/sorted_comments_spec.rb
@@ -9,10 +9,12 @@ module Decidim::Comments
     let(:options) do
       {
         order_by: order_by,
-        id: id
+        id: id,
+        after: after
       }
     end
     let(:id) { nil }
+    let(:after) { nil }
     let!(:organization) { create(:organization) }
     let!(:participatory_process) { create(:participatory_process, organization: organization) }
     let!(:component) { create(:component, participatory_space: participatory_process) }
@@ -46,6 +48,24 @@ module Decidim::Comments
 
       it "only returns the requested comment" do
         expect(subject.query).to eq [comment]
+      end
+    end
+
+    context "when filtering comments after id" do
+      let!(:comments) { create_list(:comment, 10, commentable: commentable, author: author) }
+      let(:after) { comments.first.id }
+
+      it "only returns the comments after the specified id" do
+        expect(subject.query).to eq(comments[1..-1])
+      end
+
+      context "when the after comments contain replies" do
+        let(:replies) { create_list(:comment, 5, commentable: comment, root_commentable: commentable, author: author) }
+        let(:after) { comments.last.id }
+
+        it "returns the replies" do
+          expect(subject.query).to eq(replies)
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
There are two problems currently with the dynamic comments polling:
1. If someone else comments on the same commentable page at the same time and another user is writing a comment at the same time, the other user's written comment will disappear when the next comment polling happens. Also, if they are writing a reply to another comment, the reply form will be hidden when new comments are added (and the written reply also disappears)
2. When polling for new comments, the polling result does not add new replies to the current commentable page. It only adds the root level comments to the page.

This PR fixes both of these issues.

There is also some small refactoring in the comments component because the ESLint rules require JS files to be 300 lines or under. This refactoring reduces the amount of lines with these changes to keep the file at 300 lines.

#### Testing
Prior to this fix (current Decidim versions):
- Login as a user and go to a commentable page, preferrably a page with multiple comments
- Open another (incognito/private) window and go to the same page and login as another user
- As the first user, write something in the root level comment form (but do not post it)
- As the second user, create a new root level comment on that page
- As the first user, wait for 15-20s and see your written comment disappear on the page
- As the second user, add a reply to one of the comments on the page
- As the first user, wait for 15-20s and see that the reply does not appear on the page without a page reload

After you have applied the fixes in this PR:
- Repeat the above
- As the first user, open a reply form to one of the comments and write something in it
- As the second user, write a reply in the same comment
- As the first user, wait for 15-20s and see that the reply appeared on the page
- As the first user, also see that your reply form is still open and contains the text that you have written

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.