### PR TITLE
Fix railties requirements on created applications

### DIFF
--- a/decidim-core/lib/decidim/rails.rb
+++ b/decidim-core/lib/decidim/rails.rb
@@ -10,7 +10,6 @@
 require "rails"
 
 %w(
-  active_model/railtie
   active_record/railtie
   active_storage/engine
   action_controller/railtie

--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -108,8 +108,8 @@ module Decidim
           require "decidim/rails"
 
           # Add the frameworks used by your app that are not loaded by Decidim.
-          require "action_mailbox/engine"
-          require "action_text/engine"
+          # require "action_mailbox/engine"
+          # require "action_text/engine"
           require "action_cable/engine"
           require "rails/test_unit/railtie"
         RUBY


### PR DESCRIPTION
#### :tophat: What? Why?
When creating an application using decidim, some railties not used by Decidim are not required but are used by the application (as ActionCable). This PR fixes that, adding those requires to the `config/application.rb` after loading `decidim/rails`. It also adds `active_model/railtie` as a requirement for Decidim.

In the future, it would be nice to add options to the app creation task to allow developers to use the options that the Rails app generator offers, as skipping the installation of ActionCable or using RSpec for tests.

#### :pushpin: Related Issues
- Fixes #8395

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
