### PR TITLE
Fix notification after creating survey

### DIFF
--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -5,7 +5,7 @@ require "decidim/components/namer"
 Decidim.register_component(:surveys) do |component|
   component.engine = Decidim::Surveys::Engine
   component.admin_engine = Decidim::Surveys::AdminEngine
-  component.icon = "decidim_surveys.svg"
+  component.icon = "media/images/decidim_surveys.svg"
   component.stylesheet = "decidim/surveys/surveys"
   component.permissions_class_name = "Decidim::Surveys::Permissions"
   component.serializes_specific_data = true


### PR DESCRIPTION
#### :tophat: What? Why?
After creating survey, I get notification but notifications view raises error. It looks like the icon path has just been forgotten to update.

#### Testing
1. Create and publish survey
2. Go to /notifications 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/139914841-0988b7b7-0797-4024-8b1e-da137f7d80d7.png)

:hearts: Thank you!
