### PR TITLE
Fix displaying hidden meetings in show process page

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component/show.erb
@@ -1,7 +1,8 @@
 <% if upcoming_meetings.any? %>
   <div class="section row collapse upcoming_meetings">
     <h3 class="section-heading">
-      <%= translated_attribute(model.name) %> - <%= t("decidim.participatory_spaces.highlighted_meetings.upcoming_meetings") %> <a href="<%= main_component_path(model) %>" class="text-small"><%= t("decidim.participatory_spaces.highlighted_meetings.see_all", count: meetings_count) %></a>
+      <%= translated_attribute(model.name) %> - <%= t("decidim.participatory_spaces.highlighted_meetings.upcoming_meetings") %>
+      <a href="<%= main_component_path(model) %>" class="text-small"><%= t("decidim.participatory_spaces.highlighted_meetings.see_all", count: upcoming_meetings_count) %></a>
     </h3>
     <div class="card card--list">
       <% upcoming_meetings.includes(:component).each do |meeting| %>
@@ -9,7 +10,7 @@
       <% end %>
     </div>
     <%= link_to(
-      t("decidim.participatory_spaces.highlighted_meetings.see_all", count: meetings_count),
+      t("decidim.participatory_spaces.highlighted_meetings.see_all", count: upcoming_meetings_count),
       main_component_path(model),
       class: "button button--sc hollow button--right"
     ) %>
@@ -17,7 +18,7 @@
 <% elsif past_meetings.any? %>
   <div class="section row collapse past_meetings">
     <h3 class="section-heading">
-      <%= translated_attribute(model.name) %> - <%= t("decidim.participatory_spaces.highlighted_meetings.past_meetings") %> <a href="<%= main_component_path(model) %>" class="text-small"><%= t("decidim.participatory_spaces.highlighted_meetings.see_all", count: meetings_count) %></a>
+      <%= translated_attribute(model.name) %> - <%= t("decidim.participatory_spaces.highlighted_meetings.past_meetings") %> <a href="<%= main_component_path(model) %>" class="text-small"><%= t("decidim.participatory_spaces.highlighted_meetings.see_all", count: past_meetings_count) %></a>
     </h3>
     <div class="card card--list">
       <% past_meetings.each do |meeting| %>
@@ -25,7 +26,7 @@
       <% end %>
     </div>
     <%= link_to(
-      t("decidim.participatory_spaces.highlighted_meetings.see_all", count: meetings_count),
+      t("decidim.participatory_spaces.highlighted_meetings.see_all", count: past_meetings_count),
       main_component_path(model),
       class: "button button--sc hollow button--right"
     ) %>

--- a/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component_cell.rb
@@ -18,11 +18,23 @@ module Decidim
       private
 
       def meetings
-        @meetings ||= Decidim::Meetings::Meeting.where(component: model).except_withdrawn.visible_for(current_user)
+        @meetings ||= Decidim::Meetings::Meeting.where(component: model)
+                                                .except_withdrawn
+                                                .published
+                                                .not_hidden
+                                                .visible_for(current_user)
       end
 
       def past_meetings
         @past_meetings ||= meetings.past.order(end_time: :desc, start_time: :desc).limit(3)
+      end
+
+      def past_meetings_count
+        @past_meetings_count ||= meetings.past.count
+      end
+
+      def upcoming_meetings_count
+        @upcoming_meetings_count ||= meetings.upcoming.count
       end
 
       def upcoming_meetings

--- a/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component_cell.rb
@@ -29,20 +29,20 @@ module Decidim
         @past_meetings ||= meetings.past.order(end_time: :desc, start_time: :desc).limit(3)
       end
 
-      def past_meetings_count
-        @past_meetings_count ||= meetings.past.count
-      end
-
-      def upcoming_meetings_count
-        @upcoming_meetings_count ||= meetings.upcoming.count
-      end
-
       def upcoming_meetings
         @upcoming_meetings ||= meetings.upcoming.order(:start_time, :end_time).limit(3)
       end
 
       def meetings_count
         @meetings_count ||= meetings.count
+      end
+
+      def past_meetings_count
+        @past_meetings_count ||= meetings.past.count
+      end
+
+      def upcoming_meetings_count
+        @upcoming_meetings_count ||= meetings.upcoming.count
       end
     end
   end

--- a/decidim-meetings/spec/system/participatory_processes_view_hooks_spec.rb
+++ b/decidim-meetings/spec/system/participatory_processes_view_hooks_spec.rb
@@ -8,6 +8,7 @@ describe "Meetings in process home", type: :system do
   let(:meetings_count) { 5 }
 
   context "when there are only past meetings" do
+    let!(:moderated_meeting) { create(:meeting, :moderated, :published, :past, component: component, end_time: 5.hours.ago) }
     let!(:past_meetings) do
       create_list(:meeting, meetings_count, :published, :past, component: component)
     end
@@ -15,6 +16,8 @@ describe "Meetings in process home", type: :system do
     it "shows the last three past meetings" do
       visit resource_locator(participatory_process).path
       expect(page).to have_css(".past_meetings .card--list__item", count: 3)
+
+      expect(page).not_to have_content(/#{translated(moderated_meeting.title)}/i)
 
       past_meetings.sort_by { |m| [m.end_time, m.start_time] }.last(3).each do |meeting|
         expect(page).to have_content(/#{translated(meeting.title)}/i)
@@ -26,10 +29,13 @@ describe "Meetings in process home", type: :system do
     let!(:upcoming_meetings) do
       create_list(:meeting, meetings_count, :published, :upcoming, component: component)
     end
+    let!(:moderated_meeting) { create(:meeting, :moderated, :published, :upcoming, component: component) }
 
     it "shows the first three upcoming meetings" do
       visit resource_locator(participatory_process).path
       expect(page).to have_css(".upcoming_meetings .card--list__item", count: 3)
+
+      expect(page).not_to have_content(/#{translated(moderated_meeting.title)}/i)
 
       upcoming_meetings.sort_by { |m| [m.start_time, m.end_time] }.first(3).each do |meeting|
         expect(page).to have_content(/#{translated(meeting.title)}/i)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR hides the hidden meetings from the show process page

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #8821

#### Testing
1. From the show process page  choose a meeting and report it 
2. Go to admin and hide it 
3. Revisit the show process page 
4. The Meeting should not be there anymore

:hearts: Thank you!
