### PR TITLE
Change scope picker button to disabled when necessary

### DIFF
--- a/decidim-core/app/views/decidim/scopes/picker.html.erb
+++ b/decidim-core/app/views/decidim/scopes/picker.html.erb
@@ -41,7 +41,7 @@
       <% if current || !required %>
         <a class="button" role="button" href="<%= scopes_picker_path(current: current&.id, **context) %>" aria-controls="<%= picker_target_id %>" data-picker-value="<%= current&.id || global_value %>" data-picker-text="<%= scope_name_for_picker(current, t("decidim.scopes.global")) %>" data-picker-choose>
       <% else %>
-        <a class="button muted">
+        <a class="button" disabled="true">
       <% end %>
           <%= t("decidim.scopes.picker.choose") %>
         </a>

--- a/decidim-core/spec/system/scopes_spec.rb
+++ b/decidim-core/spec/system/scopes_spec.rb
@@ -26,7 +26,7 @@ describe "Scopes picker", type: :system do
       let(:params) { { title: title, required: true } }
 
       it "does not allow to choose current scope (none)" do
-        expect(page).to have_css(".scope-picker.picker-footer .buttons a.button.muted")
+        expect(page).to have_selector(".scope-picker.picker-footer .buttons a.button[disabled='true']")
       end
 
       it "shows organization top scopes in content" do
@@ -44,8 +44,8 @@ describe "Scopes picker", type: :system do
       context "when has a current scope" do
         let(:params) { { title: title, required: true, current: scopes.first } }
 
-        it "does not allow to choose it" do
-          expect(page).to have_no_css(".scope-picker.picker-footer .buttons a.button.muted")
+        it "allows to choose it" do
+          expect(page).to have_no_selector(".scope-picker.picker-footer .buttons a.button[disabled='true']")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the fix for #8260 and seeing the specs, I saw that the original intention of this button in the scope selector was to be disabled: one of the specs says `"does not allow to choose current scope (none)"`. 

This PR drops the `muted` class in the button as it was weird and changes it to disabled that shows the intention much better.

Finally, I found another spec that also said `"does not allow to choose it"` but the code didn't do that, so I fixed it. 

#### :pushpin: Related Issues

- Fixes #8260 

#### Testing

1. Go to scope picker in processes
or
1. As admin, go to the admin panel, processes list, edit one, enable scopes, open scopes picker

### :camera: Screenshots

#### Before
![image](https://user-images.githubusercontent.com/717367/149950483-f69256bb-ef39-4222-aaa6-16b261638cf1.png)
![image](https://user-images.githubusercontent.com/717367/149950496-a61d7bb4-90b3-4d9f-87b0-23f71c434ca7.png)


#### After
![image](https://user-images.githubusercontent.com/717367/149950504-4aaeef0f-11fb-4e1c-a205-3758396f3703.png)
![image](https://user-images.githubusercontent.com/717367/149950518-924357c3-9c24-4beb-be6f-842e413dc7d5.png)



:hearts: Thank you!
