### PR TITLE
Use published meetings scope on processes landing and proposal's form

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_meetings_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_meetings_cell.rb
@@ -17,6 +17,7 @@ module Decidim
                                  .includes(component: :participatory_space)
                                  .where(component: meeting_components)
                                  .visible_for(current_user)
+                                 .published
                                  .where("end_time >= ?", Time.current)
                                  .except_withdrawn
                                  .not_hidden

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_meetings_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_meetings_cell_spec.rb
@@ -37,11 +37,15 @@ module Decidim
             let!(:moderated_meeting) do
               create(:meeting, :moderated, :published, start_time: meeting.start_time.advance(weeks: 1), component: meeting.component)
             end
+            let!(:unpublished_meeting) do
+              create(:meeting, start_time: 2.weeks.from_now, component: meeting.component)
+            end
 
             it { is_expected.not_to include(moderated_meeting) }
             it { is_expected.not_to include(past_meeting) }
             it { is_expected.to include(meeting) }
             it { is_expected.to include(second_meeting) }
+            it { is_expected.not_to include(unpublished_meeting) }
 
             it "orders them correctly" do
               expect(subject.length).to eq(2)

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_base_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_base_form.rb
@@ -82,7 +82,7 @@ module Decidim
         # Finds the Meetings of the current participatory space
         def meetings
           @meetings ||= Decidim.find_resource_manifest(:meetings).try(:resource_scope, current_component)
-                               &.order(title: :asc)
+                          &.order(title: :asc)&.published
         end
 
         # Return the meeting as author

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_base_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_base_form.rb
@@ -82,7 +82,7 @@ module Decidim
         # Finds the Meetings of the current participatory space
         def meetings
           @meetings ||= Decidim.find_resource_manifest(:meetings).try(:resource_scope, current_component)
-                          &.order(title: :asc)&.published
+                          &.published&.order(title: :asc)
         end
 
         # Return the meeting as author

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/create_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/create_proposal_spec.rb
@@ -10,7 +10,7 @@ module Decidim
         let(:component) { create(:proposal_component) }
         let(:organization) { component.organization }
         let(:meeting_component) { create(:meeting_component, participatory_space: component.participatory_space) }
-        let(:meetings) { create_list(:meeting, 3, component: meeting_component) }
+        let(:meetings) { create_list(:meeting, 3, :published, component: meeting_component) }
         let(:user) { create :user, :admin, :confirmed, organization: organization }
         let(:form) do
           form_klass.from_params(

--- a/decidim-proposals/spec/requests/collaborative_draft_search_spec.rb
+++ b/decidim-proposals/spec/requests/collaborative_draft_search_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Collaborative draft search", type: :request do
   let!(:collaborative_draft7) { create(:collaborative_draft, component: component) }
 
   let(:meetings_component) { create(:component, manifest_name: "meetings", participatory_space: participatory_space) }
-  let(:meeting) { create :meeting, component: meetings_component }
+  let(:meeting) { create :meeting, :published, component: meetings_component }
 
   let(:dummy_component) { create(:component, manifest_name: "dummy", participatory_space: participatory_space) }
   let(:dummy_resource) { create :dummy_resource, component: dummy_component }

--- a/decidim-proposals/spec/requests/proposal_search_spec.rb
+++ b/decidim-proposals/spec/requests/proposal_search_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Proposal search", type: :request do
   let!(:proposal7) { create(:proposal, :accepted, component: component) }
 
   let(:meetings_component) { create(:component, manifest_name: "meetings", participatory_space: participatory_space) }
-  let(:meeting) { create :meeting, component: meetings_component }
+  let(:meeting) { create :meeting, :published, component: meetings_component }
 
   let(:dummy_component) { create(:component, manifest_name: "dummy", participatory_space: participatory_space) }
   let(:dummy_resource) { create :dummy_resource, component: dummy_component }

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -16,7 +16,7 @@ module Decidim
       let(:component) { proposal.component }
 
       let!(:meetings_component) { create(:component, manifest_name: "meetings", participatory_space: participatory_process) }
-      let(:meetings) { create_list(:meeting, 2, component: meetings_component) }
+      let(:meetings) { create_list(:meeting, 2, :published, component: meetings_component) }
 
       let!(:proposals_component) { create(:component, manifest_name: "proposals", participatory_space: participatory_process) }
       let(:other_proposals) { create_list(:proposal, 2, component: proposals_component) }

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -235,7 +235,7 @@ shared_examples "manage proposals" do
 
         context "when proposals comes from a meeting" do
           let!(:meeting_component) { create(:meeting_component, participatory_space: participatory_process) }
-          let!(:meetings) { create_list(:meeting, 3, component: meeting_component) }
+          let!(:meetings) { create_list(:meeting, 3, :published, component: meeting_component) }
 
           it "creates a new proposal with meeting as author" do
             click_link "New proposal"

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -356,7 +356,7 @@ shared_examples "a proposal form with meeting as author" do |options|
   let(:body) { { en: "Everything would be better" } }
   let(:created_in_meeting) { true }
   let(:meeting_component) { create(:meeting_component, participatory_space: participatory_space) }
-  let(:author) { create(:meeting, component: meeting_component) }
+  let(:author) { create(:meeting, :published, component: meeting_component) }
   let!(:meeting_as_author) { author }
 
   let(:params) do

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -190,7 +190,7 @@ describe "Admin views proposal details from admin", type: :system do
 
   context "with related meetings" do
     let(:meeting_component) { create :meeting_component, participatory_space: participatory_process }
-    let(:meeting) { create :meeting, component: meeting_component }
+    let(:meeting) { create :meeting, :published, component: meeting_component }
     let(:moderated_meeting) { create :meeting, component: meeting_component }
     let!(:moderation) { create(:moderation, reportable: moderated_meeting) }
 

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -212,7 +212,7 @@ describe "Proposals", type: :system do
       let(:meeting_component) do
         create(:component, manifest_name: :meetings, participatory_space: proposal.component.participatory_space)
       end
-      let(:meeting) { create(:meeting, component: meeting_component) }
+      let(:meeting) { create(:meeting, :published, component: meeting_component) }
 
       before do
         meeting.link_resources([proposal], "proposals_from_meeting")


### PR DESCRIPTION
#### :tophat: What? Why?

This PR amends a couple of scopes around meetings that where not forcing the publication status.

#### :pushpin: Related Issues

- Fixes #8944 

#### Testing

- [x] In the upcoming meetings block in the homepage, unpublished meetings shouldn't be displayed, even if you are an admin
- [x] In the proposals form, the meetings displayed included only published meetings


:hearts: Thank you!
