### PR TITLE
Fix avatar upload validation errors are displayed twice

### DIFF
--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -51,9 +51,6 @@ module Decidim
 
     validate :all_roles_are_valid
 
-    has_one_attached :avatar
-    validates_upload :avatar, uploader: Decidim::AvatarUploader
-
     has_one_attached :data_portability_file
 
     scope :not_deleted, -> { where(deleted_at: nil) }

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -26,9 +26,6 @@ module Decidim
     validate :correct_state
     validate :unique_document_number, if: :has_document_number?
 
-    has_one_attached :avatar
-    validates_upload :avatar, uploader: Decidim::AvatarUploader
-
     devise :confirmable, :decidim_validatable, confirmation_keys: [:decidim_organization_id, :email]
 
     scope :verified, -> { where.not("extended_data->>'verified_at' IS ?", nil) }

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -31,6 +31,29 @@ describe "Account", type: :system do
 
     it_behaves_like "accessible page"
 
+    describe "update avatar" do
+      it "can update avatar" do
+        attach_file :user_avatar, Decidim::Dev.asset("avatar.jpg")
+
+        within "form.edit_user" do
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_css(".flash.success")
+      end
+
+      it "shows error when image is too big" do
+        attach_file :user_avatar, Decidim::Dev.asset("5000x5000.png")
+
+        within "form.edit_user" do
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("The image is too big", count: 1)
+        expect(page).to have_css(".flash.alert")
+      end
+    end
+
     describe "updating personal data" do
       it "updates the user's data" do
         within "form.edit_user" do


### PR DESCRIPTION
#### :tophat: What? Why?
When trying to change avatar picture with invalid file, error messages are displayed twice. This is because avatar validators are added twice for ```Decidim::User``` and ```Decidim::UserGroup``` models. [User](https://github.com/decidim/decidim/blob/9483ad8a9ff3ad8c57608651558649e8d16e69e5/decidim-core/app/models/decidim/user.rb#L55) and [UserGroup](https://github.com/decidim/decidim/blob/9483ad8a9ff3ad8c57608651558649e8d16e69e5/decidim-core/app/models/decidim/user_group.rb#L30) add avatar validators again after inheriting [UserBaseEntity](https://github.com/decidim/decidim/blob/9483ad8a9ff3ad8c57608651558649e8d16e69e5/decidim-core/app/models/decidim/user_base_entity.rb#L24).

#### Testing
1. Sign in
2. Go to "My account"
3. Try to change avatar with a file of the wrong type (e.g. .txt) or a file that is too big.
4. In rails console: ```Decidim::User.validators_on(:avatar)``` and ```Decidim::UserGroup.validators_on(:avatar)```

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/153019289-ad28dc3a-e6e7-4db1-b80c-d8f4234ec322.png)

:hearts: Thank you!
