### PR TITLE
Fix comment's get link in project view

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -66,6 +66,6 @@ edit_link(
   </div>
 </div>
 
-<%= comments_for project, polymorphic: [project.budget, project] %>
+<%= comments_for project, polymorphic: [project.budget] %>
 
 <%= javascript_pack_tag("decidim_budgets") %>

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -66,6 +66,6 @@ edit_link(
   </div>
 </div>
 
-<%= comments_for project %>
+<%= comments_for project, polymorphic: [project.budget, project] %>
 
 <%= javascript_pack_tag("decidim_budgets") %>

--- a/decidim-budgets/spec/system/comments_spec.rb
+++ b/decidim-budgets/spec/system/comments_spec.rb
@@ -20,6 +20,23 @@ describe "Comments", type: :system do
     end
   end
 
+  describe "Get link" do
+    it "opens link location" do
+      visit decidim_budgets.budget_project_path(id: commentable.id, budget_id: budget.id)
+
+      another_window = window_opened_by do
+        find(".icon--ellipses", match: :first).click
+        click_link "Get link"
+      end
+
+      within_window(another_window) do
+        expect(page).to have_content(commentable.title["en"])
+        expect(page).to have_content(comments.first.body["en"])
+        expect(page).not_to have_content(comments.second.body["en"])
+      end
+    end
+  end
+
   private
 
   def decidim_comments

--- a/decidim-budgets/spec/system/comments_spec.rb
+++ b/decidim-budgets/spec/system/comments_spec.rb
@@ -21,7 +21,7 @@ describe "Comments", type: :system do
   end
 
   describe "Get link" do
-    it "opens link location" do
+    it "opens single comment to another window" do
       visit decidim_budgets.budget_project_path(id: commentable.id, budget_id: budget.id)
 
       another_window = window_opened_by do

--- a/decidim-comments/app/cells/decidim/comments/comments_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comments_cell.rb
@@ -61,6 +61,8 @@ module Decidim
       end
 
       def commentable_path(params = {})
+        return resource_locator(options[:polymorphic]).path(params) if options[:polymorphic]
+
         resource_locator(model).path(params)
       end
 

--- a/decidim-comments/app/cells/decidim/comments/comments_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comments_cell.rb
@@ -61,7 +61,7 @@ module Decidim
       end
 
       def commentable_path(params = {})
-        return resource_locator(options[:polymorphic]).path(params) if options[:polymorphic]
+        return resource_locator(options[:polymorphic].push(model)).path(params) if options[:polymorphic]
 
         resource_locator(model).path(params)
       end

--- a/decidim-comments/app/cells/decidim/comments/comments_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comments_cell.rb
@@ -61,7 +61,7 @@ module Decidim
       end
 
       def commentable_path(params = {})
-        return resource_locator(options[:polymorphic].push(model)).path(params) if options[:polymorphic]
+        return resource_locator(Array(options[:polymorphic]).push(model)).path(params) if options[:polymorphic]
 
         resource_locator(model).path(params)
       end

--- a/decidim-comments/lib/decidim/comments/comments_helper.rb
+++ b/decidim-comments/lib/decidim/comments/comments_helper.rb
@@ -7,11 +7,11 @@ module Decidim
       # Render commentable comments inside the `expanded` template content.
       #
       # resource - A commentable resource
-      def comments_for(resource)
+      def comments_for(resource, options = {})
         return unless resource.commentable?
 
         content_for :expanded do
-          inline_comments_for(resource)
+          inline_comments_for(resource, options)
         end
       end
 
@@ -28,7 +28,8 @@ module Decidim
           resource,
           machine_translations: machine_translations_toggled?,
           single_comment: params.fetch("commentId", nil),
-          order: options[:order]
+          order: options[:order],
+          polymorphic: options[:polymorphic]
         ).to_s
       end
     end

--- a/decidim-comments/spec/helpers/comments_helper_spec.rb
+++ b/decidim-comments/spec/helpers/comments_helper_spec.rb
@@ -31,7 +31,8 @@ module Decidim
               dummy_resource,
               machine_translations: machine_translations_toggled?,
               single_comment: nil,
-              order: nil
+              order: nil,
+              polymorphic: nil
             ).and_return(cell)
 
           helper.comments_for(dummy_resource)


### PR DESCRIPTION
#### :tophat: What? Why?
Fix comment's get link in project view

#### Testing
1. Go to budgets project view (and comment project if there is no comments)
2. Click ellipses (three dots) and select "Get link" (see screenshot)

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/139273226-b4d5c7c9-e545-4088-90cb-a4fe84467d23.png)

:hearts: Thank you!
