### PR TITLE
Change user workflows to prevent user enumeration attacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Decidim.configure do |config|
 end
 ```
 
+#### User workflows change to prevent user enumeration attacks 
+
+Until now it was possible to see if an email account was registered in Decidim, by using features like "Forgot your password", as the response changed if the email existed ("`You will receive an email with instructions on how to reset your password in a few minutes`") that's different to a non-existing user account ("`could not be found. Did you sign up previously?`"). This allows User Enumration attacks, where a malicious actor can check if anyone has an acount in the platform. As per [\#8537](https://github.com/decidim/decidim/pull/8537), anyone has the same answer always "`If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes`". 
+
 ### Added
 * [#8012](https://github.com/decidim/decidim/pull/8012) Participatory space to comments, to fix the statistics. Use
 `rake decidim_comments:update_participatory_process_in_comments` to migrate existing comments to the new structure.

--- a/decidim-core/config/initializers/devise.rb
+++ b/decidim-core/config/initializers/devise.rb
@@ -88,7 +88,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -330,8 +330,19 @@ describe "Authentication", type: :system do
           perform_enqueued_jobs { find("*[type=submit]").click }
         end
 
-        expect(page).to have_content("reset your password")
+        expect(page).to have_content("If your email address exists in our database")
         expect(emails.count).to eq(1)
+      end
+
+      it "says it sends a password recovery email when is a non-existing email" do
+        visit decidim.new_user_password_path
+
+        within ".new_user" do
+          fill_in :password_user_email, with: "nonexistent@example.org"
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("If your email address exists in our database")
       end
     end
 
@@ -389,14 +400,14 @@ describe "Authentication", type: :system do
             end
           end
 
-          it "shows the last attempt warning before locking the account" do
+          it "doesn't show the last attempt warning before locking the account" do
             within ".new_user" do
               fill_in :session_user_email, with: user.email
               fill_in :session_user_password, with: "not-the-pasword"
               find("*[type=submit]").click
             end
 
-            expect(page).to have_content("You have one more attempt before your account is locked.")
+            expect(page).to have_content("Invalid")
           end
         end
 
@@ -421,7 +432,7 @@ describe "Authentication", type: :system do
               perform_enqueued_jobs { find("*[type=submit]").click }
             end
 
-            expect(page).to have_content("Your account is locked.")
+            expect(page).to have_content("Invalid")
             expect(emails.count).to eq(1)
           end
         end
@@ -440,8 +451,17 @@ describe "Authentication", type: :system do
             perform_enqueued_jobs { find("*[type=submit]").click }
           end
 
-          expect(page).to have_content("You will receive an email with instructions for how to unlock your account in a few minutes.")
+          expect(page).to have_content("If your account exists")
           expect(emails.count).to eq(1)
+        end
+
+        it "says it resends the unlock instructions when is a non-existing user account" do
+          within ".new_user" do
+            fill_in :unlock_user_email, with: user.email
+            find("*[type=submit]").click
+          end
+
+          expect(page).to have_content("If your account exists")
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

On some workflows, it's possible to check if an email was registered in the application. For instance, in the "Forgot your password?" page if an attacker tries with a registered email, she'll get an error message (`You will receive an email with instructions on how to reset your password in a few minutes.`) that's different to a non-existing user account ("`could not be found. Did you sign up previously?`"). This attack gets the name of "Account enumeration". 

This PR fixes this partially, as it isn't solved in registration form, but it is solved in others like "forgot your password" or "resend unlock instructions".


#### Testing

1. Go to [Resend confirmation instructions](http://localhost:3000/users/confirmation/new), [Forgot your password?](http://localhost:3000/users/password/new), or [Resend unlock instructions](http://localhost:3000/users/unlock/new) forms
2. Enter an existing user email 
3. Click in "Send button"
4. See alert
5. Go back to the same form
6. Enter a non-existing user email 
3. Click in "Send button"
4. See that you have the same alert

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/717367/142993867-e9c279e1-32dd-43ba-9e39-f090b8c3e4fd.png)

:hearts: Thank you!
