### PR TITLE
Create admin log records when proposals are imported from a file

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/import/proposal_creator.rb
+++ b/decidim-proposals/lib/decidim/proposals/import/proposal_creator.rb
@@ -33,7 +33,10 @@ module Decidim
 
         # Saves the proposal
         def finish!
-          super # resource.save!
+          Decidim.traceability.perform_action!(:create, self.class.resource_klass, context[:current_user], visibility: "admin-only") do
+            resource.save!
+            resource
+          end
           notify(resource)
           publish(resource)
         end

--- a/decidim-proposals/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
@@ -87,5 +87,13 @@ describe Decidim::Proposals::Import::ProposalCreator do
       subject.finish!
       expect(record.new_record?).to be(false)
     end
+
+    it "creates admin log" do
+      record = subject.produce
+      expect { subject.finish! }.to change(Decidim::ActionLog, :count).by(1)
+      expect(Decidim::ActionLog.last.user).to eq(user)
+      expect(Decidim::ActionLog.last.resource).to eq(record)
+      expect(Decidim::ActionLog.last.visibility).to eq("admin-only")
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently when admin imports proposals from file, it doesn't create any action log records. After this PR importing proposals from file creates "admin-only" action log record for each imported proposal.

#### :pushpin: Related Issues
#7084

#### Testing
1. Admin panel -> Processes -> **pick a process** -> Components -> Proposals 
2. Import -> Import proposals from a file 
3. Add file (see .xlsx example screenshot below)
4. Import
5. Go to Dashboard to see action logs or run ```Decidim::ActionLog.last(3)``` in rails console

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/157891730-d2e0be70-867c-47ef-b7f2-a45644fd3fca.png)

![image](https://user-images.githubusercontent.com/19709320/157889781-7dd88659-d748-4d38-bf81-1705f19bf79f.png)

:hearts: Thank you!
