### PR TITLE
Fix changelog link

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -23,7 +23,7 @@ Be sure to include a *title and clear description*, as much relevant information
 Include the relevant issue number if applicable.
 * Check our https://docs.decidim.org/en/develop/guide/[development_guide].
 * When the PR includes a breaking change or includes something that requires manual intervention when deploying, it's necessary to add it on the changelog upgrade notes.
-See https://docs.decidim.org/en/develop/guide_changelog/[rules for the changelog page in docs].
+See https://docs.decidim.org/en/develop/guide_conventions/#_changelog[rules for the changelog page in docs].
 
 == Do you intend to add a new feature or change an existing one?
 


### PR DESCRIPTION
#### :tophat: What? Why?

This updates the changelog link in the contributing doc to point to the appropriate location. The current one reaches a "Page Not Found" error.

#### Testing

Visit the link.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [X] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [X] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.