### PR TITLE
Add 'request info' bot configuration

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,14 @@
+# Configuration for request-info - https://github.com/behaviorbot/request-info
+#
+requestInfoReplyComment: >
+  It seems like you didn't give us much information about what you're trying to do here.
+  We would appreciate it if you could provide us with more info about this issue/PR!
+
+checkIssueTemplate: true
+
+checkPullRequestTemplate: true
+
+requestInfoOn:
+  pullRequest: true
+  issue: true
+


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing apps and integrations that we have installed in GitHub, I found that we had the 'request info' bot, although we didn't have it configured, or we didn't see it as we always have at least the default templates for new issues and PRs. 

This PR adds this config. 

More settings at https://github.com/behaviorbot/request-info

:hearts: Thank you!
