### PR TITLE
Backport "Fix displaying hidden meetings in processes group's 'upcoming meetings' content block" to v0.26

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/highlighted_meetings_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/highlighted_meetings_cell.rb
@@ -5,7 +5,13 @@ module Decidim
     module ContentBlocks
       class HighlightedMeetingsCell < Decidim::ContentBlocks::HighlightedElementsCell
         def base_relation
-          Decidim::Meetings::Meeting.except_withdrawn.where(component: published_components)
+          Decidim::Meetings::Meeting
+            .except_withdrawn
+            .published
+            .not_hidden
+            .upcoming
+            .visible_meeting_for(current_user)
+            .where(component: published_components)
         end
 
         def elements


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #8818 

:hearts: Thank you!
