### PR TITLE
Backport "Fix officialized user event missing translations" to v0.26

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -704,6 +704,11 @@ en:
           email_outro: You have received this notification because you are following %{nickname}. You can stop receiving notifications following the previous link.
           email_subject: "%{nickname} updated their profile"
           notification_title: The <a href="%{resource_path}">profile page</a> of %{name} (%{nickname}), who you are following, has been updated.
+        user_officialized:
+          email_intro: Participant %{name} (%{nickname}) has been officialized.
+          email_outro: You have received this notification because you are an administrator of the organization.
+          email_subject: "%{name} has been officialized"
+          notification_title: Participant %{name} (%{nickname}) has been officialized.
     export_mailer:
       data_portability_export:
         click_button: 'Click the next link to download your data.<br/>The file will be available until %{date}.<br/>You will need <a href="https://www.7-zip.org/">7-Zip</a> (for Windows), <a href="https://www.keka.io/en/">Keka</a> (for MacOS) or <a href="https://peazip.github.io">PeaZip</a> (for Linux) to open it. Password: %{password}'

--- a/decidim-core/spec/events/decidim/profile_updated_event_officialize_user_spec.rb
+++ b/decidim-core/spec/events/decidim/profile_updated_event_officialize_user_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ProfileUpdatedEvent do
+  include_context "when a simple event"
+
+  let(:event_name) { "decidim.events.users.user_officialized" }
+  let(:resource) { create :user }
+  let(:author) { resource }
+
+  it_behaves_like "a simple event", true
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("#{resource.name} has been officialized")
+    end
+  end
+
+  describe "email_intro" do
+    it "is generated correctly" do
+      expect(subject.email_intro)
+        .to eq("Participant #{resource.name} (@#{resource.nickname}) has been officialized.")
+    end
+  end
+
+  describe "email_outro" do
+    it "is generated correctly" do
+      expect(subject.email_outro)
+        .to eq("You have received this notification because you are an administrator of the organization.")
+    end
+  end
+
+  describe "notification_title" do
+    it "is generated correctly" do
+      expect(subject.notification_title).to eq("Participant #{resource.name} (@#{resource.nickname}) has been officialized.")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR backports https://github.com/decidim/decidim/pull/8927 to `release/0.26-stable`

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/decidim/decidim/pull/8927

:hearts: Thank you!
