### PR TITLE
Add a subtitle to votings page

### DIFF
--- a/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/description/show.erb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/description/show.erb
@@ -6,6 +6,7 @@
       </div>
     <% end %>
     <div class="columns medium-8 mediumlarge-7 content">
+      <h2><%= t(".title") %></h2>
       <div><%= description_text %></div>
     </div>
     <div class="content-height-toggler show-more">

--- a/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/description/show.erb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/description/show.erb
@@ -6,7 +6,7 @@
       </div>
     <% end %>
     <div class="columns medium-8 mediumlarge-7 content">
-      <h2><%= t("decidim.votings.content_blocks.landing_page.description.title") %></h2>
+      <h2 class="show-for-sr"><%= t("decidim.votings.content_blocks.landing_page.description.title") %></h2>
       <div><%= description_text %></div>
     </div>
     <div class="content-height-toggler show-more">

--- a/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/description/show.erb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/description/show.erb
@@ -6,7 +6,7 @@
       </div>
     <% end %>
     <div class="columns medium-8 mediumlarge-7 content">
-      <h2><%= t(".title") %></h2>
+      <h2><%= t("decidim.votings.content_blocks.landing_page.description.title") %></h2>
       <div><%= description_text %></div>
     </div>
     <div class="content-height-toggler show-more">

--- a/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/header/show.erb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/header/show.erb
@@ -6,9 +6,9 @@
           <%= translated_attribute(current_participatory_space.title) %>
         </h1>
 
-        <h3 class="text-highlight">
+        <p class="text-highlight heading3">
           <%= voting_dates %>
-        </h3>
+        </p>
       </div>
     </div>
 

--- a/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/polling_stations/address.erb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/polling_stations/address.erb
@@ -1,5 +1,5 @@
 <div class="polling_station-address">
-  <h5 class="mb-none"><%= translated_attribute polling_station.title %></h5>
+  <h4 class="mb-none heading5"><%= translated_attribute polling_station.title %></h4>
 
   <div>
     <strong><%= translated_attribute polling_station.location %></strong>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -1098,6 +1098,7 @@ en:
           description:
             show_less: Read less
             show_more: Read more
+            title: About this voting
           metrics:
             heading: Metrics
           polling_stations:


### PR DESCRIPTION
#### :tophat: What? Why?
After the heading order related changes, the votings page heading order is also broken. There are few structural issues here as well as the same issue as presented in PR #8918.

This fixes the heading order in the votings space pages as well as implements the same change to the votings space as #8918 implemented for processes and assemblies.

#### :pushpin: Related Issues

- Related to #8918, #8901 (and the rest of the related changes)

#### Testing

- Go to the voting main page
- Check the accessibility tool

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

This will introduce a new element on the voting landing page as shown in the screenshot below:

![Voting page H2](https://user-images.githubusercontent.com/864340/155702367-d763329b-f64e-4207-86a9-09abcdb4dc62.png)