### PR TITLE
Remove chromedriver version lock

### DIFF
--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -52,10 +52,6 @@ runs:
       name: Create the screenshots folder
       shell: "bash"
     - uses: nanasess/setup-chromedriver@v1.0.1
-      with:
-        # Needed temporarily to bypass issues with Chromedriver v98
-        # https://bugs.chromium.org/p/chromedriver/issues/detail?id=3999
-        chromedriver-version: '97.0.4692.71'
     - run: RAILS_ENV=test bundle exec rails assets:precompile
       name: Precompile assets
       working-directory: ./spec/decidim_dummy_app/


### PR DESCRIPTION
#### :tophat: What? Why?
#8801 added a version lock for chromedriver because of a bug with its `sendKeys` method.

In the related bug thread people have been reporting this issue would be fixed for the latest versions:
https://bugs.chromium.org/p/chromedriver/issues/detail?id=3999

I also tested with the latest chromedriver version locally and I could not make the test break which was previously broken as reported by #8801.

So, let's see...

#### :pushpin: Related Issues
- Related to #8801, https://bugs.chromium.org/p/chromedriver/issues/detail?id=3999

#### Testing
See if CI is green.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.