### PR TITLE
Fix docs for install-decidim.sh permissions

### DIFF
--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -32,7 +32,7 @@ There's also a installation script made by http://www.platoniq.net/[Platoniq] th
 [source,console]
 ----
 wget -O install-decidim.sh https://raw.githubusercontent.com/Platoniq/decidim-install/master/script/install-decidim.sh
-chmod +x decidim-install.sh
+chmod +x install-decidim.sh
 ./install-decidim.sh decidim_application
 ----
 


### PR DESCRIPTION
#### :tophat: What? Why?

We've messed up the script filename in the installation script docs. This PR fixes that. 

#### :pushpin: Related Issues
 
- Fixes  #8832


:hearts: Thank you!
