### PR TITLE
Fix submit in meetings admin form

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_services.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_services.html.erb
@@ -19,7 +19,7 @@
         <% end %>
       </div>
 
-      <button class="button add-service"><%= t(".add_service") %></button>
+      <button class="button add-service" type="button"><%= t(".add_service") %></button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?

When you go to edit a meeting in the admin and press the enter key, the form isn't submitted. 

This PR fixes that.

The problem is the same as the described on #9019, so the solution is the same. 

#### :pushpin: Related Issues

- Related to #9019


#### Testing

1. Sign is as admin
2. Edit a meeting
3. Press enter in the first input

#### Before 


https://user-images.githubusercontent.com/717367/159444887-af2f0610-7cd3-4da8-a908-082b953af536.mp4


#### After


https://user-images.githubusercontent.com/717367/159444898-57d60a2f-1d63-4591-8825-0fb25d110c4d.mp4


### :camera: Screenshots

#### Before 


https://user-images.githubusercontent.com/717367/159444887-af2f0610-7cd3-4da8-a908-082b953af536.mp4


#### After


https://user-images.githubusercontent.com/717367/159444898-57d60a2f-1d63-4591-8825-0fb25d110c4d.mp4


:hearts: Thank you!
