### PR TITLE
Fix Devise flash messages translation

### DIFF
--- a/decidim-core/config/initializers/devise.rb
+++ b/decidim-core/config/initializers/devise.rb
@@ -9,6 +9,13 @@ class RandomStalling < Devise::FailureApp
     sleep rand * 5
     super
   end
+
+  protected
+
+  def i18n_options(options)
+    options[:locale] = session[:user_locale]
+    options
+  end
 end
 
 Devise.setup do |config|

--- a/decidim-core/config/initializers/devise.rb
+++ b/decidim-core/config/initializers/devise.rb
@@ -14,7 +14,7 @@ class RandomStalling < Devise::FailureApp
 
   def i18n_options(options)
     options[:locale] = session[:user_locale]
-    options
+    super
   end
 end
 

--- a/decidim-core/spec/system/locales_spec.rb
+++ b/decidim-core/spec/system/locales_spec.rb
@@ -11,12 +11,6 @@ describe "Locales", type: :system do
       visit decidim.root_path
     end
 
-    after do
-      within_language_menu do
-        click_link "English"
-      end
-    end
-
     it "changes the locale to the chosen one" do
       within_language_menu do
         click_link "Català"
@@ -41,6 +35,31 @@ describe "Locales", type: :system do
       click_link "Inici"
 
       expect(page).to have_content("Inici")
+    end
+
+    it "displays devise messages with the right locale when not authenticated " do
+      within_language_menu do
+        click_link "Català"
+      end
+
+      visit decidim_admin.root_path
+
+      expect(page).to have_content("Has d'iniciar la sessió o registrar-te abans de continuar.")
+    end
+
+    it "displays devise messages with the right locale when authentication fails " do
+      click_link "Sign In"
+
+      within_language_menu do
+        click_link "Català"
+      end
+
+      fill_in "session_user_email", with: "toto@example.org"
+      fill_in "session_user_password", with: "toto"
+
+      click_button "Iniciar sessió"
+
+      expect(page).to have_content("Email o la contrasenya no són vàlids.")
     end
 
     context "with a signed in user" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR able devise to render its flash message with the good locale

#### :pushpin: Related Issues
- Fixes #9020 

#### Testing
- Go to https:/localhost:3000/admin while not connected
- Change language if necessary and try again
- See error

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
