### PR TITLE
Fix assemblies title when there are unpublished children

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -85,7 +85,7 @@ edit_link(
 
       <%= render_hook(:participatory_space_highlighted_elements) %>
 
-      <% if current_participatory_space.children.visible_for(current_user).count.positive? %>
+      <% if current_participatory_space.children.visible_for(current_user).published.count.positive? %>
         <section id="assemblies-grid" class="section row collapse">
           <h3 class="section-heading"><%= t("children", scope: "decidim.assemblies.show") %></h3>
           <div class="row small-up-1 medium-up-2 large-up-2 card-grid">


### PR DESCRIPTION
#### :tophat: What? Why?

When there's an unpublished private children assembly, the Assemblies title is shown. This PR fixes that. 

#### :pushpin: Related Issues

- Fixes #8162

#### Testing

1. Create a children assembly. 
2. Make it private and unpublished
3. Go to the bottom of the mother assembly. You shouldn't see the "Assemblies" title. 

### :camera: Screenshots

#### Before
![image](https://user-images.githubusercontent.com/717367/154705317-10ec0f1a-5d38-48de-9240-5de0fd2cd8ba.png)


#### After
![image](https://user-images.githubusercontent.com/717367/154705272-9d1eb10c-a24c-4230-9d9b-b42e31839864.png)

:hearts: Thank you!
