### PR TITLE
Allow assembly admins administer children assemblies

### DIFF
--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -73,30 +73,29 @@ module Decidim
       end
 
       def admin_assembly?
-        case user_role
-        when "admin"
-          true
-        when "moderator"
-          false
-        when "collaborator"
-          false
-        when "valuator"
-          false
-        end
+        assembly.present? && user_allowed_assemblies.include?(assembly) || user_role == "admin"
       end
 
       # Checks if it has any manageable assembly, with any possible role.
       def has_manageable_assemblies?(role: :any)
         return unless user
 
-        assemblies_with_role_privileges(role).any?
+        if user.admin?
+          assemblies_with_role_privileges(role).any?
+        else
+          user_allowed_assemblies.any?
+        end
       end
 
       # Whether the user can manage the given assembly or not.
       def can_manage_assembly?(role: :any)
         return unless user
 
-        assemblies_with_role_privileges(role).include? assembly
+        if user.admin?
+          assemblies_with_role_privileges(role).include? assembly
+        else
+          user_allowed_assemblies.include? assembly
+        end
       end
 
       # Returns a collection of assemblies where the given user has the
@@ -206,11 +205,9 @@ module Decidim
       end
 
       def allowed_list_of_assemblies?
-        assemblies = AssembliesWithUserRole.for(user, user_role)
-        parent_assemblies = assemblies.flat_map { |assembly| [assembly.id] + assembly.ancestors.pluck(:id) }
-        child_assemblies = assemblies.flat_map { |assembly| [assembly.id] + assembly.children.pluck(:id) }
+        parent_assemblies = user_allowed_assemblies.flat_map { |assembly| [assembly.id] + assembly.ancestors.pluck(:id) }
 
-        allowed_list_of_assemblies = Decidim::Assembly.where(id: assemblies + parent_assemblies + child_assemblies)
+        allowed_list_of_assemblies = Decidim::Assembly.where(id: user_allowed_assemblies + parent_assemblies)
         allowed_list_of_assemblies.uniq.member?(assembly)
       end
 
@@ -300,7 +297,15 @@ module Decidim
       end
 
       def user_role
-        Decidim::AssemblyUserRole.find_by(decidim_user_id: user.id).role
+        assembly_user_role = Decidim::AssemblyUserRole.find_by(decidim_user_id: user.id)
+        assembly_user_role.present? ? assembly_user_role.role : :any
+      end
+
+      def user_allowed_assemblies
+        assemblies = AssembliesWithUserRole.for(user, user_role)
+        child_assemblies = assemblies.flat_map { |assembly| [assembly.id] + assembly.children.pluck(:id) }
+
+        Decidim::Assembly.where(id: assemblies + child_assemblies)
       end
     end
   end

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -74,6 +74,8 @@ module Decidim
         user.admin? || (assembly ? can_manage_assembly?(role: :admin) : has_manageable_assemblies?)
       end
 
+      # It's an admin assembly when assembly exists and the user is allowed to
+      # manage the current assembly.
       def admin_assembly?
         assembly.present? && assembly_admin_allowed_assemblies.include?(assembly)
       end

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -72,6 +72,19 @@ module Decidim
         user.admin? || (assembly ? can_manage_assembly?(role: :admin) : has_manageable_assemblies?)
       end
 
+      def admin_assembly?
+        case user_role
+        when "admin"
+          true
+        when "moderator"
+          false
+        when "collaborator"
+          false
+        when "valuator"
+          false
+        end
+      end
+
       # Checks if it has any manageable assembly, with any possible role.
       def has_manageable_assemblies?(role: :any)
         return unless user
@@ -159,12 +172,12 @@ module Decidim
         allow! if user.admin? || has_manageable_assemblies?
       end
 
-      # Only organization admins can create a assembly
+      # Only organization admins and assemblies admins can create a assembly
       def user_can_create_assembly?
         return unless permission_action.action == :create &&
                       permission_action.subject == :assembly
 
-        toggle_allow(user.admin?)
+        toggle_allow(user.admin? || admin_assembly?)
       end
 
       def user_can_read_assemblies_setting?
@@ -193,10 +206,11 @@ module Decidim
       end
 
       def allowed_list_of_assemblies?
-        assemblies = AssembliesWithUserRole.for(user)
+        assemblies = AssembliesWithUserRole.for(user, user_role)
         parent_assemblies = assemblies.flat_map { |assembly| [assembly.id] + assembly.ancestors.pluck(:id) }
+        child_assemblies = assemblies.flat_map { |assembly| [assembly.id] + assembly.children.pluck(:id) }
 
-        allowed_list_of_assemblies = Decidim::Assembly.where(id: assemblies + parent_assemblies)
+        allowed_list_of_assemblies = Decidim::Assembly.where(id: assemblies + parent_assemblies + child_assemblies)
         allowed_list_of_assemblies.uniq.member?(assembly)
       end
 
@@ -231,13 +245,10 @@ module Decidim
       end
 
       # Process admins can perform everything *inside* that assembly. They cannot
-      # create a assembly or perform actions on assembly groups or other
-      # assemblies.
+      # perform actions on assembly groups or other assemblies.
       def assembly_admin_action?
         return unless can_manage_assembly?(role: :admin)
         return if user.admin?
-        return disallow! if permission_action.action == :create &&
-                            permission_action.subject == :assembly
 
         is_allowed = [
           :attachment,
@@ -286,6 +297,10 @@ module Decidim
 
       def assembly
         @assembly ||= context.fetch(:current_participatory_space, nil) || context.fetch(:assembly, nil)
+      end
+
+      def user_role
+        Decidim::AssemblyUserRole.find_by(decidim_user_id: user.id).role
       end
     end
   end

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -33,6 +33,8 @@ module Decidim
         user_can_list_assembly_list?
         user_can_read_current_assembly?
         user_can_create_assembly?
+        user_can_export_assembly?
+        user_can_copy_assembly?
         user_can_read_assemblies_setting?
 
         # org admins and space admins can do everything in the admin section
@@ -73,35 +75,31 @@ module Decidim
       end
 
       def admin_assembly?
-        assembly.present? && user_allowed_assemblies.include?(assembly) || user_role == "admin"
+        assembly.present? && assembly_admin_allowed_assemblies.include?(assembly)
       end
 
       # Checks if it has any manageable assembly, with any possible role.
       def has_manageable_assemblies?(role: :any)
         return unless user
 
-        if user.admin?
-          assemblies_with_role_privileges(role).any?
-        else
-          user_allowed_assemblies.any?
-        end
+        assemblies_with_role_privileges(role).any?
       end
 
       # Whether the user can manage the given assembly or not.
       def can_manage_assembly?(role: :any)
         return unless user
 
-        if user.admin?
-          assemblies_with_role_privileges(role).include? assembly
-        else
-          user_allowed_assemblies.include? assembly
-        end
+        assemblies_with_role_privileges(role).include? assembly
       end
 
       # Returns a collection of assemblies where the given user has the
       # specific role privilege.
       def assemblies_with_role_privileges(role)
-        Decidim::Assemblies::AssembliesWithUserRole.for(user, role)
+        if role == :admin
+          assembly_admin_allowed_assemblies
+        else
+          Decidim::Assemblies::AssembliesWithUserRole.for(user, role)
+        end
       end
 
       def public_list_assemblies_action?
@@ -176,6 +174,20 @@ module Decidim
         return unless permission_action.action == :create &&
                       permission_action.subject == :assembly
 
+        toggle_allow(user.admin? || admin_assembly? || user_role == "admin")
+      end
+
+      def user_can_export_assembly?
+        return unless permission_action.action == :export &&
+                      permission_action.subject == :assembly
+
+        toggle_allow(user.admin? || admin_assembly?)
+      end
+
+      def user_can_copy_assembly?
+        return unless permission_action.action == :copy &&
+                      permission_action.subject == :assembly
+
         toggle_allow(user.admin? || admin_assembly?)
       end
 
@@ -205,9 +217,9 @@ module Decidim
       end
 
       def allowed_list_of_assemblies?
-        parent_assemblies = user_allowed_assemblies.flat_map { |assembly| [assembly.id] + assembly.ancestors.pluck(:id) }
+        parent_assemblies = assembly_admin_allowed_assemblies.flat_map { |assembly| [assembly.id] + assembly.ancestors.pluck(:id) }
 
-        allowed_list_of_assemblies = Decidim::Assembly.where(id: user_allowed_assemblies + parent_assemblies)
+        allowed_list_of_assemblies = Decidim::Assembly.where(id: assembly_admin_allowed_assemblies + parent_assemblies)
         allowed_list_of_assemblies.uniq.member?(assembly)
       end
 
@@ -301,8 +313,8 @@ module Decidim
         assembly_user_role.present? ? assembly_user_role.role : :any
       end
 
-      def user_allowed_assemblies
-        assemblies = AssembliesWithUserRole.for(user, user_role)
+      def assembly_admin_allowed_assemblies
+        assemblies = AssembliesWithUserRole.for(user, :admin)
         child_assemblies = assemblies.flat_map { |assembly| [assembly.id] + assembly.children.pluck(:id) }
 
         Decidim::Assembly.where(id: assemblies + child_assemblies)

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -82,13 +82,13 @@
                 <% end %>
               </td>
               <td class="table-list__actions">
-                <% if allowed_to? :create, :assembly, assembly: assembly %>
+                <% if allowed_to? :export, :assembly, assembly: assembly %>
                   <%= icon_link_to "data-transfer-download", assembly_export_path(assembly), t("actions.export", scope: "decidim.admin"), method: :post, class: "action-icon--export" %>
                 <% else %>
                   <span class="action-space icon"></span>
                 <% end %>
 
-                <% if allowed_to? :create, :assembly, assembly: assembly %>
+                <% if allowed_to? :copy, :assembly, assembly: assembly %>
                   <%= icon_link_to "clipboard", new_assembly_copy_path(assembly), t("actions.duplicate", scope: "decidim.admin"), class: "action-icon--copy" %>
                 <% else %>
                   <span class="action-space icon"></span>

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -280,7 +280,7 @@ describe Decidim::Assemblies::Permissions do
     it_behaves_like(
       "access for roles",
       org_admin: true,
-      admin: false,
+      admin: true,
       collaborator: false,
       moderator: false,
       valuator: false
@@ -371,7 +371,7 @@ describe Decidim::Assemblies::Permissions do
           { scope: :admin, action: :create, subject: :assembly }
         end
 
-        it { is_expected.to eq false }
+        it { is_expected.to eq true }
       end
 
       shared_examples "allows any action on subject" do |action_subject|
@@ -534,7 +534,7 @@ describe Decidim::Assemblies::Permissions do
           { scope: :admin, action: :list, subject: :assembly }
         end
 
-        it { is_expected.to eq(false) }
+        it { is_expected.to eq(true) }
       end
     end
   end

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -287,6 +287,36 @@ describe Decidim::Assemblies::Permissions do
     )
   end
 
+  context "when exporting an assembly" do
+    let(:action) do
+      { scope: :admin, action: :export, subject: :assembly }
+    end
+
+    it_behaves_like(
+      "access for roles",
+      org_admin: true,
+      admin: false,
+      collaborator: false,
+      moderator: false,
+      valuator: false
+    )
+  end
+
+  context "when copying an assembly" do
+    let(:action) do
+      { scope: :admin, action: :copy, subject: :assembly }
+    end
+
+    it_behaves_like(
+      "access for roles",
+      org_admin: true,
+      admin: false,
+      collaborator: false,
+      moderator: false,
+      valuator: false
+    )
+  end
+
   context "when reading a assemblies settings" do
     let(:action) do
       { scope: :admin, action: :read, subject: :assemblies_setting }
@@ -535,6 +565,96 @@ describe Decidim::Assemblies::Permissions do
         end
 
         it { is_expected.to eq(true) }
+      end
+    end
+
+    describe "actions by assemblies types when user is an admin assembly" do
+      let!(:user) { create :assembly_admin, assembly: mother_assembly }
+      let(:mother_assembly) { create :assembly, parent: assembly, organization: organization, hashtag: "mother" }
+      let(:child_assembly) { create :assembly, parent: mother_assembly, organization: organization, hashtag: "child" }
+
+      context "when assembly is a grandmother assembly" do
+        let(:context) { { assembly: assembly } }
+
+        context "and action is :list" do
+          let(:action) do
+            { scope: :admin, action: :list, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
+
+        context "and action is :export" do
+          let(:action) do
+            { scope: :admin, action: :export, subject: :assembly }
+          end
+
+          it { is_expected.to eq(false) }
+        end
+
+        context "and action is :copy" do
+          let(:action) do
+            { scope: :admin, action: :copy, subject: :assembly }
+          end
+
+          it { is_expected.to eq(false) }
+        end
+      end
+
+      context "when assembly is a mother assembly" do
+        let(:context) { { assembly: mother_assembly } }
+
+        context "and action is :list" do
+          let(:action) do
+            { scope: :admin, action: :list, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
+
+        context "and action is :export" do
+          let(:action) do
+            { scope: :admin, action: :export, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
+
+        context "and action is :copy" do
+          let(:action) do
+            { scope: :admin, action: :copy, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
+      end
+
+      context "when assembly is a child assembly" do
+        let(:context) { { assembly: child_assembly } }
+
+        context "and action is :list" do
+          let(:action) do
+            { scope: :admin, action: :list, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
+
+        context "and action is :export" do
+          let(:action) do
+            { scope: :admin, action: :export, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
+
+        context "and action is :copy" do
+          let(:action) do
+            { scope: :admin, action: :copy, subject: :assembly }
+          end
+
+          it { is_expected.to eq(true) }
+        end
       end
     end
   end

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -567,94 +567,94 @@ describe Decidim::Assemblies::Permissions do
         it { is_expected.to eq(true) }
       end
     end
+  end
 
-    describe "actions by assemblies types when user is an admin assembly" do
-      let!(:user) { create :assembly_admin, assembly: mother_assembly }
-      let(:mother_assembly) { create :assembly, parent: assembly, organization: organization, hashtag: "mother" }
-      let(:child_assembly) { create :assembly, parent: mother_assembly, organization: organization, hashtag: "child" }
+  describe "when acting with assemblies admins and children assemblies" do
+    let!(:user) { create :assembly_admin, assembly: mother_assembly }
+    let(:mother_assembly) { create :assembly, parent: assembly, organization: organization, hashtag: "mother" }
+    let(:child_assembly) { create :assembly, parent: mother_assembly, organization: organization, hashtag: "child" }
 
-      context "when assembly is a grandmother assembly" do
-        let(:context) { { assembly: assembly } }
+    context "when assembly is a grandmother assembly" do
+      let(:context) { { assembly: assembly } }
 
-        context "and action is :list" do
-          let(:action) do
-            { scope: :admin, action: :list, subject: :assembly }
-          end
-
-          it { is_expected.to eq(true) }
+      context "and action is :list" do
+        let(:action) do
+          { scope: :admin, action: :list, subject: :assembly }
         end
 
-        context "and action is :export" do
-          let(:action) do
-            { scope: :admin, action: :export, subject: :assembly }
-          end
-
-          it { is_expected.to eq(false) }
-        end
-
-        context "and action is :copy" do
-          let(:action) do
-            { scope: :admin, action: :copy, subject: :assembly }
-          end
-
-          it { is_expected.to eq(false) }
-        end
+        it { is_expected.to eq(true) }
       end
 
-      context "when assembly is a mother assembly" do
-        let(:context) { { assembly: mother_assembly } }
-
-        context "and action is :list" do
-          let(:action) do
-            { scope: :admin, action: :list, subject: :assembly }
-          end
-
-          it { is_expected.to eq(true) }
+      context "and action is :export" do
+        let(:action) do
+          { scope: :admin, action: :export, subject: :assembly }
         end
 
-        context "and action is :export" do
-          let(:action) do
-            { scope: :admin, action: :export, subject: :assembly }
-          end
-
-          it { is_expected.to eq(true) }
-        end
-
-        context "and action is :copy" do
-          let(:action) do
-            { scope: :admin, action: :copy, subject: :assembly }
-          end
-
-          it { is_expected.to eq(true) }
-        end
+        it { is_expected.to eq(false) }
       end
 
-      context "when assembly is a child assembly" do
-        let(:context) { { assembly: child_assembly } }
-
-        context "and action is :list" do
-          let(:action) do
-            { scope: :admin, action: :list, subject: :assembly }
-          end
-
-          it { is_expected.to eq(true) }
+      context "and action is :copy" do
+        let(:action) do
+          { scope: :admin, action: :copy, subject: :assembly }
         end
 
-        context "and action is :export" do
-          let(:action) do
-            { scope: :admin, action: :export, subject: :assembly }
-          end
+        it { is_expected.to eq(false) }
+      end
+    end
 
-          it { is_expected.to eq(true) }
+    context "when assembly is a mother assembly" do
+      let(:context) { { assembly: mother_assembly } }
+
+      context "and action is :list" do
+        let(:action) do
+          { scope: :admin, action: :list, subject: :assembly }
         end
 
-        context "and action is :copy" do
-          let(:action) do
-            { scope: :admin, action: :copy, subject: :assembly }
-          end
+        it { is_expected.to eq(true) }
+      end
 
-          it { is_expected.to eq(true) }
+      context "and action is :export" do
+        let(:action) do
+          { scope: :admin, action: :export, subject: :assembly }
         end
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "and action is :copy" do
+        let(:action) do
+          { scope: :admin, action: :copy, subject: :assembly }
+        end
+
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    context "when assembly is a child assembly" do
+      let(:context) { { assembly: child_assembly } }
+
+      context "and action is :list" do
+        let(:action) do
+          { scope: :admin, action: :list, subject: :assembly }
+        end
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "and action is :export" do
+        let(:action) do
+          { scope: :admin, action: :export, subject: :assembly }
+        end
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "and action is :copy" do
+        let(:action) do
+          { scope: :admin, action: :copy, subject: :assembly }
+        end
+
+        it { is_expected.to eq(true) }
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

An assembly admin can now create and list the child assemblies of which they are an admin.

In this hierarchy: **Grandmother Assembly > Mother Assembly > Child Assembly**, if assembly admin administrates the Mother Assembly, the user can:

- Show list with Grandmother assembly and see some data (if it's promoted, title, created at, if it's private and published) but user can't do actions like export, copy or edit.
- Fully administer the Mother assembly
- Fully administer the Child assembly

#### Testing
1. Log in with an assembly admin and you are mother assembly admin.
2. You can create a child assemblies in the mother assembly and you can fully administrate Mother and Child.
3. You only can show data but don't do any action in Grandmother assembly.

### :camera: Screenshots
![imagen](https://user-images.githubusercontent.com/75725233/154682849-b5311a56-86ef-4c5d-b530-1df1b089c420.png)
![imagen](https://user-images.githubusercontent.com/75725233/154682874-e3aec8db-4e65-429e-8453-c4f2999a3941.png)
![imagen](https://user-images.githubusercontent.com/75725233/154682977-9f029336-92d4-4c53-9e33-44eda2340d6a.png)

:hearts: Thank you!
