### PR TITLE
Fix the unallowed characters in the failure artefact names

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -23,6 +23,28 @@ module Decidim
   end
 end
 
+# Customize the screenshot helper to fix the file paths for examples that have
+# unallowed characters in them. Otherwise the artefacts creation and upload
+# fails at GitHub actions. See the list of unallowed characters from:
+# https://github.com/actions/toolkit/blob/main/packages/artifact/docs/additional-information.md#non-supported-characters
+module ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper
+  # This method is not needed after update to Rails 7.0
+  def _screenshot_counter
+    @_screenshot_counter ||= 0
+    @_screenshot_counter += 1
+  end
+
+  def image_name
+    # By default, this only cleans up the forward and backward slash characters.
+    sanitized_method_name = method_name.tr("/\\()\":<>|*?", "-----------")
+    # The unique method is automatically available after update to Rails 7.0,
+    # so the following line can be removed after upgrade to Rails 7.0.
+    unique = failed? ? "failures" : (_screenshot_counter || 0).to_s
+    name = "#{unique}_#{sanitized_method_name}"
+    name[0...225]
+  end
+end
+
 Capybara.register_driver :headless_chrome do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new
   options.args << "--headless"


### PR DESCRIPTION
#### :tophat: What? Why?
The unallowed characters caused the artefacts upload to fail.

It caused errors as such in the test runs:
![Artefact upload failed](https://user-images.githubusercontent.com/717367/153558462-36f23379-3274-4104-8eeb-d6db27233c8b.png)

The unallowed characters are documented here:
https://github.com/actions/toolkit/blob/main/packages/artifact/docs/additional-information.md#non-supported-characters

#### :pushpin: Related Issues
- Fixes #8805

#### Testing
- Make one of the tests fail that contain unallowed characters (as documented in the link)
- Push it to a branch
- Run the tests for that at GitHub actions
- See that the artefact upload failed

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.