### PR TITLE
Backport "Dont add external link container inside editor" to v0.26

### DIFF
--- a/decidim-core/app/packs/src/decidim/external_link.js
+++ b/decidim-core/app/packs/src/decidim/external_link.js
@@ -5,6 +5,9 @@ const EXCLUDE_CLASSES = [
   "footer-social__icon",
   "logo-cityhall"
 ];
+const EXCLUDE_ANCESTOR_CLASSES = [
+  "editor-container"
+]
 const EXCLUDE_REL = ["license", "decidim"];
 
 const DEFAULT_MESSAGES = {
@@ -25,6 +28,9 @@ export default class ExternalLink {
 
   setup() {
     if (EXCLUDE_CLASSES.some((cls) => this.$link.hasClass(cls))) {
+      return;
+    }
+    if (EXCLUDE_ANCESTOR_CLASSES.some((cls) => this.$link.parents().hasClass(cls))) {
       return;
     }
     if (

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -182,18 +182,31 @@ describe "Edit proposals", type: :system do
     context "when rich text editor is enabled on the frontend" do
       before do
         organization.update(rich_text_editor_in_public_views: true)
-        body = proposal.body
-        body["en"] = 'Hello <a href="http://www.linux.org" target="_blank">external link</a> World'
-        proposal.update!(body: body)
       end
 
-      it "doesnt change the href" do
-        visit_component
+      context "when proposal body has link" do
+        let(:link) { "http://www.linux.org" }
+        let(:body_en) { %(Hello <a href="#{link}" target="_blank">this is a link</a> World) }
 
-        click_link proposal_title
-        click_link "Edit proposal"
+        before do
+          body = proposal.body
+          body["en"] = body_en
+          proposal.update!(body: body)
+          visit_component
+          click_link proposal_title
+        end
 
-        expect(page).to have_link("external link", href: "http://www.linux.org")
+        it "doesnt change the href" do
+          click_link "Edit proposal"
+          expect(page).to have_link("this is a link", href: link)
+        end
+
+        it "doesnt add external link container inside the editor" do
+          click_link "Edit proposal"
+          editor = page.find(".editor-container")
+          expect(editor).to have_selector("a[href='#{link}']")
+          expect(editor).not_to have_selector("a.external-link-container")
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Backport #9095 to 0.26-stable

:hearts: Thank you!
