### PR TITLE
Backport "Fix diff mode selector accessibility" to v0.26

### DIFF
--- a/decidim-core/app/cells/decidim/diff/diff_mode_dropdown.erb
+++ b/decidim-core/app/cells/decidim/diff/diff_mode_dropdown.erb
@@ -4,13 +4,18 @@
       <%= t("versions.dropdown.choose_diff_view_mode") %>
     </span>
 
-    <ul class="dropdown menu" data-dropdown-menu>
-      <li class="is-dropdown-submenu-parent">
-        <a id="diff-view-selected">
-          <%= t("versions.dropdown.option_unified") %>
+    <ul class="dropdown menu" data-dropdown-menu
+      data-autoclose="false"
+      data-disable-hover="true"
+      data-click-open="true"
+      data-close-on-click="true"
+      tabindex="-1">
+      <li class="is-dropdown-submenu-parent" tabindex="-1">
+        <a href="#diffmode-chooser-menu" id="diff-view-selected" aria-controls="diffmode-chooser-menu" aria-haspopup="true" aria-label="<%= t("versions.dropdown.choose_diff_view_mode_menu") %>">
+          <span aria-hidden="true"><%= t("versions.dropdown.option_unified") %></span>
         </a>
 
-        <ul class="menu">
+        <ul class="menu is-dropdown-submenu" id="diffmode-chooser-menu" role="menu" aria-labelledby="diff-view-selected" tabindex="-1">
           <li>
             <%= link_to "#diff-view-unified", class: "diff-view-mode", id:"diff-view-unified" do %>
               <%= t("versions.dropdown.option_unified") %>

--- a/decidim-core/app/cells/decidim/diff/show.erb
+++ b/decidim-core/app/cells/decidim/diff/show.erb
@@ -1,6 +1,8 @@
 <%= render :diff_mode_dropdown %>
 <%= render :diff_mode_html %>
 
-<% diff_data.each do |data| %>
-  <%= attribute(data) %>
-<% end %>
+<div aria-live="polite">
+  <% diff_data.each do |data| %>
+    <%= attribute(data) %>
+  <% end %>
+</div>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1738,6 +1738,7 @@ en:
     dropdown:
       choose_diff_view_html: 'HTML view mode:'
       choose_diff_view_mode: 'Compare view mode:'
+      choose_diff_view_mode_menu: Choose compare mode
       option_escaped: Escaped
       option_split: Side-by-side
       option_unescaped: Unescaped


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the fix from #8879 to 0.26.

#### :pushpin: Related Issues
- Related to #8879

#### Testing
See #8879.

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.