### PR TITLE
Add 'Internal' section in changelog generator

### DIFF
--- a/bin/changelog_generator
+++ b/bin/changelog_generator
@@ -120,7 +120,7 @@ types = {
   "Internal" => {
     label: "type: internal",
     skip_modules: false
-  },
+  }
 }
 
 types.each do |type_title, type_data|

--- a/bin/changelog_generator
+++ b/bin/changelog_generator
@@ -116,7 +116,11 @@ types = {
   "Developer improvements" => {
     label: "target: developer-experience",
     skip_modules: true
-  }
+  },
+  "Internal" => {
+    label: "type: internal",
+    skip_modules: false
+  },
 }
 
 types.each do |type_title, type_data|


### PR DESCRIPTION
#### :tophat: What? Why?

While preparing v0.26.0.rc1 and generating the changelog, I found that the `target: developer experience` tag didn't make much sense as it was used. For me, changelog primary target should be implementers (people that use Decidim) and it was mixed with thing like CI or gem updates that don't bring much value in a CHANGELOG file. 

For these kinds of PRs I've created a new kind of label: `type: internal`, so we can separate by it in the changelog. I'm not so sure if we should just skip it and not even show it in the final changelog, but for now I'm leaving it. 

For a better understanding: 

1. Before this change:  https://github.com/decidim/decidim/blob/release/0.25-stable/CHANGELOG.md#developer-improvements-5
2. After this change: https://github.com/decidim/decidim/blob/release/0.26-stable/CHANGELOG.md#developer-improvements

Also, this means that we keep separating from keepachangelog.com but for now I'm OK with separating the implementers/admin side of things in the changelog. 

:hearts: Thank you!
