### PR TITLE
Fix the illogical heading orders with the budget component views

### DIFF
--- a/decidim-budgets/app/cells/decidim/budgets/budget_list_item/show.erb
+++ b/decidim-budgets/app/cells/decidim/budgets/budget_list_item/show.erb
@@ -1,16 +1,16 @@
 <div class="<%= card_class %> budget-list__item budget-list__item-cell">
   <div class="budget-list__text flex-horizontal">
     <%= link_to budget_path(budget), class: link_class do %>
-      <h5 class="card--list__heading">
+      <h3 class="card--list__heading">
         <%= translated_attribute(title) %>
-      </h5>
+      </h3>
     <% end %>
 
-    <h5>
+    <div class="heading5">
       <strong>
         <%= budget_to_currency(total_budget) %>
       </strong>
-    </h5>
+    </div>
 
     <%= decidim_sanitize html_truncate(translated_attribute(description), length: 140) %>
   </div>

--- a/decidim-budgets/app/cells/decidim/budgets/project_list_item/project_text.erb
+++ b/decidim-budgets/app/cells/decidim/budgets/project_list_item/project_text.erb
@@ -1,11 +1,11 @@
 <div class="budget-list__text card__text">
   <div>
     <%= link_to resource_path, class: "card__link" do %>
-      <h5 class="card__title budget-list__title">
+      <h3 class="card__title budget-list__title">
         <%= cell("decidim/budgets/project_selected_status", model) %>
 
         <%= resource_title %>
-      </h5>
+      </h3>
     <% end %>
 
     <div class="show-for-medium">

--- a/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
@@ -2,9 +2,9 @@
   <div class="callout warning">
     <div class="row">
       <div class="columns medium-8 large-9">
-        <h3 class="heading3">
+        <h2 class="heading3">
           <%= t(".rules.title") %>
-        </h3>
+        </h2>
         <ul>
           <%= raw current_rule_explanation %>
         </ul>
@@ -16,23 +16,23 @@
   <div class="card__content">
     <% if include_heading %>
       <% if current_order_checked_out? %>
-        <h3 class="heading3">
+        <h2 class="heading3">
           <%= t(".checked_out.title") %>
           <% unless current_workflow.single? %>
             <small><%= translated_attribute(budget.title) %></small>
           <% end %>
-        </h3>
+        </h2>
         <p>
           <%= raw t(".checked_out.description", cancel_link: link_to(t(".cancel_order"), budget_order_path(return_to: "budget"), method: :delete, class: "cancel-order", data: { confirm: t(".are_you_sure") })) %>
         </p>
       <% else %>
-        <h3 class="heading3">
+        <h2 class="heading3">
           <% if current_workflow.single? %>
             <%= t(".title") %>
           <% else %>
             <%= translated_attribute(budget.title) %>
           <% end %>
-        </h3>
+        </h2>
         <p>
           <%= raw current_rule_description %>
         </p>


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes some illogical heading orders with the budgets component.

As a sidenote, I think the budget component's index view that lists the budgets should have a `<h2>` level heading before the budgets listing. Now it only has a `<h2>` at the "my budgets" section which is confusing as the rest of the budgets does not have any heading. The screen reader user may think that all of the budgets are "my budgets" because they are under the same `<h2>` level heading. But this is another discussion as it is a change in functionality.

WCAG 2.2 / 1.3.1 Info and Relationships (Level A)

https://www.w3.org/TR/WCAG22/#info-and-relationships
https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html

#### Testing
Check the heading orders in the budgets list view.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.