### PR TITLE
Fix proposals' cards with big images

### DIFF
--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -122,7 +122,7 @@ module Decidim
       end
 
       def resource_image_path
-        @resource_image_path ||= has_image? ? model.attachments.find_by("content_type like '%image%'").url : nil
+        @resource_image_path ||= has_image? ? model.attachments.find_by("content_type like '%image%'").thumbnail_url : nil
       end
 
       def cache_hash

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
@@ -79,7 +79,7 @@ module Decidim::Proposals
 
         it "renders the first image in the card whatever the order between attachments" do
           expect(subject).to have_css(".card__image")
-          expect(subject.find(".card__image")[:src]).to eq(attachment_2_img.url)
+          expect(subject.find(".card__image")[:src]).to eq(attachment_2_img.thumbnail_url)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

When there are processes with multiple proposals with big (and heavy) images, we serve the big images in the card. This PR fixes that. 

#### :pushpin: Related Issues
 
- Fixes #8946 

#### Testing

1. Go to a process with proposals component with the "enable attachments" setting enabled
2.    Create a new proposal with a big image attached
3.   Go to the public proposal listing page
4.    See that it isn't the original size in the network tab of your developer tools



### :camera: Screenshots

#### Before

![image](https://user-images.githubusercontent.com/717367/156381640-66b77b0a-ae42-41ab-afc4-5db8184ea61a.png)




#### After 
![image](https://user-images.githubusercontent.com/717367/156381661-38984011-c425-47ec-8430-11afa5d553b0.png)
:hearts: Thank you!
