### PR TITLE
Add .keep file to empty directory to include on git committing

### DIFF
--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -88,6 +88,8 @@ module Decidim
 
         # Create empty directory for images
         empty_directory "app/packs/images"
+        # Add a .keep file so directory is included in git when committing
+        run "touch app/packs/images/.keep"
 
         # Regenerate webpacker binstubs
         remove_file "bin/yarn"


### PR DESCRIPTION
#### :tophat: What? Why?

After creating a new Decidim application and committing it I realised that the folder `app/packs/images` is not included (unless you have included an image) because is empty, and the Javascript of Decidim [relies in the existence of that folder to compile](https://github.com/decidim/decidim/blob/develop/decidim-generators/lib/decidim/generators/app_templates/decidim_application.js#L5)

Adding a `.keep` file ensures the directory is committed to git

#### :pushpin: Related Issues

#### Testing

1. Create a new decidim app
2. Add to a new git repo and commit
3. The folder should be in the repo

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
