### PR TITLE
Hide more information link when there's no description on an election

### DIFF
--- a/decidim-elections/app/helpers/decidim/elections/votes_helper.rb
+++ b/decidim-elections/app/helpers/decidim/elections/votes_helper.rb
@@ -14,7 +14,9 @@ module Decidim
       end
 
       def more_information?(answer)
-        answer.description || answer.proposals.any? || answer.photos.any?
+        translated_attribute(answer.description).present? ||
+          answer.proposals.any? ||
+          answer.photos.any?
       end
     end
   end

--- a/decidim-elections/spec/helpers/decidim/elections/votes_helper_spec.rb
+++ b/decidim-elections/spec/helpers/decidim/elections/votes_helper_spec.rb
@@ -5,12 +5,20 @@ require "spec_helper"
 module Decidim
   module Elections
     describe VotesHelper do
+      let(:question) { create :question, :complete, answers: 3, random_answers_order: random_answers_order }
+      let(:random_answers_order) { true }
+
+      let(:helper) do
+        Class.new(ActionView::Base) do
+          include VotesHelper
+          include TranslatableAttributes
+        end.new(ActionView::LookupContext.new(ActionController::Base.view_paths), {}, [])
+      end
+
       describe "ordered_answers" do
         subject(:uniq_results) { repetitions.times.map { helper.ordered_answers(question) }.uniq }
 
-        let(:question) { create :question, :complete, answers: 3, random_answers_order: random_answers_order }
         let(:repetitions) { 100 }
-        let(:random_answers_order) { true }
 
         it "orders answers in different order on different calls" do
           # This test could randomly fail with a very low probability (6*(5.0/6)**100, or 1 of 13.802.995 times)
@@ -30,6 +38,33 @@ module Decidim
             ordered_ids = question.answers.map { |question| [question.weight, question.id] }.sort.map(&:last)
 
             expect(uniq_results.first.map(&:id)).to eq(ordered_ids)
+          end
+        end
+      end
+
+      describe "more_information?" do
+        let(:answer) { question.answers.first }
+        let(:show_more_information) { helper.more_information?(answer) }
+
+        context "when the answer has a description" do
+          before do
+            answer.description = { "en" => "Description" }
+            answer.save!
+          end
+
+          it "returns true" do
+            expect(show_more_information).to be_truthy
+          end
+        end
+
+        context "when the answer has no description" do
+          before do
+            answer.description = {}
+            answer.save!
+          end
+
+          it "returns false" do
+            expect(show_more_information).to be_falsey
           end
         end
       end

--- a/decidim-elections/spec/system/vote_online_spec.rb
+++ b/decidim-elections/spec/system/vote_online_spec.rb
@@ -39,6 +39,36 @@ describe "Vote online in an election", type: :system do
 
       uses_the_voting_booth
     end
+
+    context "when there's description in a question" do
+      before do
+        # rubocop:disable Rails/SkipsModelValidations
+        Decidim::Elections::Answer.update_all(description: { en: "Some text" })
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+
+      it "shows a link to view more information about the election" do
+        visit_component
+        click_link translated(election.title)
+        click_link "Start voting"
+        expect(page).to have_content("MORE INFORMATION")
+      end
+    end
+
+    context "when there's no description in a question" do
+      before do
+        # rubocop:disable Rails/SkipsModelValidations
+        Decidim::Elections::Answer.update_all(description: {})
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+
+      it "does not show the more information link" do
+        visit_component
+        click_link translated(election.title)
+        click_link "Start voting"
+        expect(page).not_to have_content("MORE INFORMATION")
+      end
+    end
   end
 
   context "when the election is not published" do


### PR DESCRIPTION
#### :tophat: What? Why?

When there's an answer without any related information, we shouldn't show the more information link.

Before that, we were showing the link even if the description was empty because the check was on the field (which is a hash) instead of the actual translated value.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/5254/160248264-55f3fdf8-373d-45c1-a894-ab1aa4a48d72.png)

