### PR TITLE
Add base URI to meta image URLs

### DIFF
--- a/decidim-core/app/helpers/decidim/meta_tags_helper.rb
+++ b/decidim-core/app/helpers/decidim/meta_tags_helper.rb
@@ -16,7 +16,30 @@ module Decidim
       add_decidim_meta_description(tags[:description])
       add_decidim_meta_url(tags[:url])
       add_decidim_meta_twitter_handler(tags[:twitter_handler])
-      add_decidim_meta_image_url(tags[:image_url])
+      add_decidim_meta_image_url(add_base_url_to(tags[:image_url]))
+    end
+
+    # Public: Add base url to path if path doesn't include host.
+    # path - A String containing path (e.g. "/proposals/1" )
+    # Returns a String of URL including base URL and path, or path if it's blank.
+    def add_base_url_to(path)
+      return path if path.blank?
+      return path if URI.parse(path).host.present?
+
+      "#{resolve_base_url}#{path}"
+    end
+
+    # Public: Resolve base url (example: https://www.decidim.org) without url params
+    # Returns a String of base URL
+    def resolve_base_url
+      return request.base_url if respond_to?(:request) && request&.base_url.present?
+
+      uri = URI.parse(decidim.root_url(host: current_organization.host))
+      if uri.port.blank? || [80, 443].include?(uri.port)
+        "#{uri.scheme}://#{uri.host}"
+      else
+        "#{uri.scheme}://#{uri.host}:#{uri.port}"
+      end
     end
 
     # Public: Accumulates the given `title` so that they can be chained. Since Rails views

--- a/decidim-core/spec/helpers/decidim/meta_tags_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/meta_tags_helper_spec.rb
@@ -8,7 +8,6 @@ module Decidim
 
     let(:base_url) { "http://#{host}" }
     let(:host) { "test.host" }
-    let!(:current_organization) { create(:organization, host: host) }
 
     describe "#add_base_url_to" do
       context "with image path" do
@@ -34,6 +33,8 @@ module Decidim
       end
 
       context "when there is no request" do
+        let!(:current_organization) { create(:organization, host: host) }
+
         before do
           allow(subject).to receive(:request).and_return(nil)
         end

--- a/decidim-core/spec/helpers/decidim/meta_tags_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/meta_tags_helper_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe MetaTagsHelper do
+    subject { helper }
+
+    let(:base_url) { "http://#{host}" }
+    let(:host) { "test.host" }
+    let!(:current_organization) { create(:organization, host: host) }
+
+    describe "#add_base_url_to" do
+      context "with image path" do
+        let(:path) { "/rails/active_storage/disk/123--foobar/banner_image.jpeg" }
+
+        it "adds base url to path" do
+          expect(subject.add_base_url_to(path)).to eq("#{base_url}#{path}")
+        end
+      end
+
+      context "when path includes base url already" do
+        let(:path) { "http://test.host/rails/active_storage/disk/123--foobar/banner_image.jpeg" }
+
+        it "does not duplicate base url" do
+          expect(subject.add_base_url_to(path)).to eq(path)
+        end
+      end
+    end
+
+    describe "#resolve_base_url" do
+      it "returns base url" do
+        expect(subject.resolve_base_url).to eq(base_url)
+      end
+
+      context "when there is no request" do
+        before do
+          allow(subject).to receive(:request).and_return(nil)
+        end
+
+        it "still returns base url" do
+          allow(subject).to receive(:current_organization).and_return(current_organization)
+          expect(subject.resolve_base_url).to eq(base_url)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/helpers/decidim/meta_tags_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/meta_tags_helper_spec.rb
@@ -19,7 +19,7 @@ module Decidim
       end
 
       context "when path includes base url already" do
-        let(:path) { "http://test.host/rails/active_storage/disk/123--foobar/banner_image.jpeg" }
+        let(:path) { "#{base_url}/rails/active_storage/disk/123--foobar/banner_image.jpeg" }
 
         it "does not duplicate base url" do
           expect(subject.add_base_url_to(path)).to eq(path)


### PR DESCRIPTION
#### :tophat: What? Why?
When linking Decidim instance to social media image is usually broken (see screenshot below) because it doesn't include base url (e.g. ```https://meta.decidim.org```). Correct usage of social meta tags is described for example in [Twitter docs](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary).

#### Testing
1. Go to any decidim instance (e.g. https://meta.decidim.org/)
2. Open console (F12 in Firefox)
3. Type these commands
```js
document.querySelector("meta[name='twitter:image']").content
```
```js
document.querySelector("meta[property='og:image']").content
```
4. Content should be like ```https://meta.decidim.org/rails/active_storage/blobs/123--foobar.png```

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/161284533-61262e24-c41a-4cfb-b5cb-2691c0d580eb.png)
![image](https://user-images.githubusercontent.com/19709320/161282415-d101c16d-bc04-46a6-9aa3-9ea89d354fc9.png)

:hearts: Thank you!
