### PR TITLE
Fix Twitter hashtag search when it starts with a number

### DIFF
--- a/decidim-assemblies/app/views/layouts/decidim/_assembly_header.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/_assembly_header.html.erb
@@ -14,7 +14,7 @@
           <p class="text-highlight heading-small">
             <% if current_participatory_space.hashtag.present? %>
               <span class="process-header__hashtag">
-                <%= link_to "##{current_participatory_space.hashtag}", "https://twitter.com/hashtag/#{current_participatory_space.hashtag}", target: "_blank" %>
+                <%= link_to "##{current_participatory_space.hashtag}", twitter_hashtag_url(current_participatory_space.hashtag), target: "_blank" %>
               </span>
             <% end %>
             <%= translated_attribute(current_participatory_space.subtitle) %>

--- a/decidim-conferences/app/views/layouts/decidim/_conference_hero.html.erb
+++ b/decidim-conferences/app/views/layouts/decidim/_conference_hero.html.erb
@@ -9,7 +9,7 @@
         <h2 class="text-highlight">
           <% if current_participatory_space.hashtag.present? %>
             <span class="process-header__hashtag card__link">
-              <%= link_to "##{current_participatory_space.hashtag}", "https://twitter.com/hashtag/#{current_participatory_space.hashtag}", target: "_blank" %>
+              <%= link_to "##{current_participatory_space.hashtag}", twitter_hashtag_url(current_participatory_space.hashtag), target: "_blank" %>
             </span>
           <% end %>
           <%= translated_attribute(current_participatory_space.slogan) %>

--- a/decidim-consultations/app/views/layouts/decidim/_question_header.html.erb
+++ b/decidim-consultations/app/views/layouts/decidim/_question_header.html.erb
@@ -26,7 +26,7 @@
   <h2 class="heading2"><%= decidim_sanitize translated_attribute question.title %></h2>
   <% unless question.hashtag.blank? %>
     <div class="text-center">
-      <%= link_to "##{question.hashtag}", "https://twitter.com/hashtag/#{question.hashtag}", target: "_blank" %>
+      <%= link_to "##{question.hashtag}", twitter_hashtag_url(question.hashtag), target: "_blank" %>
     </div>
   <% end %>
 

--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -33,6 +33,7 @@ module Decidim
     helper Decidim::ViewHooksHelper
     helper Decidim::CardHelper
     helper Decidim::SanitizeHelper
+    helper Decidim::TwitterSearchHelper
 
     register_permissions(::Decidim::ApplicationController,
                          ::Decidim::Admin::Permissions,

--- a/decidim-core/app/helpers/decidim/twitter_search_helper.rb
+++ b/decidim-core/app/helpers/decidim/twitter_search_helper.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-
 module Decidim
   module TwitterSearchHelper
-
     # Builds the URL for Twitter's hashtag search.
     #
     # @param hashtag [String] The hasthag to search
@@ -12,6 +10,5 @@ module Decidim
     def twitter_hashtag_url(hashtag)
       format("https://twitter.com/hashtag/%{hashtag}?src=hash", hashtag: hashtag)
     end
-
   end
 end

--- a/decidim-core/app/helpers/decidim/twitter_search_helper.rb
+++ b/decidim-core/app/helpers/decidim/twitter_search_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+
+module Decidim
+  module TwitterSearchHelper
+
+    # Builds the URL for Twitter's hashtag search.
+    #
+    # @param hashtag [String] The hasthag to search
+    #
+    # @return [String]
+    def twitter_hashtag_url(hashtag)
+      format("https://twitter.com/hashtag/%{hashtag}?src=hash", hashtag: hashtag)
+    end
+
+  end
+end

--- a/decidim-core/spec/helpers/decidim/twitter_search_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/twitter_search_helper_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe TwitterSearchHelper do
+    describe "twitter_hashtag_url" do
+      it "returns the correct URL" do
+        expect(helper.twitter_hashtag_url("Decidim")).to eq("https://twitter.com/hashtag/Decidim?src=hash")
+      end
+
+      context "when the hashtag starts with has a number" do
+        it "returns the correct URL" do
+          expect(helper.twitter_hashtag_url("93Oscars")).to eq("https://twitter.com/hashtag/93Oscars?src=hash")
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/cells/decidim/initiatives/initiative_m/tags.erb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/initiative_m/tags.erb
@@ -1,7 +1,7 @@
 <% if model.hashtag.present? %>
   <%= link_to(
     "##{hashtag}",
-    "https://twitter.com/hashtag/#{hashtag}",
+    twitter_hashtag_url(hashtag),
     class: "card__text--category",
     target: "_blank"
   ) %>

--- a/decidim-initiatives/app/cells/decidim/initiatives/initiative_m_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/initiative_m_cell.rb
@@ -6,6 +6,7 @@ module Decidim
     # for an given instance of an Initiative
     class InitiativeMCell < Decidim::CardMCell
       include Decidim::Initiatives::Engine.routes.url_helpers
+      include Decidim::TwitterSearchHelper
 
       property :state
 

--- a/decidim-initiatives/app/views/layouts/decidim/_initiative_header.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/_initiative_header.html.erb
@@ -14,7 +14,7 @@
           <p class="text-highlight heading-small">
             <% if current_participatory_space.hashtag.present? %>
               <span class="process-header__hashtag">
-                <%= link_to "##{current_participatory_space.hashtag}", "https://twitter.com/hashtag/#{current_participatory_space.hashtag}" %>
+                <%= link_to "##{current_participatory_space.hashtag}", twitter_hashtag_url(current_participatory_space.hashtag), target: "_blank" %>
               </span>
             <% end %>
             <%= strip_tags participatory_space_helpers.translated_attribute(current_participatory_space.type.title) %>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/title/show.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/title/show.erb
@@ -23,7 +23,7 @@
           <%= icon "twitter", role: "img", aria_label: "Twitter", class: "mr-xs" %>
           <%= link_to(
             "##{hashtag_text}",
-            "https://twitter.com/hashtag/#{hashtag_text}",
+            twitter_hashtag_url(hashtag_text),
             target: "_blank"
           ) %>
         </div>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/title_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/title_cell.rb
@@ -6,6 +6,7 @@ module Decidim
       class TitleCell < Decidim::ViewModel
         include Decidim::SanitizeHelper
         include Decidim::IconHelper
+        include Decidim::TwitterSearchHelper
 
         delegate :group_url, to: :participatory_process_group
 

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m/tags.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m/tags.erb
@@ -1,7 +1,7 @@
 <% if model.hashtag.present? %>
   <%= link_to(
     "##{decidim_html_escape(model.hashtag)}",
-    "https://twitter.com/hashtag/#{decidim_html_escape(model.hashtag)}",
+    twitter_hashtag_url(decidim_html_escape(model.hashtag)),
     class: "card__text--category",
     target: "_blank"
    ) %>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_m_cell.rb
@@ -7,6 +7,7 @@ module Decidim
     class ProcessMCell < Decidim::CardMCell
       include Decidim::SanitizeHelper
       include Decidim::TranslationsHelper
+      include Decidim::TwitterSearchHelper
 
       private
 

--- a/decidim-participatory_processes/app/views/layouts/decidim/_process_header.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/_process_header.html.erb
@@ -14,7 +14,7 @@
           <p class="text-highlight heading-small">
             <% if current_participatory_space.hashtag.present? %>
               <span class="process-header__hashtag">
-                <%= link_to "##{decidim_html_escape(current_participatory_space.hashtag)}", "https://twitter.com/hashtag/#{decidim_html_escape(current_participatory_space.hashtag)}", target: "_blank" %>
+                <%= link_to "##{decidim_html_escape(current_participatory_space.hashtag)}", twitter_hashtag_url(decidim_html_escape(current_participatory_space.hashtag)), target: "_blank" %>
               </span>
             <% end %>
             <%= translated_attribute(current_participatory_space.subtitle) %>

--- a/decidim-participatory_processes/spec/cells/decidim/participatory_process_groups/content_blocks/title_cell_spec.rb
+++ b/decidim-participatory_processes/spec/cells/decidim/participatory_process_groups/content_blocks/title_cell_spec.rb
@@ -47,7 +47,7 @@ describe Decidim::ParticipatoryProcessGroups::ContentBlocks::TitleCell, type: :c
 
     it "shows some meta attributes" do
       expect(subject).to have_selector("svg.icon--twitter")
-      expect(subject).to have_link("#hashtag", href: "https://twitter.com/hashtag/hashtag")
+      expect(subject).to have_link("#hashtag", href: "https://twitter.com/hashtag/hashtag?src=hash")
       expect(subject).to have_selector("svg.icon--external-link")
       expect(subject).to have_link("www.example.org/group", href: group_url)
       expect(subject).to have_selector("svg.icon--globe")


### PR DESCRIPTION
#### :tophat: What? Why?

As an administrator, when I configure a process with a Twitter hashtag and this hashtag starts with numbers (for instance, #20BiennalEsplugues) the generated URL doesn't work.

This PR fixes it by changing the URL to one that works with hashtags. As it was hard-coded in the different modules, I moved this to a helper. 

#### :pushpin: Related Issues
 
- Fixes #9029

#### Testing

1. Sign in as admin
2. Edit a participatory process
3. Add `#20BiennalEsplugues` as hashtag.
4. Save
5. Go to frontend
6. Click in hashtag link
7. See that it works

:hearts: Thank you!
