### PR TITLE
Fix Spring errors with Rails 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ PR [\#8411] https://github.com/decidim/decidim/pull/8411 changes the following:
 - ActiveSupport - Remove deprecated fallback to I18n.default_locale when config.i18n.fallbacks is empty.
   - This change should be transparent for all the Decidim users that have configured the `Decidim.default_locale`
 
+If you are using Spring, it is highly suggested to add the following line at the top of your application's `config/spring.rb` (especially if you are seeing the following messages in the console `ERROR: directory is already being watched!`):
+
+```ruby
+require "decidim/spring"
+```
+
 #### Dynamic attachment uploads
 PR [\#8681] https://github.com/decidim/decidim/pull/8681 Changes the way file uploads work in Decidim. Files are now dynamically uploaded inside the modal so we can give the user immediate feedback on validation. There are now two different types of file fields: titled and untitled. Titled file fields related to ```Decidim::Attachment``` internally.
 

--- a/decidim-core/lib/decidim/spring.rb
+++ b/decidim-core/lib/decidim/spring.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A special Spring watcher for Decidim to ignore specific paths from the
+  # watching causing excessive use of inodes, issues with CPU usage and with
+  # startup/stop. This should be loaded at the application's config/spring.rb
+  # file.
+  module SpringWatcher
+    def start
+      super
+      listener.ignore(/^(node_modules|storage|tmp)/)
+    end
+  end
+end
+
+Spring::Watcher::Listen.prepend Decidim::SpringWatcher

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -151,7 +151,7 @@ module Decidim
       end
 
       def tweak_spring
-        return unless spring_install?
+        return unless File.exist?("config/spring.rb")
 
         prepend_to_file "config/spring.rb", "require \"decidim/spring\"\n\n"
       end

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -150,6 +150,12 @@ module Decidim
         RUBY
       end
 
+      def tweak_spring
+        return unless spring_install?
+
+        prepend_to_file "config/spring.rb", "require \"decidim/spring\"\n\n"
+      end
+
       def add_ignore_uploads
         append_file ".gitignore", "\n# Ignore public uploads\npublic/uploads" unless options["skip_git"]
       end

--- a/decidim-generators/lib/decidim/generators/test/generator_examples.rb
+++ b/decidim-generators/lib/decidim/generators/test/generator_examples.rb
@@ -43,7 +43,11 @@ shared_examples_for "a new development application" do
       expect(schema).to match(/create_table "#{table}"|create_table :#{table}/)
     end
 
+    # Check that important node modules were installed
     expect(Pathname.new("#{test_app}/node_modules/@rails/webpacker")).to be_directory
+
+    # Check that the configuration tweaks are applied properly
+    expect(File.read("#{test_app}/config/spring.rb")).to match(%r{^require "decidim/spring"})
   end
 end
 


### PR DESCRIPTION
#### :tophat: What? Why?
As described at https://github.com/decidim/decidim/pull/8411#issuecomment-1063027902 and https://github.com/decidim/decidim/pull/8610#issuecomment-1070788000, Spring gives a bunch of the following kind of errors after the Rails 6.1 upgrade:

```
** ERROR: directory is already being watched! **
```

This fixes these errors.

#### :pushpin: Related Issues
- Related to #8411, #8610

#### Testing
```
$ ./bin/spring stop && ./bin/rails c
```

See that no errors are printed out (also make sure you have Spring enabled).

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.