### PR TITLE
Fix amendable events title

### DIFF
--- a/decidim-core/app/events/decidim/amendable/amendment_base_event.rb
+++ b/decidim-core/app/events/decidim/amendable/amendment_base_event.rb
@@ -6,7 +6,7 @@ module Decidim::Amendable
                     :emendation_path, :emendation_author_nickname, :emendation_author_path
 
     def amendable_title
-      @amendable_title ||= amendable_resource.title
+      @amendable_title ||= translated_attribute(amendable_resource.title)
     end
 
     def amendable_type

--- a/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_accepted_event_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_accepted_event_examples.rb
@@ -8,7 +8,6 @@ shared_examples "amendment accepted event" do
 
   it_behaves_like "a simple event"
 
-  let(:amendable_title) { amendable.title }
   let(:emendation_author_nickname) { "@#{emendation.creator_author.nickname}" }
   let(:emendation_path) { Decidim::ResourceLocatorPresenter.new(emendation).path }
   let(:emendation_author_path) { Decidim::UserPresenter.new(emendation.creator_author).profile_path }

--- a/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_created_event_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_created_event_examples.rb
@@ -13,7 +13,6 @@ shared_examples "amendment created event" do
 
   it_behaves_like "a simple event"
 
-  let(:amendable_title) { amendable.title }
   let(:emendation_author_nickname) { "@#{emendation.creator_author.nickname}" }
   let(:emendation_path) { Decidim::ResourceLocatorPresenter.new(emendation).path }
   let(:emendation_author_path) { Decidim::UserPresenter.new(emendation.creator_author).profile_path }

--- a/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_promoted_event_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_promoted_event_examples.rb
@@ -8,7 +8,6 @@ shared_examples "amendment promoted event" do
 
   it_behaves_like "a simple event"
 
-  let(:amendable_title) { amendable.title }
   let(:emendation_author_nickname) { "@#{emendation.creator_author.nickname}" }
   let(:emendation_path) { Decidim::ResourceLocatorPresenter.new(emendation).path }
   let(:emendation_author_path) { Decidim::UserPresenter.new(emendation.creator_author).profile_path }

--- a/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_rejected_event_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_rejected_event_examples.rb
@@ -8,7 +8,6 @@ shared_examples "amendment rejected event" do
 
   it_behaves_like "a simple event"
 
-  let(:amendable_title) { amendable.title }
   let(:emendation_author_nickname) { "@#{emendation.creator_author.nickname}" }
   let(:emendation_path) { Decidim::ResourceLocatorPresenter.new(emendation).path }
   let(:emendation_author_path) { Decidim::UserPresenter.new(emendation.creator_author).profile_path }

--- a/decidim-proposals/spec/events/decidim/proposals/amendable/amendment_accepted_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/amendable/amendment_accepted_event_spec.rb
@@ -6,9 +6,10 @@ module Decidim
   module Amendable
     describe AmendmentAcceptedEvent do
       let!(:component) { create(:proposal_component) }
-      let!(:amendable) { create(:proposal, component: component, title: "My super proposal") }
+      let!(:amendable) { create(:proposal, component: component, title: amendable_title) }
       let!(:emendation) { create(:proposal, component: component, title: "My super emendation") }
       let!(:amendment) { create :amendment, amendable: amendable, emendation: emendation }
+      let(:amendable_title) { "My super proposal" }
 
       include_examples "amendment accepted event"
     end

--- a/decidim-proposals/spec/events/decidim/proposals/amendable/amendment_created_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/amendable/amendment_created_event_spec.rb
@@ -6,9 +6,10 @@ module Decidim
   module Amendable
     describe AmendmentCreatedEvent do
       let!(:component) { create(:proposal_component) }
-      let!(:amendable) { create(:proposal, component: component, title: "My super proposal") }
+      let!(:amendable) { create(:proposal, component: component, title: amendable_title) }
       let!(:emendation) { create(:proposal, component: component, title: "My super emendation") }
       let!(:amendment) { create :amendment, amendable: amendable, emendation: emendation }
+      let(:amendable_title) { "My super proposal" }
 
       include_examples "amendment created event"
     end

--- a/decidim-proposals/spec/events/decidim/proposals/amendable/amendment_promoted_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/amendable/amendment_promoted_event_spec.rb
@@ -6,10 +6,11 @@ module Decidim
   module Amendable
     describe EmendationPromotedEvent do
       let!(:component) { create(:proposal_component) }
-      let!(:amendable) { create(:proposal, component: component, title: "My super proposal") }
+      let!(:amendable) { create(:proposal, component: component, title: amendable_title) }
       let!(:emendation) { create(:proposal, component: component, title: "My super emendation") }
       let!(:amendment) { create :amendment, amendable: amendable, emendation: emendation }
       let(:amendable_type) { "proposal" }
+      let(:amendable_title) { "My super proposal" }
 
       include_examples "amendment promoted event"
     end

--- a/decidim-proposals/spec/events/decidim/proposals/amendable/amendment_rejected_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/amendable/amendment_rejected_event_spec.rb
@@ -6,9 +6,10 @@ module Decidim
   module Amendable
     describe AmendmentRejectedEvent do
       let!(:component) { create(:proposal_component) }
-      let!(:amendable) { create(:proposal, component: component, title: "My super proposal") }
+      let!(:amendable) { create(:proposal, component: component, title: amendable_title) }
       let!(:emendation) { create(:proposal, component: component, title: "My super emendation") }
       let!(:amendment) { create :amendment, amendable: amendable, emendation: emendation }
+      let(:amendable_title) { "My super proposal" }
 
       include_examples "amendment rejected event"
     end


### PR DESCRIPTION
#### :tophat: What? Why?

There are some incorrect translation variables in some notifcations regarding Amendments.

This PR fixes it.

While doing it, I also found a bug in the specs, they were passing even though they should have been red. This is because we were using the model attribute (`amendable.title`) instead of the string title (`"My super proposal"` in the specs). This is also fixed. 



#### :pushpin: Related Issues
 
- Fixes https://meta.decidim.org/processes/bug-report/f/210/proposals/16232

#### Testing

<details>
<summary>Failing specs (click to see)</summary>

```bash 
$ cd decidim-proposals
$ bundle exec rspec ./spec/events/decidim/proposals/amendable/

Randomized with seed 38321

Decidim::Amendable::AmendmentCreatedEvent
  email_outro
    is generated correctly (FAILED - 1)
  email_subject
    is generated correctly (FAILED - 2)
  email_intro
    is generated correctly (FAILED - 3)
  notification_title
    is generated correctly (FAILED - 4)
  behaves like a simple event
    notification_title
      is generated correctly
    email_outro
      is generated correctly
    resource_title
      responds to the method
    resource_path
      is generated correctly
    i18n_options
      includes the i18n scope
      is expected to include {:resource_path => (satisfy block)}
      is expected to include {:resource_url => (start with "http")}
      is expected to include {:resource_title => (satisfy block)}
      is expected to include {:participatory_space_title => (satisfy block)}
      is expected to include {:participatory_space_url => (start with "http")}
    email_subject
      is generated correctly
    participatory_space_url
      is generated correctly
    email_intro
      is generated correctly
    resource_url
      is generated correctly
    email_greeting
      is generated correctly
    safe_resource_text
      is generated correctly
    types
      supports notifications
      supports emails

Decidim::Amendable::AmendmentRejectedEvent
  notification_title
    is generated correctly (FAILED - 5)
  behaves like a simple event
    resource_path
      is generated correctly
    types
      supports notifications
      supports emails
    email_outro
      is generated correctly
    email_subject
      is generated correctly
    notification_title
      is generated correctly
    email_intro
      is generated correctly
    resource_url
      is generated correctly
    participatory_space_url
      is generated correctly
    safe_resource_text
      is generated correctly
    resource_title
      responds to the method
    i18n_options
      is expected to include {:participatory_space_url => (start with "http")}
      is expected to include {:resource_url => (start with "http")}
      is expected to include {:resource_title => (satisfy block)}
      includes the i18n scope
      is expected to include {:participatory_space_title => (satisfy block)}
      is expected to include {:resource_path => (satisfy block)}
    email_greeting
      is generated correctly
  email_subject
    is generated correctly (FAILED - 6)
  email_outro
    is generated correctly (FAILED - 7)
  email_intro
    is generated correctly (FAILED - 8)

Decidim::Amendable::AmendmentAcceptedEvent
  email_subject
    is generated correctly (FAILED - 9)
  email_outro
    is generated correctly (FAILED - 10)
  email_intro
    is generated correctly (FAILED - 11)
  behaves like a simple event
    email_greeting
      is generated correctly
    participatory_space_url
      is generated correctly
    notification_title
      is generated correctly
    safe_resource_text
      is generated correctly
    email_intro
      is generated correctly
    email_subject
      is generated correctly
    resource_path
      is generated correctly
    types
      supports notifications
      supports emails
    i18n_options
      is expected to include {:participatory_space_url => (start with "http")}
      includes the i18n scope
      is expected to include {:resource_url => (start with "http")}
      is expected to include {:resource_title => (satisfy block)}
      is expected to include {:participatory_space_title => (satisfy block)}
      is expected to include {:resource_path => (satisfy block)}
    resource_url
      is generated correctly
    resource_title
      responds to the method
    email_outro
      is generated correctly
  notification_title
    is generated correctly (FAILED - 12)

Decidim::Amendable::EmendationPromotedEvent
  notification_title
    is generated correctly (FAILED - 13)
  email_intro
    is generated correctly (FAILED - 14)
  email_outro
    is generated correctly (FAILED - 15)
  email_subject
    is generated correctly
  behaves like a simple event
    email_greeting
      is generated correctly
    email_intro
      is generated correctly
    types
      supports notifications
      supports emails
    resource_path
      is generated correctly
    resource_url
      is generated correctly
    i18n_options
      is expected to include {:participatory_space_title => (satisfy block)}
      includes the i18n scope
      is expected to include {:resource_url => (start with "http")}
      is expected to include {:resource_title => (satisfy block)}
      is expected to include {:participatory_space_url => (start with "http")}
      is expected to include {:resource_path => (satisfy block)}
    participatory_space_url
      is generated correctly
    email_outro
      is generated correctly
    notification_title
      is generated correctly
    safe_resource_text
      is generated correctly
    resource_title
      responds to the method
    email_subject
      is generated correctly

Failures:

  1) Decidim::Amendable::AmendmentCreatedEvent email_outro is generated correctly
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected: "You have received this notification because you are following My super proposal. You can stop receiving notifications following the previous link."
            got: "You have received this notification because you are following {\"en\"=>\"My super proposal\"}. You can stop receiving notifications following the previous link."
     
       (compared using ==)
     Shared Example Group: "amendment created event" called from ./spec/events/decidim/proposals/amendable/amendment_created_event_spec.rb:14
     # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_created_event_examples.rb:36:in `block (3 levels) in <top (required)>'

  2) Decidim::Amendable::AmendmentCreatedEvent email_subject is generated correctly
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected: "New amendment for My super proposal"
            got: "New amendment for {\"en\"=>\"My super proposal\"}"
     
       (compared using ==)
     Shared Example Group: "amendment created event" called from ./spec/events/decidim/proposals/amendable/amendment_created_event_spec.rb:14
     # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_created_event_examples.rb:23:in `block (3 levels) in <top (required)>'

  3) Decidim::Amendable::AmendmentCreatedEvent email_intro is generated correctly
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected: "A new amendment has been created for My super proposal. You can see it from this page:"
            got: "A new amendment has been created for {\"en\"=>\"My super proposal\"}. You can see it from this page:"
     
       (compared using ==)
     Shared Example Group: "amendment created event" called from ./spec/events/decidim/proposals/amendable/amendment_created_event_spec.rb:14
     # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_created_event_examples.rb:29:in `block (3 levels) in <top (required)>'

  4) Decidim::Amendable::AmendmentCreatedEvent notification_title is generated correctly
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected: "A new amendment has been created for <a href=\"/processes/quo-eum-4/f/511/proposals/512\">My super proposal</a>."
            got: "A new amendment has been created for <a href=\"/processes/quo-eum-4/f/511/proposals/512\">{\"en\"=>\"My super proposal\"}</a>."
     
       (compared using ==)
     Shared Example Group: "amendment created event" called from ./spec/events/decidim/proposals/amendable/amendment_created_event_spec.rb:14
     # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_created_event_examples.rb:43:in `block (3 levels) in <top (required)>'

  5) Decidim::Amendable::AmendmentRejectedEvent notification_title is generated correctly
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected: "The <a href=\"/processes/fuga-a-23/f/530/proposals/551\">amendment</a> created by <a href=\"/profile...> has been rejected for <a href=\"/processes/fuga-a-23/f/530/proposals/550\">My super proposal</a>."
            got: "The <a href=\"/processes/fuga-a-23/f/530/proposals/551\">amendment</a> created by <a href=\"/profile...ected for <a href=\"/processes/fuga-a-23/f/530/proposals/550\">{\"en\"=>\"My super proposal\"}</a>."
     
       (compared using ==)
     Shared Example Group: "amendment rejected event" called from ./spec/events/decidim/proposals/amendable/amendment_rejected_event_spec.rb:14
     # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_rejected_event_examples.rb:38:in `block (3 levels) in <top (required)>'

  6) Decidim::Amendable::AmendmentRejectedEvent email_subject is generated correctly
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected: "Amendment rejected for My super proposal from @jpg0m_121"
            got: "Amendment rejected for {\"en\"=>\"My super proposal\"} from @jpg0m_121"
     
       (compared using ==)
     Shared Example Group: "amendment rejected event" called from ./spec/events/decidim/proposals/amendable/amendment_rejected_event_spec.rb:14
     # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_rejected_event_examples.rb:18:in `block (3 levels) in <top (required)>'

  7) Decidim::Amendable::AmendmentRejectedEvent email_outro is generated correctly
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected: "You have received this notification because you are following My super proposal. You can stop receiving notifications following the previous link."
            got: "You have received this notification because you are following {\"en\"=>\"My super proposal\"}. You can stop receiving notifications following the previous link."
     
       (compared using ==)
     Shared Example Group: "amendment rejected event" called from ./spec/events/decidim/proposals/amendable/amendment_rejected_event_spec.rb:14
     # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_rejected_event_examples.rb:31:in `block (3 levels) in <top (required)>'

  8) Decidim::Amendable::AmendmentRejectedEvent email_intro is generated correctly
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected: "An amendment has been rejected for My super proposal. You can see it from this page:"
            got: "An amendment has been rejected for {\"en\"=>\"My super proposal\"}. You can see it from this page:"
     
       (compared using ==)
     Shared Example Group: "amendment rejected event" called from ./spec/events/decidim/proposals/amendable/amendment_rejected_event_spec.rb:14
     # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_rejected_event_examples.rb:24:in `block (3 levels) in <top (required)>'

  9) Decidim::Amendable::AmendmentAcceptedEvent email_subject is generated correctly
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected: "Accepted amendment for My super proposal from @mgxrq_130"
            got: "Accepted amendment for {\"en\"=>\"My super proposal\"} from @mgxrq_130"
     
       (compared using ==)
     Shared Example Group: "amendment accepted event" called from ./spec/events/decidim/proposals/amendable/amendment_accepted_event_spec.rb:14
     # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_accepted_event_examples.rb:18:in `block (3 levels) in <top (required)>'

  10) Decidim::Amendable::AmendmentAcceptedEvent email_outro is generated correctly
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected: "You have received this notification because you are following My super proposal. You can stop receiving notifications following the previous link."
             got: "You have received this notification because you are following {\"en\"=>\"My super proposal\"}. You can stop receiving notifications following the previous link."
      
        (compared using ==)
      Shared Example Group: "amendment accepted event" called from ./spec/events/decidim/proposals/amendable/amendment_accepted_event_spec.rb:14
      # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_accepted_event_examples.rb:31:in `block (3 levels) in <top (required)>'

  11) Decidim::Amendable::AmendmentAcceptedEvent email_intro is generated correctly
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected: "An amendment has been accepted for My super proposal. You can see it from this page:"
             got: "An amendment has been accepted for {\"en\"=>\"My super proposal\"}. You can see it from this page:"
      
        (compared using ==)
      Shared Example Group: "amendment accepted event" called from ./spec/events/decidim/proposals/amendable/amendment_accepted_event_spec.rb:14
      # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_accepted_event_examples.rb:24:in `block (3 levels) in <top (required)>'

  12) Decidim::Amendable::AmendmentAcceptedEvent notification_title is generated correctly
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected: "The <a href=\"/processes/neque-voluptatem-66/f/573/proposals/637\">amendment</a> created by <a href=... accepted for <a href=\"/processes/neque-voluptatem-66/f/573/proposals/636\">My super proposal</a>."
             got: "The <a href=\"/processes/neque-voluptatem-66/f/573/proposals/637\">amendment</a> created by <a href=...<a href=\"/processes/neque-voluptatem-66/f/573/proposals/636\">{\"en\"=>\"My super proposal\"}</a>."
      
        (compared using ==)
      Shared Example Group: "amendment accepted event" called from ./spec/events/decidim/proposals/amendable/amendment_accepted_event_spec.rb:14
      # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_accepted_event_examples.rb:38:in `block (3 levels) in <top (required)>'

  13) Decidim::Amendable::EmendationPromotedEvent notification_title is generated correctly
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected: "A <a href=\"/processes/fugit-dolore-67/f/574/proposals/639\">rejected amendment</a> for <a href=\"/p...> has been published as a new proposal by <a href=\"/profiles/23moep3qpn_194\">@23moep3qpn_194</a>."
             got: "A <a href=\"/processes/fugit-dolore-67/f/574/proposals/639\">rejected amendment</a> for <a href=\"/p...> has been published as a new proposal by <a href=\"/profiles/23moep3qpn_194\">@23moep3qpn_194</a>."
      
        (compared using ==)
      Shared Example Group: "amendment promoted event" called from ./spec/events/decidim/proposals/amendable/amendment_promoted_event_spec.rb:15
      # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_promoted_event_examples.rb:38:in `block (3 levels) in <top (required)>'

  14) Decidim::Amendable::EmendationPromotedEvent email_intro is generated correctly
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected: "A rejected amendment for My super proposal has been published as a new proposal. You can see it from this page:"
             got: "A rejected amendment for {\"en\"=>\"My super proposal\"} has been published as a new proposal. You can see it from this page:"
      
        (compared using ==)
      Shared Example Group: "amendment promoted event" called from ./spec/events/decidim/proposals/amendable/amendment_promoted_event_spec.rb:15
      # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_promoted_event_examples.rb:24:in `block (3 levels) in <top (required)>'

  15) Decidim::Amendable::EmendationPromotedEvent email_outro is generated correctly
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected: "You have received this notification because you are following My super proposal. You can stop receiving notifications following the previous link."
             got: "You have received this notification because you are following {\"en\"=>\"My super proposal\"}. You can stop receiving notifications following the previous link."
      
        (compared using ==)
      Shared Example Group: "amendment promoted event" called from ./spec/events/decidim/proposals/amendable/amendment_promoted_event_spec.rb:15
      # /home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/amendable/amendment_promoted_event_examples.rb:31:in `block (3 levels) in <top (required)>'

Finished in 1 minute 15.03 seconds (files took 6.22 seconds to load)
88 examples, 15 failures

Failed examples:

rspec ./spec/events/decidim/proposals/amendable/amendment_created_event_spec.rb[1:4:1] # Decidim::Amendable::AmendmentCreatedEvent email_outro is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_created_event_spec.rb[1:2:1] # Decidim::Amendable::AmendmentCreatedEvent email_subject is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_created_event_spec.rb[1:3:1] # Decidim::Amendable::AmendmentCreatedEvent email_intro is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_created_event_spec.rb[1:5:1] # Decidim::Amendable::AmendmentCreatedEvent notification_title is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_rejected_event_spec.rb[1:5:1] # Decidim::Amendable::AmendmentRejectedEvent notification_title is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_rejected_event_spec.rb[1:2:1] # Decidim::Amendable::AmendmentRejectedEvent email_subject is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_rejected_event_spec.rb[1:4:1] # Decidim::Amendable::AmendmentRejectedEvent email_outro is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_rejected_event_spec.rb[1:3:1] # Decidim::Amendable::AmendmentRejectedEvent email_intro is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_accepted_event_spec.rb[1:2:1] # Decidim::Amendable::AmendmentAcceptedEvent email_subject is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_accepted_event_spec.rb[1:4:1] # Decidim::Amendable::AmendmentAcceptedEvent email_outro is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_accepted_event_spec.rb[1:3:1] # Decidim::Amendable::AmendmentAcceptedEvent email_intro is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_accepted_event_spec.rb[1:5:1] # Decidim::Amendable::AmendmentAcceptedEvent notification_title is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_promoted_event_spec.rb[1:5:1] # Decidim::Amendable::EmendationPromotedEvent notification_title is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_promoted_event_spec.rb[1:3:1] # Decidim::Amendable::EmendationPromotedEvent email_intro is generated correctly
rspec ./spec/events/decidim/proposals/amendable/amendment_promoted_event_spec.rb[1:4:1] # Decidim::Amendable::EmendationPromotedEvent email_outro is generated correctly

Randomized with seed 38321



```

</details>
 
### :camera: Screenshots

Bug screenshot: 
![image](https://user-images.githubusercontent.com/717367/159242826-660565ef-f766-421d-bec0-b92aa4927910.png)


:hearts: Thank you!
