### PR TITLE
Fix answered proposals display

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/extras/_quill.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/extras/_quill.scss
@@ -13,8 +13,7 @@
 }
 
 .ql-reset-decidim{
-  display: flex;
-  flex-direction: column;
+  display: inline;
   padding: 0;
   white-space: inherit;
 }


### PR DESCRIPTION
#### :tophat: What? Why?
While in the v0.26.0.rc2  approval process, we've found a bug in styling of answered proposals. See screenshots. 

This PR fixes that. 

#### :pushpin: Related Issues

- Related to #8120

#### Testing

Go to an answered proposal page. See the answer label well. 

### :camera: Screenshots

#### Before

![image](https://user-images.githubusercontent.com/717367/154672684-e288257d-815e-4245-a534-c133816c3af4.png)


#### After
![image](https://user-images.githubusercontent.com/717367/154672691-6f635434-5d60-4b40-9b08-025c4bdfaae2.png)

:hearts: Thank you!
