### PR TITLE
Improve logo link aria label

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_logo.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_logo.html.erb
@@ -1,5 +1,5 @@
 <% if organization %>
-  <%= link_to decidim.root_url(host: organization.host), "aria-label": t("front_page_link", scope: "decidim.accessibility", organization: organization.name) do %>
+  <%= link_to decidim.root_url(host: organization.host), "aria-label": t("front_page_link", scope: "decidim.accessibility") do %>
     <% if organization.logo.attached? %>
       <%= image_tag organization.attached_uploader(:logo).variant_path(:medium), alt: t("logo", scope: "decidim.accessibility", organization: organization.name) %>
     <% else %>

--- a/decidim-core/app/views/layouts/decidim/_logo.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_logo.html.erb
@@ -1,5 +1,5 @@
 <% if organization %>
-  <%= link_to decidim.root_url(host: organization.host), title: t("logo", scope: "decidim.accessibility", organization: organization.name) do %>
+  <%= link_to decidim.root_url(host: organization.host), "aria-label": t("front_page_link", scope: "decidim.accessibility", organization: organization.name) do %>
     <% if organization.logo.attached? %>
       <%= image_tag organization.attached_uploader(:logo).variant_path(:medium), alt: t("logo", scope: "decidim.accessibility", organization: organization.name) %>
     <% else %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -108,6 +108,7 @@ en:
   decidim:
     accessibility:
       external_link: External link
+      front_page_link: Go to front page
       logo: "%{organization}'s official logo"
       skip_button: Skip to main content
     account:


### PR DESCRIPTION
#### :tophat: What? Why?
The logo link label is named illogically for screen reader users.

The link label should indicate for the screen reader what happens when the user clicks the link.

WCAG 2.2 / 2.4.6 Headings and Labels (Level AA)

https://www.w3.org/TR/WCAG22/#headings-and-labels
https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html

#### Testing
Ask a screen reader user to test the logo link.

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.