### PR TITLE
Add autocomplete attribute to Devise fields

### DIFF
--- a/decidim-core/app/views/decidim/devise/confirmations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/confirmations/new.html.erb
@@ -16,7 +16,7 @@
             <%= render "devise/shared/error_messages", resource: resource %>
 
             <div class="field">
-              <%= f.email_field :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+              <%= f.email_field :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), autocomplete: "on" %>
             </div>
 
             <div class="actions">

--- a/decidim-core/app/views/decidim/devise/confirmations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/confirmations/new.html.erb
@@ -16,7 +16,7 @@
             <%= render "devise/shared/error_messages", resource: resource %>
 
             <div class="field">
-              <%= f.email_field :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), autocomplete: "on" %>
+              <%= f.email_field :email, autofocus: true, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), autocomplete: "email" %>
             </div>
 
             <div class="actions">

--- a/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
@@ -21,17 +21,17 @@
 
             <div class="user-nickname">
               <div class="field">
-                <%= f.text_field :nickname, help_text: t("devise.invitations.edit.nickname_help", organization: current_organization.name), required: "required", prefix: { value: "@", small: 1, large: 1 }, autocomplete: "on" %>
+                <%= f.text_field :nickname, help_text: t("devise.invitations.edit.nickname_help", organization: current_organization.name), required: "required", prefix: { value: "@", small: 1, large: 1 }, autocomplete: "nickname" %>
               </div>
             </div>
 
             <% if f.object.class.require_password_on_accepting %>
               <div class="field">
-                <p><%= f.password_field :password, required: "required", minlength: ::Devise.password_length.min, maxlength: ::Devise.password_length.max %></p>
+                <p><%= f.password_field :password, required: "required", autocomplete: "new-password", minlength: ::Devise.password_length.min, maxlength: ::Devise.password_length.max %></p>
               </div>
 
               <div class="field">
-                <p><%= f.password_field :password_confirmation, required: "required", minlength: ::Devise.password_length.min, maxlength: ::Devise.password_length.max %></p>
+                <p><%= f.password_field :password_confirmation, required: "required", autocomplete: "new-password", minlength: ::Devise.password_length.min, maxlength: ::Devise.password_length.max %></p>
               </div>
             <% end %>
           </div>

--- a/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
@@ -21,7 +21,7 @@
 
             <div class="user-nickname">
               <div class="field">
-                <%= f.text_field :nickname, help_text: t("devise.invitations.edit.nickname_help", organization: current_organization.name), required: "required", prefix: { value: "@", small: 1, large: 1 } %>
+                <%= f.text_field :nickname, help_text: t("devise.invitations.edit.nickname_help", organization: current_organization.name), required: "required", prefix: { value: "@", small: 1, large: 1 }, autocomplete: "on" %>
               </div>
             </div>
 

--- a/decidim-core/app/views/decidim/devise/omniauth_registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/omniauth_registrations/new.html.erb
@@ -18,18 +18,18 @@
 
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :name, help_text: t(".username_help") %>
+                <%= f.text_field :name, help_text: t(".username_help"), autocomplete: "on" %>
               </div>
             </div>
 
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name) %>
+                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), autocomplete: "on" %>
               </div>
             </div>
 
             <div class="field">
-              <%= f.email_field :email %>
+              <%= f.email_field :email, autocomplete: "on" %>
             </div>
 
             <%= f.hidden_field :uid %>

--- a/decidim-core/app/views/decidim/devise/omniauth_registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/omniauth_registrations/new.html.erb
@@ -18,18 +18,18 @@
 
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :name, help_text: t(".username_help"), autocomplete: "on" %>
+                <%= f.text_field :name, help_text: t(".username_help"), autocomplete: "name" %>
               </div>
             </div>
 
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), autocomplete: "on" %>
+                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), autocomplete: "nickname" %>
               </div>
             </div>
 
             <div class="field">
-              <%= f.email_field :email, autocomplete: "on" %>
+              <%= f.email_field :email, autocomplete: "email" %>
             </div>
 
             <%= f.hidden_field :uid %>

--- a/decidim-core/app/views/decidim/devise/passwords/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/passwords/edit.html.erb
@@ -16,11 +16,11 @@
             <%= f.hidden_field :reset_password_token %>
 
             <div class="field">
-              <%= f.password_field :password, autocomplete: "off", help_text: t("devise.passwords.edit.password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH) %>
+              <%= f.password_field :password, autocomplete: "new-password", help_text: t("devise.passwords.edit.password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH) %>
             </div>
 
             <div class="field">
-              <%= f.password_field :password_confirmation, autocomplete: "off" %>
+              <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
             </div>
 
             <div class="actions">

--- a/decidim-core/app/views/decidim/devise/passwords/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/passwords/new.html.erb
@@ -14,7 +14,7 @@
         <div class="card__content">
           <%= decidim_form_for(resource, namespace: "password", as: resource_name, url: password_path(resource_name), html: { method: :post, class: "register-form new_user" }) do |f| %>
             <div class="field">
-              <%= f.email_field :email, autofocus: true, autocomplete: "on" %>
+              <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
             </div>
 
             <div class="actions">

--- a/decidim-core/app/views/decidim/devise/passwords/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/passwords/new.html.erb
@@ -14,7 +14,7 @@
         <div class="card__content">
           <%= decidim_form_for(resource, namespace: "password", as: resource_name, url: password_path(resource_name), html: { method: :post, class: "register-form new_user" }) do |f| %>
             <div class="field">
-              <%= f.email_field :email, autofocus: true %>
+              <%= f.email_field :email, autofocus: true, autocomplete: "on" %>
             </div>
 
             <div class="actions">

--- a/decidim-core/app/views/decidim/devise/registrations/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/edit.html.erb
@@ -6,7 +6,7 @@
   <%= invisible_captcha %>
 
   <div class="field">
-    <%= f.email_field :email, autocomplete: "on" %>
+    <%= f.email_field :email, autocomplete: "email" %>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
@@ -16,19 +16,19 @@
   <% end %>
 
   <div class="field">
-    <%= f.password_field :password, autocomplete: "off" %>
+    <%= f.password_field :password, autocomplete: "new-password" %>
   </div>
 
   <div class="field">
-    <%= f.password_field :password_confirmation %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="field">
-    <%= f.password_field :current_password %>
+    <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>
 
   <div class="field">
-    <%= f.text_field :name, autocomplete: "on" %>
+    <%= f.text_field :name, autocomplete: "name" %>
   </div>
 
   <div><%= f.submit t("devise.registrations.edit.update") %></div>

--- a/decidim-core/app/views/decidim/devise/registrations/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/edit.html.erb
@@ -6,7 +6,7 @@
   <%= invisible_captcha %>
 
   <div class="field">
-    <%= f.email_field :email %>
+    <%= f.email_field :email, autocomplete: "on" %>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
@@ -28,7 +28,7 @@
   </div>
 
   <div class="field">
-    <%= f.text_field :name %>
+    <%= f.text_field :name, autocomplete: "on" %>
   </div>
 
   <div><%= f.submit t("devise.registrations.edit.update") %></div>

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -34,26 +34,26 @@
 
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :name, help_text: t(".username_help"), autocomplete: "on" %>
+                <%= f.text_field :name, help_text: t(".username_help"), autocomplete: "name" %>
               </div>
             </div>
 
             <div class="user-nickname">
               <div class="field">
-                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), prefix: { value: "@", small: 1, large: 1 }, autocomplete: "on" %>
+                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), prefix: { value: "@", small: 1, large: 1 }, autocomplete: "nickname" %>
               </div>
             </div>
 
             <div class="field">
-              <%= f.email_field :email, autocomplete: "on" %>
+              <%= f.email_field :email, autocomplete: "email" %>
             </div>
 
             <div class="field">
-              <%= f.password_field :password, help_text: t(".password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH), autocomplete: "off" %>
+              <%= f.password_field :password, help_text: t(".password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH), autocomplete: "new-password" %>
             </div>
 
             <div class="field">
-              <%= f.password_field :password_confirmation %>
+              <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
             </div>
           </div>
         </div>

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -34,18 +34,18 @@
 
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :name, help_text: t(".username_help") %>
+                <%= f.text_field :name, help_text: t(".username_help"), autocomplete: "on" %>
               </div>
             </div>
 
             <div class="user-nickname">
               <div class="field">
-                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), prefix: { value: "@", small: 1, large: 1 } %>
+                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), prefix: { value: "@", small: 1, large: 1 }, autocomplete: "on" %>
               </div>
             </div>
 
             <div class="field">
-              <%= f.email_field :email %>
+              <%= f.email_field :email, autocomplete: "on" %>
             </div>
 
             <div class="field">

--- a/decidim-core/app/views/decidim/devise/sessions/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/sessions/new.html.erb
@@ -33,7 +33,7 @@
               <%= decidim_form_for(resource, namespace: "session", as: resource_name, url: session_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
                 <div>
                   <div class="field">
-                    <%= f.email_field :email %>
+                    <%= f.email_field :email, autocomplete: "on" %>
                   </div>
                   <div class="field">
                     <%= f.password_field :password, autocomplete: "off" %>

--- a/decidim-core/app/views/decidim/devise/sessions/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/sessions/new.html.erb
@@ -33,10 +33,10 @@
               <%= decidim_form_for(resource, namespace: "session", as: resource_name, url: session_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
                 <div>
                   <div class="field">
-                    <%= f.email_field :email, autocomplete: "on" %>
+                    <%= f.email_field :email, autocomplete: "email" %>
                   </div>
                   <div class="field">
-                    <%= f.password_field :password, autocomplete: "off" %>
+                    <%= f.password_field :password, autocomplete: "current-password" %>
                   </div>
                 </div>
                   <% if devise_mapping.rememberable? %>

--- a/decidim-core/app/views/decidim/devise/unlocks/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/unlocks/new.html.erb
@@ -16,7 +16,7 @@
               <%= render "devise/shared/error_messages", resource: resource %>
 
               <div class="field">
-                <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+                <%= f.email_field :email, autofocus: true, autocomplete: "on" %>
               </div>
 
               <div class="actions">

--- a/decidim-core/app/views/decidim/devise/unlocks/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/unlocks/new.html.erb
@@ -16,7 +16,7 @@
               <%= render "devise/shared/error_messages", resource: resource %>
 
               <div class="field">
-                <%= f.email_field :email, autofocus: true, autocomplete: "on" %>
+                <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
               </div>
 
               <div class="actions">


### PR DESCRIPTION
#### :tophat: What? Why?

Add `autocomplete` HTML input attribute to Devise text fields and email fields.
 
#### :pushpin: Related Issues
- Related to #6202 (Don't fixe entirely)

#### Testing

1. Run your application
2. Go to sign_in route
3. See email and text fields have `autocomplete` attribute


#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

#### Additional informations

To be honest, I don't see difference on my browser, even if attribute is defined on input. Tell me if it isn't working or if you see expected behaviour.

:hearts: Thank you!
