### PR TITLE
Fix processes count in processes group title cell

### DIFF
--- a/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/title/show.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/title/show.erb
@@ -4,12 +4,12 @@
     <div class="columns medium-9">
       <%= decidim_sanitize_editor translated_attribute(participatory_process_group.description) %>
       <div class="row">
-        <div class="column medium-3 text-muted">
+        <div class="column medium-6 text-muted">
           <%= icon "grid-three-up", role: "img", "aria-hidden": true, class: "mr-xs" %>
           <%= t("decidim.participatory_process_groups.content_blocks.title.participatory_processes", count: participatory_processes_count) %>
         </div>
         <% if has_meta_scope? %>
-          <div class="column medium-3 end text-muted">
+          <div class="column medium-6 end text-muted">
             <%= icon "globe", class: "mr-xs" %>
             <strong><%= t("decidim.participatory_process_groups.content_blocks.title.meta_scope") %></strong>
             <%= translated_attribute(meta_scope) %>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/title/show.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/title/show.erb
@@ -4,7 +4,7 @@
     <div class="columns medium-9">
       <%= decidim_sanitize_editor translated_attribute(participatory_process_group.description) %>
       <div class="row">
-        <div class="column medium-2 text-muted">
+        <div class="column medium-3 text-muted">
           <%= icon "grid-three-up", role: "img", "aria-hidden": true, class: "mr-xs" %>
           <%= t("decidim.participatory_process_groups.content_blocks.title.participatory_processes", count: participatory_processes_count) %>
         </div>


### PR DESCRIPTION
#### :tophat: What? Why?

On some locales (for instance, French) a line was shown in two lines, breaking a bit the design.

This PR fixes it. 

All the credits go to @sdelcroix as I only applied it, but the bug and the fix was provided by they. 

#### :pushpin: Related Issues
 
- Fixes #9056

#### Testing

Go to a processes groups with multiple processes in the FR locale  

### :camera: Screenshots

(I cheated and didn't change the locale, as it was just too much work) 

#### Before


![image](https://user-images.githubusercontent.com/717367/159877253-fa43d299-0bc0-48c4-a7a6-c91bfa6c1c72.png)

#### After

![image](https://user-images.githubusercontent.com/717367/159877234-b595d0d9-32b0-42b9-9821-753c28929cae.png)


:hearts: Thank you!
