### PR TITLE
Fix details on conference speakers: affiliation order, personal URL link, seeds and more info link 

### DIFF
--- a/decidim-conferences/app/cells/decidim/conferences/conference_speaker/show.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/conference_speaker/show.erb
@@ -11,6 +11,11 @@
         <%= position %>
       </div>
     <% end %>
+    <% if affiliation.presence %>
+      <div class="data-extra">
+        <%= affiliation %>
+      </div>
+    <% end %>
     <div class="data-extra">
       <% if nickname.present? %>
         <%= link_to profile_path, class: "card-link" do %>
@@ -34,6 +39,11 @@
           <% if position.presence %>
             <div class="data-role"><%= position %></div>
           <% end %>
+          <% if affiliation.presence %>
+            <div class="data-extra">
+              <%= affiliation %>
+            </div>
+          <% end %>
           <div class="data-extra">
             <% if nickname.present? %>
               <%= link_to profile_path, class: "card-link" do %>
@@ -51,11 +61,6 @@
           <% if twitter_handle.presence %>
             <div>
               <%= twitter_handle %>
-            </div>
-          <% end %>
-          <% if affiliation.presence %>
-            <div>
-              <%= affiliation %>
             </div>
           <% end %>
         </div>

--- a/decidim-conferences/app/cells/decidim/conferences/conference_speaker/show.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/conference_speaker/show.erb
@@ -18,12 +18,11 @@
     <% end %>
     <div class="data-extra">
       <% if nickname.present? %>
-        <%= link_to profile_path, class: "card-link" do %>
-          <%= nickname %> <span><u><%= t(".more_info") %></u></span>
-        <% end %>
+        <%= link_to nickname, profile_path, class: "card-link" %>
       <% else %>
         <div class="author__nickname">&nbsp;</div>
       <% end %>
+      <div><u><%= t(".more_info") %></u></div>
     </div>
   </div>
   <div class="speaker-bio js-bio">
@@ -46,12 +45,11 @@
           <% end %>
           <div class="data-extra">
             <% if nickname.present? %>
-              <%= link_to profile_path, class: "card-link" do %>
-                <%= nickname %> <span><u><%= t(".more_info") %></u></span>
-              <% end %>
+              <%= link_to nickname, profile_path, class: "card-link" %>
             <% else %>
               <div class="author__nickname">&nbsp;</div>
             <% end %>
+            <div><u><%= t(".more_info") %></u></div>
           </div>
           <% if personal_url.presence %>
             <div>

--- a/decidim-conferences/app/cells/decidim/conferences/conference_speaker_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/conference_speaker_cell.rb
@@ -72,9 +72,7 @@ module Decidim
       def personal_url
         return unless model.personal_url.presence || (model.user.presence && model.user.personal_url.presence)
 
-        link_to model.personal_url || model.user.personal_url, target: "_blank", class: "card-link", rel: "noopener" do
-          "#{icon "external-link"}" "&nbsp;#{t(".personal_website")}"
-        end
+        link_to t(".personal_website"), model.personal_url || model.user.personal_url, target: "_blank", class: "card-link", rel: "noopener"
       end
 
       def meetings

--- a/decidim-conferences/lib/decidim/conferences/participatory_space.rb
+++ b/decidim-conferences/lib/decidim/conferences/participatory_space.rb
@@ -175,7 +175,7 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
           user: conference.organization.users.sample,
           full_name: Faker::Name.name,
           position: Decidim::Faker::Localized.word,
-          affiliation: Decidim::Faker::Localized.paragraph(sentence_count: 3),
+          affiliation: Decidim::Faker::Localized.sentence(word_count: 3),
           short_bio: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
             Decidim::Faker::Localized.paragraph(sentence_count: 3)
           end,


### PR DESCRIPTION
## :tophat: What? Why?

As we were configuring [conference speakers for Decidim Fest 2021 on Metadecidim](https://meta.decidim.org/conferences/DecidimFest21/speakers?locale=ca), a couple of bugs were detected:

1. affiliation was hidden after the hover, so it wasn't visible
2. in the personal URL there were two "external link" icons: one that was from the speakers' first iteration and another one introduced by the (relatively) new automatic "external link icon"
3. when there isn't any participant account associated, the "more info" link isn't visible
4. while working on this, I've also seen that there was a problem with seeds: they were too long and didn't reflect the real use cases that we were seeing.

This PR fixes all of this.

## :pushpin: Related Issues
*Link your PR to an issue*
- Related to #7397 
- Fixes #3781 

## Testing
Go to conference speakers, the new fixes should be visible 
See screenshots to see how it should be seen

## :camera: Screenshots

### 1. Affiliation after hover

#### Before

![image](https://user-images.githubusercontent.com/717367/135990306-4d63ea23-4aae-4a57-ba70-4a42446d68a5.png)

![image](https://user-images.githubusercontent.com/717367/135990328-0ecb4d57-29a2-4ac8-add3-323cb8531788.png)


#### After
![image](https://user-images.githubusercontent.com/717367/135990351-5a7855cd-19a8-42f9-8bf0-8132c351febb.png)

![image](https://user-images.githubusercontent.com/717367/135990364-d93b65cc-6472-42e3-82c0-37061772ecfc.png)

### 2. Personal URL icon

#### Before
![image](https://user-images.githubusercontent.com/717367/135978516-1f0c70a8-7a9a-4d3f-a033-2c09a4fcd80f.png)
#### After
![image](https://user-images.githubusercontent.com/717367/135978547-686f0702-c9f7-42bd-b33b-2506a5f37380.png)


### 3. Seeds
#### Before
![image](https://user-images.githubusercontent.com/717367/135978237-807a7238-9c6f-4907-ac13-5c07e50fd0c6.png)
#### After
![image](https://user-images.githubusercontent.com/717367/135992000-ba04e7ee-46b0-4285-9d46-0b517fc42605.png)



### 4. More info link
#### Before

![image](https://user-images.githubusercontent.com/717367/135991460-3d8053d2-0a74-4916-a62b-ed673a7bb35a.png)

#### After
![image](https://user-images.githubusercontent.com/717367/135991770-8c06f5fd-4e24-4569-8598-a7a9197f1b6e.png)


:hearts: Thank you!
