### PR TITLE
Use capybara's BIG_SCREEN_SIZE in elections system public specs

### DIFF
--- a/.github/workflows/ci_elections_system_public.yml
+++ b/.github/workflows/ci_elections_system_public.yml
@@ -25,6 +25,7 @@ env:
   RUBY_VERSION: 2.7.1
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-elections
+  BIG_SCREEN_SIZE: "true"
 
 jobs:
   main:


### PR DESCRIPTION
#### :tophat: What? Why?

We have a new failing spec related to a change in capybara behavior: 

>      Selenium::WebDriver::Error::ElementNotInteractableError:
>        element not interactable: element has zero size
>          (Session info: headless chrome=96.0.4664.45)

[See fail example](https://github.com/decidim/decidim/runs/4321410951?check_suite_focus=true).

This was solved already by @alecslupu in #8531, so I'm applying the same solution here. I don't know if it'd be better to just enable the BIG_SCREEN_SIZE configuration always, as this will probably begin to fail in other system specs
 
#### Testing

CI for "[CI] Elections (system public)" should be green

:hearts: Thank you!
