### PR TITLE
Fix CSS layout wrapper top padding

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/modules/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_layout.scss
@@ -3,7 +3,7 @@
   position: relative;
 
   @include breakpoint(medium){
-    padding: 3rem 1.5rem 3rem;
+    padding: 3rem 1.5rem;
   }
 
   @include breakpoint(large){

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_layout.scss
@@ -3,7 +3,7 @@
   position: relative;
 
   @include breakpoint(medium){
-    padding: 5rem 1.5rem 3rem;
+    padding: 3rem 1.5rem 3rem;
   }
 
   @include breakpoint(large){


### PR DESCRIPTION
#### :tophat: What? Why?

Sometime ago, we detected with @carolromero that the top padding was a little too much.  This PR fixes that. 

(I know that we're starting the "Redesign Decidim" thing, but this one, I see it every day and can't live with it)

As I have a terrible eye for design stuff, this needs @carolromero approval

### :camera: Screenshots

|Before | After|
|-----|----|
|![image](https://user-images.githubusercontent.com/717367/143474705-676c55d5-94c0-46b9-a46f-7f442606d91a.png)| ![image](https://user-images.githubusercontent.com/717367/143474724-2898786e-f57a-4155-81c5-706024a83e32.png)|

:hearts: Thank you!
