### PR TITLE
Fix a bug with attachment attributes caused by AttributeObject migration

### DIFF
--- a/decidim-core/lib/decidim/attachment_attributes.rb
+++ b/decidim-core/lib/decidim/attachment_attributes.rb
@@ -37,7 +37,7 @@ module Decidim
         define_method name do
           return instance_variable_get(variable_name) if instance_variable_defined?(variable_name)
 
-          original = @attributes["photos"].value_before_type_cast
+          original = @attributes[name.to_s].value_before_type_cast
           return original if original && !original.is_a?(Array)
 
           instance_variable_set(

--- a/decidim-core/spec/lib/attachment_attributes_spec.rb
+++ b/decidim-core/spec/lib/attachment_attributes_spec.rb
@@ -19,8 +19,8 @@ module Decidim
     let(:model) { klass.new }
 
     describe ".attachments_attribute do" do
-      let(:attachments) { create_list(:attachment, 10) }
-      let(:attachment_ids) { attachments.map(&:id).map(&:to_s) }
+      let(:photos) { create_list(:attachment, 10) }
+      let(:photos_ids) { photos.map(&:id).map(&:to_s) }
 
       before do
         klass.class_eval do
@@ -36,13 +36,39 @@ module Decidim
       end
 
       it "adds the argument reader method that converts the IDs to attachments" do
-        model.photos = attachment_ids
-        expect(model.photos).to match_array(attachments)
+        model.photos = photos_ids
+        expect(model.photos).to match_array(photos)
       end
 
       it "returns the original value if the original value is not an array" do
         model.photos = "test"
         expect(model.photos).to eq("test")
+      end
+
+      context "with two attachments attributes" do
+        let(:documents) { create_list(:attachment, 10) }
+        let(:documents_ids) { documents.map(&:id).map(&:to_s) }
+
+        before do
+          klass.class_eval do
+            attachments_attribute :documents
+          end
+        end
+
+        it "creates the documents and add_documents array arguments" do
+          expect(klass.attribute_types["documents"]).to be_a(Decidim::Attributes::Array)
+          expect(klass.attribute_types["documents"].value_type).to be(Integer)
+          expect(klass.attribute_types["add_documents"]).to be_a(Decidim::Attributes::Array)
+          expect(klass.attribute_types["add_documents"].value_type).to be(Object)
+        end
+
+        it "adds the argument reader method that converts the IDs to attachments" do
+          model.photos = photos_ids
+          expect(model.photos).to match_array(photos)
+
+          model.documents = documents_ids
+          expect(model.documents).to match_array(documents)
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
#8669 caused a bug with the `attachments_attribute` method for other attribute names than "photos".

This fixes the issue so that functionality is as it was.

#### :pushpin: Related Issues
- Related to #8669

#### Testing
- For proposals or initiatives, add both photos and documents as attachments
- Now, call e.g. `Decidim::Proposals::Proposal.find(1).documents`
- Expect to receive the documents of the proposal, not its photos

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.