### PR TITLE
Disable "codecov/patch" status check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,7 @@ ignore:
   - "decidim-*/lib/decidim/**/participatory_space.rb"
 coverage:
   status:
+    patch: false
     project:
       default:
         threshold: 0.1%


### PR DESCRIPTION
#### :tophat: What? Why?

We've detected that the codecov/patch status check isn't worked as expected in a couple PRs, for instance: 

https://github.com/decidim/decidim/pull/8411/checks?check_run_id=4850662189
https://github.com/decidim/decidim/pull/8738#issuecomment-1020698224 (translation: _I added test of the rake task and the coverage still does not pass_)

This PR disables this check. 

:hearts: Thank you!
