### PR TITLE
Fix some non-localized user emails

### DIFF
--- a/decidim-core/app/mailers/decidim/block_user_mailer.rb
+++ b/decidim-core/app/mailers/decidim/block_user_mailer.rb
@@ -5,17 +5,18 @@ module Decidim
   # when their account was blocked
   class BlockUserMailer < ApplicationMailer
     def notify(user, justification)
-      @user = user
-      @organization = user.organization
-      @justification = justification
-      mail(
-        to: user.email,
-        subject: I18n.t(
+      with_user(user) do
+        @user = user
+        @organization = user.organization
+        @justification = justification
+        subject = I18n.t(
           "decidim.block_user_mailer.notify.subject",
           organization_name: @organization.name,
           justification: @justification
         )
-      )
+
+        mail(to: user.email, subject: subject)
+      end
     end
   end
 end

--- a/decidim-core/app/mailers/decidim/newsletters_opt_in_mailer.rb
+++ b/decidim-core/app/mailers/decidim/newsletters_opt_in_mailer.rb
@@ -5,11 +5,13 @@ module Decidim
   # their own newsletter notifications settings. GDPR releated
   class NewslettersOptInMailer < ApplicationMailer
     def notify(user, token)
-      @user = user
-      @organization = user.organization
-      @token = token
+      with_user(user) do
+        @user = user
+        @organization = user.organization
+        @token = token
 
-      mail(to: user.email, subject: I18n.t("decidim.newsletters_opt_in_mailer.notify.subject", organization_name: @organization.name))
+        mail(to: user.email, subject: I18n.t("decidim.newsletters_opt_in_mailer.notify.subject", organization_name: @organization.name))
+      end
     end
   end
 end

--- a/decidim-core/app/mailers/decidim/user_report_mailer.rb
+++ b/decidim-core/app/mailers/decidim/user_report_mailer.rb
@@ -10,12 +10,14 @@ module Decidim
       @token = token
       @reason = reason
       @admin = admin
-      mail(to: admin.email, subject: I18n.t(
-        "decidim.user_report_mailer.notify.subject",
-        organization_name: @organization.name,
-        reason: @reason,
-        token: @token
-      ))
+      with_user(admin) do
+        mail(to: admin.email, subject: I18n.t(
+          "decidim.user_report_mailer.notify.subject",
+          organization_name: @organization.name,
+          reason: @reason,
+          token: @token
+        ))
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently there are some emails that are not being translated depending on the user preference. This PR fixes this issue.

#### Testing
Set the default organization locale to a language. Choose an user, set the locale in some other language. Trigger the events that are issuing those emails. You should receive them in user's (recipient's) language.


:hearts: Thank you!
