### PR TITLE
Fix reply to a conversation with deleted participants

### DIFF
--- a/decidim-core/app/cells/decidim/user_conversation/show.erb
+++ b/decidim-core/app/cells/decidim/user_conversation/show.erb
@@ -10,10 +10,12 @@
         <% end %>
       </div>
 
-      <% if conversation.accept_user?(user) %>
+      <% if conversation.with_deleted_users?(user) %>
+        <div class="callout warning margin-top-2"><%= t "decidim.user_conversations.show.deleted_accounts" %></div>
+      <% elsif conversation.accept_user?(user) %>
         <%= render view: :reply, locals: { title: t("decidim.user_conversations.reply.title_reply") } %>
       <% else %>
-        <em><%= t "decidim.user_conversations.show.not_allowed" %></em>
+        <div class="callout warning margin-top-2"><%= t "decidim.user_conversations.show.not_allowed" %></div>
       <% end %>
     </div>
   </div>

--- a/decidim-core/app/models/decidim/messaging/conversation.rb
+++ b/decidim-core/app/models/decidim/messaging/conversation.rb
@@ -132,6 +132,15 @@ module Decidim
       end
 
       #
+      # Given a user, returns if ALL the interlocutors have their accounts deleted
+      #
+      # @return Boolean
+      #
+      def with_deleted_users?(user)
+        interlocutors(user).all?(&:deleted?)
+      end
+
+      #
       # Given a user, returns if the user is participating in the conversation
       # for groups being part of a conversation all their admin member are accepted
       #

--- a/decidim-core/app/views/decidim/messaging/conversations/show.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/show.html.erb
@@ -5,9 +5,11 @@
     <% end %>
   </div>
 
-  <% if conversation.accept_user?(current_user) %>
+  <% if conversation.with_deleted_users?(current_user) %>
+    <div class="callout warning margin-top-2"><%= t ".deleted_accounts" %></div>
+  <% elsif conversation.accept_user?(current_user) %>
     <%= render "reply", form: @form, conversation: conversation %>
   <% else %>
-    <em><%= t ".not_allowed" %></em>
+    <div class="callout warning margin-top-2"><%= t ".not_allowed" %></div>
   <% end %>
 <% end %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -980,6 +980,7 @@ en:
         show:
           back: Back to all conversations
           chat_with: Conversation with
+          deleted_accounts: You can't have a conversation with deleted accounts.
           not_allowed: This participant does not accept direct messages.
           title: Conversation with %{usernames}
         start:
@@ -1344,6 +1345,7 @@ en:
         title_reply: Reply
       show:
         back: Show all conversations
+        deleted_accounts: You can't have a conversation with deleted accounts.
         not_allowed: This user does not accept any more direct messages.
         title: Conversation with %{usernames}
       update:

--- a/decidim-core/spec/models/decidim/messaging/conversation_spec.rb
+++ b/decidim-core/spec/models/decidim/messaging/conversation_spec.rb
@@ -48,6 +48,27 @@ describe Decidim::Messaging::Conversation do
           expect(conversation.accept_user?(originator)).to eq(true)
         end
       end
+
+      context "and all the interlocutor have their accounts deleted" do
+        before do
+          allow(interlocutor).to receive(:deleted?).and_return(true)
+          allow(interlocutor2).to receive(:deleted?).and_return(true)
+        end
+
+        it "with_deleted_users? returns true" do
+          expect(conversation.with_deleted_users?(originator)).to eq(true)
+        end
+      end
+
+      context "and one of the interlocutor has the account deleted" do
+        before do
+          allow(interlocutor).to receive(:deleted?).and_return(true)
+        end
+
+        it "with_deleted_users? returns false" do
+          expect(conversation.with_deleted_users?(originator)).to eq(false)
+        end
+      end
     end
 
     context "when the originator is a group" do


### PR DESCRIPTION
Restrict the conversation if all the participants (excluding the current user) have their accounts deleted.

#### :tophat: What? Why?
*Please describe your pull request.*

#### :pushpin: Related Issues

- Fixes https://github.com/decidim/decidim/issues/8414

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
