### PR TITLE
Show hidden comments replies

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comment/moderation_data.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/moderation_data.erb
@@ -1,0 +1,1 @@
+<%= render partial: "decidim/comments/comments/moderated.html", locals: { comment: model } %>

--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -1,5 +1,7 @@
 <%= content_tag :div, id: "comment_#{model.id}", class: comment_classes, data: { comment_id: model.id } do %>
-  <% if model.deleted? %>
+  <% if model.hidden? %>
+    <%= render :moderation_data %>
+  <% elsif model.deleted? %>
     <%= render :deletion_data %>
   <% else %>
     <div class="comment__header">

--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -32,14 +32,14 @@
     </div>
   <% end %>
   <div id="comment-<%= model.id %>-replies">
-    <% if has_replies? %>
+    <% if has_replies_in_children? %>
       <% replies.each do |reply| %>
         <%= cell("decidim/comments/comment", reply, root_depth: root_depth, order: order, reloaded: reloaded?) %>
       <% end %>
     <% end %>
   </div>
   <% if can_reply? %>
-    <div class="comment__additionalreply<%= " hide" unless has_replies? %>">
+    <div class="comment__additionalreply<%= " hide" unless commentable? %>">
       <button class="comment__reply muted-link" aria-controls="<%= reply_id %>" data-toggle="<%= reply_id %>">
         <%= icon "pencil", class: "icon--small", role: "img", "aria-hidden": true %>&nbsp;<%= t("decidim.components.comment.reply") %>
       </button>

--- a/decidim-comments/app/cells/decidim/comments/comment_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comment_cell.rb
@@ -34,7 +34,7 @@ module Decidim
       end
 
       def perform_caching?
-        super && has_replies? == false
+        super && has_replies_in_children? == false
       end
 
       private
@@ -181,8 +181,16 @@ module Decidim
         depth.even?
       end
 
+      def commentable?
+        has_replies? && !model.deleted? && !model.hidden?
+      end
+
       def has_replies?
         model.comment_threads.includes(:moderation).collect { |c| !c.deleted? && !c.hidden? }.any?
+      end
+
+      def has_replies_in_children?
+        has_replies? || model.comment_threads.includes(:moderation).collect { |t| t.comment_threads.includes(:moderation).collect { |c| !c.deleted? && !c.hidden? }.any? }.any?
       end
 
       # action_authorization_button expects current_component to be available

--- a/decidim-comments/app/cells/decidim/comments/comment_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comment_cell.rb
@@ -182,7 +182,7 @@ module Decidim
       end
 
       def has_replies?
-        model.comment_threads.any?
+        model.comment_threads.includes(:moderation).collect { |c| !c.deleted? && !c.hidden? }.any?
       end
 
       # action_authorization_button expects current_component to be available

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -101,13 +101,6 @@ module Decidim
         root_commentable.accepts_new_comments? && depth < MAX_DEPTH
       end
 
-      # Public: Override comment threads to exclude hidden ones.
-      #
-      # Returns comment.
-      def comment_threads
-        super.reject(&:hidden?)
-      end
-
       # Public: Override Commentable concern method `users_to_notify_on_comment_created`.
       # Return the comment author together with whatever ActiveRecord::Relation is returned by
       # the `commentable`. This will cause the comment author to be notified when the

--- a/decidim-comments/app/queries/decidim/comments/sorted_comments.rb
+++ b/decidim-comments/app/queries/decidim/comments/sorted_comments.rb
@@ -31,7 +31,6 @@ module Decidim
       # level of nested replies.
       def query
         scope = base_scope
-                .not_hidden
                 .includes(:author, :user_group, :up_votes, :down_votes)
 
         case @options[:order_by]

--- a/decidim-comments/app/views/decidim/comments/comments/_moderated.html.erb
+++ b/decidim-comments/app/views/decidim/comments/comments/_moderated.html.erb
@@ -1,0 +1,5 @@
+<div class="comment__header">
+  <div class="comment__deleted">
+    <%= t("decidim.components.comment.moderated_at", date: l(comment.moderation.hidden_at, format: :decidim_short)) %>
+  </div>
+</div>

--- a/decidim-comments/app/views/decidim/comments/comments/_moderated.html.erb
+++ b/decidim-comments/app/views/decidim/comments/comments/_moderated.html.erb
@@ -1,5 +1,5 @@
 <div class="comment__header">
-  <div class="comment__deleted">
+  <div class="comment__moderated">
     <%= t("decidim.components.comment.moderated_at", date: l(comment.moderation.hidden_at, format: :decidim_short)) %>
   </div>
 </div>

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -71,6 +71,7 @@ en:
         edit: Edit
         edited: Edited
         hide_replies: Hide replies
+        moderated_at: Comment moderated on %{date}
         reply: Reply
         report:
           action: Report

--- a/decidim-comments/lib/decidim/api/comment_type.rb
+++ b/decidim-comments/lib/decidim/api/comment_type.rb
@@ -74,7 +74,7 @@ module Decidim
       end
 
       def has_comments?
-        object.comment_threads.size.positive?
+        object.comment_threads.not_hidden.size.positive?
       end
 
       def already_reported

--- a/decidim-comments/lib/decidim/api/commentable_interface.rb
+++ b/decidim-comments/lib/decidim/api/commentable_interface.rb
@@ -25,7 +25,7 @@ module Decidim
       field :total_comments_count, GraphQL::Types::Int, description: "The number of comments in all levels this resource holds", null: false
 
       def comments(order_by: nil, single_comment_id: nil)
-        SortedComments.for(object, order_by: order_by, id: single_comment_id)
+        SortedComments.for(object, order_by: order_by, id: single_comment_id).not_hidden
       end
 
       def total_comments_count
@@ -36,7 +36,7 @@ module Decidim
 
       # rubocop:disable Naming/PredicateName
       def has_comments
-        object.comment_threads.size.positive?
+        object.comment_threads.not_hidden.size.positive?
       end
       # rubocop:enable Naming/PredicateName
 

--- a/decidim-comments/spec/cells/decidim/comments/comment_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comment_cell_spec.rb
@@ -55,6 +55,28 @@ module Decidim::Comments
         end
       end
 
+      context "when moderated" do
+        let(:comment) { create(:comment, commentable: commentable, created_at: 1.day.ago) }
+        let!(:moderation) { create(:moderation, hidden_at: 6.hours.ago, reportable: comment) }
+
+        it "renders the card with a deletion message and replies" do
+          expect(subject).to have_css("#comment_#{comment.id}")
+          expect(subject).to have_css("#comment-#{comment.id}-replies", text: "")
+          expect(subject).to have_css(".comment__moderated")
+          expect(subject).to have_no_css("button[data-open='loginModal'][title='#{I18n.t("decidim.components.comment.report.title")}']")
+          expect(subject).to have_no_css("a[href='/processes/#{participatory_process.slug}/f/#{component.id}/dummy_resources/#{commentable.id}?commentId=#{comment.id}#comment_#{comment.id}']")
+          expect(subject).to have_no_content(comment.body.values.first)
+          expect(subject).to have_no_content(I18n.l(comment.created_at, format: :decidim_short))
+          expect(subject).to have_content(I18n.l(moderation.hidden_at, format: :decidim_short))
+          expect(subject).to have_no_content(comment.author.name)
+
+          expect(subject).to have_no_css(".comment__additionalreply")
+          expect(subject).to have_no_css(".add-comment")
+          expect(subject).to have_no_css(".comment__reply")
+          expect(subject).to have_no_css("#flagModalComment#{comment.id}")
+        end
+      end
+
       context "when edited" do
         before do
           allow(comment).to receive(:edited?).and_return(true)

--- a/decidim-comments/spec/cells/decidim/comments/comment_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comment_cell_spec.rb
@@ -59,7 +59,7 @@ module Decidim::Comments
         let(:comment) { create(:comment, commentable: commentable, created_at: 1.day.ago) }
         let!(:moderation) { create(:moderation, hidden_at: 6.hours.ago, reportable: comment) }
 
-        it "renders the card with a deletion message and replies" do
+        it "renders the card with a moderation message and replies" do
           expect(subject).to have_css("#comment_#{comment.id}")
           expect(subject).to have_css("#comment-#{comment.id}-replies", text: "")
           expect(subject).to have_css(".comment__moderated")

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -62,16 +62,14 @@ module Decidim::Comments
           end
 
           it "renders the thread" do
-            expect(subject).to have_css(".section-heading", text: "10 comments")
             expect(subject).to have_css(".callout.primary.loading-comments p", text: "Loading comments ...")
             expect(subject).not_to have_content(comment.body.values.first)
-            expect(subject).to have_css(".add-comment")
-            expect(subject).to have_content("Sign in with your account or sign up to add your comment.")
+            expect(subject).not_to have_css(".add-comment")
           end
 
           it "does not render the single comment warning" do
-            expect(subject).not_to have_css(".callout.secondary", text: "You are seeing a single comment")
-            expect(subject).not_to have_css(".callout.secondary", text: "View all comments")
+            expect(subject).to have_css(".callout.secondary", text: "You are seeing a single comment")
+            expect(subject).to have_css(".callout.secondary", text: "View all comments")
           end
         end
       end

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -67,7 +67,7 @@ module Decidim::Comments
             expect(subject).not_to have_css(".add-comment")
           end
 
-          it "does not render the single comment warning" do
+          it "renders the single comment warning" do
             expect(subject).to have_css(".callout.secondary", text: "You are seeing a single comment")
             expect(subject).to have_css(".callout.secondary", text: "View all comments")
           end

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -223,6 +223,12 @@ module Decidim
           expect(parent.comment_threads.count).to eq 3
         end
 
+        it "returns 2 when a comment has been moderated" do
+          Decidim::Moderation.create!(reportable: comments.last, participatory_space: comments.last.participatory_space, hidden_at: 1.day.ago)
+
+          expect(parent.comment_threads.count).to eq 3
+        end
+
         describe "#body_length" do
           context "when no default comments length specified" do
             let!(:body) { { en: ::Faker::Lorem.sentence(word_count: 1000) } }

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -223,12 +223,6 @@ module Decidim
           expect(parent.comment_threads.count).to eq 3
         end
 
-        it "returns 2 when a comment has been moderated" do
-          Decidim::Moderation.create!(reportable: comments.last, participatory_space: comments.last.participatory_space, hidden_at: 1.day.ago)
-
-          expect(parent.comment_threads.count).to eq 2
-        end
-
         describe "#body_length" do
           context "when no default comments length specified" do
             let!(:body) { { en: ::Faker::Lorem.sentence(word_count: 1000) } }

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -223,7 +223,7 @@ module Decidim
           expect(parent.comment_threads.count).to eq 3
         end
 
-        it "returns 2 when a comment has been moderated" do
+        it "still returns 3 when a comment has been moderated" do
           Decidim::Moderation.create!(reportable: comments.last, participatory_space: comments.last.participatory_space, hidden_at: 1.day.ago)
 
           expect(parent.comment_threads.count).to eq 3

--- a/decidim-comments/spec/queries/sorted_comments_spec.rb
+++ b/decidim-comments/spec/queries/sorted_comments_spec.rb
@@ -69,6 +69,17 @@ module Decidim::Comments
       end
     end
 
+    context "when the comment is hidden" do
+      before do
+        moderation = create(:moderation, reportable: comment, participatory_space: comment.component.participatory_space, report_count: 1, hidden_at: Time.current)
+        create(:report, moderation: moderation)
+      end
+
+      it "is not included in the query" do
+        expect(subject.query).not_to be_empty
+      end
+    end
+
     context "when order_by is not default" do
       context "when order by recent" do
         let!(:order_by) { "recent" }

--- a/decidim-comments/spec/queries/sorted_comments_spec.rb
+++ b/decidim-comments/spec/queries/sorted_comments_spec.rb
@@ -75,7 +75,7 @@ module Decidim::Comments
         create(:report, moderation: moderation)
       end
 
-      it "is not included in the query" do
+      it "is included in the query" do
         expect(subject.query).not_to be_empty
       end
     end

--- a/decidim-comments/spec/queries/sorted_comments_spec.rb
+++ b/decidim-comments/spec/queries/sorted_comments_spec.rb
@@ -69,17 +69,6 @@ module Decidim::Comments
       end
     end
 
-    context "when the comment is hidden" do
-      before do
-        moderation = create(:moderation, reportable: comment, participatory_space: comment.component.participatory_space, report_count: 1, hidden_at: Time.current)
-        create(:report, moderation: moderation)
-      end
-
-      it "is not included in the query" do
-        expect(subject.query).to be_empty
-      end
-    end
-
     context "when order_by is not default" do
       context "when order by recent" do
         let!(:order_by) { "recent" }

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_comments.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_comments.scss
@@ -31,6 +31,7 @@ $comment-form-bg: $light-gray;
   display: flex;
 
   .comment__edited,
+  .comment__moderated,
   .comment__deleted{
     font-style: italic;
     color: $muted;


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the case when a Comment on a resource is being moderated leaving the children comments hidden. Before this PR, the resource could display a count of 2 comments, but only displaying only a single comment. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #8660

#### Testing
1. login as administrator 
2. Go to a resource show page (meeting / proposal etc )
3. Add comments/ replies 
4. Report / delete some of them
5. Go to admin area & hide the reported content 
6. Go back to the page visited on step 2 
7. Observe and provide feedback :)

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![image](https://user-images.githubusercontent.com/105683/154362297-26ebbdf1-f2d6-4d60-a55d-df70facdb8cb.png)

:hearts: Thank you!
