### PR TITLE
Backport "Lock graphql version to 1.12 minor" to v0.26

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ PATH
       devise-i18n (~> 1.2)
       devise_invitable (~> 2.0)
     decidim-api (0.26.0.rc1)
-      graphql (~> 1.12, >= 1.12.3)
+      graphql (~> 1.12, < 1.13)
       rack-cors (~> 1.0)
       redcarpet (~> 3.5, >= 3.5.1)
     decidim-assemblies (0.26.0.rc1)
@@ -452,7 +452,7 @@ GEM
       faraday (>= 1.0)
       faraday_middleware
       graphql-client
-    graphql (1.13.4)
+    graphql (1.12.23)
     graphql-client (0.17.0)
       activesupport (>= 3.0)
       graphql (~> 1.10)

--- a/decidim-api/decidim-api.gemspec
+++ b/decidim-api/decidim-api.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib,vendor,docs}/**/*", "Rakefile", "README.md"]
 
-  s.add_dependency "graphql", "~> 1.12", ">= 1.12.3"
+  s.add_dependency "graphql", "~> 1.12", "< 1.13"
   s.add_dependency "rack-cors", "~> 1.0"
   s.add_dependency "redcarpet", "~> 3.5", ">= 3.5.1"
 

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -32,7 +32,7 @@ PATH
       devise-i18n (~> 1.2)
       devise_invitable (~> 2.0)
     decidim-api (0.26.0.rc1)
-      graphql (~> 1.12, >= 1.12.3)
+      graphql (~> 1.12, < 1.13)
       rack-cors (~> 1.0)
       redcarpet (~> 3.5, >= 3.5.1)
     decidim-assemblies (0.26.0.rc1)
@@ -447,7 +447,7 @@ GEM
       faraday (>= 1.0)
       faraday_middleware
       graphql-client
-    graphql (1.13.4)
+    graphql (1.12.23)
     graphql-client (0.17.0)
       activesupport (>= 3.0)
       graphql (~> 1.10)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -42,7 +42,7 @@ PATH
       devise-i18n (~> 1.2)
       devise_invitable (~> 2.0)
     decidim-api (0.26.0.rc1)
-      graphql (~> 1.12, >= 1.12.3)
+      graphql (~> 1.12, < 1.13)
       rack-cors (~> 1.0)
       redcarpet (~> 3.5, >= 3.5.1)
     decidim-assemblies (0.26.0.rc1)
@@ -452,7 +452,7 @@ GEM
       faraday (>= 1.0)
       faraday_middleware
       graphql-client
-    graphql (1.13.4)
+    graphql (1.12.23)
     graphql-client (0.17.0)
       activesupport (>= 3.0)
       graphql (~> 1.10)


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #8694 to v0.26

:hearts: Thank you!
