### PR TITLE
Change default sort order on admin moderations

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
@@ -67,6 +67,10 @@ module Decidim
 
       private
 
+      def ransack_params
+        query_params[:q] || { s: "created_at desc" }
+      end
+
       # Private: This method is used by the `Filterable` concern as the base query
       #          without applying filtering and/or sorting options.
       def collection

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -9,13 +9,6 @@ shared_examples "sorted moderations" do
     end
   end
   let!(:moderation) { moderations.first }
-  # let!(:hidden_moderations) do
-  #   reportables.last(1).map do |reportable|
-  #     moderation = create(:moderation, reportable: reportable, report_count: 3, reported_content: reportable.reported_searchable_content_text, hidden_at: Time.current)
-  #     create_list(:report, 3, moderation: moderation, reason: :spam)
-  #     moderation
-  #   end
-  # end
   let(:moderations_link_text) { "Moderations" }
 
   before do

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -1,5 +1,38 @@
 # frozen_string_literal: true
 
+shared_examples "sorted moderations" do
+  let!(:moderations) do
+    reportables.first(reportables.length - 1).map do |reportable|
+      moderation = create(:moderation, reportable: reportable, report_count: 1, reported_content: reportable.reported_searchable_content_text)
+      create(:report, moderation: moderation)
+      moderation
+    end
+  end
+  let!(:moderation) { moderations.first }
+  let!(:hidden_moderations) do
+    reportables.last(1).map do |reportable|
+      moderation = create(:moderation, reportable: reportable, report_count: 3, reported_content: reportable.reported_searchable_content_text, hidden_at: Time.current)
+      create_list(:report, 3, moderation: moderation, reason: :spam)
+      moderation
+    end
+  end
+  let(:moderations_link_text) { "Moderations" }
+
+  before do
+    visit participatory_space_path
+    click_link moderations_link_text
+  end
+
+  it "sorts the most recent first" do
+    within ".pagination" do
+      click_link "Last"
+    end
+    all("tbody tr").each_with_index do |row, _index|
+      expect(row.find("td:first-child")).to have_content(reportables.first.id)
+    end
+  end
+end
+
 shared_examples "manage moderations" do
   let!(:moderations) do
     reportables.first(reportables.length - 1).map do |reportable|

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -9,13 +9,13 @@ shared_examples "sorted moderations" do
     end
   end
   let!(:moderation) { moderations.first }
-  let!(:hidden_moderations) do
-    reportables.last(1).map do |reportable|
-      moderation = create(:moderation, reportable: reportable, report_count: 3, reported_content: reportable.reported_searchable_content_text, hidden_at: Time.current)
-      create_list(:report, 3, moderation: moderation, reason: :spam)
-      moderation
-    end
-  end
+  # let!(:hidden_moderations) do
+  #   reportables.last(1).map do |reportable|
+  #     moderation = create(:moderation, reportable: reportable, report_count: 3, reported_content: reportable.reported_searchable_content_text, hidden_at: Time.current)
+  #     create_list(:report, 3, moderation: moderation, reason: :spam)
+  #     moderation
+  #   end
+  # end
   let(:moderations_link_text) { "Moderations" }
 
   before do

--- a/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
@@ -26,4 +26,9 @@ describe "Admin manages global moderations", type: :system do
   it_behaves_like "manage moderations" do
     let(:moderations_link_text) { "Global moderations" }
   end
+
+  it_behaves_like "sorted moderations" do
+    let!(:reportables) { create_list(:dummy_resource, 17, component: current_component) }
+    let(:moderations_link_text) { "Global moderations" }
+  end
 end

--- a/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
@@ -52,6 +52,11 @@ describe "Space admin manages global moderations", type: :system do
     it_behaves_like "manage moderations" do
       let(:moderations_link_text) { "Global moderations" }
     end
+
+    it_behaves_like "sorted moderations" do
+      let!(:reportables) { create_list(:dummy_resource, 17, component: current_component) }
+      let(:moderations_link_text) { "Global moderations" }
+    end
   end
 
   context "when the user can manage a space without moderations" do

--- a/decidim-admin/spec/system/space_moderator_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_moderator_manages_global_moderations_spec.rb
@@ -28,6 +28,11 @@ describe "Space moderator manages global moderations", type: :system do
     it_behaves_like "manage moderations" do
       let(:moderations_link_text) { "Global moderations" }
     end
+
+    it_behaves_like "sorted moderations" do
+      let!(:reportables) { create_list(:dummy_resource, 17, component: current_component) }
+      let(:moderations_link_text) { "Global moderations" }
+    end
   end
 
   context "when the user can manage a space without moderations" do

--- a/decidim-assemblies/spec/system/admin/assembly_moderator_manages_assembly_moderations_spec.rb
+++ b/decidim-assemblies/spec/system/admin/assembly_moderator_manages_assembly_moderations_spec.rb
@@ -17,4 +17,8 @@ describe "Assembly moderator manages assembly moderations", type: :system do
   end
 
   it_behaves_like "manage moderations"
+
+  it_behaves_like "sorted moderations" do
+    let!(:reportables) { create_list(:dummy_resource, 17, component: current_component) }
+  end
 end

--- a/decidim-comments/spec/system/admin_manages_comments_spec.rb
+++ b/decidim-comments/spec/system/admin_manages_comments_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Admin manages comments", type: :system do
   let(:manifest_name) { "dummy" }
   let!(:dummy) { create :dummy_resource, component: current_component }
-  let!(:resources) { create_list(:dummy_resource, 3, component: current_component) }
+  let!(:resources) { create_list(:dummy_resource, 2, component: current_component) }
   let!(:reportables) do
     resources.map do |resource|
       create(:comment, commentable: resource)
@@ -18,4 +18,8 @@ describe "Admin manages comments", type: :system do
   include_context "when managing a component as an admin"
 
   it_behaves_like "manage moderations"
+
+  it_behaves_like "sorted moderations" do
+    let!(:reportables) { create_list(:dummy_resource, 17, component: current_component) }
+  end
 end

--- a/decidim-conferences/spec/system/admin/conference_moderator_manages_conference_moderations_spec.rb
+++ b/decidim-conferences/spec/system/admin/conference_moderator_manages_conference_moderations_spec.rb
@@ -17,4 +17,8 @@ describe "Conference moderator manages conference moderations", type: :system do
   end
 
   it_behaves_like "manage moderations"
+
+  it_behaves_like "sorted moderations" do
+    let!(:reportables) { create_list(:dummy_resource, 17, component: current_component) }
+  end
 end

--- a/decidim-initiatives/spec/system/admin/admin_manages_comments_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_comments_spec.rb
@@ -21,6 +21,25 @@ describe "Admin manages comments", type: :system do
     visit decidim_admin_initiatives.initiatives_path
   end
 
+  it_behaves_like "sorted moderations" do
+    let!(:reportables) { create_list(:comment, 17, commentable: commentable) }
+    let!(:moderations) do
+      reportables.first(reportables.length - 1).map do |reportable|
+        moderation = create(:moderation, reportable: reportable, participatory_space: commentable, report_count: 1)
+        create(:report, moderation: moderation)
+        moderation
+      end
+    end
+
+    let!(:hidden_moderations) do
+      reportables.last(1).map do |reportable|
+        moderation = create(:moderation, reportable: reportable, participatory_space: commentable, report_count: 3, hidden_at: Time.current)
+        create_list(:report, 3, moderation: moderation, reason: :spam)
+        moderation
+      end
+    end
+  end
+
   it_behaves_like "manage moderations" do
     let!(:moderations) do
       reportables.first(reportables.length - 1).map do |reportable|

--- a/decidim-initiatives/spec/system/admin/admin_manages_comments_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_comments_spec.rb
@@ -30,14 +30,6 @@ describe "Admin manages comments", type: :system do
         moderation
       end
     end
-    #
-    # let!(:hidden_moderations) do
-    #   reportables.last(1).map do |reportable|
-    #     moderation = create(:moderation, reportable: reportable, participatory_space: commentable, report_count: 3, hidden_at: Time.current)
-    #     create_list(:report, 3, moderation: moderation, reason: :spam)
-    #     moderation
-    #   end
-    # end
   end
 
   it_behaves_like "manage moderations" do

--- a/decidim-initiatives/spec/system/admin/admin_manages_comments_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_comments_spec.rb
@@ -30,14 +30,14 @@ describe "Admin manages comments", type: :system do
         moderation
       end
     end
-
-    let!(:hidden_moderations) do
-      reportables.last(1).map do |reportable|
-        moderation = create(:moderation, reportable: reportable, participatory_space: commentable, report_count: 3, hidden_at: Time.current)
-        create_list(:report, 3, moderation: moderation, reason: :spam)
-        moderation
-      end
-    end
+    #
+    # let!(:hidden_moderations) do
+    #   reportables.last(1).map do |reportable|
+    #     moderation = create(:moderation, reportable: reportable, participatory_space: commentable, report_count: 3, hidden_at: Time.current)
+    #     create_list(:report, 3, moderation: moderation, reason: :spam)
+    #     moderation
+    #   end
+    # end
   end
 
   it_behaves_like "manage moderations" do

--- a/decidim-participatory_processes/spec/system/admin/process_moderator_manages_process_moderations_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/process_moderator_manages_process_moderations_spec.rb
@@ -25,4 +25,8 @@ describe "Process moderator manages process moderations", type: :system do
   end
 
   it_behaves_like "manage moderations"
+
+  it_behaves_like "sorted moderations" do
+    let!(:reportables) { create_list(:dummy_resource, 17, component: current_component) }
+  end
 end

--- a/decidim-proposals/spec/system/admin/admin_manages_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_manages_proposals_spec.rb
@@ -24,4 +24,8 @@ describe "Admin manages proposals", type: :system do
   it_behaves_like "merge proposals"
   it_behaves_like "split proposals"
   it_behaves_like "publish answers"
+
+  it_behaves_like "sorted moderations" do
+    let!(:reportables) { create_list(:proposal, 17, component: current_component) }
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Having a big number of reported items makes hard the administrators to manage the results. 
This PR is adding a default sort order to have the most recent reported elements on the first page, in reverse order.  

#### Testing
- Login as admin 
- Visit the Global Moderation Panel
- See the reports are in reverse order.

### :camera: Screenshots

####  Before
![Selecció_0052](https://user-images.githubusercontent.com/717367/147915913-dad4e01a-48d5-49fc-be02-6a8aac935060.png)


#### After
![Selecció_0042](https://user-images.githubusercontent.com/717367/147915916-d4b34a5a-8f14-47dc-983e-9e460161a053.png)


:hearts: Thank you!
