### PR TITLE
Backport "Fix details on conference speakers: affiliation order, personal URL link, seeds and more info link" to v0.25

### DIFF
--- a/decidim-conferences/app/cells/decidim/conferences/conference_speaker/show.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/conference_speaker/show.erb
@@ -11,14 +11,18 @@
         <%= position %>
       </div>
     <% end %>
+    <% if affiliation.presence %>
+      <div class="data-extra">
+        <%= affiliation %>
+      </div>
+    <% end %>
     <div class="data-extra">
       <% if nickname.present? %>
-        <%= link_to profile_path, class: "card-link" do %>
-          <%= nickname %> <span><u><%= t(".more_info") %></u></span>
-        <% end %>
+        <%= link_to nickname, profile_path, class: "card-link" %>
       <% else %>
         <div class="author__nickname">&nbsp;</div>
       <% end %>
+      <div><u><%= t(".more_info") %></u></div>
     </div>
   </div>
   <div class="speaker-bio js-bio">
@@ -34,14 +38,18 @@
           <% if position.presence %>
             <div class="data-role"><%= position %></div>
           <% end %>
+          <% if affiliation.presence %>
+            <div class="data-extra">
+              <%= affiliation %>
+            </div>
+          <% end %>
           <div class="data-extra">
             <% if nickname.present? %>
-              <%= link_to profile_path, class: "card-link" do %>
-                <%= nickname %> <span><u><%= t(".more_info") %></u></span>
-              <% end %>
+              <%= link_to nickname, profile_path, class: "card-link" %>
             <% else %>
               <div class="author__nickname">&nbsp;</div>
             <% end %>
+            <div><u><%= t(".more_info") %></u></div>
           </div>
           <% if personal_url.presence %>
             <div>
@@ -51,11 +59,6 @@
           <% if twitter_handle.presence %>
             <div>
               <%= twitter_handle %>
-            </div>
-          <% end %>
-          <% if affiliation.presence %>
-            <div>
-              <%= affiliation %>
             </div>
           <% end %>
         </div>

--- a/decidim-conferences/app/cells/decidim/conferences/conference_speaker_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/conference_speaker_cell.rb
@@ -72,9 +72,7 @@ module Decidim
       def personal_url
         return unless model.personal_url.presence || (model.user.presence && model.user.personal_url.presence)
 
-        link_to model.personal_url || model.user.personal_url, target: "_blank", class: "card-link", rel: "noopener" do
-          "#{icon "external-link"}" "&nbsp;#{t(".personal_website")}"
-        end
+        link_to t(".personal_website"), model.personal_url || model.user.personal_url, target: "_blank", class: "card-link", rel: "noopener"
       end
 
       def meetings

--- a/decidim-conferences/lib/decidim/conferences/participatory_space.rb
+++ b/decidim-conferences/lib/decidim/conferences/participatory_space.rb
@@ -175,7 +175,7 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
           user: conference.organization.users.sample,
           full_name: Faker::Name.name,
           position: Decidim::Faker::Localized.word,
-          affiliation: Decidim::Faker::Localized.paragraph(sentence_count: 3),
+          affiliation: Decidim::Faker::Localized.sentence(word_count: 3),
           short_bio: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
             Decidim::Faker::Localized.paragraph(sentence_count: 3)
           end,


### PR DESCRIPTION
#### :tophat: What? Why?

This PR backports "Fix details on conference speakers: affiliation order, personal URL link, seeds and more info link" to the latest release v0.25

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #8378 

:hearts: Thank you!
