### PR TITLE
Add location data to proposals export and import

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/import/proposal_creator.rb
+++ b/decidim-proposals/lib/decidim/proposals/import/proposal_creator.rb
@@ -77,11 +77,11 @@ module Decidim
         end
 
         def latitude
-          data.has_key?(:coordinates) ? data[:coordinates]["latitude"] : data[:"coordinates/latitude"].to_f
+          data.has_key?(:latitude) ? data[:latitude] : nil
         end
 
         def longitude
-          data.has_key?(:coordinates) ? data[:coordinates]["longitude"] : data[:"coordinates/longitude"].to_f
+          data.has_key?(:longitude) ? data[:longitude] : nil
         end
 
         def available_locales

--- a/decidim-proposals/lib/decidim/proposals/import/proposal_creator.rb
+++ b/decidim-proposals/lib/decidim/proposals/import/proposal_creator.rb
@@ -46,6 +46,9 @@ module Decidim
             scope: scope,
             title: title,
             body: body,
+            address: address,
+            latitude: latitude,
+            longitude: longitude,
             component: component,
             published_at: Time.current
           )
@@ -67,6 +70,18 @@ module Decidim
 
         def body
           locale_hasher("body", available_locales)
+        end
+
+        def address
+          data.has_key?(:address) ? data[:address] : nil
+        end
+
+        def latitude
+          data.has_key?(:coordinates) ? data[:coordinates]["latitude"] : data[:"coordinates/latitude"].to_f
+        end
+
+        def longitude
+          data.has_key?(:coordinates) ? data[:coordinates]["longitude"] : data[:"coordinates/longitude"].to_f
         end
 
         def available_locales

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -34,10 +34,8 @@ module Decidim
           title: proposal.title,
           body: proposal.body,
           address: proposal.address,
-          coordinates: {
-            latitude: proposal.latitude,
-            longitude: proposal.longitude
-          },
+          latitude: proposal.latitude,
+          longitude: proposal.longitude,
           state: proposal.state.to_s,
           reference: proposal.reference,
           answer: ensure_translatable(proposal.answer),

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -33,6 +33,11 @@ module Decidim
           component: { id: component.id },
           title: proposal.title,
           body: proposal.body,
+          address: proposal.address,
+          coordinates: {
+            latitude: proposal.latitude,
+            longitude: proposal.longitude
+          },
           state: proposal.state.to_s,
           reference: proposal.reference,
           answer: ensure_translatable(proposal.answer),

--- a/decidim-proposals/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
@@ -14,6 +14,9 @@ describe Decidim::Proposals::Import::ProposalCreator do
       scope: scope,
       :"title/en" => Faker::Lorem.sentence,
       :"body/en" => Faker::Lorem.paragraph(sentence_count: 3),
+      address: "#{Faker::Address.street_name}, #{Faker::Address.city}",
+      latitude: Faker::Address.latitude,
+      longitude: Faker::Address.longitude,
       component: component,
       published_at: moment
     }
@@ -52,6 +55,9 @@ describe Decidim::Proposals::Import::ProposalCreator do
         :"body/en" => data[:"body/en"],
         category: data[:category],
         scope: data[:scope],
+        address: data[:address],
+        latitude: data[:latitude],
+        longitude: data[:longitude],
         component: data[:component],
         published_at: data[:published_at]
       )
@@ -68,6 +74,9 @@ describe Decidim::Proposals::Import::ProposalCreator do
       expect(record.scope).to eq(scope)
       expect(record.title["en"]).to eq(data[:"title/en"])
       expect(record.body["en"]).to eq(data[:"body/en"])
+      expect(record.address).to eq(data[:address])
+      expect(record.latitude).to eq(data[:latitude])
+      expect(record.longitude).to eq(data[:longitude])
       expect(record.published_at).to be >= (moment)
     end
   end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -64,6 +64,18 @@ module Decidim
           expect(serialized).to include(body: proposal.body)
         end
 
+        it "serializes the address" do
+          expect(serialized).to include(address: proposal.address)
+        end
+
+        it "serializes the latitude" do
+          expect(serialized).to include(latitude: proposal.latitude)
+        end
+
+        it "serializes the longitude" do
+          expect(serialized).to include(longitude: proposal.longitude)
+        end
+
         it "serializes the amount of supports" do
           expect(serialized).to include(supports: proposal.proposal_votes_count)
         end


### PR DESCRIPTION
#### :tophat: What? Why?

As @PierreMesure said:

> Lets Decidim export proposals with their location metadata (address, latitude, longitude) and reimport from a file.

This supersedes his job, adding specs and dropping the :coordinates parent key. I think it's easier to just follow the Proposals' data model (like `proposal.latitude`). 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Extracted from #8604
- Related to [MetaDecidim#16871](https://meta.decidim.org/processes/roadmap/f/122/proposals/16871), #1223, #5186 
- Fixes #7062

#### Testing
- Export proposals from a Proposals component with geotagging
- Reimport them back in another component

:hearts: Thank you!
