### PR TITLE
Fix profile notifications

### DIFF
--- a/decidim-core/app/cells/decidim/followers/show.erb
+++ b/decidim-core/app/cells/decidim/followers/show.erb
@@ -1,4 +1,4 @@
-<div class="empty-notifications callout secondary <%= "hide" if followers.any? %>">
+<div class="callout secondary <%= "hide" if followers.any? %>">
   <p><%= t("decidim.followers.no_followers") %></p>
 </div>
 <div class="row small-up-1 medium-up-2 card-grid">

--- a/decidim-core/app/cells/decidim/following/show.erb
+++ b/decidim-core/app/cells/decidim/following/show.erb
@@ -1,6 +1,6 @@
 <% if public_followings.any? %>
   <% if non_public_followings? %>
-    <div class="empty-notifications callout secondary">
+    <div class="callout secondary">
       <p><%= t("decidim.following.non_public_followings") %></p>
     </div>
   <% end %>
@@ -12,7 +12,7 @@
   </div>
   <%= decidim_paginate public_followings %>
 <% else %>
-  <div class="empty-notifications callout secondary">
+  <div class="callout secondary">
     <p><%= t("decidim.following.no_followings") %></p>
   </div>
 <% end %>

--- a/decidim-core/app/cells/decidim/groups/show.erb
+++ b/decidim-core/app/cells/decidim/groups/show.erb
@@ -1,5 +1,5 @@
 <%= cell "decidim/user_group_pending_invitations_list", model %>
-<div class="empty-notifications callout secondary <%= "hide" if user_groups.any? %>">
+<div class="callout secondary <%= "hide" if user_groups.any? %>">
   <p><%= t("decidim.groups.no_user_groups") %></p>
 </div>
 <div class="row small-up-1 medium-up-2 card-grid">

--- a/decidim-core/app/cells/decidim/members/show.erb
+++ b/decidim-core/app/cells/decidim/members/show.erb
@@ -1,4 +1,4 @@
-<div class="empty-notifications callout secondary <%= "hide" if memberships.any? %>">
+<div class="callout secondary <%= "hide" if memberships.any? %>">
   <p><%= t("decidim.members.no_members") %></p>
 </div>
 <div class="row small-up-1 medium-up-2 card-grid">


### PR DESCRIPTION
#### :tophat: What? Why?
When viewing user group members, page shows "This group doesn't have any members yet." even it has members. This happens because [notifications.js](https://github.com/decidim/decidim/blob/develop/decidim-core/app/packs/src/decidim/notifications.js#L13) removed 'hide' class.

Fixes also similar issues with followers and user's own groups page (see screenshots below)

#### :pushpin: Related Issues
https://github.com/decidim/decidim/pull/1784

#### Testing
1. Sign in
2. Usermenu -> "My public profile"
3. "Groups"
4. **pick a group** (after picking path should be similar to "/profiles/usergroupnickname/members")
5. See notification (screenshot below) even group has members.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/156191038-c2fb804f-99ed-44e4-ae3b-61296dc24219.png)

![image](https://user-images.githubusercontent.com/19709320/156198127-3451d32a-1e1f-4f5e-afc4-596ff81437e9.png)

![image](https://user-images.githubusercontent.com/19709320/156200005-cae456d4-5e19-411c-b79d-32fefaa1afbd.png)

:hearts: Thank you!
