### PR TITLE
Fix CVE-2021-41136 (HTTP Request Smuggling in puma)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "decidim-templates", path: "."
 gem "bootsnap", "~> 1.4"
 
 gem "foundation_rails_helper", git: "https://github.com/sgruhier/foundation_rails_helper.git"
-gem "puma", ">= 5.3.1"
+gem "puma", ">= 5.5.1"
 
 gem "faker", "~> 2.14"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -606,7 +606,7 @@ GEM
       actionmailer (>= 3)
       premailer (~> 1.7, >= 1.7.9)
     public_suffix (4.0.6)
-    puma (5.3.2)
+    puma (5.5.2)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -858,7 +858,7 @@ DEPENDENCIES
   foundation_rails_helper!
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
-  puma (>= 5.3.1)
+  puma (>= 5.5.1)
   rubocop-faker
   simplecov (~> 0.19.0)
   spring (~> 2.0)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -601,7 +601,7 @@ GEM
       actionmailer (>= 3)
       premailer (~> 1.7, >= 1.7.9)
     public_suffix (4.0.6)
-    puma (5.3.2)
+    puma (5.5.2)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -606,7 +606,7 @@ GEM
       actionmailer (>= 3)
       premailer (~> 1.7, >= 1.7.9)
     public_suffix (4.0.6)
-    puma (5.3.2)
+    puma (5.5.2)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -858,7 +858,7 @@ DEPENDENCIES
   foundation_rails_helper!
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
-  puma (>= 5.3.1)
+  puma (>= 5.5.1)
   rubocop-faker
   simplecov (~> 0.19.0)
   spring (~> 2.0)


### PR DESCRIPTION
#### :tophat: What? Why?
Current version of puma has a security issue caused by [CVE-2021-41136](https://github.com/puma/puma/security/advisories/GHSA-48w2-rm65-62xx) 
```
Name: puma
Version: 5.3.2
CVE: CVE-2021-41136
GHSA: GHSA-48w2-rm65-62xx
Criticality: Low
URL: https://github.com/puma/puma/security/advisories/GHSA-48w2-rm65-62xx
Title: Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling') in puma
Solution: upgrade to ~> 4.3.9, >= 5.5.1
```


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
- The following PR does not address any user experience, but user security .

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
