### PR TITLE
Fix cache_hash generation in AuthorCell

### DIFF
--- a/decidim-core/app/cells/decidim/author_cell.rb
+++ b/decidim-core/app/cells/decidim/author_cell.rb
@@ -65,6 +65,7 @@ module Decidim
       hash = []
 
       hash.push(I18n.locale)
+      hash.push(model.cache_key_with_version) if model.respond_to?(:cache_key_with_version)
       hash.push(from_context.cache_key_with_version) if from_context.respond_to?(:cache_key_with_version)
       hash.push(current_user.try(:id))
       hash.push(current_user.present?)

--- a/decidim-core/app/cells/decidim/author_cell.rb
+++ b/decidim-core/app/cells/decidim/author_cell.rb
@@ -65,7 +65,7 @@ module Decidim
       hash = []
 
       hash.push(I18n.locale)
-      hash.push(model.cache_key_with_version) if model.respond_to?(:cache_key_with_version)
+      hash.push(from_context.cache_key_with_version) if from_context.respond_to?(:cache_key_with_version)
       hash.push(current_user.try(:id))
       hash.push(current_user.present?)
       hash.push(commentable?)


### PR DESCRIPTION
#### :tophat: What? Why?
While in the v0.26.0.rc2 approval process, we've found a bug in the generation of the cache for AuthorCell. 

This PR fixes that. 

The problem is that we're using `model` for generating the cache, but this is the author, so any content from the same author will have the same `AuthorCell`. As here we have things that are specific for the resource that we're in (for instance, the link to the comments or endorsements) then this is an issue because it gives you always the same links. 

We should use the `from_context` so we've the resource itself. 

```ruby
[63, 72] in /home/apereira/Work/decidim/decidim/decidim-core/app/cells/decidim/author_cell.rb
   63: 
   64:     def cache_hash
   65:       hash = []
   66: 
   67:       debugger
=> 68:       hash.push(I18n.locale)
   69:       hash.push(model.cache_key_with_version) if model.respond_to?(:cache_key_with_version)
   70:       hash.push(endorsable?)
   71:       hash.push(actionable?)
   72:       hash.push(withdrawable?)
(byebug) model
#<Decidim::User id: 1, email: "admin@example.org", created_at: "2022-02-07 08:52:18", updated_at: "2022-02-18 10:44:41", decidim_organization_id: 1, name: "Amb. Kellye Kuhn", locale: "en", avatar: nil, delete_reason: nil, deleted_at: nil, admin: true, managed: false, roles: [], email_on_notification: true, nickname: "alberto_schuppe", personal_url: "http://kessler-kihn.name/marylyn.wiegand", about: "Et doloribus at. Minus eos illo.", accepted_tos_version: "2022-02-08 09:48:28", newsletter_token: "", newsletter_notifications_at: "2022-02-15 13:54:12", extended_data: {}, following_count: 12, followers_count: 1, notification_types: "all", session_token: "c56f1c2c72fd028199f72669b7076abd", direct_message_types: "all", blocked: false, blocked_at: nil, block_id: nil, email_on_moderations: true, follows_count: 1, allow_push_notifications: true, officialized_at: nil, officialized_as: nil, admin_terms_accepted_at: "2022-02-07 08:52:18", component_notification_settings: {}>
(byebug) from_context
#<Decidim::Blogs::Post id: 5, title: {"ca"=>"Sed et expedita unde est.", "en"=>"Aut tenetur corporis culpa enim.", "machine_translations"=>{"es"=>"Aut facilis facere voluptatibus esse."}}, body: {"ca"=>"<p>Necessitatibus nulla quis. Autem quaerat molestias. Corrupti occaecati consequuntur. Dolorem molestiae vitae. Enim adipisci iusto. Consequatur at totam. Id dolor maxime. Sed qui porro. Recusandae laborum facilis. Aut ipsam et. Dolor numquam enim. Optio quia itaque. Illo vitae qui. Optio amet quia. Et temporibus ipsam. Occaecati non quia. Quia odit aut. Rerum hic corrupti. Deserunt quisquam accusamus. Eos exercitationem qui.</p>", "en"=>"<p>Nemo quia voluptatem. Omnis possimus sint. Ut dolor esse. Illum laudantium quae. Dolores voluptatibus error. Doloribus dignissimos et. Aut ducimus tenetur. Vitae voluptas incidunt. Officia nostrum doloribus. Beatae eum vitae. Cum recusandae eveniet. Tempore ut quia. In nam numquam. Necessitatibus accusantium aut. Facilis non error. Omnis corrupti consequatur. Consequatur tempore neque. Maxime porro suscipit. Aliquid repellat quam. Occaecati autem officia.</p>", "machine_translations"=>{"es"=>"<p>Adipisci repellat eligendi. Labore non aperiam. Quia tenetur facere. Necessitatibus sunt ullam. Est facilis nostrum. Magnam doloremque tenetur. Natus quo maxime. Suscipit est non. Non similique et. Quia aspernatur et. Quod deserunt perferendis. Dolor similique placeat. Natus velit non. Rem delectus est. Molestias nobis sapiente. At totam reprehenderit. Quibusdam sint et. Est minus mollitia. Animi voluptate sequi. Amet exercitationem sit.</p>"}}, decidim_component_id: 9, created_at: "2022-02-07 08:54:30", updated_at: "2022-02-07 08:54:30", decidim_author_id: 1, decidim_author_type: "Decidim::UserBaseEntity", decidim_user_group_id: nil, endorsements_count: 0, comments_count: 2, follows_count: 0>
```


#### :pushpin: Related Issues

- Related to #8566

#### Testing

1. Enable cache 
2. Go to a page with multiple contents from the same participant. For instance, a seeded blog component in a space. 
3. See that the link for the comments doesn't match with the one of the resource

### :camera: Screenshots

The bug: 

![image](https://user-images.githubusercontent.com/717367/154678676-d2baf196-6ef9-4564-8cb1-01ab42a86830.png)


:hearts: Thank you!
