### PR TITLE
Fix SQL to make version display faster

### DIFF
--- a/decidim-core/app/helpers/decidim/resource_versions_helper.rb
+++ b/decidim-core/app/helpers/decidim/resource_versions_helper.rb
@@ -13,7 +13,7 @@ module Decidim
     #
     # Returns a String.
     def resource_version(resource, options = {})
-      return unless resource.respond_to?(:versions) && resource.versions.present?
+      return unless resource.respond_to?(:versions) && resource.versions_count.positive?
 
       html = []
       html << resource_version_number(resource.versions_count)


### PR DESCRIPTION
#### :tophat: What? Why?
`Decidim::ResourceVersionsHelper#resource_version` shows only the version number.
Therefore, do not generate unnecessary (sometimes slow) SQL `SELECT versions.* FROM versions WHERE ...`

##### Background

There seemed to be some very heavy load on our instance.
We investigated and found out that these were when showing `decidim/debates/debates#show`.

This page calls the method `Decidim::ResourceVersionsHelper#resource_version` to show the versions.
In the `resource.versions.present?` part of this method definition, we make a SQL `SELECT "versions". * FROM "versions" WHERE ... `.
In our instance, the contents of `versions` table can be very large, so this query seemed to be heavy (taking more than a few tens of seconds).

This is the reason why we made this patch.

#### :pushpin: Related Issues

#### Testing

1. Open a debate page (nothing changed).
2. See SQL logs.

Before this patch: 

```
  PaperTrail::Version Load (1.0ms)  SELECT "versions".* FROM "versions" WHERE "versions"."item_id" = $1 AND "versions"."item_type" = $2 ORDER BY "versions"."created_at" ASC, "versions"."id" ASC  [["item_id", 25], ["item_type", "Decidim::Debates::Debate"]]
  ↳ /Users/maki/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/activerecord-5.2.5/lib/active_record/log_subscriber.rb:98
   (1.0ms)  SELECT COUNT(*) FROM "versions" WHERE "versions"."item_id" = $1 AND "versions"."item_type" = $2  [["item_id", 25], ["item_type", "Decidim::Debates::Debate"]]
  ↳ /Users/maki/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/activerecord-5.2.5/lib/active_record/log_subscriber.rb:98
```

After this patch:

```
   (0.9ms)  SELECT COUNT(*) FROM "versions" WHERE "versions"."item_id" = $1 AND "versions"."item_type" = $2  [["item_id", 25], ["item_type", "Decidim::Debates::Debate"]]
  ↳ app/helpers/decidim/resource_versions_helper.rb:19
  CACHE  (0.0ms)  SELECT COUNT(*) FROM "versions" WHERE "versions"."item_id" = $1 AND "versions"."item_type" = $2  [["item_id", 25], ["item_type", "Decidim::Debates::Debate"]]
  ↳ app/helpers/decidim/resource_versions_helper.rb:22
```

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

Here is a view of the version number that caused this problem (the display itself will not change):

<img width="358" alt="versions_in_debate" src="https://user-images.githubusercontent.com/10401/136942969-7c7ce1d1-10ef-4bd4-8ab7-2eb82da565a7.png">


:hearts: Thank you!
