### PR TITLE
Fix display warning message in meetings

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -1,7 +1,7 @@
-<% if params.dig("filter", "state").present? && params["filter"]["state"] == "withdrawn" %>
+<% if params.dig("filter", "with_availability").present? && params["filter"]["with_availability"] == "withdrawn" %>
   <div class="callout warning">
     <%= t("decidim.meetings.meetings.index.text_banner",
-          go_back_link: link_to(t("decidim.meetings.meetings.index.click_here"), meetings_path("filter[state]" => nil)),
+          go_back_link: link_to(t("decidim.meetings.meetings.index.click_here"), meetings_path("filter[with_availability]" => nil)),
           ).html_safe %>
   </div>
 <% end %>

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -27,6 +27,44 @@ describe "Explore meetings", :slow, type: :system do
       end
     end
 
+    context "when checking withdrawn meetings" do
+      context "when there are no withrawn meetings" do
+        let!(:meeting) { create_list(:meeting, 3, :published, component: component) }
+
+        before do
+          visit_component
+          click_link "See all withdrawn meetings"
+        end
+
+        # it_behaves_like "accessible page"
+
+        it "shows an empty page with a message" do
+          expect(page).to have_content("No meetings match your search criteria or there isn't any meeting scheduled.")
+          within ".callout.warning", match: :first do
+            expect(page).to have_content("You are viewing the list of meetings withdrawn by their authors.")
+          end
+        end
+      end
+
+      context "when there are withrawn meetings" do
+        let!(:withdrawn_meetings) { create_list(:meeting, 3, :withdrawn, :published, component: component) }
+
+        before do
+          visit_component
+          click_link "See all withdrawn meetings"
+        end
+
+        # it_behaves_like "accessible page"
+
+        it "shows all the withdrawn meetings" do
+          expect(page).to have_css(".card--meeting.alert", count: 3)
+          within ".callout.warning", match: :first do
+            expect(page).to have_content("You are viewing the list of meetings withdrawn by their authors.")
+          end
+        end
+      end
+    end
+
     context "with hidden meetings" do
       let(:meeting) { meetings.last }
 

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -36,8 +36,6 @@ describe "Explore meetings", :slow, type: :system do
           click_link "See all withdrawn meetings"
         end
 
-        # it_behaves_like "accessible page"
-
         it "shows an empty page with a message" do
           expect(page).to have_content("No meetings match your search criteria or there isn't any meeting scheduled.")
           within ".callout.warning", match: :first do

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -52,8 +52,6 @@ describe "Explore meetings", :slow, type: :system do
           click_link "See all withdrawn meetings"
         end
 
-        # it_behaves_like "accessible page"
-
         it "shows all the withdrawn meetings" do
           expect(page).to have_css(".card--meeting.alert", count: 3)
           within ".callout.warning", match: :first do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes a regression introduced in https://github.com/decidim/decidim/pull/8748, in which The withdrawn meetings is not being displayed.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #8748 
- Fixes #8871 

#### Testing

- Visit any meeting component index page in frontend
- Click on "See all withdrawn meetings"
- Observe the message is not displayed.
- Apply patch
- Refresh
- Observe the message is displayed.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![image](https://user-images.githubusercontent.com/105683/155010540-a894a381-6c76-4432-9e39-b122165ad745.png)

:hearts: Thank you!
