### PR TITLE
Add a parameter to specify a list of allowed ips on /admin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -862,4 +862,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.2.19
+   2.2.29

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -862,4 +862,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.2.29
+   2.2.19

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -230,8 +230,13 @@ module Decidim
     end
   end
 
-  # Exposes a configuration option: the whitelist ips
+  # Exposes a configuration option: the :system accesslist ips
   config_accessor :system_accesslist_ips do
+    []
+  end
+
+  # Exposes a configuration option: the :system accesslist ips
+  config_accessor :admin_accesslist_ips do
     []
   end
 

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -230,12 +230,12 @@ module Decidim
     end
   end
 
-  # Exposes a configuration option: the :system accesslist ips
+  # Exposes a configuration option: the system accesslist ips
   config_accessor :system_accesslist_ips do
     []
   end
 
-  # Exposes a configuration option: the :system accesslist ips
+  # Exposes a configuration option: the admin accesslist ips
   config_accessor :admin_accesslist_ips do
     []
   end

--- a/decidim-core/spec/system/accesslist_spec.rb
+++ b/decidim-core/spec/system/accesslist_spec.rb
@@ -5,29 +5,15 @@ require "rack/attack"
 
 describe "Access list", type: :system do
   let!(:organization) { create(:organization) }
-  let!(:admin) { create(:admin) }
 
   before do
     switch_to_host(organization.host)
-    login_as admin, scope: :admin
+    login_as user, scope: scope
   end
 
-  it "allows access to participants side" do
-    visit decidim.root_path
-
-    expect(page).to have_content(organization.name)
-  end
-
-  it "allows access to admin side page" do
-    visit decidim_system.root_path
-
-    expect(page).to have_content("Dashboard")
-  end
-
-  context "when an access list has been specified" do
-    before do
-      allow(Decidim.config).to receive(:system_accesslist_ips).and_return(["127.0.0.1"])
-    end
+  context "when logged as admin" do
+    let!(:user) { create(:user, :admin, :confirmed, organization: organization) }
+    let(:scope) { :user }
 
     it "allows access to participants side" do
       visit decidim.root_path
@@ -35,11 +21,65 @@ describe "Access list", type: :system do
       expect(page).to have_content(organization.name)
     end
 
-    it "allows access to admin side page" do
+    it "allows access to admin side" do
+      visit decidim_admin.root_path
+
+      expect(page).to have_content("Dashboard")
+    end
+
+    context "when an access list to admin has been specified" do
+      before do
+        allow(Decidim.config).to receive(:admin_accesslist_ips).and_return(["127.0.0.1"])
+      end
+
+      it "allows access to participants side" do
+        visit decidim.root_path
+
+        expect(page).to have_content(organization.name)
+      end
+
+      it "allows access to admin side page" do
+        visit decidim_admin.root_path
+
+        expect(page).not_to have_content("Dashboard")
+        expect(page).to have_content("Forbidden")
+      end
+    end
+  end
+
+  context "when logged as system admin" do
+    let!(:user) { create(:admin) }
+    let(:scope) { :admin }
+
+    it "allows access to participants side" do
+      visit decidim.root_path
+
+      expect(page).to have_content(organization.name)
+    end
+
+    it "allows access to admin side" do
       visit decidim_system.root_path
 
-      expect(page).not_to have_content("Dashboard")
-      expect(page).to have_content("Forbidden")
+      expect(page).to have_content("Dashboard")
+    end
+
+    context "when an access list to system has been specified" do
+      before do
+        allow(Decidim.config).to receive(:system_accesslist_ips).and_return(["127.0.0.1"])
+      end
+
+      it "allows access to participants side" do
+        visit decidim.root_path
+
+        expect(page).to have_content(organization.name)
+      end
+
+      it "allows access to system side page" do
+        visit decidim_system.root_path
+
+        expect(page).not_to have_content("Dashboard")
+        expect(page).to have_content("Forbidden")
+      end
     end
   end
 end

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -19,10 +19,11 @@ Decidim.configure do |config|
   # this value for that specific organization.
   config.default_locale = :en
 
-  # Restrict access to the system part with an authorized ip list.
+  # Restrict access to the system or admin part with an authorized ip list.
   # You can use a single ip like ("1.2.3.4"), or an ip subnet like ("1.2.3.4/24")
   # You may specify multiple ip in an array ["1.2.3.4", "1.2.3.4/24"]
   # config.system_accesslist_ips = ["127.0.0.1"]
+  # config.admin_accesslist_ips = ["127.0.0.1"]
 
   # Defines a list of custom content processors. They are used to parse and
   # render specific tags inside some user-provided content. Check the docs for


### PR DESCRIPTION
#### :tophat: What? Why?
Exposing the system part in production can endanger the administration of the platform, by specifying an ip address list, or a subnetwork, it is possible to restrict this access.

When the parameter is not filled in, filtering does not work.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #5669

#### Testing
* Add an a random ip
* Try to access admin side
* See forbidden message

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
<img width="1680" alt="Capture d’écran 2020-01-28 à 22 42 17" src="https://user-images.githubusercontent.com/20232956/73307951-81f5a400-421f-11ea-8f6e-7f81ac840268.png">

:hearts: Thank you!
