### PR TITLE
Add timeline entry title in Accountability projects

### DIFF
--- a/decidim-accountability/app/commands/decidim/accountability/admin/create_timeline_entry.rb
+++ b/decidim-accountability/app/commands/decidim/accountability/admin/create_timeline_entry.rb
@@ -25,13 +25,14 @@ module Decidim
 
         private
 
-        attr_reader :timeline_entry
+        attr_reader :timeline_entry, :form
 
         def create_timeline_entry
           @timeline_entry = TimelineEntry.create!(
-            decidim_accountability_result_id: @form.decidim_accountability_result_id,
-            entry_date: @form.entry_date,
-            description: @form.description
+            decidim_accountability_result_id: form.decidim_accountability_result_id,
+            entry_date: form.entry_date,
+            title: form.title,
+            description: form.description
           )
         end
       end

--- a/decidim-accountability/app/commands/decidim/accountability/admin/update_timeline_entry.rb
+++ b/decidim-accountability/app/commands/decidim/accountability/admin/update_timeline_entry.rb
@@ -34,8 +34,9 @@ module Decidim
 
         def update_timeline_entry
           timeline_entry.update!(
-            entry_date: @form.entry_date,
-            description: @form.description
+            entry_date: form.entry_date,
+            title: form.title,
+            description: form.description
           )
         end
       end

--- a/decidim-accountability/app/forms/decidim/accountability/admin/timeline_entry_form.rb
+++ b/decidim-accountability/app/forms/decidim/accountability/admin/timeline_entry_form.rb
@@ -10,10 +10,11 @@ module Decidim
 
         attribute :decidim_accountability_result_id, Integer
         attribute :entry_date, Decidim::Attributes::LocalizedDate
+        translatable_attribute :title, String
         translatable_attribute :description, String
 
         validates :entry_date, presence: true
-        validates :description, translatable_presence: true
+        validates :title, translatable_presence: true
       end
     end
   end

--- a/decidim-accountability/app/models/decidim/accountability/timeline_entry.rb
+++ b/decidim-accountability/app/models/decidim/accountability/timeline_entry.rb
@@ -7,6 +7,7 @@ module Decidim
     class TimelineEntry < Accountability::ApplicationRecord
       include Decidim::TranslatableResource
 
+      translatable_fields :title
       translatable_fields :description
       belongs_to :result, foreign_key: "decidim_accountability_result_id", class_name: "Decidim::Accountability::Result", inverse_of: :timeline_entries
     end

--- a/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/_form.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/_form.html.erb
@@ -9,7 +9,11 @@
     </div>
 
     <div class="row column">
-      <%= form.translated :text_field, :description %>
+      <%= form.translated :text_field, :title %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :editor, :description %>
     </div>
   </div>
 </div>

--- a/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/index.html.erb
@@ -13,7 +13,7 @@
         <thead>
           <tr>
             <th><%= t("models.timeline_entry.fields.entry_date", scope: "decidim.accountability") %></th>
-            <th><%= t("models.timeline_entry.fields.description", scope: "decidim.accountability") %></th>
+            <th><%= t("models.timeline_entry.fields.title", scope: "decidim.accountability") %></th>
             <th class="actions"><%= t("actions.title", scope: "decidim.accountability") %></th>
           </tr>
         </thead>
@@ -21,7 +21,7 @@
           <% timeline_entries.each do |timeline_entry| %>
             <tr data-id="<%= timeline_entry.id %>">
               <td><%= timeline_entry.entry_date %><br></td>
-              <td><%= translated_attribute(timeline_entry.description) %></td>
+              <td><%= translated_attribute(timeline_entry.title) %></td>
               <td class="table-list__actions">
                 <% if allowed_to? :update, :timeline_entry, timeline_entry: timeline_entry %>
                   <%= icon_link_to "pencil", edit_result_timeline_entry_path(timeline_entry.result, timeline_entry), t("actions.edit", scope: "decidim.accountability"), class: "action-icon--edit" %>

--- a/decidim-accountability/app/views/decidim/accountability/results/_timeline.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_timeline.html.erb
@@ -17,11 +17,7 @@
               </h4>
 
               <% if translated_attribute(timeline_entry.description).present? %>
-                <a data-toggle="timeline_entry__description_toggle_<%= timeline_entry.id %>" class="button small hollow">
-                  <%= t(".read_more") %>
-                </a>
-
-                <div id="timeline_entry__description_toggle_<%= timeline_entry.id %>" data-toggler="is-hidden" class="timeline__description__description is-hidden">
+                <div class="timeline__description__description">
                   <%== translated_attribute timeline_entry.description %>
                 </div>
               <% end %>

--- a/decidim-accountability/app/views/decidim/accountability/results/_timeline.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_timeline.html.erb
@@ -13,8 +13,14 @@
                 <%= timeline_entry.entry_date %>
               </span>
               <h4 class="timeline__title">
-                <%= translated_attribute timeline_entry.description %>
+                <%= translated_attribute timeline_entry.title %>
               </h4>
+
+              <% if translated_attribute(timeline_entry.description).present? %>
+                <p class="timeline__description__description">
+                  <%== translated_attribute timeline_entry.description %>
+                </p>
+              <% end %>
             </div>
           </div>
         </li>

--- a/decidim-accountability/app/views/decidim/accountability/results/_timeline.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_timeline.html.erb
@@ -17,9 +17,13 @@
               </h4>
 
               <% if translated_attribute(timeline_entry.description).present? %>
-                <p class="timeline__description__description">
+                <a data-toggle="timeline_entry__description_toggle_<%= timeline_entry.id %>" class="button small hollow">
+                  <%= t(".read_more") %>
+                </a>
+
+                <div id="timeline_entry__description_toggle_<%= timeline_entry.id %>" data-toggler="is-hidden" class="timeline__description__description is-hidden">
                   <%== translated_attribute timeline_entry.description %>
-                </p>
+                </div>
               <% end %>
             </div>
           </div>

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -159,7 +159,6 @@ en:
             progress: Progress
         timeline_entry:
           fields:
-            description: Description
             entry_date: Date
             title: Title
       result_m:

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -161,6 +161,7 @@ en:
           fields:
             description: Description
             entry_date: Date
+            title: Title
       result_m:
         executed: Executed
         view: View

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
       timeline_entry:
         description: Description
         entry_date: Date
+        title: Title
     models:
       decidim/accountability/proposal_linked_event: Proposal included in a result
       decidim/accountability/result_progress_updated_event: Result progress updated

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -193,6 +193,7 @@ en:
             proposals: Proposals
             votes: Supports
         timeline:
+          read_more: Read more
           title: Project evolution
     admin:
       filters:

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -193,7 +193,6 @@ en:
             proposals: Proposals
             votes: Supports
         timeline:
-          read_more: Read more
           title: Project evolution
     admin:
       filters:

--- a/decidim-accountability/db/migrate/20220331150008_add_title_to_timeline_entries.rb
+++ b/decidim-accountability/db/migrate/20220331150008_add_title_to_timeline_entries.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTitleToTimelineEntries < ActiveRecord::Migration[6.1]
+  def change
+    add_column :decidim_accountability_timeline_entries, :title, :jsonb
+  end
+end

--- a/decidim-accountability/db/migrate/20220331150155_move_legacy_description_to_title_of_timeline_entries.rb
+++ b/decidim-accountability/db/migrate/20220331150155_move_legacy_description_to_title_of_timeline_entries.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MoveLegacyDescriptionToTitleOfTimelineEntries < ActiveRecord::Migration[6.1]
+  class TimelineEntry < ApplicationRecord
+    self.table_name = :decidim_accountability_timeline_entries
+  end
+
+  def up
+    TimelineEntry.find_each do |timeline_entry|
+      timeline_entry.update!(title: timeline_entry.description, description: nil)
+    end
+  end
+end

--- a/decidim-accountability/lib/decidim/accountability/component.rb
+++ b/decidim-accountability/lib/decidim/accountability/component.rb
@@ -160,7 +160,7 @@ Decidim.register_component(:accountability) do |component|
             child_result.timeline_entries.create!(
               entry_date: child_result.start_date + i.days,
               title: Decidim::Faker::Localized.sentence(word_count: 2),
-              description: Decidim::Faker::Localized.sentence(sentence_count: 1)
+              description: Decidim::Faker::Localized.paragraph(sentence_count: 1)
             )
           end
 

--- a/decidim-accountability/lib/decidim/accountability/component.rb
+++ b/decidim-accountability/lib/decidim/accountability/component.rb
@@ -159,7 +159,8 @@ Decidim.register_component(:accountability) do |component|
           rand(0..5).times do |i|
             child_result.timeline_entries.create!(
               entry_date: child_result.start_date + i.days,
-              description: Decidim::Faker::Localized.sentence(word_count: 2)
+              title: Decidim::Faker::Localized.sentence(word_count: 2),
+              description: Decidim::Faker::Localized.sentence(sentence_count: 1)
             )
           end
 

--- a/decidim-accountability/lib/decidim/accountability/test/factories.rb
+++ b/decidim-accountability/lib/decidim/accountability/test/factories.rb
@@ -45,6 +45,7 @@ FactoryBot.define do
   factory :timeline_entry, class: "Decidim::Accountability::TimelineEntry" do
     result { create(:result) }
     entry_date { "12/7/2017" }
+    title { generate_localized_title }
     description { generate_localized_title }
   end
 end

--- a/decidim-accountability/lib/decidim/api/timeline_entry_type.rb
+++ b/decidim-accountability/lib/decidim/api/timeline_entry_type.rb
@@ -7,6 +7,7 @@ module Decidim
 
       field :id, GraphQL::Types::ID, "The internal ID for this timeline entry", null: false
       field :entry_date, Decidim::Core::DateType, "The entry date for this timeline entry", null: true
+      field :title, Decidim::Core::TranslatedFieldType, "The title for this timeline entry", null: true
       field :description, Decidim::Core::TranslatedFieldType, "The description for this timeline entry", null: true
       field :created_at, Decidim::Core::DateTimeType, "When this timeline entry was created", null: true
       field :updated_at, Decidim::Core::DateTimeType, "When this timeline entry was updated", null: true

--- a/decidim-accountability/spec/commands/admin/create_timeline_entry_spec.rb
+++ b/decidim-accountability/spec/commands/admin/create_timeline_entry_spec.rb
@@ -12,6 +12,7 @@ module Decidim::Accountability
     let(:result) { create :result, component: current_component }
 
     let(:date) { "2017-8-23" }
+    let(:title) { "Title" }
     let(:description) { "description" }
 
     let(:form) do
@@ -19,6 +20,7 @@ module Decidim::Accountability
         invalid?: invalid,
         decidim_accountability_result_id: result.id,
         entry_date: date,
+        title: { en: title },
         description: { en: description }
       )
     end
@@ -42,6 +44,11 @@ module Decidim::Accountability
       it "sets the entry date" do
         subject.call
         expect(timeline_entry.entry_date).to eq(Date.new(2017, 8, 23))
+      end
+
+      it "sets the title" do
+        subject.call
+        expect(translated(timeline_entry.title)).to eq title
       end
 
       it "sets the description" do

--- a/decidim-accountability/spec/commands/admin/update_timeline_entry_spec.rb
+++ b/decidim-accountability/spec/commands/admin/update_timeline_entry_spec.rb
@@ -14,12 +14,14 @@ module Decidim::Accountability
     let(:timeline_entry) { create :timeline_entry, result: result }
 
     let(:date) { "2017-9-23" }
+    let(:title) { "New title" }
     let(:description) { "new description" }
 
     let(:form) do
       double(
         invalid?: invalid,
         entry_date: date,
+        title: { en: title },
         description: { en: description }
       )
     end

--- a/decidim-accountability/spec/forms/admin/timeline_entry_form_spec.rb
+++ b/decidim-accountability/spec/forms/admin/timeline_entry_form_spec.rb
@@ -18,6 +18,9 @@ module Decidim::Accountability
     let(:result) { create :result, component: current_component }
 
     let(:entry_date) { "12/3/2017" }
+    let(:title) do
+      Decidim::Faker::Localized.sentence(word_count: 3)
+    end
     let(:description) do
       Decidim::Faker::Localized.sentence(word_count: 3)
     end
@@ -26,6 +29,7 @@ module Decidim::Accountability
       {
         decidim_accountability_result_id: result.id,
         entry_date: entry_date,
+        title_en: title[:en],
         description_en: description[:en]
       }
     end
@@ -38,10 +42,16 @@ module Decidim::Accountability
       it { is_expected.not_to be_valid }
     end
 
+    describe "when title is missing" do
+      let(:title) { { en: nil } }
+
+      it { is_expected.not_to be_valid }
+    end
+
     describe "when description is missing" do
       let(:description) { { en: nil } }
 
-      it { is_expected.not_to be_valid }
+      it { is_expected.to be_valid }
     end
   end
 end

--- a/decidim-accountability/spec/types/integration_schema_spec.rb
+++ b/decidim-accountability/spec/types/integration_schema_spec.rb
@@ -50,6 +50,7 @@ describe "Decidim::Api::QueryType" do
       "timelineEntries" => [
         {
           "createdAt" => result.timeline_entries.first.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+          "title" => { "translation" => result.timeline_entries.first.title[locale] },
           "description" => { "translation" => result.timeline_entries.first.description[locale] },
           "entryDate" => result.timeline_entries.first.entry_date.to_s,
           "id" => result.timeline_entries.first.id.to_s,
@@ -159,6 +160,9 @@ describe "Decidim::Api::QueryType" do
               timelineEntries {
                 id
                 createdAt
+                title {
+                  translation(locale:"#{locale}")
+                }
                 description {
                   translation(locale:"#{locale}")
                 }
@@ -265,6 +269,9 @@ describe "Decidim::Api::QueryType" do
           timelineEntries {
             id
             createdAt
+            title {
+              translation(locale:"#{locale}")
+            }
             description {
               translation(locale:"#{locale}")
             }

--- a/decidim-accountability/spec/types/timeline_entry_type_spec.rb
+++ b/decidim-accountability/spec/types/timeline_entry_type_spec.rb
@@ -26,6 +26,14 @@ module Decidim
         end
       end
 
+      describe "title" do
+        let(:query) { '{ title { translation(locale:"en")}}' }
+
+        it "returns the title field" do
+          expect(response["title"]["translation"]).to eq(model.title["en"])
+        end
+      end
+
       describe "description" do
         let(:query) { '{ description { translation(locale:"en")}}' }
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a `title` attribute to the `TimelineEntry` model, forms and views.

So a `timeline_entry` has a `title` (required) and  `description` (optional) attributes.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #9089

#### Testing

- as an admin go to manage a result and add new  or edit an entry.
- then go to the public view and scroll to the "project evolution" section.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

![image](https://user-images.githubusercontent.com/210216/165106489-0bbee083-3377-45d3-b195-f7e945bc86a8.png)

![Screenshot from 2022-04-06 15-16-52](https://user-images.githubusercontent.com/210216/161984177-26ab7afa-015d-4ac1-95aa-47494cbe7ed9.png)

:hearts: Thank you!
