### PR TITLE
Fix wrong display of deleted accounts in conversations

### DIFF
--- a/decidim-core/app/cells/decidim/user_conversation/conversation_header.erb
+++ b/decidim-core/app/cells/decidim/user_conversation/conversation_header.erb
@@ -9,6 +9,6 @@
   <% end %>
 
   <div class="ml-s">
-    <%= t("decidim.user_conversations.show.title", usernames: interlocutors_names) %>
+    <%= t("decidim.user_conversations.show.title", usernames: interlocutors_names).html_safe %>
   </div>
 </div>

--- a/decidim-core/app/cells/decidim/user_conversations/conversation_item.erb
+++ b/decidim-core/app/cells/decidim/user_conversations/conversation_item.erb
@@ -10,7 +10,7 @@
     </li>
     <li class="card-data__item card--list__item card-data__item--expand absolutes">
       <div class="mr-s">
-        <%= t("decidim.user_conversations.index.from") %>: <strong><%= conversation_interlocutors(conversation) %></strong>
+        <%= t("decidim.user_conversations.index.from") %>: <strong><%= conversation_interlocutors(conversation).html_safe %></strong>
         <br>
         <span class="muted">
           <%= truncate conversation.last_message.body, length: 150 %>

--- a/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
+++ b/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
@@ -28,10 +28,18 @@ module Decidim
       # Generates a visualization of users for listing conversations threads
       #
       def username_list(users, shorten: false)
-        return users.pluck(:name).join(", ") unless shorten
-        return users.pluck(:name).join(", ") unless users.count > 3
+        content_tags = []
+        first_users = shorten ? users.first(3) : users
+        deleted_user_tag = content_tag(:span, t("decidim.profile.deleted"), class: "label label--small label--basic")
+        first_users.each do |u|
+          content_tags.push(u.deleted? ? deleted_user_tag : content_tag(:strong, u.name))
+        end
 
-        "#{users.first(3).pluck(:name).join(", ")} + #{users.count - 3}"
+        return content_tags.join(", ") unless shorten
+        return content_tags.join(", ") unless users.count > 3
+
+        content_tags.push(content_tag(:strong, " + #{users.count - 3}"))
+        content_tags.join(", ")
       end
 
       #

--- a/decidim-core/app/views/decidim/messaging/conversations/_conversation.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_conversation.html.erb
@@ -17,7 +17,7 @@
         <% if conversation.interlocutors(current_user).count == 1 %>
           <%= t("from", scope: "decidim.messaging.conversations.index") %>: <%= conversation_name_for(conversation.interlocutors(current_user)) %>
         <% else %>
-          <%= t("from", scope: "decidim.messaging.conversations.index") %>: <strong><%= username_list(conversation.interlocutors(current_user), shorten: true) %></strong>
+          <%= t("from", scope: "decidim.messaging.conversations.index") %>: <strong><%= username_list(conversation.interlocutors(current_user), shorten: true).html_safe %></strong>
         <% end %>
         <br>
         <span class="muted">
@@ -45,7 +45,7 @@
           <% if conversation.interlocutors(current_user).count == 1 %>
             <%= icon "chevron-right", class: "card__link icon--big", role: "img", aria_label: t(".show", sender: conversation.interlocutors(current_user).first.name) %>
           <% else %>
-            <%= icon "chevron-right", class: "card__link icon--big", role: "img", aria_label: t(".show", sender: username_list(conversation.interlocutors(current_user))) %>
+            <%= icon "chevron-right", class: "card__link icon--big", role: "img", aria_label: t(".show", sender: strip_tags(username_list(conversation.interlocutors(current_user)))) %>
           <% end %>
         <% end %>
       </div>

--- a/decidim-core/app/views/decidim/messaging/conversations/_show.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_show.html.erb
@@ -1,6 +1,6 @@
 <div class="wrapper">
   <div class="row">
-    <div class="columns medium-9 medium-centered tabs-panel is-active" id="conversations" role="tabpanel" aria-label="<%= conversation_label_for(participants) %>">
+    <div class="columns medium-9 medium-centered tabs-panel is-active" id="conversations" role="tabpanel" aria-label="<%= strip_tags(conversation_label_for(participants)) %>">
       <div class="conversation">
 
         <div class="conversation-header flex--cc absolutes">
@@ -26,7 +26,7 @@
               <% if participants.count == 1 %>
                 <%= t(".chat_with") %> <%= conversation_name_for(participants) %>
               <% else %>
-                <%= t(".title", usernames: username_list(participants)) %>
+                <%= t(".title", usernames: username_list(participants)).html_safe %>
               <% end %>
             </h1>
           </div>

--- a/decidim-core/config/brakeman.ignore
+++ b/decidim-core/config/brakeman.ignore
@@ -2,6 +2,36 @@
   "ignored_warnings": [
     {
       "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "211ff4b5e0d738e40e3c7f6d27b6905f23b1ed4e20347c179af3df40f6e5694d",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/decidim/messaging/conversations/_conversation.html.erb",
+      "line": 20,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "username_list((Unresolved Model).new.interlocutors(current_user), :shorten => true)",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "decidim/messaging/conversations/index",
+          "line": 25,
+          "file": "app/views/decidim/messaging/conversations/index.html.erb",
+          "rendered": {
+            "name": "decidim/messaging/conversations/_conversation",
+            "file": "app/views/decidim/messaging/conversations/_conversation.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "decidim/messaging/conversations/_conversation"
+      },
+      "user_input": "(Unresolved Model).new.interlocutors(current_user)",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "2c7f1da812b5d4b350d2260b604e9061ef082ecae90073ae09fe2eb46c1b9a08",
       "check_name": "LinkToHref",
@@ -71,8 +101,49 @@
       "user_input": "params",
       "confidence": "Weak",
       "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "b46eb40178db883a8a9065d3affe7fb7868369084048fd88321f887d8618eea5",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped parameter value",
+      "file": "app/views/decidim/messaging/conversations/_show.html.erb",
+      "line": 29,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "t(\".title\", :usernames => username_list(form(ConversationForm).from_params(params, :sender => current_user).recipient.to_a))",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Decidim::Messaging::ConversationsController",
+          "method": "new",
+          "line": 35,
+          "file": "app/controllers/decidim/messaging/conversations_controller.rb",
+          "rendered": {
+            "name": "decidim/messaging/conversations/new",
+            "file": "app/views/decidim/messaging/conversations/new.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "decidim/messaging/conversations/new",
+          "line": 1,
+          "file": "app/views/decidim/messaging/conversations/new.html.erb",
+          "rendered": {
+            "name": "decidim/messaging/conversations/_show",
+            "file": "app/views/decidim/messaging/conversations/_show.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "decidim/messaging/conversations/_show"
+      },
+      "user_input": "params",
+      "confidence": "Weak",
+      "note": ""
     }
   ],
-  "updated": "2021-09-12 08:05:16 +0000",
-  "brakeman_version": "5.1.1"
+  "updated": "2021-12-22 09:55:40 +0000",
+  "brakeman_version": "5.1.2"
 }

--- a/decidim-core/spec/helpers/decidim/messaging/conversation_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/messaging/conversation_helper_spec.rb
@@ -54,6 +54,27 @@ module Decidim
         end
       end
 
+      describe "#username_list" do
+        let(:user) { create :user, :confirmed }
+        let(:participants) { [user] }
+
+        before do
+          helper.instance_variable_set(:@virtual_path, "decidim.messaging.conversations.show")
+        end
+
+        it "includes the user name" do
+          expect(helper.username_list(participants)).to eq "<strong>#{user.name}</strong>"
+        end
+
+        context "when user is deleted" do
+          let(:user) { create :user, :deleted }
+
+          it "doesn't include the user name" do
+            expect(helper.username_list(participants)).to eq "<span class=\"label label--small label--basic\">Participant deleted</span>"
+          end
+        end
+      end
+
       describe "#conversation_name_for" do
         let(:user) { create :user, :confirmed }
         let(:participants) { [user] }


### PR DESCRIPTION
When having a conversation with multiple participants and some of them or all have their account deleted, nothing is displayed in the conversation's header.

#### :tophat: What? Why?
*Please describe your pull request.*

#### :pushpin: Related Issues

https://github.com/decidim/decidim/issues/8639

#### Testing

1. Create a conversation with multiple participants
2. Login is as one of the interlocutors and delete that account
3. Go to Conversations list
4. Go to the conversation page

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
