### PR TITLE
Increase text contrast in current phase of a participatory process

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/modules/_timeline.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_timeline.scss
@@ -92,7 +92,7 @@ $timeline-padding: 1rem;
   color: $dark-gray;
 
   .timeline__item--current &{
-    color: rgba($white, .8);
+    color: $white;
   }
 }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Some days ago, all backport PRs to 0.25 started to fail, even when those PR were working well in the `develop` branch. 

The reason is related to the color contrast between a text and the background: `Elements must have sufficient color contrast`. The colors are `#f5d8d4` (foreground) and `#cb3c29` (background), and the combination should not be used for small texts. The following image shows the problem. 

![imagen](https://user-images.githubusercontent.com/453545/137745291-e14aba51-582f-442e-ac4a-ca0fcfea0762.png)

This PR uses white instead of `#f5d8d4` for the foreground color, resulting in a combination allowed.

The problem that I couldn't detect is why is this not failing in the `develop` branch. I've checked that the tests detect the contrast problem if I change the foreground and background colors for all the steps, but it doesn't complaint if the problem is caused by the active phase.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #8402, #8405 and #8406

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
