### PR TITLE
Fix heading order in the process steps page

### DIFF
--- a/decidim-participatory_processes/app/views/decidim/participatory_process_steps/_participatory_process_step.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_process_steps/_participatory_process_step.html.erb
@@ -7,7 +7,7 @@
       <span class="timeline__date text-small">
         <%= participatory_space_helpers.step_dates(participatory_process_step) %>
       </span>
-      <h4 class="timeline__title heading4"><%= translated_attribute(participatory_process_step.title) %></h4>
+      <h3 class="timeline__title heading4"><%= translated_attribute(participatory_process_step.title) %></h3>
     </div>
     <div class="timeline__content">
       <%= translated_attribute(participatory_process_step.description).html_safe %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_process_steps/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_process_steps/index.html.erb
@@ -10,7 +10,7 @@
             <%= t(".back_to_process") %>
           <% end %>
 
-          <h3 class="section-heading"><%= t("participatory_process_steps.index.process_steps", scope: "decidim") %></h3>
+          <h2 class="section-heading"><%= t("participatory_process_steps.index.process_steps", scope: "decidim") %></h2>
           <%= render partial: "timeline" %>
         </div>
       </div>


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes the illogical heading order at the process steps page. This also fixes an accessibility violation that would be added by #8901 without this change.

WCAG 2.2 / 1.3.1 Info and Relationships (Level A)

https://www.w3.org/TR/WCAG22/#info-and-relationships
https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html

#### :pushpin: Related Issues
- Related to #8901

#### Testing
Check the process steps page heading order.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.