### PR TITLE
Fix links formatting in documentation

### DIFF
--- a/docs/modules/configure/pages/environment_variables.adoc
+++ b/docs/modules/configure/pages/environment_variables.adoc
@@ -450,7 +450,7 @@ Separate each item of the array with a comma AND a space, for instance:
 
 *This is not recommended to activate unless you know what you are doing*
 
-For more details https://github.com/rails/rails/issues/39643
+More details at https://github.com/rails/rails/issues/39643[Rails issue #39643]
 
 Additional context: This has been revealed as an issue during a security audit on Future of Europe installation
 
@@ -493,12 +493,12 @@ Note that this only applies to production environments.
 |No
 
 |RAILS_MAX_THREADS
-|Specifies the maximum number of concurrent database connections and `threads` that Puma will use to serve requests. Please refer to http://guides.rubyonrails.org/configuring.html#database-pooling for more information.
+|Specifies the maximum number of concurrent database connections and `threads` that Puma will use to serve requests. Please refer to http://guides.rubyonrails.org/configuring.html#database-pooling[Database pooling at Rails Guides] for more information.
 |5
 |No
 
 |REDIS_URL
-|If using Sidekiq as a queue adapter for processing background jobs, a Redis database is needed. Sidekiq uses this env var if defined, if not defaults to `localhost:6379`. Please refer to https://github.com/mperham/sidekiq/wiki/Using-Redis for more information.
+|If using Sidekiq as a queue adapter for processing background jobs, a Redis database is needed. Sidekiq uses this env var if defined, if not defaults to `localhost:6379`. Please refer to https://github.com/mperham/sidekiq/wiki/Using-Redis[Sidekiq documentation] for more information.
 |5
 |No
 

--- a/docs/modules/develop/pages/guide_development_app.adoc
+++ b/docs/modules/develop/pages/guide_development_app.adoc
@@ -26,7 +26,7 @@ echo "DATABASE_PASSWORD=changeme" >> ~/.rbenv-vars
 
 Of course you should change the password before anything.
 
-2. Then you can create a `development_app` from inside the project's root folder with the command:
+3. Then you can create a `development_app` from inside the project's root folder with the command:
 
 [source,console]
 ----

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -117,7 +117,7 @@ You can configure it with `crontab -e`, for instance if you've created your Deci
 We also have other guides on how to configure some extra components:
 
 * xref:services:activejob.adoc[ActiveJob]: For background jobs (like sending emails).
-* xref:services:geocoding.adoc[Geocoding]: How to enable geocoding for proposals and meetings.
+* xref:services:maps.adoc[Maps]: How to enable geocoding for proposals and meetings.
 * xref:services:social_providers.adoc[Social providers integration]: Enable sign up from social networks.
 
 == Deploy

--- a/docs/modules/install/pages/update.adoc
+++ b/docs/modules/install/pages/update.adoc
@@ -4,7 +4,7 @@ IMPORTANT: This section was initially copied from https://platoniq.github.io/dec
 
 Because Decidim is a gem in our system, to update it we will have to edit our `Gemfile` and specify the new version number.
 
-To keep our system up to date, we can visit the page https://github.com/decidim/decidim/releases and compare with our `Gemfile`. See if the lines specifying the gem called "decidim-something" are followed by the number corresponding to the latest release:
+To keep our system up to date, we can visit the page https://github.com/decidim/decidim/releases[Releases] and compare with our `Gemfile`. See if the lines specifying the gem called "decidim-something" are followed by the number corresponding to the latest release:
 
 [source,ruby]
 ----
@@ -91,5 +91,5 @@ gem "decidim-dev", DECIDIM_VERSION
 
 . Make a full backup of the database before updating, just in case something unexpected happens.
 . If you are more than update away. Always update from one version to the immediately next one and then repeat the process until you are up to date.
-. Always check the instructions for a certain version upgrade in https://github.com/decidim/decidim/releases. Some releases require to perform certain actions as they may change some database structures. Follow that instructions if you are affected.
-. Check also the file https://github.com/decidim/decidim/blob/develop/CHANGELOG.md It may have relevant information for updates between versions.
+. Always check the instructions for a certain version upgrade in https://github.com/decidim/decidim/releases[Releases]. Some releases require to perform certain actions as they may change some database structures. Follow that instructions if you are affected.
+. Check also the file https://github.com/decidim/decidim/blob/develop/CHANGELOG.md[CHANGELOG] It may have relevant information for updates between versions.

--- a/docs/modules/services/pages/index.adoc
+++ b/docs/modules/services/pages/index.adoc
@@ -1,0 +1,11 @@
+= Services
+
+There are multiple services that can be enabled in a Decidim installation. It's important to note that the only mandatory services are the xref:services:activejob.adoc[Active Job] queue and the xref:services:smtp.adoc[SMTP] server. The others are optional and depend on your specific usecase.
+
+* xref:services:activejob.adoc[Active Job]
+* xref:services:elections_bulletin_board.adoc[Elections Bulletin Board]
+* xref:services:etherpad.adoc[Etherpad]
+* xref:services:maps.adoc[Maps]
+* xref:services:smtp.adoc[SMTP]
+* xref:services:social_providers.adoc[Social Providers]
+


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing docs.decidim.org I found multiple tiny bugs:

1. Some links that are not linking correctly
2. Some links that are the full URL that could be added with a title
3. A section missing that could be interesting to explain about the Services mandatory in Decidim 
4.  A list that went from 2 to 2 where it should go to 3 

This PR fixes these details. 

Related to https://github.com/decidim/documentation/pull/85 


:hearts: Thank you!
