### PR TITLE
Remove 'required field' explanation from conversation textearea

### DIFF
--- a/decidim-core/app/views/decidim/messaging/conversations/_start.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_start.html.erb
@@ -6,7 +6,6 @@
   </h2>
 
   <%= form_for form, url: decidim.conversations_path, remote: true do |f| %>
-    <%= form_required_explanation %>
 
     <% @form.recipient.each do |recipient| %>
       <%= f.hidden_field :recipient_id, id: nil, name: "conversation[recipient_id][]", value: recipient.id %>


### PR DESCRIPTION
#### :tophat: What? Why?

On a new conversation form we have a message that says that the fields marked with "*" are required, but we don't have any label to add this message.

This PR removes the message. 

#### :pushpin: Related Issues

- Fixes #7020

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/717367/148960090-86990205-fbf1-44e7-84be-6cdbfa4993b7.png)


:hearts: Thank you!
