### PR TITLE
Add missing 'Locale' string in i18n in account page

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -23,9 +23,9 @@ en:
       user:
         about: About
         email: Your email
+        locale: Locale
         name: Your name
         nickname: Nickname
-        locale: Locale
         password: Password
         password_confirmation: Confirm your password
         personal_url: Personal URL

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
         email: Your email
         name: Your name
         nickname: Nickname
+        locale: Locale
         password: Password
         password_confirmation: Confirm your password
         personal_url: Personal URL


### PR DESCRIPTION
#### :tophat: What? Why?

We have an untranslated string in the account form: 

![Firefox_Screenshot_2022-03-04T11-06-29 262Z](https://user-images.githubusercontent.com/717367/156752944-4baf4965-1e44-457f-b7b7-6627d03c55f4.png)

This PR adds it. 

:hearts: Thank you!
