### PR TITLE
Fix footer actions caching on proposals' card

### DIFF
--- a/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -143,6 +143,8 @@ module Decidim
         hash << Digest::MD5.hexdigest(model.authors.map(&:cache_key_with_version).to_s)
         hash << (model.must_render_translation?(model.organization) ? 1 : 0) if model.respond_to?(:must_render_translation?)
         hash << model.component.participatory_space.active_step.id if model.component.participatory_space.try(:active_step)
+        hash << has_footer?
+        hash << has_actions?
 
         hash.join(Decidim.cache_key_separator)
       end


### PR DESCRIPTION
#### :tophat: What? Why?

We have a problem with the proposals cards' footer and caching. We're caching even though it changes depending on the context. It's really well explained on 

This PR fixes that.  

#### :pushpin: Related Issues

- Fixes #8960

#### Testing



1.    Activate cache locally bundle exec rails dev:cache
2.    Navigate to a participatory process show view
3.    See current proposals on show view, and see footer contains button "View proposal"
4.   Navigate to the proposals index view
5.    See previous proposals present with footer of participatory process view rather than footer with supports count


### :camera: Screenshots

#### Before


![image](https://user-images.githubusercontent.com/717367/157279530-fe0e25c4-132c-48f6-b180-23950d004d2b.png)


#### After

![image](https://user-images.githubusercontent.com/717367/157279546-2cd7f11f-f2bb-45fd-9d61-73dcb3c994b5.png)


:hearts: Thank you!
