### PR TITLE
Prevent Faker Address country_code from raising RetryLimitExceeded

### DIFF
--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -66,10 +66,10 @@ if !Rails.env.production? || ENV["SEED"]
       organization: organization
     )
 
-    3.times do
+    3.times do |time|
       parent = Decidim::Scope.create!(
         name: Decidim::Faker::Localized.literal(Faker::Address.unique.state),
-        code: Faker::Address.unique.country_code,
+        code: "#{Faker::Address.country_code}_#{time}",
         scope_type: province,
         organization: organization
       )


### PR DESCRIPTION
#### :tophat: What? Why?

Seeds are failing when executing with another locale than default (`:en`). 
It seems that Faker i18n translations are different between english and other languages, see [english](https://github.com/faker-ruby/faker/blob/91950218dd39119e420ca431fc9fae09b53986c7/lib/locales/en/address.yml#L500) failing key `country_code` and [french](https://github.com/faker-ruby/faker/blob/91950218dd39119e420ca431fc9fae09b53986c7/lib/locales/fr/address.yml#L4) for example.  

In this PR, country code is no longer generated using `unique` of Faker but with the current index when creating Scope.

#### :pushpin: Related Issues
- Fixes #4667

#### Testing
Step to reproduce are well explained in the related issue : 

1. In a Decidim application (like development_app)
2. Update the Decidim's locale in `config/initializers/decidim.rb` :
```
[...]
  config.available_locales = %w(fr)
  # organization from the System area, system admins will be able to overwrite
  config.default_locale = :fr
[...]
```
3. Then clear the database and execute seeds : `bundle exec rake db:setup`
4. Seeds should run without failure.

You can also try with an other default locale like `:ca`, `:es`, etc...
 
#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
