### PR TITLE
Change pt-BR locale from pt to pt-BR

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -36,9 +36,8 @@ files:
         nl: nl
         no: no
         pl: pl
-        pt: pt
-        pt-PT: pt
         pt-BR: pt-BR
+        pt-PT: pt
         ro-RO: ro
         rumany: ru
         sk: sk

--- a/decidim-accountability/config/locales/pt-BR.yml
+++ b/decidim-accountability/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       result:

--- a/decidim-admin/config/locales/pt-BR.yml
+++ b/decidim-admin/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       area:

--- a/decidim-assemblies/config/locales/pt-BR.yml
+++ b/decidim-assemblies/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       assemblies_setting:

--- a/decidim-blogs/config/locales/pt-BR.yml
+++ b/decidim-blogs/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     models:
       decidim/blogs/create_post_event: Nova postagem no blog

--- a/decidim-budgets/config/locales/pt-BR.yml
+++ b/decidim-budgets/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       budget:

--- a/decidim-comments/config/locales/pt-BR.yml
+++ b/decidim-comments/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     models:
       decidim/comments/comment_by_followed_user_event: Comente

--- a/decidim-conferences/config/locales/pt-BR.yml
+++ b/decidim-conferences/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       conference:

--- a/decidim-consultations/config/locales/pt-BR.yml
+++ b/decidim-consultations/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       consultation:

--- a/decidim-core/config/locales/pt-BR.yml
+++ b/decidim-core/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       account:

--- a/decidim-debates/config/locales/pt-BR.yml
+++ b/decidim-debates/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       debate:

--- a/decidim-dev/config/locales/pt-BR.yml
+++ b/decidim-dev/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       dummy_resource:

--- a/decidim-elections/config/locales/pt-BR.yml
+++ b/decidim-elections/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       answer:

--- a/decidim-forms/config/locales/pt-BR.yml
+++ b/decidim-forms/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       answer:

--- a/decidim-initiatives/config/locales/pt-BR.yml
+++ b/decidim-initiatives/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       initiative:

--- a/decidim-meetings/config/locales/pt-BR.yml
+++ b/decidim-meetings/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       agenda:

--- a/decidim-pages/config/locales/pt-BR.yml
+++ b/decidim-pages/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activerecord:
     models:
       decidim/pages/page:

--- a/decidim-participatory_processes/config/locales/pt-BR.yml
+++ b/decidim-participatory_processes/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       participatory_process:

--- a/decidim-proposals/config/locales/pt-BR.yml
+++ b/decidim-proposals/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       collaborative_draft:

--- a/decidim-sortitions/config/locales/pt-BR.yml
+++ b/decidim-sortitions/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       sortition:

--- a/decidim-surveys/config/locales/pt-BR.yml
+++ b/decidim-surveys/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     models:
       decidim/surveys/closed_survey_event: Estudo finalizado

--- a/decidim-system/config/locales/pt-BR.yml
+++ b/decidim-system/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       oauth_application:

--- a/decidim-templates/config/locales/pt-BR.yml
+++ b/decidim-templates/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       questionnaire:

--- a/decidim-verifications/config/locales/pt-BR.yml
+++ b/decidim-verifications/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt:
+pt-BR:
   activemodel:
     attributes:
       config:


### PR DESCRIPTION
#### :tophat: What? Why?

The language mapping for `pt-BR` is broken, as it's `pt` (the same as `pt-PT`) and it doesn't work.

This PR changes it manually. Let's hope that @decidim-bot doesn't change it in the future (again) 🙏🏽 🙏🏽 

#### :pushpin: Related Issues

- Reverts to #8523 
- Fixes #8549 

#### Testing

1.    Add "pt" and "pt-BR" to available_locales in config/initializer/decidim.rb
2.    Add "pt" and "pt-BR" to an existing organization (through console)
3.    Sign in as a participant.
4.    Go to http://localhost:3000/account/delete?locale=pt-BR - see that you have "Motivo para excluir sua conta" ( I18n.t("activemodel.attributes.account.delete_reason"), the first one in decidim-core/config/locales/pt-BR.yml

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/717367/143412233-5d57bdad-8982-485d-ba46-7e99e9bbee3e.png)


:hearts: Thank you!
