### PR TITLE
Fix meetings with multiple dates

### DIFF
--- a/decidim-debates/lib/decidim/debates/component.rb
+++ b/decidim-debates/lib/decidim/debates/component.rb
@@ -96,6 +96,13 @@ Decidim.register_component(:debates) do |component|
 
     5.times do |x|
       finite = x != 2
+      if finite
+        start_time = [rand(1..20).weeks.from_now, rand(1..20).weeks.ago].sample
+        end_time = start_time + [rand(1..4).hours, rand(1..20).days].sample
+      else
+        start_time = nil
+        end_time = nil
+      end
       params = {
         component: component,
         category: participatory_space.categories.sample,
@@ -106,8 +113,8 @@ Decidim.register_component(:debates) do |component|
         instructions: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
           Decidim::Faker::Localized.paragraph(sentence_count: 3)
         end,
-        start_time: (3.weeks.from_now if finite),
-        end_time: (3.weeks.from_now + 4.hours if finite),
+        start_time: start_time,
+        end_time: end_time,
         author: component.organization
       }
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -43,15 +43,8 @@ edit_link(
 
     <div class="card extra">
       <div class="card__content">
-        <div class="extra__date">
-          <%= l meeting.start_time, format: "%d" %>
-          <span class="extra__month"><%= l meeting.start_time, format: "%B" %>
-            <%= l(meeting.start_time, format: "%Y") if meeting.start_time.year != Date.current.year %>
-          </span>
-        </div>
-        <div class="extra__time">
-          <%= meeting.start_time.strftime("%H:%M") %> - <%= meeting.end_time.strftime("%H:%M") %>
-        </div>
+        <%= cell("decidim/date_range", { start: meeting.start_time, end: meeting.end_time }) %>
+
         <%= cell "decidim/meetings/join_meeting_button", meeting, big_button: true, show_remaining_slots: true %>
         <%= render partial: "decidim/shared/follow_button", locals: { followable: meeting, large: false  } %>
       </div>

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -129,6 +129,7 @@ Decidim.register_component(:meetings) do |component|
 
     2.times do
       start_time = [rand(1..20).weeks.from_now, rand(1..20).weeks.ago].sample
+      end_time = start_time + [rand(1..4).hours, rand(1..20).days].sample
       params = {
         component: component,
         scope: Faker::Boolean.boolean(true_ratio: 0.5) ? global : scopes.sample,
@@ -140,7 +141,7 @@ Decidim.register_component(:meetings) do |component|
         location: Decidim::Faker::Localized.sentence,
         location_hints: Decidim::Faker::Localized.sentence,
         start_time: start_time,
-        end_time: start_time + rand(1..4).hours,
+        end_time: end_time,
         address: "#{Faker::Address.street_address} #{Faker::Address.zip} #{Faker::Address.city}",
         latitude: Faker::Address.latitude,
         longitude: Faker::Address.longitude,


### PR DESCRIPTION
#### :tophat: What? Why?

1. While reviewing some new meetings features, I stumbled with the bug that meetings of multiple days weren't shown correctly in the show page, although they were show well in the card. This PR fixes that.
2. It also adds support for these kinds of meetings in the seeds, so it was easier to check.
3. Finally, as this multiple dates feature is also used in the debates' module, I've changed its seeds. 

#### :pushpin: Related Issues

- Fixes  #8161

#### Testing

1. Change the end date of a meeting to multiple weeks from the start date
2. See it changed in the show page

For the others changes, just regenerating the seeds of the development database is enough. 


### :camera: Screenshots

#### Before

![image](https://user-images.githubusercontent.com/717367/140499226-ea9b40b4-ab0a-4f9b-9571-7a46f127ae64.png)


#### After

![image](https://user-images.githubusercontent.com/717367/140499235-dbb5580d-b846-4ee7-883a-0846802e59fe.png)

:hearts: Thank you!
