### PR TITLE
Backport "Fix timeout in comment view and during meetings" to v0.26

### DIFF
--- a/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
+++ b/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
@@ -6,7 +6,9 @@ module Decidim
     #
     class CommentsController < Decidim::Comments::ApplicationController
       include Decidim::ResourceHelper
+      include Decidim::SkipTimeoutable
 
+      prepend_before_action :skip_timeout, only: :index
       before_action :authenticate_user!, only: [:create]
       before_action :set_commentable, except: [:destroy, :update]
       before_action :ensure_commentable!, except: [:destroy, :update]

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -200,17 +200,17 @@ export default class CommentsComponent {
     this._stopPolling();
 
     this.pollTimeout = setTimeout(() => {
-      $.ajax({
+      Rails.ajax({
         url: this.commentsUrl,
-        method: "GET",
-        contentType: "application/javascript",
-        data: {
+        type: "GET",
+        data: new URLSearchParams({
           "commentable_gid": this.commentableGid,
           "root_depth": this.rootDepth,
-          order: this.order,
-          after: this.lastCommentId
-        }
-      }).done(() => this._pollComments());
+          "order": this.order,
+          "after": this.lastCommentId
+        }),
+        success: this._pollComments()
+      })
     }, this.pollingInterval);
   }
 

--- a/decidim-comments/spec/controllers/decidim/comments/comments_controller_spec.rb
+++ b/decidim-comments/spec/controllers/decidim/comments/comments_controller_spec.rb
@@ -22,6 +22,12 @@ module Decidim
           expect(subject).to render_template(:index)
         end
 
+        it "tells devise not to reset timeout counter" do
+          expect(request.env["devise.skip_timeoutable"]).to eq(nil)
+          get :index, xhr: true, params: { commentable_gid: commentable.to_signed_global_id.to_s }
+          expect(request.env["devise.skip_timeoutable"]).to eq(true)
+        end
+
         context "when requested without an XHR request" do
           it "redirects to the commentable" do
             get :index, params: { commentable_gid: commentable.to_signed_global_id.to_s }

--- a/decidim-core/app/controllers/concerns/decidim/skip_timeoutable.rb
+++ b/decidim-core/app/controllers/concerns/decidim/skip_timeoutable.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  # We don't want to reset timeout timer on routes where we make requests automatically
+  # (e.g. asking time before timeout or fetching comments).
+  module SkipTimeoutable
+    extend ActiveSupport::Concern
+
+    private
+
+    def skip_timeout
+      request.env["devise.skip_timeoutable"] = true
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/timeouts_controller.rb
+++ b/decidim-core/app/controllers/decidim/timeouts_controller.rb
@@ -5,6 +5,8 @@ require "active_support/concern"
 module Decidim
   # Tells/Extends time before inactivity warning or automatic logout.
   class TimeoutsController < Decidim::ApplicationController
+    include Decidim::SkipTimeoutable
+
     # Skip these methods because they can call Devise's store_location_for, which can save timeouts path to session.
     skip_before_action :store_current_location
 
@@ -22,12 +24,6 @@ module Decidim
       respond_to do |format|
         format.js
       end
-    end
-
-    private
-
-    def skip_timeout
-      request.env["devise.skip_timeoutable"] = true
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -119,5 +119,9 @@ module Decidim
         [base_url, "/", process.active_step.cta_path].join("")
       end
     end
+
+    def prevent_timeout_seconds
+      0
+    end
   end
 end

--- a/decidim-core/app/packs/src/decidim/session_timeouter.js
+++ b/decidim-core/app/packs/src/decidim/session_timeouter.js
@@ -82,7 +82,7 @@ $(() => {
     }
 
     const timeRemaining = Math.round((endsAt - moment()) / 1000);
-    if (timeRemaining > 150) {
+    if (timeRemaining > 170) {
       return;
     }
 

--- a/decidim-core/app/packs/src/decidim/session_timeouter.js
+++ b/decidim-core/app/packs/src/decidim/session_timeouter.js
@@ -1,5 +1,4 @@
 import moment from "moment"
-import Foundation from "foundation-sites"
 
 $(() => {
   let sessionTimeOutEnabled = true;
@@ -8,17 +7,18 @@ $(() => {
   const secondsUntilTimeoutPath = $timeoutModal.data("seconds-until-timeout-path");
   const heartbeatPath = $timeoutModal.data("heartbeat-path");
   const interval = parseInt($timeoutModal.data("session-timeout-interval"), 10);
+  const preventTimeOutSeconds = $timeoutModal.data("prevent-timeout-seconds");
   let endsAt = moment().add(timeoutInSeconds, "seconds");
   let lastAction = moment();
-  const popup = new Foundation.Reveal($timeoutModal);
   const $continueSessionButton = $("#continueSession");
   let lastActivityCheck = moment();
   // 5 * 60 seconds = 5 Minutes
   const activityCheckInterval = 5 * 60;
+  const preventTimeOutUntil = moment().add(preventTimeOutSeconds, "seconds");
 
   // Ajax request is made at timeout_modal.html.erb
   $continueSessionButton.on("click", () => {
-    $("#timeoutModal").foundation("close");
+    $timeoutModal.foundation("close");
     // In admin panel we have to hide all overlays
     $(".reveal-overlay").css("display", "none");
     lastActivityCheck = moment();
@@ -86,6 +86,11 @@ $(() => {
       return;
     }
 
+    if (moment() < preventTimeOutUntil) {
+      heartbeat();
+      return;
+    }
+
     sessionTimeLeft().then((result) => {
       const secondsUntilSessionExpires = result.seconds_remaining;
       setTimer(secondsUntilSessionExpires);
@@ -95,7 +100,7 @@ $(() => {
       } else if (secondsUntilSessionExpires <= 90) {
         $timeoutModal.find("#reveal-hidden-sign-out")[0].click();
       } else if (secondsUntilSessionExpires <= 150) {
-        popup.open();
+        $timeoutModal.foundation("open");
       }
     });
   }, interval);

--- a/decidim-core/app/views/layouts/decidim/_timeout_modal.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_timeout_modal.html.erb
@@ -1,9 +1,11 @@
 <% if current_user && !current_user.remember_created_at %>
   <% timeout_time_seconds = Decidim.config.expire_session_after.to_i %>
+  <% prevent_timeout_for = try(:prevent_timeout_seconds) || 0 %>
   <div class="reveal" id="timeoutModal" data-close-on-click="false" data-close-on-esc="false"
     data-seconds-until-timeout-path="<%= decidim.seconds_until_timeout_path %>"
     data-heartbeat-path="<%= decidim.heartbeat_path %>"
     data-session-timeout="<%= timeout_time_seconds %>"
+    data-prevent-timeout-seconds="<%= prevent_timeout_for %>"
     data-session-timeout-interval="<%= Decidim.config.session_timeout_interval.to_i * 1000 %>" data-reveal>
     <h2><%= t(".title") %></h2>
     <p><%= t(".body", minutes: (timeout_time_seconds / 60) - 2) %></p>

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -104,7 +104,7 @@ module Decidim
       private
 
       def meeting
-        @meeting ||= Meeting.not_hidden.where(component: current_component).find(params[:id])
+        @meeting ||= Meeting.not_hidden.where(component: current_component).find_by(id: params[:id])
       end
 
       def meetings

--- a/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
@@ -69,6 +69,24 @@ module Decidim
       def render_meeting_body(meeting)
         render_sanitized_content(meeting, :description)
       end
+
+      def prevent_timeout_seconds
+        return 0 unless respond_to?(:meeting)
+        return 0 if !current_user || !meeting || !meeting.live?
+        return 0 unless online_or_hybrid_meeting?(meeting)
+        return 0 unless iframe_embed_or_live_event_page?(meeting)
+        return 0 unless meeting.iframe_access_level_allowed_for_user?(current_user)
+
+        (meeting.end_time - Time.current).to_i
+      end
+
+      def online_or_hybrid_meeting?(meeting)
+        meeting.online_meeting? || meeting.hybrid_meeting?
+      end
+
+      def iframe_embed_or_live_event_page?(meeting)
+        meeting.iframe_embed_type == ("embed_in_meeting_page" || "open_in_live_event_page")
+      end
     end
   end
 end

--- a/decidim-meetings/app/views/decidim/meetings/layouts/live_event.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/layouts/live_event.html.erb
@@ -5,6 +5,7 @@
     <%= render partial: "layouts/decidim/head" %>
     <%= javascript_pack_tag "decidim_meetings" %>
     <%= render partial: "layouts/decidim/js_configuration" %>
+    <%= render partial: "layouts/decidim/timeout_modal" %>
   </head>
 
   <body>

--- a/decidim-meetings/spec/system/live_meeting_spec.rb
+++ b/decidim-meetings/spec/system/live_meeting_spec.rb
@@ -37,4 +37,37 @@ describe "Meeting live event", type: :system do
     click_link "close"
     expect(page).to have_current_path meeting_path
   end
+
+  context "when user is logged and session is about to timeout" do
+    before do
+      allow(Decidim.config).to receive(:expire_session_after).and_return(2.minutes)
+      allow(Decidim.config).to receive(:session_timeout_interval).and_return(1.second)
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit meeting_live_event_path
+    end
+
+    context "when meeting is live" do
+      let(:meeting) { create(:meeting, :published, :online, :embed_in_meeting_page_iframe_embed_type, component: component, start_time: 1.minute.ago, end_time: end_time) }
+      let(:end_time) { Time.current + 1.hour }
+
+      it "does not timeout user" do
+        travel 5.minutes
+        expect(page).to have_selector("[aria-label='User account: #{user.name}']")
+        expect(page).not_to have_content("If you continue being inactive", wait: 4)
+        expect(page).not_to have_content("You were inactive for too long")
+      end
+
+      context "and ends soon" do
+        let(:end_time) { Time.current + 15.seconds }
+
+        it "logouts user" do
+          travel 1.minute
+          expect(page).to have_content("If you continue being inactive", wait: 30)
+          allow(Time).to receive(:current).and_return(Time.current + 1.minute)
+          expect(page).to have_content("You are not allowed to view this meeting")
+        end
+      end
+    end
+  end
 end

--- a/decidim-meetings/spec/system/meeting_spec.rb
+++ b/decidim-meetings/spec/system/meeting_spec.rb
@@ -144,4 +144,49 @@ describe "Meeting", type: :system, download: true do
       end
     end
   end
+
+  context "when user is logged and session is about to timeout" do
+    before do
+      allow(Decidim.config).to receive(:expire_session_after).and_return(2.minutes)
+      allow(Decidim.config).to receive(:session_timeout_interval).and_return(1.second)
+      login_as user, scope: :user
+    end
+
+    context "when meeting is live" do
+      let(:meeting) { create(:meeting, :published, component: component, start_time: 1.minute.ago, end_time: Time.current + 1.hour) }
+
+      it "does not timeout user" do
+        visit_meeting
+        travel 1.minute
+        expect(page).not_to have_content("If you continue being inactive", wait: 4)
+        expect(page).not_to have_content("You were inactive for too long")
+      end
+    end
+
+    context "when meeting is in future" do
+      let(:meeting) { create(:meeting, :published, component: component, start_time: Time.current + 1.day, end_time: Time.current + 1.day + 2.hours) }
+
+      it "timeouts user normally" do
+        visit_meeting
+        travel 1.minute
+        expect(page).to have_content("You were inactive for too long")
+      end
+
+      context "when comments are enabled" do
+        let(:comment) { create(:comment, commentable: meeting) }
+
+        before do
+          component.settings[:comments_enabled] = true
+        end
+
+        it "fetching comments doesnt prevent timeout" do
+          visit_meeting
+          comment
+          expect(page).to have_content(translated(comment.body), wait: 30)
+          expect(page).to have_content("If you continue being inactive", wait: 30)
+          expect(page).to have_content("You were inactive for too long", wait: 30)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
:tophat: What? Why?
Backport #9070 to 0.26-stable.

There is also little change compared to #9070, because I noticed that tab A is preventing timeout tab B could still show timeout modal. This can happen because we check both of these when there's 150 seconds time left, so it's basically race condition. It's fixed here.

:hearts: Thank you!
