### PR TITLE
Fix the HTML diff mode accessibility

### DIFF
--- a/decidim-core/app/cells/decidim/diff/diff_mode_html.erb
+++ b/decidim-core/app/cells/decidim/diff/diff_mode_html.erb
@@ -5,21 +5,26 @@
         <%= t("versions.dropdown.choose_diff_view_html") %>
       </span>
 
-      <ul class="dropdown menu" data-dropdown-menu>
-        <li class="is-dropdown-submenu-parent">
-          <a id="diff-view-selected">
-            <%= t("versions.dropdown.option_unescaped") %>
+      <ul class="dropdown menu" data-dropdown-menu
+        data-autoclose="false"
+        data-disable-hover="true"
+        data-click-open="true"
+        data-close-on-click="true"
+        role="menubar">
+        <li class="is-dropdown-submenu-parent" role="presentation">
+          <a href="#htmlmode-chooser-menu" id="diff-view-html-selected" aria-controls="htmlmode-chooser-menu" aria-haspopup="true" aria-label="<%= t("versions.dropdown.choose_diff_view_mode_menu") %>" role="menuitem">
+            <span aria-hidden="true"><%= t("versions.dropdown.option_unescaped") %></span>
           </a>
 
-          <ul class="menu">
-            <li>
-              <%= link_to "#unescaped-html", class: "diff-view-html", id:"unescaped-html" do %>
+          <ul class="menu is-dropdown-submenu" id="htmlmode-chooser-menu" role="menu" aria-labelledby="diff-view-html-selected">
+            <li role="presentation">
+              <%= link_to "#diff-view-unescaped-html", class: "diff-view-html", id: "diff-view-unescaped-html", role: "menuitem" do %>
                 <%= t("versions.dropdown.option_unescaped") %>
               <% end %>
             </li>
 
-            <li>
-              <%= link_to "#escaped-html", class: "diff-view-html", id:"escaped-html" do %>
+            <li role="presentation">
+              <%= link_to "#diff-view-escaped-html", class: "diff-view-html", id: "diff-view-escaped-html", role: "menuitem" do %>
                 <%= t("versions.dropdown.option_escaped") %>
               <% end %>
             </li>

--- a/decidim-core/app/packs/src/decidim/diff_mode_dropdown.js
+++ b/decidim-core/app/packs/src/decidim/diff_mode_dropdown.js
@@ -33,15 +33,15 @@ $(() => {
   $(document).on("click", ".diff-view-by a.diff-view-html", (event) => {
     event.preventDefault();
     const $target = $(event.target);
-    $target.parents(".is-dropdown-submenu-parent").find("#diff-view-selected").text($target.text());
+    $target.parents(".is-dropdown-submenu-parent").find("#diff-view-html-selected").text($target.text());
     const $visibleDiffViewsId = $allDiffViews.not(".hide").first().attr("id").split("_").slice(1, -1).join("_");
     const $visibleDiffViews = $allDiffViews.filter(`[id*=${$visibleDiffViewsId}]`)
 
-    if ($target.attr("id") === "escaped-html") {
+    if ($target.attr("id") === "diff-view-escaped-html") {
       $visibleDiffViews.filter("[id$=_unescaped]").addClass("hide");
       $visibleDiffViews.filter("[id$=_escaped]").removeClass("hide");
     }
-    if ($target.attr("id") === "unescaped-html") {
+    if ($target.attr("id") === "diff-view-unescaped-html") {
       $visibleDiffViews.filter("[id$=_escaped]").addClass("hide");
       $visibleDiffViews.filter("[id$=_unescaped]").removeClass("hide");
     }


### PR DESCRIPTION
#### :tophat: What? Why?
This applies the same accessibility fixes as #8879 and #8912 combined to the HTML diff mode selector.

When implementing #8912, I added some accessibility tests to the diff mode pages and noticed that they have duplicate IDs on them. The issue is that the diff mode selector and the HTML mode selector use the same IDs.

This fixes the issue by applying unique IDs to the HTML diff mode selector while also fixing the same accessibility issues with the HTML diff mode selector.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #8912, #8879

#### Testing
- Enable HTML editor for the participants from the settings
- Check the accessibility tool issues on the diff mode page (e.g. a version page)

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![Two diff modes on the version page](https://user-images.githubusercontent.com/864340/155572271-a87bc138-4f87-450c-a049-a52c7b546869.png)