### PR TITLE
Upgrade Bootstrap Tags Input

### DIFF
--- a/decidim-core/app/packs/src/decidim/input_tags.js
+++ b/decidim-core/app/packs/src/decidim/input_tags.js
@@ -1,4 +1,4 @@
-import "bootstrap-tagsinput"
+import "bootstrap-tagsinput-2021"
 
 $(() => {
   const $tagContainer = $(".js-tags-container");

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_input-tags.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_input-tags.scss
@@ -1,4 +1,4 @@
-@import "bootstrap-tagsinput/src/bootstrap-tagsinput";
+@import "bootstrap-tagsinput-2021/src/bootstrap-tagsinput";
 
 $tag-padding: .25rem;
 $tag-margin: .2rem;

--- a/decidim-system/app/packs/stylesheets/decidim/system/_forms.scss
+++ b/decidim-system/app/packs/stylesheets/decidim/system/_forms.scss
@@ -1,4 +1,4 @@
-@import "bootstrap-tagsinput/src/bootstrap-tagsinput";
+@import "bootstrap-tagsinput-2021/src/bootstrap-tagsinput";
 
 $tag-padding: .25rem;
 $tag-margin: .2rem;

--- a/decidim_app-design/package-lock.json
+++ b/decidim_app-design/package-lock.json
@@ -4375,10 +4375,10 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
-    "node_modules/bootstrap-tagsinput": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-tagsinput/-/bootstrap-tagsinput-0.7.1.tgz",
-      "integrity": "sha1-/+Owa74qEGlF7ygUVoAFqU8hGTc="
+    "node_modules/bootstrap-tagsinput-2021": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/bootstrap-tagsinput-2021/-/bootstrap-tagsinput-2021-0.8.6.tgz",
+      "integrity": "sha512-/ZbR3Hl6BtpbuVuoXPxiyoh4a4fKyoyKn4pFXyL4fGEEQ3uwPS4/urrJ5O9ew2WkfBkJUdHnCLtNuVeUlz6HoA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -21450,7 +21450,7 @@
         "@joeattardi/emoji-button": "^4.6.0",
         "@zeitiger/appendaround": "^1.0.0",
         "axios": "^0.21.1",
-        "bootstrap-tagsinput": "^0.7.1",
+        "bootstrap-tagsinput-2021": "^0.8.6",
         "classnames": "^2.2.5",
         "d3": "5.4.0",
         "diff": "^5.0.0",
@@ -22730,7 +22730,7 @@
         "@joeattardi/emoji-button": "^4.6.0",
         "@zeitiger/appendaround": "^1.0.0",
         "axios": "^0.21.1",
-        "bootstrap-tagsinput": "^0.7.1",
+        "bootstrap-tagsinput-2021": "^0.8.6",
         "classnames": "^2.2.5",
         "d3": "5.4.0",
         "diff": "^5.0.0",
@@ -24965,10 +24965,10 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
-    "bootstrap-tagsinput": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-tagsinput/-/bootstrap-tagsinput-0.7.1.tgz",
-      "integrity": "sha1-/+Owa74qEGlF7ygUVoAFqU8hGTc="
+    "bootstrap-tagsinput-2021": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/bootstrap-tagsinput-2021/-/bootstrap-tagsinput-2021-0.8.6.tgz",
+      "integrity": "sha512-/ZbR3Hl6BtpbuVuoXPxiyoh4a4fKyoyKn4pFXyL4fGEEQ3uwPS4/urrJ5O9ew2WkfBkJUdHnCLtNuVeUlz6HoA=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/decidim_app-design/packages/core/package.json
+++ b/decidim_app-design/packages/core/package.json
@@ -17,7 +17,7 @@
     "@joeattardi/emoji-button": "^4.6.0",
     "@zeitiger/appendaround": "^1.0.0",
     "axios": "^0.21.1",
-    "bootstrap-tagsinput": "^0.7.1",
+    "bootstrap-tagsinput-2021": "^0.8.6",
     "classnames": "^2.2.5",
     "d3": "5.4.0",
     "diff": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4375,10 +4375,10 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
-    "node_modules/bootstrap-tagsinput": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-tagsinput/-/bootstrap-tagsinput-0.7.1.tgz",
-      "integrity": "sha1-/+Owa74qEGlF7ygUVoAFqU8hGTc="
+    "node_modules/bootstrap-tagsinput-2021": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/bootstrap-tagsinput-2021/-/bootstrap-tagsinput-2021-0.8.6.tgz",
+      "integrity": "sha512-/ZbR3Hl6BtpbuVuoXPxiyoh4a4fKyoyKn4pFXyL4fGEEQ3uwPS4/urrJ5O9ew2WkfBkJUdHnCLtNuVeUlz6HoA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -21450,7 +21450,7 @@
         "@joeattardi/emoji-button": "^4.6.0",
         "@zeitiger/appendaround": "^1.0.0",
         "axios": "^0.21.1",
-        "bootstrap-tagsinput": "^0.7.1",
+        "bootstrap-tagsinput-2021": "^0.8.6",
         "classnames": "^2.2.5",
         "d3": "5.4.0",
         "diff": "^5.0.0",
@@ -22730,7 +22730,7 @@
         "@joeattardi/emoji-button": "^4.6.0",
         "@zeitiger/appendaround": "^1.0.0",
         "axios": "^0.21.1",
-        "bootstrap-tagsinput": "^0.7.1",
+        "bootstrap-tagsinput-2021": "^0.8.6",
         "classnames": "^2.2.5",
         "d3": "5.4.0",
         "diff": "^5.0.0",
@@ -24965,10 +24965,10 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
-    "bootstrap-tagsinput": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-tagsinput/-/bootstrap-tagsinput-0.7.1.tgz",
-      "integrity": "sha1-/+Owa74qEGlF7ygUVoAFqU8hGTc="
+    "bootstrap-tagsinput-2021": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/bootstrap-tagsinput-2021/-/bootstrap-tagsinput-2021-0.8.6.tgz",
+      "integrity": "sha512-/ZbR3Hl6BtpbuVuoXPxiyoh4a4fKyoyKn4pFXyL4fGEEQ3uwPS4/urrJ5O9ew2WkfBkJUdHnCLtNuVeUlz6HoA=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "@joeattardi/emoji-button": "^4.6.0",
     "@zeitiger/appendaround": "^1.0.0",
     "axios": "^0.21.1",
-    "bootstrap-tagsinput": "^0.7.1",
+    "bootstrap-tagsinput-2021": "^0.8.6",
     "classnames": "^2.2.5",
     "d3": "5.4.0",
     "diff": "^5.0.0",


### PR DESCRIPTION
#### :tophat: What? Why?
Upgrade Bootstrap Tags Input to mitigate  Cross-site Scripting (XSS) 
More details: https://security.snyk.io/vuln/npm:bootstrap-tagsinput:20160720

:hearts: Thank you!
