### PR TITLE
Fix conference speakers when there isn't any avatar

### DIFF
--- a/decidim-conferences/app/cells/decidim/conferences/conference_speaker_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/conference_speaker_cell.rb
@@ -42,7 +42,7 @@ module Decidim
       def avatar_path
         return Decidim::UserPresenter.new(model.user).avatar_url if model.user.present?
 
-        model.attached_uploader(:avatar).path
+        Decidim::ConferenceSpeakerPresenter.new(model).avatar_url
       end
 
       def has_profile?

--- a/decidim-conferences/lib/decidim/conferences/test/factories.rb
+++ b/decidim-conferences/lib/decidim/conferences/test/factories.rb
@@ -121,7 +121,10 @@ FactoryBot.define do
     short_bio { generate_localized_title }
     twitter_handle { Faker::Internet.user_name }
     personal_url { Faker::Internet.url }
-    avatar { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
+
+    trait :with_avatar do
+      avatar { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
+    end
 
     trait :with_user do
       user { create(:user, organization: conference.organization) }

--- a/decidim-conferences/spec/cells/decidim/conferences/conference_speaker_cell_spec.rb
+++ b/decidim-conferences/spec/cells/decidim/conferences/conference_speaker_cell_spec.rb
@@ -7,36 +7,41 @@ module Decidim::Conferences
     controller Decidim::Conferences::ConferencesController
 
     context "when rendering a speaker without a user" do
-      let!(:conference) { create(:conference) }
-      let(:conference_speaker) { create(:conference_speaker, conference: conference) }
+      let(:conference_speaker) { create_speaker_with_trait(nil) }
       let(:model) { Decidim::ConferenceSpeakerPresenter.new(conference_speaker) }
 
       it "renders the card" do
-        html = cell("decidim/conferences/conference_speaker", model).call
-        expect(html).to have_css(".conference-speaker")
+        call_and_expect_speaker_cell(model)
       end
     end
 
     context "when rendering a speaker with an avatar" do
-      let!(:conference) { create(:conference) }
-      let(:conference_speaker) { create(:conference_speaker, :with_avatar, conference: conference) }
+      let(:conference_speaker) { create_speaker_with_trait(:with_avatar) }
       let(:model) { Decidim::ConferenceSpeakerPresenter.new(conference_speaker) }
 
       it "renders the card" do
-        html = cell("decidim/conferences/conference_speaker", model).call
-        expect(html).to have_css(".conference-speaker")
+        call_and_expect_speaker_cell(model)
       end
     end
 
     context "when rendering a speaker with a user" do
-      let!(:conference) { create(:conference) }
-      let(:conference_speaker) { create(:conference_speaker, :with_user, conference: conference) }
+      let(:conference_speaker) { create_speaker_with_trait(:with_user) }
       let(:model) { Decidim::ConferenceSpeakerPresenter.new(conference_speaker) }
 
       it "renders the card" do
-        html = cell("decidim/conferences/conference_speaker", model).call
-        expect(html).to have_css(".conference-speaker")
+        call_and_expect_speaker_cell(model)
       end
+    end
+
+    private
+
+    def create_speaker_with_trait(trait)
+      create(:conference_speaker, trait)
+    end
+
+    def call_and_expect_speaker_cell(model)
+      html = cell("decidim/conferences/conference_speaker", model).call
+      expect(html).to have_css(".conference-speaker")
     end
   end
 end

--- a/decidim-conferences/spec/cells/decidim/conferences/conference_speaker_cell_spec.rb
+++ b/decidim-conferences/spec/cells/decidim/conferences/conference_speaker_cell_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Conferences
+  describe ConferenceSpeakerCell, type: :cell do
+    controller Decidim::Conferences::ConferencesController
+
+    context "when rendering a speaker without a user" do
+      let!(:conference) { create(:conference) }
+      let(:conference_speaker) { create(:conference_speaker, conference: conference) }
+      let(:model) { Decidim::ConferenceSpeakerPresenter.new(conference_speaker) }
+
+      it "renders the card" do
+        html = cell("decidim/conferences/conference_speaker", model).call
+        expect(html).to have_css(".conference-speaker")
+      end
+    end
+
+    context "when rendering a speaker with an avatar" do
+      let!(:conference) { create(:conference) }
+      let(:conference_speaker) { create(:conference_speaker, :with_avatar, conference: conference) }
+      let(:model) { Decidim::ConferenceSpeakerPresenter.new(conference_speaker) }
+
+      it "renders the card" do
+        html = cell("decidim/conferences/conference_speaker", model).call
+        expect(html).to have_css(".conference-speaker")
+      end
+    end
+
+    context "when rendering a speaker with a user" do
+      let!(:conference) { create(:conference) }
+      let(:conference_speaker) { create(:conference_speaker, :with_user, conference: conference) }
+      let(:model) { Decidim::ConferenceSpeakerPresenter.new(conference_speaker) }
+
+      it "renders the card" do
+        html = cell("decidim/conferences/conference_speaker", model).call
+        expect(html).to have_css(".conference-speaker")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

From #8367:

> When creating a new speaker, if no avatar image is uploaded, a server error occurs.

This PR fixes that. It's actually a one line fix proposed by @alecslupu in the [same bug report](https://github.com/decidim/decidim/issues/8367#issuecomment-957157071), although with some specs on the different cases of conference speakers. 


#### :pushpin: Related Issues

- Fixes  #8367

#### Testing

0. Sign in as admin, go to admin panel
1. Create a conference
2. Create a new conference speaker without an avatar
3. Visit the conference speakers page 

Without this fix it should give a 500 error, with this fix everything should work well.


:hearts: Thank you!
