### PR TITLE
Local HTML validator for the CI

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -45,11 +45,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_admin_system.yml
+++ b/.github/workflows/ci_admin_system.yml
@@ -40,11 +40,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -40,11 +40,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -43,11 +43,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -42,11 +42,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -40,11 +40,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: "-W:no-deprecated"
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -41,11 +41,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -41,11 +41,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -39,11 +39,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -41,11 +41,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_elections_system_admin.yml
+++ b/.github/workflows/ci_elections_system_admin.yml
@@ -43,6 +43,9 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
       bulletin_board:
         image: codegram/decidim-bulletin-board:0.22.3
         ports: ["8000:8000"]
@@ -59,6 +62,7 @@ jobs:
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: "-W:no-deprecated"
+      VALIDATOR_HTML_URI: http://localhost:8888/
       ELECTIONS_BULLETIN_BOARD_SERVER: http://localhost:8000/api
     steps:
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_elections_system_public.yml
+++ b/.github/workflows/ci_elections_system_public.yml
@@ -43,6 +43,9 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
       bulletin_board:
         image: codegram/decidim-bulletin-board:0.22.3
         ports: ["8000:8000"]
@@ -59,6 +62,7 @@ jobs:
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: "-W:no-deprecated"
+      VALIDATOR_HTML_URI: http://localhost:8888/
       ELECTIONS_BULLETIN_BOARD_SERVER: http://localhost:8000/api
     steps:
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_initiatives_system_admin.yml
+++ b/.github/workflows/ci_initiatives_system_admin.yml
@@ -42,11 +42,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_initiatives_system_public.yml
+++ b/.github/workflows/ci_initiatives_system_public.yml
@@ -42,11 +42,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -43,11 +43,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -43,11 +43,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -22,7 +22,6 @@ env:
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-pages
   PARALLEL_TEST_PROCESSORS: 2
-  VALIDATOR_HTML_URI: http://localhost:8888/
 
 jobs:
   main:
@@ -49,6 +48,7 @@ jobs:
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -22,6 +22,7 @@ env:
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-pages
   PARALLEL_TEST_PROCESSORS: 2
+  VALIDATOR_HTML_URI: http://localhost:8888/
 
 jobs:
   main:
@@ -40,6 +41,9 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -41,11 +41,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -45,11 +45,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_proposals_system_public.yml
+++ b/.github/workflows/ci_proposals_system_public.yml
@@ -45,11 +45,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -42,11 +42,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -43,11 +43,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -39,11 +39,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -42,11 +42,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -40,11 +40,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/decidim-dev/lib/decidim/dev/test/w3c_rspec_validators_overrides.rb
+++ b/decidim-dev/lib/decidim/dev/test/w3c_rspec_validators_overrides.rb
@@ -32,3 +32,16 @@ module W3CValidators
     end
   end
 end
+
+# This allows us to dynamically load the validator URL from the ENV.
+module W3cRspecValidators
+  class Config
+    # rubocop:disable Naming/MemoizedInstanceVariableName
+    def self.get
+      @config ||= {
+        w3c_service_uri: ENV.fetch("VALIDATOR_HTML_URI", "https://validator.w3.org/nu/")
+      }.stringify_keys
+    end
+    # rubocop:enable Naming/MemoizedInstanceVariableName
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
The official W3C HTML Nu Validator has been offline today (2022-02-28). This causes the HTML validation tests to fail.

This PR adds a local validator service through the official Docker container and configures it to be used in the CI pipelines.

#### Testing
See whether the CI is green.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.