### PR TITLE
Fix issues with the session/environment security configs

### DIFF
--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -145,9 +145,9 @@ module Decidim
   # the mails.
   config_accessor :mailer_sender
 
-  # Whether SSL should be enabled or not.
+  # Whether SSL should be forced or not.
   config_accessor :force_ssl do
-    true
+    Rails.env.starts_with?("production") || Rails.env.starts_with?("staging")
   end
 
   # Having this on true will change the way the svg assets are being served.

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -304,7 +304,7 @@ module Decidim
 
       initializer "SSL and HSTS" do
         Rails.application.configure do
-          config.force_ssl = Rails.env.production? && Decidim.config.force_ssl
+          config.force_ssl = Decidim.config.force_ssl
         end
       end
 

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -315,7 +315,7 @@ module Decidim
       end
 
       initializer "Expire sessions" do
-        Rails.application.config.session_store :cookie_store, expire_after: Decidim.config.expire_session_after
+        Rails.application.config.session_store :cookie_store, secure: Decidim.config.force_ssl, expire_after: Decidim.config.expire_session_after
       end
 
       initializer "decidim.core.register_resources" do

--- a/decidim-core/spec/lib/decidim_spec.rb
+++ b/decidim-core/spec/lib/decidim_spec.rb
@@ -37,4 +37,54 @@ describe Decidim do
       described_class.seed!
     end
   end
+
+  describe ".force_ssl" do
+    let!(:orig_force_ssl) { described_class.force_ssl }
+    let(:rails_env) { "test" }
+
+    before do
+      allow(Rails).to receive(:env).and_return(rails_env)
+      load "#{Decidim::Core::Engine.root}/lib/decidim/core.rb"
+    end
+
+    after do
+      described_class.force_ssl = orig_force_ssl
+    end
+
+    it "returns false for the test environment" do
+      expect(described_class.force_ssl).to eq(false)
+    end
+
+    context "when the Rails.env is set to production" do
+      let(:rails_env) { "production" }
+
+      it "returns true" do
+        expect(described_class.force_ssl).to eq(true)
+      end
+    end
+
+    context "when the Rails.env is set to production_foo" do
+      let(:rails_env) { "production_foo" }
+
+      it "returns true" do
+        expect(described_class.force_ssl).to eq(true)
+      end
+    end
+
+    context "when the Rails.env is set to staging" do
+      let(:rails_env) { "staging" }
+
+      it "returns true" do
+        expect(described_class.force_ssl).to eq(true)
+      end
+    end
+
+    context "when the Rails.env is set to staging_foo" do
+      let(:rails_env) { "staging_foo" }
+
+      it "returns true" do
+        expect(described_class.force_ssl).to eq(true)
+      end
+    end
+  end
 end

--- a/decidim-core/spec/lib/engine_spec.rb
+++ b/decidim-core/spec/lib/engine_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Core
+  describe Engine do
+    describe "initializers" do
+      let(:initializer_name) { nil }
+      let(:initializer) { described_class.initializers.find { |i| i.name == initializer_name } }
+
+      context "when running the 'SSL and HSTS' initializer" do
+        let(:initializer_name) { "SSL and HSTS" }
+
+        before do
+          allow(Decidim.config).to receive(:force_ssl).and_return(decidim_force_ssl)
+          initializer.run
+        end
+
+        after do
+          Rails.application.config.force_ssl = false
+        end
+
+        context "when Decidim.config.force_ssl is true" do
+          let(:decidim_force_ssl) { true }
+
+          it "configures the force_ssl according to the Decidim setting" do
+            expect(Rails.application.config.force_ssl).to be(true)
+          end
+        end
+
+        context "when Decidim.config.force_ssl is false" do
+          let(:decidim_force_ssl) { false }
+
+          it "configures the force_ssl according to the Decidim setting" do
+            expect(Rails.application.config.force_ssl).to be(false)
+          end
+        end
+      end
+
+      context "when running the 'Expire sessions' initializer" do
+        let(:initializer_name) { "Expire sessions" }
+        let(:decidim_force_ssl) { false }
+        let(:decidim_expire_session_after) { 30.minutes }
+
+        before do
+          allow(Decidim.config).to receive(:force_ssl).and_return(decidim_force_ssl)
+          allow(Decidim.config).to receive(:expire_session_after).and_return(decidim_expire_session_after)
+          initializer.run
+        end
+
+        after do
+          Rails.application.config.force_ssl = false
+          Rails.application.config.expire_session_after = 30.minutes
+        end
+
+        context "when Decidim.config.force_ssl is true" do
+          let(:decidim_force_ssl) { true }
+
+          it "configures the session cookie store with the secure flag" do
+            expect(Rails.application.config.session_options).to eq(
+              secure: true,
+              expire_after: 30.minutes
+            )
+          end
+        end
+
+        context "when Decidim.config.force_ssl is false" do
+          let(:decidim_force_ssl) { false }
+
+          it "configures the session cookie store without the secure flag" do
+            expect(Rails.application.config.session_options).to eq(
+              secure: false,
+              expire_after: 30.minutes
+            )
+          end
+        end
+
+        context "when expire session after is set to a custom amount" do
+          let(:decidim_expire_session_after) { 1.hour }
+
+          it "configures the session cookie store with the correct expire after value" do
+            expect(Rails.application.config.session_options).to eq(
+              secure: false,
+              expire_after: 1.hour
+            )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This allows configuring the Rails `force_ssl` configuration also for environments that are not matching exactly `production` but also for environments such as `production`, `production_other`, `staging`, `staging_other`, etc.

Another fix is that this sets the `secure` flag for the session cookie store in case the Decidim `force_ssl` configuration has been set to `true`. Otherwise the session cookie won't be marked as secure unless the environment is `production` (e.g. the case with `staging` and such environments).

#### Testing
- Run Decidim under HTTPs e.g. with `RAILS_ENV=staging`
- Configure `Decidim.force_ssl = true` within the Decidim initializer
- Request the website
- See that the cookie was not set as secure (for production envronments it's set as secure when `Rails.application.config.force_ssl` is set to true but not for other envs)
- Open the Rails console with the same `RAILS_ENV`
- Run `Rails.application.config.force_ssl` in the console
- See that the `force_ssl` config is not set to `true` as expected

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.