### PR TITLE
Fix proposals seeds after reordering of modules loading

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "decidim/components/namer"
+require "decidim/meetings"
 
 Decidim.register_component(:proposals) do |component|
   component.engine = Decidim::Proposals::Engine


### PR DESCRIPTION
#### :tophat: What? Why?

#8971 changed the proposals/meeting libs loading order. This has broken the seeding of proposals that require meetings to be loaded.

This PR fixes this by requiring the meetings module before seeding.

#### :pushpin: Related Issues

- Related to #8971, #8732

:hearts: Thank you!
