### PR TITLE
Fix comments heading order

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
@@ -1,5 +1,5 @@
 <div class="add-comment">
-  <h3 class="section-heading"><%= t("decidim.components.add_comment_form.title") %></h3>
+  <h4 class="section-heading"><%= t("decidim.components.add_comment_form.title") %></h4>
 
   <% if user_signed_in? %>
     <% if alignment_enabled? %>

--- a/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
@@ -1,5 +1,5 @@
 <div class="add-comment">
-  <h5 class="section-heading"><%= t("decidim.components.add_comment_form.title") %></h5>
+  <h3 class="section-heading"><%= t("decidim.components.add_comment_form.title") %></h3>
 
   <% if user_signed_in? %>
     <% if alignment_enabled? %>

--- a/decidim-comments/app/cells/decidim/comments/comments/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/show.erb
@@ -2,7 +2,7 @@
   <div class="columns large-9 comments-container" id="comments">
     <div class="comments">
       <div class="row collapse order-by">
-        <h4 class="order-by__text section-heading">
+        <h2 class="order-by__text section-heading">
           <% if single_comment? %>
             <%= t("decidim.components.comments.comment_details_title") %>
           <% else %>
@@ -10,7 +10,7 @@
               <%= t("decidim.components.comments.title", count: comments_count) %>
             </span>
           <% end %>
-        </h4>
+        </h2>
         <%= render :order_control %>
       </div>
       <%= single_comment_warning %>

--- a/decidim-comments/app/cells/decidim/comments/comments/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/show.erb
@@ -2,7 +2,7 @@
   <div class="columns large-9 comments-container" id="comments">
     <div class="comments">
       <div class="row collapse order-by">
-        <h2 class="order-by__text section-heading">
+        <h3 class="order-by__text section-heading">
           <% if single_comment? %>
             <%= t("decidim.components.comments.comment_details_title") %>
           <% else %>
@@ -10,7 +10,7 @@
               <%= t("decidim.components.comments.title", count: comments_count) %>
             </span>
           <% end %>
-        </h2>
+        </h3>
         <%= render :order_control %>
       </div>
       <%= single_comment_warning %>


### PR DESCRIPTION
#### :tophat: What? Why?
The comments section heading order is illogical.

Also, the comments main heading should be a `<h3>` in the Decidim default layout for it to be logical compared to most of the contexts where the comment section is displayed in the Decidim default layout.

Currently e.g. on this page:
https://meta.decidim.org/processes/RedesignDecidim/f/1662/posts/235

The current `<h4>` level indicates that the comments section is a subsection of the last text section titled "Methodology: Open design / participated design". The correct top-level context of the comments section should be the blog article's title which is `<h2>` and therefore `<h3>` makes more sense for the comments section.

Many screen reader users users glance the page quickly by going through its headings in which case this can be confusing.

WCAG 2.2 / 1.3.1 Info and Relationships (Level A)

https://www.w3.org/TR/WCAG22/#info-and-relationships
https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html

#### :pushpin: Related Issues
- Related to #8877, #8893

#### Testing
Give the linked blog page to a visually impaired user and ask them to read it.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.