### PR TITLE
Fix ActionMailer preview loading

### DIFF
--- a/decidim-core/config/initializers/mail_previews.rb
+++ b/decidim-core/config/initializers/mail_previews.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-Rails.application.configure do
-  config.action_mailer.preview_path = Decidim::Core::Engine.root.join("spec/mailers")
-end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -556,6 +556,20 @@ module Decidim
         Decidim.register_assets_path File.expand_path("app/packs", root)
       end
 
+      initializer "decidim_core.preview_mailer" do
+        # Load in mailer previews for apps to use in development.
+        # We need to make sure we call `Preview.all` before requiring our
+        # previews, otherwise any previews the app attempts to add need to be
+        # manually required.
+        if Rails.env.development? || Rails.env.test?
+          ActionMailer::Preview.all
+
+          Dir[root.join("spec/mailers/previews/**/*_preview.rb")].each do |file|
+            require_dependency file
+          end
+        end
+      end
+
       config.to_prepare do
         FoundationRailsHelper::FlashHelper.include Decidim::FlashHelperExtensions
       end

--- a/decidim-core/spec/lib/engine_spec.rb
+++ b/decidim-core/spec/lib/engine_spec.rb
@@ -87,5 +87,9 @@ module Decidim::Core
         end
       end
     end
+
+    it "loads engine mailer previews" do
+      expect(ActionMailer::Preview.all).to include(Decidim::DeviseMailerPreview)
+    end
   end
 end

--- a/decidim-initiatives/config/initializers/mail_previews.rb
+++ b/decidim-initiatives/config/initializers/mail_previews.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-Rails.application.configure do
-  config.action_mailer.preview_path = Decidim::Initiatives::Engine.root.join("spec/mailers")
-end

--- a/decidim-initiatives/lib/decidim/initiatives/engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/engine.rb
@@ -122,6 +122,20 @@ module Decidim
       initializer "decidim_initiatives.webpacker.assets_path" do
         Decidim.register_assets_path File.expand_path("app/packs", root)
       end
+
+      initializer "decidim_initiatives.preview_mailer" do
+        # Load in mailer previews for apps to use in development.
+        # We need to make sure we call `Preview.all` before requiring our
+        # previews, otherwise any previews the app attempts to add need to be
+        # manually required.
+        if Rails.env.development? || Rails.env.test?
+          ActionMailer::Preview.all
+
+          Dir[root.join("spec/mailers/previews/**/*_preview.rb")].each do |file|
+            require_dependency file
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-initiatives/spec/lib/decidim/initiatives/engine_spec.rb
+++ b/decidim-initiatives/spec/lib/decidim/initiatives/engine_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Initiatives::Engine do
+  it "loads engine mailer previews" do
+    expect(ActionMailer::Preview.all).to include(Decidim::Initiatives::InitiativesMailerPreview)
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
> We have Rails mailer preview in two engines: decidim-core and decidim-initiatives.
> The problem is that the current mailer preview API doesn't allow that, so we only have the ones from decidim-initiatives.

This fixes the action-mailer-preview issue by moving the loading of the app's previews to an `after_initialize` block

#### :pushpin: Related Issues

- Fixes #8934

#### Testing
Run the Dummy App and go to http://localhost:3000/rails/mailers/
You should be able to see all mailers listed and not only the `decidim-initiatives` ones

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/39539196/156070056-e7b10f4c-87d9-4530-97ba-56bc195bb778.png)


:hearts: Thank you!
