### PR TITLE
Fix consistency in creation actions phrasing: "Participants can create XXX"

### DIFF
--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -18,7 +18,7 @@ en:
       decidim/debates/close_debate_event: Debate closed
       decidim/debates/create_debate_event: Debate
       decidim/debates/creation_disabled_event: Debates disabled
-      decidim/debates/creation_enabled_event: Debates enabled
+      decidim/debates/creation_enabled_event: Debates creation enabled
   activerecord:
     models:
       decidim/debates/debate:
@@ -42,7 +42,7 @@ en:
           step:
             announcement: Announcement
             comments_blocked: Comments blocked
-            creation_enabled: Debate creation by participants enabled
+            creation_enabled: Participants can create debates
             endorsements_blocked: Endorsements blocked
             endorsements_enabled: Endorsements enabled
     debates:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -197,7 +197,7 @@ en:
             answers_with_costs: Enable costs on proposal answers
             automatic_hashtags: Hashtags added to all proposals
             comments_blocked: Comments blocked
-            creation_enabled: Proposal creation enabled
+            creation_enabled: Participants can create proposals
             default_sort_order: Default proposal sorting
             default_sort_order_help: Default it means that if the supports are enabled, the proposals will be shown sorted by random, and if the supports are blocked, then they will be sorted by the most supported.
             default_sort_order_options:


### PR DESCRIPTION
#### :tophat: What? Why?

When going to a participatory process and configuring a Debates component, it says `Debate creation by participants enabled`. But when going to a Proposals component, "Proposal creation enabled". Finally, when going to Meetings, it says "Participants can create meetings". 

This PR brings consistency to these actions, now it's always "Participants can create XXX"

:hearts: Thank you!
