### PR TITLE
Disable webpack-dev-server overlay

### DIFF
--- a/decidim-core/lib/decidim/webpacker/webpacker.yml
+++ b/decidim-core/lib/decidim/webpacker/webpacker.yml
@@ -33,7 +33,7 @@ development:
     hmr: false
     client:
       # Should we show a full-screen overlay in the browser when there are compiler errors or warnings?
-      overlay: true
+      overlay: false
       # May also be a string
       # webSocketURL:
       #  hostname: "0.0.0.0"


### PR DESCRIPTION
#### :tophat: What? Why?
Every time the page is reloaded and when running the `webpack-dev-server`, the page shows a popup in the browser showing all the webpack warnings.

This is completely unnecessary and just slows down front-end development as these same errors are also printed in the console. This probably originates from the default configurations.

See the screenshots for more information.

#### Testing
Reload any page when serving assets through `webpack-dev-server` and see the popup.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
This is the popup shown in the browser:
![Error popup shown in the browser](https://user-images.githubusercontent.com/864340/159558193-d6478e0c-c590-4115-a0fd-f1a57e4a7712.png)

These are the errors shown in the console:
![Errors shown in the console](https://user-images.githubusercontent.com/864340/159558334-ed3529eb-5653-45e9-8ca2-a50acca4794b.png)

Notice that they are exactly the same.
