### PR TITLE
Add different authors in proposal seeds

### DIFF
--- a/decidim-blogs/app/commands/decidim/blogs/admin/create_post.rb
+++ b/decidim-blogs/app/commands/decidim/blogs/admin/create_post.rb
@@ -8,7 +8,7 @@ module Decidim
       class CreatePost < Rectify::Command
         def initialize(form, current_user)
           @form = form
-          @current_user = participatory_space.organization
+          @current_user = current_user
         end
 
         # Creates the post if valid.
@@ -28,11 +28,12 @@ module Decidim
         private
 
         def create_post!
-          attributes = {º
+          attributes = {
             title: @form.title,
             body: @form.body,
             component: @form.current_component,
-            author: @form.author.current_user
+            author: @form.author
+          }
 
           @post = Decidim.traceability.create!(
             Post,

--- a/decidim-blogs/app/commands/decidim/blogs/admin/create_post.rb
+++ b/decidim-blogs/app/commands/decidim/blogs/admin/create_post.rb
@@ -8,7 +8,7 @@ module Decidim
       class CreatePost < Rectify::Command
         def initialize(form, current_user)
           @form = form
-          @current_user = current_user
+          @current_user = participatory_space.organization
         end
 
         # Creates the post if valid.
@@ -28,12 +28,11 @@ module Decidim
         private
 
         def create_post!
-          attributes = {
+          attributes = {º
             title: @form.title,
             body: @form.body,
             component: @form.current_component,
-            author: @form.author
-          }
+            author: @form.author.current_user
 
           @post = Decidim.traceability.create!(
             Post,

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -265,7 +265,17 @@ Decidim.register_component(:proposals) do |component|
         visibility: "all"
       ) do
         proposal = Decidim::Proposals::Proposal.new(params)
-        proposal.add_coauthor(participatory_space.organization)
+        coauthor = case n
+                   when 0
+                     Decidim::User.where(decidim_organization_id: participatory_space.decidim_organization_id).all.sample
+                   when 1
+                     Decidim::UserGroup.where(decidim_organization_id: participatory_space.decidim_organization_id).all.sample
+                   # when 2
+                   # Decidim::Meetings::Meeting.where(decidim_organization_id: participatory_space.decidim_organization_id).all.sample
+                   else
+                     participatory_space.organization
+        end
+        proposal.add_coauthor(coauthor)
         proposal.save!
         proposal
       end

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -282,13 +282,6 @@ Decidim.register_component(:proposals) do |component|
         proposal
       end
 
-      if n.positive?
-        Decidim::User.where(decidim_organization_id: participatory_space.decidim_organization_id).all.sample(n).each do |author|
-          user_group = [true, false].sample ? Decidim::UserGroups::ManageableUserGroups.for(author).verified.sample : nil
-          proposal.add_coauthor(author, user_group: user_group)
-        end
-      end
-
       if proposal.state.nil?
         email = "amendment-author-#{participatory_space.underscored_name}-#{participatory_space.id}-#{n}-amend#{n}@example.org"
         name = "#{Faker::Name.name} #{participatory_space.id} #{n} amend#{n}"

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -276,9 +276,8 @@ Decidim.register_component(:proposals) do |component|
                      Decidim::UserGroup.where(decidim_organization_id: participatory_space.decidim_organization_id).order(Arel.sql("RANDOM()")).first
                    when 2
                      Decidim::Meetings::Meeting.where(component: component).order(Arel.sql("RANDOM()")).first
-                   else
                      participatory_space.organization
-        end
+                   end
         proposal.add_coauthor(coauthor)
         proposal.save!
         proposal

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -271,7 +271,6 @@ Decidim.register_component(:proposals) do |component|
         coauthor = case n
                    when 0
                      Decidim::User.where(decidim_organization_id: participatory_space.decidim_organization_id).order(Arel.sql("RANDOM()")).first
-
                    when 1
                      Decidim::UserGroup.where(decidim_organization_id: participatory_space.decidim_organization_id).order(Arel.sql("RANDOM()")).first
                    when 2

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -267,15 +267,15 @@ Decidim.register_component(:proposals) do |component|
         proposal = Decidim::Proposals::Proposal.new(params)
 
         proposal.add_coauthor(participatory_space.organization)
-        
+
         coauthor = case n
                    when 0
-                    Decidim::User.where(decidim_organization_id: participatory_space.decidim_organization_id).order(Arel.sql('RANDOM()')).first
+                     Decidim::User.where(decidim_organization_id: participatory_space.decidim_organization_id).order(Arel.sql("RANDOM()")).first
 
                    when 1
-                    Decidim::UserGroup.where(decidim_organization_id: participatory_space.decidim_organization_id).order(Arel.sql('RANDOM()')).first
+                     Decidim::UserGroup.where(decidim_organization_id: participatory_space.decidim_organization_id).order(Arel.sql("RANDOM()")).first
                    when 2
-                    Decidim::Meetings::Meeting.where(component: component).order(Arel.sql('RANDOM()')).first
+                     Decidim::Meetings::Meeting.where(component: component).order(Arel.sql("RANDOM()")).first
                    else
                      participatory_space.organization
         end

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -276,6 +276,7 @@ Decidim.register_component(:proposals) do |component|
                      Decidim::UserGroup.where(decidim_organization_id: participatory_space.decidim_organization_id).order(Arel.sql("RANDOM()")).first
                    when 2
                      Decidim::Meetings::Meeting.where(component: component).order(Arel.sql("RANDOM()")).first
+                   else
                      participatory_space.organization
                    end
         proposal.add_coauthor(coauthor)

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -266,8 +266,6 @@ Decidim.register_component(:proposals) do |component|
       ) do
         proposal = Decidim::Proposals::Proposal.new(params)
 
-        proposal.add_coauthor(participatory_space.organization)
-
         coauthor = case n
                    when 0
                      Decidim::User.where(decidim_organization_id: participatory_space.decidim_organization_id).order(Arel.sql("RANDOM()")).first

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -265,13 +265,17 @@ Decidim.register_component(:proposals) do |component|
         visibility: "all"
       ) do
         proposal = Decidim::Proposals::Proposal.new(params)
+
+        proposal.add_coauthor(participatory_space.organization)
+        
         coauthor = case n
                    when 0
-                     Decidim::User.where(decidim_organization_id: participatory_space.decidim_organization_id).all.sample
+                    Decidim::User.where(decidim_organization_id: participatory_space.decidim_organization_id).order(Arel.sql('RANDOM()')).first
+
                    when 1
-                     Decidim::UserGroup.where(decidim_organization_id: participatory_space.decidim_organization_id).all.sample
-                   # when 2
-                   # Decidim::Meetings::Meeting.where(decidim_organization_id: participatory_space.decidim_organization_id).all.sample
+                    Decidim::UserGroup.where(decidim_organization_id: participatory_space.decidim_organization_id).order(Arel.sql('RANDOM()')).first
+                   when 2
+                    Decidim::Meetings::Meeting.where(component: component).order(Arel.sql('RANDOM()')).first
                    else
                      participatory_space.organization
         end

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -265,6 +265,8 @@ Decidim.register_component(:proposals) do |component|
         visibility: "all"
       ) do
         proposal = Decidim::Proposals::Proposal.new(params)
+        
+        meeting_component = participatory_space.components.find_by(manifest_name: "meetings")
 
         coauthor = case n
                    when 0
@@ -272,7 +274,7 @@ Decidim.register_component(:proposals) do |component|
                    when 1
                      Decidim::UserGroup.where(decidim_organization_id: participatory_space.decidim_organization_id).order(Arel.sql("RANDOM()")).first
                    when 2
-                     Decidim::Meetings::Meeting.where(component: component).order(Arel.sql("RANDOM()")).first
+                     Decidim::Meetings::Meeting.where(component: meeting_component).order(Arel.sql("RANDOM()")).first
                    else
                      participatory_space.organization
                    end

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -265,7 +265,6 @@ Decidim.register_component(:proposals) do |component|
         visibility: "all"
       ) do
         proposal = Decidim::Proposals::Proposal.new(params)
-        
         meeting_component = participatory_space.components.find_by(manifest_name: "meetings")
 
         coauthor = case n


### PR DESCRIPTION
#### :tophat: What? Why?
The seed data include proposals with different origins (Meetings, Groups and Participants) instead of only proposals with official origin.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/7247

#### Testing
1. Reseed the application (bin/rails db:drop db:create db:migrate && bin/rails db:seed) or re-create it if reseeding throws errors (bin/rake development_app).
2. Go to a proposal index in a participatory process.
3. See that there are proposals created by organizations, participants, groups and meetings. 

:hearts: Thank you!
