### PR TITLE
Fix security instructions

### DIFF
--- a/SECURITY.adoc
+++ b/SECURITY.adoc
@@ -26,5 +26,5 @@ To download our key:
 
 [source,bash]
 ----
-gpg --keyserver pgp.key-server.io --recv 84B935C4
+gpg --keyserver pgp.mit.edu --recv 84B935C4
 ----

--- a/docs/modules/develop/pages/security.adoc
+++ b/docs/modules/develop/pages/security.adoc
@@ -29,5 +29,5 @@ is `C1BD 8981 D83C 23F9 D419 FE42 149A D0F9 84B9 35C4`. To download our key:
 
 [source,bash]
 ----
-gpg --keyserver pgp.key-server.io --recv 84B935C4
+gpg --keyserver pgp.mit.edu --recv 84B935C4
 ----

--- a/docs/modules/develop/pages/security.adoc
+++ b/docs/modules/develop/pages/security.adoc
@@ -5,15 +5,7 @@
 Until we have the version 1.0 we support only the last minor and major
 version with security updates.
 
-|===
-| Version | Supported
-
-| 0.21.x
-| :white_check_mark:
-
-| \<= 0.20
-| :x:
-|===
+https://github.com/decidim/decidim/blob/doc/security-keyserver/SECURITY.adoc[See the last supported version].
 
 == Reporting a Vulnerability
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes some details in the security report docs:

* Fix the key server, as it wasn't working. Pointed by @Quentinchampenois - thanks!
* As we have two security.adoc files (one for github and another for docs.decidim.org) we didn't have it synchronized regarding the supported version. We fixed with a link.

:hearts: Thank you!
