### PR TITLE
Fix accessibility issue related to the documents collection toggle

### DIFF
--- a/decidim-core/app/views/decidim/application/_collection.html.erb
+++ b/decidim-core/app/views/decidim/application/_collection.html.erb
@@ -1,11 +1,11 @@
 <% unless attachment_collection.unused? %>
   <div class="docs__container">
-    <span data-toggle="docs-collection-<%= attachment_collection.id %>"><%= icon "caret-right", class: "icon--small", role: "img", "aria-hidden": true %>&nbsp;
+    <button type="button" data-toggle="docs-collection-<%= attachment_collection.id %>"><%= icon "caret-right", class: "icon--small", role: "img", "aria-hidden": true %>&nbsp;
       <strong><%= translated_attribute(attachment_collection.name) %></strong>
 
       <% attachment_collection_documents_count =  attachment_collection.attachments.select(&:document?).count %>
       <small>(<%= attachment_collection_documents_count %> <%= t("decidim.application.collection.documents", count: attachment_collection_documents_count) %>)</small>
-    </span>
+    </button>
 
     <div id="docs-collection-<%= attachment_collection.id %>" class="docs__content hide" data-toggler=".hide">
       <p><%= translated_attribute(attachment_collection.description) %></p>


### PR DESCRIPTION
#### :tophat: What? Why?
The document collection toggle has an accessibility violation because you cannot set an `aria-expanded` attribute to a `<span>` element. The allowed roles can be seen e.g. at:
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded

Also, the elements that behave in a specific way should have consistent identificators as described in the related accessibility links.

WCAG 2.2 / 3.2.4 Consistent Identification (Level AA)

https://www.w3.org/TR/WCAG22/#consistent-identification
https://www.w3.org/WAI/WCAG22/Understanding/consistent-identification.html

#### Testing
Take a look at the accessibility tool at the participatory process index page with the default seeds.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![Accessibility issue related to the document collection toggle](https://user-images.githubusercontent.com/864340/155348008-53e20d58-55f8-468e-9f92-3cd9b0d8810b.png)