### PR TITLE
Adapt accountability results scopes for responsive view

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/results/_scope_filters_small.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_scope_filters_small.html.erb
@@ -1,0 +1,33 @@
+<div class="scope-filters section">
+  <% if current_component.has_subscopes? %>
+    <div><%= t("results.filters.scopes", scope: "decidim.accountability") %></div>
+
+    <ul class="tags tags--action">
+      <div>
+        <button data-open="filter-box" class="filters-controls__trigger">
+          filter
+          <%= icon "caret-bottom", class: "icon--small float-right", aria_label: "unfold", role: "img" %>
+        </button>
+      </div>
+
+      <div class="reveal" id="filter-box" data-reveal>
+        <div class="reveal__header">
+          <h3 class="reveal__title">Filtrer par:</h3>
+          <button class="close-button" data-close aria-label="close" type="button">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="filters">
+          <% current_participatory_space.subscopes.each do |scope| %>
+            <li <%= active_class_if_current(scope.id) %>>
+              <%= link_to url_for(filter: { scope_id: scope.id, category_id: category.try(:id) }) do %>
+                <span class="show-for-sr"><%= Decidim::Scope.model_name.human(count: 1) %></span>
+                <%= translated_attribute(scope.name) %>
+              <% end %>
+            </li>
+          <% end %>
+        </div>
+      </div>
+    </ul>
+  <% end %>
+</div>

--- a/decidim-accountability/app/views/decidim/accountability/results/_scope_filters_small.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_scope_filters_small.html.erb
@@ -1,31 +1,37 @@
 <div class="scope-filters section">
   <% if current_component&.has_subscopes? %>
-    <div><%= t("results.filters.scopes", scope: "decidim.accountability") %></div>
+    <div><%= t("filter_by", scope: "decidim.accountability.results.filters") %></div>
 
     <ul class="tags tags--action">
       <div>
-        <button data-open="filter-box" class="filters-controls__trigger">
-          <%= t("filter_by", scope: "decidim.searches.filters_small_view") %>:
+        <button data-open="data_picker-modal" class="filters-controls__trigger">
+          <%= t("select_scope", scope: "decidim.accountability.results.filters") %>
           <%= icon "caret-bottom", class: "icon--small float-right", aria_label: "unfold", role: "img" %>
         </button>
       </div>
 
-      <div class="reveal" id="filter-box" data-reveal>
-        <div class="reveal__header">
-          <h3 class="reveal__title"><%= t("filter_by", scope: "decidim.searches.filters_small_view") %>:</h3>
-          <button class="close-button" data-close aria-label="close" type="button">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <div class="filters">
-          <% current_participatory_space.try(:subscopes).each do |scope| %>
-            <li <%= active_class_if_current(scope.id) %>>
-              <%= link_to url_for(filter: { scope_id: scope.id, category_id: category.try(:id) }) do %>
-                <span class="show-for-sr"><%= Decidim::Scope.model_name.human(count: 1) %></span>
-                <%= translated_attribute(scope.name) %>
-              <% end %>
-            </li>
-          <% end %>
+      <div class="reveal" id="data_picker-modal" data-reveal>
+        <div class="data_picker-modal-content">
+          <div class="scope-picker picker-header picker-list">
+            <h3 class="data_picker-title"><%= t("select_scope", scope: "decidim.accountability.results.filters") %></h3>
+            <button class="close-button" data-close aria-label="close" type="button">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="scope-picker picker-content picker-list">
+            <div class="picker-scrollable-content">
+              <ul role="group" aria-label="<%= t("change", scope: "decidim.scopes.picker") %>">
+                <% current_participatory_space.try(:subscopes).each do |scope| %>
+                  <li class="picker-multiple"<%= active_class_if_current(scope.id) %>>
+                    <%= link_to url_for(filter: { scope_id: scope.id, category_id: category.try(:id) }) do %>
+                      <span class="show-for-sr"><%= Decidim::Scope.model_name.human(count: 1) %></span>
+                      <%= translated_attribute(scope.name) %>
+                    <% end %>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
+          </div>
         </div>
       </div>
     </ul>

--- a/decidim-accountability/app/views/decidim/accountability/results/_scope_filters_small.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_scope_filters_small.html.erb
@@ -1,24 +1,24 @@
 <div class="scope-filters section">
-  <% if current_component.has_subscopes? %>
+  <% if current_component&.has_subscopes? %>
     <div><%= t("results.filters.scopes", scope: "decidim.accountability") %></div>
 
     <ul class="tags tags--action">
       <div>
         <button data-open="filter-box" class="filters-controls__trigger">
-          filter
+          <%= t("filter_by", scope: "decidim.searches.filters_small_view") %>:
           <%= icon "caret-bottom", class: "icon--small float-right", aria_label: "unfold", role: "img" %>
         </button>
       </div>
 
       <div class="reveal" id="filter-box" data-reveal>
         <div class="reveal__header">
-          <h3 class="reveal__title">Filtrer par:</h3>
+          <h3 class="reveal__title"><%= t("filter_by", scope: "decidim.searches.filters_small_view") %>:</h3>
           <button class="close-button" data-close aria-label="close" type="button">
             <span aria-hidden="true">&times;</span>
           </button>
         </div>
         <div class="filters">
-          <% current_participatory_space.subscopes.each do |scope| %>
+          <% current_participatory_space.try(:subscopes).each do |scope| %>
             <li <%= active_class_if_current(scope.id) %>>
               <%= link_to url_for(filter: { scope_id: scope.id, category_id: category.try(:id) }) do %>
                 <span class="show-for-sr"><%= Decidim::Scope.model_name.human(count: 1) %></span>

--- a/decidim-accountability/app/views/decidim/accountability/results/home.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/home.html.erb
@@ -1,9 +1,14 @@
 <div class="row accountability">
   <div class="small-12 columns">
     <%= render partial: "home_header" %>
-    <%= render partial: "scope_filters", locals: { url_method: :root_path } %>
+    <div class="hide-for-mediumlarge">
+      <%= render partial: "scope_filters_small" %>
+    </div>
+    <div class="show-for-mediumlarge">
+      <%= render partial: "scope_filters", locals: { url_method: :results_path } %>
+    </div>
     <%= render partial: "home_categories" %>
   </div>
 </div>
 
-<%= javascript_pack_tag "decidim_accountability" %>
+<%= javascript_include_tag "decidim/accountability/accountability" %>

--- a/decidim-accountability/app/views/decidim/accountability/results/home.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/home.html.erb
@@ -11,4 +11,4 @@
   </div>
 </div>
 
-<%= javascript_include_tag "decidim/accountability/accountability" %>
+<%= javascript_pack_tag "decidim_accountability" %>

--- a/decidim-accountability/app/views/decidim/accountability/results/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/index.html.erb
@@ -1,6 +1,11 @@
 <div class="row accountability">
   <div class="small-12 columns">
-    <%= render partial: "scope_filters", locals: { url_method: :results_path } %>
+    <div class="hide-for-mediumlarge">
+      <%= render partial: "scope_filters_small" %>
+    </div>
+    <div class="show-for-mediumlarge">
+      <%= render partial: "scope_filters", locals: { url_method: :results_path } %>
+    </div>
   </div>
 
   <div class="small-12 columns">

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -171,7 +171,9 @@ en:
             other: "%{count} results"
         filters:
           all: All
+          filter_by: 'Filter by:'
           scopes: Scopes
+          select_scope: Select a scope
         home:
           categories_label: Categories
           subcategories_label: Subcategories

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -84,6 +84,27 @@ describe "Explore results", versioning: true, type: :system do
         end
       end
 
+      context "when user navigates in responsive mode" do
+        before do
+          driven_by(:iphone)
+          visit path
+        end
+
+        it "doesn't show current scope active" do
+          expect(page).not_to have_css("ul.tags.tags--action li.active")
+        end
+
+        it "renders scopes with scope picker" do
+          expect(page).not_to have_link(translated(result.scope.name))
+
+          within ".hide-for-mediumlarge" do
+            click_button "Filter by:"
+          end
+
+          expect(page).to have_link(translated(result.scope.name))
+        end
+      end
+
       it "maintains scope filter" do
         click_link translated(category.name)
 

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -98,10 +98,14 @@ describe "Explore results", versioning: true, type: :system do
           expect(page).not_to have_link(translated(result.scope.name))
 
           within ".hide-for-mediumlarge" do
-            click_button "Filter by:"
+            expect(page).to have_content("Filter by:")
+            click_button "Select a scope"
           end
 
-          expect(page).to have_link(translated(result.scope.name))
+          within "#data_picker-modal" do
+            expect(page).to have_content("Select a scope")
+            expect(page).to have_link(translated(result.scope.name))
+          end
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

As a user when navigating on the accountability results on responsive display, scopes filter can expand on a large part of screen. 

This PR implements a scope selector for the responsive display and keeps the orignal scopes filter for the desktop display.

#### :pushpin: Related Issues
- Fixes https://meta.decidim.org/processes/roadmap/f/122/proposals/15782

#### Testing

* Seed application
* Visit : `http://localhost:3000/processes/[YOUR_PP]/f/15/results`
* Look at the scope filter on desktop display
* Then with inspector, toggle device toolbar (responsive mode on Chrome)
* See the scope selector 

### :camera: Screenshots
 
**Desktop view**

<img width="600" alt="Screenshot 2021-10-06 at 10 13 05" src="https://user-images.githubusercontent.com/26109239/136167986-19a392b6-22ac-4ecb-97fa-0426ce718b65.png">


**Responsive view**

<img width="550" alt="Screenshot 2021-11-24 at 18 05 32" src="https://user-images.githubusercontent.com/26109239/143303311-f3618f13-d3e7-4a0e-a119-5f13a5130e0d.png">

<img width="550" alt="Screenshot 2021-11-24 at 18 05 48" src="https://user-images.githubusercontent.com/26109239/143303367-c0175dd5-b08b-4069-b1a4-1725731ac610.png">


:hearts: Thank you!
