### PR TITLE
Do not send upcoming meeting notification for hidden or withdrawn meetings

### DIFF
--- a/decidim-meetings/app/jobs/decidim/meetings/upcoming_meeting_notification_job.rb
+++ b/decidim-meetings/app/jobs/decidim/meetings/upcoming_meeting_notification_job.rb
@@ -7,6 +7,8 @@ module Decidim
 
       def perform(meeting_id, checksum)
         meeting = Decidim::Meetings::Meeting.find(meeting_id)
+        return if meeting.hidden? || meeting.withdrawn?
+
         send_notification(meeting) if verify_checksum(meeting, checksum)
       end
 

--- a/decidim-meetings/app/jobs/decidim/meetings/upcoming_meeting_notification_job.rb
+++ b/decidim-meetings/app/jobs/decidim/meetings/upcoming_meeting_notification_job.rb
@@ -8,8 +8,9 @@ module Decidim
       def perform(meeting_id, checksum)
         meeting = Decidim::Meetings::Meeting.find(meeting_id)
         return if meeting.hidden? || meeting.withdrawn?
+        return unless verify_checksum(meeting, checksum)
 
-        send_notification(meeting) if verify_checksum(meeting, checksum)
+        send_notification(meeting)
       end
 
       def self.generate_checksum(meeting)

--- a/decidim-meetings/spec/jobs/decidim/meetings/upcoming_meeting_notification_job_spec.rb
+++ b/decidim-meetings/spec/jobs/decidim/meetings/upcoming_meeting_notification_job_spec.rb
@@ -39,4 +39,26 @@ describe Decidim::Meetings::UpcomingMeetingNotificationJob do
       subject.perform_now(meeting.id, checksum)
     end
   end
+
+  context "when the meeting is hidden" do
+    let!(:moderation) { create(:moderation, reportable: meeting, report_count: 1, hidden_at: Time.current) }
+
+    it "doesn't notify the upcoming meeting" do
+      expect(Decidim::EventsManager)
+        .not_to receive(:publish)
+
+      subject.perform_now(meeting.id, checksum)
+    end
+  end
+
+  context "when the meeting is withdrawn" do
+    let(:meeting) { create :meeting, :withdrawn, start_time: start_time }
+
+    it "doesn't notify the upcoming meeting" do
+      expect(Decidim::EventsManager)
+        .not_to receive(:publish)
+
+      subject.perform_now(meeting.id, checksum)
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
It can be noticed that the 48h notification is received for a hidden/withdrawn meeting.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #9126 

#### Testing
Steps to reproduce the behavior (hidden meeting):

Create a meeting that will start in 48h and a few minutes
Report the meeting
Hide the meeting via Admin dashboard - Reports
Wait for the notification
Notification is received

Steps to reproduce the behavior (withdrawn meeting):

Create a meeting that will start in 48h and a few minutes
Withdraw the meeting
Wait for the notification
Notification is received

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
