### PR TITLE
Fix illogical heading order for the versions list

### DIFF
--- a/decidim-core/app/cells/decidim/versions_list_item/show.erb
+++ b/decidim-core/app/cells/decidim/versions_list_item/show.erb
@@ -2,9 +2,9 @@
   <div class="card--list__text">
     <div>
       <%= link_to version_path do %>
-        <h6 class="card--list__heading heading6">
+        <h4 class="card--list__heading heading6">
           <%= i18n_version_index %>
-        </h6>
+        </h4>
       <% end %>
       <div class="author-data">
         <%= render_resource_editor(version) %>


### PR DESCRIPTION
#### :tophat: What? Why?
The versions list items order is illogical.

Take a look e.g. at this page:
https://meta.decidim.org/processes/roadmap/f/122/proposals/16942/versions

After the "Versions" heading, the heading jumps from h3 -> h6.

WCAG 2.2 / 1.3.1 Info and Relationships (Level A)

https://www.w3.org/TR/WCAG22/#info-and-relationships
https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html

#### Testing
Give the linked versions page to a visually impaired user and ask them to read it.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.