### PR TITLE
Update bundler version requirement

### DIFF
--- a/decidim-generators/decidim-generators.gemspec
+++ b/decidim-generators/decidim-generators.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "decidim-core", Decidim::Generators.version
 
-  s.add_development_dependency "bundler", "~> 1.12"
+  s.add_development_dependency "bundler", "~> 2.2"
 end


### PR DESCRIPTION
#### :tophat: What? Why?

We have an ancient bundler version in one of our gemspec files. This PR fixes that. 

:hearts: Thank you!
