### PR TITLE
Fix multiple notifications related to managed user events

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -699,16 +699,16 @@ en:
         email_subject: "%{endorser_nickname} has performed a new endorsement"
         notification_title: The <a href="%{resource_path}">%{resource_title}</a> %{resource_type} has been endorsed by <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a>.
       users:
-        user_officialized:
-          email_intro: Participant %{name} (%{nickname}) has been officialized.
-          email_outro: You have received this notification because you are an administrator of the organization.
-          email_subject: "%{name} has been officialized"
-          notification_title: Participant %{name} (%{nickname}) has been officialized.
         profile_updated:
           email_intro: The <a href="%{resource_url}">profile page</a> of %{name} (%{nickname}), who you are following, has been updated.
           email_outro: You have received this notification because you are following %{nickname}. You can stop receiving notifications following the previous link.
           email_subject: "%{nickname} updated their profile"
           notification_title: The <a href="%{resource_path}">profile page</a> of %{name} (%{nickname}), who you are following, has been updated.
+        user_officialized:
+          email_intro: Participant %{name} (%{nickname}) has been officialized.
+          email_outro: You have received this notification because you are an administrator of the organization.
+          email_subject: "%{name} has been officialized"
+          notification_title: Participant %{name} (%{nickname}) has been officialized.
     export_mailer:
       data_portability_export:
         click_button: 'Click the next link to download your data.<br/>The file will be available until %{date}.<br/>You will need <a href="https://www.7-zip.org/">7-Zip</a> (for Windows), <a href="https://www.keka.io/en/">Keka</a> (for MacOS) or <a href="https://peazip.github.io">PeaZip</a> (for Linux) to open it. Password: %{password}'

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -699,6 +699,11 @@ en:
         email_subject: "%{endorser_nickname} has performed a new endorsement"
         notification_title: The <a href="%{resource_path}">%{resource_title}</a> %{resource_type} has been endorsed by <a href="%{endorser_path}">%{endorser_name} %{endorser_nickname}</a>.
       users:
+        user_officialized:
+          email_intro: Participant %{name} (%{nickname}) has been officialized.
+          email_outro: You have received this notification because you are an administrator of the organization.
+          email_subject: "%{name} has been officialized"
+          notification_title: Participant %{name} (%{nickname}) has been officialized.
         profile_updated:
           email_intro: The <a href="%{resource_url}">profile page</a> of %{name} (%{nickname}), who you are following, has been updated.
           email_outro: You have received this notification because you are following %{nickname}. You can stop receiving notifications following the previous link.

--- a/decidim-core/spec/events/decidim/profile_updated_event_officialize_user_spec.rb
+++ b/decidim-core/spec/events/decidim/profile_updated_event_officialize_user_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ProfileUpdatedEvent do
+  include_context "when a simple event"
+
+  let(:event_name) { "decidim.events.users.user_officialized" }
+  let(:resource) { create :user }
+  let(:author) { resource }
+
+  it_behaves_like "a simple event", true
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("#{resource.name} has been officialized")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro)
+        .to eq("Participant #{resource.name} (@#{resource.nickname}) has been officialized.")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro)
+        .to eq("You have received this notification because you are an administrator of the organization.")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title).to eq("Participant #{resource.name} (@#{resource.nickname}) has been officialized.")
+    end
+  end
+end

--- a/decidim-verifications/app/commands/decidim/verifications/authorize_user.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/authorize_user.rb
@@ -7,8 +7,9 @@ module Decidim
       # Public: Initializes the command.
       #
       # handler - An AuthorizationHandler object.
-      def initialize(handler)
+      def initialize(handler, organization)
         @handler = handler
+        @organization = organization
       end
 
       # Executes the command. Broadcasts these events:
@@ -39,7 +40,7 @@ module Decidim
           event: "decidim.events.verifications.managed_user_error_event",
           event_class: Decidim::Verifications::ManagedUserErrorEvent,
           resource: conflict,
-          affected_users: Decidim::User.where(admin: true)
+          affected_users: Decidim::User.where(admin: true, organization: @organization)
         )
       end
 

--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -35,7 +35,7 @@ module Decidim
       end
 
       def create
-        AuthorizeUser.call(handler) do
+        AuthorizeUser.call(handler, current_organization) do
           on(:ok) do
             flash[:notice] = t("authorizations.create.success", scope: "decidim.verifications")
             redirect_to redirect_url || authorizations_path

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -79,7 +79,10 @@ en:
     events:
       verifications:
         verify_with_managed_user:
-          notification_title: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify herself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>
+          email_intro: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify herself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>.
+          email_outro: Check the <a href="/admin/conflicts">Verifications's conflicts list</a> and contact the participant to verify her details and solve the issue.
+          email_subject: Failed verification attempt against a managed participant
+          notification_title: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify herself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>.
     verifications:
       authorizations:
         authorization_metadata:

--- a/decidim-verifications/spec/commands/decidim/verifications/authorize_user_spec.rb
+++ b/decidim-verifications/spec/commands/decidim/verifications/authorize_user_spec.rb
@@ -4,8 +4,9 @@ require "spec_helper"
 
 module Decidim::Verifications
   describe AuthorizeUser do
-    subject { described_class.new(handler) }
+    subject { described_class.new(handler, organization) }
 
+    let(:organization) { create(:organization) }
     let(:user) { create(:user, :confirmed) }
     let(:document_number) { "12345678X" }
     let(:handler) do
@@ -107,7 +108,7 @@ module Decidim::Verifications
             event: "decidim.events.verifications.managed_user_error_event",
             event_class: Decidim::Verifications::ManagedUserErrorEvent,
             resource: conflict,
-            affected_users: Decidim::User.where(admin: true)
+            affected_users: Decidim::User.where(admin: true, organization: organization)
           )
         end
       end

--- a/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
+++ b/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
@@ -38,7 +38,25 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
 
   describe "notification_title" do
     it "is generated correctly" do
-      expect(subject.notification_title).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify herself with the data of the managed participant <a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>")
+      expect(subject.notification_title).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify herself with the data of the managed participant <a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>.")
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("Failed verification attempt against a managed participant")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify herself with the data of the managed participant <a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>.")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro).to eq("Check the <a href=\"/admin/conflicts\">Verifications's conflicts list</a> and contact the participant to verify her details and solve the issue.")
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes a group of bugs related with the admin notifications related with managed users.

*Verification conflict email*
Related to issue https://github.com/decidim/decidim/issues/8392.
When an admin is notified via email that a participant tried to verify with the data of an already verified managed user the email shows no contents because translations are missing (see screenshot).

*Verification report event is sent accross multitenant organizations*
Related to issue https://github.com/decidim/decidim/issues/8807.
The `managed_user_error_event` notifies all admins in all organizations instead of filtering by organization.

```
[Ajuntament de Sant Just Desvern] <http://participa311-santjust.diba.cat/>

Hola Suport Participa311 Diba,

translation missing: ca.decidim.events.verifications.verify_with_managed_user.email_intro

Xxxx Xxxx<http://participa311-manlleu.diba.cat/profiles/xxxxxx>

translation missing: ca.decidim.events.verifications.verify_with_managed_user.email_outro

Ajuntament de Sant Just Desvern<http://participa311-santjust.diba.cat/>
```

*Missing translation keys for officialization notification*
Related to issue https://github.com/decidim/decidim/issues/8661.


#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/decidim/decidim/issues/8392
- Fixes https://github.com/decidim/decidim/issues/8807
- Fixes https://github.com/decidim/decidim/issues/8661

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Verification conflict untranslated email*
![imatge](https://user-images.githubusercontent.com/199462/155144053-29ea5cd9-b784-464f-8fa9-a81df42df0c3.png)

:hearts: Thank you!
