### PR TITLE
Don't display blocked users in mentions

### DIFF
--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -63,12 +63,6 @@ module Decidim
     scope :officialized, -> { where.not(officialized_at: nil) }
     scope :not_officialized, -> { where(officialized_at: nil) }
 
-    scope :confirmed, -> { where.not(confirmed_at: nil) }
-    scope :not_confirmed, -> { where(confirmed_at: nil) }
-
-    scope :blocked, -> { where(blocked: true) }
-    scope :not_blocked, -> { where(blocked: false) }
-
     scope :interested_in_scopes, lambda { |scope_ids|
       actual_ids = scope_ids.select(&:presence)
       if actual_ids.count.positive?

--- a/decidim-core/app/models/decidim/user_base_entity.rb
+++ b/decidim-core/app/models/decidim/user_base_entity.rb
@@ -25,6 +25,12 @@ module Decidim
 
     validates :name, format: { with: REGEXP_NAME }
 
+    scope :confirmed, -> { where.not(confirmed_at: nil) }
+    scope :not_confirmed, -> { where(confirmed_at: nil) }
+
+    scope :blocked, -> { where(blocked: true) }
+    scope :not_blocked, -> { where(blocked: false) }
+
     # Public: Returns a collection with all the public entities this user is following.
     #
     # This can't be done as with a `has_many :following, through: :following_follows`

--- a/decidim-core/lib/decidim/api/functions/user_entity_finder.rb
+++ b/decidim-core/lib/decidim/api/functions/user_entity_finder.rb
@@ -22,8 +22,8 @@ module Decidim
           filters[argument.to_sym] = v
         end
         Decidim::UserBaseEntity
-          .where.not(confirmed_at: nil)
-          .where(blocked_at: nil)
+          .confirmed
+          .not_blocked
           .find_by(filters)
       end
     end

--- a/decidim-core/lib/decidim/api/functions/user_entity_finder.rb
+++ b/decidim-core/lib/decidim/api/functions/user_entity_finder.rb
@@ -23,6 +23,7 @@ module Decidim
         end
         Decidim::UserBaseEntity
           .where.not(confirmed_at: nil)
+          .where(blocked_at: nil)
           .find_by(filters)
       end
     end

--- a/decidim-core/lib/decidim/api/functions/user_entity_list.rb
+++ b/decidim-core/lib/decidim/api/functions/user_entity_list.rb
@@ -20,6 +20,7 @@ module Decidim
         @query = Decidim::UserBaseEntity
                  .where(organization: ctx[:current_organization])
                  .where.not(confirmed_at: nil)
+                 .where(blocked_at: nil)
                  .includes(avatar_attachment: :blob)
         add_filter_keys(args[:filter])
         add_order_keys(args[:order].to_h)

--- a/decidim-core/lib/decidim/api/functions/user_entity_list.rb
+++ b/decidim-core/lib/decidim/api/functions/user_entity_list.rb
@@ -19,8 +19,8 @@ module Decidim
       def call(_obj, args, ctx)
         @query = Decidim::UserBaseEntity
                  .where(organization: ctx[:current_organization])
-                 .where.not(confirmed_at: nil)
-                 .where(blocked_at: nil)
+                 .confirmed
+                 .not_blocked
                  .includes(avatar_attachment: :blob)
         add_filter_keys(args[:filter])
         add_order_keys(args[:order].to_h)

--- a/decidim-core/spec/types/user_entity_input_filter_spec.rb
+++ b/decidim-core/spec/types/user_entity_input_filter_spec.rb
@@ -22,6 +22,15 @@ module Decidim
           expect(users).to include({ "id" => user.id.to_s, "__typename" => "User" },
                                    "id" => user_group.id.to_s, "__typename" => "UserGroup")
         end
+
+        context "when user is blocked" do
+          let(:user) { create(:user, :blocked, :confirmed, organization: current_organization) }
+
+          it "doesn't returns all the types" do
+            users = response["users"]
+            expect(users).to include("id" => user_group.id.to_s, "__typename" => "UserGroup")
+          end
+        end
       end
 
       context "when user or groups are not confirmed" do
@@ -42,6 +51,15 @@ module Decidim
           users = response["users"]
           expect(users).to include("id" => user.id.to_s)
           expect(users).not_to include("id" => user_group.id.to_s)
+        end
+
+        context "when user is blocked" do
+          let(:user) { create(:user, :blocked, :confirmed, organization: current_organization) }
+
+          it "doesn't returns all the types" do
+            users = response["users"]
+            expect(users).to eq([])
+          end
         end
       end
 
@@ -86,6 +104,14 @@ module Decidim
             expect(response["users"]).to include("name" => user5.name)
             expect(response["users"]).to include("name" => user6.name)
           end
+
+          context "when user is blocked" do
+            let!(:user1) { create(:user, :blocked, :confirmed, nickname: "_foo_user_1", name: "FooBar User 1", organization: current_organization) }
+
+            it "doesn't returns matching users" do
+              expect(response["users"]).not_to include("name" => user1.name)
+            end
+          end
         end
 
         context "when search a user by name" do
@@ -100,6 +126,14 @@ module Decidim
             expect(response["users"]).to include("name" => user5.name)
             expect(response["users"]).to include("name" => user6.name)
           end
+
+          context "when user is blocked" do
+            let!(:user1) { create(:user, :blocked, :confirmed, nickname: "_foo_user_1", name: "FooBar User 1", organization: current_organization) }
+
+            it "doesn't returns matching users" do
+              expect(response["users"]).not_to include("name" => user1.name)
+            end
+          end
         end
 
         context "when search a user by wildcard" do
@@ -113,6 +147,14 @@ module Decidim
             expect(response["users"]).not_to include("name" => user4.name)
             expect(response["users"]).to include("name" => user5.name)
             expect(response["users"]).to include("name" => user6.name)
+          end
+
+          context "when user is blocked" do
+            let!(:user1) { create(:user, :blocked, :confirmed, nickname: "_foo_user_1", name: "FooBar User 1", organization: current_organization) }
+
+            it "doesn't returns matching users" do
+              expect(response["users"]).not_to include("name" => user1.name)
+            end
           end
         end
 
@@ -129,6 +171,14 @@ module Decidim
             expect(response["users"]).to include("name" => user5.name)
             expect(response["users"]).to include("name" => user6.name)
           end
+
+          context "when user is blocked" do
+            let!(:user1) { create(:user, :blocked, :confirmed, nickname: "_foo_user_1", name: "FooBar User 1", organization: current_organization) }
+
+            it "doesn't returns matching users" do
+              expect(response["users"]).not_to include("name" => user1.name)
+            end
+          end
         end
 
         context "when search a user by wildcard but with exclusion list" do
@@ -144,6 +194,14 @@ module Decidim
             expect(response["users"]).not_to include("name" => user5.name)
             expect(response["users"]).to include("name" => user6.name)
           end
+
+          context "when user is blocked" do
+            let!(:user1) { create(:user, :blocked, :confirmed, nickname: "_foo_user_1", name: "FooBar User 1", organization: current_organization) }
+
+            it "doesn't returns matching users" do
+              expect(response["users"]).not_to include("name" => user1.name)
+            end
+          end
         end
 
         context "when search a user by wildcard but with multiple exclusion list" do
@@ -158,6 +216,14 @@ module Decidim
             expect(response["users"]).not_to include("name" => user4.name)
             expect(response["users"]).not_to include("name" => user5.name)
             expect(response["users"]).not_to include("name" => user6.name)
+          end
+
+          context "when user is blocked" do
+            let!(:user1) { create(:user, :blocked, :confirmed, nickname: "_foo_user_1", name: "FooBar User 1", organization: current_organization) }
+
+            it "doesn't returns matching users" do
+              expect(response["users"]).not_to include("name" => user1.name)
+            end
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
When mentioning blocked users in a comment, blocked users result appear, this PR fixes this.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #8662

#### Testing

1. Block a user
2. Type in the user's nickname in a comment text area
3. See results

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
Before:
<img width="1221" alt="Capture d’écran 2022-01-05 à 23 02 29" src="https://user-images.githubusercontent.com/20232956/148296248-3b162deb-115b-4270-88f2-2948084f6f98.png">
After:
<img width="900" alt="Capture d’écran 2022-01-05 à 23 05 09" src="https://user-images.githubusercontent.com/20232956/148296252-61e09f74-57de-46fc-8fe9-300d612c6a46.png">

:hearts: Thank you!
