### PR TITLE
Fix illogical heading orders in the elections component

### DIFF
--- a/decidim-elections/app/cells/decidim/elections/election_preview/show.erb
+++ b/decidim-elections/app/cells/decidim/elections/election_preview/show.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="columns large-8">
-    <h2 class="section-heading"><%= t("decidim.elections.elections.preview.title") %></h2>
+    <h3 class="section-heading"><%= t("decidim.elections.elections.preview.title") %></h3>
 
     <p><%= t("decidim.elections.elections.preview.description") %></p>
 

--- a/decidim-elections/app/cells/decidim/elections/election_results/show.erb
+++ b/decidim-elections/app/cells/decidim/elections/election_results/show.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="columns large-8">
-    <h2 class="section-heading"><%= t("decidim.elections.elections.results.title") %></h2>
+    <h3 class="section-heading"><%= t("decidim.elections.elections.results.title") %></h3>
 
     <p><%= t("decidim.elections.elections.results.description") %></p>
 

--- a/decidim-elections/app/views/decidim/elections/elections/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/show.html.erb
@@ -24,9 +24,9 @@ edit_link(
       <% end %>
     <% end %>
 
-    <h1 class="heading3">
+    <h2 class="heading3">
       <%== present(election).title %>
-    </h1>
+    </h2>
     <div class="card__callout">
       <%= cell "decidim/elections/remaining_time_callout", election %>
     </div>


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes some illogical heading orders in the elections component. The elections component page also has two `<h1>` headings on the same page right now which is an accessibility violation.

WCAG 2.2 / 1.3.1 Info and Relationships (Level A)

https://www.w3.org/TR/WCAG22/#info-and-relationships
https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html

#### Testing
Check the heading orders in the elections component.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.