### PR TITLE
Fix email for verification conflict with managed users

### DIFF
--- a/decidim-verifications/app/events/decidim/verifications/managed_user_error_event.rb
+++ b/decidim-verifications/app/events/decidim/verifications/managed_user_error_event.rb
@@ -3,11 +3,15 @@
 module Decidim
   module Verifications
     class ManagedUserErrorEvent < Decidim::Events::SimpleEvent
+      include Rails.application.routes.mounted_helpers
+
       delegate :profile_path, :profile_url, :name, to: :updated_user
 
       def i18n_scope
         "decidim.events.verifications.verify_with_managed_user"
       end
+
+      delegate :conflicts_path, to: :decidim_admin
 
       def resource_path
         profile_path
@@ -22,7 +26,7 @@ module Decidim
       end
 
       def default_i18n_options
-        super.merge({ managed_user_path: managed_user.profile_path, managed_user_name: managed_user.name })
+        super.merge({ conflicts_path: conflicts_path, managed_user_path: managed_user.profile_path, managed_user_name: managed_user.name })
       end
 
       private

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -79,10 +79,10 @@ en:
     events:
       verifications:
         verify_with_managed_user:
-          email_intro: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify herself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>.
-          email_outro: Check the <a href="/admin/conflicts">Verifications's conflicts list</a> and contact the participant to verify her details and solve the issue.
+          email_intro: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify themself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>.
+          email_outro: Check the <a href="%{conflicts_path}">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue.
           email_subject: Failed verification attempt against a managed participant
-          notification_title: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify herself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>.
+          notification_title: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify themself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>.
     verifications:
       authorizations:
         authorization_metadata:

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -79,7 +79,10 @@ en:
     events:
       verifications:
         verify_with_managed_user:
-          notification_title: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify herself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>
+          email_intro: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify herself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>.
+          email_outro: Check the <a href="/admin/conflicts">Verifications's conflicts list</a> and contact the participant to verify her details and solve the issue.
+          email_subject: Failed verification attempt against a managed participant
+          notification_title: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify herself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>.
     verifications:
       authorizations:
         authorization_metadata:

--- a/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
+++ b/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
@@ -38,7 +38,25 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
 
   describe "notification_title" do
     it "is generated correctly" do
-      expect(subject.notification_title).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify herself with the data of the managed participant <a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>")
+      expect(subject.notification_title).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify herself with the data of the managed participant <a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>.")
+    end
+  end
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("Failed verification attempt against a managed participant")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify herself with the data of the managed participant <a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>.")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro).to eq("Check the <a href=\"/admin/conflicts\">Verifications's conflicts list</a> and contact the participant to verify her details and solve the issue.")
     end
   end
 end

--- a/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
+++ b/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
@@ -38,7 +38,7 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
 
   describe "notification_title" do
     it "is generated correctly" do
-      expect(subject.notification_title).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify herself with the data of the managed participant <a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>.")
+      expect(subject.notification_title).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify themself with the data of the managed participant <a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>.")
     end
   end
 
@@ -50,13 +50,13 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
 
   describe "email_intro" do
     it "is generated correctly" do
-      expect(subject.email_intro).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify herself with the data of the managed participant <a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>.")
+      expect(subject.email_intro).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify themself with the data of the managed participant <a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>.")
     end
   end
 
   describe "email_outro" do
     it "is generated correctly" do
-      expect(subject.email_outro).to eq("Check the <a href=\"/admin/conflicts\">Verifications's conflicts list</a> and contact the participant to verify her details and solve the issue.")
+      expect(subject.email_outro).to eq("Check the <a href=\"/admin/conflicts\">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue.")
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When an admin is notified via email that a participant tried to verify with the data of an already verified managed user the email shows no contents because translations are missing (see screenshot).

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to issue #8392.
- This PR is a split of a single fix than the 3 in: https://github.com/decidim/decidim/pull/8888

#### Testing
- Impersonate a user with some verification credentials
- With a registered user try to verify using the same verification credentials
- Check the email sent to admins (in local envs make sure you have a jobs backend running in order to receive the email)

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Verification conflict untranslated email*
![image](https://user-images.githubusercontent.com/199462/155972166-a6184c39-d945-4f06-94ca-88110b6dd710.png)

:hearts: Thank you!
