### PR TITLE
Prevent race condition between prevenTimeout and show modal

### DIFF
--- a/decidim-core/app/packs/src/decidim/session_timeouter.js
+++ b/decidim-core/app/packs/src/decidim/session_timeouter.js
@@ -82,7 +82,7 @@ $(() => {
     }
 
     const timeRemaining = Math.round((endsAt - moment()) / 1000);
-    if (timeRemaining > 150) {
+    if (timeRemaining > 170) {
       return;
     }
 


### PR DESCRIPTION
#### :tophat: What? Why?
After #9070 there is race condition between preventing timeout and showing timeout modal. So if user has meeting going on in tab A and homepage open in tab B, tab B could still show logout modal even if tab A is preventing timeout.

#### :pushpin: Related Issues
#9070
#9091

#### Testing

0. (OPTIONAL) Change expire_session_after default time (in minutes) from development_app/config/secrets.yml
1. Create online meeting with embedded url
2. Go to that meetings page
3. Open another tab and go to some other url (e.g. /admin)
4. There was 50% change that /admin shows timeout modal.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
