### PR TITLE
Fix accountability categories' colors

### DIFF
--- a/decidim-accountability/app/packs/stylesheets/decidim/accountability/accountability/_categories.scss
+++ b/decidim-accountability/app/packs/stylesheets/decidim/accountability/accountability/_categories.scss
@@ -1,7 +1,6 @@
 .accountability{
   .categories{
     a:hover{
-      background-color: var(--secondary);
       text-decoration: underline;
     }
 
@@ -69,7 +68,7 @@
 
       .card__link{
         .category--line{
-          background-color: var(--secondary);
+          background-color: $light-gray-dark;
           border-radius: 4px;
           min-height: 9rem;
           padding: 1rem;


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing a PR on the accountability pages, I saw that we have the CSS broken, as it's unreadable. See screenshots below.

This PR fixes that. 

#### :pushpin: Related Issues

- Introduced by #7172
 

#### Testing

1. Go to accountability public page in a space
2. See categories

### :camera: Screenshots

#### Before
![image](https://user-images.githubusercontent.com/717367/154507051-cbf30c59-e8ad-4b63-8d93-6b26aa92d2fb.png)



#### After

![image](https://user-images.githubusercontent.com/717367/154506999-27f83348-b520-4125-982c-f0106c7547bc.png)


:hearts: Thank you!
