### PR TITLE
Fix duplicated answers in surveys

### DIFF
--- a/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
+++ b/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
@@ -20,7 +20,7 @@ module Decidim
       #
       # Broadcasts :ok if successful, :invalid otherwise.
       def call
-        return broadcast(:invalid) if @form.invalid?
+        return broadcast(:invalid) if @form.invalid? || user_already_answered?
 
         answer_questionnaire
 
@@ -32,7 +32,7 @@ module Decidim
         end
       end
 
-      attr_reader :form
+      attr_reader :form, :questionnaire, :current_user
 
       private
 
@@ -95,6 +95,10 @@ module Decidim
           @form = @main_form
           raise ActiveRecord::Rollback if @errors
         end
+      end
+
+      def user_already_answered?
+        questionnaire.answered_by?(current_user || form.context.session_token)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
It's possible to answer a survey with the same session if the survey is opened in different tabs before answering the first time.

![bug_encuesta_sin_registrar](https://user-images.githubusercontent.com/75725233/143464948-76bbcbfc-640c-42e0-91c4-30ef6ee9d80c.gif)

This PR corrects that, checking if the user or visitor has already answered the survey, to avoid duplicate responses.

![fix_encuesta](https://user-images.githubusercontent.com/75725233/143465198-c1600e98-12bd-4d96-b817-c8055a7f2d0d.gif)


#### Testing

- Create a survey in a participatory process
- Open two tabs with the survey (it's no required sign in)
- Answer the survey in one tab
- Try to answer the survey in another tab and verify that there is an error (it's correct)

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.


:hearts: Thank you!
