### PR TITLE
Add the "choose language" string in all locales to the language chooser

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_language_chooser.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_language_chooser.html.erb
@@ -7,10 +7,17 @@
       data-close-on-click="true"
       role="menubar">
       <li class="is-dropdown-submenu-parent" role="presentation">
-        <%= link_to t("name", scope: "locale"), "#language-chooser-menu", id: "language-chooser-control", "aria-label": t("layouts.decidim.language_chooser.choose_language"), "aria-controls": "language-chooser-menu", "aria-haspopup": "menu", role: "menuitem" %>
+        <%= link_to "#language-chooser-menu", id: "language-chooser-control", "aria-controls": "language-chooser-menu", "aria-haspopup": "menu", role: "menuitem" do %>
+          <span aria-hidden="true"><%= t("name", scope: "locale") %></span>
+          <span class="show-for-sr">
+            <% available_locales.each do |locale| %>
+              <span lang="<%= locale %>"><%= I18n.with_locale(locale) { t("layouts.decidim.language_chooser.choose_language") } %></span>
+            <% end %>
+          </span>
+        <% end %>
         <ul class="menu is-dropdown-submenu" id="language-chooser-menu" role="menu" aria-labelledby="language-chooser-control">
           <% (available_locales - [I18n.locale.to_s]).each do |locale| %>
-            <li lang="<%= locale %>" role="presentation"><%= link_to locale_name(locale), decidim.locale_path(locale: locale), method: :post, role: "menuitem" %></li>
+            <li role="presentation"><%= link_to locale_name(locale), decidim.locale_path(locale: locale), method: :post, role: "menuitem", lang: locale %></li>
           <% end %>
         </ul>
       </li>


### PR DESCRIPTION
#### :tophat: What? Why?
Users using Decidim in other languages than the language initially provided for them cannot understand the "choose language" text, so it should be shown in all locales available for the users.

This also moves the "lang" attribute in the language controls to the link instead of the `<li>` element which is apparently more correct (according to the original issue report).

There is an related issue with the dropdown control which is that the contents of the control are automatically added to the `aria-label` attribute which is incorrect. I will look into this as a separate issue, it may also come from Foundation.

WCAG 2.2 / 3.1.2 Language of Parts (Level AA)

https://www.w3.org/TR/WCAG22/#language-of-parts
https://www.w3.org/WAI/WCAG22/Understanding/language-of-parts.html

#### Testing
Ask a person speaking only another language to choose the language on a Decidim page.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.