### PR TITLE
Test ensuring the moderated comments are not computed in stats

### DIFF
--- a/decidim-proposals/spec/system/homepage_stats_spec.rb
+++ b/decidim-proposals/spec/system/homepage_stats_spec.rb
@@ -4,9 +4,9 @@ require "spec_helper"
 
 describe "Homepage", type: :system do
   include_context "with a component"
-  let(:manifest_name) { "meetings" }
+  let(:manifest_name) { "proposals" }
 
-  let!(:meetings) { create_list(:meeting, 3, :published, component: component, author: component.organization) }
+  let!(:meetings) { create_list(:proposal, 3, :published, component: component, users: [component.organization]) }
   let!(:moderation) { create :moderation, reportable: meetings.first, hidden_at: 1.day.ago }
 
   let(:day) { Time.zone.yesterday }
@@ -19,8 +19,8 @@ describe "Homepage", type: :system do
     visit decidim.root_path
   end
 
-  it "display unhidden meeting count" do
-    within(".meetings_count") do
+  it "display unhidden proposal count" do
+    within(".proposals_count") do
       expect(page).to have_content(2)
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds 2 additional tests that would test the comments in meetings and proposals are not added to the stats count. 

#### Testing
There is no decidim functionality added. Only several tests. 

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
