### PR TITLE
Add missing reveal__title classes

### DIFF
--- a/decidim-core/app/cells/decidim/fingerprint/show.erb
+++ b/decidim-core/app/cells/decidim/fingerprint/show.erb
@@ -3,7 +3,7 @@
 </div>
 
 <div id="<%= modal_name %>" class="reveal fingerprint-dialog" data-reveal aria-labelledby="modalTitle" aria-hidden="true" role="dialog">
-  <h2 id="modalTitle"><%= t "decidim.fingerprint.title" %></h2>
+  <h2 id="modalTitle" class="reveal__title"><%= t "decidim.fingerprint.title" %></h2>
   <p><%= t "decidim.fingerprint.explanation" %></p>
   <p>
     <strong><%= t "decidim.fingerprint.value" %>:</strong>

--- a/decidim-core/app/cells/decidim/user_conversations/add_conversation_users.erb
+++ b/decidim-core/app/cells/decidim/user_conversations/add_conversation_users.erb
@@ -2,7 +2,7 @@
   <div class="wrapper wrapper--inner">
     <div class="row">
       <div class="large-12">
-        <h2 id="modalTitle"> <%= t "decidim.user_conversations.index.modal_title" %> </h2>
+        <h2 id="modalTitle" class="reveal__title"><%= t "decidim.user_conversations.index.modal_title" %></h2>
       </div>
     </div>
     <div class="row">

--- a/decidim-core/app/views/decidim/endorsements/identities.html.erb
+++ b/decidim-core/app/views/decidim/endorsements/identities.html.erb
@@ -1,5 +1,5 @@
 <div class="reveal__header reveal__header--nomargin reveal__bg p-s">
-  <h6 class="heading6 m-none"><%= t ".select_identity" %></h6>
+  <h6 class="heading6 m-none reveal__title"><%= t ".select_identity" %></h6>
 </div>
 <ul class="reveal__list">
 <%= render_endorsement_identity(resource, current_user) %>

--- a/decidim-core/app/views/decidim/messaging/conversations/_add_conversation_users.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_add_conversation_users.html.erb
@@ -2,7 +2,7 @@
   <div class="wrapper wrapper--inner">
     <div class="row">
       <div class="large-12">
-        <h2 id="modalTitle"> <%= t(".modal_title") %> </h2>
+        <h2 id="modalTitle" class="reveal__title"><%= t(".modal_title") %></h2>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
#### :tophat: What? Why?
Some reveals are missing the `reveal__title` class which is relevant for the modal title to get focus when it is opened (for accessibility).

The logic that does was implemented at #8294 and is currently here:
https://github.com/decidim/decidim/blob/a27caa6d56ef534439e5789bceff113db643d1a0/decidim-core/app/packs/src/decidim/dialog_mode.js#L94

#### :pushpin: Related Issues
- Related to #8294

#### Testing
Open these modals and check that it places the focus in the title element of the modal.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.