### PR TITLE
Fix activity cell disappearing author images

### DIFF
--- a/decidim-core/app/cells/decidim/activity_cell.rb
+++ b/decidim-core/app/cells/decidim/activity_cell.rb
@@ -95,6 +95,9 @@ module Decidim
       hash << I18n.locale.to_s
       hash << model.class.name.underscore
       hash << model.cache_key_with_version
+      if (author_cell = author)
+        hash.push(Digest::MD5.hexdigest(author_cell.send(:cache_hash)))
+      end
 
       hash.join(Decidim.cache_key_separator)
     end


### PR DESCRIPTION
#### :tophat: What? Why?
The activity cells do not consider if the author record has changed after the cell was cached.

For example, if the author changes their image, the images can suddenly disappear from the activity logs as shown in the attached screenshot (the user changed their avatar).

This also causes some other issues, such as the "Send private message" link linking to the sign in page even when the user is already signed in.

#### Testing
- Enable caching for the system (default in production environments, e.g. MetaDecidim)
- Sign in as a user
- Add an avatar to the user
- Create some activity that will appear in the activity listings (e.g. front page, user profile, etc.)
- Take a look at the activity listing and see that the user avatar thumbnail is correctly displayed
- Go to "My account" and change your avatar image
- Take a look at the activity listing and see that the avatar disappeared because the cached image no longer exists

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

Disappearing avatar images in the activity log:
![Disappearing author avatars in activity logs](https://user-images.githubusercontent.com/864340/154261007-199b30c6-6d1f-4323-b04f-e6df9f3d5319.png)