### PR TITLE
Lock i18n-tasks to v0.9.34

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ PATH
       decidim (= 0.26.0.dev)
       erb_lint (~> 0.0.35)
       factory_bot_rails (~> 4.8)
-      i18n-tasks (~> 0.9.18)
+      i18n-tasks (= 0.9.34)
       mdl (~> 0.5)
       nokogiri (~> 1.11, >= 1.11.4)
       puma (~> 5.0)

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency "byebug", "~> 11.0"
   s.add_dependency "db-query-matchers", "~> 0.10.0"
   s.add_dependency "erb_lint", "~> 0.0.35"
-  s.add_dependency "i18n-tasks", "~> 0.9.18"
+  s.add_dependency "i18n-tasks", "= 0.9.34"
   s.add_dependency "mdl", "~> 0.5"
   s.add_dependency "nokogiri", "~> 1.11", ">= 1.11.4"
   s.add_dependency "puma", "~> 5.0"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -121,7 +121,7 @@ PATH
       decidim (= 0.26.0.dev)
       erb_lint (~> 0.0.35)
       factory_bot_rails (~> 4.8)
-      i18n-tasks (~> 0.9.18)
+      i18n-tasks (= 0.9.34)
       mdl (~> 0.5)
       nokogiri (~> 1.11, >= 1.11.4)
       puma (~> 5.0)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -131,7 +131,7 @@ PATH
       decidim (= 0.26.0.dev)
       erb_lint (~> 0.0.35)
       factory_bot_rails (~> 4.8)
-      i18n-tasks (~> 0.9.18)
+      i18n-tasks (= 0.9.34)
       mdl (~> 0.5)
       nokogiri (~> 1.11, >= 1.11.4)
       puma (~> 5.0)


### PR DESCRIPTION
#### :tophat: What? Why?

As I was preparing the v0.25.2 I stumbled upon an API change in i18n-tasks. This PR locks the version to the one we're using. 

We'll handle the API change in another future PR.  

#### :pushpin: Related Issues

- Related to #8542
 
:hearts: Thank you!
