### PR TITLE
Fix heading order in the consultation question page

### DIFF
--- a/decidim-consultations/app/views/decidim/consultations/questions/show.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/questions/show.html.erb
@@ -40,17 +40,17 @@
 
     <div class="columns medium-5">
       <% unless translated_attribute(current_question.origin_scope).blank? %>
-        <h4 class="heading6"><%= t "question.origin_scope", scope: "activemodel.attributes" %></h4>
+        <h3 class="heading6"><%= t "question.origin_scope", scope: "activemodel.attributes" %></h3>
         <p><%= translated_attribute current_question.origin_scope %></p>
       <% end %>
 
-      <h4 class="heading6"><%= t "question.promoter_group", scope: "activemodel.attributes" %></h4>
+      <h3 class="heading6"><%= t "question.promoter_group", scope: "activemodel.attributes" %></h3>
       <p><%= translated_attribute current_question.promoter_group %></p>
 
-      <h4 class="heading6"><%= t "question.scope", scope: "activemodel.attributes" %></h4>
+      <h3 class="heading6"><%= t "question.scope", scope: "activemodel.attributes" %></h3>
       <p><%= translated_attribute current_question.scope.name %></p>
 
-      <h4 class="heading6"><%= t "question.participatory_scope", scope: "activemodel.attributes" %></h4>
+      <h3 class="heading6"><%= t "question.participatory_scope", scope: "activemodel.attributes" %></h3>
       <p><%= translated_attribute current_question.participatory_scope %></p>
     </div>
   </div>

--- a/decidim-consultations/app/views/layouts/decidim/_question_header.html.erb
+++ b/decidim-consultations/app/views/layouts/decidim/_question_header.html.erb
@@ -23,7 +23,7 @@
 <%= yield :question_header_instructions if content_for? :question_header_instructions %>
 
 <div class="row column consultations-title">
-  <h1 class="heading2"><%= decidim_sanitize translated_attribute question.title %></h1>
+  <h2 class="heading2"><%= decidim_sanitize translated_attribute question.title %></h2>
   <% unless question.hashtag.blank? %>
     <div class="text-center">
       <%= link_to "##{question.hashtag}", "https://twitter.com/hashtag/#{question.hashtag}", target: "_blank" %>


### PR DESCRIPTION
#### :tophat: What? Why?
The consultation question page had incorrect heading as well as a duplicate H1 element on the page.

This PR fixes that issue.

#### Testing
- Go to the consultations question page
- Take a look at the accessibility tool

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.