### PR TITLE
Remove actions from debates' cards

### DIFF
--- a/decidim-debates/app/cells/decidim/debates/debate_m_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/debate_m_cell.rb
@@ -51,6 +51,10 @@ module Decidim
         start_date != end_date
       end
 
+      def has_actions?
+        false
+      end
+
       def debate_date
         return render(:open_date) unless start_date && end_date
         return render(:multiple_dates) if spans_multiple_dates?


### PR DESCRIPTION
#### :tophat: What? Why?

Debates cards have the number of comments and endorsements. This isn't consistent in how other "CardsM" work and breaks the design. 

This PR removes these links.
 
#### :pushpin: Related Issues

- Fixes #8058

#### Testing

Go to a debates list page in a participatory space. See that there isn't these links anymore. 

### :camera: Screenshots

#### Before

![image](https://user-images.githubusercontent.com/717367/154703570-12611109-0988-4c9b-b959-e1566d635cb4.png)


#### After 

![image](https://user-images.githubusercontent.com/717367/154703576-1a94c488-5d11-4c22-b725-dcf172e0ad4d.png)


:hearts: Thank you!
