### PR TITLE
Fix cache key on ActivityCell

### DIFF
--- a/decidim-core/app/cells/decidim/activity_cell.rb
+++ b/decidim-core/app/cells/decidim/activity_cell.rb
@@ -92,6 +92,7 @@ module Decidim
 
     def cache_hash
       hash = []
+      hash << I18n.locale.to_s
       hash << model.class.name.underscore
       hash << model.cache_key_with_version
 


### PR DESCRIPTION
#### :tophat: What? Why?
When having multiple languages enabled in the organization the activity cell does not take into account the language,  resulting in displaying the Last activities in the language of most recent cache. 

For example, the cache may be generated while browsing the site in English, and someone that is browsing the website in Spanish may see the latest activities in english. 

#### Testing
Visit: 
- [https://meta.decidim.org/?locale=es](Meta Decidim Spanish)
- [https://meta.decidim.org/](Meta Decidim English)

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/105683/147230918-f3d23294-9f72-4569-878e-b0b87705dad1.png)

:hearts: Thank you!
