### PR TITLE
Inherit from Decidim::Query at PublicActivities

### DIFF
--- a/decidim-core/app/queries/decidim/public_activities.rb
+++ b/decidim-core/app/queries/decidim/public_activities.rb
@@ -22,7 +22,7 @@ module Decidim
   #   contained in any of them as spaces.
   # :scopes - a collection of `Decidim::Scope`. It will return any activity that
   #   took place in any of those scopes.
-  class PublicActivities < Rectify::Query
+  class PublicActivities < Decidim::Query
     def initialize(organization, options = {})
       @organization = organization
       @resource_name = options[:resource_name]


### PR DESCRIPTION
#### :tophat: What? Why?
#8761 refactored all the query classes to inherit from `Decidim::Query` to make refactoring them easier.

Meanwhile #8748 was being implemented which introduced a new query class.

This changes the new query class also to inherit from `Decidim::Query`.

#### :pushpin: Related Issues
- Related to #8761, #8748

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.