### PR TITLE
Fix error when accessing the meetings of a conference with speakers related 

### DIFF
--- a/decidim-conferences/app/models/decidim/conference_meeting.rb
+++ b/decidim-conferences/app/models/decidim/conference_meeting.rb
@@ -3,7 +3,7 @@
 module Decidim
   # It represents a meeting of the conference
   class ConferenceMeeting < Decidim::Meetings::Meeting
-    translatable_fields *Decidim::Meetings::Meeting.translatable_fields_list
+    translatable_fields(*Decidim::Meetings::Meeting.translatable_fields_list)
 
     has_many :conference_speaker_conference_meetings, dependent: :destroy
     has_many :conference_speakers, through: :conference_speaker_conference_meetings, class_name: "Decidim::ConferenceSpeaker"

--- a/decidim-conferences/app/models/decidim/conference_meeting.rb
+++ b/decidim-conferences/app/models/decidim/conference_meeting.rb
@@ -3,9 +3,11 @@
 module Decidim
   # It represents a meeting of the conference
   class ConferenceMeeting < Decidim::Meetings::Meeting
+    translatable_fields *Decidim::Meetings::Meeting.translatable_fields_list
+
     has_many :conference_speaker_conference_meetings, dependent: :destroy
     has_many :conference_speakers, through: :conference_speaker_conference_meetings, class_name: "Decidim::ConferenceSpeaker"
-    has_many :conference_meeting_registration_types, dependent: :destroy
+    has_many :conference_meeting_registration_types, dependent: :destroy, class_name: "Decidim::Conferences::ConferenceMeetingRegistrationType"
     has_many :registration_types, through: :conference_meeting_registration_types, foreign_key: "registration_type_id", class_name: "Decidim::Conferences::RegistrationType"
   end
 end

--- a/decidim-conferences/app/presenters/decidim/conference_speaker_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conference_speaker_presenter.rb
@@ -33,6 +33,16 @@ module Decidim
       false
     end
 
+    def avatar
+      attached_uploader(:avatar)
+    end
+
+    def avatar_url(variant = nil)
+      return avatar.default_url unless avatar.attached?
+
+      avatar.path(variant: variant)
+    end
+
     private
 
     def user

--- a/decidim-conferences/lib/decidim/conferences/participatory_space.rb
+++ b/decidim-conferences/lib/decidim/conferences/participatory_space.rb
@@ -227,6 +227,17 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
       Decidim.component_manifests.each do |manifest|
         manifest.seed!(conference.reload)
       end
+
+      Decidim::ConferenceMeeting.where(component: conference.components).each do |conference_meeting|
+        next unless Faker::Boolean.boolean(true_ratio: 0.5)
+
+        conference.speakers.sample(3).each do |speaker|
+          Decidim::ConferenceSpeakerConferenceMeeting.create!(
+            conference_meeting: conference_meeting,
+            conference_speaker: speaker
+          )
+        end
+      end
     end
   end
 end

--- a/decidim-conferences/lib/decidim/conferences/test/factories.rb
+++ b/decidim-conferences/lib/decidim/conferences/test/factories.rb
@@ -2,6 +2,7 @@
 
 require "decidim/faker/localized"
 require "decidim/dev"
+require "decidim/meetings/test/factories"
 
 FactoryBot.define do
   sequence(:conference_slug) do |n|
@@ -124,6 +125,49 @@ FactoryBot.define do
 
     trait :with_user do
       user { create(:user, organization: conference.organization) }
+    end
+
+    trait :with_meeting do
+      transient do
+        meetings_component { create(:meetings_component, participatory_space: conference.participatory_space) }
+      end
+
+      after :build do |conference_speaker, evaluator|
+        conference_speaker.conference_speaker_conference_meetings << build(:conference_speaker_conference_meeting,
+                                                                           meetings_component: evaluator.meetings_component,
+                                                                           conference_speaker: conference_speaker)
+      end
+    end
+  end
+
+  factory :conference_speaker_conference_meeting, class: "Decidim::ConferenceSpeakerConferenceMeeting" do
+    transient do
+      conference { create(:conference) }
+      meetings_component { create(:meetings_component, participatory_space: conference.participatory_space) }
+    end
+
+    conference_meeting { create(:conference_meeting, :published, conference: conference, component: meetings_component) }
+    conference_speaker { create(:conference_speaker, conference: conference) }
+  end
+
+  factory :conference_meeting_registration_type, class: "Decidim::Conferences::ConferenceMeetingRegistrationType" do
+    transient do
+      conference { create(:conference) }
+    end
+
+    conference_meeting
+    registration_type { build(:registration_type, conference: conference) }
+  end
+
+  factory :conference_meeting, parent: :meeting, class: "Decidim::ConferenceMeeting" do
+    transient do
+      conference { create(:conference) }
+    end
+
+    after :build do |conference_meeting, evaluator|
+      conference_meeting.conference_meeting_registration_types << build(:conference_meeting_registration_type,
+                                                                        conference_meeting: conference_meeting,
+                                                                        conference: evaluator.conference)
     end
   end
 

--- a/decidim-conferences/spec/system/conference_program_spec.rb
+++ b/decidim-conferences/spec/system/conference_program_spec.rb
@@ -37,14 +37,8 @@ describe "Conference program", type: :system do
   end
 
   context "when there are some conference meetings" do
-    let!(:meetings) do
-      create_list(
-        :meeting,
-        3,
-        :published,
-        component: component
-      )
-    end
+    let!(:conference_speakers) { create_list(:conference_speaker, 3, :with_meeting, conference: conference, meetings_component: component) }
+    let(:meetings) { Decidim::ConferenceMeeting.where(component: component) }
 
     before do
       visit decidim_conferences.conference_conference_program_path(conference, component)

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -149,7 +149,8 @@ Decidim.register_component(:meetings) do |component|
         author: participatory_space.organization,
         registration_terms: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
           Decidim::Faker::Localized.paragraph(sentence_count: 3)
-        end
+        end,
+        published_at: Faker::Boolean.boolean(true_ratio: 0.8) ? Time.current : nil
       }
 
       _hybrid_meeting = Decidim.traceability.create!(


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the error when showing the list of meetings from a conference when they have related speakers. It adds regression tests for it, and add seeds to help devs to detect problems related to it. Finally, it also modifies seeds to publish most of the meetings created. 

#### :pushpin: Related Issues
- Fixes #8364

#### Testing
1. Go to Conferences admin in the Speakers section.
2. Add or edit a speaker.
3. Select some meetings in the "Related meetings" and save the speaker.
4. Visit the Program page in the Conference front-end zone.
5. Check that the meeting includes the speaker avatar and name.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
