### PR TITLE
Add conversation link to comment notification

### DIFF
--- a/decidim-comments/app/events/decidim/comments/comment_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_event.rb
@@ -35,7 +35,7 @@ module Decidim
         end
 
         def resource_url_params
-          { anchor: "comment_#{comment.id}" }
+          { anchor: "comment_#{comment.id}", commentId: comment.id }
         end
       end
     end

--- a/decidim-comments/spec/events/decidim/comments/comment_by_followed_user_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_by_followed_user_event_spec.rb
@@ -37,7 +37,7 @@ module Decidim
           expect(subject.notification_title)
             .to start_with("There is a new comment by <a href=\"#{author_path}\">#{author_name} #{author_nickname}</a> in")
           expect(subject.notification_title)
-            .to end_with("<a href=\"#{resource_path}#comment_#{comment.id}\">#{resource_title}</a>.")
+            .to end_with("<a href=\"#{resource_path}?commentId=#{comment.id}#comment_#{comment.id}\">#{resource_title}</a>.")
         end
       end
     end

--- a/decidim-comments/spec/events/decidim/comments/comment_by_followed_user_group_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_by_followed_user_group_event_spec.rb
@@ -39,7 +39,7 @@ module Decidim
           expect(subject.notification_title)
             .to start_with("There is a new comment by <a href=\"#{user_group_path}\">#{CGI.escapeHTML(user_group.name)} @#{user_group.nickname}</a> in")
           expect(subject.notification_title)
-            .to end_with("<a href=\"#{resource_path}#comment_#{comment.id}\">#{resource_title}</a>.")
+            .to end_with("<a href=\"#{resource_path}?commentId=#{comment.id}#comment_#{comment.id}\">#{resource_title}</a>.")
         end
       end
     end

--- a/decidim-comments/spec/events/decidim/comments/comment_created_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_created_event_spec.rb
@@ -33,7 +33,7 @@ describe Decidim::Comments::CommentCreatedEvent do
         .to include("There is a new comment from <a href=\"/profiles/#{comment_author.nickname}\">#{comment_author.name} @#{comment_author.nickname}</a>")
 
       expect(subject.notification_title)
-        .to include(" in <a href=\"#{resource_path}#comment_#{comment.id}\">#{resource_title}</a>")
+        .to include(" in <a href=\"#{resource_path}?commentId=#{comment.id}#comment_#{comment.id}\">#{resource_title}</a>")
     end
   end
 end

--- a/decidim-comments/spec/events/decidim/comments/reply_created_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/reply_created_event_spec.rb
@@ -36,7 +36,7 @@ describe Decidim::Comments::ReplyCreatedEvent do
         .to start_with("<a href=\"/profiles/#{comment_author.nickname}\">#{comment_author_name} @#{comment_author.nickname}</a> has replied your comment in")
 
       expect(subject.notification_title)
-        .to end_with("your comment in <a href=\"#{resource_path}#comment_#{comment.id}\">#{translated resource.title}</a>")
+        .to end_with("your comment in <a href=\"#{resource_path}?commentId=#{comment.id}#comment_#{comment.id}\">#{translated resource.title}</a>")
     end
   end
 end

--- a/decidim-comments/spec/events/decidim/comments/user_group_mentioned_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/user_group_mentioned_event_spec.rb
@@ -48,7 +48,7 @@ describe Decidim::Comments::UserGroupMentionedEvent do
   describe "notification_title" do
     it "is generated correctly" do
       expect(subject.notification_title)
-        .to include("You have been mentioned in <a href=\"#{resource_path}#comment_#{comment.id}\">#{html_escape(translated(resource.title))}</a>")
+        .to include("You have been mentioned in <a href=\"#{resource_path}?commentId=#{comment.id}#comment_#{comment.id}\">#{html_escape(translated(resource.title))}</a>")
 
       expect(subject.notification_title)
         .to include(" as a member of <a href=\"/profiles/#{group.nickname}\">#{html_escape(group.name)} @#{group.nickname}</a>")

--- a/decidim-comments/spec/events/decidim/comments/user_mentioned_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/user_mentioned_event_spec.rb
@@ -38,7 +38,7 @@ describe Decidim::Comments::UserMentionedEvent do
   describe "notification_title" do
     it "is generated correctly" do
       expect(subject.notification_title)
-        .to include("You have been mentioned in <a href=\"#{resource_path}#comment_#{comment.id}\">#{translated resource.title}</a>")
+        .to include("You have been mentioned in <a href=\"#{resource_path}?commentId=#{comment.id}#comment_#{comment.id}\">#{translated resource.title}</a>")
 
       expect(subject.notification_title)
         .to include(" by <a href=\"/profiles/#{comment_author.nickname}\">#{comment_author.name} @#{comment_author.nickname}</a>")

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -600,6 +600,12 @@ FactoryBot.define do
         some_extra_data: "1"
       }
     end
+
+    trait :comment_notification do
+      event_class { "Decidim::Comments::CommentCreatedEvent" }
+      event_name { "decidim.events.comments.comment_created" }
+      extra { { comment_id: create(:comment).id } }
+    end
   end
 
   factory :action_log, class: "Decidim::ActionLog" do

--- a/decidim-core/spec/spec_helper.rb
+++ b/decidim-core/spec/spec_helper.rb
@@ -8,3 +8,5 @@ ENV["NODE_ENV"] ||= "test"
 Decidim::Dev.dummy_app_path = File.expand_path(File.join("..", "spec", "decidim_dummy_app"))
 
 require "decidim/dev/test/base_spec_helper"
+
+WebMock.allow_net_connect!(net_http_connect_on_start: true)

--- a/decidim-core/spec/spec_helper.rb
+++ b/decidim-core/spec/spec_helper.rb
@@ -8,5 +8,3 @@ ENV["NODE_ENV"] ||= "test"
 Decidim::Dev.dummy_app_path = File.expand_path(File.join("..", "spec", "decidim_dummy_app"))
 
 require "decidim/dev/test/base_spec_helper"
-
-WebMock.allow_net_connect!(net_http_connect_on_start: true)

--- a/decidim-core/spec/system/notifications_spec.rb
+++ b/decidim-core/spec/system/notifications_spec.rb
@@ -111,4 +111,21 @@ describe "Notifications", type: :system do
       end
     end
   end
+
+  context "with comment notifications" do
+    let!(:notification) { create :notification, :comment_notification, user: user }
+
+    before do
+      page.visit decidim.notifications_path
+    end
+
+    it "shows the comment notification with the conversation link" do
+      comment_id = notification.extra["comment_id"]
+      comment_definition_string = "commentId=#{comment_id}#comment_#{comment_id}"
+      links = page.all(".card.card--widget a")
+      hrefs = links.find { |link| link[:href].include?(comment_definition_string) }
+
+      expect(hrefs).not_to be(nil)
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds conversation link to comment notification. It's deeply explained in the issue #8482 .

#### :pushpin: Related Issues
*Link your PR to an issue*
- Issue #8482

#### Testing
You need a comment notification. You can send some comments in a proposals and it's even better if you add some replies  to that comment.
After that, go to /notifications, and there, you''ll see some notifications about those comments, click on the last link and you'll be redirected to the conversation.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

![image](https://user-images.githubusercontent.com/7511154/144151624-c5e81646-709d-4cb9-bc4d-719b9eba2606.png)

![image](https://user-images.githubusercontent.com/7511154/144151589-d2b9ebe4-0f62-4c46-a574-3b19e0af4715.png)

:hearts: Thank you!
