### PR TITLE
Fix displaying hidden related resources

### DIFF
--- a/decidim-core/lib/decidim/resourceable.rb
+++ b/decidim-core/lib/decidim/resourceable.rb
@@ -62,6 +62,7 @@ module Decidim
 
         scope = manifest.resource_scope(component)
         scope = scope.where("#{self.class.table_name}.id != ?", id) if manifest.model_class == self.class
+        scope = scope.not_hidden if manifest.model_class.respond_to?(:not_hidden)
         scope.includes(:component).where.not(decidim_components: { published_at: nil })
       end
 

--- a/decidim-core/spec/lib/resourceable_spec.rb
+++ b/decidim-core/spec/lib/resourceable_spec.rb
@@ -91,6 +91,20 @@ module Decidim
             expect(resource.sibling_scope(:dummy)).to be_empty
           end
         end
+
+        context "when the target component is moderated" do
+          let(:participatory_process) { create(:participatory_process) }
+
+          let!(:resource) { create(:dummy_resource, component: current_component) }
+          let!(:current_component) { create(:component, manifest_name: :dummy, participatory_space: participatory_process) }
+          let!(:target_component) { create(:component, manifest_name: :dummy, participatory_space: participatory_process) }
+          let!(:target_resource) { create(:dummy_resource, component: target_component) }
+          let!(:moderation) { create(:moderation, reportable: target_resource, hidden_at: Time.current) }
+
+          it "doesn't return anything from that component" do
+            expect(resource.sibling_scope(:dummy)).to be_empty
+          end
+        end
       end
 
       context "when there's no resource manifest" do

--- a/decidim-meetings/spec/shared/linked_resources_interface_examples.rb
+++ b/decidim-meetings/spec/shared/linked_resources_interface_examples.rb
@@ -9,6 +9,7 @@ shared_examples_for "linked resources interface" do
     let(:proposal_component) do
       create(:component, manifest_name: :proposals, participatory_space: model.component.participatory_space)
     end
+    let(:moderation) { create(:moderation, reportable: linked_proposals.last) }
 
     describe "when no proposals are linked" do
       it "does not include the services" do
@@ -24,6 +25,13 @@ shared_examples_for "linked resources interface" do
       it "includes the required data" do
         ids = response["proposalsFromMeeting"].map { |item| item["id"] }
         expect(ids).to include(*linked_proposals.map(&:id).map(&:to_s))
+      end
+
+      it "hides the moderated proposals" do
+        moderation.update(hidden_at: Time.current)
+
+        ids = response["proposalsFromMeeting"].map { |item| item["id"] }
+        expect(ids).not_to include(linked_proposals.last.id.to_s)
       end
     end
   end

--- a/decidim-proposals/app/cells/decidim/proposals/proposals_picker_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposals_picker_cell.rb
@@ -63,6 +63,7 @@ module Decidim
         @proposals ||= Decidim.find_resource_manifest(:proposals).try(:resource_scope, component)
                          &.includes(:component)
                          &.published
+                         &.not_hidden
                          &.order(id: :asc)
       end
 

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -191,6 +191,8 @@ describe "Admin views proposal details from admin", type: :system do
   context "with related meetings" do
     let(:meeting_component) { create :meeting_component, participatory_space: participatory_process }
     let(:meeting) { create :meeting, component: meeting_component }
+    let(:moderated_meeting) { create :meeting, component: meeting_component }
+    let!(:moderation) { create(:moderation, reportable: moderated_meeting) }
 
     it "lists the related meetings" do
       proposal.link_resources(meeting, "proposals_from_meeting")
@@ -198,6 +200,17 @@ describe "Admin views proposal details from admin", type: :system do
 
       within "#related-meetings" do
         expect(page).to have_selector("a", text: translated(meeting.title))
+      end
+    end
+
+    it "hides the moderated related meeting" do
+      proposal.link_resources(moderated_meeting, "proposals_from_meeting")
+      moderation.update(hidden_at: Time.current)
+
+      go_to_admin_proposal_page(proposal)
+
+      within "#related-meetings" do
+        expect(page).not_to have_selector("a", text: translated(moderated_meeting.title))
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
The content linked in a resource page (Ex: Related meetings on proposal page) is being displayed even though the linked resource is moderated ( and hidden )


#### Testing
1. As an user create a Meeting and a Proposal 
2. Report the meeting or proposal 
3. Go to admin, and hide one of them
4. The Other resource should not show the moderated linked resource 
-  Example: If you hide the Proposal, on the Meeting page you should not be able to see the hidden Proposal 

:hearts: Thank you!
