### PR TITLE
Fix wrong time (catalan)

### DIFF
--- a/decidim-core/config/locales/ca.yml
+++ b/decidim-core/config/locales/ca.yml
@@ -1722,8 +1722,8 @@ ca:
         mailer:
           invitation_instructions:
             accept_until_format: "%B %d, %Y %I:%M %p"
-      long: "%B %d, %Y %H:%M"
-      long_dashed: "%A-%m-%d %H:%M:%S"
+      long: "%d de %B, %Y %H:%M"
+      long_dashed: "%d-%m-%Y %H:%M:%S"
       short: "%d/%m/%Y %H:%M"
       time_of_day: "%H:%M"
   versions:


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes a wrong time translation in the catalan language.