### PR TITLE
Fix diff mode dropdown duplidate IDs

### DIFF
--- a/decidim-core/app/cells/decidim/diff/diff_mode_dropdown.erb
+++ b/decidim-core/app/cells/decidim/diff/diff_mode_dropdown.erb
@@ -1,3 +1,10 @@
+<%
+menu_id = attribute_diff_id("diffmode-chooser-menu")
+selected_id = attribute_diff_id("diff-view-selected")
+button_unified_id = attribute_diff_id("diff-view-unified")
+button_split_id = attribute_diff_id("diff-view-unified")
+%>
+
 <div class="diff-view-by show-for-mediumlarge">
   <div class="diff-view-by__dropdown">
     <span class="diff-view-by__text">
@@ -11,19 +18,19 @@
       data-close-on-click="true"
       tabindex="-1">
       <li class="is-dropdown-submenu-parent" tabindex="-1">
-        <a href="#diffmode-chooser-menu" id="diff-view-selected" aria-controls="diffmode-chooser-menu" aria-haspopup="true" aria-label="<%= t("versions.dropdown.choose_diff_view_mode_menu") %>">
+        <a href="#<%= menu_id %>" id="<%= selected_id %>" aria-controls="<%= menu_id %>" aria-haspopup="true" aria-label="<%= t("versions.dropdown.choose_diff_view_mode_menu") %>">
           <span aria-hidden="true"><%= t("versions.dropdown.option_unified") %></span>
         </a>
 
-        <ul class="menu is-dropdown-submenu" id="diffmode-chooser-menu" role="menu" aria-labelledby="diff-view-selected" tabindex="-1">
+        <ul class="menu is-dropdown-submenu" id="<%= menu_id %>" role="menu" aria-labelledby="<%= selected_id %>" tabindex="-1">
           <li>
-            <%= link_to "#diff-view-unified", class: "diff-view-mode", id:"diff-view-unified" do %>
+            <%= link_to "##{button_unified_id}", class: "diff-view-mode", id: button_unified_id do %>
               <%= t("versions.dropdown.option_unified") %>
             <% end %>
           </li>
 
           <li>
-            <%= link_to "#diff-view-split", class: "diff-view-mode", id:"diff-view-split" do %>
+            <%= link_to "##{button_split_id}", class: "diff-view-mode", id: button_split_id do %>
               <%= t("versions.dropdown.option_split") %>
             <% end %>
           </li>


### PR DESCRIPTION
#### :tophat: What? Why?
If the page has multiple diff mode dropdowns on it, the page has duplicate IDs right now.

This was discovered when I added accessibility tests to the version pages at #8912.

The error report can be seen e.g. at this test run:
https://github.com/decidim/decidim/runs/5321121060?check_suite_focus=true

```
  1) Explore versions when showing version behaves like accessible page passes HTML validation
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }

       ######
       line 1242: Duplicate ID “diff-view-selected”.

                 <a id="diff-view-selected" role="menuitem" aria-haspopup="true" aria-label="
                   Unescaped
       >>          ">
                   Unescaped
                 </a>

     [Image screenshot]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_explore_versions_when_showing_version_behaves_like_accessible_page_passes_html_validation_438.png

            [Page HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_explore_versions_when_showing_version_behaves_like_accessible_page_passes_html_validation_438.html


     Shared Example Group: "accessible page" called from ./spec/system/debates_versions_spec.rb:64
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:14:in `block (2 levels) in <top (required)>'

  2) Explore versions when showing version behaves like accessible page passes accessibility tests
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }

       Found 1 accessibility violation:

       1) duplicate-id-aria: IDs used in ARIA and labels must be unique (critical)
           https://dequeuniversity.com/rules/axe/4.3/duplicate-id-aria?application=axeAPI
           The following 1 node violate this rule:
           
               Selector: a[href$="\#diffmode-chooser-menu"]
               HTML: <a href="#diffmode-chooser-menu" id="diff-view-selected" aria-controls="diffmode-chooser-menu" aria-haspopup="true" aria-label="Unified" role="menuitem"><span aria-hidden="true">Unified</span></a>
               Fix any of the following:
               - Document has multiple elements referenced with ARIA with the same id attribute: diff-view-selected
               
       Invocation: axe.run({:exclude=>[]}, {}, callback);
```

#### :pushpin: Related Issues
- Related to #8912

#### Testing
1. Go to the on of the version pages when the HTML editor is enabled
2. Check the accessibility tool for errors on that page (or the IDs of the diff mode selectors)

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![Two diff mode dropdowns on the same page](https://user-images.githubusercontent.com/864340/155564703-3f53c15b-06c9-4c68-8f3d-b223e7149c15.png)