### PR TITLE
Enable the RSpec/RepeatedExampleGroupDescription rubocop cop

### DIFF
--- a/.rubocop_ruby.yml
+++ b/.rubocop_ruby.yml
@@ -1269,10 +1269,11 @@ RSpec/NamedSubject:
   Enabled: false
 
 RSpec/RepeatedExampleGroupDescription:
-  Enabled: false
+  Enabled: true
 
 RSpec/RepeatedExampleGroupBody:
   Enabled: false
+
 RSpec/VerifiedDoubles:
   Enabled: false
 

--- a/decidim-admin/spec/helpers/aria_selected_link_to_helper_spec.rb
+++ b/decidim-admin/spec/helpers/aria_selected_link_to_helper_spec.rb
@@ -21,7 +21,7 @@ module Decidim
         end
       end
 
-      context "when it's ponting to the current path" do
+      context "when it's pointing to the current path" do
         before do
           expect(helper)
             .to receive(:is_active_link?)

--- a/decidim-admin/spec/helpers/aria_selected_link_to_helper_spec.rb
+++ b/decidim-admin/spec/helpers/aria_selected_link_to_helper_spec.rb
@@ -33,7 +33,7 @@ module Decidim
         end
       end
 
-      context "when it's ponting to the current path" do
+      context "when it isn't pointing to the current path" do
         before do
           expect(helper)
             .to receive(:is_active_link?)

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -524,7 +524,7 @@ describe Decidim::Assemblies::Permissions do
         it { is_expected.to eq(true) }
       end
 
-      context "when the assembly has one ancestor" do
+      context "when the assembly has one sucessor" do
         before do
           create :assembly_user_role, user: user, assembly: assembly.parent
         end

--- a/decidim-assemblies/spec/system/private_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/private_assemblies_spec.rb
@@ -67,7 +67,7 @@ describe "Private Assemblies", type: :system do
           visit decidim_assemblies.assemblies_path
         end
 
-        it "lists only the not private assembly" do
+        it "doesn't list the private assembly" do
           within "#parent-assemblies" do
             within "#parent-assemblies h3" do
               expect(page).to have_content("1")
@@ -88,10 +88,10 @@ describe "Private Assemblies", type: :system do
           visit decidim_assemblies.assemblies_path
         end
 
-        context "when the user is admin" do
+        context "when the user isn't admin" do
           let(:logged_in_user) { user }
 
-          it "lists only the not private assembly" do
+          it "doesn't list the private assembly" do
             within "#parent-assemblies" do
               within "#parent-assemblies h3" do
                 expect(page).to have_content("1")

--- a/decidim-assemblies/spec/system/private_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/private_assemblies_spec.rb
@@ -16,7 +16,7 @@ describe "Private Assemblies", type: :system do
     context "and the assembly is transparent" do
       let!(:private_assembly) { create :assembly, :published, organization: organization, private_space: true, is_transparent: true }
 
-      context "and no user is loged in" do
+      context "and no user is logged in" do
         before do
           switch_to_host(organization.host)
           visit decidim_assemblies.assemblies_path
@@ -36,7 +36,7 @@ describe "Private Assemblies", type: :system do
         end
       end
 
-      context "when user is loged in and is not a assembly private user" do
+      context "when user is logged in and is not an assembly private user" do
         before do
           switch_to_host(organization.host)
           login_as user, scope: :user
@@ -61,7 +61,7 @@ describe "Private Assemblies", type: :system do
     context "when the assembly is not transparent" do
       let!(:private_assembly) { create :assembly, :published, organization: organization, private_space: true, is_transparent: false }
 
-      context "and no user is loged in" do
+      context "and no user is logged in" do
         before do
           switch_to_host(organization.host)
           visit decidim_assemblies.assemblies_path
@@ -81,7 +81,7 @@ describe "Private Assemblies", type: :system do
         end
       end
 
-      context "when user is loged in and is not a assembly private user" do
+      context "when user is logged in and is not an assembly private user" do
         before do
           switch_to_host(organization.host)
           login_as logged_in_user, scope: :user
@@ -129,7 +129,7 @@ describe "Private Assemblies", type: :system do
         end
       end
 
-      context "when user is loged in and is assembly private user" do
+      context "when user is logged in and is an assembly private user" do
         before do
           switch_to_host(organization.host)
           login_as other_user, scope: :user

--- a/decidim-blogs/spec/types/integration_schema_spec.rb
+++ b/decidim-blogs/spec/types/integration_schema_spec.rb
@@ -219,12 +219,6 @@ describe "Decidim::Api::QueryType" do
 
           it { expect(edges).to eq([{ "node" => { "id" => other_post.id.to_s } }]) }
         end
-
-        context "with updatedBefore" do
-          let(:criteria) { "filter: { updatedBefore: \"#{post.created_at.to_date}\" } " }
-
-          it { expect(edges).to eq([{ "node" => { "id" => other_post.id.to_s } }]) }
-        end
       end
     end
   end

--- a/decidim-budgets/spec/permissions/decidim/budgets/admin/permissions_spec.rb
+++ b/decidim-budgets/spec/permissions/decidim/budgets/admin/permissions_spec.rb
@@ -18,7 +18,7 @@ describe Decidim::Budgets::Admin::Permissions do
   let(:project) { create :project, component: budgets_component }
   let(:permission_action) { Decidim::PermissionAction.new(action) }
 
-  context "when scope is not admin" do
+  context "when scope and action are both random" do
     let(:action) do
       { scope: :foo, action: :bar, subject: :budget }
     end

--- a/decidim-core/spec/presenters/decidim/log/value_types/area_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/log/value_types/area_presenter_spec.rb
@@ -22,7 +22,7 @@ describe Decidim::Log::ValueTypes::AreaPresenter, type: :helper do
       end
     end
 
-    context "when the area is found" do
+    context "when the area isn't found" do
       let(:value) { area.id + 1 }
 
       it "shows a string explaining the problem" do

--- a/decidim-core/spec/presenters/decidim/log/value_types/scope_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/log/value_types/scope_presenter_spec.rb
@@ -22,7 +22,7 @@ describe Decidim::Log::ValueTypes::ScopePresenter, type: :helper do
       end
     end
 
-    context "when the scope is found" do
+    context "when the scope isn't found" do
       let(:value) { scope.id + 1 }
 
       it "shows a string explaining the problem" do

--- a/decidim-core/spec/presenters/decidim/nil_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/nil_presenter_spec.rb
@@ -71,14 +71,6 @@ module Decidim
       end
     end
 
-    describe "with metrics related methods" do
-      [:highlighted, :not_highlighted, :highlighted_metrics, :not_highlighted_metrics].each do |method|
-        let(:method) { method }
-
-        it { is_expected.to eq("") }
-      end
-    end
-
     describe "with hashtag related methods" do
       [:name, :hashtag_path, :display_hashtag, :display_hashtag_name].each do |method|
         let(:method) { method }

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -290,193 +290,43 @@ describe "Conversations", type: :system do
     end
   end
 
-  context "when multiple participants conversation" do
-    let(:user1) { create(:user, organization: organization) }
-    let(:user2) { create(:user_group, organization: organization) }
-    let(:user3) { create(:user, organization: organization) }
-    let(:user4) { create(:user, organization: organization) }
-    let(:user5) { create(:user, organization: organization) }
-    let(:user6) { create(:user, organization: organization) }
-    let(:user7) { create(:user, organization: organization) }
-    let(:user8) { create(:user, organization: organization) }
-    let(:user9) { create(:user, organization: organization) }
-    let(:user10) { create(:user, organization: organization) }
+  describe "when having a conversation with multiple participants" do
+    context "and it's with only one participant" do
+      let(:user1) { create(:user, organization: organization) }
+      let!(:conversation2) do
+        Decidim::Messaging::Conversation.start!(
+          originator: user,
+          interlocutors: [user1],
+          body: "Hi!"
+        )
+      end
 
-    describe "GET conversations" do
-      context "when 2 participants conversation" do
-        let!(:conversation2) do
-          Decidim::Messaging::Conversation.start!(
-            originator: user,
-            interlocutors: [user1],
-            body: "Hi!"
-          )
-        end
-
+      context "when starting the conversation" do
         before do
           visit decidim.new_conversation_path(recipient_id: user1.id)
         end
 
-        it "shows only 1 other participant name" do
+        it "shows only the other participant name" do
           within ".conversation-header .ml-s" do
             expect(page).to have_content(user1.name)
             expect(page).not_to have_content(user.name)
           end
         end
       end
-    end
 
-    describe "GET conversations" do
-      context "when 4 participants conversation" do
-        let!(:conversation4) do
-          Decidim::Messaging::Conversation.start!(
-            originator: user,
-            interlocutors: [user1, user2, user3],
-            body: "Hi all 4 people!"
-          )
-        end
-
-        before do
-          visit decidim.new_conversation_path(recipient_id: [
-                                                user1.id, user2.id, user3.id
-                                              ])
-        end
-
-        it "shows the other 3 participant name" do
-          within ".conversation-header .ml-s" do
-            expect(page).to have_content(user1.name)
-            expect(page).to have_content(user2.name)
-            expect(page).to have_content(user3.name)
-            expect(page).not_to have_content(user.name)
-          end
-        end
-      end
-    end
-
-    describe "GET conversations" do
-      context "when 10 participants conversation" do
-        let!(:conversation10) do
-          Decidim::Messaging::Conversation.start!(
-            originator: user,
-            interlocutors: [user1, user2, user3, user4, user5, user6, user7, user8, user9],
-            body: "Hi all 10 people!"
-          )
-        end
-
-        before do
-          visit decidim.new_conversation_path(recipient_id: [
-                                                user1.id, user2.id, user3.id,
-                                                user4.id, user5.id, user6.id,
-                                                user7.id, user8.id, user9.id
-                                              ])
-        end
-
-        it_behaves_like "accessible page"
-
-        it "shows the other 9 participant name" do
-          within ".conversation-header .ml-s" do
-            expect(page).to have_content(user1.name)
-            expect(page).to have_content(user2.name)
-            expect(page).to have_content(user3.name)
-            expect(page).to have_content(user4.name)
-            expect(page).to have_content(user5.name)
-            expect(page).to have_content(user6.name)
-            expect(page).to have_content(user7.name)
-            expect(page).to have_content(user8.name)
-            expect(page).to have_content(user9.name)
-            expect(page).not_to have_content(user.name)
-          end
-        end
-      end
-    end
-
-    describe "GET existent conversation" do
-      context "when 2 participants conversation" do
-        let!(:conversation2) do
-          Decidim::Messaging::Conversation.start!(
-            originator: user,
-            interlocutors: [user1],
-            body: "Hi!"
-          )
-        end
-
+      context "when going to the conversation" do
         before do
           visit decidim.conversation_path(id: conversation2.id)
         end
 
-        it "shows only 1 other participant name" do
+        it "shows only the other participant name" do
           within ".conversation-header .ml-s" do
             expect(page).to have_content(user1.name)
           end
         end
       end
-    end
 
-    describe "GET existent conversation" do
-      context "when 4 participants conversation" do
-        let!(:conversation4) do
-          Decidim::Messaging::Conversation.start!(
-            originator: user,
-            interlocutors: [user1, user2, user3],
-            body: "Hi all 4 people!"
-          )
-        end
-
-        before do
-          visit decidim.conversation_path(id: conversation4.id)
-        end
-
-        it "shows the other 3 participant name" do
-          within ".conversation-header .ml-s" do
-            expect(page).to have_content(user1.name)
-            expect(page).to have_content(user2.name)
-            expect(page).to have_content(user3.name)
-            expect(page).not_to have_content(user.name)
-          end
-        end
-      end
-    end
-
-    describe "GET existent conversation" do
-      context "when 10 participants conversation" do
-        let!(:conversation10) do
-          Decidim::Messaging::Conversation.start!(
-            originator: user,
-            interlocutors: [user1, user2, user3, user4, user5, user6, user7, user8, user9],
-            body: "Hi all 10 people!"
-          )
-        end
-
-        before do
-          visit decidim.conversation_path(id: conversation10.id)
-        end
-
-        it "shows the other 9 participant name" do
-          within ".conversation-header .ml-s" do
-            expect(page).to have_content(user1.name)
-            expect(page).to have_content(user2.name)
-            expect(page).to have_content(user3.name)
-            expect(page).to have_content(user4.name)
-            expect(page).to have_content(user5.name)
-            expect(page).to have_content(user6.name)
-            expect(page).to have_content(user7.name)
-            expect(page).to have_content(user8.name)
-            expect(page).to have_content(user9.name)
-            expect(page).not_to have_content(user.name)
-          end
-        end
-      end
-    end
-
-    describe "GET conversations index" do
-      context "when 2 participants conversation" do
-        let!(:conversation2) do
-          Decidim::Messaging::Conversation.start!(
-            originator: user,
-            interlocutors: [user1],
-            body: "Hi!"
-          )
-        end
-
+      context "when listing the conversations" do
         before do
           visit decidim.conversations_path
         end
@@ -490,16 +340,51 @@ describe "Conversations", type: :system do
       end
     end
 
-    describe "GET conversations index" do
-      context "when 4 participants conversation" do
-        let!(:conversation4) do
-          Decidim::Messaging::Conversation.start!(
-            originator: user,
-            interlocutors: [user1, user2, user3],
-            body: "Hi all 4 people!"
-          )
+    context "and it's with four participants" do
+      let(:user1) { create(:user, organization: organization) }
+      let(:user2) { create(:user_group, organization: organization) }
+      let(:user3) { create(:user, organization: organization) }
+      let!(:conversation4) do
+        Decidim::Messaging::Conversation.start!(
+          originator: user,
+          interlocutors: [user1, user2, user3],
+          body: "Hi all 4 people!"
+        )
+      end
+
+      context "when starting the conversation" do
+        before do
+          visit decidim.new_conversation_path(recipient_id: [
+                                                user1.id, user2.id, user3.id
+                                              ])
         end
 
+        it "shows the other three participants names" do
+          within ".conversation-header .ml-s" do
+            expect(page).to have_content(user1.name)
+            expect(page).to have_content(user2.name)
+            expect(page).to have_content(user3.name)
+            expect(page).not_to have_content(user.name)
+          end
+        end
+      end
+
+      context "when going to the conversation" do
+        before do
+          visit decidim.conversation_path(id: conversation4.id)
+        end
+
+        it "shows the other three participants names" do
+          within ".conversation-header .ml-s" do
+            expect(page).to have_content(user1.name)
+            expect(page).to have_content(user2.name)
+            expect(page).to have_content(user3.name)
+            expect(page).not_to have_content(user.name)
+          end
+        end
+      end
+
+      context "when listing the conversations" do
         before do
           visit decidim.conversations_path
         end
@@ -515,16 +400,73 @@ describe "Conversations", type: :system do
       end
     end
 
-    describe "GET conversations index" do
-      context "when 10 participants conversation" do
-        let!(:conversation10) do
-          Decidim::Messaging::Conversation.start!(
-            originator: user,
-            interlocutors: [user1, user2, user3, user4, user5, user6, user7, user8, user9],
-            body: "Hi all 10 people!"
-          )
+    context "and it's with ten participants" do
+      let(:user1) { create(:user, organization: organization) }
+      let(:user2) { create(:user_group, organization: organization) }
+      let(:user3) { create(:user, organization: organization) }
+      let(:user4) { create(:user, organization: organization) }
+      let(:user5) { create(:user, organization: organization) }
+      let(:user6) { create(:user, organization: organization) }
+      let(:user7) { create(:user, organization: organization) }
+      let(:user8) { create(:user, organization: organization) }
+      let(:user9) { create(:user, organization: organization) }
+      let!(:conversation10) do
+        Decidim::Messaging::Conversation.start!(
+          originator: user,
+          interlocutors: [user1, user2, user3, user4, user5, user6, user7, user8, user9],
+          body: "Hi all 10 people!"
+        )
+      end
+
+      context "when starting the conversation" do
+        before do
+          visit decidim.new_conversation_path(recipient_id: [
+                                                user1.id, user2.id, user3.id,
+                                                user4.id, user5.id, user6.id,
+                                                user7.id, user8.id, user9.id
+                                              ])
         end
 
+        it_behaves_like "accessible page"
+
+        it "shows the other nine participants names" do
+          within ".conversation-header .ml-s" do
+            expect(page).to have_content(user1.name)
+            expect(page).to have_content(user2.name)
+            expect(page).to have_content(user3.name)
+            expect(page).to have_content(user4.name)
+            expect(page).to have_content(user5.name)
+            expect(page).to have_content(user6.name)
+            expect(page).to have_content(user7.name)
+            expect(page).to have_content(user8.name)
+            expect(page).to have_content(user9.name)
+            expect(page).not_to have_content(user.name)
+          end
+        end
+      end
+
+      context "when going to the conversation" do
+        before do
+          visit decidim.conversation_path(id: conversation10.id)
+        end
+
+        it "shows the other nine participants names" do
+          within ".conversation-header .ml-s" do
+            expect(page).to have_content(user1.name)
+            expect(page).to have_content(user2.name)
+            expect(page).to have_content(user3.name)
+            expect(page).to have_content(user4.name)
+            expect(page).to have_content(user5.name)
+            expect(page).to have_content(user6.name)
+            expect(page).to have_content(user7.name)
+            expect(page).to have_content(user8.name)
+            expect(page).to have_content(user9.name)
+            expect(page).not_to have_content(user.name)
+          end
+        end
+      end
+
+      context "when listing the conversations" do
         before do
           visit decidim.conversations_path
         end

--- a/decidim-core/spec/validators/passthru_validator_spec.rb
+++ b/decidim-core/spec/validators/passthru_validator_spec.rb
@@ -108,7 +108,7 @@ describe PassthruValidator do
         it { is_expected.to be_valid }
       end
 
-      context "when the if condition returns false" do
+      context "when the unless condition returns false" do
         let(:validator_settings) { { unless: -> { false } } }
 
         it { is_expected.to be_invalid }

--- a/decidim-elections/spec/jobs/decidim/votings/census/admin/create_datum_job_spec.rb
+++ b/decidim-elections/spec/jobs/decidim/votings/census/admin/create_datum_job_spec.rb
@@ -31,7 +31,7 @@ describe Decidim::Votings::Census::Admin::CreateDatumJob do
       end
     end
 
-    context "when the dataset is missing" do
+    context "when the user is missing" do
       let!(:user) { nil }
 
       it "does not create a datum" do

--- a/decidim-elections/spec/models/decidim/votings/ballot_style_spec.rb
+++ b/decidim-elections/spec/models/decidim/votings/ballot_style_spec.rb
@@ -25,7 +25,7 @@ describe Decidim::Votings::BallotStyle do
         end
       end
 
-      context "when the ballot style has questions from this election" do
+      context "when the ballot style has questions from another election" do
         let(:ballot_style) { create(:ballot_style) }
 
         it "returns the questions for the specified election" do
@@ -43,7 +43,7 @@ describe Decidim::Votings::BallotStyle do
         end
       end
 
-      context "when the ballot style has questions from this election" do
+      context "when the ballot style has questions from another election" do
         let(:ballot_style) { create(:ballot_style) }
 
         it "returns the questions for the specified election" do

--- a/decidim-forms/spec/models/decidim/forms/display_condition_spec.rb
+++ b/decidim-forms/spec/models/decidim/forms/display_condition_spec.rb
@@ -72,7 +72,7 @@ module Decidim
         context "when condition_type is :answered" do
           let(:condition_type) { :answered }
 
-          context "and body is empty" do
+          context "and form is empty" do
             let(:answer_form) { nil }
 
             it "is not fulfilled" do
@@ -100,7 +100,7 @@ module Decidim
         context "when condition_type is :not_answered" do
           let(:condition_type) { :not_answered }
 
-          context "and body is empty" do
+          context "and form is empty" do
             let(:answer_form) { nil }
 
             it "is not fulfilled" do

--- a/decidim-initiatives/spec/system/admin/initiatives_type_scopes_controller_spec.rb
+++ b/decidim-initiatives/spec/system/admin/initiatives_type_scopes_controller_spec.rb
@@ -55,14 +55,6 @@ describe "InitiativeTypeScopesController", type: :system do
         expect(page).to have_content("The scope has been successfully updated")
       end
     end
-  end
-
-  context "when editing an initiative type scope" do
-    let!(:initiative_type_scope) { create :initiatives_type_scope, type: initiatives_type }
-
-    before do
-      visit decidim_admin_initiatives.edit_initiatives_type_path(initiatives_type)
-    end
 
     it "removes the initiative type scope" do
       click_link "Configure"

--- a/decidim-meetings/spec/system/admin/filter_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/filter_meetings_spec.rb
@@ -104,7 +104,7 @@ describe "Admin filters meetings", type: :system do
       end
     end
 
-    context "when filtering official " do
+    context "when filtering user groups " do
       context "when no citizen event is present" do
         it_behaves_like "a filtered collection", options: "Origin", filter: "User Groups" do
           let(:in_filter) { translated(user_group_meeting.title) }

--- a/decidim-meetings/spec/system/live_meeting_access_spec.rb
+++ b/decidim-meetings/spec/system/live_meeting_access_spec.rb
@@ -286,7 +286,7 @@ describe "Meeting live event access", type: :system do
     end
   end
 
-  context "when online meeting is not live and is not embedded" do
+  context "when online meeting is not live and it's embedded" do
     let(:meeting) { create :meeting, :published, :embed_in_meeting_page_iframe_embed_type, :online, :embeddable, component: component }
 
     it "doesn't show the meeting link embedded" do

--- a/decidim-participatory_processes/spec/system/private_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/private_participatory_processes_spec.rb
@@ -14,7 +14,7 @@ describe "Private Participatory Processes", type: :system do
   let!(:participatory_space_private_user_2) { create :participatory_space_private_user, user: other_user_2, privatable_to: private_participatory_process }
 
   context "when there are private participatory processes" do
-    context "and no user is loged in" do
+    context "and no user is logged in" do
       before do
         switch_to_host(organization.host)
         visit decidim_participatory_processes.participatory_processes_path
@@ -34,7 +34,7 @@ describe "Private Participatory Processes", type: :system do
       end
     end
 
-    context "when user is loged in and is not a participatory space private user" do
+    context "when user is logged in and is not a participatory space private user" do
       before do
         switch_to_host(organization.host)
         login_as user, scope: :user
@@ -75,7 +75,7 @@ describe "Private Participatory Processes", type: :system do
       end
     end
 
-    context "when user is loged in and is participatory space private user" do
+    context "when user is logged in and is participatory space private user" do
       before do
         switch_to_host(organization.host)
         login_as other_user, scope: :user

--- a/decidim-proposals/spec/queries/decidim/proposals/similar_proposals_spec.rb
+++ b/decidim-proposals/spec/queries/decidim/proposals/similar_proposals_spec.rb
@@ -31,7 +31,7 @@ describe Decidim::Proposals::SimilarProposals do
     end
   end
 
-  context "when machine_translations is disabled" do
+  context "when machine_translations is enabled" do
     let(:enabled) { true }
     let(:proposal_body) { { "en": "100% match for body" } }
     let(:proposal_title) { { "en": "100% match for title" } }

--- a/decidim-proposals/spec/system/admin/admin_manages_participatory_texts_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_manages_participatory_texts_spec.rb
@@ -156,19 +156,4 @@ describe "Admin manages participatory texts", type: :system do
       expect(translated(proposal.body).delete("\r")).to eq(new_body)
     end
   end
-
-  describe "updating participatory texts in draft mode" do
-    let!(:proposal) { create :proposal, :draft, component: current_component, participatory_text_level: "article" }
-    let!(:new_body) { Faker::Lorem.unique.sentences(number: 3).join("\n") }
-
-    it "persists changes and all proposals remain as drafts" do
-      visit_participatory_texts
-      validate_occurrences(sections: 0, subsections: 0, articles: 1)
-      edit_participatory_text_body(0, new_body)
-      save_participatory_text_drafts
-      validate_occurrences(sections: 0, subsections: 0, articles: 1)
-      proposal.reload
-      expect(translated(proposal.body).delete("\r")).to eq(new_body)
-    end
-  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

As #6499 says:

>PR #5785 disabled the RSpec/RepeatedExampleGroupDescription cop, but it is a good way to reduce duplicated code in rspec tests.

#### :pushpin: Related Issues
 
- Fixes #6499

#### Testing

##### Before (with the cop enabled)

```
Inspecting 6110 files
6110 files inspected, 47 offenses detected, 8 offenses auto-correctable
```

##### After (with the cop enabled)
```
Inspecting 6110 files
(...)
6110 files inspected, no offenses detected
```

:hearts: Thank you!
