### PR TITLE
Add a webpacker.yml file for the decidim generator

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_templates/webpacker.yml
+++ b/decidim-generators/lib/decidim/generators/app_templates/webpacker.yml
@@ -1,0 +1,18 @@
+# Basic webpacker file for the generator
+# See decidim-core/lib/decidim/webpacker/webpacker.yml for the one actually used in Decidim
+
+default: &default
+  source_path: app/packs
+  source_entry_path: entrypoints
+  public_root_path: public
+  webpack_compile_output: true
+  cache_path: tmp/webpacker-cache
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -91,6 +91,10 @@ module Decidim
 
         # Regenerate webpacker binstubs
         remove_file "bin/yarn"
+
+        # copy a dummy webpacker file to make webpacker operations possible
+        copy_file "webpacker.yml", "config/webpacker.yml"
+
         rails "webpacker:binstubs"
 
         # Run Decidim custom webpacker installation


### PR DESCRIPTION
#### :tophat: What? Why?

Running the command `decidim my-decidim` is suposed to create a rails application with decidim inside.
However, I've been founding some errors when doing it (using gem `0.25.1`).

The console output (failing and aborting part) is:

```
 cp $(bundle exec i18n-tasks gem-path)/templates/rspec/i18n_spec.rb spec/
        gsub  config/boot.rb
      append  .gitignore
      remove  public/404.html
      remove  public/500.html
      create  config/initializers/decidim.rb
       route  mount Decidim::Core::Engine => '/'
      append  db/seeds.rb
      create  config/initializers/carrierwave.rb
      create  config/initializers/social_share_button.rb
      create  config/secrets.yml
      remove  app/views/layouts/application.html.erb
      remove  app/views/layouts/mailer.text.erb
      insert  config/environments/production.rb
      create  app/packs/stylesheets/decidim/decidim_application.scss
      create  app/packs/stylesheets/decidim/_decidim-settings.scss
      create  app/packs/src/decidim/decidim_application.js
      create  app/packs/images
      remove  bin/yarn
rails aborted!
Webpacker configuration file not found /home/runner/work/decidim-install/decidim-install/decidim-app/config/webpacker.yml. Please run rails webpacker:install Error: No such file or directory @ rb_check_realpath_internal - /home/runner/work/decidim-install/decidim-install/decidim-app/config/webpacker.yml
/home/runner/work/decidim-install/decidim-install/decidim-app/config/environment.rb:5:in `<main>'
/home/runner/work/decidim-install/decidim-install/decidim-app/bin/rails:4:in `<main>'

Caused by:
Errno::ENOENT: No such file or directory @ rb_check_realpath_internal - /home/runner/work/decidim-install/decidim-install/decidim-app/config/webpacker.yml
/home/runner/work/decidim-install/decidim-install/decidim-app/config/environment.rb:5:in `<main>'
/home/runner/work/decidim-install/decidim-install/decidim-app/bin/rails:4:in `<main>'
```

I've found that this is because this command in the `install_generator.rb` file:

https://github.com/decidim/decidim/blob/40d47302d0dfb3506f998081894c7dbc43f43c41/decidim-generators/lib/decidim/generators/install_generator.rb#L94

It seems that any operation suboperation with `rails webpacker:...` requires to hava a minimal `config/webpacker.yml` file.
This pr adds one, that permits the whole operation to continue (then this file is substituted by the one in the gem `decidim-core`).

**NOTE**: this should be backported in a new release for version `0.25.2`

#### Testing

```
gem install decidim -v 0.25.1
decidim my-decidim
```

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
