### PR TITLE
Backport "Remove unnecessary spacer from external link indicator" to v0.25

### DIFF
--- a/decidim-core/app/packs/src/decidim/external_link.js
+++ b/decidim-core/app/packs/src/decidim/external_link.js
@@ -37,7 +37,12 @@ export default class ExternalLink {
     }
 
     this.$link.addClass("external-link-container");
-    this.$link.append(`&nbsp;${this.generateElement()}`);
+    let spacer = "&nbsp;";
+    if (this.$link.text().trim().length < 1) {
+      // Fixes image links extra space
+      spacer = "";
+    }
+    this.$link.append(`${spacer}${this.generateElement()}`);
   }
 
   generateElement() {


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the fix from #8291 to 0.25.

#### :pushpin: Related Issues
- Related to #8291

#### Testing
See #8291.

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.