### PR TITLE
Add noreferrer and ugc to links

### DIFF
--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -206,7 +206,7 @@ module Decidim
             %(Content with <a href="http://urls.net" onmouseover="alert('hello')">URLs</a> of anchor type and text urls like https://decidim.org. And a malicous <a href="javascript:document.cookies">click me</a>)
           end
           let(:result) do
-            %(<div><p>Content with URLs of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="nofollow noopener">https://decidim.org</a>. And a malicous click me</p></div>)
+            %(<div><p>Content with URLs of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="nofollow noopener noreferrer ugc">https://decidim.org</a>. And a malicous click me</p></div>)
           end
 
           it "converts all URLs to links and strips attributes in anchors" do

--- a/decidim-core/app/cells/decidim/profile_sidebar/show.erb
+++ b/decidim-core/app/cells/decidim/profile_sidebar/show.erb
@@ -23,7 +23,7 @@
       <small><%= decidim_html_escape(profile_user.about.to_s) %></small>
     </div>
     <% if profile_user.personal_url.present? %>
-      <%= link_to html_truncate(profile_user.personal_url.gsub(%r{https?\:\/\/}, ""), length: 30), profile_user.personal_url, rel: "nofollow noopener" %>
+      <%= link_to html_truncate(profile_user.personal_url.gsub(%r{https?\:\/\/}, ""), length: 30), profile_user.personal_url, rel: "nofollow noopener noreferrer ugc" %>
     <% end %>
   </div>
   <% if profile_user.badge.present? %>

--- a/decidim-core/lib/decidim/content_renderers/link_renderer.rb
+++ b/decidim-core/lib/decidim/content_renderers/link_renderer.rb
@@ -20,7 +20,7 @@ module Decidim
       def render(options = {})
         return content unless content.is_a?(String)
 
-        options = { target: "_blank", rel: "nofollow noopener" }.merge(options)
+        options = { target: "_blank", rel: "nofollow noopener noreferrer ugc" }.merge(options)
         auto_link(content, options)
       end
 

--- a/decidim-core/spec/content_renderers/decidim/link_renderer_spec.rb
+++ b/decidim-core/spec/content_renderers/decidim/link_renderer_spec.rb
@@ -33,7 +33,7 @@ module Decidim
         let(:content) { "foo #{url} bar" }
 
         it "does not include target" do
-          expect(renderer.render(options)).to eq("foo <a href=\"#{url}\" rel=\"nofollow noopener\">#{url}</a> bar")
+          expect(renderer.render(options)).to eq("foo <a href=\"#{url}\" rel=\"nofollow noopener noreferrer ugc\">#{url}</a> bar")
         end
       end
 
@@ -41,7 +41,7 @@ module Decidim
         it "renders link tag" do
           urls.each do |url|
             rendered = described_class.new(url).render
-            expect(rendered).to eq("<a href=\"#{url}\" target=\"_blank\" rel=\"nofollow noopener\">#{url}</a>")
+            expect(rendered).to eq("<a href=\"#{url}\" target=\"_blank\" rel=\"nofollow noopener noreferrer ugc\">#{url}</a>")
           end
         end
       end
@@ -51,7 +51,7 @@ module Decidim
           urls.each do |url|
             text = ::Faker::Lorem.sentence
             rendered = described_class.new("#{text} #{url}").render
-            expect(rendered).to eq("#{text} <a href=\"#{url}\" target=\"_blank\" rel=\"nofollow noopener\">#{url}</a>")
+            expect(rendered).to eq("#{text} <a href=\"#{url}\" target=\"_blank\" rel=\"nofollow noopener noreferrer ugc\">#{url}</a>")
           end
         end
       end
@@ -63,7 +63,7 @@ module Decidim
           urls.each do |url|
             punctuations.each do |punctuation|
               rendered = described_class.new("#{url}#{punctuation}").render
-              expect(rendered).to eq("<a href=\"#{url}\" target=\"_blank\" rel=\"nofollow noopener\">#{url}</a>#{punctuation}")
+              expect(rendered).to eq("<a href=\"#{url}\" target=\"_blank\" rel=\"nofollow noopener noreferrer ugc\">#{url}</a>#{punctuation}")
             end
           end
         end
@@ -74,7 +74,7 @@ module Decidim
           urls.each do |url|
             text = ::Faker::Lorem.sentence
             rendered = described_class.new("#{url} #{text}").render
-            expect(rendered).to eq("<a href=\"#{url}\" target=\"_blank\" rel=\"nofollow noopener\">#{url}</a> #{text}")
+            expect(rendered).to eq("<a href=\"#{url}\" target=\"_blank\" rel=\"nofollow noopener noreferrer ugc\">#{url}</a> #{text}")
           end
         end
       end
@@ -85,7 +85,7 @@ module Decidim
             before_text = ::Faker::Lorem.paragraph
             after_text = ::Faker::Lorem.sentence
             rendered = described_class.new("#{before_text} #{url} #{after_text}").render
-            expect(rendered).to eq("#{before_text} <a href=\"#{url}\" target=\"_blank\" rel=\"nofollow noopener\">#{url}</a> #{after_text}")
+            expect(rendered).to eq("#{before_text} <a href=\"#{url}\" target=\"_blank\" rel=\"nofollow noopener noreferrer ugc\">#{url}</a> #{after_text}")
           end
         end
       end
@@ -96,7 +96,7 @@ module Decidim
             before_text = ::Faker::Lorem.sentence
             after_text = ::Faker::Lorem.paragraph
             rendered = described_class.new("#{before_text}#{url}#{after_text}").render
-            expect(rendered).to eq("#{before_text}<a href=\"#{url + after_text.split(" ").first}\" target=\"_blank\" rel=\"nofollow noopener\">#{url + after_text.split(" ").first}</a> #{after_text.split(" ").drop(1).join(" ")}")
+            expect(rendered).to eq("#{before_text}<a href=\"#{url + after_text.split(" ").first}\" target=\"_blank\" rel=\"nofollow noopener noreferrer ugc\">#{url + after_text.split(" ").first}</a> #{after_text.split(" ").drop(1).join(" ")}")
           end
         end
       end

--- a/decidim-core/spec/models/decidim/messaging/message_spec.rb
+++ b/decidim-core/spec/models/decidim/messaging/message_spec.rb
@@ -36,7 +36,7 @@ describe Decidim::Messaging::Message do
     end
 
     let(:result) do
-      %(Content with <a href="http://urls.net">URLs</a> of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="nofollow noopener">https://decidim.org</a>.)
+      %(Content with <a href="http://urls.net">URLs</a> of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="nofollow noopener noreferrer ugc">https://decidim.org</a>.)
     end
 
     it "converts all URLs to links" do

--- a/decidim-proposals/spec/presenters/decidim/proposals/collaborative_draft_presenter_spec.rb
+++ b/decidim-proposals/spec/presenters/decidim/proposals/collaborative_draft_presenter_spec.rb
@@ -15,7 +15,7 @@ module Decidim
           And a malicous <a href="javascript:document.cookies">click me</a>
         EOCONTENT
         let(:result) { <<~EORESULT }
-          Content with URLs of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="nofollow noopener">https://decidim.org</a>.
+          Content with URLs of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="nofollow noopener noreferrer ugc">https://decidim.org</a>.
           And a malicous click me
         EORESULT
 

--- a/decidim-proposals/spec/presenters/decidim/proposals/proposal_presenter_spec.rb
+++ b/decidim-proposals/spec/presenters/decidim/proposals/proposal_presenter_spec.rb
@@ -15,7 +15,7 @@ module Decidim
           And a malicous <a href="javascript:document.cookies">click me</a>
         EOCONTENT
         let(:result) { <<~EORESULT }
-          Content with URLs of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="nofollow noopener">https://decidim.org</a>.
+          Content with URLs of anchor type and text urls like <a href="https://decidim.org" target="_blank" rel="nofollow noopener noreferrer ugc">https://decidim.org</a>.
           And a malicous click me
         EORESULT
 


### PR DESCRIPTION
#### :tophat: What? Why?

To discourage spam bots from using Decidim platforms to promote their websites and gain SEO juice.

The following keywords have been added to the personal URL of profile pages and links in the body of personal messages, comments, debates...
- `noreferrer` ([source](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noreferrer)), which instructs the browser not to pass the URL of the Decidim platform as a referrer to the opened URL. This will effectively prevent a spammer from tracking how much traffic they get from adding their link to the platform.
- `ugc` ([source](https://developers.google.com/search/docs/advanced/guidelines/qualify-outbound-links)), which stands for *user-generated content* and is a new keyword introduced by Google a few years ago to replace `nofollow` which was too general.

As [this article](https://moz.com/blog/nofollow-sponsored-ugc) explains, Google introduced `ugc` in 2019 but the way they interpret it is still evolving and they still have to deal with a legacy of websites only using `nofollow` to qualify all unapproved content (as Decidim does today). So adding the keyword is a way to make Decidim compatible with it already now and gives search engines a thinner way to characterise user-generated content on it.

An important remark is that the `link_renderer` that this PR modifies is only used in very few cases (the main ones being comments and private messages) so there are many examples of user-generated content that will not benefit of that change. A few examples are:
- the body of a proposal if the rich editor is enabled
- the body of a debate if the rich editor is enabled
- the body of a user-created meeting

It would be interesting to refactor this helper so it can be applied more easily to all type of user-generated content.

#### :pushpin: Related Issues
- Related to [#8779](https://github.com/decidim/decidim/pull/8779), [#5651](https://github.com/decidim/decidim/pull/5651)

#### Testing

Just check a link on a user profile, in a comment or a proposal for the presence of `rel="nofollow noopener noreferrer ugc"`

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [X] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [X] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [X] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [X] :heavy_check_mark: **DO** build locally before pushing.
- [X] :heavy_check_mark: **DO** make sure tests pass.
- [X] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [X] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [X] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [X] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [X] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [X] :x:**AVOID** breaking the continuous integration build.
- [X] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

No visual changes

:hearts: Thank you!
