### PR TITLE
Fix participatory groups leaks on other organizations/tenants

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/promoted_participatory_processes_shared_examples.rb
+++ b/decidim-dev/lib/decidim/dev/test/promoted_participatory_processes_shared_examples.rb
@@ -35,6 +35,11 @@ shared_examples "with promoted participatory processes and groups" do
         organization: organization
       )
 
+      _external_promoted_group = create(
+        :participatory_process_group,
+        :promoted
+      )
+
       expect(controller.helpers.promoted_collection).to(
         match_array([promoted_group, promoted_process])
       )

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_groups_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_groups_controller.rb
@@ -29,7 +29,7 @@ module Decidim
       end
 
       def set_group
-        @group = Decidim::ParticipatoryProcessGroup.find(params[:id])
+        @group = Decidim::ParticipatoryProcessGroup.where(organization: current_organization).find(params[:id])
       end
 
       attr_reader :group

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
@@ -73,7 +73,7 @@ module Decidim
       end
 
       def promoted_participatory_process_groups
-        @promoted_participatory_process_groups ||= PromotedParticipatoryProcessGroups.new
+        @promoted_participatory_process_groups ||= OrganizationPromotedParticipatoryProcessGroups.new(current_organization)
       end
 
       def promoted_collection
@@ -93,8 +93,8 @@ module Decidim
       end
 
       def participatory_process_groups
-        @participatory_process_groups ||= Decidim::ParticipatoryProcessGroup
-                                          .where(id: filtered_processes.grouped.group_ids)
+        @participatory_process_groups ||= OrganizationParticipatoryProcessGroups.new(current_organization).query
+                                                                                .where(id: filtered_processes.grouped.group_ids)
       end
 
       def stats

--- a/decidim-participatory_processes/app/queries/decidim/participatory_processes/organization_promoted_participatory_process_groups.rb
+++ b/decidim-participatory_processes/app/queries/decidim/participatory_processes/organization_promoted_participatory_process_groups.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    # This query class filters participatory process groups given an organization.
+    class OrganizationPromotedParticipatoryProcessGroups < Rectify::Query
+      def initialize(organization)
+        @organization = organization
+      end
+
+      def query
+        PromotedParticipatoryProcessGroups.new.query.where(organization: @organization)
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/spec/controllers/participatory_process_groups_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/participatory_process_groups_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ParticipatoryProcesses
+    describe ParticipatoryProcessGroupsController, type: :controller do
+      routes { Decidim::ParticipatoryProcesses::Engine.routes }
+
+      let(:organization) { create(:organization) }
+      let!(:process_group) { create :participatory_process_group, organization: organization }
+
+      describe "GET show" do
+        before do
+          request.env["decidim.current_organization"] = organization
+        end
+
+        context "when the process group belongs to the organization" do
+          it "shows the content" do
+            get :show, params: { id: process_group.id }
+
+            expect(response).to be_successful
+          end
+        end
+
+        context "when the process group do not belong to the organization" do
+          let!(:process_group) { create :participatory_process_group }
+
+          it "redirects to 404 if there aren't any" do
+            expect { get :show, params: { id: process_group.id } }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
@@ -79,6 +79,11 @@ module Decidim
             organization: other_organization
           )
 
+          _manipulated_other_groups = create(
+            :participatory_process_group,
+            participatory_processes: [create(:participatory_process, organization: organization)]
+          )
+
           expect(controller.helpers.collection)
             .to match_array([*published, *organization_groups])
         end

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -232,7 +232,7 @@ describe "Participatory Processes", type: :system do
       end
 
       context "when there are promoted participatory process groups" do
-        let!(:promoted_group) { create(:participatory_process_group, :promoted, :with_participatory_processes) }
+        let!(:promoted_group) { create(:participatory_process_group, :promoted, :with_participatory_processes, organization: organization) }
         let(:promoted_items_titles) { page.all("#highlighted-processes .card__title").map(&:text) }
 
         before do
@@ -272,6 +272,16 @@ describe "Participatory Processes", type: :system do
           it "shows a CTA button inside group card" do
             within("#highlighted-processes") do
               expect(page).to have_link(cta_settings[:button_text_en], href: cta_settings[:button_url])
+            end
+          end
+
+          context "and promoted group belongs to another organization" do
+            let!(:promoted_group) { create(:participatory_process_group, :promoted, :with_participatory_processes) }
+
+            it "shows a CTA button inside group card" do
+              within("#highlighted-processes") do
+                expect(page).not_to have_link(cta_settings[:button_text_en], href: cta_settings[:button_url])
+              end
             end
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?

If you have a multi-tenant site, Participatory Processes Groups are not isolated. This PR solves these some cases:

- [x] When visiting using the url `/processes_groups/ID` where ID is a process group belonging to another organization
- [x] When displaying promoted participatory groups in one organization, there are shown in all the others in the same database.
- [x] When a process group has (wrongly) assigned processes from other tenants

This should be backported to 0.24 as well.

:hearts: Thank you!
