### PR TITLE
Backport "Add missing 'Locale' string in i18n in account page" to v0.26

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
       user:
         about: About
         email: Your email
+        locale: Locale
         name: Your name
         nickname: Nickname
         password: Password


### PR DESCRIPTION
#### :tophat: What? Why?

Backport  #8969

:hearts: Thank you!
