### PR TITLE
Fix conference partner logo is not optional on create

### DIFF
--- a/decidim-conferences/app/views/decidim/conferences/admin/partners/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/partners/_form.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <div class="row column">
-      <%= form.upload :logo %>
+      <%= form.upload :logo, optional: false %>
     </div>
   </div>
 </div>

--- a/decidim-conferences/app/views/decidim/conferences/admin/partners/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/partners/_form.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <div class="row column">
-      <%= form.upload :logo, optional: false %>
+      <%= form.upload :logo, optional: @form.persisted? %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
When creating conference partner it requires logo for the partner. Currently we don't pass this requirement to the view and validations hide message to upload modal after we try to send the form.

#### :pushpin: Related Issues
 #9031

#### Testing
1. Sign in as admin
2. User menu -> Admin panel -> Conferences -> Partners -> New partner 
3. Fill the form (but dont add logo) and click "Create"

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/158986416-3034e1c2-a727-4ace-94d7-704537f28c34.png)

:hearts: Thank you!
