### PR TITLE
Change default window size in Capybara configuration

### DIFF
--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -25,7 +25,6 @@ env:
   RUBY_VERSION: 2.7.1
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-meetings
-  BIG_SCREEN_SIZE: "true"
 
 jobs:
   main:

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -30,7 +30,7 @@ Capybara.register_driver :headless_chrome do |app|
   options.args << if ENV["BIG_SCREEN_SIZE"].present?
                     "--window-size=1920,3000"
                   else
-                    "--window-size=1024,768"
+                    "--window-size=1920,1080"
                   end
 
   Capybara::Selenium::Driver.new(

--- a/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
@@ -41,7 +41,12 @@ shared_examples "manage process steps examples" do
     page.find(".datepicker-dropdown .day", text: "22").click
 
     within ".new_participatory_process_step" do
-      find("*[type=submit]").click
+      # For some reason, the form submit button click can fail unless the page
+      # is first scrolled to this element
+      # Got the idea from:
+      # https://stackoverflow.com/a/39103252
+      page.scroll_to(find(".form-general-submit"))
+      find(".form-general-submit").click
     end
 
     expect(page).to have_admin_callout("successfully")

--- a/decidim-proposals/spec/system/amendable/amendment_wizard_spec.rb
+++ b/decidim-proposals/spec/system/amendable/amendment_wizard_spec.rb
@@ -225,8 +225,8 @@ describe "Amendment Wizard", type: :system do
           find("*[type=submit]").click
         end
 
-        # It seems that from version 83 of chromdriver, it gets really picky
-        # Content mus be inside the virtual window of test
+        # It seems that from version 83 of chromedriver, it gets really picky
+        # Content must be inside the virtual window of test
         # Got the idea from:
         # https://stackoverflow.com/a/39103252
         page.scroll_to(find(".edit_amendment"))


### PR DESCRIPTION
#### :tophat: What? Why?

We're seeing flaky tests regarding the window size of Capybara/Selenium.

Instead of adding the BIG_SCREEN_SIZE variable in every CI workflow (the #8556 approach), this changes the default screen size, as it makes sense in 2021.

1920x1080 is the [most common resolution at the moment](https://gs.statcounter.com/screen-resolution-stats) (9.78 of the market):

![image](https://user-images.githubusercontent.com/717367/144066648-1421adf9-5aaf-4951-a555-f05a3b881ada.png)

Also is the one used by other platforms like [BrowserStack]( https://www.browserstack.com/docs/automate/selenium/change-screen-resolution):

> resolution: A string. Default resolution is 1920x1080  

#### :pushpin: Related Issues

- Related to #8556 


#### Testing

We shouldn't see flakies with the error

>      Selenium::WebDriver::Error::ElementNotInteractableError:
>        element not interactable: element has zero size
>          (Session info: headless chrome=96.0.4664.45)


:hearts: Thank you!
