### PR TITLE
Fix pt-BR issue

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -36,8 +36,9 @@ files:
         nl: nl
         no: no
         pl: pl
-        pt-BR: pt-BR
+        pt: pt
         pt-PT: pt
+        pt-BR: pt-BR
         ro-RO: ro
         rumany: ru
         sk: sk


### PR DESCRIPTION
#### :tophat: What? Why?
Helping on https://github.com/decidim/decidim/pull/6221#issuecomment-940410700 pt-BR issue. 
[`pt-BR` yml files](https://github.com/decidim/decidim/blob/27cdb9e63f3378dc8eb293859e218449c13d9c46/decidim-accountability/config/locales/pt-BR.yml) have the `pt:` prefix, and not the expected `pt-BR` one.


My guess is that with the current crowdin.yml config: 
```
        pt-BR: pt-BR
        pt-PT: pt
```
Crowdin tries to have a 2 letters fallback, and as it is not provided, will take the first variant (here `pt-BR`), and thus is ending having `pt:` translated with `pt-BR` 

So as in french, I propose to change it to have `pt: pt` to make sure default `pt-BR` is considered as a variant.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/decidim/decidim/pull/6221#issuecomment-940410700

#### Testing
*Describe the best way to test or validate your PR.*


