### PR TITLE
Fix the meetings export to also include unpublished meetings

### DIFF
--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -42,7 +42,6 @@ Decidim.register_component(:meetings) do |component|
   component.exports :meetings do |exports|
     exports.collection do |component_instance|
       Decidim::Meetings::Meeting
-        .published
         .not_hidden
         .visible
         .where(component: component_instance)

--- a/decidim-meetings/lib/decidim/meetings/meeting_serializer.rb
+++ b/decidim-meetings/lib/decidim/meetings/meeting_serializer.rb
@@ -45,7 +45,8 @@ module Decidim
           followers: meeting.follows.size,
           url: url,
           related_proposals: related_proposals,
-          related_results: related_results
+          related_results: related_results,
+          published: meeting.published_at.present?
         }
       end
 

--- a/decidim-meetings/spec/lib/decidim/meetings/component_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/component_spec.rb
@@ -120,6 +120,7 @@ describe "Meetings component" do # rubocop:disable RSpec/DescribeClass
     let!(:first_meeting) { create :meeting, :published }
     let(:component) { first_meeting.component }
     let!(:second_meeting) { create :meeting, :published, component: component }
+    let!(:unpublished_meeting) { create :meeting, component: component }
     let(:participatory_process) { component.participatory_space }
     let(:organization) { participatory_process.organization }
 
@@ -127,7 +128,7 @@ describe "Meetings component" do # rubocop:disable RSpec/DescribeClass
       let!(:user) { create :user, admin: true, organization: organization }
 
       it "exports all meetings from the component" do
-        expect(subject).to match_array([first_meeting, second_meeting])
+        expect(subject).to match_array([first_meeting, second_meeting, unpublished_meeting])
       end
     end
   end

--- a/decidim-meetings/spec/lib/decidim/meetings/meeting_serializer_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/meeting_serializer_spec.rb
@@ -9,7 +9,7 @@ module Decidim
         described_class.new(meeting)
       end
 
-      let!(:meeting) { create(:meeting, contributions_count: 5, attendees_count: 10, attending_organizations: "Some organization") }
+      let!(:meeting) { create(:meeting, :published, contributions_count: 5, attendees_count: 10, attending_organizations: "Some organization") }
       let!(:category) { create(:category, participatory_space: component.participatory_space) }
       let!(:scope) { create(:scope, organization: component.participatory_space.organization) }
       let(:participatory_process) { component.participatory_space }
@@ -121,6 +121,10 @@ module Decidim
         it "serializes related results" do
           expect(serialized[:related_results].length).to eq(2)
           expect(serialized[:related_results].first).to match(%r{http.*/results})
+        end
+
+        it "serialized the published column" do
+          expect(serialized).to include(published: meeting.published?)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR:

- [ ] includes all meetings in the export (not just the published ones)
- [ ] adds a column to the export named published indicating if the meeting is published or not

#### :pushpin: Related Issues

- Fixes #8729

#### Testing

As an admin:

- go to a participatory space meetings
- unpublish some meetings
- ask for an export
- check all meetings have been included, not just the published ones

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

Screenshot of the new column in a exported file (CSV):

<img width="191" alt="Screenshot 2022-02-22 at 06 54 47" src="https://user-images.githubusercontent.com/17616/155071642-bc039b83-900c-4a51-8364-356069302468.png">

:hearts: Thank you!
