### PR TITLE
Add useful error for custom-authorizations development

### DIFF
--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -71,9 +71,19 @@ module Decidim
       def valid_handler
         return true if handler
 
-        logger.warn "Invalid authorization handler given: #{handler_name} doesn't"\
-          "exist or you haven't added it to `Decidim.authorization_handlers`"
+        msg = <<-MSG
+        Invalid authorization handler given: #{handler_name} doesn't
+        exist or you haven't added it to `Decidim.authorization_handlers.
 
+        Make sure this name matches with your registrations:\n\n
+        Decidim::Verifications.register_workflow(:#{handler_name}) do
+          ...
+        end
+        MSG
+
+        raise msg if Rails.env.development?
+
+        logger.warn msg
         redirect_to(authorizations_path) && (return false)
       end
 


### PR DESCRIPTION


#### :tophat: What? Why?
The idea is to throw an error when server is running in dev mode to give
developers an idea of wha't going wrong with their workflow registration

Usually this errors are more useful during its development rather than
running in prod

#### :pushpin: Related Issues
N/A

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

<img width="1789" alt="image" src="https://user-images.githubusercontent.com/39539196/154407586-05c2dd32-5d99-4486-a9f9-ec007ff247ef.png">

:hearts: Thank you!
