### PR TITLE
Fix logical heading order for the endorsers list

### DIFF
--- a/decidim-core/app/cells/decidim/endorsers_list/show.erb
+++ b/decidim-core/app/cells/decidim/endorsers_list/show.erb
@@ -1,7 +1,7 @@
 <div id="list-of-endorsements" class="section">
   <div class="row">
     <div class="columns large-12">
-      <h4 class="section-heading"><%= t("decidim.proposals.proposals.show.endorsements_list") %></h4>
+      <h3 class="section-heading"><%= t("decidim.proposals.proposals.show.endorsements_list") %></h3>
     </div>
     <div class="columns large-12">
       <%= cell(


### PR DESCRIPTION
#### :tophat: What? Why?
The heading order for the endorsers list is illogical for all elements.

Take this debate at MetaDecidim for an example:
https://meta.decidim.org/processes/roadmap/f/219/debates/231

You can see that the heading order jumps from h2 -> h4 at the endorsers list.

WCAG 2.2 / 1.3.1 Info and Relationships (Level A)

https://www.w3.org/TR/WCAG22/#info-and-relationships
https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html

#### Testing
Check the heading order on the linked debate page (or any other resource with endorsements).

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.