### PR TITLE
Fix mobile nav keyboard focus

### DIFF
--- a/decidim-core/app/packs/src/decidim/dialog_mode.test.js
+++ b/decidim-core/app/packs/src/decidim/dialog_mode.test.js
@@ -17,6 +17,7 @@ jest.mock("jquery", () => {
 import $ from "jquery"; // eslint-disable-line id-length
 import "foundation-sites";
 
+import FocusGuard from "./focus_guard.js";
 import dialogMode from "./dialog_mode.js";
 
 describe("dialogMode", () => {
@@ -53,6 +54,16 @@ describe("dialogMode", () => {
       </div>
     </div>
   `;
+
+  window.focusGuard = new FocusGuard(document.body);
+
+  // Mock the isVisible element because these elements do not have offsetWidth
+  // or offsetHeight during the test which are checked against to see whether
+  // the element is visible or not.
+  jest.spyOn(window.focusGuard, "isVisible").mockImplementation((element) => {
+    const display = global.window.getComputedStyle(element).display;
+    return ["inline", "block", "inline-block"].includes(display);
+  });
 
   beforeEach(() => {
     $("body").html(content);

--- a/decidim-core/app/packs/src/decidim/focus_guard.js
+++ b/decidim-core/app/packs/src/decidim/focus_guard.js
@@ -1,0 +1,142 @@
+import { Keyboard } from "foundation-sites"
+
+const focusGuardClass = "focusguard";
+const focusableNodes = ["A", "IFRAME", "OBJECT", "EMBED"];
+const focusableDisableableNodes = ["BUTTON", "INPUT", "TEXTAREA", "SELECT"];
+
+export default class FocusGuard {
+  constructor(container) {
+    this.container = container;
+    this.guardedElement = null;
+  }
+
+  trap(element) {
+    if (this.guardedElement) {
+      Keyboard.releaseFocus($(this.guardedElement));
+    }
+
+    this.enable();
+    this.guardedElement = element;
+
+    // Call the release focus first so that we don't accidentally add the
+    // keyboard trap twice. Note that the Foundation methods expect the elements
+    // to be jQuery elements which is why we pass them through jQuery.
+    Keyboard.releaseFocus($(element));
+    Keyboard.trapFocus($(element));
+  }
+
+  enable() {
+    // Check if the guards already exists due to some other dialog
+    const guards = this.container.querySelectorAll(`:scope > .${focusGuardClass}`);
+    if (guards.length > 0) {
+      // Make sure the guards are the first and last element as there have
+      // been changes in the DOM.
+      guards.forEach((guard) => {
+        if (guard.dataset.position === "start") {
+          this.container.prepend(guard);
+        } else {
+          this.container.append(guard);
+        }
+      })
+
+      return;
+    }
+
+    // Add guards at the start and end of the document and attach their focus
+    // listeners
+    const startGuard = this.createFocusGuard("start");
+    const endGuard = this.createFocusGuard("end");
+
+    this.container.prepend(startGuard);
+    this.container.append(endGuard);
+
+    startGuard.addEventListener("focus", () => this.handleContainerFocus(startGuard));
+    endGuard.addEventListener("focus", () => this.handleContainerFocus(endGuard));
+  }
+
+  disable() {
+    const guards = this.container.querySelectorAll(`:scope > .${focusGuardClass}`);
+    guards.forEach((guard) => guard.remove());
+
+    if (this.guardedElement) {
+      // Note that the Foundation methods expect the elements to be jQuery
+      // elements which is why we pass them through jQuery.
+      Keyboard.releaseFocus($(this.guardedElement));
+      this.guardedElement = null;
+    }
+  }
+
+  createFocusGuard(position) {
+    const guard = document.createElement("div");
+    guard.className = focusGuardClass;
+    guard.dataset.position = position;
+    guard.tabIndex = 0;
+    guard.setAttribute("aria-hidden", "true");
+
+    return guard;
+  };
+
+  handleContainerFocus(guard) {
+    if (!this.guardedElement) {
+      guard.blur();
+      return;
+    }
+
+    const visibleNodes = Array.from(this.guardedElement.querySelectorAll("*")).filter((item) => {
+      return this.isVisible(item);
+    });
+
+    let target = null;
+    if (guard.dataset.position === "start") {
+      // Focus at the start guard, so focus the first focusable element after that
+      for (let ind = 0; ind < visibleNodes.length; ind += 1) {
+        if (!this.isFocusGuard(visibleNodes[ind]) && this.isFocusable(visibleNodes[ind])) {
+          target = visibleNodes[ind];
+          break;
+        }
+      }
+    } else {
+      // Focus at the end guard, so focus the first focusable element after that
+      for (let ind = visibleNodes.length - 1; ind >= 0; ind -= 1) {
+        if (!this.isFocusGuard(visibleNodes[ind]) && this.isFocusable(visibleNodes[ind])) {
+          target = visibleNodes[ind];
+          break;
+        }
+      }
+    }
+
+    if (target) {
+      target.focus();
+    } else {
+      // If no focusable element was found, blur the guard focus
+      guard.blur();
+    }
+  };
+
+  isVisible(element) {
+    return element.offsetWidth > 0 || element.offsetHeight > 0;
+  }
+
+  isFocusGuard(element) {
+    return element.classList.contains(focusGuardClass);
+  }
+
+  isFocusable(element) {
+    if (focusableNodes.indexOf(element.nodeName) > -1) {
+      return true;
+    }
+    if (focusableDisableableNodes.indexOf(element.nodeName) > -1 || element.getAttribute("contenteditable")) {
+      if (element.getAttribute("disabled")) {
+        return false;
+      }
+      return true;
+    }
+
+    const tabindex = parseInt(element.getAttribute("tabindex"), 10);
+    if (!isNaN(tabindex) && tabindex >= 0) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -14,6 +14,7 @@ import DataPicker from "src/decidim/data_picker"
 import FormFilterComponent from "src/decidim/form_filter"
 import addInputEmoji from "src/decidim/input_emoji"
 import dialogMode from "src/decidim/dialog_mode"
+import FocusGuard from "src/decidim/focus_guard"
 
 window.Decidim = window.Decidim || {};
 window.Decidim.config = new Configuration()
@@ -26,6 +27,7 @@ window.Decidim.addInputEmoji = addInputEmoji;
 
 $(() => {
   window.theDataPicker = new DataPicker($(".data-picker"));
+  window.focusGuard = new FocusGuard(document.querySelector("body"));
 
   $(document).foundation();
   $(document).on("open.zf.reveal", (ev) => {

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -34,6 +34,15 @@ $(() => {
     dialogMode($(ev.target));
   });
 
+  // Trap the focus within the mobile menu if the user enters it. This is an
+  // accessibility feature forcing the focus within the
+  $("#offCanvas").on("openedEnd.zf.offCanvas", (ev) => {
+    ev.target.querySelector(".main-nav a").focus();
+    window.focusGuard.trap(ev.target);
+  }).on("closed.zf.offCanvas", () => {
+    window.focusGuard.disable();
+  });
+
   fixDropdownMenus();
 
   svg4everybody();

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -35,7 +35,8 @@ $(() => {
   });
 
   // Trap the focus within the mobile menu if the user enters it. This is an
-  // accessibility feature forcing the focus within the
+  // accessibility feature forcing the focus within the offcanvas container
+  // which holds the mobile menu.
   $("#offCanvas").on("openedEnd.zf.offCanvas", (ev) => {
     ev.target.querySelector(".main-nav a").focus();
     window.focusGuard.trap(ev.target);


### PR DESCRIPTION
#### :tophat: What? Why?
The mobile navigation focus is problematic for assistive technologies currently.

There are two problems with it:
1. When the menu is opened, focus is placed in the close button instead of the first menu element
2. When the user is browsing the menu items, the focus does not stay within the menu when the user reaches the last element of the menu (the focus goes back to the document)

We already had the tab guarding functionality implemented for the modals and this PR extracts that to its own class so that we can utilize the same functionality in the mobile menu as well.

#### Testing
Open the **mobile** menu in Chrome inspector and browse the menu with a screen reader using the TAB or arrow keys.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.