### PR TITLE
Fix blocked users appear in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Until now it was possible to see if an email account was registered in Decidim, 
 
 #### Blocked user in global search
 
-PR [\#8657](https://github.com/decidim/decidim/pull/8657) Blocked users are present in global search, to update the search and make them disappear, Run in a rails console or create a migration with:
+PR [\#8658](https://github.com/decidim/decidim/pull/8658) Blocked users are present in global search, to update the search and make them disappear, Run in a rails console or create a migration with:
 
 ```ruby
   Decidim::User.find_each(&:try_update_index_for_search_resource)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,19 @@ Decidim.configure do |config|
 end
 ```
 
-#### User workflows change to prevent user enumeration attacks 
+#### User workflows change to prevent user enumeration attacks
 
-Until now it was possible to see if an email account was registered in Decidim, by using features like "Forgot your password", as the response changed if the email existed ("`You will receive an email with instructions on how to reset your password in a few minutes`") that's different to a non-existing user account ("`could not be found. Did you sign up previously?`"). This allows User Enumration attacks, where a malicious actor can check if anyone has an acount in the platform. As per [\#8537](https://github.com/decidim/decidim/pull/8537), anyone has the same answer always "`If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes`". 
+Until now it was possible to see if an email account was registered in Decidim, by using features like "Forgot your password", as the response changed if the email existed ("`You will receive an email with instructions on how to reset your password in a few minutes`") that's different to a non-existing user account ("`could not be found. Did you sign up previously?`"). This allows User Enumration attacks, where a malicious actor can check if anyone has an acount in the platform. As per [\#8537](https://github.com/decidim/decidim/pull/8537), anyone has the same answer always "`If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes`".
+
+#### Blocked user in global search
+
+PR [\#8657](https://github.com/decidim/decidim/pull/8657) Blocked users are present in global search, to update the search and make them disappear, Run in a rails console or create a migration with:
+
+```ruby
+  Decidim::User.find_each(&:try_update_index_for_search_resource)
+```
+
+Please be aware that it could take a while if your database has a lot of Users.
 
 ### Added
 * [#8012](https://github.com/decidim/decidim/pull/8012) Participatory space to comments, to fix the statistics. Use

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -92,8 +92,8 @@ module Decidim
                         A: :name,
                         datetime: :created_at
                       },
-                      index_on_create: ->(user) { !user.deleted? || !user.blocked? },
-                      index_on_update: ->(user) { !user.deleted? || !user.blocked? })
+                      index_on_create: ->(user) { !(user.deleted? || user.blocked?) },
+                      index_on_update: ->(user) { !(user.deleted? || user.blocked?) })
 
     before_save :ensure_encrypted_password
 

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -92,8 +92,8 @@ module Decidim
                         A: :name,
                         datetime: :created_at
                       },
-                      index_on_create: ->(user) { !user.deleted? },
-                      index_on_update: ->(user) { !user.deleted? })
+                      index_on_create: ->(user) { !user.deleted? || !user.blocked? },
+                      index_on_update: ->(user) { !user.deleted? || !user.blocked? })
 
     before_save :ensure_encrypted_password
 


### PR DESCRIPTION
#### :tophat: What? Why?
When a user has been blocked it still appears in the search

#### :pushpin: Related Issues
- Fixes #8647

#### Testing
* Block a user
* Type username in search
* Observe absence

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing] to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
<img width="1680" alt="Capture d’écran 2021-12-23 à 18 51 12" src="https://user-images.githubusercontent.com/20232956/147276210-eb2d52d8-ed4d-4907-b436-d75c86a3407c.png">
<img width="1680" alt="Capture d’écran 2021-12-23 à 18 51 56" src="https://user-images.githubusercontent.com/20232956/147276157-f6154158-7104-469d-b849-5e757bf64bc5.png">
<img width="1680" alt="Capture d’écran 2021-12-23 à 18 52 37" src="https://user-images.githubusercontent.com/20232956/147570910-1d3d5e7c-4ac9-4590-98e1-b46de778ae33.png">


:hearts: Thank you!
