### PR TITLE
Backport "Fix surveys exports with free text in multiple option" to v0.25

### DIFF
--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
@@ -21,10 +21,13 @@ module Decidim
           return "-" if answer.choices.empty?
 
           choices = answer.choices.map do |choice|
-            choice.try(:custom_body) || choice.try(:body)
+            {
+              answer_option_body: choice.try(:answer_option).try(:translated_body),
+              choice_body: body_or_custom_body(choice)
+            }
           end
 
-          return choices.first if answer.question.question_type == "single_option"
+          return choice(choices.first) if answer.question.question_type == "single_option"
 
           content_tag(:ul) do
             safe_join(choices.map { |c| choice(c) })
@@ -52,10 +55,22 @@ module Decidim
           # rubocop:enable Style/StringConcatenation
         end
 
-        def choice(choice_body)
+        def choice(choice_hash)
           content_tag :li do
-            choice_body
+            render_body_for choice_hash
           end
+        end
+
+        def render_body_for(choice_hash)
+          return choice_hash[:answer_option_body] if choice_hash[:choice_body].blank?
+
+          "#{choice_hash[:answer_option_body]} (#{choice_hash[:choice_body]})"
+        end
+
+        def body_or_custom_body(choice)
+          return choice.custom_body if choice.try(:custom_body).present?
+
+          ""
         end
       end
     end

--- a/decidim-forms/lib/decidim/forms/test/factories.rb
+++ b/decidim-forms/lib/decidim/forms/test/factories.rb
@@ -144,6 +144,14 @@ FactoryBot.define do
     question { create(:questionnaire_question) }
     body { generate_localized_title }
     free_text { false }
+
+    trait :free_text_enabled do
+      free_text { true }
+    end
+
+    trait :free_text_disabled do
+      free_text { false }
+    end
   end
 
   factory :answer_choice, class: "Decidim::Forms::AnswerChoice" do

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_answers.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_answers.rb
@@ -69,6 +69,24 @@ shared_examples_for "manage questionnaire answers" do
           expect(page).to have_content("User identifier")
         end
       end
+
+      context "when multiple answer choice" do
+        let(:first_type) { "multiple_option" }
+        let!(:answer1) { create :answer, questionnaire: questionnaire, question: first, body: nil }
+        let!(:answer_option) { create :answer_option, question: first }
+        let!(:answer_choice) { create :answer_choice, answer: answer1, answer_option: answer_option, body: translated(answer_option.body, locale: I18n.locale) }
+
+        before do
+          find_all("a.action-icon.action-icon--eye").first.click
+        end
+
+        it "shows the answers page with custom body" do
+          within "#answers" do
+            expect(page).to have_css("dt", text: translated(first.body))
+            expect(page).to have_css("li", text: translated(answer_option.body))
+          end
+        end
+      end
     end
 
     context "and managing individual answer page" do

--- a/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
+++ b/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
@@ -73,7 +73,7 @@ module Decidim
           normalize_matrix_choices(answer, choices)
         else
           choices.map do |choice|
-            choice.try(:custom_body) || choice.try(:body)
+            format_free_text_for choice
           end
         end
       end
@@ -93,6 +93,12 @@ module Decidim
 
       def answer_translated_attribute_name(attribute)
         I18n.t(attribute.to_sym, scope: "decidim.forms.user_answers_serializer")
+      end
+
+      def format_free_text_for(choice)
+        return choice.try(:body) if choice.try(:custom_body).blank?
+
+        "#{choice.try(:body)} (#{choice.try(:custom_body)})"
       end
     end
   end

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
@@ -40,7 +40,7 @@ module Decidim
 
         context "when it is a single_option question" do
           it "Returns the choice's body" do
-            expect(subject.body).to eq(answer_choice.body)
+            expect(subject.body).to eq("<li>#{answer_choice.body}</li>")
           end
         end
 
@@ -62,6 +62,15 @@ module Decidim
 
         it "Returns the choices wrapped in <li> elements inside a <ul>" do
           expect(subject.body).to eq("<ul><li>#{answer_choice_1.body}</li><li>#{answer_choice_2.body}</li></ul>")
+        end
+
+        context "and free text is enabled on answer options" do
+          let!(:answer_option_1) { create :answer_option, :free_text_enabled }
+          let!(:answer_option_2) { create :answer_option, :free_text_enabled }
+
+          it "returns the choices and question wrapped in <li> elements inside a <ul>" do
+            expect(subject.body).to eq("<ul><li>#{answer_option_1.translated_body}</li><li>#{answer_option_2.translated_body}</li></ul>")
+          end
         end
       end
     end

--- a/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -88,11 +88,11 @@ module Decidim
           serialized_files_answer = files_answer.attachments.map(&:url)
 
           expect(serialized).to include(
-            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => multichoice_answer_choices.map(&:body)
+            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => [multichoice_answer_choices.first.body, multichoice_answer_choices.last.body]
           )
 
           expect(serialized).to include(
-            "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => ["Free text"]
+            "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => ["#{translated(singlechoice_answer_choice.body)} (Free text)"]
           )
 
           expect(serialized).to include(

--- a/decidim-meetings/spec/serializers/registration_serializer_spec.rb
+++ b/decidim-meetings/spec/serializers/registration_serializer_spec.rb
@@ -63,7 +63,7 @@ module Decidim::Meetings
         let!(:singlechoice_free_question) { create :questionnaire_question, questionnaire: meeting.questionnaire, question_type: "single_option" }
         let!(:singlechoice_free_answer_options) do
           options = create_list :answer_option, 2, question: singlechoice_free_question
-          options << create(:answer_option, question: singlechoice_free_question, free_text: true)
+          options << create(:answer_option, :free_text_enabled, question: singlechoice_free_question)
 
           options
         end
@@ -92,13 +92,13 @@ module Decidim::Meetings
             "#{questions.last.position + 1}. #{translated(questions.last.body, locale: I18n.locale)}" => answers.last.body
           )
           expect(serialized[:registration_form_answers]).to include(
-            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => multichoice_answer_choices.map(&:body)
+            "#{multichoice_question.position + 1}. #{translated(multichoice_question.body, locale: I18n.locale)}" => [multichoice_answer_choices.first.body, multichoice_answer_choices.last.body]
           )
           expect(serialized[:registration_form_answers]).to include(
             "#{singlechoice_question.position + 1}. #{translated(singlechoice_question.body, locale: I18n.locale)}" => [singlechoice_answer_choice.body]
           )
           expect(serialized[:registration_form_answers]).to include(
-            "#{singlechoice_free_question.position + 1}. #{translated(singlechoice_free_question.body, locale: I18n.locale)}" => ["Free text answer"]
+            "#{singlechoice_free_question.position + 1}. #{translated(singlechoice_free_question.body, locale: I18n.locale)}" => ["#{singlechoice_free_answer_choice.body} (Free text answer)"]
           )
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

When survey contains answer with multiple answer choices, exports can be difficult to read for administrators. So this PR backports the fix in #8582 on `v0.25-stable`

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to ask : https://github.com/decidim/decidim/pull/8582#issuecomment-1000130091

:hearts: Thank you!
