### PR TITLE
Fix geocoding NaN values

### DIFF
--- a/decidim-core/lib/decidim/map/autocomplete.rb
+++ b/decidim-core/lib/decidim/map/autocomplete.rb
@@ -57,11 +57,7 @@ module Decidim
             @template.snippets.add(:head, @template.snippets.for(:geocoding))
           end
 
-          options[:value] ||= object.send(attribute) if object.respond_to?(attribute)
-          if object.respond_to?(:latitude) && object.respond_to?(:longitude)
-            point = [object.latitude, object.longitude]
-            options["data-coordinates"] ||= point.join(",")
-          end
+          options = merge_coordinate_options(attribute, options)
 
           field(attribute, options) do |opts|
             builder.geocoding_field(
@@ -70,6 +66,17 @@ module Decidim
               opts
             )
           end
+        end
+
+        private
+
+        def merge_coordinate_options(attribute, options)
+          options[:value] ||= object.send(attribute) if object.respond_to?(attribute)
+          if object.respond_to?(:latitude) && object.respond_to?(:longitude) && object.latitude.present? && object.longitude.present?
+            point = [object.latitude, object.longitude]
+            options["data-coordinates"] ||= point.join(",")
+          end
+          options
         end
       end
     end

--- a/decidim-core/lib/decidim/map/autocomplete.rb
+++ b/decidim-core/lib/decidim/map/autocomplete.rb
@@ -57,7 +57,7 @@ module Decidim
             @template.snippets.add(:head, @template.snippets.for(:geocoding))
           end
 
-          options = merge_coordinate_options(attribute, options)
+          options = merge_geocoding_options(attribute, options)
 
           field(attribute, options) do |opts|
             builder.geocoding_field(
@@ -70,7 +70,7 @@ module Decidim
 
         private
 
-        def merge_coordinate_options(attribute, options)
+        def merge_geocoding_options(attribute, options)
           options[:value] ||= object.send(attribute) if object.respond_to?(attribute)
           if object.respond_to?(:latitude) && object.respond_to?(:longitude) && object.latitude.present? && object.longitude.present?
             point = [object.latitude, object.longitude]

--- a/decidim-core/spec/lib/map/autocomplete_spec.rb
+++ b/decidim-core/spec/lib/map/autocomplete_spec.rb
@@ -58,6 +58,28 @@ module Decidim
           <input autocomplete="off" data-decidim-geocoding="#{config}" type="text" name="test[address]" id="test_address" />
         ).strip)
       end
+
+      context "when object responds to latitude and longitude" do
+        let(:object) do
+          double(
+            latitude: nil,
+            longitude: nil
+          )
+        end
+
+        let(:form_markup) do
+          template.form_for :test, url: "/test" do |form|
+            allow(form).to receive(:object).and_return(object)
+            form.geocoding_field(:address)
+          end
+        end
+
+        it "does not add empty values" do
+          expect(form_markup).not_to include(%(
+            data-coordinates=
+          ).strip)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently when geocoding is enabled and user creates proposal and address field is left empty it will contain NaN value. This breaks map because it cant calculate average of NaN values.



#### Testing
1. Enable geocoding
2. Create proposal without address
3. Go to proposals index (and reload page)
4. See js error in console
5. (You have to remove NaN (latitude/longitude) values from database to make the map work again.)

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

![image](https://user-images.githubusercontent.com/19709320/151944264-cd17d36c-68c7-4a03-b62b-505017ebee04.png)


:hearts: Thank you!
