### PR TITLE
Lock chromedriver to 97.0.4692.71 because of sendKeys bug

### DIFF
--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -52,6 +52,10 @@ runs:
       name: Create the screenshots folder
       shell: "bash"
     - uses: nanasess/setup-chromedriver@v1.0.1
+      with:
+        # Needed temporarily to bypass issues with Chromedriver v98
+        # https://bugs.chromium.org/p/chromedriver/issues/detail?id=3999
+        chromedriver-version: '97.0.4692.71'
     - run: RAILS_ENV=test bundle exec rails assets:precompile
       name: Precompile assets
       working-directory: ./spec/decidim_dummy_app/


### PR DESCRIPTION
#### :tophat: What? Why?
Started getting weird errors in the system specs that are using the `send_keys` method to send keystrokes to the browser.

Example run that failed because of this:
https://github.com/decidim/decidim/runs/5147193462?check_suite_focus=true

Example failure looks as follows (in the decidim-admin gem):

```
Failures:

  1) Admin manages organization edit when using the rich text editor when the admin terms of use content is empty deletes paragraph changes pressing backspace
     Failure/Error:
       expect(find(
         "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
       )["innerHTML"]).to eq("<p>e</p>".gsub("\n", ""))

       expected: "<p>e</p>"
            got: "<p>ef</p><p>g</p>"

       (compared using ==)

     [Image screenshot]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_organization_edit_when_using_the_rich_text_editor_when_the_admin_terms_of_use_content_is_empty_deletes_paragraph_changes_pressing_backspace_582.png
            [Page HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_organization_edit_when_using_the_rich_text_editor_when_the_admin_terms_of_use_content_is_empty_deletes_paragraph_changes_pressing_backspace_582.html


     # ./spec/system/admin_manages_organization_spec.rb:61:in `block (5 levels) in <top (required)>'
```

Note the extra "" characters in the actual output (as well as other differences).

Apparently this is because of a bug in Chromedriver v98 which is currently loaded to the test environment:
![Chromedriver version in GitHub actions](https://user-images.githubusercontent.com/864340/153502350-45021f00-194a-49b9-a012-210c8b5258fe.png)

Further information about the bug:
https://bugs.chromium.org/p/chromedriver/issues/detail?id=3999

Workaround from that issue:
![Workaround for this is to downgrade chromedriver to 97.0.4692.71. It works with latest Chrome 98.0.4758.82
](https://user-images.githubusercontent.com/864340/153502833-fee5562c-0aeb-42a8-8365-d4228a1093b0.png)

#### :pushpin: Related Issues
- Related to https://bugs.chromium.org/p/chromedriver/issues/detail?id=3999

#### Testing
- Download v98 of Chromedriver to your local machine
- Go to the decidim-admin folder
- Run the following spec: `bundle exec rspec spec/system/admin_manages_organization_spec.rb`
- See many errors
- Revert Chromedriver back to v97
- Run the same spec again

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.