### PR TITLE
Allow admins to disable email notifications for reported users

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -865,7 +865,7 @@ DEPENDENCIES
   web-console (~> 4.2)
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.7.5p203
 
 BUNDLED WITH
    2.2.31

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -865,7 +865,7 @@ DEPENDENCIES
   web-console (~> 4.2)
 
 RUBY VERSION
-   ruby 2.7.5p203
+   ruby 2.7.1p83
 
 BUNDLED WITH
    2.2.31

--- a/decidim-core/app/commands/decidim/create_user_report.rb
+++ b/decidim-core/app/commands/decidim/create_user_report.rb
@@ -55,7 +55,9 @@ module Decidim
     end
 
     def send_notification_to_admins!
-      current_organization.admins.each do |admin|
+      @current_user.organization.admins.each do |admin|
+        next unless admin.email_on_moderations
+
         Decidim::UserReportJob.perform_later(admin, report)
       end
     end

--- a/decidim-core/app/models/decidim/user_moderation.rb
+++ b/decidim-core/app/models/decidim/user_moderation.rb
@@ -12,8 +12,6 @@ module Decidim
     scope :unblocked, -> { joins(:user).where(decidim_users: { blocked: false }) }
 
     delegate :organization, to: :user
-    scope :blocked, -> { joins(:user).where(decidim_users: { blocked: true }) }
-    scope :unblocked, -> { joins(:user).where(decidim_users: { blocked: false }) }
 
     def self.log_presenter_class_for(_log)
       Decidim::AdminLog::UserModerationPresenter

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1115,7 +1115,7 @@ en:
         administrators: Administrators
         allow_public_contact: Allow anyone to send me a direct message, even if I don't follow them.
         direct_messages: Receive direct messages from anyone
-        email_on_moderations: I want to receive an email every time something is reported for moderation.
+        email_on_moderations: I want to receive an email every time something or someone is reported for moderation.
         email_on_notification: I want to receive an email every time I receive a notification.
         everything_followed: Everything I follow
         newsletter_notifications: I want to receive newsletters

--- a/decidim-core/spec/commands/decidim/create_user_report_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_user_report_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe CreateUserReport do
+    describe "call" do
+      let(:current_organization) { create(:organization) }
+      let(:component) { create(:component, organization: current_organization) }
+      let!(:reported_user) { create(:user, :confirmed, organization: current_organization) }
+      let(:reportable) { reported_user }
+      let!(:admin) { create(:user, :admin, :confirmed, organization: current_organization) }
+      let!(:admin_no_moderation_mail) { create(:user, :admin, :confirmed, organization: current_organization, email_on_moderations: false) }
+      let(:user) { create(:user, :confirmed, organization: current_organization) }
+      let(:form) { ReportForm.from_params(form_params) }
+      let(:form_params) do
+        {
+          reason: "spam",
+          details: "some details about the report"
+        }
+      end
+
+      let(:command) { described_class.new(form, reportable, user) }
+
+      describe "when the form is not valid" do
+        before do
+          expect(form).to receive(:invalid?).and_return(true)
+        end
+
+        it "broadcasts invalid" do
+          expect { command.call }.to broadcast(:invalid)
+        end
+
+        it "doesn't create the report" do
+          expect { command.call }.not_to change(UserReport, :count)
+        end
+      end
+
+      describe "when the form is valid" do
+        before do
+          expect(form).to receive(:invalid?).and_return(false)
+        end
+
+        it "broadcasts ok" do
+          expect { command.call }.to broadcast(:ok)
+        end
+
+        it "creates a report" do
+          command.call
+          last_report = UserReport.last
+          expect(last_report.user).to eq(user)
+        end
+
+        it "creates a moderation" do
+          command.call
+          last_moderation = UserModeration.last
+
+          expect(last_moderation.user).to eq(reportable)
+          expect(last_moderation.reports.count).to eq(1)
+        end
+
+        it "stores the details to the report" do
+          command.call
+          last_report = UserReport.last
+          expect(last_report.details).to eq("some details about the report")
+        end
+
+        it "calls the report job in order to send the emails" do
+          allow(UserReportJob).to receive(:perform_later).and_call_original
+          command.call
+          last_report = UserReport.last
+          expect(UserReportJob).to have_received(:perform_later).with(admin, last_report)
+        end
+
+        context "when having multiple admins" do
+          let!(:another_admin) { create(:user, :admin, :confirmed, organization: current_organization) }
+
+          it "calls twice the report job in order to send the emails and ingore the admin_no_moderation_mail" do
+            expect(UserReportJob).to receive(:perform_later).twice.with(a_kind_of(Decidim::User), a_kind_of(Decidim::UserReport))
+
+            command.call
+          end
+        end
+
+        it "doesnt send an email to the admin when he/she doesnt allow it" do
+          allow(UserReportJob).to receive(:perform_later).and_call_original
+          command.call
+          expect(UserReportJob).not_to have_received(:perform_later).with(admin_no_moderation_mail, a_kind_of(Decidim::UserReport))
+        end
+
+        context "and the reportable has been already reported two times" do
+          before do
+            expect(form).to receive(:invalid?).at_least(:once).and_return(false)
+            (Decidim.max_reports_before_hiding - 1).times do
+              described_class.new(form, reportable, create(:user, organization: current_organization)).call
+            end
+          end
+
+          it "doesn't create an additional moderation" do
+            expect { command.call }.not_to change(UserModeration, :count)
+
+            last_moderation = UserModeration.last
+            expect(last_moderation.report_count).to eq(3)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
As an admin/moderator I want to be able to switch off notifications coming from reported users via my profile -> notifications settings so that I can make sure I am following the information I am interested in.

Currently, there is an option for admins/moderators in order to switch off receiving the email notifications related to reported content, and we want to adjust it to also take into account reported users. 
We will also need to change the text from _"I want to receive an email every time something is reported for moderation."_ to _"I want to receive an email every time something is reported for moderation."_

#### :tophat: What? Why?
*Please describe your pull request.*

#### :pushpin: Related Issues
Meata proposal: https://meta.decidim.org/processes/roadmap/f/122/proposals/16938


#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screen
![Screenshot from 2022-03-22 15-48-23](https://user-images.githubusercontent.com/66411127/159497905-57384467-ca6a-4556-8506-86019a8c7a99.png)
shots

:hearts: Thank you!
