### PR TITLE
Remove presenters in the meetings admin backoffice

### DIFF
--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -55,10 +55,6 @@ module Decidim
           end
 
           self.decidim_category_id = model.categorization.decidim_category_id if model.categorization
-          presenter = MeetingPresenter.new(model)
-
-          self.title = presenter.title(all_locales: title.is_a?(Hash))
-          self.description = presenter.description(all_locales: description.is_a?(Hash))
           self.type_of_meeting = model.type_of_meeting
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes a bug where the meetings presenter changed the original database content for the title and description fields. That caused every time a meeting was re-open, such markup was altered over and over. In plain text, you couldn't notice the difference, but in lists, the linebreaks were ruined.

#### :pushpin: Related Issues
- Fixes #8948

#### Testing
- Open an specific meeting in the admin site
- Adds some lists to the description fields
- Check the public view: everything should be OK
- Open again the the admin view
- Description field remains exactly the same as your previous edition

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
