### PR TITLE
Fix displaying hidden meetings in homepage's "upcoming meetings" content block

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_meetings_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_meetings_cell.rb
@@ -19,6 +19,7 @@ module Decidim
                                  .visible_meeting_for(current_user)
                                  .where("end_time >= ?", Time.current)
                                  .except_withdrawn
+                                 .not_hidden
                                  .order(start_time: :asc)
                                  .limit(limit)
         end

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -159,6 +159,12 @@ FactoryBot.define do
     trait :open_in_new_tab_iframe_embed_type do
       iframe_embed_type { :open_in_new_tab }
     end
+
+    trait :moderated do
+      after(:create) do |meeting, _evaluator|
+        create(:moderation, reportable: meeting, hidden_at: 2.days.ago)
+      end
+    end
   end
 
   factory :registration, class: "Decidim::Meetings::Registration" do

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_meetings_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_meetings_cell_spec.rb
@@ -34,7 +34,11 @@ module Decidim
             let!(:second_meeting) do
               create(:meeting, :published, start_time: meeting.start_time.advance(weeks: 1), component: meeting.component)
             end
+            let!(:moderated_meeting) do
+              create(:meeting, :moderated, :published, start_time: meeting.start_time.advance(weeks: 1), component: meeting.component)
+            end
 
+            it { is_expected.not_to include(moderated_meeting) }
             it { is_expected.not_to include(past_meeting) }
             it { is_expected.to include(meeting) }
             it { is_expected.to include(second_meeting) }


### PR DESCRIPTION
#### :tophat: What? Why?
Currently any Hidden meeting is being displayed on the upcomming meeting section on the homepage. 



#### Testing
1. As a regular user, create and publish a meeting in the future
2. Go to homepage and observe that is being displayed in the upcoming meeting 
3. Report and Moderate (hide) that particular meeting 
4. Refresh the homepage and observe the meeting is not being displayed. 

:hearts: Thank you!
