### PR TITLE
Truncate the meetings card description

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/meeting_m_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_m_cell.rb
@@ -28,7 +28,7 @@ module Decidim
       end
 
       def description
-        present(model).description(strip_tags: true)
+        present(model).description(strip_tags: true).truncate(120, separator: /\s/)
       end
 
       def badge

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
@@ -25,10 +25,21 @@ module Decidim::Meetings
         expect(cell_html).to have_no_content(I18n.l(meeting.created_at.to_date, format: :decidim_short))
       end
 
-      context "when an image is attached to the meeting" do
+      context "when there are long descriptions" do
+        before do
+          meeting.update!(description: { en: "A really long text" * 800 })
+        end
+
+        it "truncates the description" do
+          truncated_description_length = cell_html.find(".card__text--paragraph").text.strip.length
+          expect(truncated_description_length).to be < 130
+        end
+      end
+
+      context "with attached image" do
         let!(:attachment) { create(:attachment, attached_to: meeting) }
 
-        it "renders the picture" do
+        it "renders the image" do
           expect(cell_html).to have_css(".card__image")
         end
       end
@@ -43,7 +54,7 @@ module Decidim::Meetings
         meeting.reload
       end
 
-      it "escapes them correclty" do
+      it "escapes them correctly" do
         expect(the_cell.title).not_to eq("#{@original_title} &amp;&#39;&lt;")
         # as the `cell` test helper wraps content in a Capybara artifact that already converts html entities
         # we should compare with the expected visual result, as we were checking the DOM instead of the html


### PR DESCRIPTION
#### :tophat: What? Why?

On v0.26 we've detected that we've lost the truncation in the description of the meetings M cards. This PR fixes that.  


#### :pushpin: Related Issues
 
- Related to  #8511
- Fixes #8951 

#### Testing

Put lots of characters in the description of a meeting
Go to the meetings list page 

### :camera: Screenshots

#### Before

![image](https://user-images.githubusercontent.com/717367/156390381-90e5a503-b9b2-4f55-90da-7381441d90c7.png)

#### After 

![image](https://user-images.githubusercontent.com/717367/156390401-3b3dbbbf-6f79-4c80-addd-3a26c15edba3.png)

---

As a note, for what I've seen in other installations we'd lost the "(read more)" ellipsis, but as far as I see this is not consistent with other components (like proposals M card don't have it) so I think we can drop that. 

![image](https://user-images.githubusercontent.com/717367/156390591-45d4634f-64af-43ed-9307-281bf34bc7d4.png)

:hearts: Thank you!
