### PR TITLE
Fix main navigation aria-current attribute

### DIFF
--- a/decidim-core/app/presenters/decidim/menu_item_presenter.rb
+++ b/decidim-core/app/presenters/decidim/menu_item_presenter.rb
@@ -27,7 +27,7 @@ module Decidim
 
     def render
       content_tag :li, class: link_wrapper_classes do
-        output = [link_to(composed_label, url)]
+        output = [link_to(composed_label, url, link_options)]
         output.push(@view.send(:simple_menu, @menu_item.submenu).render) if @menu_item.submenu
 
         safe_join(output)
@@ -35,6 +35,14 @@ module Decidim
     end
 
     private
+
+    def link_options
+      if is_active_link?(url, active)
+        { aria: { current: "page" } }
+      else
+        {}
+      end
+    end
 
     def composed_label
       icon_name.present? ? icon(icon_name) + label : label

--- a/decidim-core/spec/presenters/decidim/menu_item_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/menu_item_presenter_spec.rb
@@ -15,5 +15,31 @@ module Decidim
     it "renders the url" do
       expect(subject.render).to have_link("Foo", href: "/boo")
     end
+
+    it "does not add the aria-current attribute for non-active page" do
+      expect(subject.render).not_to include('aria-current="page"')
+    end
+
+    context "when the link URL is active" do
+      let(:request) { double }
+      let(:current_path) { "/boo" }
+
+      before do
+        allow(view).to receive(:request).and_return(request)
+        allow(request).to receive(:original_fullpath).and_return(current_path)
+      end
+
+      it "adds the aria-current attribute to the link" do
+        expect(subject.render).to include('aria-current="page"')
+      end
+
+      context "and the page is a sub-page of the menu link" do
+        let(:current_path) { "/boo/bar" }
+
+        it "adds the aria-current attribute to the link" do
+          expect(subject.render).to include('aria-current="page"')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This adds the `aria-current` attribute to the main navigation which was missing.

WCAG 2.2 / 1.3.1 Info and Relationships (Level A)

https://www.w3.org/TR/WCAG22/#info-and-relationships
https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html

#### Testing
Test browsing the menu with a screen reader that supports `aria-current`. When the focus in that link, the screen reader should announce "current page" (if it supports this).

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.