### PR TITLE
Dont add external link container inside editor

### DIFF
--- a/decidim-core/app/packs/src/decidim/external_link.js
+++ b/decidim-core/app/packs/src/decidim/external_link.js
@@ -5,6 +5,9 @@ const EXCLUDE_CLASSES = [
   "footer-social__icon",
   "logo-cityhall"
 ];
+const EXCLUE_ANCESTORS_CLASSES = [
+  "editor-container"
+]
 const EXCLUDE_REL = ["license", "decidim"];
 
 const DEFAULT_MESSAGES = {
@@ -25,6 +28,9 @@ export default class ExternalLink {
 
   setup() {
     if (EXCLUDE_CLASSES.some((cls) => this.$link.hasClass(cls))) {
+      return;
+    }
+    if (EXCLUE_ANCESTORS_CLASSES.some((cls) => this.$link.parents().hasClass(cls))) {
       return;
     }
     if (

--- a/decidim-core/app/packs/src/decidim/external_link.js
+++ b/decidim-core/app/packs/src/decidim/external_link.js
@@ -5,7 +5,7 @@ const EXCLUDE_CLASSES = [
   "footer-social__icon",
   "logo-cityhall"
 ];
-const EXCLUE_ANCESTORS_CLASSES = [
+const EXCLUDE_ANCESTOR_CLASSES = [
   "editor-container"
 ]
 const EXCLUDE_REL = ["license", "decidim"];
@@ -30,7 +30,7 @@ export default class ExternalLink {
     if (EXCLUDE_CLASSES.some((cls) => this.$link.hasClass(cls))) {
       return;
     }
-    if (EXCLUE_ANCESTORS_CLASSES.some((cls) => this.$link.parents().hasClass(cls))) {
+    if (EXCLUDE_ANCESTOR_CLASSES.some((cls) => this.$link.parents().hasClass(cls))) {
       return;
     }
     if (

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -215,13 +215,12 @@ describe "Edit proposals", type: :system do
     end
 
     context "when rich text editor is enabled on the frontend" do
-      let(:link) { "http://www.linux.org" }
-
       before do
         organization.update(rich_text_editor_in_public_views: true)
       end
 
       context "when proposal body has link" do
+        let(:link) { "http://www.linux.org" }
         let(:body_en) { %(Hello <a href="#{link}" target="_blank">this is a link</a> World) }
 
         before do
@@ -242,8 +241,6 @@ describe "Edit proposals", type: :system do
           editor = page.find(".editor-container")
           expect(editor).to have_selector("a[href='#{link}']")
           expect(editor).not_to have_selector("a.external-link-container")
-          click_button "Send"
-          expect(page).to have_link("this is a link", href: link)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently external links are added to links inside editor also, this doesn't make much sense because author knows that the link they added is external. This also adds problem that we add extra content to a link each time it is opened with the editor. Here we prevent external link containers to be added inside the editor.

#### :pushpin: Related Issues
https://github.com/decidim/decidim/issues/9055

#### Testing

See #9055

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
