### PR TITLE
Fix duplicate ID on the budgets index page

### DIFF
--- a/decidim-budgets/app/cells/decidim/budgets/budgets_list/voted.erb
+++ b/decidim-budgets/app/cells/decidim/budgets/budgets_list/voted.erb
@@ -4,7 +4,7 @@
       <%= t(:voted_on, scope: i18n_scope, links: budgets_link_list(voted)) %>
     </p>
 
-    <div id="voted-budgets" class="card card--list budget-list">
+    <div id="voted-budgets-list" class="card card--list budget-list">
       <% voted.each do |budget| %>
         <%= cell("decidim/budgets/budget_list_item", budget) %>
       <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
There is a duplicate ID on the voted budgets page which causes a HTML validation issue on that page.

WCAG 2.2 / 4.1.1 Parsing (Level A)

https://www.w3.org/TR/WCAG22/#parsing
https://www.w3.org/WAI/WCAG22/Understanding/parsing.html

#### Testing
Check the accessibility tool at the budgets index page when you have multiple budgets.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![Duplicate ID violation at the budgets index page](https://user-images.githubusercontent.com/864340/155350224-44aa8fdc-ed1e-4478-a11f-2c08e2726777.png)