### PR TITLE
Add "nofollow noopener" rel to the profile personal URL

### DIFF
--- a/decidim-core/app/cells/decidim/profile_sidebar/show.erb
+++ b/decidim-core/app/cells/decidim/profile_sidebar/show.erb
@@ -23,7 +23,7 @@
       <small><%= decidim_html_escape(profile_user.about.to_s) %></small>
     </div>
     <% if profile_user.personal_url.present? %>
-      <%= link_to html_truncate(profile_user.personal_url.gsub(%r{https?\:\/\/}, ""), length: 30), profile_user.personal_url %>
+      <%= link_to html_truncate(profile_user.personal_url.gsub(%r{https?\:\/\/}, ""), length: 30), profile_user.personal_url, rel: "nofollow noopener" %>
     <% end %>
   </div>
   <% if profile_user.badge.present? %>


### PR DESCRIPTION
#### :tophat: What? Why?
There are many so called "profile spammers" on all Decidim instances. They create a profile, fill in the personal URL and about section and then they don't do anything on the website.

They do this to get link juice from the external site towards their site.

Here's some examples from MetaDecidim:
- https://meta.decidim.org/profiles/ankitatop10/activity
- https://meta.decidim.org/profiles/andywilliamy/activity
- https://meta.decidim.org/profiles/levinsmith0444/activity
- etc. (there are many more)

Let's stop giving them "link juice" for their unethical SEO practices.

#### :pushpin: Related Issues
- Related to #8239

#### Testing
- Go to the profile page
- Inspect the personal URL link in the sidebar to see it has the `rel="nofollow noopener"` attribute
- Smile as you just prevented these SEO experts from one of their tricks

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.