### PR TITLE
Fix the way the results are displayed in search page

### DIFF
--- a/decidim-core/app/cells/decidim/search_results_cell.rb
+++ b/decidim-core/app/cells/decidim/search_results_cell.rb
@@ -29,7 +29,7 @@ module Decidim
     end
 
     def selected_resource_type
-      params.dig(:filter, :resource_type)
+      params.dig(:filter, :with_resource_type)
     end
 
     def has_selected_resource_type?

--- a/decidim-core/app/views/decidim/searches/_filters.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters.html.erb
@@ -1,5 +1,5 @@
 <label class="text-medium mb-s"><%= t(".jump_to") %></label>
-<% if params.dig(:filter, :resource_type).present? %>
+<% if params.dig(:filter, :with_resource_type).present? %>
   <p class="text-secondary">
     <%= link_to main_search_path do %>
       <%= icon "caret-left", class: "icon--small", role: "img", "aria-hidden": true %>&nbsp;<%= t(".back") %>


### PR DESCRIPTION
#### :tophat: What? Why?
 When using the global search, the list of resources are being displayed. When filtering the resource type, the Section Header and View All button are left in place for each one of the resources. This has been introduced in #8748

This PR is fixing the regression. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #8748
- Fixes #8859

#### Testing
Go to the search page, select and choose some resources from the filter. 

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![image](https://user-images.githubusercontent.com/105683/155013548-9ffda03a-6af2-42e9-bc0a-24b1b3f459b5.png)

:hearts: Thank you!
