### PR TITLE
Fix diff mode selector roles and tabindexes

### DIFF
--- a/decidim-accountability/spec/system/explore_versions_spec.rb
+++ b/decidim-accountability/spec/system/explore_versions_spec.rb
@@ -67,6 +67,8 @@ describe "Explore versions", versioning: true, type: :system do
       end
     end
 
+    it_behaves_like "accessible page"
+
     it "shows the version number" do
       expect(page).to have_content("VERSION NUMBER\n2 out of 2")
     end

--- a/decidim-accountability/spec/system/explore_versions_spec.rb
+++ b/decidim-accountability/spec/system/explore_versions_spec.rb
@@ -67,8 +67,6 @@ describe "Explore versions", versioning: true, type: :system do
       end
     end
 
-    it_behaves_like "accessible page"
-
     it "shows the version number" do
       expect(page).to have_content("VERSION NUMBER\n2 out of 2")
     end

--- a/decidim-core/app/cells/decidim/diff/diff_mode_dropdown.erb
+++ b/decidim-core/app/cells/decidim/diff/diff_mode_dropdown.erb
@@ -9,21 +9,21 @@
       data-disable-hover="true"
       data-click-open="true"
       data-close-on-click="true"
-      tabindex="-1">
-      <li class="is-dropdown-submenu-parent" tabindex="-1">
-        <a href="#diffmode-chooser-menu" id="diff-view-selected" aria-controls="diffmode-chooser-menu" aria-haspopup="true" aria-label="<%= t("versions.dropdown.choose_diff_view_mode_menu") %>">
+      role="menubar">
+      <li class="is-dropdown-submenu-parent" role="presentation">
+        <a href="#diffmode-chooser-menu" id="diff-view-selected" aria-controls="diffmode-chooser-menu" aria-haspopup="true" aria-label="<%= t("versions.dropdown.choose_diff_view_mode_menu") %>" role="menuitem">
           <span aria-hidden="true"><%= t("versions.dropdown.option_unified") %></span>
         </a>
 
-        <ul class="menu is-dropdown-submenu" id="diffmode-chooser-menu" role="menu" aria-labelledby="diff-view-selected" tabindex="-1">
-          <li>
-            <%= link_to "#diff-view-unified", class: "diff-view-mode", id:"diff-view-unified" do %>
+        <ul class="menu is-dropdown-submenu" id="diffmode-chooser-menu" role="menu" aria-labelledby="diff-view-selected">
+          <li role="presentation">
+            <%= link_to "#diff-view-unified", class: "diff-view-mode", id:"diff-view-unified", role: "menuitem" do %>
               <%= t("versions.dropdown.option_unified") %>
             <% end %>
           </li>
 
-          <li>
-            <%= link_to "#diff-view-split", class: "diff-view-mode", id:"diff-view-split" do %>
+          <li role="presentation">
+            <%= link_to "#diff-view-split", class: "diff-view-mode", id:"diff-view-split", role: "menuitem" do %>
               <%= t("versions.dropdown.option_split") %>
             <% end %>
           </li>

--- a/decidim-debates/spec/system/debates_versions_spec.rb
+++ b/decidim-debates/spec/system/debates_versions_spec.rb
@@ -61,6 +61,8 @@ describe "Explore versions", versioning: true, type: :system do
       end
     end
 
+    it_behaves_like "accessible page"
+
     it "shows the version number" do
       expect(page).to have_content("VERSION NUMBER\n2 out of 2")
     end

--- a/decidim-initiatives/spec/system/initiatives_versions_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_versions_spec.rb
@@ -91,6 +91,8 @@ describe "Explore versions", versioning: true, type: :system do
       end
     end
 
+    it_behaves_like "accessible page"
+
     it "shows the version number" do
       expect(page).to have_content("VERSION NUMBER\n2 out of 2")
     end

--- a/decidim-meetings/spec/system/explore_versions_spec.rb
+++ b/decidim-meetings/spec/system/explore_versions_spec.rb
@@ -70,6 +70,8 @@ describe "Explore versions", versioning: true, type: :system do
       end
     end
 
+    it_behaves_like "accessible page"
+
     it "shows the version number" do
       expect(page).to have_content("VERSION NUMBER\n2 out of 2")
     end

--- a/decidim-proposals/spec/system/amendable/amendment_diff_spec.rb
+++ b/decidim-proposals/spec/system/amendable/amendment_diff_spec.rb
@@ -25,6 +25,8 @@ describe "Amendment Diff", versioning: true, type: :system do
         visit emendation_path
       end
 
+      it_behaves_like "accessible page"
+
       it "shows the changed attributes compared to the last version of the amended proposal" do
         expect(page).to have_content('Amendment to "Updated long enough title"')
 

--- a/decidim-proposals/spec/system/collaborative_drafts_versions_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_versions_spec.rb
@@ -64,6 +64,8 @@ describe "Explore versions", versioning: true, type: :system do
       end
     end
 
+    it_behaves_like "accessible page"
+
     it "shows the version number" do
       expect(page).to have_content("VERSION NUMBER\n2 out of 2")
     end

--- a/decidim-proposals/spec/system/proposals_versions_spec.rb
+++ b/decidim-proposals/spec/system/proposals_versions_spec.rb
@@ -85,6 +85,8 @@ describe "Explore versions", versioning: true, type: :system do
       end
     end
 
+    it_behaves_like "accessible page"
+
     it "shows the version number" do
       expect(page).to have_content("VERSION NUMBER\n2 out of 2")
     end


### PR DESCRIPTION
#### :tophat: What? Why?
This is a subsequent PR for #8879 which fixed the keyboard accessibility and label for the diff mode dropdown.

As a side effect, it introduced some other accessibility errors that were shown by the accessibility tool. This fixes those issues and adds the "accessible page" system specs to multiple pages displaying these diff mode selectors.

I also removed the "tabindex" attributes which come from a legacy version. I compared the dropdown markup with the language selector dropdown and it also did not have those. The `tabindex` attributes are unnecessary when the elements have the proper `role` attributes.

#### :pushpin: Related Issues
- Related to #8879

#### Testing
Go to the diff mode page (e.g. a proposal version or collaborative draft) and take a look at the accessibility tool (see attached screenshot).

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![Accessibility issues related to the diff mode dropdown](https://user-images.githubusercontent.com/864340/155555507-1c03e1d4-d34e-4618-bdae-fd2f78c92596.png)