### PR TITLE
Fix published and title in seeded meetings

### DIFF
--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -156,14 +156,22 @@ Decidim.register_component(:meetings) do |component|
       _hybrid_meeting = Decidim.traceability.create!(
         Decidim::Meetings::Meeting,
         admin_user,
-        params.merge(type_of_meeting: :hybrid, online_meeting_url: "http://example.org"),
+        params.merge(
+          title: Decidim::Faker::Localized.sentence(word_count: 2),
+          type_of_meeting: :hybrid,
+          online_meeting_url: "http://example.org"
+        ),
         visibility: "all"
       )
 
       _online_meeting = Decidim.traceability.create!(
         Decidim::Meetings::Meeting,
         admin_user,
-        params.merge(type_of_meeting: :online, online_meeting_url: "http://example.org"),
+        params.merge(
+          title: Decidim::Faker::Localized.sentence(word_count: 2),
+          type_of_meeting: :online,
+          online_meeting_url: "http://example.org"
+        ),
         visibility: "all"
       )
 


### PR DESCRIPTION
#### :tophat: What? Why?

While working with a seeded database there were a couple of problems introduced by the latest features related to meetings:

1) ~By default no meeting was published~ (Fixed on #8369)
2) Some meetings have the same title

That imposed difficulties on working with certain features, for instance, #8333. This PR solves these two bugs.

#### :pushpin: Related Issues

- Related to #7893 
- Related to #6572

#### Testing

Start with a fresh database and seed it:

```bash
bin/rails db:drop
bin/rails db:create
bin/rails db:migrate
bin/rails db:seed
```

### :camera: Screenshots

#### Before

![imatge](https://user-images.githubusercontent.com/717367/135046435-7fc254e9-47b4-43ce-8b9d-f7d73e598863.png)

![imatge](https://user-images.githubusercontent.com/717367/135046427-44b20c6c-2121-41ed-bb8c-f4e48d5a48fd.png)

#### After

![imatge](https://user-images.githubusercontent.com/717367/134936227-89a04fc4-40a4-4f6b-ba9a-480ff10db7d5.png)

![imatge](https://user-images.githubusercontent.com/717367/134936207-eee4fb00-6b9f-4352-8024-22a1cfc7dfb2.png)

:hearts: Thank you!
