### PR TITLE
Change Gitter to Matrix.org in documentation

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -2,11 +2,11 @@
 
 We're really glad you're reading this, because we need volunteer contributors to help this project come to fruition.
 
-If you haven't already, come find us in https://app.element.io/#/room/#decidimdevs:matrix.org[our Matrix chat room].
-
-We have other chat rooms for designers, translators, and other volunteers. They're all in https://app.element.io/#/room/#decidim:matrix.org[our Decidim Matrix.org Space].
-
 Please note that by making a Pull Request in this repository you're agreeing with https://decidim.org/contract[Decidim's Social Contract].
+
+== Do you want to say hello to us?
+
+Come find us at https://matrix.to/#/#decidim:matrix.org[our Matrix.org space]. We have chat rooms for developers, designers and translators.
 
 == Did you find a bug?
 
@@ -39,7 +39,7 @@ You can read in detail about this process in https://docs.decidim.org/en/governa
 
 == Do you have questions about the source code?
 
-* Ask any question about how to use Decidim in https://app.element.io/#/room/#decidimdevs:matrix.org[our Decidim Devs Matrix chat room].
+* Ask any question about how to use Decidim in https://matrix.to/#/#decidimdevs:matrix.org[our Decidim Devs Matrix chat room].
 
 == Do you want to contribute to Decidim documentation?
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,9 +1,10 @@
 = How to contribute to Decidim
 
-We're really glad you're reading this, because we need volunteer developers to help this project come to fruition.
+We're really glad you're reading this, because we need volunteer contributors to help this project come to fruition.
 
-If you haven't already, come find us in https://app.element.io/#/room/#decidimdevs:matrix.org[our Decidim Devs Matrix chat room].
-We have other chat room for designers, translators, and other volunteers. They're all in https://app.element.io/#/room/#decidim:matrix.org[our Decidim Matrix Space].
+If you haven't already, come find us in https://app.element.io/#/room/#decidimdevs:matrix.org[our Matrix chat room].
+
+We have other chat rooms for designers, translators, and other volunteers. They're all in https://app.element.io/#/room/#decidim:matrix.org[our Decidim Matrix.org Space].
 
 Please note that by making a Pull Request in this repository you're agreeing with https://decidim.org/contract[Decidim's Social Contract].
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -2,7 +2,8 @@
 
 We're really glad you're reading this, because we need volunteer developers to help this project come to fruition.
 
-If you haven't already, come find us in https://gitter.im/decidim/decidim[Gitter]. We want you working on things you're excited about.
+If you haven't already, come find us in https://app.element.io/#/room/#decidimdevs:matrix.org[our Decidim Devs Matrix chat room].
+We have other chat room for designers, translators, and other volunteers. They're all in https://app.element.io/#/room/#decidim:matrix.org[our Decidim Matrix Space].
 
 Please note that by making a Pull Request in this repository you're agreeing with https://decidim.org/contract[Decidim's Social Contract].
 
@@ -37,7 +38,7 @@ You can read in detail about this process in https://docs.decidim.org/en/governa
 
 == Do you have questions about the source code?
 
-* Ask any question about how to use Decidim in https://gitter.im/decidim/decidim[Gitter].
+* Ask any question about how to use Decidim in https://app.element.io/#/room/#decidimdevs:matrix.org[our Decidim Devs Matrix chat room].
 
 == Do you want to contribute to Decidim documentation?
 

--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ All members of the Decidim community agree with http://www.decidim.org/contract/
 
 '''
 
-image:https://img.shields.io/gem/v/decidim.svg[Gem,link=https://rubygems.org/gems/decidim] image:https://img.shields.io/gem/dt/decidim.svg[Gem,link=https://rubygems.org/gems/decidim] image:https://img.shields.io/github/contributors/decidim/decidim.svg[GitHub contributors,link=https://github.com/decidim/decidim/graphs/contributors] image:http://img.shields.io/badge/yard-docs-blue.svg[Yard Docs,link=http://rubydoc.info/github/decidim/decidim/master] image:https://img.shields.io/gitter/room/nwjs/nw.js.svg[Gitter,link=https://gitter.im/decidim/decidim]
+image:https://img.shields.io/gem/v/decidim.svg[Gem,link=https://rubygems.org/gems/decidim] image:https://img.shields.io/gem/dt/decidim.svg[Gem,link=https://rubygems.org/gems/decidim] image:https://img.shields.io/github/contributors/decidim/decidim.svg[GitHub contributors,link=https://github.com/decidim/decidim/graphs/contributors] image:http://img.shields.io/badge/yard-docs-blue.svg[Yard Docs,link=http://rubydoc.info/github/decidim/decidim/master] image:https://img.shields.io/matrix/decidimdevs:matrix.org[Matrix,link=https://app.element.io/#/room/#decidimdevs:matrix.org]
 
 Code quality
 
@@ -103,7 +103,7 @@ We recommend doing that on GitHub (or any other code hosting platform) before pu
 
 You can read more on "http://producingoss.com/en/governments-and-open-source.html#starting-open-for-govs[Being Open Source From Day One is Especially Important for Government Projects]".
 
-If you have any trouble you can contact us on https://gitter.im/decidim/decidim[Gitter].
+If you have any trouble you can contact us on https://app.element.io/#/room/#decidimdevs:matrix.org[Decidim Devs Matrix.org chat room].
 
 == Example applications
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-:doctype: book
+D:doctype: book
 
 image::https://cdn.rawgit.com/decidim/decidim/develop/logo.svg[Decidim Logo,400]
 
@@ -103,7 +103,7 @@ We recommend doing that on GitHub (or any other code hosting platform) before pu
 
 You can read more on "http://producingoss.com/en/governments-and-open-source.html#starting-open-for-govs[Being Open Source From Day One is Especially Important for Government Projects]".
 
-If you have any trouble you can contact us on https://app.element.io/#/room/#decidimdevs:matrix.org[Decidim Devs Matrix.org chat room].
+If you have any trouble you can contact us on https://app.element.io/#/room/#decidimdevs:matrix.org[our Matrix.org chat room for developers].
 
 == Example applications
 

--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ All members of the Decidim community agree with http://www.decidim.org/contract/
 
 '''
 
-image:https://img.shields.io/gem/v/decidim.svg[Gem,link=https://rubygems.org/gems/decidim] image:https://img.shields.io/gem/dt/decidim.svg[Gem,link=https://rubygems.org/gems/decidim] image:https://img.shields.io/github/contributors/decidim/decidim.svg[GitHub contributors,link=https://github.com/decidim/decidim/graphs/contributors] image:http://img.shields.io/badge/yard-docs-blue.svg[Yard Docs,link=http://rubydoc.info/github/decidim/decidim/master] image:https://img.shields.io/matrix/decidimdevs:matrix.org[Matrix,link=https://app.element.io/#/room/#decidimdevs:matrix.org]
+image:https://img.shields.io/gem/v/decidim.svg[Gem,link=https://rubygems.org/gems/decidim] image:https://img.shields.io/gem/dt/decidim.svg[Gem,link=https://rubygems.org/gems/decidim] image:https://img.shields.io/github/contributors/decidim/decidim.svg[GitHub contributors,link=https://github.com/decidim/decidim/graphs/contributors] image:http://img.shields.io/badge/yard-docs-blue.svg[Yard Docs,link=http://rubydoc.info/github/decidim/decidim/master] image:https://img.shields.io/matrix/decidimdevs:matrix.org[Matrix,link=https://matrix.to/#/#decidimdevs:matrix.org]
 
 Code quality
 

--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -10,7 +10,7 @@ In order to develop on decidim, you'll need:
 * *ImageMagick*
 * *Chrome* browser and https://sites.google.com/a/chromium.org/chromedriver/[chromedriver].
 
-We're starting with an Ubuntu 20.04 LTS. This is an opinionated guide, so you're free to use the technology that you are most comfortable. If you have any doubts and you're blocked you can go and ask on https://app.element.io/#/room/#decidimdevs:matrix.org[our Matrix.org chat room].
+We're starting with an Ubuntu 20.04 LTS. This is an opinionated guide, so you're free to use the technology that you are most comfortable. If you have any doubts and you're blocked you can go and ask on https://matrix.to/#/#decidimdevs:matrix.org[our Matrix.org chat room for developers].
 
 We recommend to have at least some basic proficiency in Ruby on Rails (a good starting point is http://guides.rubyonrails.org/getting_started.html[Getting Started with Ruby on Rails]) and have some knowledge on how gems work.
 

--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -10,7 +10,7 @@ In order to develop on decidim, you'll need:
 * *ImageMagick*
 * *Chrome* browser and https://sites.google.com/a/chromium.org/chromedriver/[chromedriver].
 
-We're starting with an Ubuntu 20.04 LTS. This is an opinionated guide, so you're free to use the technology that you are most comfortable. If you have any doubts and you're blocked you can go and ask on https://app.element.io/#/room/#decidimdevs:matrix.org[our Matrix chat room].
+We're starting with an Ubuntu 20.04 LTS. This is an opinionated guide, so you're free to use the technology that you are most comfortable. If you have any doubts and you're blocked you can go and ask on https://app.element.io/#/room/#decidimdevs:matrix.org[our Matrix.org chat room].
 
 We recommend to have at least some basic proficiency in Ruby on Rails (a good starting point is http://guides.rubyonrails.org/getting_started.html[Getting Started with Ruby on Rails]) and have some knowledge on how gems work.
 

--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -10,7 +10,7 @@ In order to develop on decidim, you'll need:
 * *ImageMagick*
 * *Chrome* browser and https://sites.google.com/a/chromium.org/chromedriver/[chromedriver].
 
-We're starting with an Ubuntu 20.04 LTS. This is an opinionated guide, so you're free to use the technology that you are most comfortable. If you have any doubts and you're blocked you can go and ask on https://gitter.im/decidim/decidim[our Gitter].
+We're starting with an Ubuntu 20.04 LTS. This is an opinionated guide, so you're free to use the technology that you are most comfortable. If you have any doubts and you're blocked you can go and ask on https://app.element.io/#/room/#decidimdevs:matrix.org[our Matrix chat room].
 
 We recommend to have at least some basic proficiency in Ruby on Rails (a good starting point is http://guides.rubyonrails.org/getting_started.html[Getting Started with Ruby on Rails]) and have some knowledge on how gems work.
 


### PR DESCRIPTION
#### :tophat: What? Why?

For having more transparency and availability for contributors and community communication, we're deprecating Gitter.im chat room and migrating to Matrix.org/Element, after a [discussion in Metadecidim](https://meta.decidim.org/processes/roadmap/f/122/proposals/16219).

Thanks @oliverbarnes for the proposal!

#### :pushpin: Related Issues

- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/16219

#### Testing
See that the new documentation has the correct links

:hearts: Thank you!
