### PR TITLE
Fix HTTPOnly and secure flag on the cookie acceptance cookie

### DIFF
--- a/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
+++ b/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
@@ -10,6 +10,7 @@ module Decidim
         Decidim.config.consent_cookie_name,
         value: "true",
         path: "/",
+        httponly: true,
         secure: request.session_options[:secure],
         expires: 1.year.from_now.utc
       )

--- a/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
+++ b/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
@@ -10,6 +10,7 @@ module Decidim
         Decidim.config.consent_cookie_name,
         value: "true",
         path: "/",
+        secure: request.session_options[:secure],
         expires: 1.year.from_now.utc
       )
 

--- a/decidim-core/spec/controllers/cookie_policy_controller_spec.rb
+++ b/decidim-core/spec/controllers/cookie_policy_controller_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe CookiePolicyController, type: :controller do
+    routes { Decidim::Core::Engine.routes }
+
+    let(:organization) { create(:organization) }
+    let(:extra_session_options) { {} }
+    let(:session_options) { request.session_options.merge(extra_session_options) }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      default_session_options session_options
+    end
+
+    after do
+      default_session_options Rack::Session::Abstract::Persisted::DEFAULT_OPTIONS
+    end
+
+    describe "GET /accept" do
+      it "sets the consent cookie for the user" do
+        get :accept
+
+        expect(response.cookies[Decidim.config.consent_cookie_name]).to eq("true")
+        expect(response["Set-Cookie"]).to match(%r{^decidim-cc=true; path=/; expires=[^;]+$})
+      end
+
+      context "when the session options define the secure flag" do
+        let(:extra_session_options) { { secure: true } }
+
+        it "sets the consent cookie for the user as secure" do
+          get :accept
+
+          expect(response.cookies[Decidim.config.consent_cookie_name]).to eq("true")
+          expect(response["Set-Cookie"]).to match(%r{^decidim-cc=true; path=/; expires=[^;]+; secure$})
+        end
+      end
+    end
+
+    private
+
+    # Hack because there is no way to provide the session options through the
+    # environment.
+    #
+    # See: https://github.com/rails/rails/blob/6-0-stable/actionpack/lib/action_controller/test_case.rb
+    def default_session_options(options)
+      ActionController::TestSession.send(:remove_const, :DEFAULT_OPTIONS)
+      ActionController::TestSession.const_set(:DEFAULT_OPTIONS, options)
+    end
+  end
+end

--- a/decidim-core/spec/controllers/cookie_policy_controller_spec.rb
+++ b/decidim-core/spec/controllers/cookie_policy_controller_spec.rb
@@ -24,7 +24,7 @@ module Decidim
         get :accept
 
         expect(response.cookies[Decidim.config.consent_cookie_name]).to eq("true")
-        expect(response["Set-Cookie"]).to match(%r{^decidim-cc=true; path=/; expires=[^;]+$})
+        expect(response["Set-Cookie"]).to match(%r{^decidim-cc=true; path=/; expires=[^;]+; HttpOnly$})
       end
 
       context "when the session options define the secure flag" do
@@ -34,7 +34,7 @@ module Decidim
           get :accept
 
           expect(response.cookies[Decidim.config.consent_cookie_name]).to eq("true")
-          expect(response["Set-Cookie"]).to match(%r{^decidim-cc=true; path=/; expires=[^;]+; secure$})
+          expect(response["Set-Cookie"]).to match(%r{^decidim-cc=true; path=/; expires=[^;]+; secure; HttpOnly$})
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
The `decidim-cc` cookie gets set without the HTTPOnly flag and in non-production environments without the secure flag.

These are not major security vulnerabilities because there is nothing very secure stored in that cookie but it causes some security auditing tools to mark it as a low level issue to be notified.

#### Testing
- Go to Meta Decidim
- Accept the cookie dialog
- Check the cookies from the developer console
- See that it is stored without the `HTTPOnly` flag
- Furthermore, in non-production environments (such as `staging`), this cookie gets set without the secure flag

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Cookie flags on the decidim-cc cookie](https://user-images.githubusercontent.com/864340/134936121-94b2997c-37f7-4983-ada6-8665ffef9bfa.png)