### PR TITLE
Fix deprecation warnings from rails 6.1 update

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_import.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_import.rb
@@ -14,13 +14,12 @@ module Decidim
         transaction do
           form.importer.import!
 
-          return broadcast(:ok, imported_data)
+          broadcast(:ok, imported_data)
         rescue StandardError
+          # Something went wrong with import/finish
+          broadcast(:invalid)
           raise ActiveRecord::Rollback
         end
-
-        # Something went wrong with import/finish
-        broadcast(:invalid)
       end
 
       attr_reader :form

--- a/decidim-admin/app/forms/decidim/admin/import_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/import_form.rb
@@ -44,8 +44,8 @@ module Decidim
       def verify_import
         return if importer.verify
 
-        importer.errors.each do |_col, message|
-          errors.add(:file, message)
+        importer.errors.each do |error|
+          errors.add(:file, error.message)
         end
       end
 

--- a/decidim-admin/spec/commands/decidim/admin/update_content_block_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_content_block_spec.rb
@@ -14,7 +14,7 @@ module Decidim::Admin
       }
     end
     let(:uploaded_image) do
-      ActiveStorage::Blob.create_after_upload!(
+      ActiveStorage::Blob.create_and_upload!(
         io: File.open(Decidim::Dev.asset("city.jpeg")),
         filename: "city.jpeg",
         content_type: "image/jpeg"
@@ -71,7 +71,7 @@ module Decidim::Admin
 
       context "when the image exists" do
         let(:original_image) do
-          ActiveStorage::Blob.create_after_upload!(
+          ActiveStorage::Blob.create_and_upload!(
             io: File.open(Decidim::Dev.asset("city.jpeg")),
             filename: "city.jpeg",
             content_type: "image/jpeg"

--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -66,13 +66,13 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
           Decidim::Faker::Localized.paragraph(sentence_count: 3)
         end,
         organization: organization,
-        hero_image: ActiveStorage::Blob.create_after_upload!(
+        hero_image: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city.jpeg")),
           filename: "hero_image.jpeg",
           content_type: "image/jpeg",
           metadata: nil
         ), # Keep after organization
-        banner_image: ActiveStorage::Blob.create_after_upload!(
+        banner_image: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city2.jpeg")),
           filename: "banner_image.jpeg",
           content_type: "image/jpeg",
@@ -159,13 +159,13 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
           Decidim::Faker::Localized.paragraph(sentence_count: 3)
         end,
         organization: organization,
-        hero_image: ActiveStorage::Blob.create_after_upload!(
+        hero_image: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city.jpeg")),
           filename: "hero_image.jpeg",
           content_type: "image/jpeg",
           metadata: nil
         ), # Keep after organization
-        banner_image: ActiveStorage::Blob.create_after_upload!(
+        banner_image: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city2.jpeg")),
           filename: "banner_image.jpeg",
           content_type: "image/jpeg",
@@ -197,7 +197,7 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
           attachment_collection: attachment_collection,
           attached_to: current_assembly,
           content_type: "application/pdf",
-          file: ActiveStorage::Blob.create_after_upload!(
+          file: ActiveStorage::Blob.create_and_upload!(
             io: File.open(File.join(seeds_root, "Exampledocument.pdf")),
             filename: "Exampledocument.pdf",
             content_type: "application/pdf",
@@ -210,7 +210,7 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
           description: Decidim::Faker::Localized.sentence(word_count: 5),
           attached_to: current_assembly,
           content_type: "image/jpeg",
-          file: ActiveStorage::Blob.create_after_upload!(
+          file: ActiveStorage::Blob.create_and_upload!(
             io: File.open(File.join(seeds_root, "city.jpeg")),
             filename: "city.jpeg",
             content_type: "image/jpeg",
@@ -223,7 +223,7 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
           description: Decidim::Faker::Localized.sentence(word_count: 5),
           attached_to: current_assembly,
           content_type: "application/pdf",
-          file: ActiveStorage::Blob.create_after_upload!(
+          file: ActiveStorage::Blob.create_and_upload!(
             io: File.open(File.join(seeds_root, "Exampledocument.pdf")),
             filename: "Exampledocument.pdf",
             content_type: "application/pdf",

--- a/decidim-assemblies/spec/commands/create_assembly_member_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_member_spec.rb
@@ -11,7 +11,7 @@ module Decidim::Assemblies
     let!(:current_user) { create :user, :confirmed, organization: assembly.organization }
     let(:existing_user) { false }
     let(:non_user_avatar) do
-      ActiveStorage::Blob.create_after_upload!(
+      ActiveStorage::Blob.create_and_upload!(
         io: File.open(Decidim::Dev.asset("avatar.jpg")),
         filename: "avatar.jpeg",
         content_type: "image/jpeg"
@@ -55,7 +55,7 @@ module Decidim::Assemblies
       context "when image is invalid" do
         let(:existing_user) { false }
         let(:non_user_avatar) do
-          ActiveStorage::Blob.create_after_upload!(
+          ActiveStorage::Blob.create_and_upload!(
             io: File.open(Decidim::Dev.asset("invalid.jpeg")),
             filename: "avatar.jpeg",
             content_type: "image/jpeg"

--- a/decidim-assemblies/spec/commands/create_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_spec.rb
@@ -111,7 +111,7 @@ module Decidim::Assemblies
 
     context "when the uploaded hero image has too large dimensions" do
       let(:hero_image) do
-        ActiveStorage::Blob.create_after_upload!(
+        ActiveStorage::Blob.create_and_upload!(
           io: File.open(Decidim::Dev.asset("5000x5000.png")),
           filename: "5000x5000.png",
           content_type: "image/png"

--- a/decidim-assemblies/spec/commands/update_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/update_assembly_spec.rb
@@ -110,7 +110,7 @@ module Decidim::Assemblies
         let(:attachment_params) do
           {
             banner_image: banner_image.blob,
-            hero_image: ActiveStorage::Blob.create_after_upload!(
+            hero_image: ActiveStorage::Blob.create_and_upload!(
               io: File.open(Decidim::Dev.asset("5000x5000.png")),
               filename: "5000x5000.png",
               content_type: "image/png"

--- a/decidim-assemblies/spec/presenters/decidim/assembly_member_presenter_spec.rb
+++ b/decidim-assemblies/spec/presenters/decidim/assembly_member_presenter_spec.rb
@@ -121,7 +121,7 @@ module Decidim
 
       context "when a image is attached" do
         let(:non_user_avatar) do
-          ActiveStorage::Blob.create_after_upload!(
+          ActiveStorage::Blob.create_and_upload!(
             io: File.open(Decidim::Dev.asset("avatar.jpg")),
             filename: "avatar.jpeg",
             content_type: "image/jpeg"

--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -163,7 +163,7 @@ Decidim.register_component(:budgets) do |component|
           attachment_collection: attachment_collection,
           attached_to: project,
           content_type: "application/pdf",
-          file: ActiveStorage::Blob.create_after_upload!(
+          file: ActiveStorage::Blob.create_and_upload!(
             io: File.open(File.join(__dir__, "seeds", "Exampledocument.pdf")),
             filename: "Exampledocument.pdf",
             content_type: "application/pdf",
@@ -175,7 +175,7 @@ Decidim.register_component(:budgets) do |component|
           description: Decidim::Faker::Localized.sentence(word_count: 5),
           attached_to: project,
           content_type: "image/jpeg",
-          file: ActiveStorage::Blob.create_after_upload!(
+          file: ActiveStorage::Blob.create_and_upload!(
             io: File.open(File.join(__dir__, "seeds", "city.jpeg")),
             filename: "city.jpeg",
             content_type: "image/jpeg",
@@ -187,7 +187,7 @@ Decidim.register_component(:budgets) do |component|
           description: Decidim::Faker::Localized.sentence(word_count: 5),
           attached_to: project,
           content_type: "application/pdf",
-          file: ActiveStorage::Blob.create_after_upload!(
+          file: ActiveStorage::Blob.create_and_upload!(
             io: File.open(File.join(__dir__, "seeds", "Exampledocument.pdf")),
             filename: "Exampledocument.pdf",
             content_type: "application/pdf",

--- a/decidim-conferences/app/mailers/decidim/conferences/admin/send_conference_diploma_mailer.rb
+++ b/decidim-conferences/app/mailers/decidim/conferences/admin/send_conference_diploma_mailer.rb
@@ -35,8 +35,8 @@ module Decidim
         def add_diploma_attachment
           diploma = WickedPdf.new.pdf_from_string(
             render_to_string(pdf: "conference-diploma",
-                             template: "decidim/conferences/admin/send_conference_diploma_mailer/diploma_user.html.erb",
-                             layout: "decidim/diploma.html.erb"),
+                             template: "decidim/conferences/admin/send_conference_diploma_mailer/diploma_user",
+                             layout: "decidim/diploma"),
             orientation: "Landscape"
           )
 

--- a/decidim-conferences/lib/decidim/conferences/participatory_space.rb
+++ b/decidim-conferences/lib/decidim/conferences/participatory_space.rb
@@ -64,13 +64,13 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
           Decidim::Faker::Localized.paragraph(sentence_count: 3)
         end,
         organization: organization,
-        hero_image: ActiveStorage::Blob.create_after_upload!(
+        hero_image: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city.jpeg")),
           filename: "hero_image.jpeg",
           content_type: "image/jpeg",
           metadata: nil
         ), # Keep after organization
-        banner_image: ActiveStorage::Blob.create_after_upload!(
+        banner_image: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city2.jpeg")),
           filename: "banner_image.jpeg",
           content_type: "image/jpeg",
@@ -126,7 +126,7 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
         attachment_collection: attachment_collection,
         attached_to: conference,
         content_type: "application/pdf",
-        file: ActiveStorage::Blob.create_after_upload!(
+        file: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "Exampledocument.pdf")),
           filename: "Exampledocument.pdf",
           content_type: "application/pdf",
@@ -139,7 +139,7 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
         description: Decidim::Faker::Localized.sentence(word_count: 5),
         attached_to: conference,
         content_type: "image/jpeg",
-        file: ActiveStorage::Blob.create_after_upload!(
+        file: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city.jpeg")),
           filename: "city.jpeg",
           content_type: "image/jpeg",
@@ -152,7 +152,7 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
         description: Decidim::Faker::Localized.sentence(word_count: 5),
         attached_to: conference,
         content_type: "application/pdf",
-        file: ActiveStorage::Blob.create_after_upload!(
+        file: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "Exampledocument.pdf")),
           filename: "Exampledocument.pdf",
           content_type: "application/pdf",
@@ -193,7 +193,7 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
             link: Faker::Internet.url,
             partner_type: type,
             conference: conference,
-            logo: ActiveStorage::Blob.create_after_upload!(
+            logo: ActiveStorage::Blob.create_and_upload!(
               io: File.open(File.join(seeds_root, "logo.png")),
               filename: "logo.png",
               content_type: "image/png",

--- a/decidim-conferences/spec/commands/create_conference_speaker_spec.rb
+++ b/decidim-conferences/spec/commands/create_conference_speaker_spec.rb
@@ -22,7 +22,7 @@ module Decidim::Conferences
     end
     let(:meeting_ids) { meetings.map(&:id) }
     let(:avatar) do
-      ActiveStorage::Blob.create_after_upload!(
+      ActiveStorage::Blob.create_and_upload!(
         io: File.open(Decidim::Dev.asset("avatar.jpg")),
         filename: "avatar.jpeg",
         content_type: "image/jpeg"
@@ -73,7 +73,7 @@ module Decidim::Conferences
 
       context "when image is invalid" do
         let(:avatar) do
-          ActiveStorage::Blob.create_after_upload!(
+          ActiveStorage::Blob.create_and_upload!(
             io: File.open(Decidim::Dev.asset("invalid.jpeg")),
             filename: "avatar.jpeg",
             content_type: "image/jpeg"

--- a/decidim-conferences/spec/commands/create_partner_spec.rb
+++ b/decidim-conferences/spec/commands/create_partner_spec.rb
@@ -10,7 +10,7 @@ module Decidim::Conferences
     let(:user) { nil }
     let!(:current_user) { create :user, :confirmed, organization: conference.organization }
     let(:logo) do
-      ActiveStorage::Blob.create_after_upload!(
+      ActiveStorage::Blob.create_and_upload!(
         io: File.open(Decidim::Dev.asset("avatar.jpg")),
         filename: "avatar.jpeg",
         content_type: "image/jpeg"
@@ -50,7 +50,7 @@ module Decidim::Conferences
 
       context "when image is invalid" do
         let(:logo) do
-          ActiveStorage::Blob.create_after_upload!(
+          ActiveStorage::Blob.create_and_upload!(
             io: File.open(Decidim::Dev.asset("invalid.jpeg")),
             filename: "avatar.jpeg",
             content_type: "image/jpeg"

--- a/decidim-conferences/spec/commands/update_conference_speaker_spec.rb
+++ b/decidim-conferences/spec/commands/update_conference_speaker_spec.rb
@@ -22,7 +22,7 @@ module Decidim::Conferences
     end
     let(:meeting_ids) { meetings.map(&:id) }
     let(:avatar) do
-      ActiveStorage::Blob.create_after_upload!(
+      ActiveStorage::Blob.create_and_upload!(
         io: File.open(Decidim::Dev.asset("avatar.jpg")),
         filename: "avatar.jpeg",
         content_type: "image/jpeg"
@@ -73,7 +73,7 @@ module Decidim::Conferences
 
       context "when image is invalid" do
         let(:avatar) do
-          ActiveStorage::Blob.create_after_upload!(
+          ActiveStorage::Blob.create_and_upload!(
             io: File.open(Decidim::Dev.asset("invalid.jpeg")),
             filename: "avatar.jpeg",
             content_type: "image/jpeg"

--- a/decidim-conferences/spec/commands/update_partner_spec.rb
+++ b/decidim-conferences/spec/commands/update_partner_spec.rb
@@ -11,7 +11,7 @@ module Decidim::Conferences
     let(:partner) { create :partner, :main_promotor, conference: conference }
     let!(:current_user) { create :user, :confirmed, organization: conference.organization }
     let(:logo) do
-      ActiveStorage::Blob.create_after_upload!(
+      ActiveStorage::Blob.create_and_upload!(
         io: File.open(Decidim::Dev.asset("avatar.jpg")),
         filename: "avatar.jpeg",
         content_type: "image/jpeg"
@@ -49,7 +49,7 @@ module Decidim::Conferences
 
       context "when image is invalid" do
         let(:logo) do
-          ActiveStorage::Blob.create_after_upload!(
+          ActiveStorage::Blob.create_and_upload!(
             io: File.open(Decidim::Dev.asset("invalid.jpeg")),
             filename: "invalid.jpeg",
             content_type: "image/jpeg"

--- a/decidim-consultations/lib/decidim/consultations/participatory_space.rb
+++ b/decidim-consultations/lib/decidim/consultations/participatory_space.rb
@@ -50,7 +50,7 @@ Decidim.register_participatory_space(:consultations) do |participatory_space|
       start_voting_date: Time.zone.today,
       end_voting_date: Time.zone.today + 1.month,
       organization: organization,
-      banner_image: ActiveStorage::Blob.create_after_upload!(
+      banner_image: ActiveStorage::Blob.create_and_upload!(
         io: File.open(File.join(seeds_root, "city2.jpeg")),
         filename: "banner_image.jpeg",
         content_type: "image/jpeg",
@@ -82,7 +82,7 @@ Decidim.register_participatory_space(:consultations) do |participatory_space|
       start_voting_date: Time.zone.today - 2.months,
       end_voting_date: Time.zone.today - 1.month,
       organization: organization,
-      banner_image: ActiveStorage::Blob.create_after_upload!(
+      banner_image: ActiveStorage::Blob.create_and_upload!(
         io: File.open(File.join(seeds_root, "city2.jpeg")),
         filename: "banner_image.jpeg",
         content_type: "image/jpeg",
@@ -113,7 +113,7 @@ Decidim.register_participatory_space(:consultations) do |participatory_space|
       start_voting_date: Time.zone.today + 1.month + 1.day,
       end_voting_date: Time.zone.today + 2.months,
       organization: organization,
-      banner_image: ActiveStorage::Blob.create_after_upload!(
+      banner_image: ActiveStorage::Blob.create_and_upload!(
         io: File.open(File.join(seeds_root, "city2.jpeg")),
         filename: "banner_image.jpeg",
         content_type: "image/jpeg",
@@ -148,13 +148,13 @@ Decidim.register_participatory_space(:consultations) do |participatory_space|
             Decidim::Faker::Localized.paragraph(sentence_count: 3)
           end,
           organization: organization,
-          hero_image: ActiveStorage::Blob.create_after_upload!(
+          hero_image: ActiveStorage::Blob.create_and_upload!(
             io: File.open(File.join(seeds_root, "city.jpeg")),
             filename: "hero_image.jpeg",
             content_type: "image/jpeg",
             metadata: nil
           ), # Keep after organization
-          banner_image: ActiveStorage::Blob.create_after_upload!(
+          banner_image: ActiveStorage::Blob.create_and_upload!(
             io: File.open(File.join(seeds_root, "city2.jpeg")),
             filename: "banner_image.jpeg",
             content_type: "image/jpeg",
@@ -188,7 +188,7 @@ Decidim.register_participatory_space(:consultations) do |participatory_space|
           description: Decidim::Faker::Localized.sentence(word_count: 5),
           attached_to: question,
           content_type: "image/jpeg",
-          file: ActiveStorage::Blob.create_after_upload!(
+          file: ActiveStorage::Blob.create_and_upload!(
             io: File.open(File.join(seeds_root, "city.jpeg")),
             filename: "city.jpeg",
             content_type: "image/jpeg",
@@ -201,7 +201,7 @@ Decidim.register_participatory_space(:consultations) do |participatory_space|
           description: Decidim::Faker::Localized.sentence(word_count: 5),
           attached_to: question,
           content_type: "application/pdf",
-          file: ActiveStorage::Blob.create_after_upload!(
+          file: ActiveStorage::Blob.create_and_upload!(
             io: File.open(File.join(seeds_root, "Exampledocument.pdf")),
             filename: "Exampledocument.pdf",
             content_type: "application/pdf",

--- a/decidim-core/app/forms/url_validator.rb
+++ b/decidim-core/app/forms/url_validator.rb
@@ -6,7 +6,7 @@
 #
 class UrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors[attribute] << (options[:message] || "must be a valid URL") unless url_valid?(value)
+    record.errors.add attribute, (options[:message] || "must be a valid URL") unless url_valid?(value)
   end
 
   # a URL may be technically well-formed but may

--- a/decidim-core/app/helpers/decidim/attachments_helper.rb
+++ b/decidim-core/app/helpers/decidim/attachments_helper.rb
@@ -10,7 +10,7 @@ module Decidim
     #
     # Returns nothing.
     def attachments_for(attached_to)
-      render partial: "decidim/application/attachments.html", locals: { attached_to: attached_to }
+      render partial: "decidim/application/attachments", locals: { attached_to: attached_to }
     end
 
     # Renders the attachment's title.

--- a/decidim-core/app/helpers/decidim/followable_helper.rb
+++ b/decidim-core/app/helpers/decidim/followable_helper.rb
@@ -5,7 +5,7 @@ module Decidim
   module FollowableHelper
     # Invokes the decidim/shared/follow_button partial.
     def follow_button_for(model, large = nil)
-      render partial: "decidim/shared/follow_button.html", locals: { followable: model, large: large }
+      controller.view_context.render partial: "decidim/shared/follow_button", locals: { followable: model, large: large }
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -121,7 +121,7 @@ module Decidim
       extra_items = items.slice((max_items + 1)..-1) || []
       active_item = items.find { |item| item[:active] }
 
-      render partial: "decidim/shared/extended_navigation_bar.html", locals: {
+      controller.view_context.render partial: "decidim/shared/extended_navigation_bar", locals: {
         items: items,
         extra_items: extra_items,
         active_item: active_item,

--- a/decidim-core/app/validators/password_validator.rb
+++ b/decidim-core/app/validators/password_validator.rb
@@ -35,7 +35,7 @@ class PasswordValidator < ActiveModel::EachValidator
     return true if strong?
 
     @weak_password_reasons.each do |reason|
-      record.errors[attribute] << get_message(reason)
+      record.errors.add attribute, get_message(reason)
     end
 
     false

--- a/decidim-core/app/validators/password_validator.rb
+++ b/decidim-core/app/validators/password_validator.rb
@@ -35,7 +35,7 @@ class PasswordValidator < ActiveModel::EachValidator
     return true if strong?
 
     @weak_password_reasons.each do |reason|
-      record.errors.add attribute, get_message(reason)
+      record.errors[attribute] << get_message(reason)
     end
 
     false

--- a/decidim-core/app/views/decidim/application/_attachments.html.erb
+++ b/decidim-core/app/views/decidim/application/_attachments.html.erb
@@ -1,12 +1,12 @@
 <% if attached_to.attachments.any? %>
   <div class="row attachments">
     <div class="columns large-12">
-      <%= render partial: "decidim/application/documents.html", locals: { documents: attached_to.documents } %>
+      <%= render partial: "decidim/application/documents", locals: { documents: attached_to.documents } %>
     </div>
   </div>
   <div class="row attachments">
     <div class="columns large-12">
-      <%= render partial: "decidim/application/photos.html", locals: { photos: attached_to.photos } %>
+      <%= render partial: "decidim/application/photos", locals: { photos: attached_to.photos } %>
     </div>
   </div>
 <% end %>

--- a/decidim-core/app/views/decidim/application/_collection.html.erb
+++ b/decidim-core/app/views/decidim/application/_collection.html.erb
@@ -12,7 +12,7 @@
 
       <div class="card card--list">
         <% documents.each do |document| %>
-          <%= render partial: "decidim/application/document.html", locals: { document: document } %>
+          <%= render partial: "decidim/application/document", locals: { document: document } %>
         <% end %>
       </div>
     </div>

--- a/decidim-core/app/views/decidim/application/_documents.html.erb
+++ b/decidim-core/app/views/decidim/application/_documents.html.erb
@@ -4,12 +4,12 @@
     <% if (documents_without_collection = documents.reject(&:attachment_collection_id?)).any? %>
       <div class="card card--list">
         <% documents_without_collection.each do |document| %>
-          <%= render partial: "decidim/application/document.html", locals: { document: document } %>
+          <%= render partial: "decidim/application/document", locals: { document: document } %>
         <% end %>
       </div>
     <% end %>
     <% documents.select(&:attachment_collection_id?).group_by(&:attachment_collection).sort_by { |c, d| c.weight }.each do |collection, documents| %>
-      <%= render partial: "decidim/application/collection.html", locals: { attachment_collection: collection, documents: documents } %>
+      <%= render partial: "decidim/application/collection", locals: { attachment_collection: collection, documents: documents } %>
     <% end %>
   </div>
 <% end %>

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -211,7 +211,7 @@ if !Rails.env.production? || ENV["SEED"]
   Decidim::System::CreateDefaultContentBlocks.call(organization)
 
   hero_content_block = Decidim::ContentBlock.find_by(organization: organization, manifest_name: :hero, scope_name: :homepage)
-  hero_content_block.images_container.background_image = ActiveStorage::Blob.create_after_upload!(
+  hero_content_block.images_container.background_image = ActiveStorage::Blob.create_and_upload!(
     io: File.open(File.join(seeds_root, "homepage_image.jpg")),
     filename: "homepage_image.jpg",
     content_type: "image/jpeg",

--- a/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_form_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_form_examples.rb
@@ -21,7 +21,7 @@ shared_examples "an amendment form" do
 
     it "only adds errors to this field" do
       subject.valid?
-      expect(subject.errors.keys).to eq [:title]
+      expect(subject.errors.attribute_names).to eq [:title]
     end
   end
 

--- a/decidim-core/spec/cells/decidim/content_blocks/hero_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/content_blocks/hero_cell_spec.rb
@@ -31,7 +31,7 @@ describe Decidim::ContentBlocks::HeroCell, type: :cell do
 
   context "when the content block has a background image" do
     let(:background_image) do
-      ActiveStorage::Blob.create_after_upload!(
+      ActiveStorage::Blob.create_and_upload!(
         io: File.open(Decidim::Dev.asset("city.jpeg")),
         filename: "city.jpeg",
         content_type: "image/jpeg"

--- a/decidim-core/spec/forms/password_validator_spec.rb
+++ b/decidim-core/spec/forms/password_validator_spec.rb
@@ -7,15 +7,14 @@ describe PasswordValidator do
     let(:organization) { create(:organization) }
     let(:validator) { described_class.new(options).validate_each(record, attribute, value) }
 
+    let(:errors) { ActiveModel::Errors.new(attribute.to_s => []) }
     let(:record) do
       double(
         name: ::Faker::Name.name,
         email: ::Faker::Internet.email,
         nickname: ::Faker::Internet.username(specifier: 10..15),
         current_organization: organization,
-        errors: {
-          attribute.to_s => []
-        }
+        errors: errors
       )
     end
     let(:attribute) { "password" }

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -597,7 +597,7 @@ module Decidim
       let(:filename) { "my_image.jpg" }
       let(:image?) { false }
       let(:blob) do
-        ActiveStorage::Blob.create_after_upload!(
+        ActiveStorage::Blob.create_and_upload!(
           io: File.open(Decidim::Dev.asset("city.jpeg")),
           filename: filename
         )
@@ -667,7 +667,7 @@ module Decidim
       context "when it is not an image" do
         let(:filename) { "my_file.pdf" }
         let(:blob) do
-          ActiveStorage::Blob.create_after_upload!(
+          ActiveStorage::Blob.create_and_upload!(
             io: File.open(Decidim::Dev.asset("Exampledocument.pdf")),
             filename: filename
           )

--- a/decidim-core/spec/models/decidim/attachment_spec.rb
+++ b/decidim-core/spec/models/decidim/attachment_spec.rb
@@ -26,7 +26,7 @@ module Decidim
         subject do
           build(
             :attachment,
-            file: ActiveStorage::Blob.create_after_upload!(
+            file: ActiveStorage::Blob.create_and_upload!(
               io: File.open(attachment_path),
               filename: "image.jpeg",
               content_type: "image/jpeg"

--- a/decidim-core/spec/models/decidim/editor_image_spec.rb
+++ b/decidim-core/spec/models/decidim/editor_image_spec.rb
@@ -27,7 +27,7 @@ describe Decidim::EditorImage do
       subject do
         build(
           :editor_image,
-          file: ActiveStorage::Blob.create_after_upload!(
+          file: ActiveStorage::Blob.create_and_upload!(
             io: File.open(Decidim::Dev.asset("malicious.jpg")),
             filename: "image.jpeg",
             content_type: "image/jpeg"

--- a/decidim-core/spec/models/decidim/user_group_spec.rb
+++ b/decidim-core/spec/models/decidim/user_group_spec.rb
@@ -77,7 +77,7 @@ module Decidim
         let(:user_group) do
           build(
             :user_group,
-            avatar: ActiveStorage::Blob.create_after_upload!(
+            avatar: ActiveStorage::Blob.create_and_upload!(
               io: File.open(avatar_path),
               filename: "malicious.jpeg",
               content_type: "image/jpeg"

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -162,7 +162,7 @@ module Decidim
         let(:user) do
           build(
             :user,
-            avatar: ActiveStorage::Blob.create_after_upload!(
+            avatar: ActiveStorage::Blob.create_and_upload!(
               io: File.open(avatar_path),
               filename: "malicious.jpeg",
               content_type: "image/jpeg"

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/attachment_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/attachment_helpers.rb
@@ -16,7 +16,7 @@ module AttachmentHelpers
     filename = options[:filename] || upload_test_file_filename(file)
     content_type = options[:content_type] || upload_test_file_content_type(file)
 
-    blob = ActiveStorage::Blob.create_after_upload!(
+    blob = ActiveStorage::Blob.create_and_upload!(
       io: File.open(file),
       filename: filename,
       content_type: content_type

--- a/decidim-elections/lib/decidim/elections/component.rb
+++ b/decidim-elections/lib/decidim/elections/component.rb
@@ -145,7 +145,7 @@ Decidim.register_component(:elections) do |component|
             description: Decidim::Faker::Localized.sentence(word_count: 5),
             attached_to: answer,
             content_type: "image/jpeg",
-            file: ActiveStorage::Blob.create_after_upload!(
+            file: ActiveStorage::Blob.create_and_upload!(
               io: File.open(File.join(__dir__, "seeds", "city.jpeg")),
               filename: "city.jpeg",
               content_type: "image/jpeg",
@@ -245,7 +245,7 @@ Decidim.register_component(:elections) do |component|
             description: Decidim::Faker::Localized.sentence(word_count: 5),
             attached_to: answer,
             content_type: "image/jpeg",
-            file: ActiveStorage::Blob.create_after_upload!(
+            file: ActiveStorage::Blob.create_and_upload!(
               io: File.open(File.join(__dir__, "seeds", "city.jpeg")),
               filename: "city.jpeg",
               content_type: "image/jpeg",
@@ -369,7 +369,7 @@ Decidim.register_component(:elections) do |component|
             description: Decidim::Faker::Localized.sentence(word_count: 5),
             attached_to: answer,
             content_type: "image/jpeg",
-            file: ActiveStorage::Blob.create_after_upload!(
+            file: ActiveStorage::Blob.create_and_upload!(
               io: File.open(File.join(__dir__, "seeds", "city.jpeg")),
               filename: "city.jpeg",
               content_type: "image/jpeg",
@@ -488,7 +488,7 @@ Decidim.register_component(:elections) do |component|
           description: Decidim::Faker::Localized.sentence(word_count: 5),
           attached_to: answer,
           content_type: "image/jpeg",
-          file: ActiveStorage::Blob.create_after_upload!(
+          file: ActiveStorage::Blob.create_and_upload!(
             io: File.open(File.join(__dir__, "seeds", "city.jpeg")),
             filename: "city.jpeg",
             content_type: "image/jpeg",

--- a/decidim-elections/lib/decidim/votings/participatory_space.rb
+++ b/decidim-elections/lib/decidim/votings/participatory_space.rb
@@ -51,7 +51,7 @@ Decidim.register_participatory_space(:votings) do |participatory_space|
           Decidim::Faker::Localized.paragraph(sentence_count: 3)
         end,
         scope: n.positive? ? nil : Decidim::Scope.reorder(Arel.sql("RANDOM()")).first,
-        banner_image: ActiveStorage::Blob.create_after_upload!(
+        banner_image: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city.jpeg")),
           filename: "banner_image.jpeg",
           content_type: "image/jpeg",

--- a/decidim-elections/spec/forms/decidim/elections/admin/answer_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/answer_form_spec.rb
@@ -59,7 +59,7 @@ describe Decidim::Elections::Admin::AnswerForm do
       it "adds an error to the `:attachment` field" do
         expect(subject).not_to be_valid
         expect(subject.errors.full_messages).to match_array(["Title en can't be blank", "Attachment Needs to be reattached"])
-        expect(subject.errors.keys).to match_array([:title_en, :attachment])
+        expect(subject.errors.attribute_names).to match_array([:title_en, :attachment])
       end
     end
   end

--- a/decidim-elections/spec/forms/decidim/elections/admin/election_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/election_form_spec.rb
@@ -83,7 +83,7 @@ describe Decidim::Elections::Admin::ElectionForm do
       it "adds an error to the `:attachment` field" do
         expect(subject).not_to be_valid
         expect(subject.errors.full_messages).to match_array(["Title en can't be blank", "Attachment Needs to be reattached"])
-        expect(subject.errors.keys).to match_array([:title_en, :attachment])
+        expect(subject.errors.attribute_names).to match_array([:title_en, :attachment])
       end
     end
   end

--- a/decidim-forms/lib/decidim/exporters/form_pdf.rb
+++ b/decidim-forms/lib/decidim/exporters/form_pdf.rb
@@ -15,11 +15,11 @@ module Decidim
       end
 
       def template
-        "decidim/forms/admin/questionnaires/answers/export/pdf.html.erb"
+        "decidim/forms/admin/questionnaires/answers/export/pdf"
       end
 
       def layout
-        "decidim/forms/admin/questionnaires/questionnaire_answers.html.erb"
+        "decidim/forms/admin/questionnaires/questionnaire_answers"
       end
 
       def locals

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type_scope.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type_scope.rb
@@ -26,8 +26,8 @@ module Decidim
           if initiative_type_scope.persisted?
             broadcast(:ok, initiative_type_scope)
           else
-            initiative_type_scope.errors.each do |attribute, error|
-              form.errors.add(attribute, error)
+            initiative_type_scope.errors.each do |error|
+              form.errors.add(error.attribute, error.message)
             end
 
             broadcast(:invalid)

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -163,7 +163,8 @@ module Decidim
           output = render_to_string(
             pdf: "votes_#{current_initiative.id}",
             layout: "decidim/admin/initiatives_votes",
-            template: "decidim/initiatives/admin/initiatives/export_pdf_signatures.pdf.erb"
+            template: "decidim/initiatives/admin/initiatives/export_pdf_signatures",
+            format: [:pdf]
           )
           output = pdf_signature_service.new(pdf: output).signed_pdf if pdf_signature_service
 

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -61,7 +61,7 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
         title: Decidim::Faker::Localized.sentence(word_count: 5),
         description: Decidim::Faker::Localized.sentence(word_count: 25),
         organization: organization,
-        banner_image: ActiveStorage::Blob.create_after_upload!(
+        banner_image: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city2.jpeg")),
           filename: "banner_image.jpeg",
           content_type: "image/jpeg",
@@ -112,7 +112,7 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
         description: Decidim::Faker::Localized.sentence(word_count: 5),
         attached_to: initiative,
         content_type: "image/jpeg",
-        file: ActiveStorage::Blob.create_after_upload!(
+        file: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city.jpeg")),
           filename: "city.jpeg",
           content_type: "image/jpeg",

--- a/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     organization
     # Keep banner_image after organization
     banner_image do
-      ActiveStorage::Blob.create_after_upload!(
+      ActiveStorage::Blob.create_and_upload!(
         io: File.open(Decidim::Dev.test_file("city2.jpeg", "image/jpeg")),
         filename: "city2.jpeg",
         content_type: "image/jpeg"

--- a/decidim-initiatives/spec/forms/initiative_form_spec.rb
+++ b/decidim-initiatives/spec/forms/initiative_form_spec.rb
@@ -169,7 +169,7 @@ module Decidim
           it "adds an error to the `:attachment` field" do
             expect(subject).not_to be_valid
             expect(subject.errors.full_messages).to match_array(["Title can't be blank", "Attachment Needs to be reattached"])
-            expect(subject.errors.keys).to match_array([:title, :attachment])
+            expect(subject.errors.attribute_names).to match_array([:title, :attachment])
           end
         end
       end

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -236,7 +236,7 @@ Decidim.register_component(:meetings) do |component|
         attachment_collection: attachment_collection,
         attached_to: meeting,
         content_type: "application/pdf",
-        file: ActiveStorage::Blob.create_after_upload!(
+        file: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(__dir__, "seeds", "Exampledocument.pdf")),
           filename: "Exampledocument.pdf",
           content_type: "application/pdf",
@@ -248,7 +248,7 @@ Decidim.register_component(:meetings) do |component|
         description: Decidim::Faker::Localized.sentence(word_count: 5),
         attached_to: meeting,
         content_type: "image/jpeg",
-        file: ActiveStorage::Blob.create_after_upload!(
+        file: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(__dir__, "seeds", "city.jpeg")),
           filename: "city.jpeg",
           content_type: "image/jpeg",
@@ -260,7 +260,7 @@ Decidim.register_component(:meetings) do |component|
         description: Decidim::Faker::Localized.sentence(word_count: 5),
         attached_to: meeting,
         content_type: "application/pdf",
-        file: ActiveStorage::Blob.create_after_upload!(
+        file: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(__dir__, "seeds", "Exampledocument.pdf")),
           filename: "Exampledocument.pdf",
           content_type: "application/pdf",

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -74,7 +74,7 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
         hashtag: Faker::Internet.slug,
         group_url: Faker::Internet.url,
         organization: organization,
-        hero_image: ActiveStorage::Blob.create_after_upload!(
+        hero_image: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city.jpeg")),
           filename: "hero_image.jpeg",
           content_type: "image/jpeg",
@@ -125,13 +125,13 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
           Decidim::Faker::Localized.paragraph(sentence_count: 3)
         end,
         organization: organization,
-        hero_image: ActiveStorage::Blob.create_after_upload!(
+        hero_image: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city.jpeg")),
           filename: "hero_image.jpeg",
           content_type: "image/jpeg",
           metadata: nil
         ), # Keep after organization
-        banner_image: ActiveStorage::Blob.create_after_upload!(
+        banner_image: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city2.jpeg")),
           filename: "banner_image.jpeg",
           content_type: "image/jpeg",
@@ -209,7 +209,7 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
         attachment_collection: attachment_collection,
         content_type: "application/pdf",
         attached_to: process,
-        file: ActiveStorage::Blob.create_after_upload!(
+        file: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "Exampledocument.pdf")),
           filename: "Exampledocument.pdf",
           content_type: "application/pdf",
@@ -222,7 +222,7 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
         description: Decidim::Faker::Localized.sentence(word_count: 5),
         attached_to: process,
         content_type: "image/jpeg",
-        file: ActiveStorage::Blob.create_after_upload!(
+        file: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "city.jpeg")),
           filename: "city.jpeg",
           content_type: "image/jpeg",
@@ -235,7 +235,7 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
         description: Decidim::Faker::Localized.sentence(word_count: 5),
         attached_to: process,
         content_type: "application/pdf",
-        file: ActiveStorage::Blob.create_after_upload!(
+        file: ActiveStorage::Blob.create_and_upload!(
           io: File.open(File.join(seeds_root, "Exampledocument.pdf")),
           filename: "Exampledocument.pdf",
           content_type: "application/pdf",

--- a/decidim-proposals/spec/forms/decidim/proposals/proposal_wizard_create_step_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/proposal_wizard_create_step_form_spec.rb
@@ -44,7 +44,7 @@ module Decidim
 
         it "only adds errors to this field" do
           subject.valid?
-          expect(subject.errors.keys).to eq [:title]
+          expect(subject.errors.attribute_names).to eq [:title]
         end
       end
 

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -290,10 +290,10 @@ shared_examples "a proposal form" do |options|
 
         if options[:i18n]
           expect(subject.errors.full_messages).to match_array(["Title en can't be blank", "Add photos Needs to be reattached"])
-          expect(subject.errors.keys).to match_array([:title_en, :add_photos])
+          expect(subject.errors.attribute_names).to match_array([:title_en, :add_photos])
         else
           expect(subject.errors.full_messages).to match_array(["Title can't be blank", "Title is too short (under 15 characters)", "Add photos Needs to be reattached"])
-          expect(subject.errors.keys).to match_array([:title, :add_photos])
+          expect(subject.errors.attribute_names).to match_array([:title, :add_photos])
         end
       end
     end

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -76,9 +76,9 @@ shared_examples "a proposal form" do |options|
     it "only adds errors to this field" do
       subject.valid?
       if options[:i18n]
-        expect(subject.errors.keys).to eq [:title_en]
+        expect(subject.errors.attribute_names).to eq [:title_en]
       else
-        expect(subject.errors.keys).to eq [:title]
+        expect(subject.errors.attribute_names).to eq [:title]
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR aims to fix all the deprecations resulted in the Rails 6.1 upgrade (https://github.com/decidim/decidim/pull/8411)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #8411 

#### Testing
Browse the Action logs and see there are no Deprecation warnings. 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
