### PR TITLE
Backport "Fix flaky test in UpdateAssemblyMember" to v0.26

### DIFF
--- a/decidim-assemblies/spec/commands/update_assembly_member_spec.rb
+++ b/decidim-assemblies/spec/commands/update_assembly_member_spec.rb
@@ -30,7 +30,7 @@ module Decidim::Assemblies
           ceased_date: nil,
           designation_date: Time.current,
           position: Decidim::AssemblyMember::POSITIONS.sample,
-          position_other: "",
+          position_other: Faker::Lorem.word,
           existing_user: existing_user,
           non_user_avatar: non_user_avatar,
           user_id: user&.id


### PR DESCRIPTION
#### :tophat: What? Why?
As it's failing in the last commit of `release/0.26-stable`, we need to backport #8739 to this branch. 

:hearts: Thank you!
