### PR TITLE
Add a subtitle to assemblies and processes pages

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -35,7 +35,7 @@ edit_link(
   <div class="row">
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
-        <h2><%= t(".title") %></h2>
+        <h2 class="show-for-sr"><%= t(".title") %></h2>
         <div class="lead">
           <%= decidim_sanitize_editor translated_attribute(current_participatory_space.short_description) %>
         </div>

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -35,6 +35,7 @@ edit_link(
   <div class="row">
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
+        <h2><%= t(".title") %></h2>
         <div class="lead">
           <%= decidim_sanitize_editor translated_attribute(current_participatory_space.short_description) %>
         </div>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -320,6 +320,9 @@ en:
         new_import:
           accepted_types:
             json: JSON
+      assemblies:
+        show:
+          title: About this assembly
       assembly_members:
         index:
           members: Members

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -27,7 +27,7 @@
   <div class="row">
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
-        <h2><%= t(".title") %></h2>
+        <h2 class="show-for-sr"><%= t(".title") %></h2>
         <% if participatory_process_group.present? %>
           <%= render partial: "participatory_process_group" %>
         <% end %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -27,6 +27,7 @@
   <div class="row">
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
+        <h2><%= t(".title") %></h2>
         <% if participatory_process_group.present? %>
           <%= render partial: "participatory_process_group" %>
         <% end %>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -436,6 +436,8 @@ en:
           see: See
         index:
           loading: Loading results...
+        show:
+          title: About this process
       show:
         area: Area
         belongs_to_group: This process belongs to


### PR DESCRIPTION
#### :tophat: What? Why?
After the heading level standardization, the heading order is now broken on the participatory space main page for processes and assemblies. The problem is with the "sections" on that main page, such as "related documents", "related images", etc.

I suggest that we add a subtitle to these pages as shown in the screenshots to fix this problem.

We could also change the heading order of the elements on the participatory space main page but the problem with that is that these same elements, such as "related documents" and "related images" are used also e.g. on the proposal pages where the current `<h3>` order is correct. Therefore, we would need to create extra logic in these templates to decide which is the correct heading order in which context which would add unnecessary logic in the templates.

I know that this is not a simple "fix" per se, as it adds a new element to these pages, but I'm not sure what would be the correct way to solve this issue otherwise as explained above.

#### :pushpin: Related Issues
- Related to #8901 (and the rest of the related changes)

#### Testing
- Go to the process or assembly main page
- Check the accessibility tool

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

Here is the error that is currently shown on the process page for instance:
![Heading order error](https://user-images.githubusercontent.com/864340/155701343-ac90322c-5234-4e5d-8dac-07ffe2ca417b.png)

I suggest that we add these subtitles to fix the problem with the heading order:

![Assembly page H2](https://user-images.githubusercontent.com/864340/155701540-7709c525-9751-418e-ba8a-0b728299eb0d.png)

![Process page H2](https://user-images.githubusercontent.com/864340/155701625-e446c47f-3fff-42ab-bb27-d68841ea3b1a.png)
