### PR TITLE
Fix surveys exports with free text in multiple option

### DIFF
--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
@@ -23,7 +23,7 @@ module Decidim
           choices = answer.choices.map do |choice|
             {
               answer_option_body: choice.try(:answer_option).try(:translated_body),
-              choice_body: choice.try(:custom_body).presence || choice.try(:body).present? ? "-" : ""
+              choice_body: body_or_custom_body(choice)
             }
           end
 
@@ -63,6 +63,12 @@ module Decidim
           content_tag content_tag do
             body
           end
+        end
+
+        def body_or_custom_body(choice)
+          return choice.custom_body if choice.try(:custom_body).present?
+
+          choice.try(:body).present? ? "-" : ""
         end
       end
     end

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
@@ -56,19 +56,21 @@ module Decidim
         end
 
         def choice(choice_hash)
-          render_body_for(choice_hash[:answer_option_body], :em) + render_body_for(choice_hash[:choice_body])
+          content_tag :li do
+            render_body_for choice_hash
+          end
         end
 
-        def render_body_for(body, content_tag = :li)
-          content_tag content_tag do
-            body
-          end
+        def render_body_for(choice_hash)
+          return choice_hash[:answer_option_body] if choice_hash[:choice_body].blank?
+
+          "#{choice_hash[:answer_option_body]} (#{choice_hash[:choice_body]})"
         end
 
         def body_or_custom_body(choice)
           return choice.custom_body if choice.try(:custom_body).present?
 
-          choice.try(:body).present? ? "-" : ""
+          ""
         end
       end
     end

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
@@ -27,7 +27,7 @@ module Decidim
             }
           end
 
-          return choices.first[:answer_option_body] if answer.question.question_type == "single_option"
+          return choice(choices.first) if answer.question.question_type == "single_option"
 
           content_tag(:ul) do
             safe_join(choices.map { |c| choice(c) })
@@ -56,7 +56,7 @@ module Decidim
         end
 
         def choice(choice_hash)
-          render_body_for(choice_hash[:answer_option_body], :strong) + render_body_for(choice_hash[:choice_body])
+          render_body_for(choice_hash[:answer_option_body], :em) + render_body_for(choice_hash[:choice_body])
         end
 
         def render_body_for(body, content_tag = :li)

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
@@ -21,10 +21,13 @@ module Decidim
           return "-" if answer.choices.empty?
 
           choices = answer.choices.map do |choice|
-            choice.try(:custom_body) || choice.try(:body)
+            {
+              answer_option_body: choice.try(:answer_option).try(:translated_body),
+              choice_body: choice.try(:custom_body).presence || choice.try(:body).present? ? "-" : ""
+            }
           end
 
-          return choices.first if answer.question.question_type == "single_option"
+          return choices.first[:answer_option_body] if answer.question.question_type == "single_option"
 
           content_tag(:ul) do
             safe_join(choices.map { |c| choice(c) })
@@ -52,9 +55,13 @@ module Decidim
           # rubocop:enable Style/StringConcatenation
         end
 
-        def choice(choice_body)
-          content_tag :li do
-            choice_body
+        def choice(choice_hash)
+          render_body_for(choice_hash[:answer_option_body], :strong) + render_body_for(choice_hash[:choice_body])
+        end
+
+        def render_body_for(body, content_tag = :li)
+          content_tag content_tag do
+            body
           end
         end
       end

--- a/decidim-forms/lib/decidim/forms/test/factories.rb
+++ b/decidim-forms/lib/decidim/forms/test/factories.rb
@@ -144,6 +144,14 @@ FactoryBot.define do
     question { create(:questionnaire_question) }
     body { generate_localized_title }
     free_text { false }
+
+    trait :free_text_enabled do
+      free_text { true }
+    end
+
+    trait :free_text_disabled do
+      free_text { false }
+    end
   end
 
   factory :answer_choice, class: "Decidim::Forms::AnswerChoice" do

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_answers.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_answers.rb
@@ -83,7 +83,7 @@ shared_examples_for "manage questionnaire answers" do
         it "shows the answers page with custom body" do
           within "#answers" do
             expect(page).to have_css("dt", text: translated(first.body))
-            expect(page).to have_css("strong", text: translated(answer_option.body))
+            expect(page).to have_css("em", text: translated(answer_option.body))
             expect(page).to have_content(translated(answer_option.body))
             expect(page).to have_css("li", text: "-")
           end

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_answers.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_answers.rb
@@ -83,9 +83,7 @@ shared_examples_for "manage questionnaire answers" do
         it "shows the answers page with custom body" do
           within "#answers" do
             expect(page).to have_css("dt", text: translated(first.body))
-            expect(page).to have_css("em", text: translated(answer_option.body))
-            expect(page).to have_content(translated(answer_option.body))
-            expect(page).to have_css("li", text: "-")
+            expect(page).to have_css("li", text: translated(answer_option.body))
           end
         end
       end

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_answers.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_answers.rb
@@ -69,6 +69,26 @@ shared_examples_for "manage questionnaire answers" do
           expect(page).to have_content("User identifier")
         end
       end
+
+      context "when multiple answer choice" do
+        let(:first_type) { "multiple_option" }
+        let!(:answer1) { create :answer, questionnaire: questionnaire, question: first, body: nil }
+        let!(:answer_option) { create :answer_option, question: first }
+        let!(:answer_choice) { create :answer_choice, answer: answer1, answer_option: answer_option, body: translated(answer_option.body, locale: I18n.locale) }
+
+        before do
+          find_all("a.action-icon.action-icon--eye").first.click
+        end
+
+        it "shows the answers page with custom body" do
+          within "#answers" do
+            expect(page).to have_css("dt", text: translated(first.body))
+            expect(page).to have_css("strong", text: translated(answer_option.body))
+            expect(page).to have_content(translated(answer_option.body))
+            expect(page).to have_css("li", text: "-")
+          end
+        end
+      end
     end
 
     context "and managing individual answer page" do

--- a/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
+++ b/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
@@ -73,7 +73,7 @@ module Decidim
           normalize_matrix_choices(answer, choices)
         else
           choices.map do |choice|
-            choice.try(:custom_body) || choice.try(:body)
+            [choice.try(:body), choice.try(:custom_body).presence || "-"].to_json
           end
         end
       end

--- a/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
+++ b/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
@@ -73,7 +73,7 @@ module Decidim
           normalize_matrix_choices(answer, choices)
         else
           choices.map do |choice|
-            [choice.try(:body), choice.try(:custom_body).presence || "-"].to_json
+            format_free_text_for choice
           end
         end
       end
@@ -93,6 +93,12 @@ module Decidim
 
       def answer_translated_attribute_name(attribute)
         I18n.t(attribute.to_sym, scope: "decidim.forms.user_answers_serializer")
+      end
+
+      def format_free_text_for(choice)
+        return choice.try(:body) if choice.try(:custom_body).blank?
+
+        "#{choice.try(:body)} (#{choice.try(:custom_body)})"
       end
     end
   end

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
@@ -40,7 +40,7 @@ module Decidim
 
         context "when it is a single_option question" do
           it "Returns the choice's body" do
-            expect(subject.body).to eq("<em>#{answer_choice.body}</em><li>-</li>")
+            expect(subject.body).to eq("<li>#{answer_choice.body}</li>")
           end
         end
 
@@ -48,7 +48,7 @@ module Decidim
           let!(:question) { create :questionnaire_question, questionnaire: questionnaire, question_type: "multiple_option" }
 
           it "Returns the choice's body as a <li> element inside a <ul>" do
-            expect(subject.body).to eq("<ul><em>#{answer_choice.body}</em><li>-</li></ul>")
+            expect(subject.body).to eq("<ul><li>#{answer_choice.body}</li></ul>")
           end
         end
       end
@@ -61,7 +61,7 @@ module Decidim
         let!(:answer_choice_2) { create :answer_choice, answer: answer, answer_option: answer_option_2, body: translated(answer_option_2.body, locale: I18n.locale) }
 
         it "Returns the choices wrapped in <li> elements inside a <ul>" do
-          expect(subject.body).to eq("<ul><em>#{answer_choice_1.body}</em><li>-</li><em>#{answer_choice_2.body}</em><li>-</li></ul>")
+          expect(subject.body).to eq("<ul><li>#{answer_choice_1.body}</li><li>#{answer_choice_2.body}</li></ul>")
         end
 
         context "and free text is enabled on answer options" do
@@ -69,7 +69,7 @@ module Decidim
           let!(:answer_option_2) { create :answer_option, :free_text_enabled }
 
           it "returns the choices and question wrapped in <li> elements inside a <ul>" do
-            expect(subject.body).to eq("<ul><em>#{answer_option_1.translated_body}</em><li>-</li><em>#{answer_option_2.translated_body}</em><li>-</li></ul>")
+            expect(subject.body).to eq("<ul><li>#{answer_option_1.translated_body}</li><li>#{answer_option_2.translated_body}</li></ul>")
           end
         end
       end

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
@@ -40,7 +40,7 @@ module Decidim
 
         context "when it is a single_option question" do
           it "Returns the choice's body" do
-            expect(subject.body).to eq(answer_choice.body)
+            expect(subject.body).to eq("<em>#{answer_choice.body}</em><li>-</li>")
           end
         end
 
@@ -48,7 +48,7 @@ module Decidim
           let!(:question) { create :questionnaire_question, questionnaire: questionnaire, question_type: "multiple_option" }
 
           it "Returns the choice's body as a <li> element inside a <ul>" do
-            expect(subject.body).to eq("<ul><strong>#{answer_choice.body}</strong><li>-</li></ul>")
+            expect(subject.body).to eq("<ul><em>#{answer_choice.body}</em><li>-</li></ul>")
           end
         end
       end
@@ -61,7 +61,7 @@ module Decidim
         let!(:answer_choice_2) { create :answer_choice, answer: answer, answer_option: answer_option_2, body: translated(answer_option_2.body, locale: I18n.locale) }
 
         it "Returns the choices wrapped in <li> elements inside a <ul>" do
-          expect(subject.body).to eq("<ul><strong>#{answer_choice_1.body}</strong><li>-</li><strong>#{answer_choice_2.body}</strong><li>-</li></ul>")
+          expect(subject.body).to eq("<ul><em>#{answer_choice_1.body}</em><li>-</li><em>#{answer_choice_2.body}</em><li>-</li></ul>")
         end
 
         context "and free text is enabled on answer options" do
@@ -69,7 +69,7 @@ module Decidim
           let!(:answer_option_2) { create :answer_option, :free_text_enabled }
 
           it "returns the choices and question wrapped in <li> elements inside a <ul>" do
-            expect(subject.body).to eq("<ul><strong>#{answer_option_1.translated_body}</strong><li>-</li><strong>#{answer_option_2.translated_body}</strong><li>-</li></ul>")
+            expect(subject.body).to eq("<ul><em>#{answer_option_1.translated_body}</em><li>-</li><em>#{answer_option_2.translated_body}</em><li>-</li></ul>")
           end
         end
       end

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
@@ -48,7 +48,7 @@ module Decidim
           let!(:question) { create :questionnaire_question, questionnaire: questionnaire, question_type: "multiple_option" }
 
           it "Returns the choice's body as a <li> element inside a <ul>" do
-            expect(subject.body).to eq("<ul><li>#{answer_choice.body}</li></ul>")
+            expect(subject.body).to eq("<ul><strong>#{answer_choice.body}</strong><li>-</li></ul>")
           end
         end
       end
@@ -61,7 +61,16 @@ module Decidim
         let!(:answer_choice_2) { create :answer_choice, answer: answer, answer_option: answer_option_2, body: translated(answer_option_2.body, locale: I18n.locale) }
 
         it "Returns the choices wrapped in <li> elements inside a <ul>" do
-          expect(subject.body).to eq("<ul><li>#{answer_choice_1.body}</li><li>#{answer_choice_2.body}</li></ul>")
+          expect(subject.body).to eq("<ul><strong>#{answer_choice_1.body}</strong><li>-</li><strong>#{answer_choice_2.body}</strong><li>-</li></ul>")
+        end
+
+        context "and free text is enabled on answer options" do
+          let!(:answer_option_1) { create :answer_option, :free_text_enabled }
+          let!(:answer_option_2) { create :answer_option, :free_text_enabled }
+
+          it "returns the choices and question wrapped in <li> elements inside a <ul>" do
+            expect(subject.body).to eq("<ul><strong>#{answer_option_1.translated_body}</strong><li>-</li><strong>#{answer_option_2.translated_body}</strong><li>-</li></ul>")
+          end
         end
       end
     end

--- a/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -88,11 +88,11 @@ module Decidim
           serialized_files_answer = files_answer.attachments.map(&:url)
 
           expect(serialized).to include(
-            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => multichoice_answer_choices.map(&:body)
+            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => [[multichoice_answer_choices.first.body, "-"].to_json, [multichoice_answer_choices.last.body, "-"].to_json]
           )
 
           expect(serialized).to include(
-            "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => ["Free text"]
+            "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => [[translated(singlechoice_answer_choice.body), "Free text"].to_json]
           )
 
           expect(serialized).to include(

--- a/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -88,11 +88,11 @@ module Decidim
           serialized_files_answer = files_answer.attachments.map(&:url)
 
           expect(serialized).to include(
-            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => [[multichoice_answer_choices.first.body, "-"].to_json, [multichoice_answer_choices.last.body, "-"].to_json]
+            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => [multichoice_answer_choices.first.body, multichoice_answer_choices.last.body]
           )
 
           expect(serialized).to include(
-            "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => [[translated(singlechoice_answer_choice.body), "Free text"].to_json]
+            "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => ["#{translated(singlechoice_answer_choice.body)} (Free text)"]
           )
 
           expect(serialized).to include(

--- a/decidim-meetings/spec/serializers/registration_serializer_spec.rb
+++ b/decidim-meetings/spec/serializers/registration_serializer_spec.rb
@@ -92,13 +92,13 @@ module Decidim::Meetings
             "#{questions.last.position + 1}. #{translated(questions.last.body, locale: I18n.locale)}" => answers.last.body
           )
           expect(serialized[:registration_form_answers]).to include(
-            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => [[multichoice_answer_choices.first.body, "-"].to_json, [multichoice_answer_choices.last.body, "-"].to_json]
+            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => [multichoice_answer_choices.first.body, multichoice_answer_choices.last.body]
           )
           expect(serialized[:registration_form_answers]).to include(
-            "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => [[singlechoice_answer_choice.body, "-"].to_json]
+            "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => [singlechoice_answer_choice.body]
           )
           expect(serialized[:registration_form_answers]).to include(
-            "#{singlechoice_free_question.position + 1}. #{translated(singlechoice_free_question.body, locale: I18n.locale)}" => [[singlechoice_free_answer_choice.body, "Free text answer"].to_json]
+            "#{singlechoice_free_question.position + 1}. #{translated(singlechoice_free_question.body, locale: I18n.locale)}" => ["#{singlechoice_free_answer_choice.body} (Free text answer)"]
           )
         end
       end

--- a/decidim-meetings/spec/serializers/registration_serializer_spec.rb
+++ b/decidim-meetings/spec/serializers/registration_serializer_spec.rb
@@ -63,7 +63,7 @@ module Decidim::Meetings
         let!(:singlechoice_free_question) { create :questionnaire_question, questionnaire: meeting.questionnaire, question_type: "single_option" }
         let!(:singlechoice_free_answer_options) do
           options = create_list :answer_option, 2, question: singlechoice_free_question
-          options << create(:answer_option, question: singlechoice_free_question, free_text: true)
+          options << create(:answer_option, :free_text_enabled, question: singlechoice_free_question)
 
           options
         end
@@ -92,13 +92,13 @@ module Decidim::Meetings
             "#{questions.last.position + 1}. #{translated(questions.last.body, locale: I18n.locale)}" => answers.last.body
           )
           expect(serialized[:registration_form_answers]).to include(
-            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => multichoice_answer_choices.map(&:body)
+            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => [[multichoice_answer_choices.first.body, "-"].to_json, [multichoice_answer_choices.last.body, "-"].to_json]
           )
           expect(serialized[:registration_form_answers]).to include(
-            "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => [singlechoice_answer_choice.body]
+            "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => [[singlechoice_answer_choice.body, "-"].to_json]
           )
           expect(serialized[:registration_form_answers]).to include(
-            "#{singlechoice_free_question.position + 1}. #{translated(singlechoice_free_question.body, locale: I18n.locale)}" => ["Free text answer"]
+            "#{singlechoice_free_question.position + 1}. #{translated(singlechoice_free_question.body, locale: I18n.locale)}" => [[singlechoice_free_answer_choice.body, "Free text answer"].to_json]
           )
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

When survey contains answer with multiple answer choices, exports can be difficult to read for administrators. So this PR aims to change format of answer choices in exports. The format is now : 

* When free text is disabled or user just check option without filling free text
`"answer choice"`

* When free text is enabled and user fill free text
`"answer choice (free text)"`

* When there is several choices
`"answer choice 1 (free text 1), answer choice 2 (free text 2)"` or `"answer choice 1 (free text 1), answer choice 2"`

Also, admin response show view can be enhanced when displaying multiple choice answers.

#### :pushpin: Related Issues
- Fixes #6087

#### Testing

**Test format in exports**
1. Create a survey with sorting and multiple choices questions (enabling free text)
2. Answer the survey
3. Export the answers in admin panel
4. See answer choices as Array in exports

**Test admin response show view**
1. Create a survey with sorting and multiple choices questions (enabling free text)
2. Answer the survey
3. Access responses index
4. Click on a response eye icon
5. See display updated

### :camera: Screenshots
**Admin response show view**
<img width="1037" alt="Screenshot 2021-12-20 at 16 20 56" src="https://user-images.githubusercontent.com/26109239/146903232-f79f36dd-af8c-41dd-8c0c-40580966dd1f.png">


**Exports**
**CSV**
<img width="1114" alt="Screenshot 2021-12-20 at 16 22 35" src="https://user-images.githubusercontent.com/26109239/146903172-60fdad40-c8e2-439e-a9c4-3c56487d233a.png">


#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

#### Additional context
I tried to simplify my fix however the forms / surveys are complex to understand

:hearts: Thank you!
