### PR TITLE
Add rendered view instrumentation information

### DIFF
--- a/decidim-core/lib/decidim/view_model.rb
+++ b/decidim-core/lib/decidim/view_model.rb
@@ -37,6 +37,16 @@ module Decidim
 
     private
 
+    def render_template(template, options, &block)
+      ActiveSupport::Notifications.instrument(
+        "render_template.action_view",
+        identifier: template.file,
+        layout: nil
+      ) do
+        super
+      end
+    end
+
     def instrument(name, **options)
       ActiveSupport::Notifications.instrument("render_#{name}.action_view", options) do |payload|
         yield payload


### PR DESCRIPTION
#### :tophat: What? Why?
When using Sentry or ELK stack there is no information about the rendered cells (what cell is being rendered) in the stacktrace. 
This PR fixes the issue to improve the developer experience

#### Testing
The product is not being changed. Only the developer experience is being targeted.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [X] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
Original: 
![image](https://user-images.githubusercontent.com/105683/142635761-01a524d8-dba0-4def-8878-2688f2eba889.png)

After: 
![image](https://user-images.githubusercontent.com/105683/142636036-3031bbd6-cb31-43c2-bd72-1ca4723c4dee.png)


:hearts: Thank you!
