### PR TITLE
Backport "Fix character counter with emoji picker close to maximum characters" to v0.26

### DIFF
--- a/decidim-core/app/packs/src/decidim/input_character_counter.js
+++ b/decidim-core/app/packs/src/decidim/input_character_counter.js
@@ -95,6 +95,9 @@ export default class InputCharacterCounter {
       if (remaining === 1) {
         message = MESSAGES.charactersLeft.one;
       }
+      this.$input[0].dispatchEvent(
+        new CustomEvent("characterCounter", {detail: {remaining: remaining}})
+      );
       showMessages.push(message.replace(COUNT_KEY, remaining));
     }
 
@@ -118,4 +121,4 @@ $(() => {
   });
 });
 
-export { InputCharacterCounter, createCharacterCounter };
+export {InputCharacterCounter, createCharacterCounter};

--- a/decidim-core/app/packs/src/decidim/input_emoji.js
+++ b/decidim-core/app/packs/src/decidim/input_emoji.js
@@ -1,4 +1,4 @@
-import { EmojiButton } from "@joeattardi/emoji-button";
+import {EmojiButton} from "@joeattardi/emoji-button";
 
 // eslint-disable-next-line require-jsdoc
 export default function addInputEmoji() {
@@ -37,9 +37,24 @@ export default function addInputEmoji() {
       // belong to for Foundation Abide to show them automatically.
       parent.querySelectorAll(".form-error").forEach((el) => wrapper.appendChild(el));
 
-      btnContainer.addEventListener("click", () => picker.togglePicker(btnContainer))
+      let handlerPicker = function () {
+        picker.togglePicker(btnContainer);
+      }
 
-      picker.on("emoji", ({ emoji }) => {
+      btnContainer.addEventListener("click", handlerPicker);
+
+      elem.addEventListener("characterCounter", (event) => {
+        if (event.detail.remaining >= 4) {
+          btnContainer.addEventListener("click", handlerPicker);
+          btnContainer.removeAttribute("style");
+        } else {
+          btnContainer.removeEventListener("click", handlerPicker);
+          btnContainer.setAttribute("style", "color:lightgrey");
+        }
+      });
+
+
+      picker.on("emoji", ({emoji}) => {
         elem.value += ` ${emoji} `
 
         const event = new Event("emoji.added");

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -132,6 +132,33 @@ shared_examples "comments" do
             end
           end
         end
+
+        it "let the emoji button works properly when there are not too much characters" do
+          if component.present?
+            component.update!(settings: { comments_max_length: 100 })
+            visit current_path
+
+            within ".add-comment form" do
+              find(:css, "textarea:enabled").set("toto")
+              expect(page).not_to have_selector(".emoji-picker__wrapper")
+              find("svg").click
+            end
+            expect(page).to have_selector(".emoji-picker__wrapper")
+          end
+        end
+
+        it "deactivate the emoji button when there are less than 4 characters left" do
+          if component.present?
+            component.update!(settings: { comments_max_length: 30 })
+            visit current_path
+
+            within ".add-comment form" do
+              find(:css, "textarea:enabled").set("0123456789012345678901234567")
+              find("svg").click
+              expect(page).not_to have_selector(".emoji-picker__wrapper")
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backports https://github.com/decidim/decidim/pull/8916

#### :pushpin: Related Issues
- Fixes #8707 

#### Testing
- Write into a textarea until there are less than 4 characters left
- Notice that the emoji button is disabled
- Remove characters until there are more than 4 characters left
- Notice that the emoji button is enabled

:hearts: Thank you!
