### PR TITLE
Fix reporting a proposal when author is a meeting

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
@@ -14,13 +14,14 @@ module Decidim
           reportable_authors = reportable.try(:authors) || [reportable.try(:normalized_author)]
           content_tag :ul, class: "reportable-authors" do
             reportable_authors.select(&:present?).map do |author|
-              if author.is_a? User
+              case author
+              when User
                 content_tag :li do
                   link_to current_or_new_conversation_path_with(author), target: "_blank", rel: "noopener" do
                     "#{author.name} #{icon "envelope-closed"}".html_safe
                   end
                 end
-              elsif author.is_a? Decidim::Meetings::Meeting
+              when Decidim::Meetings::Meeting
                 content_tag :li do
                   link_to resource_locator(author).path, target: "_blank", rel: "noopener" do
                     translated_attribute(author.title)

--- a/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/moderations/reports_helper.rb
@@ -6,6 +6,8 @@ module Decidim
       # This module includes helpers to show moderation reports in admin
       module ReportsHelper
         include Decidim::Messaging::ConversationHelper
+        include Decidim::ResourceHelper
+        include Decidim::TranslationsHelper
 
         # Public: Returns the reportable's author names separated by commas.
         def reportable_author_name(reportable)
@@ -16,6 +18,12 @@ module Decidim
                 content_tag :li do
                   link_to current_or_new_conversation_path_with(author), target: "_blank", rel: "noopener" do
                     "#{author.name} #{icon "envelope-closed"}".html_safe
+                  end
+                end
+              elsif author.is_a? Decidim::Meetings::Meeting
+                content_tag :li do
+                  link_to resource_locator(author).path, target: "_blank", rel: "noopener" do
+                    translated_attribute(author.title)
                   end
                 end
               else

--- a/decidim-admin/spec/helpers/moderations/reports_helper_spec.rb
+++ b/decidim-admin/spec/helpers/moderations/reports_helper_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/proposals/test/factories"
+
+module Decidim
+  module Admin
+    module Moderations
+      describe ReportsHelper do
+        subject do
+          Nokogiri::HTML(
+            helper.reportable_author_name(reportable)
+          )
+        end
+
+        before do
+          allow(helper).to receive(:current_or_new_conversation_path_with).and_return("/conversations/1")
+        end
+
+        context "with different reportable authors types" do
+          describe "when it's a dummy resource author " do
+            let(:reportable) { create(:dummy_resource, title: { "en" => "<p>Dummy<br> Title</p>" }) }
+
+            it "returns the author's name" do
+              expect(helper.reportable_author_name(reportable)).to include("reportable-authors")
+              expect(helper.reportable_author_name(reportable)).to include(reportable.author.name)
+            end
+          end
+
+          describe "when it's a user author" do
+            let!(:proposal) { create(:proposal) }
+            let(:reportable) { proposal }
+
+            it "returns the user's name" do
+              expect(helper.reportable_author_name(reportable)).to include("reportable-authors")
+              expect(helper.reportable_author_name(reportable)).to include(reportable.authors.first.name)
+            end
+          end
+
+          describe "when it's a meeting author" do
+            let!(:proposal) { create(:proposal, :official_meeting) }
+            let(:reportable) { proposal }
+
+            it "returns the meeting's title" do
+              expect(helper.reportable_author_name(reportable)).to include("reportable-authors")
+              expect(helper.reportable_author_name(reportable)).to include(translated_attribute(reportable.authors.first.title))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -235,8 +235,9 @@ module Decidim
       end
 
       # Public: Overrides the `reported_searchable_content_extras` Reportable concern method.
+      # Returns authors name or title in case it's a meeting
       def reported_searchable_content_extras
-        [authors.map(&:name).join("\n")]
+        [authors.map { |p| p.respond_to?(:name) ? p.name : p.title }.join("\n")]
       end
 
       # Public: Whether the proposal is official or not.

--- a/decidim-proposals/spec/system/report_proposal_spec.rb
+++ b/decidim-proposals/spec/system/report_proposal_spec.rb
@@ -17,5 +17,33 @@ describe "Report Proposal", type: :system do
            participatory_space: participatory_process)
   end
 
+  context "when the author is a meeting" do
+    let!(:proposal) { create(:proposal, :official_meeting, component: component) }
+    let(:reportable) { proposal }
+    let(:reportable_path) { resource_locator(reportable).path }
+
+    before do
+      login_as user, scope: :user
+    end
+
+    it "reports the resource" do
+      visit reportable_path
+
+      expect(page).to have_selector(".author-data__extra")
+
+      within ".author-data__extra", match: :first do
+        page.find("button").click
+      end
+
+      expect(page).to have_css(".flag-modal", visible: :visible)
+
+      within ".flag-modal" do
+        click_button "Report"
+      end
+
+      expect(page).to have_content "report has been created"
+    end
+  end
+
   include_examples "reports"
 end


### PR DESCRIPTION
#### :tophat: What? Why?

When reporting a proposal which author is a meeting, it gives an exception.

While reviewing it, I found out that this also breaks when going to the reports in "Global moderations".

This PR fixes both of these bugs. 

#### :pushpin: Related Issues
 
- Fixes #8568

#### Testing

1. Create a process with a proposals component and a meetings component
2. Create a meeting in the meetings component
3. Create a proposal that comes from the meeting you created
4. View the proposal and report it as inappropriate by clicking the flag icon
5. Select an option and click "Report"
6. See that the report is saved

And then also...

1. Log in as admin
2. Go to "Global moderations"
3. Click in "Expand" button of this report
4. See that it works 

:hearts: Thank you!
