### PR TITLE
Change the correct element type for the change password button

### DIFF
--- a/decidim-core/app/views/decidim/account/show.html.erb
+++ b/decidim-core/app/views/decidim/account/show.html.erb
@@ -30,7 +30,7 @@
       <% else %>
         <% if current_organization.sign_in_enabled? %>
           <p>
-            <a data-toggle="passwordChange" class="change-password" href="#passwordChange"><%= t ".change_password" %></a>
+            <button type="button" data-toggle="passwordChange" class="link change-password"><%= t ".change_password" %></button>
           </p>
           <div id="passwordChange" class="toggle-show" data-toggler=".is-expanded">
             <%= render partial: "password_fields", locals: { form: f } %>


### PR DESCRIPTION
#### :tophat: What? Why?
The "change password" button on the account page is not a link. It is a button and should be presented as such.

WCAG 2.2 / 3.2.4 Consistent Identification (Level AA)

https://www.w3.org/TR/WCAG22/#consistent-identification
https://www.w3.org/WAI/WCAG22/Understanding/consistent-identification.html

#### Testing
Ask some accessibility expert.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.