### PR TITLE
Backport "Remove the label from the dropdown menu opener" to v0.26

### DIFF
--- a/decidim-core/app/cells/decidim/diff/diff_mode_dropdown.erb
+++ b/decidim-core/app/cells/decidim/diff/diff_mode_dropdown.erb
@@ -12,7 +12,7 @@
       role="menubar">
       <li class="is-dropdown-submenu-parent" role="presentation">
         <a href="#diffmode-chooser-menu" id="diff-view-selected" aria-controls="diffmode-chooser-menu" aria-haspopup="true" aria-label="<%= t("versions.dropdown.choose_diff_view_mode_menu") %>" role="menuitem">
-          <span aria-hidden="true"><%= t("versions.dropdown.option_unified") %></span>
+          <%= t("versions.dropdown.option_unified") %>
         </a>
 
         <ul class="menu is-dropdown-submenu" id="diffmode-chooser-menu" role="menu" aria-labelledby="diff-view-selected">

--- a/decidim-core/app/cells/decidim/diff/diff_mode_html.erb
+++ b/decidim-core/app/cells/decidim/diff/diff_mode_html.erb
@@ -13,7 +13,7 @@
         role="menubar">
         <li class="is-dropdown-submenu-parent" role="presentation">
           <a href="#htmlmode-chooser-menu" id="diff-view-html-selected" aria-controls="htmlmode-chooser-menu" aria-haspopup="true" aria-label="<%= t("versions.dropdown.choose_diff_view_mode_menu") %>" role="menuitem">
-            <span aria-hidden="true"><%= t("versions.dropdown.option_unescaped") %></span>
+            <%= t("versions.dropdown.option_unescaped") %>
           </a>
 
           <ul class="menu is-dropdown-submenu" id="htmlmode-chooser-menu" role="menu" aria-labelledby="diff-view-html-selected">

--- a/decidim-core/app/packs/src/decidim/dropdowns_menus.js
+++ b/decidim-core/app/packs/src/decidim/dropdowns_menus.js
@@ -13,6 +13,7 @@ export default function fixDropdownMenus() {
     // user to focus on the li element instead of the <a> element where we
     // actually need the focus to be in.
     $("li.is-dropdown-submenu-parent", element).removeAttr("aria-haspopup").removeAttr("aria-label");
+    $("li.is-dropdown-submenu-parent > a:first", element).removeAttr("aria-label");
     // Foundation marks the wrong role for the submenu elements
     $("ul.is-dropdown-submenu", element).attr("role", "menu");
   })


### PR DESCRIPTION
#### :tophat: What? Why?
Backports the fix from #8972 to 0.26.

#### :pushpin: Related Issues
- Related to #8972

#### Testing
See #8972.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.