### PR TITLE
Fix performance issues on assemblies page when having many private users

### DIFF
--- a/decidim-assemblies/app/models/decidim/assembly.rb
+++ b/decidim-assemblies/app/models/decidim/assembly.rb
@@ -93,21 +93,6 @@ module Decidim
                       index_on_create: ->(_assembly) { false },
                       index_on_update: ->(assembly) { assembly.visible? })
 
-    # Overwriting existing method Decidim::HasPrivateUsers.visible_for
-    def self.visible_for(user)
-      if user
-        return all if user.admin?
-
-        left_outer_joins(:participatory_space_private_users).where(
-          %{private_space = false OR
-          (private_space = true AND is_transparent = true) OR
-          decidim_participatory_space_private_users.decidim_user_id = ?}, user.id
-        ).distinct
-      else
-        public_spaces
-      end
-    end
-
     # Overwriting existing method Decidim::HasPrivateUsers.public_spaces
     def self.public_spaces
       where(private_space: false).or(where(private_space: true).where(is_transparent: true)).published


### PR DESCRIPTION
#### :tophat: What? Why?
This PR tries to fix a performance issue detected on a Decidim instance with many private users for participatory spaces. 

The `visible_for` method from the `HasPrivateUsers` concern was overriden in the `Assembly` model to include the transparent assemblies in the results. But after that the original method was refactored in the concern. Now is enough to override the `public_spaces` to have the correct results, so there is no need to override it in the `Assembly` model.

Apart from that, the current approach makes the query very slow where there are a lot of private users in the database. The left join used can't use the right index to filter by the current user, so it generates a big intermediate join table in the database server that affects the whole app performance.

Finally, the current code also returns different results from the `HasPrivateUsers` version, as it's not filtering the non published assemblies from the returned relation.

:hearts: Thank you!
