### PR TITLE
Fix translatable presence validator for hyphenated locales

### DIFF
--- a/decidim-core/app/forms/translatable_presence_validator.rb
+++ b/decidim-core/app/forms/translatable_presence_validator.rb
@@ -9,7 +9,7 @@
 # object (or the `default_locale` of the form's organization) for the given field.
 class TranslatablePresenceValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, _value)
-    translated_attr = "#{attribute}_#{default_locale_for(record)}"
+    translated_attr = "#{attribute}_#{default_locale_for(record)}".gsub("-", "__")
     record.errors.add(translated_attr, :blank) if record.send(translated_attr).blank?
   end
 

--- a/decidim-core/app/forms/translatable_presence_validator.rb
+++ b/decidim-core/app/forms/translatable_presence_validator.rb
@@ -22,7 +22,7 @@ class TranslatablePresenceValidator < ActiveModel::EachValidator
       record.current_organization.default_locale
     else
       record.errors.add(:current_organization, :blank)
-      []
+      Decidim.default_locale
     end
   end
 end

--- a/decidim-core/spec/forms/translatable_presence_validator_spec.rb
+++ b/decidim-core/spec/forms/translatable_presence_validator_spec.rb
@@ -69,5 +69,22 @@ module Decidim
         expect(record.errors[:description_en]).to eq ["can't be blank"]
       end
     end
+
+    context "when translation name is hyphenated" do
+      let(:available_locales) { ["en", "ca", "es-MX"] }
+      let(:default_locale) { :'es-MX' }
+      let(:description) do
+        {
+          "es-MX": "Descripción"
+        }
+      end
+
+      before { allow(Decidim).to receive(:available_locales).and_return(available_locales) }
+
+      it "validates the record" do
+        subject
+        expect(record).to be_valid
+      end
+    end
   end
 end

--- a/decidim-core/spec/forms/translatable_presence_validator_spec.rb
+++ b/decidim-core/spec/forms/translatable_presence_validator_spec.rb
@@ -86,5 +86,15 @@ module Decidim
         expect(record).to be_valid
       end
     end
+
+    context "when organization is blank" do
+      let(:organization) { nil }
+
+      it "does not validate the record" do
+        subject
+        expect(record.errors).not_to be_empty
+        expect(record.errors[:current_organization]).to eq ["can't be blank"]
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
**Fix TranslatablePresenceValidator - Hyphenated locale**

When translatable-attributes are defined, it does replaces `-`  with
`__`. The validator was missing this conversion and wasn't able to find
the proper method

This fixes the translatable-presence-validator for hypenated locales

#### :pushpin: Related Issues
- Fixes #8787


#### Testing
Have added tests, but I think other way of validating this fix is by following the described issue at #8787  

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
