### PR TITLE
Display friendly report reason and details in moderation emails

### DIFF
--- a/decidim-core/app/commands/decidim/create_user_report.rb
+++ b/decidim-core/app/commands/decidim/create_user_report.rb
@@ -56,7 +56,7 @@ module Decidim
 
     def send_notification_to_admins!
       current_organization.admins.each do |admin|
-        Decidim::UserReportJob.perform_later(admin, current_user, form.reason, reportable)
+        Decidim::UserReportJob.perform_later(admin, current_user, report)
       end
     end
 

--- a/decidim-core/app/commands/decidim/create_user_report.rb
+++ b/decidim-core/app/commands/decidim/create_user_report.rb
@@ -56,7 +56,7 @@ module Decidim
 
     def send_notification_to_admins!
       current_organization.admins.each do |admin|
-        Decidim::UserReportJob.perform_later(admin, current_user, report)
+        Decidim::UserReportJob.perform_later(admin, report)
       end
     end
 

--- a/decidim-core/app/jobs/decidim/user_report_job.rb
+++ b/decidim-core/app/jobs/decidim/user_report_job.rb
@@ -4,8 +4,8 @@ module Decidim
   class UserReportJob < ApplicationJob
     queue_as :user_report
 
-    def perform(admin, reporting_user, report)
-      UserReportMailer.notify(admin, reporting_user, report).deliver_now
+    def perform(admin, report)
+      UserReportMailer.notify(admin, report).deliver_now
     end
   end
 end

--- a/decidim-core/app/jobs/decidim/user_report_job.rb
+++ b/decidim-core/app/jobs/decidim/user_report_job.rb
@@ -4,8 +4,8 @@ module Decidim
   class UserReportJob < ApplicationJob
     queue_as :user_report
 
-    def perform(admin, token, reason, user)
-      UserReportMailer.notify(admin, token, reason, user).deliver_now
+    def perform(admin, reporting_user, report)
+      UserReportMailer.notify(admin, reporting_user, report).deliver_now
     end
   end
 end

--- a/decidim-core/app/mailers/decidim/user_report_mailer.rb
+++ b/decidim-core/app/mailers/decidim/user_report_mailer.rb
@@ -4,7 +4,7 @@ module Decidim
   # A custom mailer to notify Decidim users
   # that they have been reported
   class UserReportMailer < ApplicationMailer
-    def notify(admin, token, report)
+    def notify(admin, report)
       @report = report
       @admin = admin
       @organization = report.moderation.user.organization

--- a/decidim-core/app/mailers/decidim/user_report_mailer.rb
+++ b/decidim-core/app/mailers/decidim/user_report_mailer.rb
@@ -4,18 +4,15 @@ module Decidim
   # A custom mailer to notify Decidim users
   # that they have been reported
   class UserReportMailer < ApplicationMailer
-    def notify(admin, token, reason, user)
-      @user = user
-      @organization = user.organization
-      @token = token
-      @reason = reason
+    def notify(admin, token, report)
+      @report = report
       @admin = admin
+      @organization = report.moderation.user.organization
       with_user(admin) do
         mail(to: admin.email, subject: I18n.t(
           "decidim.user_report_mailer.notify.subject",
-          organization_name: @organization.name,
-          reason: @reason,
-          token: @token
+          organization_name: report.moderation.user.organization.name,
+          reason: @report.reason
         ))
       end
     end

--- a/decidim-core/app/views/decidim/user_report_mailer/notify.html.erb
+++ b/decidim-core/app/views/decidim/user_report_mailer/notify.html.erb
@@ -1,7 +1,14 @@
 <p class="email-greeting"><%= t ".hello", admin: h(@admin.name) %></p>
 
-<p class="email-instructions"><%= t ".body_1", user: h(@user.user_name), token: h(@token.name) %></p>
+<p class="email-instructions"><%= t ".body_1", user: h(@report.moderation.user.name), token: h(@report.user.name) %></p>
 
-<p class="email-instructions"><%= t ".body_2", reason: h(@reason) %></p>
+<p class="email-instructions"><%= t ".body_2", reason: t(@report.reason, organization_name: @report.moderation.user.organization.name, scope: "decidim.shared.flag_user_modal") %></p>
 
-<p class="email-closing"><%= t(".greetings", organization_name: h(@organization.name), organization_url: decidim.root_url(host: @organization.host)).html_safe %></p>
+<% if @report.details.present? %>
+  <p class="email-instructions"><%= t(".details") %></p>
+  <blockquote>
+    <%= @report.details %>
+  </blockquote>
+<% end %>
+
+<p class="email-closing"><%= t(".greetings", organization_name: h(@report.moderation.user.organization.name), organization_url: decidim.root_url(host: @report.moderation.user.organization.host)).html_safe %></p>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1402,7 +1402,7 @@ en:
       notify:
         body_1: User %{user} has been reported by %{token}
         body_2: 'Reason: %{reason}'
-        details: "User provided details"
+        details: User provided details
         greetings: Greetings,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
         hello: Hello %{admin},
         subject: A new user has been reported in %{organization_name}

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1402,6 +1402,7 @@ en:
       notify:
         body_1: User %{user} has been reported by %{token}
         body_2: 'Reason: %{reason}'
+        details: "User provided details"
         greetings: Greetings,<br/>%{organization_name}<br/><a href="%{organization_url}">%{organization_url}</a>
         hello: Hello %{admin},
         subject: A new user has been reported in %{organization_name}

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -713,7 +713,7 @@ FactoryBot.define do
 
   factory :user_report, class: "Decidim::UserReport" do
     reason { "spam" }
-    moderation { build(:user_moderation) }
+    moderation { create(:user_moderation, user: user) }
     user { build(:user, organization: moderation.organization) }
   end
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -714,7 +714,7 @@ FactoryBot.define do
   factory :user_report, class: "Decidim::UserReport" do
     reason { "spam" }
     moderation { create(:user_moderation, user: user) }
-    user { build(:user, organization: moderation.organization) }
+    user { build(:user) }
   end
 
   factory :user_moderation, class: "Decidim::UserModeration" do

--- a/decidim-core/spec/mailers/user_report_mailer_spec.rb
+++ b/decidim-core/spec/mailers/user_report_mailer_spec.rb
@@ -13,7 +13,7 @@ module Decidim
     let(:reason) { "spam" }
 
     describe "#notify" do
-      let(:mail) { described_class.notify(admin, reporter, user_report) }
+      let(:mail) { described_class.notify(admin, user_report) }
 
       describe "email body" do
         it "includes the reported user name" do

--- a/decidim-core/spec/mailers/user_report_mailer_spec.rb
+++ b/decidim-core/spec/mailers/user_report_mailer_spec.rb
@@ -7,11 +7,13 @@ module Decidim
     let(:organization) { create(:organization, name: "Test Organization") }
     let(:admin) { create(:user, :admin, organization: organization) }
     let(:reporter) { create(:user, :confirmed, organization: organization) }
+    let(:moderation) { create(:user_moderation, user: user) }
+    let(:user_report) { create(:user_report, user: reporter, reason: reason, details: "Lorem ipsum", moderation: moderation) }
     let(:user) { create(:user, :confirmed, organization: organization) }
     let(:reason) { "spam" }
 
     describe "#notify" do
-      let(:mail) { described_class.notify(admin, reporter, reason, user) }
+      let(:mail) { described_class.notify(admin, reporter, user_report) }
 
       describe "email body" do
         it "includes the reported user name" do
@@ -23,7 +25,7 @@ module Decidim
         end
 
         it "includes the reason" do
-          expect(email_body(mail)).to include(reason)
+          expect(email_body(mail)).to include(I18n.t(reason, scope: "decidim.shared.flag_user_modal"))
         end
 
         context "when the user is already blocked" do
@@ -31,8 +33,9 @@ module Decidim
 
           it "includes the reported user's original name" do
             # The `user.name` is set to "Blocked user"
-            expect(email_body(mail)).not_to include(user.name)
-            expect(email_body(mail)).to include(user.user_name)
+            expect(email_body(mail)).to include(user.name)
+            expect(email_body(mail)).to include(reporter.name)
+            expect(email_body(mail)).to include(admin.name)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR enriches the user reported mailer by adding a more friendly reason (Changed from token like "does_not_belong" to "Contains illegal activity, suicide threats, personal information, or something else you think doesn't belong on $Organization")

Also, it starts displaying the extra details provided by user directly to the mail. 

### :camera: Screenshots
Before 
![image](https://user-images.githubusercontent.com/105683/154536144-40c87199-d11e-45fc-9484-075915db9612.png)

After:
![image](https://user-images.githubusercontent.com/105683/154474900-f0ec9da9-5186-416f-b32f-b8e716480146.png)

:hearts: Thank you!
