### PR TITLE
Don't start poll meetings component when DOM elements are not present

### DIFF
--- a/decidim-meetings/app/packs/src/decidim/meetings/meetings_polls.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/meetings_polls.js
@@ -5,37 +5,42 @@ $(() => {
   // Mount polls component for users
   const $container = $("[data-decidim-meetings-poll]");
   const $counter = $("#visible-questions-count");
-  const poll = new MeetingsPollComponent($container, $container.data("decidim-meetings-poll"), $counter);
 
-  $(".meeting-polls__action-list").on("click", (event) => {
-    event.preventDefault();
+  if ($container.length) {
+    const poll = new MeetingsPollComponent($container, $container.data("decidim-meetings-poll"), $counter);
 
-    if (poll.isMounted()) {
-      $(event.target).removeClass(OPEN_CLASS);
-      $container.removeClass(OPEN_CLASS);
-      poll.unmountComponent();
-    } else {
-      $(event.target).addClass(OPEN_CLASS);
-      $container.addClass(OPEN_CLASS);
-      poll.mountComponent();
-    }
-  });
+    $(".meeting-polls__action-list").on("click", (event) => {
+      event.preventDefault();
+
+      if (poll.isMounted()) {
+        $(event.target).removeClass(OPEN_CLASS);
+        $container.removeClass(OPEN_CLASS);
+        poll.unmountComponent();
+      } else {
+        $(event.target).addClass(OPEN_CLASS);
+        $container.addClass(OPEN_CLASS);
+        poll.mountComponent();
+      }
+    });
+  }
 
   // Mount polls component for admins
   const $adminContainer = $("[data-decidim-admin-meetings-poll]");
-  const adminPoll = new MeetingsPollComponent($adminContainer, $adminContainer.data("decidim-admin-meetings-poll"));
 
-  $(".meeting-polls__action-administrate").on("click", (event) => {
-    event.preventDefault();
+  if ($adminContainer.length) {
+    const adminPoll = new MeetingsPollComponent($adminContainer, $adminContainer.data("decidim-admin-meetings-poll"));
+    $(".meeting-polls__action-administrate").on("click", (event) => {
+      event.preventDefault();
 
-    if (adminPoll.isMounted()) {
-      $(event.target).removeClass(OPEN_CLASS);
-      $adminContainer.removeClass(OPEN_CLASS);
-      adminPoll.unmountComponent();
-    } else {
-      $(event.target).addClass(OPEN_CLASS);
-      $adminContainer.addClass(OPEN_CLASS);
-      adminPoll.mountComponent();
-    }
-  });
+      if (adminPoll.isMounted()) {
+        $(event.target).removeClass(OPEN_CLASS);
+        $adminContainer.removeClass(OPEN_CLASS);
+        adminPoll.unmountComponent();
+      } else {
+        $(event.target).addClass(OPEN_CLASS);
+        $adminContainer.addClass(OPEN_CLASS);
+        adminPoll.mountComponent();
+      }
+    });
+  }
 });


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes the PollComponent of Meetings module, which was being called in the DOM even when the container object didn't exist. With this PR this behaviour is prevented and the JS error is removed.

#### :pushpin: Related Issues

- Fixes #8640

#### Testing

Steps to reproduce the behavior:

1. Sign in as admin
1. Enable "Participants can create meetings" in the configuration of meetings in a participatory process
1. Open the JavaScript console of your browsers web development tool
1. Go to the meeting creation form of participants
1. You won't see the error

Besides that, in the specs there was a warning showing the JS error:

```
WARNING 2022-01-03 10:59:38 +0100: http://19.lvh.me:52643/packs-test/js/vendors-node_modules_jquery_dist_jquery-exposed_js.js 4118:17 "jQuery.Deferred exception: Cannot read properties of undefined (reading 'questionsUrl')" "TypeError: Cannot read properties of undefined (reading 'questionsUrl')\n    at new PollComponent (http://19.lvh.me:52643/packs-test/js/decidim_meetings.js:417:32)\n    at HTMLDocument.\u003Canonymous> (http://19.lvh.me:52643/packs-test/js/decidim_meetings.js:322:14)\n    at mightThrow (http://19.lvh.me:52643/packs-test/js/vendors-node_modules_jquery_dist_jquery-exposed_js.js:3835:29)\n    at process (http://19.lvh.me:52643/packs-test/js/vendors-node_modules_jquery_dist_jquery-exposed_js.js:3903:12)" undefined
```

This warning has disappeared too. Because this was a JS error that didn't prevent the functionality to work I haven't added a test.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ x :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
