### PR TITLE
Lighthouse metrics report in CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,3 +37,5 @@ Individual workflows with changes:
   - `ci_proposals_system_admin.yml`: Runs the system specs for the admin section
   - `ci_proposals_system_public.yml`: Runs the system specs for the public section
   - `ci_proposals_unit_tests.yml`: Runs the unit tests
+
+- `ci_performance_metrics_monitoring.yml`: runs Lighthouse metrics expectations against the app to get performance metrics

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -1,0 +1,89 @@
+name: "[CI] Performance Metrics monitoring"
+on:
+  push:
+    branches:
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
+    paths:
+      - "*"
+      - ".github/**"
+      - "decidim-api/**"
+      - "decidim-core/**"
+      - "decidim-dev/**"
+
+env:
+  CI: "true"
+  SIMPLECOV: "true"
+  RUBY_VERSION: 2.7.1
+  NODE_VERSION: 16.9.1
+  RAILS_ENV: development
+
+jobs:
+  main:
+    name: Tests
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
+    timeout-minutes: 60
+    services:
+      postgres:
+        image: postgres:11
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_PASSWORD: postgres
+    env:
+      DATABASE_USERNAME: postgres
+      DATABASE_PASSWORD: postgres
+      DATABASE_HOST: localhost
+      RUBYOPT: '-W:no-deprecated'
+    steps:
+      - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
+        if: "github.ref != 'refs/heads/develop'"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/checkout@v2.0.0
+        with:
+          fetch-depth: 1
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Get npm cache directory path
+        id: npm-cache-dir-path
+        run: echo "::set-output name=dir::$(npm get cache)-${{ env.DECIDIM_MODULE }}"
+      - uses: actions/cache@v2
+        id: npm-cache
+        with:
+          path: ${{ steps.npm-cache-dir-path.outputs.dir }}
+          key: npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            npm-
+      - run: bundle exec rake development_app
+        name: Create development app
+      - run: bundle exec rails assets:precompile
+        name: Precompile assets
+        working-directory: ./development_app/
+      - run: bundle exec rails decidim:lighthouse:prepare_urls
+        name: Setup lighthouse urls
+        working-directory: ./development_app/
+      - run: bundle exec rails server -b localhost -d
+        name: Run Rails server
+        working-directory: ./development_app/
+      - name: Audit URLs using Lighthouse
+        uses: treosh/lighthouse-ci-action@v8
+        with:
+          runs: 3 # run more than once to warm up the application
+          uploadArtifacts: true # save results as an action artifacts
+          budgetPath: ./.github/workflows/lighthouse_budget.json # test performance budgets
+          temporaryPublicStorage: true # upload lighthouse report to the temporary storage

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -84,6 +84,6 @@ jobs:
         uses: treosh/lighthouse-ci-action@v8
         with:
           runs: 3 # run more than once to warm up the application
-          uploadArtifacts: true # save results as an action artifacts
+          uploadArtifacts: true
           budgetPath: ./.github/workflows/lighthouse_budget.json # test performance budgets
           temporaryPublicStorage: true # upload lighthouse report to the temporary storage

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -86,4 +86,4 @@ jobs:
           runs: 3 # run more than once to warm up the application
           uploadArtifacts: true
           budgetPath: ./.github/workflows/lighthouse_budget.json # test performance budgets
-          temporaryPublicStorage: true # upload lighthouse report to the temporary storage
+          temporaryPublicStorage: true

--- a/.github/workflows/lighthouse_budget.json
+++ b/.github/workflows/lighthouse_budget.json
@@ -1,0 +1,23 @@
+[
+  {
+    "path": "/*",
+    "timings": [
+      {
+        "metric": "first-contentful-paint",
+        "budget": 2000
+      },
+      {
+        "metric": "speed-index",
+        "budget": 4000
+      },
+      {
+        "metric": "interactive",
+        "budget": 5000
+      },
+      {
+        "metric": "largest-contentful-paint",
+        "budget": 2500
+      }
+    ]
+  }
+]

--- a/.github/workflows/lighthouse_budget.json
+++ b/.github/workflows/lighthouse_budget.json
@@ -12,7 +12,7 @@
       },
       {
         "metric": "interactive",
-        "budget": 5000
+        "budget": 10000
       },
       {
         "metric": "largest-contentful-paint",

--- a/.github/workflows/lighthouse_budget.json
+++ b/.github/workflows/lighthouse_budget.json
@@ -8,7 +8,7 @@
       },
       {
         "metric": "speed-index",
-        "budget": 4000
+        "budget": 10000
       },
       {
         "metric": "interactive",

--- a/.github/workflows/lighthouse_budget.json
+++ b/.github/workflows/lighthouse_budget.json
@@ -16,7 +16,7 @@
       },
       {
         "metric": "largest-contentful-paint",
-        "budget": 2500
+        "budget": 10000
       }
     ]
   }

--- a/.github/workflows/lighthouse_budget.json
+++ b/.github/workflows/lighthouse_budget.json
@@ -4,7 +4,7 @@
     "timings": [
       {
         "metric": "first-contentful-paint",
-        "budget": 2000
+        "budget": 10000
       },
       {
         "metric": "speed-index",

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "This configuration is used by .github/workflows/ci_metrics_monitoring.yml workflow",
+  "ci": {
+    "collect": {
+      "_comment": "url is empty because is filled dynamically in CI execution",
+      "url": [],
+      "settings": {
+        "chromeFlags": "--disable-gpu --no-sandbox",
+        "throttlingMethod": "devtools",
+        "preset": "desktop",
+        "throttling": {
+          "cpuSlowdownMultiplier": 1
+        }
+      }
+    }
+  }
+}
+

--- a/decidim-dev/lib/tasks/lighthouse_report.rake
+++ b/decidim-dev/lib/tasks/lighthouse_report.rake
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :lighthouse do
+    desc "Prepares seeds for Lighthouse report"
+    task prepare_urls: :environment do
+      # Lighhouse report is executed in CI and should check:
+      # - homepage
+      # - a participatory process page
+      # - a meeting page
+      # - a proposal page
+      #
+      # Because seeds make urls dynamic, this task updates the lighthouse configuration
+      # to add dynamically the urls to check.
+
+      HOST = "http://localhost:3000"
+      # homepage
+      urls = ["/"]
+      # participatory process page
+      urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::ParticipatoryProcess.published.first).path
+      # meeting page
+      urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::Meetings::Meeting.published.first).path
+      # proposal page
+      urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::Proposals::Proposal.published.first).path
+
+      # Update lighthouse configuration with the urls
+      lighthouse_rc_path = Rails.root.join("../.lighthouserc.json")
+      lighthouserc = JSON.parse(File.read(lighthouse_rc_path))
+      lighthouserc["ci"]["collect"]["url"] = urls.map { |url| "#{HOST}#{url}" }
+      File.write(lighthouse_rc_path, lighthouserc.to_json)
+    end
+  end
+end

--- a/decidim-dev/lib/tasks/lighthouse_report.rake
+++ b/decidim-dev/lib/tasks/lighthouse_report.rake
@@ -16,7 +16,6 @@ namespace :decidim do
       host = "http://localhost:3000"
       urls = ["/"]
       urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::ParticipatoryProcess.published.first).path
-      # meeting page
       urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::Meetings::Meeting.published.first).path
       # proposal page
       urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::Proposals::Proposal.published.first).path

--- a/decidim-dev/lib/tasks/lighthouse_report.rake
+++ b/decidim-dev/lib/tasks/lighthouse_report.rake
@@ -14,7 +14,6 @@ namespace :decidim do
       # to add dynamically the urls to check.
 
       HOST = "http://localhost:3000"
-      # homepage
       urls = ["/"]
       # participatory process page
       urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::ParticipatoryProcess.published.first).path

--- a/decidim-dev/lib/tasks/lighthouse_report.rake
+++ b/decidim-dev/lib/tasks/lighthouse_report.rake
@@ -15,7 +15,6 @@ namespace :decidim do
 
       HOST = "http://localhost:3000"
       urls = ["/"]
-      # participatory process page
       urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::ParticipatoryProcess.published.first).path
       # meeting page
       urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::Meetings::Meeting.published.first).path

--- a/decidim-dev/lib/tasks/lighthouse_report.rake
+++ b/decidim-dev/lib/tasks/lighthouse_report.rake
@@ -17,7 +17,6 @@ namespace :decidim do
       urls = ["/"]
       urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::ParticipatoryProcess.published.first).path
       urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::Meetings::Meeting.published.first).path
-      # proposal page
       urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::Proposals::Proposal.published.first).path
 
       # Update lighthouse configuration with the urls

--- a/decidim-dev/lib/tasks/lighthouse_report.rake
+++ b/decidim-dev/lib/tasks/lighthouse_report.rake
@@ -22,7 +22,7 @@ namespace :decidim do
       # Update lighthouse configuration with the urls
       lighthouse_rc_path = Rails.root.join("../.lighthouserc.json")
       lighthouserc = JSON.parse(File.read(lighthouse_rc_path))
-      lighthouserc["ci"]["collect"]["url"] = urls.map { |url| "#{HOST}#{url}" }
+      lighthouserc["ci"]["collect"]["url"] = urls.map { |url| "#{host}#{url}" }
       File.write(lighthouse_rc_path, lighthouserc.to_json)
     end
   end

--- a/decidim-dev/lib/tasks/lighthouse_report.rake
+++ b/decidim-dev/lib/tasks/lighthouse_report.rake
@@ -13,7 +13,7 @@ namespace :decidim do
       # Because seeds make urls dynamic, this task updates the lighthouse configuration
       # to add dynamically the urls to check.
 
-      HOST = "http://localhost:3000"
+      host = "http://localhost:3000"
       urls = ["/"]
       urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::ParticipatoryProcess.published.first).path
       # meeting page


### PR DESCRIPTION
#### :tophat: What? Why?

This PR setups a new workflow in Github Actions CI to run a Lighthouse report against:

- homepage
- a participatory process page
- a meeting page
- a proposal page

In order to run the report in a controlled environment, the report is executed in a rails server running on the same Github Action. This server executes a development app with seeds.

Because seeds are random, a Rake task has been included to add dynamically the urls to lighthouse configuration file.

**About the reports**

There are two ways to check the reports:

- after the execution reports are uploaded to a temporary URL provided by Google, i.e https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1641881796341-54898.report.html
- reports are archived in Github Actions history in Zip files that users can download: https://github.com/decidim/decidim/actions/workflows/ci_metrics_monitoring.yml

**About the performance**

The report numbers are worse that in a production application running in a optimized hardware (such as Heroku or Linode), but I think it's useful to set a baseline.

Based on these numbers we could create some expectations and make the Github Action check to fail if the performance has been downgraded.

#### :pushpin: Related Issues

- Fixes #8470 

#### Testing

Just review the results of the Github Action and check the reports.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
