### PR TITLE
Add `pptx` in allowed_file_extensions (of admin)

### DIFF
--- a/decidim-core/lib/decidim/organization_settings.rb
+++ b/decidim-core/lib/decidim/organization_settings.rb
@@ -105,7 +105,7 @@ module Decidim
           "upload" => {
             "allowed_file_extensions" => {
               "default" => %w(jpg jpeg gif png bmp pdf rtf txt),
-              "admin" => %w(jpg jpeg gif png bmp pdf doc docx xls xlsx ppt ppx rtf txt odt ott odf otg ods ots),
+              "admin" => %w(jpg jpeg gif png bmp pdf doc docx xls xlsx ppt pptx ppx rtf txt odt ott odf otg ods ots),
               "image" => %w(jpg jpeg gif png bmp ico)
             },
             "allowed_content_types" => {

--- a/decidim-core/spec/lib/organization_settings_spec.rb
+++ b/decidim-core/spec/lib/organization_settings_spec.rb
@@ -12,7 +12,7 @@ module Decidim
       {
         "allowed_file_extensions" => {
           "default" => %w(jpg jpeg gif png bmp pdf rtf txt),
-          "admin" => %w(jpg jpeg gif png bmp pdf doc docx xls xlsx ppt ppx rtf txt odt ott odf otg ods ots),
+          "admin" => %w(jpg jpeg gif png bmp pdf doc docx xls xlsx ppt pptx ppx rtf txt odt ott odf otg ods ots),
           "image" => %w(jpg jpeg gif png bmp ico)
         },
         "allowed_content_types" => {


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes the issue #8501 .

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #8501

#### Testing

With this fix, we can see `pptx` as allowed file  in the upload form.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

:hearts: Thank you!
