### PR TITLE
Show only current organization in verification conflicts with multitenants

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/conflicts_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/conflicts_controller.rb
@@ -5,10 +5,8 @@ module Decidim
     class ConflictsController < Decidim::Admin::ApplicationController
       layout "decidim/admin/users"
 
-      before_action :users_current_organization, only: :index
-
       def index
-        @conflicts = Decidim::Verifications::Conflict.where(current_user: @organization_users)
+        @conflicts = Decidim::Verifications::Conflict.where(current_user: current_organization_users_ids)
       end
 
       def edit
@@ -46,8 +44,8 @@ module Decidim
 
       private
 
-      def users_current_organization
-        @organization_users = Decidim::User.where(decidim_organization_id: current_organization.id).pluck(:id)
+      def current_organization_users_ids
+        @current_organization_users_ids ||= Decidim::User.where(decidim_organization_id: current_organization.id).pluck(:id)
       end
     end
   end

--- a/decidim-admin/app/controllers/decidim/admin/conflicts_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/conflicts_controller.rb
@@ -6,7 +6,9 @@ module Decidim
       layout "decidim/admin/users"
 
       def index
-        @conflicts = Decidim::Verifications::Conflict.where(current_user: current_organization_users_ids)
+        @conflicts = Decidim::Verifications::Conflict.joins(:current_user).where(
+          decidim_users: { decidim_organization_id: current_organization.id }
+        )
       end
 
       def edit
@@ -40,12 +42,6 @@ module Decidim
             redirect_to decidim.root_path
           end
         end
-      end
-
-      private
-
-      def current_organization_users_ids
-        @current_organization_users_ids ||= Decidim::User.where(decidim_organization_id: current_organization.id).pluck(:id)
       end
     end
   end

--- a/decidim-admin/app/controllers/decidim/admin/conflicts_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/conflicts_controller.rb
@@ -5,8 +5,10 @@ module Decidim
     class ConflictsController < Decidim::Admin::ApplicationController
       layout "decidim/admin/users"
 
+      before_action :users_current_organization, only: :index
+
       def index
-        @conflicts = Decidim::Verifications::Conflict.all
+        @conflicts = Decidim::Verifications::Conflict.where(current_user: @organization_users)
       end
 
       def edit
@@ -40,6 +42,12 @@ module Decidim
             redirect_to decidim.root_path
           end
         end
+      end
+
+      private
+
+      def users_current_organization
+        @organization_users = Decidim::User.where(decidim_organization_id: current_organization.id).pluck(:id)
       end
     end
   end

--- a/decidim-admin/spec/factories.rb
+++ b/decidim-admin/spec/factories.rb
@@ -2,3 +2,4 @@
 
 require "decidim/core/test/factories"
 require "decidim/participatory_processes/test/factories"
+require "decidim/verifications/test/factories"

--- a/decidim-admin/spec/shared/manage_impersonations_examples.rb
+++ b/decidim-admin/spec/shared/manage_impersonations_examples.rb
@@ -274,6 +274,35 @@ shared_examples "manage impersonations examples" do
     end
   end
 
+  describe "verifications conflicts" do
+    context "when have verifications conflicts in current organization" do
+      let(:managed_user) { create(:user, :managed, organization: organization) }
+      let(:current_user) { create(:user, name: "Rigoberto", organization: organization) }
+      let!(:conflict) { create(:conflict, current_user: current_user, managed_user: managed_user) }
+
+      it "show only verifications of current organization" do
+        navigate_to_impersonations_page
+        click_link "Verification conflicts"
+
+        expect(page).to have_content("Rigoberto")
+      end
+    end
+
+    context "when have verifications conflicts in other organization" do
+      let(:other_organization) { create(:organization, available_authorizations: available_authorizations) }
+      let(:current_user) { create(:user, name: "Rigoberto", organization: other_organization) }
+      let(:managed_user) { create(:user, :managed, organization: other_organization) }
+      let!(:conflict) { create(:conflict, current_user: current_user, managed_user: managed_user) }
+
+      it "show only verifications of current organization" do
+        navigate_to_impersonations_page
+        click_link "Verification conflicts"
+
+        expect(page).not_to have_content("Rigoberto")
+      end
+    end
+  end
+
   private
 
   def fill_in_the_impersonation_form(document_number, name: nil, reason: nil)


### PR DESCRIPTION
#### :tophat: What? Why?
In multitenant instances, all of the verification conflicts appear, but they should be filtered by users belonging to the current organization.

#### Testing

1. Go to admin dashboard > Participants
2. Go to Verifications Conflicts
3. Only must show conflicts of current organization

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.


:hearts: Thank you!
