### PR TITLE
Revert the i18n-tasks initialization syntax

### DIFF
--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -7,7 +7,7 @@ describe "I18n sanity" do
     ENV["ENFORCED_LOCALES"].presence || "en"
   end
 
-  let(:i18n) { I18n::Tasks::BaseTask.new({ locales: locales.split(",") }, config_file: nil) }
+  let(:i18n) { I18n::Tasks::BaseTask.new(locales: locales.split(",")) }
   let(:missing_keys) { i18n.missing_keys }
   let(:unused_keys) { i18n.unused_keys }
   let(:non_normalized_paths) { i18n.non_normalized_paths }
@@ -16,7 +16,7 @@ describe "I18n sanity" do
   it "correct Norwegian locale keys should be surrounded by quotation marks" do
     # otherwise psych evaluates `no:` to `false`
     # see https://makandracards.com/makandra/24809-yaml-keys-like-yes-or-no-evaluate-to-true-and-false
-    i18n = I18n::Tasks::BaseTask.new({ locales: "no" }, config_file: nil)
+    i18n = I18n::Tasks::BaseTask.new(locales: "no")
     forest = i18n.data_forest(["no"])
     stats = i18n.forest_stats(forest)
     expect(stats[:locales]).to eq("no")


### PR DESCRIPTION
#### :tophat: What? Why?

While releasing v0.25.2, we've updated i18n-tasks, and it changed the initialization syntax. 

On #8544, @alecslupu updated the syntax, and @microstudi [mentioned](
https://github.com/decidim/decidim/pull/8544#issuecomment-992469688): 

> BTW, I've filed an issue related to this in https://github.com/glebm/i18n-tasks/issues/401 as mixing optional and keywords arguments doesn't seem the best approach to me

That PR got accepted, the gem released, so while [bumping to v0.27.0.dev](3d53e430be86f5f12c6790cd1caec339f94de3fb), I've upgraded i18n-tasks, and we got the old syntax back. This PR updates this initialization syntax to the old one. 

#### :pushpin: Related Issues

- Related to #8544
 
#### Testing

"`[CI] Main folder`" specs should be green

:hearts: Thank you!
