### PR TITLE
Add more filter options to directory meetings page

### DIFF
--- a/decidim-meetings/app/controllers/concerns/decidim/meetings/filterable.rb
+++ b/decidim-meetings/app/controllers/concerns/decidim/meetings/filterable.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Meetings
+    # A controller concern to specify default filter parameters for the controller resources.
+    module Filterable
+      extend ActiveSupport::Concern
+
+      included do
+        private
+
+        def default_filter_type_params
+          %w(all) + Decidim::Meetings::Meeting::TYPE_OF_MEETING
+        end
+
+        def default_search_params
+          {
+            scope: Meeting.not_hidden.visible_meeting_for(current_user)
+          }
+        end
+
+        def default_filter_origin_params
+          filter_origin_params = %w(citizens)
+          filter_origin_params << "official"
+          filter_origin_params << "user_group" if current_organization.user_groups_enabled?
+          filter_origin_params
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/controllers/decidim/meetings/directory/application_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/directory/application_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    # This controller is the abstract class from which all other controllers of
+    # this engine inherit.
+    #
+    # Note that it inherits from `Decidim::Components::BaseController`, which
+    # override its layout and provide all kinds of useful methods.
+    module Directory
+      class ApplicationController < Decidim::ApplicationController
+        helper Decidim::Meetings::Directory::ApplicationHelper
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
@@ -4,7 +4,7 @@ module Decidim
   module Meetings
     module Directory
       # Exposes the meeting resource so users can view them
-      class MeetingsController < Decidim::ApplicationController
+      class MeetingsController < Decidim::Meetings::Directory::ApplicationController
         layout "layouts/decidim/application"
 
         include FilterResource
@@ -46,15 +46,30 @@ module Decidim
           {
             date: "upcoming",
             search_text: "",
-            scope_id: "",
-            space: "all"
+            activity: "all",
+            scope_id: default_filter_scope_params,
+            space: "all",
+            type: ["all"],
+            origin: default_filter_origin_params,
+            category_id: ["all"] + current_organization.public_participatory_spaces.pluck(:id).map(&:to_s)
           }
+        end
+
+        def default_filter_scope_params
+          %w(all global) + current_organization.scopes.pluck(:id).map(&:to_s)
         end
 
         def default_search_params
           {
             scope: Meeting.not_hidden.visible_meeting_for(current_user)
           }
+        end
+
+        def default_filter_origin_params
+          filter_origin_params = %w(citizens)
+          filter_origin_params << "official"
+          filter_origin_params << "user_group" if current_organization.user_groups_enabled?
+          filter_origin_params
         end
 
         def context_params

--- a/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
@@ -8,6 +8,7 @@ module Decidim
         layout "layouts/decidim/application"
 
         include FilterResource
+        include Filterable
         include Paginable
 
         helper Decidim::WidgetUrlsHelper
@@ -63,25 +64,8 @@ module Decidim
           %w(all) + current_organization.public_participatory_spaces.collect(&:model_name).uniq.collect(&:name).collect(&:underscore)
         end
 
-        def default_filter_type_params
-          %w(all) + Decidim::Meetings::Meeting::TYPE_OF_MEETING
-        end
-
         def default_filter_scope_params
           %w(all global) + current_organization.scopes.pluck(:id).map(&:to_s)
-        end
-
-        def default_search_params
-          {
-            scope: Meeting.not_hidden.visible_meeting_for(current_user)
-          }
-        end
-
-        def default_filter_origin_params
-          filter_origin_params = %w(citizens)
-          filter_origin_params << "official"
-          filter_origin_params << "user_group" if current_organization.user_groups_enabled?
-          filter_origin_params
         end
 
         def context_params

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -5,10 +5,12 @@ module Decidim
     # Exposes the meeting resource so users can view them
     class MeetingsController < Decidim::Meetings::ApplicationController
       include FilterResource
+      include Filterable
       include Flaggable
       include Withdrawable
       include FormFactory
       include Paginable
+
       helper Decidim::WidgetUrlsHelper
       helper Decidim::ResourceVersionsHelper
 
@@ -131,23 +133,6 @@ module Decidim
           state: nil,
           origin: default_filter_origin_params,
           type: default_filter_type_params
-        }
-      end
-
-      def default_filter_origin_params
-        filter_origin_params = %w(citizens)
-        filter_origin_params << "official"
-        filter_origin_params << "user_group" if current_organization.user_groups_enabled?
-        filter_origin_params
-      end
-
-      def default_filter_type_params
-        %w(all) + Decidim::Meetings::Meeting::TYPE_OF_MEETING
-      end
-
-      def default_search_params
-        {
-          scope: Meeting.not_hidden.visible_meeting_for(current_user)
         }
       end
     end

--- a/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
@@ -68,8 +68,8 @@ module Decidim
         def directory_filter_categories_values
           participatory_spaces = current_organization.public_participatory_spaces
           list_of_ps = participatory_spaces.flat_map do |current_participatory_space|
-            next if current_participatory_space.is_a?(Decidim::Consultation)
-            next if current_participatory_space.is_a?(Decidim::Votings::Voting)
+            next if defined?(Decidim::Consultation) && current_participatory_space.is_a?(Decidim::Consultation)
+            next if defined?(Decidim::Votings::Voting) && current_participatory_space.is_a?(Decidim::Votings::Voting)
 
             sorted_main_categories = current_participatory_space.categories.first_class.includes(:subcategories).sort_by do |category|
               [category.weight, translated_attribute(category.name, current_organization)]
@@ -90,6 +90,8 @@ module Decidim
               )
             end
 
+            next if categories_values.empty?
+
             key_point = current_participatory_space.class.name.gsub("::", "__") + current_participatory_space.id.to_s
 
             TreeNode.new(
@@ -98,9 +100,10 @@ module Decidim
             )
           end
 
+          list_of_ps.compact!
           TreeNode.new(
             TreePoint.new("", t("decidim.proposals.application_helper.filter_category_values.all")),
-            list_of_ps.compact!
+            list_of_ps
           )
         end
 

--- a/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
@@ -91,8 +91,6 @@ module Decidim
 
             next if categories_values.empty?
 
-            next if categories_values.empty?
-
             key_point = current_participatory_space.class.name.gsub("::", "__") + current_participatory_space.id.to_s
 
             TreeNode.new(

--- a/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
@@ -75,20 +75,7 @@ module Decidim
               [category.weight, translated_attribute(category.name, current_organization)]
             end
 
-            categories_values = sorted_main_categories.flat_map do |category|
-              sorted_descendant_categories = category.descendants.includes(:subcategories).sort_by do |subcategory|
-                [subcategory.weight, translated_attribute(subcategory.name, current_organization)]
-              end
-
-              subcategories = sorted_descendant_categories.flat_map do |subcategory|
-                TreePoint.new(subcategory.id.to_s, translated_attribute(subcategory.name, current_organization))
-              end
-
-              TreeNode.new(
-                TreePoint.new(category.id.to_s, translated_attribute(category.name, current_organization)),
-                subcategories
-              )
-            end
+            categories_values = categories_values(sorted_main_categories)
 
             next if categories_values.empty?
 
@@ -125,6 +112,25 @@ module Decidim
             ["all", t("decidim.meetings.meetings.filters.all")],
             ["my_meetings", t("decidim.meetings.meetings.filters.my_meetings")]
           ]
+        end
+
+        protected
+
+        def categories_values(sorted_main_categories)
+          sorted_main_categories.flat_map do |category|
+            sorted_descendant_categories = category.descendants.includes(:subcategories).sort_by do |subcategory|
+              [subcategory.weight, translated_attribute(subcategory.name, current_organization)]
+            end
+
+            subcategories = sorted_descendant_categories.flat_map do |subcategory|
+              TreePoint.new(subcategory.id.to_s, translated_attribute(subcategory.name, current_organization))
+            end
+
+            TreeNode.new(
+              TreePoint.new(category.id.to_s, translated_attribute(category.name, current_organization)),
+              subcategories
+            )
+          end
         end
       end
     end

--- a/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
@@ -49,7 +49,7 @@ module Decidim
           scopes_values.prepend(TreePoint.new("global", t("decidim.scopes.global")))
 
           TreeNode.new(
-            TreePoint.new("", t("decidim.proposals.application_helper.filter_scope_values.all")),
+            TreePoint.new("", t("decidim.meetings.application_helper.filter_scope_values.all")),
             scopes_values
           )
         end
@@ -65,11 +65,23 @@ module Decidim
           end
         end
 
+        def directory_meeting_spaces_values
+          participatory_spaces = current_organization.public_participatory_spaces
+
+          spaces = participatory_spaces.collect(&:model_name).uniq.map do |participatory_space|
+            TreePoint.new(participatory_space.name.underscore, participatory_space.human(count: 2))
+          end
+
+          TreeNode.new(
+            TreePoint.new("", t("decidim.meetings.application_helper.filter_meeting_space_values.all")),
+            spaces
+          )
+        end
+
         def directory_filter_categories_values
           participatory_spaces = current_organization.public_participatory_spaces
           list_of_ps = participatory_spaces.flat_map do |current_participatory_space|
-            next if defined?(Decidim::Consultation) && current_participatory_space.is_a?(Decidim::Consultation)
-            next if defined?(Decidim::Votings::Voting) && current_participatory_space.is_a?(Decidim::Votings::Voting)
+            next unless current_participatory_space.respond_to?(:categories)
 
             sorted_main_categories = current_participatory_space.categories.first_class.includes(:subcategories).sort_by do |category|
               [category.weight, translated_attribute(category.name, current_organization)]
@@ -89,7 +101,7 @@ module Decidim
 
           list_of_ps.compact!
           TreeNode.new(
-            TreePoint.new("", t("decidim.proposals.application_helper.filter_category_values.all")),
+            TreePoint.new("", t("decidim.meetings.application_helper.filter_category_values.all")),
             list_of_ps
           )
         end

--- a/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    # Custom helpers, scoped to the meetings engine.
+    #
+    module Directory
+      module ApplicationHelper
+        include PaginateHelper
+        include Decidim::MapHelper
+        include Decidim::Meetings::MapHelper
+        include Decidim::Meetings::MeetingsHelper
+        include Decidim::Comments::CommentsHelper
+        include Decidim::SanitizeHelper
+        include Decidim::CheckBoxesTreeHelper
+
+        def filter_type_values
+          type_values = []
+          Decidim::Meetings::Meeting::TYPE_OF_MEETING.each do |type|
+            type_values << TreePoint.new(type, t("decidim.meetings.meetings.filters.type_values.#{type}"))
+          end
+
+          TreeNode.new(
+            TreePoint.new("", t("decidim.meetings.meetings.filters.type_values.all")),
+            type_values
+          )
+        end
+
+        def filter_date_values
+          TreeNode.new(
+            TreePoint.new("", t("decidim.meetings.meetings.filters.date_values.all")),
+            [
+              TreePoint.new("upcoming", t("decidim.meetings.meetings.filters.date_values.upcoming")),
+              TreePoint.new("past", t("decidim.meetings.meetings.filters.date_values.past"))
+            ]
+          )
+        end
+
+        def directory_filter_scopes_values
+          main_scopes = current_organization.scopes.top_level
+
+          scopes_values = main_scopes.includes(:scope_type, :children).flat_map do |scope|
+            TreeNode.new(
+              TreePoint.new(scope.id.to_s, translated_attribute(scope.name, current_organization)),
+              scope_children_to_tree(scope)
+            )
+          end
+
+          scopes_values.prepend(TreePoint.new("global", t("decidim.scopes.global")))
+
+          TreeNode.new(
+            TreePoint.new("", t("decidim.proposals.application_helper.filter_scope_values.all")),
+            scopes_values
+          )
+        end
+
+        def scope_children_to_tree(scope)
+          return unless scope.children.any?
+
+          scope.children.includes(:scope_type, :children).flat_map do |child|
+            TreeNode.new(
+              TreePoint.new(child.id.to_s, translated_attribute(child.name, current_organization)),
+              scope_children_to_tree(child)
+            )
+          end
+        end
+
+        def directory_filter_categories_values
+          participatory_spaces = current_organization.public_participatory_spaces
+          list_of_ps = participatory_spaces.flat_map do |current_participatory_space|
+            next if current_participatory_space.is_a?(Decidim::Consultation)
+            next if current_participatory_space.is_a?(Decidim::Votings::Voting)
+
+            sorted_main_categories = current_participatory_space.categories.first_class.includes(:subcategories).sort_by do |category|
+              [category.weight, translated_attribute(category.name, current_organization)]
+            end
+
+            categories_values = sorted_main_categories.flat_map do |category|
+              sorted_descendant_categories = category.descendants.includes(:subcategories).sort_by do |subcategory|
+                [subcategory.weight, translated_attribute(subcategory.name, current_organization)]
+              end
+
+              subcategories = sorted_descendant_categories.flat_map do |subcategory|
+                TreePoint.new(subcategory.id.to_s, translated_attribute(subcategory.name, current_organization))
+              end
+
+              TreeNode.new(
+                TreePoint.new(category.id.to_s, translated_attribute(category.name, current_organization)),
+                subcategories
+              )
+            end
+
+            key_point = current_participatory_space.class.name.gsub("::", "__") + current_participatory_space.id.to_s
+
+            TreeNode.new(
+              TreePoint.new(key_point, translated_attribute(current_participatory_space.title, current_organization)),
+              categories_values
+            )
+          end
+
+          TreeNode.new(
+            TreePoint.new("", t("decidim.proposals.application_helper.filter_category_values.all")),
+            list_of_ps.compact!
+          )
+        end
+
+        def directory_filter_origin_values
+          origin_values = []
+          origin_values << TreePoint.new("official", t("decidim.meetings.meetings.filters.origin_values.official"))
+          origin_values << TreePoint.new("citizens", t("decidim.meetings.meetings.filters.origin_values.citizens"))
+          origin_values << TreePoint.new("user_group", t("decidim.meetings.meetings.filters.origin_values.user_groups")) if current_organization.user_groups_enabled?
+
+          TreeNode.new(
+            TreePoint.new("", t("decidim.meetings.meetings.filters.origin_values.all")),
+            origin_values
+          )
+        end
+
+        # Options to filter meetings by activity.
+        def activity_filter_values
+          [
+            ["all", t("decidim.meetings.meetings.filters.all")],
+            ["my_meetings", t("decidim.meetings.meetings.filters.my_meetings")]
+          ]
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
@@ -91,6 +91,8 @@ module Decidim
 
             next if categories_values.empty?
 
+            next if categories_values.empty?
+
             key_point = current_participatory_space.class.name.gsub("::", "__") + current_participatory_space.id.to_s
 
             TreeNode.new(

--- a/decidim-meetings/app/services/decidim/meetings/directory/meeting_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/directory/meeting_search.rb
@@ -4,6 +4,14 @@ module Decidim
   module Meetings
     module Directory
       class MeetingSearch < Decidim::Meetings::MeetingSearch
+        text_search_fields :title, :description
+
+        def search_space
+          return query if options[:space].blank? || options[:space] == "all"
+
+          query.joins(:component).where(decidim_components: { participatory_space_type: options[:space].collect(&:classify) })
+        end
+
         private
 
         # Private: Creates an array of category ids.

--- a/decidim-meetings/app/services/decidim/meetings/directory/meeting_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/directory/meeting_search.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    module Directory
+      class MeetingSearch < Decidim::Meetings::MeetingSearch
+        private
+
+        # Private: Creates an array of category ids.
+        # It contains categories' subcategories ids as well.
+        def all_category_ids
+          cat_ids = fetch_category_ids
+
+          component.flat_map do |comp|
+            comp
+              .categories
+              .where(id: cat_ids)
+              .or(comp.categories.where(parent_id: cat_ids))
+              .pluck(:id).tap { |ids| ids.prepend(nil) if category_ids.include?("without") }
+          end
+        end
+
+        # take a param list like ["2", "10", "Decidim__Assembly4", "Decidim__Assembly2"]
+        # return a param list like [47, 48, 43, 44, 45, 46, 41, 42, 27, 28, 32, 31, 29, 30, 26, 25]
+        def fetch_category_ids
+          cat_ids = category_ids.without("without")
+
+          additional_ids = cat_ids.keep_if { |a| a =~ /Decidim__/ }
+          additional_ids = parse_category_ids(additional_ids)
+          cat_ids.map(&:to_i).without(0).push(*additional_ids)
+        end
+
+        # this function expects an array of the following format : [ "Decidim__Assembly4", "Decidim__Assembly2"]
+        # It will transform each parameter into an array of class_name and id [["Decidim::Assembly", "4"], ["Decidim::Assembly", "2"]]
+        # After we rebuild the find query and retrun the category_ids for each participatory space
+        def parse_category_ids(additional_ids)
+          additional_ids = additional_ids.map { |a| a.gsub("__", "::").gsub(/(\d)/, '.\1').split(".") }
+          additional_ids = additional_ids.map { |v| v.first.safe_constantize.send(:find, v.last.to_i).category_ids }
+          additional_ids.flatten
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/services/decidim/meetings/directory/meeting_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/directory/meeting_search.rb
@@ -25,16 +25,17 @@ module Decidim
         def fetch_category_ids
           cat_ids = category_ids.without("without")
 
-          additional_ids = cat_ids.keep_if { |a| a =~ /Decidim__/ }
+          additional_ids = cat_ids.select { |a| a =~ /Decidim__/ }
+
           additional_ids = parse_category_ids(additional_ids)
-          cat_ids.map(&:to_i).without(0).push(*additional_ids)
+          cat_ids.collect(&:to_i).without(0).push(*additional_ids)
         end
 
         # this function expects an array of the following format : [ "Decidim__Assembly4", "Decidim__Assembly2"]
         # It will transform each parameter into an array of class_name and id [["Decidim::Assembly", "4"], ["Decidim::Assembly", "2"]]
         # After we rebuild the find query and retrun the category_ids for each participatory space
         def parse_category_ids(additional_ids)
-          additional_ids = additional_ids.map { |a| a.gsub("__", "::").gsub(/(\d)/, '.\1').split(".") }
+          additional_ids = additional_ids.map { |a| a.gsub("__", "::").gsub(/(\d+)/, '.\1').split(".") }
           additional_ids = additional_ids.map { |v| v.first.safe_constantize.send(:find, v.last.to_i).category_ids }
           additional_ids.flatten
         end

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/_filters.html.erb
@@ -1,0 +1,34 @@
+<%= render partial: "decidim/shared/filter_form_help", locals: { skip_to_id: "meetings" } %>
+
+<%= filter_form_for filter do |form| %>
+  <div class="filters__section">
+    <div class="filters__search">
+      <div class="input-group">
+        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t("decidim.meetings.meetings.filters.search"), title: t("decidim.meetings.meetings.filters.search"), "aria-label": t("decidim.meetings.meetings.filters.search"), data: { disable_dynamic_change: true } %>
+        <div class="input-group-button">
+          <button type="submit" class="button" aria-controls="meetings">
+            <%= icon "magnifying-glass", aria_label: t("decidim.meetings.meetings.filters.search"), role: "img" %>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <% unless @forced_past_meetings %>
+    <%= form.check_boxes_tree :date, filter_date_values, legend_title: t("decidim.meetings.meetings.filters.date") %>
+  <% end %>
+
+  <%= form.check_boxes_tree :type, filter_type_values, legend_title: t("decidim.meetings.meetings.filters.type") %>
+
+  <%= form.check_boxes_tree :scope_id, directory_filter_scopes_values, legend_title: t("decidim.meetings.meetings.filters.scope") %>
+
+  <%= form.check_boxes_tree :category_id, directory_filter_categories_values, legend_title: t("decidim.meetings.meetings.filters.category") %>
+
+  <%= form.check_boxes_tree :origin, directory_filter_origin_values, legend_title: t("decidim.meetings.meetings.filters.origin") %>
+
+  <%= form.collection_radio_buttons :space, @meeting_spaces, :first, :last, legend_title: t("decidim.meetings.directory.meetings.index.space_type") %>
+
+  <% if current_user %>
+    <%= form.collection_radio_buttons :activity, activity_filter_values, :first, :last, { legend_title: t("decidim.meetings.meetings.filters.activity") }, "aria-controls": "meetings" %>
+  <% end %>
+<% end %>

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/_filters.html.erb
@@ -26,7 +26,7 @@
 
   <%= form.check_boxes_tree :origin, directory_filter_origin_values, legend_title: t("decidim.meetings.meetings.filters.origin") %>
 
-  <%= form.collection_radio_buttons :space, @meeting_spaces, :first, :last, legend_title: t("decidim.meetings.directory.meetings.index.space_type") %>
+  <%= form.check_boxes_tree :space, directory_meeting_spaces_values, legend_title: t("decidim.meetings.directory.meetings.index.space_type") %>
 
   <% if current_user %>
     <%= form.collection_radio_buttons :activity, activity_filter_values, :first, :last, { legend_title: t("decidim.meetings.meetings.filters.activity") }, "aria-controls": "meetings" %>

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.html.erb
@@ -10,24 +10,7 @@
 
     <div class="columns mediumlarge-4 large-3">
       <div class="card card--secondary show-for-mediumlarge">
-        <%= render partial: "decidim/shared/filter_form_help", locals: { skip_to_id: "meetings" } %>
-        <%= filter_form_for filter, meetings_directory.root_path do |form| %>
-          <div class="filters__section">
-            <div class="filters__search">
-              <div class="input-group">
-                <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search"), title: t(".search"), "aria-label": t(".search") %>
-                <div class="input-group-button">
-                  <button type="submit" class="button">
-                    <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <%= form.collection_radio_buttons :date, [["upcoming", t(".upcoming")], ["past", t(".past")]], :first, :last, legend_title: t(".date") %>
-          <%= form.collection_radio_buttons :space, @meeting_spaces, :first, :last, legend_title: t(".space_type") %>
-        <% end %>
+          <%= render partial: "filters" %>
       </div>
     </div>
     <div id="meetings" class="columns mediumlarge-8 large-9">

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -380,6 +380,13 @@ en:
           value_types:
             organizer_presenter:
               not_found: 'The organizer was not found on the database (ID: %{id})'
+      application_helper:
+        filter_category_values:
+          all: All
+        filter_meeting_space_values:
+          all: All
+        filter_scope_values:
+          all: All
       calendar_modal:
         calendar_url: Calendar URL
         close_window: Close window
@@ -393,7 +400,6 @@ en:
       directory:
         meetings:
           index:
-            all: All
             meetings: Meetings
             space_type: Participatory space
       last_activity:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -394,12 +394,8 @@ en:
         meetings:
           index:
             all: All
-            date: Date
             meetings: Meetings
-            past: Past
-            search: Search
             space_type: Participatory space
-            upcoming: Upcoming
       last_activity:
         meeting_updated_at_html: "<span>Meeting updated at %{link}</span>"
         new_meeting_at_html: "<span>New meeting at %{link}</span>"

--- a/decidim-meetings/spec/services/directory/meeting_search_spec.rb
+++ b/decidim-meetings/spec/services/directory/meeting_search_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Meetings::Directory
+  describe MeetingSearch do
+    subject { described_class.new(params).results }
+
+    let!(:component) { create_list(:component, 3, manifest_name: "meetings") }
+    let(:user) { create :user, organization: component.first.organization }
+    let(:default_params) { { component: component, organization: component.first.organization, user: user } }
+    let(:params) { default_params }
+
+    describe "a resource search with categories" do
+      let(:participatory_process) { component.first.participatory_space }
+      let(:params) { default_params.merge(category_id: category_ids) }
+
+      describe "results" do
+        let!(:category1) { create :category, participatory_space: participatory_process }
+        let!(:category2) { create :category, participatory_space: participatory_process }
+        let!(:child_category) { create :category, participatory_space: participatory_process, parent: category2 }
+        let!(:meeting1) { create(:meeting, :published, component: component.first) }
+        let!(:meeting2) { create(:meeting, :published, component: component.first, category: category1) }
+        let!(:meeting3) { create(:meeting, :published, component: component.first, category: category2) }
+        let!(:meeting4) { create(:meeting, :published, component: component.first, category: child_category) }
+
+        context "when no category filter is present" do
+          let(:category_ids) { nil }
+
+          it "includes all resources" do
+            expect(subject).to match_array [meeting1, meeting2, meeting3, meeting4]
+          end
+        end
+
+        context "when a category is selected" do
+          let(:category_ids) { [category2.id] }
+
+          it "includes only resources for that category and its children" do
+            expect(subject).to match_array [meeting3, meeting4]
+          end
+        end
+
+        context "when a participatory process is selected" do
+          let(:value) { participatory_process.class.name.gsub("::", "__") + participatory_process.id.to_s }
+          let(:category_ids) { [value] }
+
+          it "includes only resources for that participatory_process - all categories and sub-categories" do
+            expect(subject).to match_array [meeting2, meeting3, meeting4]
+          end
+        end
+
+        context "when a subcategory is selected" do
+          let(:category_ids) { [child_category.id] }
+
+          it "includes only resources for that category" do
+            expect(subject).to eq [meeting4]
+          end
+        end
+
+        context "when `without` is being sent" do
+          let(:category_ids) { ["without"] }
+
+          it "returns resources without a category" do
+            expect(subject).to eq [meeting1]
+          end
+        end
+
+        context "when `without` and some category id is being sent" do
+          let(:category_ids) { ["without", category1.id] }
+
+          it "returns resources without a category and with the selected category" do
+            expect(subject).to match_array [meeting1, meeting2]
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
+++ b/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
@@ -239,7 +239,8 @@ describe "Explore meeting directory", type: :system do
 
       expect(page).to have_no_css(".card--meeting")
       within(all(".filters__section")[7]) do
-        choose "Assemblies"
+        uncheck "All"
+        check "Assemblies"
       end
 
       within ".date_check_boxes_tree_filter" do

--- a/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
+++ b/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
@@ -7,12 +7,13 @@ describe "Explore meeting directory", type: :system do
     Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path
   end
   let(:organization) { create(:organization) }
+  let(:participatory_process) { create :participatory_process, organization: organization }
   let(:components) do
     create_list(:meeting_component, 3, organization: organization)
   end
   let!(:meetings) do
     components.flat_map do |component|
-      create_list(:meeting, 2, :published, component: component)
+      create_list(:meeting, 2, :published, :not_official, component: component)
     end
   end
 
@@ -29,14 +30,179 @@ describe "Explore meeting directory", type: :system do
     expect(page).to have_css("#meetings-count", text: "6 MEETINGS")
   end
 
+  describe "category filter" do
+    context "with a category" do
+      let!(:category1) do
+        create(:category, participatory_space: participatory_process, name: { "en": "Category1" })
+      end
+      let!(:meeting) do
+        meeting = meetings.first
+        meeting.category = category1
+        meeting.save
+        meeting
+      end
+
+      it "shows tags for category" do
+        visit directory
+
+        expect(page).to have_selector("ul.tags.tags--meeting")
+        within "ul.tags.tags--meeting" do
+          expect(page).to have_content(translated(meeting.category.name))
+        end
+      end
+
+      it "allows filtering by category" do
+        visit directory
+
+        within ".category_id_check_boxes_tree_filter" do
+          check "All"
+          check translated(participatory_process.title)
+        end
+
+        expect(page).to have_content(translated(participatory_process.title))
+        expect(page).to have_content(translated(meeting.category.name))
+      end
+    end
+  end
+
+  context "with a scope" do
+    let!(:scope) { create(:scope, organization: organization) }
+    let!(:meeting) do
+      meeting = meetings.first
+      meeting.scope = scope
+      meeting.save
+      meeting
+    end
+
+    it "allows filtering by scope" do
+      visit directory
+
+      within ".scope_id_check_boxes_tree_filter" do
+        check "All"
+        check translated(meeting.scope.name)
+      end
+
+      expect(page).to have_content(translated(meeting.scope.name))
+    end
+  end
+
+  describe "origin filter" do
+    context "with 'official'" do
+      let!(:official_meeting) { create(:meeting, :published, :official, component: components.first, author: organization) }
+
+      it "lists the filtered meetings" do
+        visit directory
+
+        within ".origin_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Official"
+        end
+
+        expect(page).to have_content("1 MEETING")
+        expect(page).to have_css(".card--meeting", count: 1)
+
+        within ".card--meeting" do
+          expect(page).to have_content("Official meeting")
+        end
+      end
+    end
+
+    context "with 'groups' origin" do
+      let!(:user_group_meeting) { create(:meeting, :published, :user_group_author, component: components.first) }
+
+      it "lists the filtered meetings" do
+        visit directory
+
+        within ".origin_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Groups"
+        end
+
+        expect(page).to have_content("1 MEETING")
+        expect(page).to have_css(".card--meeting", count: 1)
+        within ".card--meeting" do
+          expect(page).to have_content(user_group_meeting.normalized_author.name)
+        end
+      end
+    end
+
+    context "with 'citizens' origin" do
+      it "lists the filtered meetings" do
+        visit directory
+
+        within ".origin_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Citizens"
+        end
+
+        expect(page).to have_css(".card--meeting", count: 6)
+        expect(page).to have_content("6 MEETINGS")
+      end
+    end
+  end
+
+  describe "type filter" do
+    context "when there are only online meetings" do
+      let!(:online_meeting1) do
+        create(:meeting, :published, :online, component: components.last)
+      end
+      let!(:online_meeting2) do
+        create(:meeting, :published, :online, component: components.last)
+      end
+
+      it "allows filtering by type 'online'" do
+        within ".type_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Online"
+        end
+
+        expect(page).to have_content(online_meeting1.title["en"])
+        expect(page).to have_content(online_meeting2.title["en"])
+        expect(page).to have_css("#meetings-count", text: "2 MEETINGS")
+      end
+    end
+
+    context "when there are only in-person meetings" do
+      let!(:in_person_meeting) do
+        create(:meeting, :published, :in_person, component: components.last)
+      end
+
+      it "allows filtering by type 'in-person'" do
+        within ".type_check_boxes_tree_filter" do
+          uncheck "All"
+          check "In-person"
+        end
+
+        expect(page).to have_content(in_person_meeting.title["en"])
+        expect(page).to have_css("#meetings-count", text: "7 MEETINGS") # default meeting component it's with type "in-person"
+      end
+    end
+
+    context "when there are hybrid meetings" do
+      let!(:online_meeting) do
+        create(:meeting, :published, :hybrid, component: components.last)
+      end
+
+      it "allows filtering by type 'both'" do
+        within ".type_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Both"
+        end
+
+        expect(page).to have_css("#meetings-count", text: "1 MEETING")
+      end
+    end
+  end
+
   context "when there's a past meeting" do
     let!(:past_meeting) do
       create(:meeting, :published, component: components.last, start_time: 1.week.ago)
     end
 
     it "allows filtering by past events" do
-      within ".filters" do
-        choose "Past"
+      within ".date_check_boxes_tree_filter" do
+        uncheck "All"
+        check "Past"
       end
 
       expect(page).to have_content(past_meeting.title["en"])
@@ -66,15 +232,18 @@ describe "Explore meeting directory", type: :system do
       # have_content to wait for the card list to change. This is a hack to
       # reset the contents to no meetings at all, and then showing only the upcoming
       # assembly meetings.
-      within ".filters" do
-        choose "Past"
+      within ".date_check_boxes_tree_filter" do
+        uncheck "All"
+        check "Past"
       end
 
       expect(page).to have_no_css(".card--meeting")
-
-      within ".filters" do
+      within(all(".filters__section")[7]) do
         choose "Assemblies"
-        choose "Upcoming"
+      end
+
+      within ".date_check_boxes_tree_filter" do
+        check "Upcoming"
       end
 
       expect(page).to have_content(assembly_meeting.title["en"])


### PR DESCRIPTION
#### :tophat: What? Why?
As a user when visiting which shows all events on the platform /meetings I'm frustrated that I don't get more filtering options that I have on the component's index page.

I'd like to be able to filter on the meetings space by :

* Space
* Type
* Scope
* Origin
* My activity

#### :pushpin: Related Issues
Meta proposal: https://meta.decidim.org/processes/roadmap/f/122/proposals/16343

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

#### Before

![imatge](https://user-images.githubusercontent.com/717367/135042949-fdb7e521-4636-4591-9c0b-f266feef9ccd.png)

#### After

![imatge](https://user-images.githubusercontent.com/717367/135042956-73860e52-7ed1-4216-a8de-e2b390aa468d.png)

:hearts: Thank you!
