### PR TITLE
Fix voting with single election

### DIFF
--- a/decidim-elections/app/cells/decidim/elections/election_vote_cta_cell.rb
+++ b/decidim-elections/app/cells/decidim/elections/election_vote_cta_cell.rb
@@ -5,14 +5,19 @@ module Decidim
     # This cell renders the results
     # for a given instance of an Election
     class ElectionVoteCtaCell < Decidim::ViewModel
+      include Decidim::Elections::HasVoteFlow
+
       delegate :current_user,
                :current_participatory_space,
-               :preview_mode?,
-               :can_preview?,
-               :vote_flow,
+               :allowed_to?,
                to: :controller
 
       private
+
+      # This is needed by HasVoteFlow
+      def election
+        model
+      end
 
       def last_vote
         @last_vote ||= Decidim::Elections::Votes::LastVoteForVoter.for(model, vote_flow.voter_id) if vote_flow.has_voter?

--- a/decidim-elections/spec/system/homepage_content_blocks_spec.rb
+++ b/decidim-elections/spec/system/homepage_content_blocks_spec.rb
@@ -6,21 +6,35 @@ describe "Homepage votings content blocks", type: :system do
   let(:organization) { create(:organization) }
   let(:show_statistics) { true }
   let!(:promoted_voting) { create(:voting, :promoted, organization: organization) }
-  let!(:unpromoted_voting) { create(:voting, organization: organization) }
-  let!(:promoted_external_voting) { create(:voting, :promoted) }
 
   before do
     create :content_block, organization: organization, scope_name: :homepage, manifest_name: :highlighted_votings
     switch_to_host(organization.host)
   end
 
-  it "includes active votings to the homepage" do
-    visit decidim.root_path
+  context "when there are multiple votings" do
+    let!(:unpromoted_voting) { create(:voting, organization: organization) }
+    let!(:promoted_external_voting) { create(:voting, :promoted) }
 
-    within "#highlighted-votings" do
+    it "includes active votings to the homepage" do
+      visit decidim.root_path
+
+      within "#highlighted-votings" do
+        expect(page).to have_i18n_content(promoted_voting.title)
+        expect(page).to have_i18n_content(unpromoted_voting.title)
+        expect(page).not_to have_i18n_content(promoted_external_voting.title)
+      end
+    end
+  end
+
+  context "when there's only one voting" do
+    it "redirects to the voting page" do
+      visit decidim.root_path
+      click_link "Votings"
+
       expect(page).to have_i18n_content(promoted_voting.title)
-      expect(page).to have_i18n_content(unpromoted_voting.title)
-      expect(page).not_to have_i18n_content(promoted_external_voting.title)
+      expect(page).to have_i18n_content(promoted_voting.description)
+      expect(page).to have_current_path(decidim_votings.voting_path(promoted_voting))
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
 
When there's only one voting enabled, and this voting only has an election, the election is rendered directly.

This was failing because the cell was delegating some methods to the controller, but the controller is trying to load the election from the params.

Instead, we should use the election that's already loaded in the cell.
