### PR TITLE
Backport "Change default window size in Capybara configuration" to v0.25

### DIFF
--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -25,7 +25,6 @@ env:
   RUBY_VERSION: 2.7.1
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-meetings
-  BIG_SCREEN_SIZE: "true"
 
 jobs:
   main:

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -30,7 +30,7 @@ Capybara.register_driver :headless_chrome do |app|
   options.args << if ENV["BIG_SCREEN_SIZE"].present?
                     "--window-size=1920,3000"
                   else
-                    "--window-size=1024,768"
+                    "--window-size=1920,1080"
                   end
 
   Capybara::Selenium::Driver.new(

--- a/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
@@ -41,7 +41,12 @@ shared_examples "manage process steps examples" do
     page.find(".datepicker-dropdown .day", text: "22").click
 
     within ".new_participatory_process_step" do
-      find("*[type=submit]").click
+      # For some reason, the form submit button click can fail unless the page
+      # is first scrolled to this element
+      # Got the idea from:
+      # https://stackoverflow.com/a/39103252
+      page.scroll_to(find(".form-general-submit"))
+      find(".form-general-submit").click
     end
 
     expect(page).to have_admin_callout("successfully")

--- a/decidim-proposals/spec/system/amendable/amendment_wizard_spec.rb
+++ b/decidim-proposals/spec/system/amendable/amendment_wizard_spec.rb
@@ -225,8 +225,8 @@ describe "Amendment Wizard", type: :system do
           find("*[type=submit]").click
         end
 
-        # It seems that from version 83 of chromdriver, it gets really picky
-        # Content mus be inside the virtual window of test
+        # It seems that from version 83 of chromedriver, it gets really picky
+        # Content must be inside the virtual window of test
         # Got the idea from:
         # https://stackoverflow.com/a/39103252
         page.scroll_to(find(".edit_amendment"))


### PR DESCRIPTION
#### :tophat: What? Why?

Backport  #8576 to v0.25

#### :pushpin: Related Issues

- Related to  #8576

:hearts: Thank you!
