### PR TITLE
Fix accountability text search

### DIFF
--- a/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
@@ -35,7 +35,7 @@ module Decidim
 
       def default_filter_params
         {
-          search_text: "",
+          search_text_cont: "",
           with_scope: "",
           with_category: ""
         }

--- a/decidim-accountability/app/models/decidim/accountability/result.rb
+++ b/decidim-accountability/app/models/decidim/accountability/result.rb
@@ -90,8 +90,9 @@ module Decidim
         Arel.sql(%{cast("decidim_accountability_results"."id" as text)})
       end
 
-      # Allow ransacker to search for a key in a hstore column (`title`.`en`)
-      ransacker_i18n :title
+      # Create i18n ransackers for :title and :description.
+      # Create the :search_text ransacker alias for searching from both of these.
+      ransacker_i18n_multi :search_text, [:title, :description]
 
       private
 

--- a/decidim-accountability/app/views/decidim/accountability/results/_search.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_search.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag results_path, method: :get do %>
   <div class="filters__search">
     <div class="input-group">
-      <%= search_field_tag "filter[search_text]", nil, class: "input-group-field", placeholder: t(".search"), value: "", title:  t(".search") %>
+      <%= search_field_tag "filter[search_text_cont]", nil, class: "input-group-field", placeholder: t(".search"), value: "", title:  t(".search") %>
       <div class="input-group-button">
         <button type="submit" class="button">
           <%= icon "magnifying-glass", aria_label: t(".search"), role: "img" %>

--- a/decidim-accountability/spec/requests/result_search_spec.rb
+++ b/decidim-accountability/spec/requests/result_search_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Result search", type: :request do
   let!(:result1) do
     create(
       :result,
+      title: Decidim::Faker::Localized.literal("A doggo in the title"),
       component: component,
       parent: nil,
       category: create(:category, participatory_space: participatory_space)
@@ -21,6 +22,7 @@ RSpec.describe "Result search", type: :request do
   let!(:result2) do
     create(
       :result,
+      description: Decidim::Faker::Localized.literal("There is a doggo in the office"),
       component: component,
       parent: result1,
       category: create(:category, participatory_space: participatory_space)
@@ -31,6 +33,14 @@ RSpec.describe "Result search", type: :request do
       :result,
       component: component,
       parent: result2,
+      category: create(:category, participatory_space: participatory_space)
+    )
+  end
+  let!(:result4) do
+    create(
+      :result,
+      component: component,
+      parent: nil,
       category: create(:category, participatory_space: participatory_space)
     )
   end
@@ -50,6 +60,7 @@ RSpec.describe "Result search", type: :request do
 
     it "displays all categories that have top-level results" do
       expect(subject).to include(translated(result1.category.name))
+      expect(subject).to include(translated(result4.category.name))
     end
 
     it "does not display the categories that only have sub-results" do
@@ -66,7 +77,7 @@ RSpec.describe "Result search", type: :request do
     context "when deep searching" do
       context "when the parent_id is nil" do
         it "returns the search on all results" do
-          expect(subject).to match_array [result1, result2]
+          expect(subject).to match_array [result1, result2, result4]
         end
       end
 
@@ -84,6 +95,14 @@ RSpec.describe "Result search", type: :request do
         it "returns the search on the children of result" do
           expect(subject).to match_array [result3]
         end
+      end
+    end
+
+    context "when searching by text" do
+      let(:filter_params) { { search_text_cont: "doggo" } }
+
+      it "returns the search results matching the word in title or description" do
+        expect(subject).to match_array [result1, result2]
       end
     end
   end

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -89,6 +89,39 @@ describe "Explore results", versioning: true, type: :system do
         end
       end
     end
+
+    context "when searching" do
+      let!(:matching_result1) do
+        create(
+          :result,
+          title: Decidim::Faker::Localized.literal("A doggo in the title"),
+          component: component
+        )
+      end
+      let!(:matching_result2) do
+        create(
+          :result,
+          title: Decidim::Faker::Localized.literal("Other matching result"),
+          description: Decidim::Faker::Localized.literal("There is a doggo in the office"),
+          component: component
+        )
+      end
+
+      it "displays the correct search results" do
+        fill_in :filter_search_text_cont, with: "doggo"
+        within "form .filters__search" do
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("2 RESULTS")
+        expect(page).to have_content(translated(matching_result1.title))
+        expect(page).to have_content(translated(matching_result2.title))
+
+        results.each do |result|
+          expect(page).not_to have_content(translated(result.title))
+        end
+      end
+    end
   end
 
   describe "index" do


### PR DESCRIPTION
#### :tophat: What? Why?
The plain text search was broken by #8748. This fixes it and adds regression tests for this feature.

#### :pushpin: Related Issues
- Related to #8748

#### Testing
- Default seed data
- Go to the accountability component
- Type anything to the search box
- Notice that all the results are displayed instead of only the matching results

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.