### PR TITLE
Fix verification report with multitenants: notify it only to admins of that organization

### DIFF
--- a/decidim-verifications/app/commands/decidim/verifications/authorize_user.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/authorize_user.rb
@@ -7,8 +7,9 @@ module Decidim
       # Public: Initializes the command.
       #
       # handler - An AuthorizationHandler object.
-      def initialize(handler)
+      def initialize(handler, organization)
         @handler = handler
+        @organization = organization
       end
 
       # Executes the command. Broadcasts these events:
@@ -39,7 +40,7 @@ module Decidim
           event: "decidim.events.verifications.managed_user_error_event",
           event_class: Decidim::Verifications::ManagedUserErrorEvent,
           resource: conflict,
-          affected_users: Decidim::User.where(admin: true)
+          affected_users: Decidim::User.where(admin: true, organization: @organization)
         )
       end
 

--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -35,7 +35,7 @@ module Decidim
       end
 
       def create
-        AuthorizeUser.call(handler) do
+        AuthorizeUser.call(handler, current_organization) do
           on(:ok) do
             flash[:notice] = t("authorizations.create.success", scope: "decidim.verifications")
             redirect_to redirect_url || authorizations_path

--- a/decidim-verifications/spec/commands/decidim/verifications/authorize_user_spec.rb
+++ b/decidim-verifications/spec/commands/decidim/verifications/authorize_user_spec.rb
@@ -4,8 +4,9 @@ require "spec_helper"
 
 module Decidim::Verifications
   describe AuthorizeUser do
-    subject { described_class.new(handler) }
+    subject { described_class.new(handler, organization) }
 
+    let(:organization) { create(:organization) }
     let(:user) { create(:user, :confirmed) }
     let(:document_number) { "12345678X" }
     let(:handler) do
@@ -107,7 +108,7 @@ module Decidim::Verifications
             event: "decidim.events.verifications.managed_user_error_event",
             event_class: Decidim::Verifications::ManagedUserErrorEvent,
             resource: conflict,
-            affected_users: Decidim::User.where(admin: true)
+            affected_users: Decidim::User.where(admin: true, organization: organization)
           )
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Related to issue https://github.com/decidim/decidim/issues/8807.

The managed_user_error_event notifies all admins in all organizations instead of filtering by organization.

```
[Ajuntament de Sant Just Desvern] <http://participa311-santjust.diba.cat/>

Hola Suport Participa311 Diba,

translation missing: ca.decidim.events.verifications.verify_with_managed_user.email_intro

Xxxx Xxxx<http://participa311-manlleu.diba.cat/profiles/xxxxxx>

translation missing: ca.decidim.events.verifications.verify_with_managed_user.email_outro

Ajuntament de Sant Just Desvern<http://participa311-santjust.diba.cat/>
```

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/8807
- This PR is a split of a single fix from the 3 in: https://github.com/decidim/decidim/pull/8888

#### Testing

1. Sign in as an admin on an instance with multiple organizations and enable document number authorization
2. As an admin, represent a new user with a certain document number
3. As a user, try to get authorized with the same authorization handler and document number
4. As an admin from another organization, see that you receive the event in your emails

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.


:hearts: Thank you!
