### PR TITLE
Fix UserAnswersSerializer for CSV exports

### DIFF
--- a/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
+++ b/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
@@ -32,13 +32,15 @@ module Decidim
       def hash_for(answer)
         {
           answer_translated_attribute_name(:id) => answer&.session_token,
-          answer_translated_attribute_name(:created_at) => answer&.created_at.to_s(:db),
+          answer_translated_attribute_name(:created_at) => answer&.created_at&.to_s(:db),
           answer_translated_attribute_name(:ip_hash) => answer&.ip_hash,
           answer_translated_attribute_name(:user_status) => answer_translated_attribute_name(answer&.decidim_user_id.present? ? "registered" : "unregistered")
         }
       end
 
       def questions_hash
+        return {} if questionnaire&.questions.blank?
+
         questionnaire.questions.each.inject({}) do |serialized, question|
           serialized.update(
             translated_question_key(question.position, question.body) => ""

--- a/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
+++ b/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
@@ -18,7 +18,7 @@ module Decidim
         answers_hash.merge!(questions_hash)
 
         @answers.each do |answer|
-          answers_hash[question_key_for(answer.question.position, answer.question.body)] = normalize_body(answer)
+          answers_hash[translated_question_key(answer.question.position, answer.question.body)] = normalize_body(answer)
         end
 
         answers_hash
@@ -41,7 +41,7 @@ module Decidim
       def questions_hash
         questionnaire.questions.each.inject({}) do |serialized, question|
           serialized.update(
-            question_key_for(question.position, question.body) => ""
+            translated_question_key(question.position, question.body) => ""
           )
         end
       end
@@ -50,7 +50,7 @@ module Decidim
         @answers.first&.questionnaire
       end
 
-      def question_key_for(idx, body)
+      def translated_question_key(idx, body)
         "#{idx + 1}. #{translated_attribute(body)}"
       end
 

--- a/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
+++ b/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
@@ -14,13 +14,13 @@ module Decidim
 
       # Public: Exports a hash with the serialized data for the user answers.
       def serialize
-        @answers.each_with_index.inject({}) do |serialized, (answer, idx)|
+        @answers.each.inject({}) do |serialized, answer|
           serialized.update(
             answer_translated_attribute_name(:id) => answer.session_token,
             answer_translated_attribute_name(:created_at) => answer.created_at.to_s(:db),
             answer_translated_attribute_name(:ip_hash) => answer.ip_hash,
             answer_translated_attribute_name(:user_status) => answer_translated_attribute_name(answer.decidim_user_id.present? ? "registered" : "unregistered"),
-            "#{idx + 1}. #{translated_attribute(answer.question.body)}" => normalize_body(answer)
+            translated_attribute(answer.question.body) => normalize_body(answer)
           )
         end
       end

--- a/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -143,7 +143,7 @@ module Decidim
           let!(:conditional_question) { create(:questionnaire_question, :conditioned, questionnaire: questionnaire, position: 4) }
 
           it "includes conditional question as empty" do
-            expect(serialized).to include("#{conditional_question.position + 1}. #{translated(conditional_question.body, locale: I18n.locale)}" => "")
+            expect(serialized).to include("5. #{translated(conditional_question.body, locale: I18n.locale)}" => "")
           end
         end
       end

--- a/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -66,7 +66,7 @@ module Decidim
         it "includes the answer for each question" do
           questions.each_with_index do |question, idx|
             expect(serialized).to include(
-              "#{idx + 1}. #{translated(question.body, locale: I18n.locale)}" => answers[idx].body
+              translated(question.body, locale: I18n.locale) => answers[idx].body
             )
           end
 
@@ -82,19 +82,19 @@ module Decidim
           serialized_files_answer = files_answer.attachments.map(&:url)
 
           expect(serialized).to include(
-            "4. #{translated(multichoice_question.body, locale: I18n.locale)}" => multichoice_answer_choices.map(&:body)
+            translated(multichoice_question.body, locale: I18n.locale) => multichoice_answer_choices.map(&:body)
           )
 
           expect(serialized).to include(
-            "5. #{translated(singlechoice_question.body, locale: I18n.locale)}" => ["Free text"]
+            translated(singlechoice_question.body, locale: I18n.locale) => ["Free text"]
           )
 
           expect(serialized).to include(
-            "6. #{translated(matrixmultiple_question.body, locale: I18n.locale)}" => serialized_matrix_answer
+            translated(matrixmultiple_question.body, locale: I18n.locale) => serialized_matrix_answer
           )
 
           expect(serialized).to include(
-            "7. #{translated(files_question.body, locale: I18n.locale)}" => serialized_files_answer
+            translated(files_question.body, locale: I18n.locale) => serialized_files_answer
           )
         end
 

--- a/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -116,6 +116,35 @@ module Decidim
             key = I18n.t(:created_at, scope: "decidim.forms.user_answers_serializer")
             expect(serialized[key]).to eq an_answer.created_at.to_s(:db)
           end
+
+          it "the IP hash of the user" do
+            key = I18n.t(:ip_hash, scope: "decidim.forms.user_answers_serializer")
+            expect(serialized[key]).to eq an_answer.ip_hash
+          end
+
+          it "the user status" do
+            key = I18n.t(:user_status, scope: "decidim.forms.user_answers_serializer")
+            expect(serialized[key]).to eq "Registered"
+          end
+
+          context "when user is not registered" do
+            before do
+              questionnaire.answers.first.update!(decidim_user_id: nil)
+            end
+
+            it "the user status is unregistered" do
+              key = I18n.t(:user_status, scope: "decidim.forms.user_answers_serializer")
+              expect(serialized[key]).to eq "Unregistered"
+            end
+          end
+        end
+
+        context "when conditional question is not answered by user" do
+          let!(:conditional_question) { create(:questionnaire_question, :conditioned, questionnaire: questionnaire, position: 4) }
+
+          it "includes conditional question as empty" do
+            expect(serialized).to include("#{conditional_question.position + 1}. #{translated(conditional_question.body, locale: I18n.locale)}" => "")
+          end
         end
       end
     end

--- a/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -60,13 +60,19 @@ module Decidim
         create :answer, :with_attachments, questionnaire: questionnaire, question: files_question, user: user, body: nil
       end
 
+      before do
+        questions.each_with_index do |question, idx|
+          question.update!(position: idx)
+        end
+      end
+
       describe "#serialize" do
         let(:serialized) { subject.serialize }
 
         it "includes the answer for each question" do
           questions.each_with_index do |question, idx|
             expect(serialized).to include(
-              translated(question.body, locale: I18n.locale) => answers[idx].body
+              "#{question.position + 1}. #{translated(question.body, locale: I18n.locale)}" => answers[idx].body
             )
           end
 
@@ -82,19 +88,19 @@ module Decidim
           serialized_files_answer = files_answer.attachments.map(&:url)
 
           expect(serialized).to include(
-            translated(multichoice_question.body, locale: I18n.locale) => multichoice_answer_choices.map(&:body)
+            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => multichoice_answer_choices.map(&:body)
           )
 
           expect(serialized).to include(
-            translated(singlechoice_question.body, locale: I18n.locale) => ["Free text"]
+            "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => ["Free text"]
           )
 
           expect(serialized).to include(
-            translated(matrixmultiple_question.body, locale: I18n.locale) => serialized_matrix_answer
+            "#{matrixmultiple_question.position + 1}. #{translated(matrixmultiple_question.body, locale: I18n.locale)}" => serialized_matrix_answer
           )
 
           expect(serialized).to include(
-            translated(files_question.body, locale: I18n.locale) => serialized_files_answer
+            "#{files_question.position + 1}. #{translated(files_question.body, locale: I18n.locale)}" => serialized_files_answer
           )
         end
 

--- a/decidim-meetings/spec/serializers/registration_serializer_spec.rb
+++ b/decidim-meetings/spec/serializers/registration_serializer_spec.rb
@@ -86,19 +86,19 @@ module Decidim::Meetings
 
         it "includes the answer for each question" do
           expect(serialized[:registration_form_answers]).to include(
-            "1. #{translated(questions.first.body, locale: I18n.locale)}" => answers.first.body
+            translated(questions.first.body, locale: I18n.locale) => answers.first.body
           )
           expect(serialized[:registration_form_answers]).to include(
-            "3. #{translated(questions.last.body, locale: I18n.locale)}" => answers.last.body
+            translated(questions.last.body, locale: I18n.locale) => answers.last.body
           )
           expect(serialized[:registration_form_answers]).to include(
-            "4. #{translated(multichoice_question.body, locale: I18n.locale)}" => multichoice_answer_choices.map(&:body)
+            translated(multichoice_question.body, locale: I18n.locale) => multichoice_answer_choices.map(&:body)
           )
           expect(serialized[:registration_form_answers]).to include(
-            "5. #{translated(singlechoice_question.body, locale: I18n.locale)}" => [singlechoice_answer_choice.body]
+            translated(singlechoice_question.body, locale: I18n.locale) => [singlechoice_answer_choice.body]
           )
           expect(serialized[:registration_form_answers]).to include(
-            "6. #{translated(singlechoice_free_question.body, locale: I18n.locale)}" => ["Free text answer"]
+            translated(singlechoice_free_question.body, locale: I18n.locale) => ["Free text answer"]
           )
         end
       end

--- a/decidim-meetings/spec/serializers/registration_serializer_spec.rb
+++ b/decidim-meetings/spec/serializers/registration_serializer_spec.rb
@@ -27,7 +27,7 @@ module Decidim::Meetings
         end
       end
 
-      context "when questtionaire enabled" do
+      context "when questionnaire enabled" do
         let(:meeting) { create :meeting, :with_registrations_enabled }
         let!(:user) { create(:user, organization: meeting.organization) }
         let!(:registration) { create(:registration, meeting: meeting, user: user) }
@@ -86,19 +86,19 @@ module Decidim::Meetings
 
         it "includes the answer for each question" do
           expect(serialized[:registration_form_answers]).to include(
-            translated(questions.first.body, locale: I18n.locale) => answers.first.body
+            "#{questions.first.position + 1}. #{translated(questions.first.body, locale: I18n.locale)}" => answers.first.body
           )
           expect(serialized[:registration_form_answers]).to include(
-            translated(questions.last.body, locale: I18n.locale) => answers.last.body
+            "#{questions.last.position + 1}. #{translated(questions.last.body, locale: I18n.locale)}" => answers.last.body
           )
           expect(serialized[:registration_form_answers]).to include(
-            translated(multichoice_question.body, locale: I18n.locale) => multichoice_answer_choices.map(&:body)
+            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => multichoice_answer_choices.map(&:body)
           )
           expect(serialized[:registration_form_answers]).to include(
-            translated(singlechoice_question.body, locale: I18n.locale) => [singlechoice_answer_choice.body]
+            "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => [singlechoice_answer_choice.body]
           )
           expect(serialized[:registration_form_answers]).to include(
-            translated(singlechoice_free_question.body, locale: I18n.locale) => ["Free text answer"]
+            "#{singlechoice_free_question.position + 1}. #{translated(singlechoice_free_question.body, locale: I18n.locale)}" => ["Free text answer"]
           )
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Remove index interpolated before question in `UserAnswersSerializer` because it can cause duplicated columns in CSV headers.

#### :pushpin: Related Issues
- Fixes #8327

#### Testing

* Log in as administrator and access backoffice
* Go to processes
* Create new survey for a process
* Define several questions 
* Add conditional questions in form 
* Answers this form with multiple accounts (Ensure there is answers with conditional and other without)
* In backoffice, exports answers with CSV exporter
* Question shouldn't have index in columns header

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
