### PR TITLE
Fix 404 link in 'how to participate' home content block

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/how_to_participate/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/how_to_participate/show.erb
@@ -41,7 +41,7 @@
     <div class="row">
       <div class="columns small-centered small-10
                 smallmedium-8 medium-6 large-4">
-        <%= link_to t("decidim.pages.home.extended.more_info", resource_name: translated_attribute(current_organization.name, current_organization)), decidim.page_path("faq"), class: "button expanded hollow button--sc" %>
+        <%= link_to t("decidim.pages.home.extended.more_info", resource_name: translated_attribute(current_organization.name, current_organization)), decidim.pages_path, class: "button expanded hollow button--sc" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
#### :tophat: What? Why?

Sometime ago I removed some of the default pages generated ("accessibility" and "FAQs") but I didn't realize that I also needed to change a button in the homepage. This PR fixed that. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #6596
- Fixes #8456 

#### Testing

1. Go to the homepage with the "how to participate" content block enabled 	
2. Click in "More info about $ORGANIZATION" button 
3. See that you go to a 404 

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/717367/141443306-b5be0b07-bc01-44b3-8e03-985dc055b4a4.png)


:hearts: Thank you!
