### PR TITLE
Fix order by weight in processes groups' processes content block

### DIFF
--- a/decidim-participatory_processes/app/queries/decidim/participatory_processes/group_participatory_processes.rb
+++ b/decidim-participatory_processes/app/queries/decidim/participatory_processes/group_participatory_processes.rb
@@ -9,7 +9,7 @@ module Decidim
       end
 
       def query
-        Decidim::ParticipatoryProcess.where(participatory_process_group: @group)
+        Decidim::ParticipatoryProcess.where(participatory_process_group: @group).order(weight: :asc)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Given that there are two or more processes in a process group,
and they have weights,
when I go to the process group page
and there's the processes content block
then I should see the processes ordered by weight. 

#### :pushpin: Related Issues
 
- Fixes #8077

#### Testing

1.   Go to a process group with 2 processes
2.    Order them with their weight field
3.    See them ordered as expected 


### :camera: Screenshots

#### Before

![image](https://user-images.githubusercontent.com/717367/149956310-6ebf5e98-d5de-4b75-99bb-6409cd657a99.png)


#### After
![image](https://user-images.githubusercontent.com/717367/149956300-74e745f5-4a7a-4d60-8166-2eacfb00003f.png)


:hearts: Thank you!
