### PR TITLE
Fix emoji picker hiding Foundation Abide form errors

### DIFF
--- a/decidim-core/app/packs/src/decidim/input_emoji.js
+++ b/decidim-core/app/packs/src/decidim/input_emoji.js
@@ -23,11 +23,19 @@ export default function addInputEmoji() {
       wrapper.className = "emoji__container"
       const btnContainer = document.createElement("div");
       btnContainer.className = "emoji__trigger"
-      btnContainer.innerHTML = '<svg aria-hidden="true" focusable="false" data-prefix="far" data-icon="smile" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><path fill="currentColor" d="M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm0 448c-110.3 0-200-89.7-200-200S137.7 56 248 56s200 89.7 200 200-89.7 200-200 200zm-80-216c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm4 72.6c-20.8 25-51.5 39.4-84 39.4s-63.2-14.3-84-39.4c-8.5-10.2-23.7-11.5-33.8-3.1-10.2 8.5-11.5 23.6-3.1 33.8 30 36 74.1 56.6 120.9 56.6s90.9-20.6 120.9-56.6c8.5-10.2 7.1-25.3-3.1-33.8-10.1-8.4-25.3-7.1-33.8 3.1z"></path></svg>'
+      const btn = document.createElement("div");
+      btn.className = "emoji__button"
+      btn.innerHTML = '<svg aria-hidden="true" focusable="false" data-prefix="far" data-icon="smile" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><path fill="currentColor" d="M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm0 448c-110.3 0-200-89.7-200-200S137.7 56 248 56s200 89.7 200 200-89.7 200-200 200zm-80-216c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm4 72.6c-20.8 25-51.5 39.4-84 39.4s-63.2-14.3-84-39.4c-8.5-10.2-23.7-11.5-33.8-3.1-10.2 8.5-11.5 23.6-3.1 33.8 30 36 74.1 56.6 120.9 56.6s90.9-20.6 120.9-56.6c8.5-10.2 7.1-25.3-3.1-33.8-10.1-8.4-25.3-7.1-33.8 3.1z"></path></svg>'
 
-      elem.parentNode.insertBefore(wrapper, elem);
+      const parent = elem.parentNode;
+      parent.insertBefore(wrapper, elem);
       wrapper.appendChild(elem);
       wrapper.appendChild(btnContainer);
+      btnContainer.appendChild(btn);
+
+      // The form errors need to be in the same container with the field they
+      // belong to for Foundation Abide to show them automatically.
+      parent.querySelectorAll(".form-error").forEach((el) => wrapper.appendChild(el));
 
       btnContainer.addEventListener("click", () => picker.togglePicker(btnContainer))
 

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_forms.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_forms.scss
@@ -135,13 +135,18 @@ input[type="radio"]{
   }
 
   &__trigger{
+    position: relative;
+    top: -$form-spacing;
+  }
+
+  &__button{
     position: absolute;
     bottom: $global-margin * .5;
     right: $global-margin;
     cursor: pointer;
   }
 
-  &__trigger svg{
+  &__button svg{
     width: 1em;
   }
 }


### PR DESCRIPTION
#### :tophat: What? Why?
The [Foundation Abide](https://get.foundation/sites/docs/abide.html) errors need to be within the same parent container as the input field they are related to:
https://github.com/foundation/foundation-sites/blob/8846fdad0289d1a0a80929c92a4245fcb781c662/js/foundation.abide.js#L179-L183

The emoji picker adds a wrapper around the input field in which case they are no longer within the same parent element as the input element.

I changed the `.emoji__trigger` to be a wrapper for the new sub-wrapper `.emoji__button` to keep the emoji button in the original place even when new elements appear below it.

#### :pushpin: Related Issues
- Related to #8889, #8735, #8118

#### Testing
I will soon create a new PR which adds the errors visible for the conversation message fields, so this can be tested along with that. Currently there are no fields in the core which would be affected by this change.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

The below screenshots have the error messages fixed for the conversation input fields which is not in the core right now. This needs to be tested with a form that has both errors attached to the input field + emoji picker attached to the input field. The errors will become visible on the conversation forms after applying another PR #8889.

#### Before

![Error message is not visible with emoji picker](https://user-images.githubusercontent.com/864340/155122880-a64c86ed-1ab5-4104-8be2-52f1eb62fe17.png)

#### After

![Error message is visible with emoji picker](https://user-images.githubusercontent.com/864340/155123052-4f2c6b2e-09eb-42d3-9d34-4c7053f47bc2.png)