### PR TITLE
Force Rails version to 6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ PATH
       premailer-rails (~> 1.10)
       rack (~> 2.2, >= 2.2.3)
       rack-attack (~> 6.0)
-      rails (~> 6.0)
+      rails (~> 6.0.4)
       rails-i18n (~> 6.0)
       ransack (~> 2.4.1)
       rectify (~> 0.13.0)

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |s|
   s.add_dependency "premailer-rails", "~> 1.10"
   s.add_dependency "rack", "~> 2.2", ">= 2.2.3"
   s.add_dependency "rack-attack", "~> 6.0"
-  s.add_dependency "rails", "~> 6.0"
+  s.add_dependency "rails", "~> 6.0.4"
   s.add_dependency "rails-i18n", "~> 6.0"
   s.add_dependency "ransack", "~> 2.4.1"
   s.add_dependency "rectify", "~> 0.13.0"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -96,7 +96,7 @@ PATH
       premailer-rails (~> 1.10)
       rack (~> 2.2, >= 2.2.3)
       rack-attack (~> 6.0)
-      rails (~> 6.0)
+      rails (~> 6.0.4)
       rails-i18n (~> 6.0)
       ransack (~> 2.4.1)
       rectify (~> 0.13.0)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -106,7 +106,7 @@ PATH
       premailer-rails (~> 1.10)
       rack (~> 2.2, >= 2.2.3)
       rack-attack (~> 6.0)
-      rails (~> 6.0)
+      rails (~> 6.0.4)
       rails-i18n (~> 6.0)
       ransack (~> 2.4.1)
       rectify (~> 0.13.0)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR applies a small part of #6832, forcing the rails version to be 6.0, and preventing to install Rails 6.1 when installing the Decidim gem without having and Rails gem installed.

#### :pushpin: Related Issues
- Related to #6832
- Fixes #8395

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
