### PR TITLE
Backport "Fix 404 link in 'how to participate' home content block" to v0.25

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/how_to_participate/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/how_to_participate/show.erb
@@ -41,7 +41,7 @@
     <div class="row">
       <div class="columns small-centered small-10
                 smallmedium-8 medium-6 large-4">
-        <%= link_to t("decidim.pages.home.extended.more_info", resource_name: translated_attribute(current_organization.name, current_organization)), decidim.page_path("faq"), class: "button expanded hollow button--sc" %>
+        <%= link_to t("decidim.pages.home.extended.more_info", resource_name: translated_attribute(current_organization.name, current_organization)), decidim.pages_path, class: "button expanded hollow button--sc" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #8513 to v0.25

:hearts: Thank you!
