### PR TITLE
Make the button link font weight consistent with normal links

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/modules/_buttons.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_buttons.scss
@@ -372,7 +372,7 @@
 .link{
   cursor: pointer;
   color: var(--secondary);
-  font-weight: 600;
+  font-weight: $anchor-font-weight;
 
   &:hover{
     color: $anchor-color-hover;
@@ -384,6 +384,7 @@
 .link-alt{
   cursor: pointer;
   color: $anchor-color;
+  font-weight: $anchor-font-weight;
 
   &:hover{
     color: $anchor-color-hover;

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_typography.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_typography.scss
@@ -9,6 +9,7 @@ input{
 
 a{
   color: $anchor-color;
+  font-weight: $anchor-font-weight;
 
   &:hover{
     color: $anchor-color-hover;

--- a/decidim-core/app/packs/stylesheets/decidim/utils/_settings.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/utils/_settings.scss
@@ -206,6 +206,7 @@ $anchor-outline-focus: 1px dotted rgba(black, .5);
 $anchor-outline-offset: 2px;
 $anchor-text-decoration: none;
 $anchor-text-decoration-hover: none;
+$anchor-font-weight: $global-weight-normal;
 $hr-width: $global-width;
 $hr-border: 1px solid $medium-gray;
 $hr-margin: 6rem auto 5rem;


### PR DESCRIPTION
#### :tophat: What? Why?
When implementing the fix at #8890, I noticed that when applying the `.link` class to a button, it has a different font-weight than a normal link.

This adds a new SCSS configuration variable for the link font-weight and applies this to both normal links as well as elements with the `.link` class.

#### :pushpin: Related Issues
- Related to #8890

#### Testing
Create a link and a button with the `.link` class on the same page and see a difference in their font weights.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

#### Before

![Elements with the link class have different font weight than normal links](https://user-images.githubusercontent.com/864340/155154001-ec5a29b0-36f9-42b9-8421-511e160a92e2.png)

#### After

![Elements with the link class have consistent font weight with the links](https://user-images.githubusercontent.com/864340/155154032-35aa9603-6b0c-426c-9084-284ca6c7f968.png)