### PR TITLE
Fix multiple mentions correct focus on element (recipient) removal

### DIFF
--- a/decidim-core/app/packs/src/decidim/input_multiple_mentions.js
+++ b/decidim-core/app/packs/src/decidim/input_multiple_mentions.js
@@ -16,6 +16,14 @@ $(() => {
   const iconsPath = window.Decidim.config.get("icons_path");
   const removeLabel = messages.removeRecipient || "Remove recipient %name%";
 
+  let emptyFocusElement = $fieldContainer[0].querySelector(".empty-list");
+  if (!emptyFocusElement) {
+    emptyFocusElement = document.createElement("div");
+    emptyFocusElement.tabIndex = "-1";
+    emptyFocusElement.className = "empty-list";
+    $selectedItems.before(emptyFocusElement);
+  }
+
   const autoComplete = new AutoComplete($searchInput[0], {
     dataMatchKeys: ["name", "nickname"],
     dataSource: (query, callback) => {
@@ -64,7 +72,7 @@ $(() => {
 
     const label = removeLabel.replace("%name%", selection.value.name);
     $selectedItems.append(`
-      <li>
+      <li tabindex="-1">
         <input type="hidden" name="${options.name}" value="${id}">
         <img src="${selection.value.avatarUrl}" class="author__avatar" alt="${selection.value.name}">
         <b>${selection.value.name}</b>
@@ -78,8 +86,12 @@ $(() => {
     $selectedItems.find(`*[data-remove="${id}"]`).on("keypress click", (evt) => {
       const target = evt.target.parentNode;
       if (target.tagName === "LI") {
+        const focusElement = target.nextElementSibling || target.previousElementSibling || emptyFocusElement;
+
         selected = selected.filter((identifier) => identifier !== id);
         target.remove();
+
+        focusElement.focus();
       }
     })
   })


### PR DESCRIPTION
#### :tophat: What? Why?
When starting a new conversation, you can add multiple recipients to the conversation in the opening modal.

When the recipients are added, they appear in the list with a remove button.

Using the NVDA screen reader and clicking the remove button places the page focus back to the "New conversation" button behind the modal.

This PR fixes the issue to keep the focus within the modal itself. The focus is placed as follows:
- If there is a next recipient after the recipient to be removed, focus that
- If there is a previous recipient after the recipient to be removed, focus that
- If there are no more recipients, place the focus in an empty focusable element above the recipients list when the screen reader announces "empty" with the current language it is configured for

I assume this is NVDA specific "feature" (place focus to the last clicked element if the current cursor position is removed) but it may apply to other screen readers as well.

#### Testing
Try the new conversation modal with NVDA.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.