### PR TITLE
Fix Devise configs that depend on Decidim configs

### DIFF
--- a/decidim-core/config/initializers/devise.rb
+++ b/decidim-core/config/initializers/devise.rb
@@ -19,12 +19,6 @@ Devise.setup do |config|
   # by default. You can change it below and use your own secret key.
   # config.secret_key = 'e1f4e9899fb5e8b3123950b19cd0f6d22ecaa8c7fb792b6db5a939edc2b3bab722d06a6a46345ee9bf12caa0178408d6134ea92ed778977b8a7ed1007a0c6dbe'
 
-  # ==> Mailer Configuration
-  # Configure the e-mail address which will be shown in Devise::Mailer,
-  # note that it will be overwritten if you use your own mailer class
-  # with default "from" parameter.
-  # config.mailer_sender = Decidim.config.mailer_sender
-
   # Configure the class responsible to send e-mails.
   config.mailer = "Decidim::DecidimDeviseMailer"
 
@@ -174,14 +168,6 @@ Devise.setup do |config|
   # Default: true
   config.allow_insecure_sign_in_after_accept = true
 
-  # ==> Configuration for :confirmable
-  # A period that the user is allowed to access the website even without
-  # confirming their account. For instance, if set to 2.days, the user will be
-  # able to access the website for two days without confirming their account,
-  # access will be blocked just in the third day. Default is 0.days, meaning
-  # the user cannot access the website without confirming their account.
-  # config.allow_unconfirmed_access_for = Decidim.unconfirmed_access_for
-
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm
   # their account within 3 days after the mail was sent, but on the fourth day
@@ -221,11 +207,6 @@ Devise.setup do |config|
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
-
-  # ==> Configuration for :timeoutable
-  # The time you want to timeout the user session without activity. After this
-  # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = Decidim.config.expire_session_after
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/decidim-core/config/initializers/devise.rb
+++ b/decidim-core/config/initializers/devise.rb
@@ -23,7 +23,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = Decidim.config.mailer_sender
+  # config.mailer_sender = Decidim.config.mailer_sender
 
   # Configure the class responsible to send e-mails.
   config.mailer = "Decidim::DecidimDeviseMailer"
@@ -180,7 +180,7 @@ Devise.setup do |config|
   # able to access the website for two days without confirming their account,
   # access will be blocked just in the third day. Default is 0.days, meaning
   # the user cannot access the website without confirming their account.
-  config.allow_unconfirmed_access_for = Decidim.unconfirmed_access_for
+  # config.allow_unconfirmed_access_for = Decidim.unconfirmed_access_for
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm
@@ -225,7 +225,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = Decidim.config.expire_session_after
+  # config.timeout_in = Decidim.config.expire_session_after
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -570,7 +570,7 @@ module Decidim
         end
       end
 
-      # These are moved from devise.rb because we need to run initializers folder before
+      # These are moved from initializers/devise.rb because we need to run initializers folder before
       # setting these or Decidim.config variables have default values.
       initializer "decidim_core.after_initializers_folder", after: "load_config_initializers" do
         Devise.setup do |config|

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -570,7 +570,7 @@ module Decidim
         end
       end
 
-      # We need to run initializers folder before setting these or they have default values.
+      # We need to run initializers folder before setting these or Decidim.config variables have default values.
       initializer "decidim_core.after_initializers_folder", after: "load_config_initializers" do
         Devise.setup do |config|
           # ==> Mailer Configuration

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -570,7 +570,8 @@ module Decidim
         end
       end
 
-      # We need to run initializers folder before setting these or Decidim.config variables have default values.
+      # These are moved from devise.rb because we need to run initializers folder before
+      # setting these or Decidim.config variables have default values.
       initializer "decidim_core.after_initializers_folder", after: "load_config_initializers" do
         Devise.setup do |config|
           # ==> Mailer Configuration

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -570,10 +570,25 @@ module Decidim
         end
       end
 
+      # We need to run initializers folder before setting these or they have default values.
       initializer "decidim_core.after_initializers_folder", after: "load_config_initializers" do
         Devise.setup do |config|
+          # ==> Mailer Configuration
+          # Configure the e-mail address which will be shown in Devise::Mailer,
+          # note that it will be overwritten if you use your own mailer class
+          # with default "from" parameter.
           config.mailer_sender = Decidim.config.mailer_sender
+
+          # A period that the user is allowed to access the website even without
+          # confirming their account. For instance, if set to 2.days, the user will be
+          # able to access the website for two days without confirming their account,
+          # access will be blocked just in the third day. Default is 0.days, meaning
+          # the user cannot access the website without confirming their account.
           config.allow_unconfirmed_access_for = Decidim.unconfirmed_access_for
+
+          # ==> Configuration for :timeoutable
+          # The time you want to timeout the user session without activity. After this
+          # time the user will be asked for credentials again. Default is 30 minutes.
           config.timeout_in = Decidim.config.expire_session_after
         end
       end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -570,6 +570,14 @@ module Decidim
         end
       end
 
+      initializer "decidim_core.after_initializers_folder", after: "load_config_initializers" do
+        Devise.setup do |config|
+          config.mailer_sender = Decidim.config.mailer_sender
+          config.allow_unconfirmed_access_for = Decidim.unconfirmed_access_for
+          config.timeout_in = Decidim.config.expire_session_after
+        end
+      end
+
       config.to_prepare do
         FoundationRailsHelper::FlashHelper.include Decidim::FlashHelperExtensions
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently if system admin changes value of  ```unconfirmed_access_for``` @ ```initializers/decidim.rb``` it doesn't do much because ```Devise.allow_unconfirmed_access_for``` is set already before we run ```initializers/decidim.rb```. Here we add core initializer which is ran after ```initializers/``` folder initializers so that we can actually change values of ```unconfirmed_access_for```, ```mailer_sender``` and ```expire_session_after``` using ```initializers/decidim.rb``` or environment variables.

#### :pushpin: Related Issues
https://github.com/decidim/decidim/pull/115
https://github.com/decidim/decidim/pull/7467
https://github.com/decidim/decidim/pull/8725

#### Testing
```
$ DECIDIM_UNCONFIRMED_ACCESS_FOR=1337 bundle exec rails c
> Devise.allow_unconfirmed_access_for
=> 1337 days
> Decidim.unconfirmed_access_for
=> 1337 days
```

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
