### PR TITLE
Fix session cookie SameSite policy

### DIFF
--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -331,6 +331,7 @@ module Decidim
 
       initializer "Expire sessions" do
         Rails.application.config.session_store :cookie_store, secure: Decidim.config.force_ssl, expire_after: Decidim.config.expire_session_after
+        Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
       end
 
       initializer "decidim.core.register_resources" do

--- a/decidim-core/spec/requests/session_spec.rb
+++ b/decidim-core/spec/requests/session_spec.rb
@@ -3,8 +3,6 @@
 require "spec_helper"
 
 RSpec.describe "Session", type: :request do
-  include Decidim::ComponentPathHelper
-
   subject { response.body }
 
   let(:request_path) { Decidim::Core::Engine.routes.url_helpers.user_session_path }

--- a/decidim-core/spec/requests/session_spec.rb
+++ b/decidim-core/spec/requests/session_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Session", type: :request do
+  include Decidim::ComponentPathHelper
+
+  subject { response.body }
+
+  let(:request_path) { Decidim::Core::Engine.routes.url_helpers.user_session_path }
+
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :confirmed, email: "user@example.org", password: "decidim123456", organization: organization) }
+
+  it "sets the correct SameSite flag for the cookie" do
+    post(
+      request_path,
+      params: { user: { email: "user@example.org", password: "decidim123456" } },
+      headers: { "HOST" => organization.host }
+    )
+
+    expect(response.headers["Set-Cookie"].split("; ")).to include("SameSite=Lax")
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This defaults the SameSite policy on the session cookie to "Lax".

Recent modern browsers already do this by default, so this is to be considered a security enhancement:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#cookies_without_samesite_default_to_samesitelax

#### Testing
Check the session cookie when visiting a Decidim site.

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.