### PR TITLE
Fix diff mode selector accessibility

### DIFF
--- a/decidim-core/app/cells/decidim/diff/diff_mode_dropdown.erb
+++ b/decidim-core/app/cells/decidim/diff/diff_mode_dropdown.erb
@@ -4,13 +4,18 @@
       <%= t("versions.dropdown.choose_diff_view_mode") %>
     </span>
 
-    <ul class="dropdown menu" data-dropdown-menu>
-      <li class="is-dropdown-submenu-parent">
-        <a id="diff-view-selected">
-          <%= t("versions.dropdown.option_unified") %>
+    <ul class="dropdown menu" data-dropdown-menu
+      data-autoclose="false"
+      data-disable-hover="true"
+      data-click-open="true"
+      data-close-on-click="true"
+      tabindex="-1">
+      <li class="is-dropdown-submenu-parent" tabindex="-1">
+        <a href="#diffmode-chooser-menu" id="diff-view-selected" aria-controls="diffmode-chooser-menu" aria-haspopup="true" aria-label="<%= t("versions.dropdown.choose_diff_view_mode_menu") %>">
+          <span aria-hidden="true"><%= t("versions.dropdown.option_unified") %></span>
         </a>
 
-        <ul class="menu">
+        <ul class="menu is-dropdown-submenu" id="diffmode-chooser-menu" role="menu" aria-labelledby="diff-view-selected" tabindex="-1">
           <li>
             <%= link_to "#diff-view-unified", class: "diff-view-mode", id:"diff-view-unified" do %>
               <%= t("versions.dropdown.option_unified") %>

--- a/decidim-core/app/cells/decidim/diff/show.erb
+++ b/decidim-core/app/cells/decidim/diff/show.erb
@@ -1,6 +1,8 @@
 <%= render :diff_mode_dropdown %>
 <%= render :diff_mode_html %>
 
-<% diff_data.each do |data| %>
-  <%= attribute(data) %>
-<% end %>
+<div aria-live="polite">
+  <% diff_data.each do |data| %>
+    <%= attribute(data) %>
+  <% end %>
+</div>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1745,6 +1745,7 @@ en:
     dropdown:
       choose_diff_view_html: 'HTML view mode:'
       choose_diff_view_mode: 'Compare view mode:'
+      choose_diff_view_mode_menu: Choose compare mode
       option_escaped: Escaped
       option_split: Side-by-side
       option_unescaped: Unescaped


### PR DESCRIPTION
#### :tophat: What? Why?
Currently users using keyboard commands or speech voice control cannot focus the diff mode selector dropdown. This PR fixes that.

There are also other accessibility issues with this element:
- The dropdown behavior is not consistent with the other dropdowns on the page (everything that looks like a dropdown should behave like a dropdown)
- The dropdown is missing a screen reader label
- The diff mode is not dynamically announced for the screen reader when it changes (thus, the aria-live attribute)

WCAG 2.2 / 2.1.1 Keyboard (Level A)
WCAG 2.2 / 4.1.2 Name, Role, Value (Level A)

https://www.w3.org/TR/WCAG22/#keyboard
https://www.w3.org/TR/WCAG22/#name-role-value
https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html
https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html

#### Testing
Ask a user using either keyboard controls or speech control to test the diff mode dropdown.

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

https://user-images.githubusercontent.com/864340/155108807-9ea951a6-10df-4358-ac07-eec42f319efa.mp4