### PR TITLE
Fix etherpad doc reference in initializer

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -251,6 +251,9 @@ Decidim.configure do |config|
 
   # Machine Translation Configuration
   #
+  # See Decidim docs at https://docs.decidim.org/en/develop/machine_translations/
+  # for more information about how it works and how to set it up.
+  #
   # Enable machine translations
   config.enable_machine_translations = false
   #

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -226,7 +226,7 @@ Decidim.configure do |config|
   # Etherpad configuration
   #
   # Only needed if you want to have Etherpad integration with Decidim. See
-  # Decidim docs at docs/services/etherpad.md in order to set it up.
+  # Decidim docs at https://docs.decidim.org/en/services/etherpad/ in order to set it up.
   #
   # config.etherpad = {
   #   server: Rails.application.secrets.etherpad[:server],

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: en
-title: "Decidim Developers Documentation"
+title: "Decidim Documentation"
 version: master
 asciidoc:
   attributes:

--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -86,7 +86,8 @@ git commit -m "Initial commit. Generated with Decidim https://decidim.org"
 
 == 5. Configure the database
 
-Modify your secrets (see `config/database.yml`). For this you can use https://github.com/laserlemon/figaro[figaro], https://github.com/bkeepers/dotenv[dotenv] or https://github.com/rbenv/rbenv-vars[rbenv-vars]. You should always be careful of not uploading your plain secrets on git or your version control system. You can also upload the encrypted secrets, using the sekrets gem or if you're on Ruby on Rails greater than 5.1 you can do it natively.
+Modify your secrets (see `config/database.yml`). For this you can use https://github.com/laserlemon/figaro[figaro], https://github.com/bkeepers/dotenv[dotenv] or https://github.com/rbenv/rbenv-vars[rbenv-vars]. You
+should always be careful of not uploading your plain secrets on git or your version control system. You can also upload the encrypted secrets, using the sekrets gem or if you're on Ruby on Rails greater than 5.1 you can do it natively.
 
 For a development environment, and if you are using rbenv, we strongly recommend you to use the https://github.com/rbenv/rbenv-vars[rbenv-vars] to facilitate the edition of ENV vars.
 

--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -102,25 +102,14 @@ Then, in **any folder above your decidim generated application**, you need to cr
 
 [source,bash]
 ----
-nano .rbenv-vars
-----
-
-[source,env]
-----
+cat << EOF > .rbenv-vars
 DATABASE_HOST=localhost
 DATABASE_USERNAME=decidim_app
 DATABASE_PASSWORD=thepassword
+EOF
 ----
 
-Be careful where you put the `.rbenv-vars` file, as if you put it in the same folder of your decidim generated application, and if you use a version control system (like `git`, which we strongly recommend), then you should ignore this file (ie with the `.gitignore` file)
-
-Finally, save it all to git:
-
-[source,bash]
-----
-git add .
-git commit -m "Add figaro configuration management"
-----
+Be careful where you put the `.rbenv-vars` file, as if you put it in the same folder of your decidim generated application, and if you use a version control system (like `git`, which we strongly recommend), then you should ignore this file (ie with the `.gitignore` file).
 
 == 6. Initializing your app for local development
 


### PR DESCRIPTION
#### :tophat: What? Why?

A couple of mini fixes in documentation from the last week or so: 

* Fix etherpad doc reference in initializer 697ff6e32f36024cbfcae0c483fc5fc24507cfed: while reviewing #8541 I've seen that we have a legacy reference to a doc file, it's better to just link to docs.decidim.org 
* Add machine translation doc reference in initializer 2da5084fbb4414a398f873f6fa167e1aaad31e36: ditto, reference to docs site. Also related to #8626  
* Fix documentation site title 7771e18efbebce7509d853026d3f8a97ee833d76: should fix https://github.com/decidim/documentation/issues/72 
* Change .rbenv-vars generation to one command d14859996e3647bb31587f1598569419c77c0118: related to what I mentioned in https://github.com/decidim/decidim/pull/8575#discussion_r772267773    

:hearts: Thank you!
