### PR TITLE
Fix the copy of components weights in participatory processes and assemblies

### DIFF
--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
@@ -87,7 +87,8 @@ module Decidim
               name: component.name,
               participatory_space: @copied_assembly,
               settings: component.settings,
-              step_settings: component.step_settings
+              step_settings: component.step_settings,
+              weight: component.weight
             )
             component.manifest.run_hooks(:copy, new_component: new_component, old_component: component)
           end

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
@@ -116,7 +116,8 @@ module Decidim
               name: component.name,
               participatory_space: @copied_process,
               settings: component.settings,
-              step_settings: copied_step_settings
+              step_settings: copied_step_settings,
+              weight: component.weight
             )
             component.manifest.run_hooks(:copy, new_component: new_component, old_component: component)
           end


### PR DESCRIPTION
#### :tophat: What? Why?

There's a bug when using the "copy" feature in participatory processes, where the weights of the components weren't copied. It also happened in assemblies. This PR fixes both cases. 

I've also seen that this "copy" feature was implemented in conferences, but this bug wasn't happening there. 

#### :pushpin: Related Issues

- Fixes #8078

#### Testing

0. Sign in as admin, go to dashboard, go to a process or assembly
1. Change the weight (aka order position) in components
2. Go to "copy" this process/assembly. Change title/slug. Check "copy components"
3. See that the weight of the components is copied

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/717367/140501875-a4bcf549-4915-415c-9094-c313a44fcb0e.png)

![image](https://user-images.githubusercontent.com/717367/140501891-b77cc868-743e-4e09-b69d-4833f2c9219c.png)

:hearts: Thank you!
