### PR TITLE
Refresh comments component after updating

### DIFF
--- a/decidim-comments/app/views/decidim/comments/comments/update.js.erb
+++ b/decidim-comments/app/views/decidim/comments/comments/update.js.erb
@@ -1,8 +1,22 @@
 $(() => {
-  const commentHtml = '<%== j(render partial: "edited_comment", locals: { comment: @comment }).strip %>';
-  const commentId = <%= @comment.id.to_json %>;
-  const $comment = $("#comment_<%= @comment.id %>");
-  const $editCommentModal = $("#editCommentModal<%= @comment.id %>");
+  var rootCommentableId = <%== "comments-for-#{@comment.commentable.commentable_type.demodulize}-#{@comment.commentable.id}".to_json %>;
+  var $comments = $("#" + rootCommentableId);
+  var config = $comments.data("decidim-comments");
+
+  component = new Decidim.CommentsComponent($comments, config);
+  component.unmountComponent();
+
+  var commentHtml = '<%== j(render partial: "edited_comment", locals: { comment: @comment }).strip %>';
+  var commentId = <%= @comment.id.to_json %>;
+  var $comment = $("#comment_<%= @comment.id %>");
 
   $comment.replaceWith(commentHtml);
+
+  $comments = $("#" + rootCommentableId);
+  $comments.foundation();
+
+  // Re-create the component
+  component = new Decidim.CommentsComponent($comments, $comments.data("decidim-comments"));
+  component.mountComponent();
+  $comments.data("comments", component);
 });


### PR DESCRIPTION
#### :tophat: What? Why?

This PR changes the udpate comment partial to reload the comments component after editing a comment to have available the menu with actions to edit again or delete on the edited comment and dependent ones.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
