### PR TITLE
Clarify the locales on the list of admins

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -174,7 +174,7 @@ en:
         reject: Reject
         share: Share
         user:
-          new: New user
+          new: New admin
         verify: Verify
       admin_terms_of_use:
         accept:
@@ -962,7 +962,7 @@ en:
         static_pages: Pages
         statistics: Activity
         user_groups: Groups
-        users: Participants
+        users: Administrators
       user_group:
         csv_verify:
           invalid: There was a problem reading the CSV file.
@@ -998,7 +998,7 @@ en:
           role: Role
         new:
           create: Invite
-          title: Invite participant as administrator
+          title: Invite new administrator
       users_statistics:
         users_count:
           admins: Admins


### PR DESCRIPTION
#### :tophat: What? Why?

This is a really small language fix for something that has been bugging several of our admins.

In the admin panel, the words used on the page with the list of admins is confusing.

<img width="719" alt="Capture d’écran 2022-02-17 à 12 15 21" src="https://user-images.githubusercontent.com/7223028/154470617-f497032f-5eca-4db3-99dd-7f894b16b9b0.png">
<img width="722" alt="Capture d’écran 2022-02-17 à 12 15 35" src="https://user-images.githubusercontent.com/7223028/154470630-ae37b00b-1b42-4502-acba-e0f6983e242f.png">

This replaces **Participants** by **Administrators** in the title and **New user** by **New admin** in the button.
It also replaces **Invite participant as administrator** by **Invite new administrator** in the form to invite a new admin.

<img width="715" alt="Capture d’écran 2022-02-17 à 12 13 51" src="https://user-images.githubusercontent.com/7223028/154470867-1245185f-5d51-4c1a-a864-487e705db475.png">
<img width="709" alt="Capture d’écran 2022-02-17 à 12 14 34" src="https://user-images.githubusercontent.com/7223028/154470873-a64f3198-5bb1-4ffa-80c2-a735d6c29732.png">

#### :pushpin: Related Issues
- I didn't create a point in MetaDecidim to keep it lightweight.
- Note that the whole code for the admin index page is old and references to "users" everywhere. I haven't changed that as such a refactor should probably be decided by a member of the Product team. I just fixed the locales to avoid confusion for platform admins.

#### Testing
- Just go to `/admin/users`

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [X] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [X] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [X] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [X] :heavy_check_mark: **DO** build locally before pushing.
- [X] :heavy_check_mark: **DO** make sure tests pass.
- [X] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [X] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [X] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [X] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [X] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [X] :x:**AVOID** breaking the continuous integration build.
- [X] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
