### PR TITLE
Fix submit form with enter when there are attachments

### DIFF
--- a/decidim-core/app/cells/decidim/upload_modal/files.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/files.erb
@@ -23,6 +23,7 @@
       id: button_id,
       name: attribute,
       class: button_class,
+      type: "button",
       data: {
         open: modal_id,
         upload: {

--- a/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
@@ -44,7 +44,7 @@ describe Decidim::UploadModal, type: :cell do
   end
 
   it "renders the open button" do
-    expect(subject).to have_css(".add-file")
+    expect(subject).to have_css(".add-file[type='button']")
   end
 
   it "renders modal" do


### PR DESCRIPTION
#### :tophat: What? Why?
After #8681 if there is attachment button inside a form enter doesn't submit the form anymore. This is because attachment buttons didn't have type 'button'.

#### :pushpin: Related Issues
https://github.com/decidim/decidim/issues/9013
https://github.com/decidim/decidim/pull/8681
https://stackoverflow.com/questions/8294465/making-enter-key-on-an-html-form-submit-instead-of-activating-button

#### Testing
1. Go to any form where there is an attachment button 
2. Focus on some input field and press enter
3. It should submit the form

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
