### PR TITLE
Change to a inclusive language: replace he/she/his/her with they/their

### DIFF
--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -352,7 +352,7 @@ en:
             invites: Invites
             search: Search
           new:
-            explanation: The participant will be invited to join a conference. If their email is not registered, it'll be invited to the organization as well.
+            explanation: The participant will be invited to join a conference. If their email is not registered, they'll be invited to the organization as well.
             invite: Invite
             new_invite: Invite participant
         conference_registrations:

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -352,7 +352,7 @@ en:
             invites: Invites
             search: Search
           new:
-            explanation: The participant will be invited to join a conference. If her email is not registered she will be invited to the organization as well.
+            explanation: The participant will be invited to join a conference. If their email is not registered, it'll be invited to the organization as well.
             invite: Invite
             new_invite: Invite participant
         conference_registrations:

--- a/decidim-core/app/commands/decidim/messaging/reply_to_conversation.rb
+++ b/decidim-core/app/commands/decidim/messaging/reply_to_conversation.rb
@@ -69,7 +69,7 @@ module Decidim
       end
 
       # in order for a recipient to receive an email it should not have direct-messages disabled
-      # if direct-messages are disabled, only send if he follows the sending user
+      # if direct-messages are disabled, only send if they follow the sending user
       def notify(recipient)
         return unless conversation.unread_count(recipient) == 1
         return unless recipient.accepts_conversation?(form.context.current_user)

--- a/decidim-core/app/commands/decidim/messaging/start_conversation.rb
+++ b/decidim-core/app/commands/decidim/messaging/start_conversation.rb
@@ -72,7 +72,7 @@ module Decidim
       end
 
       # in order for a recipient to receive an email it should not have direct-messages disabled
-      # if direct-messages are disabled, only send if he follows the sending user
+      # if direct-messages are disabled, only send if they follow the sending user
       def notify(recipient)
         return unless recipient.accepts_conversation?(form.context.current_user)
 

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   # The form object that handles the data behind updating a user's
-  # account in her profile page.
+  # account in their profile page.
   class AccountForm < Form
     include Decidim::HasUploadValidations
 

--- a/decidim-core/app/forms/decidim/notifications_settings_form.rb
+++ b/decidim-core/app/forms/decidim/notifications_settings_form.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   # The form object that handles the data behind updating a user's
-  # notifications settings in her profile page.
+  # notifications settings in their profile page.
   class NotificationsSettingsForm < Form
     mimic :user
 

--- a/decidim-core/app/forms/decidim/user_interest_scope_form.rb
+++ b/decidim-core/app/forms/decidim/user_interest_scope_form.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   # The form object that handles the data behind updating a user's
-  # interests in her profile page.
+  # interests in their profile page.
   class UserInterestScopeForm < Form
     mimic :scope
 

--- a/decidim-core/app/forms/decidim/user_interests_form.rb
+++ b/decidim-core/app/forms/decidim/user_interests_form.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   # The form object that handles the data behind updating a user's
-  # interests in her profile page.
+  # interests in their profile page.
   class UserInterestsForm < Form
     mimic :user
 

--- a/decidim-core/app/mailers/decidim/newsletters_opt_in_mailer.rb
+++ b/decidim-core/app/mailers/decidim/newsletters_opt_in_mailer.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   # A custom mailer for Decidim so we can notify users to verify
-  # his own newsletter notifications settings. GDPR releated
+  # their own newsletter notifications settings. GDPR releated
   class NewslettersOptInMailer < ApplicationMailer
     def notify(user, token)
       @user = user

--- a/decidim-core/app/models/decidim/messaging/conversation.rb
+++ b/decidim-core/app/models/decidim/messaging/conversation.rb
@@ -110,7 +110,7 @@ module Decidim
       end
 
       #
-      # Given a user, returns her interlocutors in this conversation
+      # Given a user, returns their interlocutors in this conversation
       #
       # @param user [Decidim::User] The user to find interlocutors for
       #
@@ -121,7 +121,7 @@ module Decidim
       end
 
       #
-      # Given a user, returns if ALL the interlocutors allow her to join the conversation
+      # Given a user, returns if ALL the interlocutors allow the user to join the conversation
       #
       # @return Boolean
       #

--- a/decidim-core/app/packs/src/decidim/identity_selector_dialog.js
+++ b/decidim-core/app/packs/src/decidim/identity_selector_dialog.js
@@ -1,6 +1,6 @@
 /**
  * Makes the #select-identity-button to open a popup for the user to
- * select with which identity he wants to perform an action.
+ * select with which identity they want to perform an action.
  *
  */
 $(() => {

--- a/decidim-core/app/queries/decidim/metric_manage.rb
+++ b/decidim-core/app/queries/decidim/metric_manage.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   # This class search for objects related to Metrics, and creates a new registry within
-  # his own parameters
+  # its own parameters
   class MetricManage
     def self.for(day_string, organization)
       new(day_string, organization)

--- a/decidim-core/lib/decidim/metric_manifest.rb
+++ b/decidim-core/lib/decidim/metric_manifest.rb
@@ -4,7 +4,7 @@ module Decidim
   # This class acts as a manifest for metrics.
   #
   # This manifest is a simple object that holds and stores currently available
-  # metrics and his managers, for calculations purpose
+  # metrics and its managers, for calculations purpose
   #
   class MetricManifest
     include ActiveModel::Model

--- a/decidim-core/lib/tasks/decidim_data_portability_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_data_portability_tasks.rake
@@ -55,7 +55,7 @@ namespace :decidim do
     end
   end
 
-  desc "Check and notify users to update her newsletter notifications settings"
+  desc "Check and notify users to update their newsletter notifications settings"
   task check_users_newsletter_opt_in: :environment do
     print %(
 > This will send an email to all the users that have marked the newsletter by default. This should only be run if you were using Decidim before v0.11

--- a/decidim-core/lib/tasks/decidim_metrics_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_metrics_tasks.rake
@@ -4,7 +4,7 @@ namespace :decidim do
   namespace :metrics do
     # All ------
     #
-    # Get all metrics entities and execute his own rake task.
+    # Get all metrics entities and execute its own rake task.
     # It admits a date-string parameter, in a 'YYYY-MM-DD' format from
     # today to all past dates
     desc "Execute all metrics calculation methods"

--- a/decidim-core/spec/mailers/reported_mailer_spec.rb
+++ b/decidim-core/spec/mailers/reported_mailer_spec.rb
@@ -90,7 +90,7 @@ module Decidim
             author.save!
           end
 
-          it "includes the name of the author but no link to his profile" do
+          it "includes the name of the author but no link to their profile" do
             expect(mail).not_to have_link(author.name)
           end
         end

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -139,7 +139,7 @@ describe "Account", type: :system do
         visit decidim.delete_account_path
       end
 
-      it "the user can delete his account" do
+      it "the user can delete their account" do
         fill_in :delete_user_delete_account_delete_reason, with: "I just want to delete my account"
 
         click_button "Delete my account"

--- a/decidim-core/spec/system/cookies_spec.rb
+++ b/decidim-core/spec/system/cookies_spec.rb
@@ -15,7 +15,7 @@ describe "Cookies", type: :system do
     expect(page).to have_content "This site uses cookies."
   end
 
-  it "user accept the cookie policy and it isn't shown anymore'" do
+  it "user accepts the cookie policy and it isn't shown anymore'" do
     click_button "I agree"
     expect(page).to have_no_content "This site uses cookies."
 

--- a/decidim-core/spec/system/cookies_spec.rb
+++ b/decidim-core/spec/system/cookies_spec.rb
@@ -15,7 +15,7 @@ describe "Cookies", type: :system do
     expect(page).to have_content "This site uses cookies."
   end
 
-  it "user accept the cookie policy and he doesn't see it anymore'" do
+  it "user accept the cookie policy and it isn't shown anymore'" do
     click_button "I agree"
     expect(page).to have_no_content "This site uses cookies."
 

--- a/decidim-core/spec/system/user_groups_verification_status_on_account_page_spec.rb
+++ b/decidim-core/spec/system/user_groups_verification_status_on_account_page_spec.rb
@@ -15,7 +15,7 @@ describe "User group verification status on account page", type: :system do
   context "when the user group is pending" do
     let(:user_group) { create(:user_group) }
 
-    it "the user can check its status on their account page" do
+    it "the user can check their status on their account page" do
       visit decidim.own_user_groups_path
 
       click_link "Groups"
@@ -34,7 +34,7 @@ describe "User group verification status on account page", type: :system do
   context "when the user group is rejected" do
     let(:user_group) { create(:user_group, :rejected) }
 
-    it "the user can check its status on their account page" do
+    it "the user can check their status on their account page" do
       visit decidim.own_user_groups_path
 
       click_link "Groups"
@@ -47,7 +47,7 @@ describe "User group verification status on account page", type: :system do
   context "when the user group is verified" do
     let(:user_group) { create(:user_group, :verified) }
 
-    it "the user can check its status on their account page" do
+    it "the user can check their status on their account page" do
       visit decidim.own_user_groups_path
 
       click_link "Groups"

--- a/decidim-core/spec/system/user_groups_verification_status_on_account_page_spec.rb
+++ b/decidim-core/spec/system/user_groups_verification_status_on_account_page_spec.rb
@@ -15,7 +15,7 @@ describe "User group verification status on account page", type: :system do
   context "when the user group is pending" do
     let(:user_group) { create(:user_group) }
 
-    it "the user can check its status on his account page" do
+    it "the user can check its status on their account page" do
       visit decidim.own_user_groups_path
 
       click_link "Groups"
@@ -34,7 +34,7 @@ describe "User group verification status on account page", type: :system do
   context "when the user group is rejected" do
     let(:user_group) { create(:user_group, :rejected) }
 
-    it "the user can check its status on his account page" do
+    it "the user can check its status on their account page" do
       visit decidim.own_user_groups_path
 
       click_link "Groups"
@@ -47,7 +47,7 @@ describe "User group verification status on account page", type: :system do
   context "when the user group is verified" do
     let(:user_group) { create(:user_group, :verified) }
 
-    it "the user can check its status on his account page" do
+    it "the user can check its status on their account page" do
       visit decidim.own_user_groups_path
 
       click_link "Groups"

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -1184,14 +1184,14 @@ en:
             census_verified: The participant has not voted yet.
             complete_voting: Complete voting
             identify_another: Identify another participant
-            questions_title: 'She is entitled to vote in the following questions:'
+            questions_title: 'They''re entitled to vote in the following questions:'
             questions_title_voted: 'The participant has already voted online and is entitled to vote in the following questions:'
             voted: The participant has voted
           create:
             error: The vote was not registered. Please try again.
           in_person_form:
             census_not_present: This participant is not listed in the census.
-            census_not_present_description: She must go to the census complaint office or contact support.
+            census_not_present_description: They must go to the census complaint office or contact support.
             date_of_birth: Date of birth
             day: Day
             day_placeholder: DD

--- a/decidim-elections/spec/system/vote_in_person_spec.rb
+++ b/decidim-elections/spec/system/vote_in_person_spec.rb
@@ -31,7 +31,7 @@ describe "Polling Officer zone", type: :system do
   shared_examples "a polling officer registers an in person vote" do
     include_context "with test bulletin board"
 
-    let(:questions_title) { "She is entitled to vote in the following questions:" }
+    let(:questions_title) { "They're entitled to vote in the following questions:" }
 
     it "can identify a person and register their vote", :slow do
       click_link "Identify a person"

--- a/decidim-initiatives/README.md
+++ b/decidim-initiatives/README.md
@@ -100,7 +100,7 @@ a mechanism to validate that there are no duplicated signatures. To do so the en
 a functionality that allows exporting the online signatures to validate them against physical
 signatures.
 
-The signatures are exported as a hash string in order to preserve the identity of the signer together with her privacy.
+The signatures are exported as a hash string in order to preserve the identity of the signer together with their privacy.
 Each hash is composed with the following criteria:
 
 * Algorithm used: SHA1

--- a/decidim-initiatives/app/services/decidim/initiatives/status_change_notifier.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/status_change_notifier.rb
@@ -13,7 +13,7 @@ module Decidim
       # PUBLIC
       # Notifies when an initiative has changed its status.
       #
-      # * created: Notifies the author that his initiative has been created.
+      # * created: Notifies the author that their initiative has been created.
       #
       # * validating: Administrators will be notified about the initiative that
       #   requests technical validation.

--- a/decidim-proposals/spec/system/proposals_fields_spec.rb
+++ b/decidim-proposals/spec/system/proposals_fields_spec.rb
@@ -106,7 +106,7 @@ describe "Proposals", type: :system do
                    })
           end
 
-          let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "They will not solve everything") }
+          let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "It will not solve everything") }
 
           it "creates a new proposal", :slow do
             visit complete_proposal_path(component, proposal_draft)
@@ -174,7 +174,7 @@ describe "Proposals", type: :system do
                    participatory_space: participatory_process)
           end
 
-          let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "They will not solve everything") }
+          let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "It will not solve everything") }
           let(:component_automatic_hashtags) { "AutoHashtag1 AutoHashtag2" }
           let(:component_suggested_hashtags) { "SuggestedHashtag1 SuggestedHashtag2" }
 
@@ -241,7 +241,7 @@ describe "Proposals", type: :system do
                      })
             end
 
-            let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "They will not solve everything") }
+            let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "It will not solve everything") }
 
             it "creates a new proposal as a user group", :slow do
               visit complete_proposal_path(component, proposal_draft)

--- a/decidim-proposals/spec/system/proposals_fields_spec.rb
+++ b/decidim-proposals/spec/system/proposals_fields_spec.rb
@@ -106,7 +106,7 @@ describe "Proposals", type: :system do
                    })
           end
 
-          let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "He will not solve everything") }
+          let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "They will not solve everything") }
 
           it "creates a new proposal", :slow do
             visit complete_proposal_path(component, proposal_draft)
@@ -174,7 +174,7 @@ describe "Proposals", type: :system do
                    participatory_space: participatory_process)
           end
 
-          let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "He will not solve everything") }
+          let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "They will not solve everything") }
           let(:component_automatic_hashtags) { "AutoHashtag1 AutoHashtag2" }
           let(:component_suggested_hashtags) { "SuggestedHashtag1 SuggestedHashtag2" }
 
@@ -241,7 +241,7 @@ describe "Proposals", type: :system do
                      })
             end
 
-            let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "He will not solve everything") }
+            let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "They will not solve everything") }
 
             it "creates a new proposal as a user group", :slow do
               visit complete_proposal_path(component, proposal_draft)

--- a/decidim-verifications/app/services/decidim/authorization_handler.rb
+++ b/decidim-verifications/app/services/decidim/authorization_handler.rb
@@ -29,7 +29,7 @@ module Decidim
       nil
     end
 
-    # THe attributes of the handler that should be exposed as form input when
+    # The attributes of the handler that should be exposed as form input when
     # rendering the handler in a form.
     #
     # Returns an Array of Strings.

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -189,7 +189,7 @@ en:
               verification_number: 'Verification #%{n}'
           rejections:
             create:
-              success: Verification rejected. Participant will be prompted to amend her documents
+              success: Verification rejected. Participant will be prompted to amend their documents
         authorizations:
           choose:
             choose_a_type: 'Please select how you want to be verified:'

--- a/decidim-verifications/spec/system/action_authorization_spec.rb
+++ b/decidim-verifications/spec/system/action_authorization_spec.rb
@@ -107,7 +107,7 @@ describe "Action Authorization", type: :system do
                                  metadata: { postal_code: "1234", scope_id: other_scope.id })
         end
 
-        it "prompts user to check her authorization status" do
+        it "prompts user to check their authorization status" do
           click_link "New proposal"
 
           expect(page).to have_content("Not authorized")
@@ -127,7 +127,7 @@ describe "Action Authorization", type: :system do
         context "when the postal code is missing" do
           let(:postal_code) { "" }
 
-          it "prompts user to check her authorization status" do
+          it "prompts user to check their authorization status" do
             click_link "New proposal"
 
             expect(page).to have_content("Not authorized")
@@ -140,7 +140,7 @@ describe "Action Authorization", type: :system do
         context "when the scope is missing" do
           let(:user_scope) { nil }
 
-          it "prompts user to check her authorization status" do
+          it "prompts user to check their authorization status" do
             click_link "New proposal"
 
             expect(page).to have_content("Not authorized")
@@ -153,7 +153,7 @@ describe "Action Authorization", type: :system do
           let(:user_scope) { nil }
           let(:postal_code) {}
 
-          it "prompts user to check her authorization status" do
+          it "prompts user to check their authorization status" do
             click_link "New proposal"
 
             expect(page).to have_content("Not authorized")
@@ -176,7 +176,7 @@ describe "Action Authorization", type: :system do
         click_link "New proposal"
       end
 
-      it "prompts user to check her authorization status" do
+      it "prompts user to check their authorization status" do
         expect(page).to have_content("Authorization required")
         expect(page)
           .to have_content("Your authorization has expired. In order to perform this action, you need to be reauthorized with \"Example authorization\"")
@@ -239,7 +239,7 @@ describe "Action Authorization", type: :system do
         click_link "New proposal"
       end
 
-      it "prompts user to check her authorization status" do
+      it "prompts user to check their authorization status" do
         expect(page).to have_content("Authorization is still in progress")
         expect(page)
           .to have_content("In order to perform this action, you need to be authorized with \"Dummy authorization workflow\", but your authorization is still in progress")
@@ -263,7 +263,7 @@ describe "Action Authorization", type: :system do
         click_link "New proposal"
       end
 
-      it "prompts user to check her authorization status" do
+      it "prompts user to check their authorization status" do
         expect(page).to have_content("Authorization required")
         expect(page)
           .to have_content("Your authorization has expired. In order to perform this action, you need to be reauthorized with \"Dummy authorization workflow\"")

--- a/decidim-verifications/spec/system/authorizations_spec.rb
+++ b/decidim-verifications/spec/system/authorizations_spec.rb
@@ -62,7 +62,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
     end
   end
 
-  context "when existing user from her account" do
+  context "when existing user from their account" do
     let(:organization) { create :organization, available_authorizations: authorizations }
     let(:user) { create(:user, :confirmed, organization: organization) }
 

--- a/decidim-verifications/spec/system/id_documents/id_document_offline_request_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_offline_request_spec.rb
@@ -25,7 +25,7 @@ describe "Identity document offline request", type: :system do
     expect(page).to have_content("This is my explanation text")
   end
 
-  it "allows the user fill in her identity document" do
+  it "allows the user fill in their identity document" do
     submit_upload_form(
       doc_type: "DNI",
       doc_number: "XXXXXXXX"

--- a/decidim-verifications/spec/system/id_documents/id_document_online_review_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_online_review_spec.rb
@@ -52,7 +52,7 @@ describe "Identity document online review", type: :system do
     before { click_link "Reject" }
 
     it "dismisses the verification from the list" do
-      expect(page).to have_content("Verification rejected. Participant will be prompted to amend her documents")
+      expect(page).to have_content("Verification rejected. Participant will be prompted to amend their documents")
       expect(page).to have_no_content("Verification #")
     end
 

--- a/decidim-verifications/spec/system/id_documents/id_document_online_upload_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_online_upload_spec.rb
@@ -19,7 +19,7 @@ describe "Identity document online upload", type: :system do
     expect(page).to have_content("Upload your identity document")
   end
 
-  it "allows the user to upload her identity document" do
+  it "allows the user to upload their identity document" do
     submit_upload_form(
       doc_type: "DNI",
       doc_number: "XXXXXXXX",

--- a/decidim_app-design/app/views/public/partials/_polling_officer_zone_identify.erb
+++ b/decidim_app-design/app/views/public/partials/_polling_officer_zone_identify.erb
@@ -11,7 +11,7 @@
       <% if locals[:error] %>
         <div class="callout alert mt-s">
           <h5>This participant is not listed in the census.</h5>
-          <p>She must go to the census complaint office or contact support.</p>
+          <p>They must go to the census complaint office or contact support.</p>
         </div>
       <% else %>
         <div class="row mt-sm">

--- a/decidim_app-design/app/views/public/partials/_polling_officer_zone_identify_success.erb
+++ b/decidim_app-design/app/views/public/partials/_polling_officer_zone_identify_success.erb
@@ -13,7 +13,7 @@
         </div>
         <div class="row mt-sm">
           <div class="columns large-7">
-            <p><strong>Check that her data is correct:</strong></p>
+            <p><strong>Check that their data is correct:</strong></p>
             <div class="card--secondary">
               <div class="card__content">
                 <form>

--- a/decidim_app-design/app/views/public/partials/_polling_officer_zone_questions.erb
+++ b/decidim_app-design/app/views/public/partials/_polling_officer_zone_questions.erb
@@ -11,7 +11,7 @@
       <% end %>
       <% if locals[:warning] %>
         <div class="callout warning mt-s">
-          <p>This participant has already voted online. If she continues the process, she will override her previous vote.</p>
+          <p>This participant has already voted online. If they continue the process, they will override their previous vote.</p>
         </div>
       <% end %>
       <% if locals[:error] %>
@@ -20,7 +20,7 @@
         </div>
       <% end %>
       <% if locals[:success] || locals[:warning] %>
-        <p class="mt-sm"><strong>She is entitled to vote on the following questions:</strong></p>
+        <p class="mt-sm"><strong>It's entitled to vote on the following questions:</strong></p>
         <ul class="accordion js-sortable evote__preview"
           data-accordion
           data-multi-expand="true"
@@ -70,7 +70,7 @@
             </button>
           </div>
           <p class="text-center">
-            This person hasn't voted yet, but you are about to cancel the process. Her vote will not be counted. Are you sure?
+            This person hasn't voted yet, but you are about to cancel the process. Their vote will not be counted. Are you sure?
           </p>
           <div class="row">
             <div class="columns medium-8 medium-offset-2">

--- a/decidim_app-design/app/views/public/partials/_polling_officer_zone_questions.erb
+++ b/decidim_app-design/app/views/public/partials/_polling_officer_zone_questions.erb
@@ -20,7 +20,7 @@
         </div>
       <% end %>
       <% if locals[:success] || locals[:warning] %>
-        <p class="mt-sm"><strong>It's entitled to vote on the following questions:</strong></p>
+        <p class="mt-sm"><strong>They are entitled to vote on the following questions:</strong></p>
         <ul class="accordion js-sortable evote__preview"
           data-accordion
           data-multi-expand="true"


### PR DESCRIPTION
#### :tophat: What? Why?

Sometimes, mostly in comment and specs, we refer to some people (for instance, participants) as female or male ("she" or "he"). This PR changes this wording to a more neutral ("their"). 

Also, sometimes we refer to "the thing" as "he", where it should be "it". This PR also fixes that. 

#### :pushpin: Related Issues

- Related to #6678 

:hearts: Thank you!
