### PR TITLE
Enable simplecov only for rspec step

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -23,7 +23,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-accountability
@@ -89,6 +88,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -18,7 +18,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-admin
@@ -84,6 +83,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -19,7 +19,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-api
@@ -85,6 +84,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -18,7 +18,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-assemblies
@@ -84,6 +83,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-blogs
@@ -87,6 +86,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -20,7 +20,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-budgets
@@ -86,6 +85,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -18,7 +18,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-comments
@@ -88,6 +87,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -19,7 +19,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-conferences
@@ -85,6 +84,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -19,7 +19,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-consultations
@@ -85,6 +84,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -17,7 +17,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-core
@@ -83,6 +82,8 @@ jobs:
       - run: bundle exec rspec spec/system
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_core_unit.yml
+++ b/.github/workflows/ci_core_unit.yml
@@ -17,7 +17,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-core
@@ -83,6 +82,8 @@ jobs:
       - run: bundle exec rspec --exclude-pattern 'spec/system/**/*_spec.rb'
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -19,7 +19,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-debates
@@ -85,6 +84,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_dev_system.yml
+++ b/.github/workflows/ci_dev_system.yml
@@ -16,7 +16,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-dev
@@ -82,6 +81,8 @@ jobs:
       - run: bundle exec rspec spec/system
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_elections_system_admin.yml
+++ b/.github/workflows/ci_elections_system_admin.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-elections
@@ -96,6 +95,8 @@ jobs:
       - run: bundle exec rspec spec/system/admin
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh decidim-elections-system-admin $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_elections_system_public.yml
+++ b/.github/workflows/ci_elections_system_public.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-elections
@@ -96,6 +95,8 @@ jobs:
       - run: bundle exec rspec spec/system/ --exclude-pattern 'spec/system/admin/**/*_spec.rb'
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh decidim-elections-system-public $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_elections_unit_tests.yml
+++ b/.github/workflows/ci_elections_unit_tests.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-elections
@@ -99,6 +98,8 @@ jobs:
       - run: bundle exec rspec --exclude-pattern 'spec/system/**/*_spec.rb'
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -18,7 +18,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-forms
@@ -84,6 +83,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -16,7 +16,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-generators
@@ -77,5 +76,7 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -20,7 +20,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-initiatives
@@ -86,6 +85,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
 
@@ -49,3 +48,5 @@ jobs:
         run: npm ci
       - run: bundle exec rspec
         name: RSpec
+        env:
+          SIMPLECOV: "true"

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-meetings
@@ -84,6 +83,8 @@ jobs:
       - run: bundle exec rspec spec/system/admin
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh decidim-meetings-system-admin $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-meetings
@@ -84,6 +83,8 @@ jobs:
       - run: bundle exec rspec spec/system/ --exclude-pattern 'spec/system/admin/**/*_spec.rb'
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh decidim-meetings-system-public $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_meetings_unit_tests.yml
+++ b/.github/workflows/ci_meetings_unit_tests.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-meetings
@@ -87,6 +86,8 @@ jobs:
       - run: bundle exec rspec --exclude-pattern 'spec/system/**/*_spec.rb'
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -18,7 +18,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-pages
@@ -84,6 +83,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -19,7 +19,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-participatory_processes
@@ -85,6 +84,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -23,7 +23,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-proposals
@@ -86,6 +85,8 @@ jobs:
       - run: bundle exec rspec spec/system/admin
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh decidim-proposals-system-admin $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_proposals_system_public_1.yml
+++ b/.github/workflows/ci_proposals_system_public_1.yml
@@ -23,7 +23,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-proposals
@@ -90,6 +89,8 @@ jobs:
           bundle exec rspec $list_of_files
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh decidim-proposals-system-public $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_proposals_system_public_2.yml
+++ b/.github/workflows/ci_proposals_system_public_2.yml
@@ -23,7 +23,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-proposals
@@ -90,6 +89,8 @@ jobs:
           bundle exec rspec $list_of_files
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh decidim-proposals-system-public $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -23,7 +23,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-proposals
@@ -89,6 +88,8 @@ jobs:
       - run: bundle exec rspec --exclude-pattern 'spec/system/**/*_spec.rb'
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -20,7 +20,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-sortitions
@@ -86,6 +85,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-surveys
@@ -87,6 +86,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -17,7 +17,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-system
@@ -83,6 +82,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -20,7 +20,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-templates
@@ -86,6 +85,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -18,7 +18,6 @@ on:
 
 env:
   CI: "true"
-  SIMPLECOV: "true"
   RUBY_VERSION: 2.7.5
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-verifications
@@ -84,6 +83,8 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
+        env:
+          SIMPLECOV: "true"
       - run: ./.github/upload_coverage.sh $DECIDIM_MODULE $GITHUB_EVENT_PATH
         name: Upload coverage
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
#### :tophat: What? Why?
Changing the Workflows files to ensure that only the rspec step is generating a coverage file. 

Without this PR, The Assets precompile step is creating a coverage file ( as per below printscreen) 
![image](https://user-images.githubusercontent.com/105683/147909864-10c84551-2e28-4298-a04c-190f604d3e48.png)

Without this PR, The Create test app step is creating a coverage file ( as per below printscreen) 
![image](https://user-images.githubusercontent.com/105683/147909921-7aabd96c-ddcc-42b0-b9ae-3fcaae103c5e.png)

The PR aims to generate 1 coverage file per workflow run, to make codecov successfully pass. 


:hearts: Thank you!
