### PR TITLE
Fix group mentions in notifications

### DIFF
--- a/decidim-comments/app/services/decidim/comments/new_comment_notification_creator.rb
+++ b/decidim-comments/app/services/decidim/comments/new_comment_notification_creator.rb
@@ -56,7 +56,7 @@ module Decidim
           affected_users = group.accepted_users - already_notified_users
           @already_notified_users += affected_users
 
-          notify(:user_group_mentioned, affected_users: affected_users, extra: { group: group })
+          notify(:user_group_mentioned, affected_users: affected_users, extra: { group_id: group.id })
         end
       end
 

--- a/decidim-comments/spec/events/decidim/comments/user_group_mentioned_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/user_group_mentioned_event_spec.rb
@@ -10,7 +10,7 @@ describe Decidim::Comments::UserGroupMentionedEvent do
   let(:extra) do
     {
       comment_id: comment.id,
-      group: group
+      group_id: group.id
     }
   end
 

--- a/decidim-comments/spec/services/decidim/comments/new_comment_notification_creator_spec.rb
+++ b/decidim-comments/spec/services/decidim/comments/new_comment_notification_creator_spec.rb
@@ -146,7 +146,7 @@ describe Decidim::Comments::NewCommentNotificationCreator do
             affected_users: a_collection_containing_exactly(*affected_group_users),
             extra: {
               comment_id: comment.id,
-              group: group
+              group_id: group.id
             }
           )
         expect(Decidim::EventsManager)
@@ -198,7 +198,7 @@ describe Decidim::Comments::NewCommentNotificationCreator do
               affected_users: a_collection_containing_exactly(*affected_group_users),
               extra: {
                 comment_id: comment.id,
-                group: group
+                group_id: group.id
               }
             )
           expect(Decidim::EventsManager)
@@ -232,7 +232,7 @@ describe Decidim::Comments::NewCommentNotificationCreator do
               affected_users: a_collection_containing_exactly(*affected_group_users),
               extra: {
                 comment_id: comment.id,
-                group: group
+                group_id: group.id
               }
             )
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -600,6 +600,12 @@ FactoryBot.define do
         some_extra_data: "1"
       }
     end
+
+    trait :user_group_mentioned_notification do
+      event_class { "Decidim::Comments::UserGroupMentionedEvent" }
+      event_name { "decidim.events.comments.user_group_mentioned" }
+      extra { { comment_id: create(:comment).id, group_id: create(:user_group).id } }
+    end
   end
 
   factory :action_log, class: "Decidim::ActionLog" do

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -600,12 +600,6 @@ FactoryBot.define do
         some_extra_data: "1"
       }
     end
-
-    trait :user_group_mentioned_notification do
-      event_class { "Decidim::Comments::UserGroupMentionedEvent" }
-      event_name { "decidim.events.comments.user_group_mentioned" }
-      extra { { comment_id: create(:comment).id, group_id: create(:user_group).id } }
-    end
   end
 
   factory :action_log, class: "Decidim::ActionLog" do

--- a/decidim-core/lib/decidim/events/user_group_event.rb
+++ b/decidim-core/lib/decidim/events/user_group_event.rb
@@ -35,9 +35,15 @@ module Decidim
         end
 
         def group
-          return unless extra[:group].is_a?(Decidim::UserGroup)
+          @group ||= fetch_group
+        end
 
-          extra[:group]
+        private
+
+        def fetch_group
+          return extra[:group] if extra[:group].is_a?(Decidim::UserGroup)
+
+          Decidim::UserGroup.find_by(id: extra[:group_id]) if extra[:group_id]
         end
       end
     end

--- a/decidim-core/lib/decidim/events/user_group_event.rb
+++ b/decidim-core/lib/decidim/events/user_group_event.rb
@@ -35,15 +35,7 @@ module Decidim
         end
 
         def group
-          @group ||= fetch_group
-        end
-
-        private
-
-        def fetch_group
-          return extra[:group] if extra[:group].is_a?(Decidim::UserGroup)
-
-          Decidim::UserGroup.find_by(id: extra[:group_id]) if extra[:group_id]
+          @group ||= Decidim::UserGroup.find_by(id: extra[:group_id]) if extra[:group_id]
         end
       end
     end

--- a/decidim-core/spec/system/notifications_spec.rb
+++ b/decidim-core/spec/system/notifications_spec.rb
@@ -113,7 +113,10 @@ describe "Notifications", type: :system do
   end
 
   context "with user group mentioned notifications" do
-    let!(:notification) { create :notification, :user_group_mentioned_notification, user: user }
+    let(:event_class) { "Decidim::Comments::UserGroupMentionedEvent" }
+    let(:event_name) { "decidim.events.comments.user_group_mentioned" }
+    let(:extra) { { comment_id: create(:comment).id, group_id: create(:user_group).id } }
+    let!(:notification) { create :notification, user: user, event_class: event_class, event_name: event_name, extra: extra }
 
     before do
       page.visit decidim.notifications_path

--- a/decidim-core/spec/system/notifications_spec.rb
+++ b/decidim-core/spec/system/notifications_spec.rb
@@ -111,4 +111,20 @@ describe "Notifications", type: :system do
       end
     end
   end
+
+  context "with user group mentioned notifications" do
+    let!(:notification) { create :notification, :user_group_mentioned_notification, user: user }
+
+    before do
+      page.visit decidim.notifications_path
+    end
+
+    it "shows the notification with the group mentioned" do
+      group = Decidim::UserGroup.find(notification.extra["group_id"])
+      element = page.find(".card-data__item--expand")
+      notification_text = element.text
+
+      expect(notification_text).to end_with("as a member of #{group.name} @#{group.nickname}")
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR display fix the group mention in notifications. It's deeply explained in the issue #8485 .


#### :pushpin: Related Issues
*Link your PR to an issue*
- Issue #8485 

#### Testing
You need a user_group_mentioned notification. Using a different user from yours, create a comment in a proposal that your user is following. In. that comment mention your original user.
After that, go to /notifications, and there, you''ll see a notification with the group mentioned

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![example](https://user-images.githubusercontent.com/7511154/145567158-07b3f388-2e53-4132-9498-a68b5e01222a.png)

Staging:

![staging example](https://user-images.githubusercontent.com/7511154/145788698-9b1c43cf-50fc-4af9-b805-de47fd7d83f7.png)


:hearts: Thank you!
