### PR TITLE
Add "Ongoing" option to date filter on meetings

### DIFF
--- a/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
@@ -44,6 +44,7 @@ module Decidim
         TreeNode.new(
           TreePoint.new("", t("decidim.meetings.meetings.filters.date_values.all")),
           [
+            TreePoint.new("ongoing", t("decidim.meetings.meetings.filters.date_values.ongoing")),
             TreePoint.new("upcoming", t("decidim.meetings.meetings.filters.date_values.upcoming")),
             TreePoint.new("past", t("decidim.meetings.meetings.filters.date_values.past"))
           ]

--- a/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
@@ -30,6 +30,7 @@ module Decidim
           TreeNode.new(
             TreePoint.new("", t("decidim.meetings.meetings.filters.date_values.all")),
             [
+              TreePoint.new("ongoing", t("decidim.meetings.meetings.filters.date_values.ongoing")),
               TreePoint.new("upcoming", t("decidim.meetings.meetings.filters.date_values.upcoming")),
               TreePoint.new("past", t("decidim.meetings.meetings.filters.date_values.past"))
             ]

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -58,6 +58,7 @@ module Decidim
       scope :published, -> { where.not(published_at: nil) }
       scope :past, -> { where(arel_table[:end_time].lteq(Time.current)) }
       scope :upcoming, -> { where(arel_table[:end_time].gteq(Time.current)) }
+      scope :ongoing, -> { where(arel_table[:start_time].lteq(Time.current).and(arel_table[:end_time].gteq(Time.current))) }
       scope :withdrawn, -> { where(state: "withdrawn") }
       scope :except_withdrawn, -> { where.not(state: "withdrawn").or(where(state: nil)) }
       scope :with_availability, lambda { |state_key|
@@ -68,7 +69,7 @@ module Decidim
           except_withdrawn
         end
       }
-      scope_search_multi :with_any_date, [:upcoming, :past]
+      scope_search_multi :with_any_date, [:upcoming, :past, :ongoing]
       scope :with_any_space, lambda { |*target_space|
         target_spaces = target_space.compact.reject(&:blank?)
 

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -462,6 +462,7 @@ en:
           date: Date
           date_values:
             all: All
+            ongoing: Ongoing
             past: Past
             upcoming: Upcoming
           my_meetings: My meetings

--- a/decidim-meetings/spec/requests/meeting_search_spec.rb
+++ b/decidim-meetings/spec/requests/meeting_search_spec.rb
@@ -96,9 +96,21 @@ RSpec.describe "Meeting search", type: :request do
     context "and date is upcoming" do
       let(:date) { ["upcoming"] }
 
-      it "only returns that are scheduled in the future" do
+      it "only returns meetings that are scheduled in the future" do
         expect(subject).to include(translated(meeting1.title))
         expect(subject).to include(translated(meeting2.title))
+        expect(subject).not_to include(translated(meeting3.title))
+        expect(subject).not_to include(translated(meeting4.title))
+        expect(subject).not_to include(translated(past_meeting.title))
+      end
+    end
+
+    context "and date is ongoing" do
+      let(:date) { ["ongoing"] }
+
+      it "only returns meetings that are in progress" do
+        expect(subject).to include(translated(meeting2.title))
+        expect(subject).not_to include(translated(meeting1.title))
         expect(subject).not_to include(translated(meeting3.title))
         expect(subject).not_to include(translated(meeting4.title))
         expect(subject).not_to include(translated(past_meeting.title))


### PR DESCRIPTION
Currently, the default option for the “Date” filter on meetings listings is “Upcoming” meetings, and it displays firstly the meetings with large duration that includes the current date (more than 1 day) and the meetings that take 1 day are displayed after them. 

Since there can be cases where we would want to see the upcoming meetings as for the most recent based on the current date, we suggest improving the options from this filter. 

As a guest/registered user, I want to be able to see firstly the upcoming meetings that take 1 day and not multiple days, so that I can attend to them more easily.

#### :tophat: What? Why?

In this sense, on both on the meetings' master page and meeting component from participatory process, for the Date filter, we need to include the option "Ongoing", still having the "Upcoming" option as default. 

In this way, the “Ongoing” option will include the meetings with larger duration, which includes as well the current date.

#### :pushpin: Related Issues

Metaproposal: https://meta.decidim.org/processes/roadmap/f/122/proposals/16939

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Screenshot from 2022-03-07 18-27-40](https://user-images.githubusercontent.com/66411127/157075632-bc0570e2-811f-45ee-856a-e041d634ab26.png)


:hearts: Thank you!
