### PR TITLE
Fix notifications when there is a note proposal in other spaces than processes

### DIFF
--- a/decidim-proposals/app/events/decidim/proposals/admin/proposal_note_created_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/admin/proposal_note_created_event.rb
@@ -13,7 +13,7 @@ module Decidim
         end
 
         def admin_proposal_info_url
-          decidim_admin_participatory_process_proposals.proposal_url(resource, resource.component.mounted_params)
+          send(resource.component.mounted_admin_engine).proposal_url(resource, resource.component.mounted_params)
         end
 
         private

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -240,6 +240,10 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :with_assembly_participatory_space do
+      participatory_space { create(:assembly, organization: organization) }
+    end
   end
 
   factory :proposal, class: "Decidim::Proposals::Proposal" do
@@ -417,6 +421,10 @@ FactoryBot.define do
       after :create do |proposal|
         proposal.attachments << create(:attachment, :with_pdf, attached_to: proposal)
       end
+    end
+
+    trait :with_assembly_component do
+      component { create(:proposal_component, :with_assembly_participatory_space) }
     end
   end
 

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -240,10 +240,6 @@ FactoryBot.define do
         }
       end
     end
-
-    trait :with_assembly_participatory_space do
-      participatory_space { create(:assembly, organization: organization) }
-    end
   end
 
   factory :proposal, class: "Decidim::Proposals::Proposal" do
@@ -421,10 +417,6 @@ FactoryBot.define do
       after :create do |proposal|
         proposal.attachments << create(:attachment, :with_pdf, attached_to: proposal)
       end
-    end
-
-    trait :with_assembly_component do
-      component { create(:proposal_component, :with_assembly_participatory_space) }
     end
   end
 

--- a/decidim-proposals/spec/events/decidim/proposals/admin/proposal_note_created_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/admin/proposal_note_created_event_spec.rb
@@ -39,4 +39,24 @@ describe Decidim::Proposals::Admin::ProposalNoteCreatedEvent do
         .to include(%(Someone has left a note on the proposal <a href="#{resource_path}">#{resource_title}</a>. Check it out at <a href="#{admin_proposal_info_path}">the admin panel</a>))
     end
   end
+
+  context "when proposals component added to assemblies participatory space" do
+    let(:resource) { create :proposal, :with_assembly_component, title: ::Faker::Lorem.characters(number: 25) }
+    let(:admin_proposal_info_path) { "/admin/assemblies/#{participatory_space.slug}/components/#{component.id}/manage/proposals/#{resource.id}" }
+    let(:admin_proposal_info_url) { "http://#{organization.host}/admin/assemblies/#{participatory_space.slug}/components/#{component.id}/manage/proposals/#{resource.id}" }
+
+    describe "email_intro" do
+      it "is generated correctly" do
+        expect(subject.email_intro)
+          .to eq(%(Someone has left a note on the proposal "#{resource_title}". Check it out at <a href="#{admin_proposal_info_url}">the admin panel</a>))
+      end
+    end
+
+    describe "notification_title" do
+      it "is generated correctly" do
+        expect(subject.notification_title)
+          .to include(%(Someone has left a note on the proposal <a href="#{resource_path}">#{resource_title}</a>. Check it out at <a href="#{admin_proposal_info_path}">the admin panel</a>))
+      end
+    end
+  end
 end

--- a/decidim-proposals/spec/events/decidim/proposals/admin/proposal_note_created_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/admin/proposal_note_created_event_spec.rb
@@ -41,7 +41,9 @@ describe Decidim::Proposals::Admin::ProposalNoteCreatedEvent do
   end
 
   context "when proposals component added to assemblies participatory space" do
-    let(:resource) { create :proposal, :with_assembly_component, title: ::Faker::Lorem.characters(number: 25) }
+    let(:assembly) { create(:assembly) }
+    let(:proposal_component) { create :proposal_component, participatory_space: assembly }
+    let(:resource) { create :proposal, component: proposal_component, title: ::Faker::Lorem.characters(number: 25) }
     let(:admin_proposal_info_path) { "/admin/assemblies/#{participatory_space.slug}/components/#{component.id}/manage/proposals/#{resource.id}" }
     let(:admin_proposal_info_url) { "http://#{organization.host}/admin/assemblies/#{participatory_space.slug}/components/#{component.id}/manage/proposals/#{resource.id}" }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes exception on user notifications page. the issue is on generating of proposal_url for a notification when proposal related to anything else except the participatory process.

#### 🐞  The bug
The notification was introduced [here](https://github.com/decidim/decidim/pull/5906/files#diff-ae376af46e49e67d56ef82db319afb5cb238a411c99ab1d9a6b8a1edc34bf430R16) and the related tests passes because in tests proposal is by default [created for participatory_process](https://github.com/decidim/decidim/blob/254060438af8ece769ae22db66338bc366834914/decidim-proposals/lib/decidim/proposals/test/factories.rb#L11).

So it works well with processes, and `decidim_admin_participatory_process_proposals` engine can properly generate the url for the proposal added to the participatory_process.

The thing is that proposals can be added not only to the processes, but to a few other things, like assembly, initiative, consultation, etc:
https://github.com/decidim/decidim/search?q=%22include+Decidim%3A%3AParticipable%22
(check for `include Decidim::Participable`)

In those cases the engine would be a different one (accordingly to the component, `decidim_admin_assembly_proposals` for assemblies, for example). This results to the error when rendering the ProposalNoteCreatedEvent notification:
```
     ActionController::UrlGenerationError:
       No route matches {:component_id=>113}, missing required keys: [:participatory_process_slug]
```
Participatory processes engine can't generate urls for the assemblies, and vise versa.

#### 🔧  The fix
The fix is to use the mounted engine that is different depending on the proposal component, it picked from the `Participable` concern:
https://github.com/decidim/decidim/blob/254060438af8ece769ae22db66338bc366834914/decidim-core/lib/decidim/participable.rb#L33-L35

#### Testing

1. Create an assembly
2. Add proposals component to the assembly
3. Create proposal for that component
4. Add a proposal note to trigger the event
5. Check the notification page as any user who follows that assembly (as admin user should be enough, it follows by default)

