### PR TITLE
Rename index to avoid conflicts with decidim_awesome module migrations

### DIFF
--- a/decidim-core/db/migrate/20210730112319_create_decidim_editor_images.rb
+++ b/decidim-core/db/migrate/20210730112319_create_decidim_editor_images.rb
@@ -3,8 +3,8 @@
 class CreateDecidimEditorImages < ActiveRecord::Migration[6.0]
   def change
     create_table :decidim_editor_images do |t|
-      t.references :decidim_author, null: false, foreign_key: { to_table: :decidim_users }, index: { name: "decidim_awesome_editor_images_author" }
-      t.references :decidim_organization, null: false, foreign_key: true, index: { name: "decidim_awesome_editor_images_constraint_organization" }
+      t.references :decidim_author, null: false, foreign_key: { to_table: :decidim_users }, index: { name: "decidim_editor_images_author" }
+      t.references :decidim_organization, null: false, foreign_key: true, index: { name: "decidim_editor_images_constraint_organization" }
 
       t.timestamps
     end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR changes the names of 2 indexes created by a migration based on editor images feature in decidim_awesome. The Decidim migrations use the same names for the indexes which can cause a conflict in names. Since the editor images is not yet in a release it is worth changing it before.

#### :pushpin: Related Issues

- Related to #8250


:hearts: Thank you!
