### PR TITLE
Backport "Fix the copy of components weights in participatory processes and assemblies" to v0.25

### DIFF
--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
@@ -87,7 +87,8 @@ module Decidim
               name: component.name,
               participatory_space: @copied_assembly,
               settings: component.settings,
-              step_settings: component.step_settings
+              step_settings: component.step_settings,
+              weight: component.weight
             )
             component.manifest.run_hooks(:copy, new_component: new_component, old_component: component)
           end

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
@@ -116,7 +116,8 @@ module Decidim
               name: component.name,
               participatory_space: @copied_process,
               settings: component.settings,
-              step_settings: copied_step_settings
+              step_settings: copied_step_settings,
+              weight: component.weight
             )
             component.manifest.run_hooks(:copy, new_component: new_component, old_component: component)
           end


### PR DESCRIPTION
#### :tophat: What? Why?

Backports #8498 to v0.25 

:hearts: Thank you!
