### PR TITLE
Document how to enable machine translations on organization

### DIFF
--- a/docs/modules/develop/pages/machine_translations.adoc
+++ b/docs/modules/develop/pages/machine_translations.adoc
@@ -39,4 +39,11 @@ The class will need to be implemented, or reuse one from the community. Check th
 
 == Enabling the integration, organization-wise
 
-Each organization will be able to enable/disable machine translations if they want to. They can do that from the organization configuration.
+Each organization will be able to enable/disable machine translations if they want to. They can do that from the organization configuration. At the moment this isn't configured through the System dashboard (`/system`), so it needs to be configured through the Rails console:
+
+[source,ruby]
+----
+org = Decidim::Organization.first
+org.enable_machine_translations = true
+org.save
+----

--- a/docs/modules/develop/pages/machine_translations.adoc
+++ b/docs/modules/develop/pages/machine_translations.adoc
@@ -39,11 +39,7 @@ The class will need to be implemented, or reuse one from the community. Check th
 
 == Enabling the integration, organization-wise
 
-Each organization will be able to enable/disable machine translations if they want to. They can do that from the organization configuration. At the moment this isn't configured through the System dashboard (`/system`), so it needs to be configured through the Rails console:
+Each organization will be able to enable / disable the machine translations if they want to. The administrators of the organization perform the action from `Settings` -> `Configuration` admin menu, where they able to either enable or disable the machine translation system, but also they can select the priority.
 
-[source,ruby]
-----
-org = Decidim::Organization.first
-org.enable_machine_translations = true
-org.save
-----
+* Original text first means that the platform will always display the original content as it has been added by contributors
+* Translated text first means that the platform will always display the translation first. 

--- a/docs/modules/develop/pages/machine_translations.adoc
+++ b/docs/modules/develop/pages/machine_translations.adoc
@@ -39,7 +39,7 @@ The class will need to be implemented, or reuse one from the community. Check th
 
 == Enabling the integration, organization-wise
 
-Each organization will be able to enable / disable the machine translations if they want to. The administrators of the organization perform the action from `Settings` -> `Configuration` admin menu, where they able to either enable or disable the machine translation system, but also they can select the priority.
+Each organization will be able to enable / disable the machine translations if they want to. The administrators of the organization perform the action from `Settings` -> `Configuration` admin menu, where they can enable or disable the machine translation system, and also they can select the priority.
 
 * Original text first means that the platform will always display the original content as it has been added by contributors
 * Translated text first means that the platform will always display the translation first. 


### PR DESCRIPTION
#### :tophat: What? Why?

While setting up the machine translation feature locally I couldn't find how to enable it in an organization locally, and in the documentation, this wasn't explained.

This PR adds this explanation. 
 
#### Testing
See updated doc

:hearts: Thank you!
