### PR TITLE
Make integration_schema_spec.rb stats not care about order

### DIFF
--- a/decidim-api/lib/decidim/api/test.rb
+++ b/decidim-api/lib/decidim/api/test.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "decidim/api/test/shared_examples/statistics_examples"

--- a/decidim-api/lib/decidim/api/test/shared_examples/statistics_examples.rb
+++ b/decidim-api/lib/decidim/api/test/shared_examples/statistics_examples.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples "implements stats type" do
+  context "when the space implements stats" do
+    let(:expected_data) do
+      {
+        "stats" => [
+          { "name" => "dummies_count_high", "value" => 0 },
+          { "name" => "pages_count", "value" => 0 },
+          { "name" => "proposals_count", "value" => 0 },
+          { "name" => "meetings_count", "value" => 0 },
+          { "name" => "budgets_count", "value" => 0 },
+          { "name" => "surveys_count", "value" => 0 },
+          { "name" => "results_count", "value" => 0 },
+          { "name" => "debates_count", "value" => 0 },
+          { "name" => "sortitions_count", "value" => 0 },
+          { "name" => "posts_count", "value" => 0 },
+          { "name" => "elections_count", "value" => 0 }
+        ]
+      }
+    end
+
+    it "executes sucessfully" do
+      expect { response }.not_to raise_error
+    end
+
+    it "returns the correct response" do
+      expect(stats_response).to match_array(expected_data["stats"])
+    end
+  end
+end

--- a/decidim-assemblies/spec/types/integration_schema_spec.rb
+++ b/decidim-assemblies/spec/types/integration_schema_spec.rb
@@ -64,19 +64,6 @@ describe "Decidim::Api::QueryType" do
       "showStatistics" => assembly.show_statistics?,
       "slug" => assembly.slug,
       "specialFeatures" => { "translation" => assembly.special_features[locale] },
-      "stats" => [
-        { "name" => "dummies_count_high", "value" => 0 },
-        { "name" => "pages_count", "value" => 0 },
-        { "name" => "proposals_count", "value" => 0 },
-        { "name" => "meetings_count", "value" => 0 },
-        { "name" => "budgets_count", "value" => 0 },
-        { "name" => "surveys_count", "value" => 0 },
-        { "name" => "results_count", "value" => 0 },
-        { "name" => "debates_count", "value" => 0 },
-        { "name" => "sortitions_count", "value" => 0 },
-        { "name" => "posts_count", "value" => 0 },
-        { "name" => "elections_count", "value" => 0 }
-      ],
       "subtitle" => { "translation" => assembly.subtitle[locale] },
       "target" => { "translation" => assembly.target[locale] },
       "title" => { "translation" => assembly.title[locale] },
@@ -200,10 +187,6 @@ describe "Decidim::Api::QueryType" do
         specialFeatures {
           translation(locale:"#{locale}")
         }
-        stats{
-          name
-          value
-        }
         subtitle {
           translation(locale:"#{locale}")
         }
@@ -234,8 +217,22 @@ describe "Decidim::Api::QueryType" do
       expect { response }.not_to raise_error
     end
 
-    it "has hashtags" do
+    it "returns the correct response" do
       expect(response["assemblies"].first).to eq(assembly_data)
+    end
+
+    it_behaves_like "implements stats type" do
+      let(:assemblies) do
+        %(
+          assemblies{
+            stats{
+              name
+              value
+            }
+          }
+        )
+      end
+      let(:stats_response) { response["assemblies"].first["stats"] }
     end
   end
 
@@ -353,10 +350,6 @@ describe "Decidim::Api::QueryType" do
         specialFeatures {
           translation(locale:"#{locale}")
         }
-        stats{
-          name
-          value
-        }
         subtitle {
           translation(locale:"#{locale}")
         }
@@ -378,8 +371,22 @@ describe "Decidim::Api::QueryType" do
       expect { response }.not_to raise_error
     end
 
-    it "has hashtags" do
+    it "returns the correct response" do
       expect(response["assembly"]).to eq(assembly_data)
+    end
+
+    it_behaves_like "implements stats type" do
+      let(:assemblies) do
+        %(
+          assembly(id: #{assembly.id}){
+            stats{
+              name
+              value
+            }
+          }
+        )
+      end
+      let(:stats_response) { response["assembly"]["stats"] }
     end
   end
 end

--- a/decidim-conferences/spec/types/integration_schema_spec.rb
+++ b/decidim-conferences/spec/types/integration_schema_spec.rb
@@ -40,19 +40,6 @@ describe "Decidim::Api::QueryType" do
       "slug" => conference.slug,
       "speakers" => conference.speakers.map { |s| { "id" => s.id.to_s } },
       "startDate" => conference.start_date.to_date.to_s,
-      "stats" => [
-        { "name" => "dummies_count_high", "value" => 0 },
-        { "name" => "pages_count", "value" => 0 },
-        { "name" => "proposals_count", "value" => 0 },
-        { "name" => "meetings_count", "value" => 0 },
-        { "name" => "budgets_count", "value" => 0 },
-        { "name" => "surveys_count", "value" => 0 },
-        { "name" => "results_count", "value" => 0 },
-        { "name" => "debates_count", "value" => 0 },
-        { "name" => "sortitions_count", "value" => 0 },
-        { "name" => "posts_count", "value" => 0 },
-        { "name" => "elections_count", "value" => 0 }
-      ],
       "title" => { "translation" => conference.title[locale] },
       "type" => conference.class.name,
       "updatedAt" => conference.updated_at.iso8601.to_s.gsub("Z", "+00:00")
@@ -119,10 +106,6 @@ describe "Decidim::Api::QueryType" do
           id
         }
         startDate
-        stats{
-          name
-          value
-        }
         title {
           translation(locale:"#{locale}")
         }
@@ -145,8 +128,22 @@ describe "Decidim::Api::QueryType" do
       expect { response }.not_to raise_error
     end
 
-    it "has hashtags" do
+    it "returns the correct response" do
       expect(response["conferences"].first).to eq(conference_data)
+    end
+
+    it_behaves_like "implements stats type" do
+      let(:conferences) do
+        %(
+          conferences {
+            stats{
+              name
+              value
+            }
+          }
+        )
+      end
+      let(:stats_response) { response["conferences"].first["stats"] }
     end
   end
 
@@ -211,10 +208,6 @@ describe "Decidim::Api::QueryType" do
           id
         }
         startDate
-        stats{
-          name
-          value
-        }
         title {
           translation(locale:"#{locale}")
         }
@@ -228,8 +221,22 @@ describe "Decidim::Api::QueryType" do
       expect { response }.not_to raise_error
     end
 
-    it "has hashtags" do
+    it "returns the correct response" do
       expect(response["conference"]).to eq(conference_data)
+    end
+
+    it_behaves_like "implements stats type" do
+      let(:conferences) do
+        %(
+          conference(id: #{conference.id}){
+            stats{
+              name
+              value
+            }
+          }
+        )
+      end
+      let(:stats_response) { response["conference"]["stats"] }
     end
   end
 end

--- a/decidim-consultations/spec/types/integration_schema_spec.rb
+++ b/decidim-consultations/spec/types/integration_schema_spec.rb
@@ -70,19 +70,6 @@ describe "Decidim::Api::QueryType" do
       "resultsPublishedAt" => consultation.results_published_at,
       "slug" => consultation.slug,
       "startVotingDate" => consultation.start_voting_date.to_date.to_s,
-      "stats" => [
-        { "name" => "dummies_count_high", "value" => 0 },
-        { "name" => "pages_count", "value" => 0 },
-        { "name" => "proposals_count", "value" => 0 },
-        { "name" => "meetings_count", "value" => 0 },
-        { "name" => "budgets_count", "value" => 0 },
-        { "name" => "surveys_count", "value" => 0 },
-        { "name" => "results_count", "value" => 0 },
-        { "name" => "debates_count", "value" => 0 },
-        { "name" => "sortitions_count", "value" => 0 },
-        { "name" => "posts_count", "value" => 0 },
-        { "name" => "elections_count", "value" => 0 }
-      ],
       "subtitle" => { "translation" => consultation.subtitle[locale] },
       "title" => { "translation" => consultation.title[locale] },
       "type" => consultation.class.name,
@@ -180,10 +167,6 @@ describe "Decidim::Api::QueryType" do
         resultsPublishedAt
         slug
         startVotingDate
-        stats {
-          name
-          value
-        }
         subtitle {
           translation(locale: "#{locale}")
         }
@@ -209,8 +192,22 @@ describe "Decidim::Api::QueryType" do
       expect { response }.not_to raise_error
     end
 
-    it "has hashtags" do
+    it "returns the correct response" do
       expect(response["consultations"].first).to eq(consultation_data)
+    end
+
+    it_behaves_like "implements stats type" do
+      let(:consultations) do
+        %(
+          consultations{
+            stats{
+              name
+              value
+            }
+          }
+        )
+      end
+      let(:stats_response) { response["consultations"].first["stats"] }
     end
   end
 
@@ -304,10 +301,6 @@ describe "Decidim::Api::QueryType" do
         resultsPublishedAt
         slug
         startVotingDate
-        stats {
-          name
-          value
-        }
         subtitle {
           translation(locale: "#{locale}")
         }
@@ -324,8 +317,22 @@ describe "Decidim::Api::QueryType" do
       expect { response }.not_to raise_error
     end
 
-    it "has hashtags" do
+    it "returns the correct response" do
       expect(response["consultation"]).to eq(consultation_data)
+    end
+
+    it_behaves_like "implements stats type" do
+      let(:consultations) do
+        %(
+          consultation(id: #{consultation.id}){
+            stats{
+              name
+              value
+            }
+          }
+        )
+      end
+      let(:stats_response) { response["consultation"]["stats"] }
     end
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
@@ -11,6 +11,7 @@ require "simplecov" if ENV["SIMPLECOV"]
 require "decidim/core"
 require "decidim/core/test"
 require "decidim/admin/test"
+require "decidim/api/test"
 
 require_relative "rspec_support/component"
 require_relative "rspec_support/authorization"

--- a/decidim-initiatives/spec/types/integration_schema_spec.rb
+++ b/decidim-initiatives/spec/types/integration_schema_spec.rb
@@ -55,19 +55,6 @@ describe "Decidim::Api::QueryType" do
       "signatureType" => initiative.signature_type,
       "slug" => initiative.slug,
       "state" => initiative.state,
-      "stats" => [
-        { "name" => "dummies_count_high", "value" => 0 },
-        { "name" => "pages_count", "value" => 0 },
-        { "name" => "proposals_count", "value" => 0 },
-        { "name" => "meetings_count", "value" => 0 },
-        { "name" => "budgets_count", "value" => 0 },
-        { "name" => "surveys_count", "value" => 0 },
-        { "name" => "results_count", "value" => 0 },
-        { "name" => "debates_count", "value" => 0 },
-        { "name" => "sortitions_count", "value" => 0 },
-        { "name" => "posts_count", "value" => 0 },
-        { "name" => "elections_count", "value" => 0 }
-      ],
       "title" => { "translation" => initiative.title[locale] },
       "type" => initiative.class.name,
       "updatedAt" => initiative.updated_at.iso8601.to_s.gsub("Z", "+00:00")
@@ -133,10 +120,6 @@ describe "Decidim::Api::QueryType" do
         signatureType
         slug
         state
-        stats {
-           name
-          value
-        }
         title {
           translation(locale: "#{locale}")
         }
@@ -159,8 +142,22 @@ describe "Decidim::Api::QueryType" do
       expect { response }.not_to raise_error
     end
 
-    it "has hashtags" do
+    it "returns the correct response" do
       expect(response["initiatives"].first).to eq(initiative_data)
+    end
+
+    it_behaves_like "implements stats type" do
+      let(:initiatives) do
+        %(
+          initiatives {
+            stats{
+              name
+              value
+            }
+          }
+        )
+      end
+      let(:stats_response) { response["initiatives"].first["stats"] }
     end
   end
 
@@ -223,10 +220,6 @@ describe "Decidim::Api::QueryType" do
         signatureType
         slug
         state
-        stats {
-           name
-          value
-        }
         title {
           translation(locale: "en")
         }
@@ -240,8 +233,22 @@ describe "Decidim::Api::QueryType" do
       expect { response }.not_to raise_error
     end
 
-    it "has hashtags" do
+    it "returns the correct response" do
       expect(response["initiative"]).to eq(initiative_data)
+    end
+
+    it_behaves_like "implements stats type" do
+      let(:initiatives) do
+        %(
+          initiative(id: #{initiative.id}){
+            stats{
+              name
+              value
+            }
+          }
+        )
+      end
+      let(:stats_response) { response["initiative"]["stats"] }
     end
   end
 end

--- a/decidim-participatory_processes/spec/types/integration_schema_spec.rb
+++ b/decidim-participatory_processes/spec/types/integration_schema_spec.rb
@@ -187,7 +187,7 @@ describe "Decidim::Api::QueryType" do
       "target" => { "translation" => participatory_process.target[locale] },
       "title" => { "translation" => participatory_process.title[locale] },
       "type" => "Decidim::ParticipatoryProcess",
-      "updatedAt" => participatory_process.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "updatedAt" => participatory_process.updated_at.iso8601.to_s.gsub("Z", "+00:00")
     }
   end
   let(:query) do

--- a/decidim-participatory_processes/spec/types/integration_schema_spec.rb
+++ b/decidim-participatory_processes/spec/types/integration_schema_spec.rb
@@ -113,10 +113,6 @@ describe "Decidim::Api::QueryType" do
         showStatistics
         slug
         startDate
-        stats {
-          name
-          value
-        }
         steps {
           active
           callToActionPath
@@ -192,19 +188,6 @@ describe "Decidim::Api::QueryType" do
       "title" => { "translation" => participatory_process.title[locale] },
       "type" => "Decidim::ParticipatoryProcess",
       "updatedAt" => participatory_process.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
-      "stats" => [
-        { "name" => "dummies_count_high", "value" => 0 },
-        { "name" => "pages_count", "value" => 0 },
-        { "name" => "proposals_count", "value" => 0 },
-        { "name" => "meetings_count", "value" => 0 },
-        { "name" => "budgets_count", "value" => 0 },
-        { "name" => "surveys_count", "value" => 0 },
-        { "name" => "results_count", "value" => 0 },
-        { "name" => "debates_count", "value" => 0 },
-        { "name" => "sortitions_count", "value" => 0 },
-        { "name" => "posts_count", "value" => 0 },
-        { "name" => "elections_count", "value" => 0 }
-      ]
     }
   end
   let(:query) do
@@ -221,5 +204,19 @@ describe "Decidim::Api::QueryType" do
     end
 
     it { expect(response["participatoryProcess"]).to eq(participatory_process_response) }
+
+    it_behaves_like "implements stats type" do
+      let(:participatory_process_query) do
+        %(
+          participatoryProcess{
+            stats{
+              name
+              value
+            }
+          }
+        )
+      end
+      let(:stats_response) { response["participatoryProcess"]["stats"] }
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

After some changes in the order of how we load the modules (see #8971), we're seeing some related [specs failing in CI](https://github.com/decidim/decidim/runs/5498209534?check_suite_focus=true). They're all about the order of the modules and the stats key in every space implementing their own `spec/types/integration_schema_spec.rb`. The problem is that even though the RSpec equality matcher that we were using (`eq`) doesn't care about the order on Hashes, we're using an Array in this key, and in this case it's very sensible to the order that it's using, making our specs brittles. 

So, what I've come up to is to use the `match_array` matcher for the stats key, and to DRY this a bit I introduce a shared example. 

(As far as I know there isn't like `eq` that apart from no caring of the order of hashes, it also doesn't care about the order of arrays inside these hashes. That'd be much cleaner, of course!) 

I also found that we had an example description wrongly here ("`has hashtags`"), so I correct it. 

:hearts: Thank you!
