### PR TITLE
Fix the component index views heading order for the subtitle change

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/results/_results_leaf.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_results_leaf.html.erb
@@ -1,7 +1,7 @@
 <div class="title-action">
-  <h3 id="results-count" class="title-action__title section-heading">
+  <h2 id="results-count" class="title-action__title section-heading">
     <%= heading_leaf_level_results(total_count) %>
-  </h3>
+  </h2>
 </div>
 
 <div class="row">

--- a/decidim-blogs/app/views/decidim/blogs/posts/_posts.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/_posts.html.erb
@@ -7,9 +7,9 @@
       <div class="card__content">
         <div class="card__header">
           <%= link_to post, class: "card__link" do %>
-          <h3 class="card__title">
+          <h2 class="card__title">
             <%= translated_attribute post.title %>
-          </h3>
+          </h2>
           <% end %>
           <div class="card__author">
             <%= cell "decidim/author", present(post.author), from: post, has_actions: true %>

--- a/decidim-budgets/app/cells/decidim/budgets/budgets_list/show.erb
+++ b/decidim-budgets/app/cells/decidim/budgets/budgets_list/show.erb
@@ -2,9 +2,9 @@
   <div class="columns medium-7 mediumlarge-8">
     <% if !voting_finished? && (voted?) %>
       <div class="section">
-        <h3 class="section-heading">
+        <h2 class="section-heading">
           <%= t(:my_budgets, scope: i18n_scope) %>
-        </h3>
+        </h2>
 
         <%= render :voted %>
       </div>

--- a/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
@@ -15,9 +15,9 @@
   </div>
 
   <div class="row columns">
-    <h3 class="section-heading">
+    <h2 class="section-heading">
       <%= render partial: "count" %>
-    </h3>
+    </h2>
   </div>
 
   <div class="row">

--- a/decidim-debates/app/views/decidim/debates/debates/index.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/index.html.erb
@@ -2,9 +2,9 @@
 
 <div class="row columns">
   <div class="title-action">
-    <h3 id="debates-count" class="title-action__title section-heading">
+    <h2 id="debates-count" class="title-action__title section-heading">
       <%= render partial: "count" %>
-    </h3>
+    </h2>
     <% if current_settings.creation_enabled? && current_component.participatory_space.can_participate?(current_user) %>
       <%= action_authorized_link_to :create, new_debate_path, class: "title-action__action button small", data: { "redirect_url" => new_debate_path } do %>
         <%= t(".new_debate") %>

--- a/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
@@ -8,7 +8,7 @@
 <%= render partial: "decidim/shared/component_announcement" %>
 
 <div class="row columns">
-  <h3 class="section-heading"><%= translated_attribute questionnaire.title %></h3>
+  <h2 class="section-heading"><%= translated_attribute questionnaire.title %></h2>
   <div class="row">
     <div class="columns large-<%= columns %> medium-centered lead">
       <%= decidim_sanitize_editor translated_attribute questionnaire.description %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
@@ -6,9 +6,9 @@
 
 <div class="row columns">
   <div class="title-action">
-    <h3 id="meetings-count" class="title-action__title section-heading">
+    <h2 id="meetings-count" class="title-action__title section-heading">
       <%= render partial: "count" %>
-    </h3>
+    </h2>
 
     <% if allowed_to?(:create, :meeting) %>
       <%= action_authorized_link_to :create, new_meeting_path, class: "title-action__action button small", data: { "redirect_url" => new_meeting_path } do %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
@@ -28,9 +28,9 @@
 <%= render partial: "voting_rules" %>
 <div class="row columns">
   <div class="title-action">
-    <h3 id="proposals-count" class="title-action__title section-heading">
+    <h2 id="proposals-count" class="title-action__title section-heading">
       <%= render partial: "count" %>
-    </h3>
+    </h2>
     <% if current_settings.creation_enabled && current_component.participatory_space.can_participate?(current_user) %>
       <%= action_authorized_link_to :create, new_proposal_path, class: "title-action__action button small", data: { "redirect_url" => new_proposal_path } do %>
         <%= t(".new_proposal") %>

--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/index.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/index.html.erb
@@ -1,8 +1,8 @@
 <div class="row columns">
   <div class="title-action">
-    <h3 id="sortitions-count" class="title-action__title section-heading">
+    <h2 id="sortitions-count" class="title-action__title section-heading">
       <%= render partial: "sortitions_count" %>
-    </h3>
+    </h2>
   </div>
 </div>
 <div class="row">


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes the component index views heading order after #8901 is applied.

I believe this can be merged already before #8901 because this shouldn't break the heading order (we'll see what CI says).

WCAG 2.2 / 1.3.1 Info and Relationships (Level A)

https://www.w3.org/TR/WCAG22/#info-and-relationships
https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html

#### :pushpin: Related Issues
- Related to #8901

#### Testing
Go through the pages and see if they have the accessibility error for heading orders.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.