### PR TITLE
Fix flaky test in UpdateAssemblyMember

### DIFF
--- a/decidim-assemblies/spec/commands/update_assembly_member_spec.rb
+++ b/decidim-assemblies/spec/commands/update_assembly_member_spec.rb
@@ -30,7 +30,7 @@ module Decidim::Assemblies
           ceased_date: nil,
           designation_date: Time.current,
           position: Decidim::AssemblyMember::POSITIONS.sample,
-          position_other: "",
+          position_other: Faker::Lorem.word,
           existing_user: existing_user,
           non_user_avatar: non_user_avatar,
           user_id: user&.id


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes flaky test in `UpdateAssemblyMember` spec.

The culprit is [here](https://github.com/decidim/decidim/blob/634c315a5b12b20ce16d086c14973e204889c15c/decidim-assemblies/spec/commands/update_assembly_member_spec.rb#L33), where we're using the sample method for the array of members' positions, and in the next line we're giving a position_other of an empty line, so when in some executions it gives the position of other, then the update command is invalid, as the position can't be blank. 


#### :pushpin: Related Issues
 
- Fixes #8627 
- As far as I see, this comes from the initial implementation of `AssemblyMembers` (#3008, almost 4 years ago)

#### Testing

As it's a flaky, you'll need to execute the rspec file multiple times to catch it

```bash
cd decidim-assemblies
for i in $(seq 1 20); do bundle exec rspec --bisect ./spec/commands/update_assembly_member_spec.rb ; done
``` 

:hearts: Thank you!
