### PR TITLE
Fix characters not encoded in highlighted participatory process group title

### DIFF
--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process_group.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process_group.html.erb
@@ -4,7 +4,7 @@
     <div class="columns mediumlarge-8 large-6 card--process__column">
       <div class="card__content">
         <%= link_to participatory_process_group_path(promoted_process_group), class: "card__link" do %>
-          <h2 class="card__title"><%= decidim_html_escape(translated_attribute(promoted_process_group.title)) %></h2>
+          <h2 class="card__title"><%= decidim_html_escape(translated_attribute(promoted_process_group.title)).html_safe %></h2>
         <% end %>
         <%= decidim_sanitize_editor html_truncate(translated_attribute(promoted_process_group.description), length: 630, separator: "...") %>
         <%= link_to participatory_process_group_path(promoted_process_group), class: "button small hollow card__button" do %>

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -253,7 +253,7 @@ describe "Participatory Processes", type: :system do
         it "lists all the highlighted process groups" do
           within "#highlighted-processes" do
             expect(page).to have_content(translated(promoted_group.title, locale: :en))
-            expect(page).to have_selector(".card--full", count: 1)
+            expect(page).to have_selector(".card--full", count: 2)
           end
         end
 

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -236,7 +236,7 @@ describe "Participatory Processes", type: :system do
         let(:promoted_items_titles) { page.all("#highlighted-processes .card__title").map(&:text) }
 
         before do
-          promoted_group.title["en"] = "D'Artagnan #{promoted_process.title["en"]}"
+          promoted_group.title["en"] = "D'Artagnan #{promoted_group.title["en"]}"
           promoted_group.save!
           visit decidim_participatory_processes.participatory_processes_path
         end
@@ -252,7 +252,7 @@ describe "Participatory Processes", type: :system do
 
         it "lists all the highlighted process groups" do
           within "#highlighted-processes" do
-            expect(page).to have_content(translated(promoted_process.title, locale: :en))
+            expect(page).to have_content(translated(promoted_group.title, locale: :en))
             expect(page).to have_selector(".card--full", count: 1)
           end
         end

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -236,6 +236,8 @@ describe "Participatory Processes", type: :system do
         let(:promoted_items_titles) { page.all("#highlighted-processes .card__title").map(&:text) }
 
         before do
+          promoted_group.title["en"] = "D'Artagnan #{promoted_process.title["en"]}"
+          promoted_group.save!
           visit decidim_participatory_processes.participatory_processes_path
         end
 
@@ -246,6 +248,13 @@ describe "Participatory Processes", type: :system do
         it "lists only promoted groups" do
           expect(promoted_items_titles).to include(translated(promoted_group.title, locale: :en))
           expect(promoted_items_titles).not_to include(translated(group.title, locale: :en))
+        end
+
+        it "lists all the highlighted process groups" do
+          within "#highlighted-processes" do
+            expect(page).to have_content(translated(promoted_process.title, locale: :en))
+            expect(page).to have_selector(".card--full", count: 1)
+          end
         end
 
         context "and promoted group has defined a CTA content block" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR aims to fix the title not encoded in highlighted participatory process group titles.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/decidim/decidim/pull/6798
- Fixes https://github.com/decidim/decidim/issues/8806

#### Testing
1. Create an highlighted process group with a title containing a ' or & symbol
2. Go on participatory process index
3. See that no diacritics are shown on the highlighted participatory process group card title. 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
