### PR TITLE
Remove border on all the fieldsets

### DIFF
--- a/decidim-initiatives/app/packs/stylesheets/decidim/initiatives/initiatives.scss
+++ b/decidim-initiatives/app/packs/stylesheets/decidim/initiatives/initiatives.scss
@@ -59,7 +59,6 @@
 }
 
 fieldset{
-  border: 1px solid #e8e8e8;
   padding: .5em;
   margin-bottom: 1em;
 }


### PR DESCRIPTION
#### :tophat: What? Why?

With #6790 a fieldset border was introduced by mistake: it's in `initiatives.scss` but it applies globally, typical CSS bug. 

This PR removes that.

(I know that we're starting the "Redesign Decidim" thing, but this little thing obsessed me since it was introduced 😅 )

As I have a terrible eye for design stuff, this needs @carolromero approval

#### :pushpin: Related Issues

- Related to #6790

### :camera: Screenshots

#### Before

|Before | After  |
|---------|-----------------|
| ![image](https://user-images.githubusercontent.com/717367/143473617-75b33413-81bf-4d99-9e75-a335551c629f.png) | ![image](https://user-images.githubusercontent.com/717367/143473370-a46e4e84-71c7-4985-b408-ba65b0ea4b5c.png) |
|  ![image](https://user-images.githubusercontent.com/717367/143473668-2b30e2c0-a5ad-4be6-a4c2-ce1246bddc38.png) | ![image](https://user-images.githubusercontent.com/717367/143473386-ca8f3715-e33e-4f94-8006-554923decaa2.png)|





:hearts: Thank you!
