### PR TITLE
Add emojis when user edits a comment

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/edit_comment_modal_form/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/edit_comment_modal_form/show.erb
@@ -19,7 +19,7 @@
           required: true,
           placeholder: t("decidim.components.edit_comment_modal_form.form.body.placeholder"),
           label: false,
-          data: { remaining_characters: "##{form_id}-remaining-characters" }
+          data: { remaining_characters: "##{form_id}-remaining-characters", input_emoji: true }
         ) %>
       </div>
       <button type="submit" data-close class="button button--sc"><%= t("decidim.components.edit_comment_modal_form.form.submit") %></button>

--- a/decidim-core/app/packs/src/decidim/input_emoji.js
+++ b/decidim-core/app/packs/src/decidim/input_emoji.js
@@ -7,7 +7,8 @@ export default function addInputEmoji() {
   if (containers.length) {
     containers.forEach((elem) => {
       const picker = new EmojiButton({
-        position: "bottom-end"
+        position: "bottom-end",
+        zIndex: 9999
       });
 
       const wrapper = document.createElement("div");

--- a/decidim-core/app/packs/src/decidim/input_emoji.js
+++ b/decidim-core/app/packs/src/decidim/input_emoji.js
@@ -8,8 +8,16 @@ export default function addInputEmoji() {
     containers.forEach((elem) => {
       const picker = new EmojiButton({
         position: "bottom-end",
-        zIndex: 9999
+        rootElement: elem.parentElement,
+        zIndex: 2000
       });
+
+      // if the selector is inside a modal window
+      // this allows shows the emoji menu uncut
+      const reveal = elem.closest("[data-reveal]")
+      if (reveal) {
+        reveal.style.overflowY = "unset"
+      }
 
       const wrapper = document.createElement("div");
       wrapper.className = "emoji__container"

--- a/decidim-core/app/packs/src/decidim/input_emoji.js
+++ b/decidim-core/app/packs/src/decidim/input_emoji.js
@@ -8,7 +8,7 @@ export default function addInputEmoji() {
     containers.forEach((elem) => {
       const picker = new EmojiButton({
         position: "bottom-end",
-        rootElement: elem.parentElement,
+        rootElement: elem.closest("form")?.parentElement || document.body,
         zIndex: 2000
       });
 


### PR DESCRIPTION
#### :tophat: What? Why?
Allows use emojis when editing a comment, i.e. inside a modal container

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/8689

#### Testing
##### Acceptance criteria
- [ ] I should be able to add emojis when editing my comments.
##### Step by step
1. Click the contextual menu to edit any of your comments
2. In the modal window, at the bottom-right corner, click on the smiley button
3. Click on any emoji, it will append to the text you're writing

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![imagen](https://user-images.githubusercontent.com/817526/149947296-517ad16e-c601-4235-930d-97bca459d90a.png)

:hearts: Thank you!
