### PR TITLE
Fix meetings input when rich text editor is disabled

### DIFF
--- a/decidim-meetings/app/forms/decidim/meetings/close_meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/close_meeting_form.rb
@@ -20,7 +20,7 @@ module Decidim
       # Returns nothing.
       def map_model(model)
         self.proposal_ids = model.linked_resources(:proposals, "proposals_from_meeting").pluck(:id)
-        presenter = MeetingPresenter.new(model)
+        presenter = MeetingEditionPresenter.new(model)
         self.closing_report = presenter.closing_report(all_locales: false)
       end
 

--- a/decidim-meetings/app/forms/decidim/meetings/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/meeting_form.rb
@@ -51,7 +51,7 @@ module Decidim
 
       def map_model(model)
         self.decidim_category_id = model.categorization.decidim_category_id if model.categorization
-        presenter = MeetingPresenter.new(model)
+        presenter = MeetingEditionPresenter.new(model)
         self.title = presenter.title(all_locales: false)
         self.description = presenter.description(all_locales: false)
         self.location = presenter.location(all_locales: false)

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_edition_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_edition_presenter.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    #
+    # Decorator for meetings in users context
+    #
+    class MeetingEditionPresenter < MeetingPresenter
+      def sanitized(content)
+        organization.rich_text_editor_in_public_views? ? decidim_sanitize_editor(content) : decidim_sanitize(content)
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -22,7 +22,7 @@ module Decidim
         return unless meeting
 
         handle_locales(meeting.description, all_locales) do |content|
-          renderer = Decidim::ContentRenderers::HashtagRenderer.new(decidim_sanitize_editor(content))
+          renderer = Decidim::ContentRenderers::HashtagRenderer.new(sanitized(content))
           renderer.render(links: links).html_safe
         end
       end
@@ -55,7 +55,7 @@ module Decidim
         return unless meeting
 
         handle_locales(meeting.closing_report, all_locales) do |content|
-          renderer = Decidim::ContentRenderers::HashtagRenderer.new(decidim_sanitize_editor(content))
+          renderer = Decidim::ContentRenderers::HashtagRenderer.new(sanitized(content))
           renderer.render(links: links).html_safe
         end
       end
@@ -64,7 +64,7 @@ module Decidim
         return unless meeting
 
         handle_locales(meeting.registration_email_custom_content, all_locales) do |content|
-          renderer = Decidim::ContentRenderers::HashtagRenderer.new(decidim_sanitize_editor(content))
+          renderer = Decidim::ContentRenderers::HashtagRenderer.new(sanitized(content))
           renderer.render(links: links).html_safe
         end
       end
@@ -124,6 +124,10 @@ module Decidim
         return unless meeting
 
         proposals.map.with_index { |proposal, index| "#{index + 1}) #{proposal.title}\n" }
+      end
+
+      def sanitized(content)
+        decidim_sanitize_editor(content)
       end
     end
   end

--- a/decidim-meetings/spec/system/user_edit_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_edit_meeting_spec.rb
@@ -87,6 +87,28 @@ describe "User edit meeting", type: :system do
         expect(page).to have_content("problem updating")
       end
     end
+
+    context "when rich_text_editor_in_public_views is disabled" do
+      before { organization.update(rich_text_editor_in_public_views: false) }
+
+      it "displays the description not wrapped in ql-editor div" do
+        visit_component
+
+        click_link translated(meeting.title)
+        click_link "Edit meeting"
+
+        expect(page).to have_content "EDIT YOUR MEETING"
+
+        within "form.edit_meeting" do
+          expect(page).to have_no_css("div.ql-editor")
+        end
+
+        within "textarea#meeting_description" do
+          expect(page).to have_content translated(meeting.description)
+          expect(page).to have_no_content '<div class="ql-editor ql-reset-decidim">'
+        end
+      end
+    end
   end
 
   describe "editing someone else's meeting" do


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes the behavior of application in front when a user is allowed to edit some meetings attributes like description or closing report and rich text editor in public views is disabled. This is because the meeting presenter wraps these attributes into a div and this presenter is used by the form object used to edit the meetings. This PR adds a child class used by the form object in front. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #8505

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.
