### PR TITLE
Fix display withdraw warning message in proposals

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
@@ -1,7 +1,7 @@
-<% if params.dig("filter", "state_withdraw").present? && params["filter"]["state_withdraw"] == "withdrawn" %>
+<% if params.dig("filter", "with_availability").present? && params["filter"]["with_availability"] == "withdrawn" %>
   <div class="callout warning">
     <%= t("decidim.proposals.proposals.index.text_banner",
-          go_back_link: link_to(t("decidim.proposals.proposals.index.click_here"), proposals_path("filter[state_withdraw]" => nil)),
+          go_back_link: link_to(t("decidim.proposals.proposals.index.click_here"), proposals_path("filter[with_availability]" => nil)),
           ).html_safe %>
   </div>
 <% end %>

--- a/decidim-proposals/spec/system/index_proposals_spec.rb
+++ b/decidim-proposals/spec/system/index_proposals_spec.rb
@@ -25,8 +25,6 @@ describe "Index proposals", type: :system do
         click_link "See all withdrawn proposals"
       end
 
-      # it_behaves_like "accessible page"
-
       it "shows an empty page with a message" do
         expect(page).to have_content("There isn't any proposal with this criteria")
         within ".callout.warning" do

--- a/decidim-proposals/spec/system/index_proposals_spec.rb
+++ b/decidim-proposals/spec/system/index_proposals_spec.rb
@@ -44,8 +44,6 @@ describe "Index proposals", type: :system do
         click_link "See all withdrawn proposals"
       end
 
-      # it_behaves_like "accessible page"
-
       it "shows all the withdrawn proposals" do
         expect(page).to have_css(".card--proposal.alert", count: 3)
         within ".callout.warning" do

--- a/decidim-proposals/spec/system/index_proposals_spec.rb
+++ b/decidim-proposals/spec/system/index_proposals_spec.rb
@@ -16,6 +16,45 @@ describe "Index proposals", type: :system do
     end
   end
 
+  context "when checking withdrawn proposals" do
+    context "when there are no withrawn proposals" do
+      let!(:proposals) { create_list(:proposal, 3, component: component) }
+
+      before do
+        visit_component
+        click_link "See all withdrawn proposals"
+      end
+
+      # it_behaves_like "accessible page"
+
+      it "shows an empty page with a message" do
+        expect(page).to have_content("There isn't any proposal with this criteria")
+        within ".callout.warning" do
+          expect(page).to have_content("You are viewing the list of proposals withdrawn by their authors. ")
+        end
+      end
+    end
+
+    context "when there are withrawn proposals" do
+      let!(:proposals) { create_list(:proposal, 3, component: component) }
+      let!(:withdrawn_proposals) { create_list(:proposal, 3, :withdrawn, component: component) }
+
+      before do
+        visit_component
+        click_link "See all withdrawn proposals"
+      end
+
+      # it_behaves_like "accessible page"
+
+      it "shows all the withdrawn proposals" do
+        expect(page).to have_css(".card--proposal.alert", count: 3)
+        within ".callout.warning" do
+          expect(page).to have_content("You are viewing the list of proposals withdrawn by their authors.")
+        end
+      end
+    end
+  end
+
   context "when there are no proposals" do
     context "when there are no filters" do
       it "shows generic empty message" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes a regression introduced in #8748, in which The withdrawn proposals is not being displayed. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Relates: #8748
- Fixes #8869

#### Testing

- Visit any proposal component index page in frontend
- Click on "See all withdrawn proposals"
- Observe the message is not displayed.
- Apply patch 
- Refresh 
- Observe the message is displayed.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![image](https://user-images.githubusercontent.com/105683/155006720-e4b3c46d-4deb-4f49-8562-9b54e9b4a0ae.png)

:hearts: Thank you!
