### PR TITLE
Backport "Local HTML validator for the CI" to v0.26

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -44,11 +44,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_admin_system_1.yml
+++ b/.github/workflows/ci_admin_system_1.yml
@@ -39,11 +39,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -39,11 +39,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -42,11 +42,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -41,11 +41,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -39,11 +39,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: "-W:no-deprecated"
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -40,11 +40,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -40,11 +40,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -38,11 +38,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -40,11 +40,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_elections_system_admin_1.yml
+++ b/.github/workflows/ci_elections_system_admin_1.yml
@@ -42,6 +42,9 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
       bulletin_board:
         image: codegram/decidim-bulletin-board:0.22.3
         ports: ["8000:8000"]
@@ -58,6 +61,7 @@ jobs:
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: "-W:no-deprecated"
+      VALIDATOR_HTML_URI: http://localhost:8888/
       ELECTIONS_BULLETIN_BOARD_SERVER: http://localhost:8000/api
     steps:
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_elections_system_public.yml
+++ b/.github/workflows/ci_elections_system_public.yml
@@ -42,6 +42,9 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
       bulletin_board:
         image: codegram/decidim-bulletin-board:0.22.3
         ports: ["8000:8000"]
@@ -58,6 +61,7 @@ jobs:
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: "-W:no-deprecated"
+      VALIDATOR_HTML_URI: http://localhost:8888/
       ELECTIONS_BULLETIN_BOARD_SERVER: http://localhost:8000/api
     steps:
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/ci_initiatives_system_admin.yml
+++ b/.github/workflows/ci_initiatives_system_admin.yml
@@ -41,11 +41,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_initiatives_system_public.yml
+++ b/.github/workflows/ci_initiatives_system_public.yml
@@ -41,11 +41,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -42,11 +42,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_meetings_system_public_1.yml
+++ b/.github/workflows/ci_meetings_system_public_1.yml
@@ -42,11 +42,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -39,11 +39,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -40,11 +40,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -44,11 +44,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_proposals_system_public_1.yml
+++ b/.github/workflows/ci_proposals_system_public_1.yml
@@ -44,11 +44,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -41,11 +41,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -42,11 +42,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -38,11 +38,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -41,11 +41,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -39,11 +39,15 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      validator:
+        image: ghcr.io/validator/validator:latest
+        ports: ["8888:8888"]
     env:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
+      VALIDATOR_HTML_URI: http://localhost:8888/
     steps:
       - uses: actions/checkout@v2.0.0
         with:

--- a/decidim-dev/lib/decidim/dev/test/w3c_rspec_validators_overrides.rb
+++ b/decidim-dev/lib/decidim/dev/test/w3c_rspec_validators_overrides.rb
@@ -32,3 +32,16 @@ module W3CValidators
     end
   end
 end
+
+# This allows us to dynamically load the validator URL from the ENV.
+module W3cRspecValidators
+  class Config
+    # rubocop:disable Naming/MemoizedInstanceVariableName
+    def self.get
+      @config ||= {
+        w3c_service_uri: ENV.fetch("VALIDATOR_HTML_URI", "https://validator.w3.org/nu/")
+      }.stringify_keys
+    end
+    # rubocop:enable Naming/MemoizedInstanceVariableName
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This backports the CI confirugation for local HTML validator added at #8937 to the 0.26 version branch.

It seems they have added some rate limitation to the remote service which causes the backport tests to occasionally fail if these limits are hit. So this fixes these issues for the 0.26 backport PRs.

#### :pushpin: Related Issues
- Related to #8937

#### Testing
See that CI is green.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.