### PR TITLE
Enable the RSpec/RepeatedExampleGroupBody rubocop cop

### DIFF
--- a/.rubocop_ruby.yml
+++ b/.rubocop_ruby.yml
@@ -1272,7 +1272,7 @@ RSpec/RepeatedExampleGroupDescription:
   Enabled: true
 
 RSpec/RepeatedExampleGroupBody:
-  Enabled: false
+  Enabled: true
 
 RSpec/VerifiedDoubles:
   Enabled: false

--- a/decidim-core/lib/decidim/core/test/shared_examples/resourceable.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/resourceable.rb
@@ -8,10 +8,4 @@ shared_examples_for "resourceable" do
       expect(subject.resource_title).to be_present
     end
   end
-
-  describe "resource_description" do
-    it "is defined" do
-      expect(subject.resource_title).to be_present
-    end
-  end
 end

--- a/decidim-forms/spec/models/decidim/forms/display_condition_spec.rb
+++ b/decidim-forms/spec/models/decidim/forms/display_condition_spec.rb
@@ -36,15 +36,15 @@ module Decidim
           :match,
           question: question,
           condition_question: condition_question,
-          condition_value: { en: "to Be", es: "o NO", ca: "sEr" }
+          condition_value: { en: "To be", es: "o no", ca: "ser" }
         )
       end
 
       let(:choice_body) do
         {
-          en: "to be or not to be",
-          ca: "Ser o no ser",
-          es: "Ser o no ser"
+          en: "To be or not to be, that is the question",
+          ca: "Ser o no ser, aquesta és la qüestió",
+          es: "Ser o no ser, he ahí el dilema"
         }
       end
       let(:answer_option) { create(:answer_option, question: condition_question, body: choice_body) }
@@ -138,7 +138,7 @@ module Decidim
           end
 
           context "and body contains the text in :en" do
-            let(:answer_body) { "To be or not to be" }
+            let(:answer_body) { "To be or not to be, that is the question" }
 
             it "is fulfilled" do
               expect(subject.fulfilled?(answer_form)).to be true
@@ -154,7 +154,7 @@ module Decidim
           end
 
           context "and body contains the text in :ca" do
-            let(:answer_body) { "Ser o no ser" }
+            let(:answer_body) { "Ser o no ser, aquesta és la qüestió" }
 
             it "is fulfilled" do
               expect(subject.fulfilled?(answer_form)).to be true
@@ -170,7 +170,7 @@ module Decidim
           end
 
           context "and body contains the text in :es" do
-            let(:answer_body) { "Ser o no ser" }
+            let(:answer_body) { "Ser o no ser, he ahí el dilema" }
 
             it "is fulfilled" do
               expect(subject.fulfilled?(answer_form)).to be true

--- a/decidim-verifications/spec/queries/decidim/verifications/authorizations_before_date_spec.rb
+++ b/decidim-verifications/spec/queries/decidim/verifications/authorizations_before_date_spec.rb
@@ -220,22 +220,4 @@ describe Decidim::Verifications::AuthorizationsBeforeDate do
       end
     end
   end
-
-  describe "when granted only, not impersonated" do
-    it_behaves_like "a correct usage of the query" do
-      let(:parameters) do
-        { organization: organization, date: prev_month, granted: true }
-      end
-
-      let(:expectation) do
-        [
-          granted_now,
-          granted_prev_week,
-          granted_prev_month,
-          granted_prev_year,
-          granted_managed
-        ]
-      end
-    end
-  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

While working with #8704, I thought that it was easy to implement its cop brother, `RSpec/RepeatedExampleGroupBody` 😄 

#### :pushpin: Related Issues

- Related to #8704

#### Testing

##### Before (with the cop enabled)
```
Inspecting 6112 files
6112 files inspected, 6 offenses detected
```

##### After (with the cop enabled)
```
Inspecting 6112 files
6112 files inspected, no offenses detected
```

:hearts: Thank you!
