### PR TITLE
Backport "Add .keep file to empty directory to include on git committing" to v0.26

### DIFF
--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -88,6 +88,8 @@ module Decidim
 
         # Create empty directory for images
         empty_directory "app/packs/images"
+        # Add a .keep file so directory is included in git when committing
+        run "touch app/packs/images/.keep"
 
         # Regenerate webpacker binstubs
         remove_file "bin/yarn"


### PR DESCRIPTION
#### :tophat: What? Why?

This PR is a backport of #8786 to v0.26 

#### :pushpin: Related Issues

- Related to #8786
