### PR TITLE
Remove wrong </div> in initiatives header

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_index_header.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_index_header.html.erb
@@ -41,5 +41,4 @@
   <div class="not-authorized-modal-footer reveal__footer">
     <%= link_to t(".not_authorized.authorizations_page"), decidim_verifications.authorizations_path(redirect_url: create_initiative_url(:select_initiative_type)), class: "button expanded" %>
   </div>
-  </div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?

While working on #8562, I found out that initiatives page had a bug with the wrapper (too much space). This PR fixes that. 

As I have a terrible eye for design stuff, this needs @carolromero approval

#### :pushpin: Related Issues
 
- Related to #8562  

### :camera: Screenshots

|Before|After|
|--------|-------|
| ![image](https://user-images.githubusercontent.com/717367/143475367-92101a7c-6aab-4681-a696-bccc40bc7cd1.png) |  ![image](https://user-images.githubusercontent.com/717367/143475428-28c80e9d-d85b-4c4b-bdfb-8c52ff8aa877.png)|

:hearts: Thank you!
