### PR TITLE
Fix for preview unpublished meetings by admin user

### DIFF
--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -61,7 +61,7 @@ module Decidim
       scope :except_withdrawn, -> { where.not(state: "withdrawn").or(where(state: nil)) }
 
       scope :visible_meeting_for, lambda { |user|
-        (all.published.distinct if user&.admin?) ||
+        (all.distinct if user&.admin?) ||
           if user.present?
             spaces = Decidim.participatory_space_registry.manifests.map do |manifest|
               {

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -175,17 +175,43 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
     expect(page).to have_selector("input[value='This is the second service']")
   end
 
-  it "allows the user to preview the meeting" do
+  it "allows the user to preview a published meeting" do
+    meeting_path = resource_locator(meeting).path
+
     within find("tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title) do
       klass = "action-icon--preview"
-      href = resource_locator(meeting).path
-      target = "blank"
 
       expect(page).to have_selector(
         :xpath,
-        "//a[contains(@class,'#{klass}')][@href='#{href}'][@target='#{target}']"
+        "//a[contains(@class,'#{klass}')][@href='#{meeting_path}'][@target='blank']"
       )
     end
+
+    # Visit the meeting
+    page.visit meeting_path
+
+    expect(page).to have_current_path(meeting_path)
+  end
+
+  it "allows the user to preview an unpublished meeting" do
+    unpublished_meeting = create :meeting, scope: scope, services: [], component: current_component
+    visit current_path
+
+    meeting_path = resource_locator(unpublished_meeting).path
+
+    within find("tr", text: Decidim::Meetings::MeetingPresenter.new(unpublished_meeting).title) do
+      klass = "action-icon--preview"
+
+      expect(page).to have_selector(
+        :xpath,
+        "//a[contains(@class,'#{klass}')][@href='#{meeting_path}'][@target='blank']"
+      )
+    end
+
+    # Visit the unpublished meeting
+    page.visit meeting_path
+
+    expect(page).to have_current_path(meeting_path)
   end
 
   it "creates a new meeting", :slow, :serves_geocoding_autocomplete do # rubocop:disable RSpec/ExampleLength


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes an error when previewing an unpublished meeting by an admin. The method that controls the visibility of the admins was scoping the meetings to published meetings when the user was an admin.

#### :pushpin: Related Issues

- Fixes #8652 

#### Testing

As an admin:

1. Create a new meeting
2. Try to preview the unpublished meeting
3. You should be able to see the meeting


:hearts: Thank you!
