### PR TITLE
Fix report missing trustee admin log entry

### DIFF
--- a/decidim-elections/app/commands/decidim/elections/admin/report_missing_trustee.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/report_missing_trustee.rb
@@ -40,7 +40,9 @@ module Decidim
             election,
             form.current_user,
             extra: {
-              trustee_id: form.trustee_id
+              trustee_id: form.trustee_id,
+              name: trustee.name,
+              nickname: trustee.user.nickname
             },
             visibility: "all"
           )

--- a/decidim-elections/app/commands/decidim/elections/admin/report_missing_trustee.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/report_missing_trustee.rb
@@ -32,7 +32,7 @@ module Decidim
 
         attr_accessor :form
 
-        delegate :election, :bulletin_board, to: :form
+        delegate :election, :bulletin_board, :trustee, to: :form
 
         def log_action
           Decidim.traceability.perform_action!(

--- a/decidim-elections/app/presenters/decidim/elections/admin_log/election_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/elections/admin_log/election_presenter.rb
@@ -21,11 +21,43 @@ module Decidim
 
         def action_string
           case action
-          when "publish", "unpublish", "setup", "start_key_ceremony", "start_vote", "end_vote", "start_tally", "publish_results", "create", "delete", "update"
+          when "publish", "unpublish", "setup", "start_key_ceremony", "start_vote", "end_vote", "start_tally", "report_missing_trustee", "publish_results", "create", "delete", "update"
             "decidim.elections.admin_log.election.#{action}"
           else
             super
           end
+        end
+
+        def i18n_params
+          super.merge(trustee_info)
+        end
+
+        def trustee_info
+          return {} unless action == "report_missing_trustee"
+
+          {
+              trustee_name: if trustee
+                              Decidim::Log::UserPresenter.new(trustee.user, h, trustee_extra).present
+                            else
+                              trustee_extra["name"]
+                            end
+          }
+        end
+
+        def trustee
+          @trustee ||= Decidim::Elections::Trustee.find(action_log.extra["extra"]["trustee_id"]) if action_log.extra["extra"]["trustee_id"]
+        end
+
+        def trustee_extra
+          info = {
+            "name" => trustee.name,
+            "nickname" => trustee.user&.nickname
+          }
+
+          info["name"] ||= action_log.extra["extra"]["name"]
+          info["nickname"] ||= action_log.extra["extra"]["nickname"]
+
+          info
         end
       end
     end

--- a/decidim-elections/app/presenters/decidim/elections/admin_log/election_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/elections/admin_log/election_presenter.rb
@@ -21,7 +21,8 @@ module Decidim
 
         def action_string
           case action
-          when "publish", "unpublish", "setup", "start_key_ceremony", "start_vote", "end_vote", "start_tally", "report_missing_trustee", "publish_results", "create", "delete", "update"
+          when "publish", "unpublish", "create", "delete", "update",
+               "setup", "start_key_ceremony", "start_vote", "end_vote", "start_tally", "report_missing_trustee", "publish_results"
             "decidim.elections.admin_log.election.#{action}"
           else
             super
@@ -36,11 +37,11 @@ module Decidim
           return {} unless action == "report_missing_trustee"
 
           {
-              trustee_name: if trustee
-                              Decidim::Log::UserPresenter.new(trustee.user, h, trustee_extra).present
-                            else
-                              trustee_extra["name"]
-                            end
+            trustee_name: if trustee
+                            Decidim::Log::UserPresenter.new(trustee.user, h, trustee_extra).present
+                          else
+                            trustee_extra["name"]
+                          end
           }
         end
 

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -340,6 +340,7 @@ en:
           end_vote: "%{user_name} ended the voting period for the election %{resource_name} of %{space_name} on the Bulletin Board"
           publish: "%{user_name} published the election %{resource_name} of %{space_name}"
           publish_results: "%{user_name} published the results for the election %{resource_name} of %{space_name} on the Bulletin Board"
+          report_missing_trustee: "%{user_name} reported %{trustee_name} as a missing trustee during the tally for the election %{resource_name} of %{space_name} on the Bulletin Board"
           setup: "%{user_name} created the election %{resource_name} of %{space_name} on the Bulletin Board"
           start_key_ceremony: "%{user_name} started the key ceremony for the election %{resource_name} of %{space_name} on the Bulletin Board"
           start_tally: "%{user_name} started the tally for the election %{resource_name} of %{space_name} on the Bulletin Board"

--- a/decidim-elections/spec/commands/decidim/elections/admin/report_missing_trustee_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/report_missing_trustee_spec.rb
@@ -50,7 +50,11 @@ describe Decidim::Elections::Admin::ReportMissingTrustee do
     it "logs the performed action", versioning: true do
       expect(Decidim.traceability)
         .to receive(:perform_action!)
-        .with(:report_missing_trustee, election, user, extra: { trustee_id: trustee.id }, visibility: "all")
+        .with(:report_missing_trustee, election, user, extra: {
+                trustee_id: trustee.id,
+                name: trustee.name,
+                nickname: trustee.user.nickname
+              }, visibility: "all")
         .and_call_original
 
       expect { subject.call }.to change(Decidim::ActionLog, :count)

--- a/decidim-elections/spec/presenters/decidim/elections/admin_log/election_presenter_spec.rb
+++ b/decidim-elections/spec/presenters/decidim/elections/admin_log/election_presenter_spec.rb
@@ -38,6 +38,7 @@ module Decidim
           expect(subject.present).to include(" deleted the election ")
         end
       end
+
       context "when the election is published" do
         let(:action) { :publish }
 

--- a/decidim-elections/spec/presenters/decidim/elections/admin_log/election_presenter_spec.rb
+++ b/decidim-elections/spec/presenters/decidim/elections/admin_log/election_presenter_spec.rb
@@ -6,13 +6,7 @@ module Decidim
   describe Elections::AdminLog::ElectionPresenter, type: :helper do
     subject { described_class.new(action_log, helper) }
 
-    let(:action_log) do
-      create(
-        :action_log,
-        action: publish
-      )
-    end
-    let(:publish) { :publish }
+    let(:action_log) { create(:action_log, action: action) }
 
     before do
       helper.extend(Decidim::ApplicationHelper)
@@ -20,24 +14,118 @@ module Decidim
     end
 
     describe "#present" do
+      context "when the election is created" do
+        let(:action) { :create }
+
+        it "shows the election has been created" do
+          expect(subject.present).to include(" created the election ")
+          expect(subject.present).not_to include(" on the Bulletin Board")
+        end
+      end
+
+      context "when the election is updated" do
+        let(:action) { :update }
+
+        it "shows the election has been updated" do
+          expect(subject.present).to include(" updated the election ")
+        end
+      end
+
+      context "when the election is deleted" do
+        let(:action) { :delete }
+
+        it "shows the election has been deleted" do
+          expect(subject.present).to include(" deleted the election ")
+        end
+      end
       context "when the election is published" do
+        let(:action) { :publish }
+
         it "shows the election has been published" do
           expect(subject.present).to include(" published the ")
         end
       end
 
       context "when the election is unpublished" do
-        let(:action_log) do
-          create(
-            :action_log,
-            action: unpublish
-          )
-        end
-
-        let(:unpublish) { :unpublish }
+        let(:action) { :unpublish }
 
         it "shows the election has been unpublished" do
           expect(subject.present).to include(" unpublished the ")
+        end
+      end
+
+      context "when the election is setup" do
+        let(:action) { :setup }
+
+        it "shows the election has been setup" do
+          expect(subject.present).to include(" created the election ")
+          expect(subject.present).to include(" on the Bulletin Board")
+        end
+      end
+
+      context "when the key ceremony is started" do
+        let(:action) { :start_key_ceremony }
+
+        it "shows the key ceremony has started" do
+          expect(subject.present).to include(" started the key ceremony for the election ")
+          expect(subject.present).to include(" on the Bulletin Board")
+        end
+      end
+
+      context "when the vote period is started" do
+        let(:action) { :start_vote }
+
+        it "shows the voting period has started" do
+          expect(subject.present).to include(" started the voting period for the election ")
+          expect(subject.present).to include(" on the Bulletin Board")
+        end
+      end
+
+      context "when the vote period is ended" do
+        let(:action) { :end_vote }
+
+        it "shows the voting period has ended" do
+          expect(subject.present).to include(" ended the voting period for the election ")
+          expect(subject.present).to include(" on the Bulletin Board")
+        end
+      end
+
+      context "when the tally is started" do
+        let(:action) { :start_tally }
+
+        it "shows the tally has started" do
+          expect(subject.present).to include(" started the tally for the election ")
+          expect(subject.present).to include(" on the Bulletin Board")
+        end
+      end
+
+      context "when a trustee is reported as missing" do
+        let(:action_log) { build(:action_log, action: action) }
+        let(:action) { :report_missing_trustee }
+        let(:trustee) { create(:trustee) }
+
+        before do
+          action_log.extra["extra"] = {
+            "trustee_id" => trustee.id,
+            "name" => "Somebody Trustable",
+            "nickname" => "TrustMe"
+          }
+          action_log.save!
+        end
+
+        it "shows the trustee was reported" do
+          expect(subject.present).to include("Somebody Trustable")
+          expect(subject.present).to include(" as a missing trustee during the tally for the election ")
+          expect(subject.present).to include(" on the Bulletin Board")
+        end
+      end
+
+      context "when the election results are published" do
+        let(:action) { :publish_results }
+
+        it "shows the election results are published" do
+          expect(subject.present).to include(" published the results for the election ")
+          expect(subject.present).to include(" on the Bulletin Board")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
When reporting a trustee as missing, the admin log entry didn't show the right message. This PR fixes that and adds some missing tests for the elections admin log presenter.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. On an election, during the tally process, report a trustee as missing.
2. Visit the administrator dashboard page and check the last admin log messages.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
* Before:
![imagen](https://user-images.githubusercontent.com/453545/140127560-c93b8a2d-7a0c-4037-8850-f0eff71634bb.png)

* After:
![imagen](https://user-images.githubusercontent.com/453545/140126586-17785adb-f967-4632-9cf3-2d43c20b69d4.png)

:hearts: Thank you!
