### PR TITLE
Update web-console to 4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,5 +37,5 @@ group :development do
   gem "rubocop-faker"
   gem "spring", "~> 2.0"
   gem "spring-watcher-listen", "~> 2.0"
-  gem "web-console", "4.0.4"
+  gem "web-console", "~> 4.2"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -808,7 +808,7 @@ GEM
       rexml (~> 3.2)
     warden (1.2.9)
       rack (>= 2.0.9)
-    web-console (4.0.4)
+    web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
@@ -862,7 +862,7 @@ DEPENDENCIES
   simplecov (~> 0.19.0)
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
-  web-console (= 4.0.4)
+  web-console (~> 4.2)
 
 RUBY VERSION
    ruby 2.7.5p203

--- a/decidim-generators/Gemfile
+++ b/decidim-generators/Gemfile
@@ -31,5 +31,5 @@ group :development do
   gem "listen", "~> 3.1"
   gem "spring", "~> 2.0"
   gem "spring-watcher-listen", "~> 2.0"
-  gem "web-console", "~> 4.0"
+  gem "web-console", "~> 4.2"
 end

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -856,7 +856,7 @@ DEPENDENCIES
   puma (>= 5.0.0)
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
-  web-console (~> 4.0)
+  web-console (~> 4.2)
   wicked_pdf (~> 2.1)
 
 RUBY VERSION

--- a/decidim-generators/lib/decidim/generators/component_templates/Gemfile.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/Gemfile.erb
@@ -22,5 +22,5 @@ group :development do
   gem "listen", "~> 3.1"
   gem "spring", "~> 2.0"
   gem "spring-watcher-listen", "~> 2.0"
-  gem "web-console", "~> 4.0"
+  gem "web-console", "~> 4.2"
 end

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -808,7 +808,7 @@ GEM
       rexml (~> 3.2)
     warden (1.2.9)
       rack (>= 2.0.9)
-    web-console (4.0.4)
+    web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
@@ -862,7 +862,7 @@ DEPENDENCIES
   simplecov (~> 0.19.0)
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
-  web-console (= 4.0.4)
+  web-console (~> 4.2)
 
 RUBY VERSION
    ruby 2.7.5p203


### PR DESCRIPTION
#### :tophat: What? Why?

After the update to Rails 6.1, I started seeing that 500 errors in localhost (RAILS_ENV development) were showing the 500 error page (see screenshot).

This was because the web-console version that we were using (`4.0.4`) isn't compatible with Rails 6.1. That's from v4.1, so with this PR we bump to v4.2 (latest release).

NOTE: As far as I see this is hard-coded in the `development_app`, so developers would need to update it manually or regenerate the app. 
 
#### :pushpin: Related Issues

- Related to #8411 

#### Testing

1. Make an exception in development
2. See the exception message 

### :camera: Screenshots

#### Before
![Selection_067](https://user-images.githubusercontent.com/717367/158859694-55e2bc2b-62cd-43cc-bda8-41163d3ec04d.png)


#### After 
![Selection_068](https://user-images.githubusercontent.com/717367/158859710-66eafc9c-49c4-46d5-9089-d3d8c2ac7d43.png)

:hearts: Thank you!
