### PR TITLE
Replace Decidim mentions in UI with 'the platform'

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -341,7 +341,7 @@ en:
       dashboard:
         show:
           view_more_logs: View more logs
-          welcome: Welcome to the Decidim Admin Panel.
+          welcome: Welcome to the Admin Panel.
       domain_whitelist:
         form:
           domain_too_short: Domain too short

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -271,7 +271,7 @@ en:
             duration_help: If the duration of this assembly is limited, select the end date. Otherwise, it will appear as indefinite.
             filters: Filters
             images: Images
-            included_at_help: Select the date when this assembly was added to Decidim. It does not necessarily have to be the same as the creation date.
+            included_at_help: Select the date when this assembly was added to the platform. It does not necessarily have to be the same as the creation date.
             metadata: Metadata
             other: Other
             select_a_created_by: Select a created by

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -127,7 +127,7 @@ en:
         error: There was a problem deleting your account.
         success: Your account was successfully deleted.
       show:
-        available_locales_helper: Choose the language you want to use to browse and receive notifications in the platform
+        available_locales_helper: Choose the language you want to use to browse and receive notifications on the platform
         change_password: Change password
         update_account: Update account
       update:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -127,7 +127,7 @@ en:
         error: There was a problem deleting your account.
         success: Your account was successfully deleted.
       show:
-        available_locales_helper: Choose the language you want to use to browse and receive notifications in Decidim
+        available_locales_helper: Choose the language you want to use to browse and receive notifications in the platform
         change_password: Change password
         update_account: Update account
       update:

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -581,15 +581,15 @@ en:
               generate_legend_3: Ensure your computer doesn't have a copy of the file (e.g. check the Downloads and Desktop folders).
               generate_legend_4: Make another copy of the file on a different external device and store it in a very safe place.
               submit: Submit
-              submit_legend: After following all the steps explained above, complete the process sending the public identification key to the Decidim server.
+              submit_legend: After following all the steps explained above, complete the process sending the public identification key to the server.
               submit_title: Submit the public identification key
               title: Trustee identification keys
               upload: Upload your identification keys
               upload_error:
                 invalid_format: The uploaded file doesn't contain any identification key.
                 invalid_key: The identification keys in the uploaded file can't be loaded.
-                invalid_public_key: The identification keys in the uploaded file doesn't match the public identification key stored by Decidim.
-              upload_legend: Decidim has your public identification keys, but your browser still doesn't have it. You need to import the file with your identification keys to your computer from the backup you created after generating them.
+                invalid_public_key: The identification keys in the uploaded file doesn't match the public identification key stored.
+              upload_legend: The server has your public identification keys, but your browser still doesn't have it. You need to import the file with your identification keys to your computer from the backup you created after generating them.
             not_supported_browser_description: It looks like you are using a web browser that can't be used to act as a Trustee. Make sure you're using the most recent version of your browser, or try using any of the most popular browsers to be able to complete your Trustee tasks.
             not_supported_browser_title: Upgrade browser to act as a Trustee
             trustee_role_description: You have been assigned to act as a Trustee in some of the elections celebrated in this platform.
@@ -656,9 +656,9 @@ en:
         onboarding_modal:
           close: Close modal
           create_account: Create Account
-          description: Do you want to create a new account in Decidim? You will be able to participate in the processes and be an active part of the organization.
+          description: Do you want to create a new account in the platform? You will be able to participate in the processes and be an active part of the organization.
           no_account: No, thanks.
-          title: New to Decidim?
+          title: New to the platform?
         update:
           error: There was a problem updating the vote status. Please, vote again.
         verify:
@@ -669,7 +669,7 @@ en:
             header: Vote not found!
             info: The vote code was not found in the %{link} ballot box, try again.
           form:
-            back: Back to Decidim
+            back: Back to the platform
             submit: Check
             vote_identifier: 'Identifier code:'
           header:
@@ -986,7 +986,7 @@ en:
             assign_missing_officers: There are Polling Stations without President and/or Managers. Please assign them from the Polling stations section
             update: Update
           form:
-            census_contact_information_help: This contact information is for a participant who wants to report issues with the census. It can be an email address, a contact form on another site, a Decidim survey for visitors, etc.
+            census_contact_information_help: This contact information is for a participant who wants to report issues with the census. It can be an email address, a contact form on another site, a survey for visitors, etc.
             select_a_voting_type: Please select a voting type
             slug_help: 'URL slugs are used to generate the URLs that point to this voting. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
             title: Title

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -656,7 +656,7 @@ en:
         onboarding_modal:
           close: Close modal
           create_account: Create Account
-          description: Do you want to create a new account in the platform? You will be able to participate in the processes and be an active part of the organization.
+          description: Do you want to create a new account on the platform? You will be able to participate in the processes and be an active part of the organization.
           no_account: No, thanks.
           title: New to the platform?
         update:

--- a/decidim-elections/spec/system/vote_online_inside_a_voting_spec.rb
+++ b/decidim-elections/spec/system/vote_online_inside_a_voting_spec.rb
@@ -60,7 +60,7 @@ describe "Vote online in an election inside a Voting", type: :system do
           click_button "Submit"
         end
 
-        expect(page).to have_content("New to Decidim?")
+        expect(page).to have_content("New to the platform?")
 
         within "#onboarding-modal" do
           click_button "No, thanks."
@@ -76,7 +76,7 @@ describe "Vote online in an election inside a Voting", type: :system do
       it "can vote and sign up without feedback" do
         vote_with_census_data
 
-        expect(page).to have_content("New to Decidim?")
+        expect(page).to have_content("New to the platform?")
 
         within "#onboarding-modal" do
           click_button "No, thanks."
@@ -88,7 +88,7 @@ describe "Vote online in an election inside a Voting", type: :system do
 
         expect(page).to have_current_path router.elections_path
 
-        expect(page).not_to have_content("New to Decidim?")
+        expect(page).not_to have_content("New to the platform?")
       end
     end
   end

--- a/decidim-sortitions/config/locales/en.yml
+++ b/decidim-sortitions/config/locales/en.yml
@@ -77,7 +77,7 @@ en:
           index:
             title: Sortitions
           new:
-            confirm: By pressing the next button Decidim will record the date and time (with precision of seconds) and together with the dice roll, this information will be used to generate a random selection. The action will be irreversible, once the button is clicked the result of this draw will be published, together with the data entered in this form and can not be modified, please check the content carefully
+            confirm: By pressing the next button the platform will record the date and time (with precision of seconds) and together with the dice roll, this information will be used to generate a random selection. The action will be irreversible, once the button is clicked the result of this draw will be published, together with the data entered in this form and can not be modified, please check the content carefully
             create: Create
             title: New sortition
           show:


### PR DESCRIPTION
#### :tophat: What? Why?


While reviewing #8749, I noticed that we were talking to the participant about a thing called "Decidim". As it is used by participants from many places that they may not know what's this "Decidim" thing, then we should rephrase where we talk about this to "the platform" or any other alternative depending on the context. 


:hearts: Thank you!
