### PR TITLE
Bump elections NPM dependencies to 0.23.0

### DIFF
--- a/decidim_app-design/package-lock.json
+++ b/decidim_app-design/package-lock.json
@@ -1807,8 +1807,9 @@
       "link": true
     },
     "node_modules/@decidim/decidim-bulletin_board": {
-      "version": "0.22.3",
-      "integrity": "sha512-LN7wIK9IB9Zegr++fvEY2vAWdUvReLPCe3sbPMGadX3b2aurrx/SK3B38OfRdN2eqblksMzyNYtXALszA9dU2w==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@decidim/decidim-bulletin_board/-/decidim-bulletin_board-0.23.0.tgz",
+      "integrity": "sha512-kCFVv8bgq5+7cizkS+PchiWczsmsFAqQ4phbDm99xA+wz0Rq0iG4SpkNij5Xin0bvGDdVOQ1sU5HPlIePheEZQ==",
       "dependencies": {
         "@apollo/client": "^3.2.7",
         "core-js": "^3.8.3",
@@ -1844,12 +1845,14 @@
       "link": true
     },
     "node_modules/@decidim/voting_schemes-dummy": {
-      "version": "0.22.3",
-      "integrity": "sha512-Z5CwSUJNYW2KkoE5anAqAIwHnQHqpgGL4Xu2I7YqEn3thThlbWlY9U9Eq0O6fq7/pfBQLiAFFiBBAnCDv0HC2g=="
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-dummy/-/voting_schemes-dummy-0.23.0.tgz",
+      "integrity": "sha512-pTXJm6HsL4RmuR9TfKih8iShUk5WK6jZBUESl+T+XDXs4x60Sxi8xJ8GxUb+keTUgYG3hecYnlPez9Okc4WYqw=="
     },
     "node_modules/@decidim/voting_schemes-electionguard": {
-      "version": "0.22.3",
-      "integrity": "sha512-RZn/1GO5PM6a2SuN8h/SoS4EeLYnHPWw6/tl2M26ms/Xzf1ewJIgBSiByxk4qHoqvE892rccH4+G56h6iVrIqg=="
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-electionguard/-/voting_schemes-electionguard-0.23.0.tgz",
+      "integrity": "sha512-o5/UXRc6v0Cp2BG/MtNpVAEtyNO3VdfFjJSX75E5W7G2yIu7na+D1HZyHyqIk1rgHPqdJmdg0DT7JI16fDcbXQ=="
     },
     "node_modules/@decidim/webpacker": {
       "resolved": "packages/webpacker",
@@ -17181,9 +17184,9 @@
       "version": "0.27.0-dev",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@decidim/decidim-bulletin_board": "0.22.3",
-        "@decidim/voting_schemes-dummy": "0.22.3",
-        "@decidim/voting_schemes-electionguard": "0.22.3"
+        "@decidim/decidim-bulletin_board": "0.23.0",
+        "@decidim/voting_schemes-dummy": "0.23.0",
+        "@decidim/voting_schemes-electionguard": "0.23.0"
       }
     },
     "packages/eslint-config": {
@@ -19800,8 +19803,9 @@
       }
     },
     "@decidim/decidim-bulletin_board": {
-      "version": "0.22.3",
-      "integrity": "sha512-LN7wIK9IB9Zegr++fvEY2vAWdUvReLPCe3sbPMGadX3b2aurrx/SK3B38OfRdN2eqblksMzyNYtXALszA9dU2w==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@decidim/decidim-bulletin_board/-/decidim-bulletin_board-0.23.0.tgz",
+      "integrity": "sha512-kCFVv8bgq5+7cizkS+PchiWczsmsFAqQ4phbDm99xA+wz0Rq0iG4SpkNij5Xin0bvGDdVOQ1sU5HPlIePheEZQ==",
       "requires": {
         "@apollo/client": "^3.2.7",
         "core-js": "^3.8.3",
@@ -19828,9 +19832,9 @@
     "@decidim/elections": {
       "version": "file:packages/elections",
       "requires": {
-        "@decidim/decidim-bulletin_board": "0.22.3",
-        "@decidim/voting_schemes-dummy": "0.22.3",
-        "@decidim/voting_schemes-electionguard": "0.22.3"
+        "@decidim/decidim-bulletin_board": "0.23.0",
+        "@decidim/voting_schemes-dummy": "0.23.0",
+        "@decidim/voting_schemes-electionguard": "0.23.0"
       }
     },
     "@decidim/eslint-config": {
@@ -19842,12 +19846,14 @@
       "requires": {}
     },
     "@decidim/voting_schemes-dummy": {
-      "version": "0.22.3",
-      "integrity": "sha512-Z5CwSUJNYW2KkoE5anAqAIwHnQHqpgGL4Xu2I7YqEn3thThlbWlY9U9Eq0O6fq7/pfBQLiAFFiBBAnCDv0HC2g=="
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-dummy/-/voting_schemes-dummy-0.23.0.tgz",
+      "integrity": "sha512-pTXJm6HsL4RmuR9TfKih8iShUk5WK6jZBUESl+T+XDXs4x60Sxi8xJ8GxUb+keTUgYG3hecYnlPez9Okc4WYqw=="
     },
     "@decidim/voting_schemes-electionguard": {
-      "version": "0.22.3",
-      "integrity": "sha512-RZn/1GO5PM6a2SuN8h/SoS4EeLYnHPWw6/tl2M26ms/Xzf1ewJIgBSiByxk4qHoqvE892rccH4+G56h6iVrIqg=="
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-electionguard/-/voting_schemes-electionguard-0.23.0.tgz",
+      "integrity": "sha512-o5/UXRc6v0Cp2BG/MtNpVAEtyNO3VdfFjJSX75E5W7G2yIu7na+D1HZyHyqIk1rgHPqdJmdg0DT7JI16fDcbXQ=="
     },
     "@decidim/webpacker": {
       "version": "file:packages/webpacker",

--- a/decidim_app-design/packages/elections/package.json
+++ b/decidim_app-design/packages/elections/package.json
@@ -10,8 +10,8 @@
   "author": "Decidim Contributors",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@decidim/decidim-bulletin_board": "0.22.3",
-    "@decidim/voting_schemes-dummy": "0.22.3",
-    "@decidim/voting_schemes-electionguard": "0.22.3"
+    "@decidim/decidim-bulletin_board": "0.23.0",
+    "@decidim/voting_schemes-dummy": "0.23.0",
+    "@decidim/voting_schemes-electionguard": "0.23.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1807,8 +1807,9 @@
       "link": true
     },
     "node_modules/@decidim/decidim-bulletin_board": {
-      "version": "0.22.3",
-      "integrity": "sha512-LN7wIK9IB9Zegr++fvEY2vAWdUvReLPCe3sbPMGadX3b2aurrx/SK3B38OfRdN2eqblksMzyNYtXALszA9dU2w==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@decidim/decidim-bulletin_board/-/decidim-bulletin_board-0.23.0.tgz",
+      "integrity": "sha512-kCFVv8bgq5+7cizkS+PchiWczsmsFAqQ4phbDm99xA+wz0Rq0iG4SpkNij5Xin0bvGDdVOQ1sU5HPlIePheEZQ==",
       "dependencies": {
         "@apollo/client": "^3.2.7",
         "core-js": "^3.8.3",
@@ -1844,12 +1845,14 @@
       "link": true
     },
     "node_modules/@decidim/voting_schemes-dummy": {
-      "version": "0.22.3",
-      "integrity": "sha512-Z5CwSUJNYW2KkoE5anAqAIwHnQHqpgGL4Xu2I7YqEn3thThlbWlY9U9Eq0O6fq7/pfBQLiAFFiBBAnCDv0HC2g=="
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-dummy/-/voting_schemes-dummy-0.23.0.tgz",
+      "integrity": "sha512-pTXJm6HsL4RmuR9TfKih8iShUk5WK6jZBUESl+T+XDXs4x60Sxi8xJ8GxUb+keTUgYG3hecYnlPez9Okc4WYqw=="
     },
     "node_modules/@decidim/voting_schemes-electionguard": {
-      "version": "0.22.3",
-      "integrity": "sha512-RZn/1GO5PM6a2SuN8h/SoS4EeLYnHPWw6/tl2M26ms/Xzf1ewJIgBSiByxk4qHoqvE892rccH4+G56h6iVrIqg=="
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-electionguard/-/voting_schemes-electionguard-0.23.0.tgz",
+      "integrity": "sha512-o5/UXRc6v0Cp2BG/MtNpVAEtyNO3VdfFjJSX75E5W7G2yIu7na+D1HZyHyqIk1rgHPqdJmdg0DT7JI16fDcbXQ=="
     },
     "node_modules/@decidim/webpacker": {
       "resolved": "packages/webpacker",
@@ -17181,9 +17184,9 @@
       "version": "0.27.0-dev",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@decidim/decidim-bulletin_board": "0.22.3",
-        "@decidim/voting_schemes-dummy": "0.22.3",
-        "@decidim/voting_schemes-electionguard": "0.22.3"
+        "@decidim/decidim-bulletin_board": "0.23.0",
+        "@decidim/voting_schemes-dummy": "0.23.0",
+        "@decidim/voting_schemes-electionguard": "0.23.0"
       }
     },
     "packages/eslint-config": {
@@ -19800,8 +19803,9 @@
       }
     },
     "@decidim/decidim-bulletin_board": {
-      "version": "0.22.3",
-      "integrity": "sha512-LN7wIK9IB9Zegr++fvEY2vAWdUvReLPCe3sbPMGadX3b2aurrx/SK3B38OfRdN2eqblksMzyNYtXALszA9dU2w==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@decidim/decidim-bulletin_board/-/decidim-bulletin_board-0.23.0.tgz",
+      "integrity": "sha512-kCFVv8bgq5+7cizkS+PchiWczsmsFAqQ4phbDm99xA+wz0Rq0iG4SpkNij5Xin0bvGDdVOQ1sU5HPlIePheEZQ==",
       "requires": {
         "@apollo/client": "^3.2.7",
         "core-js": "^3.8.3",
@@ -19828,9 +19832,9 @@
     "@decidim/elections": {
       "version": "file:packages/elections",
       "requires": {
-        "@decidim/decidim-bulletin_board": "0.22.3",
-        "@decidim/voting_schemes-dummy": "0.22.3",
-        "@decidim/voting_schemes-electionguard": "0.22.3"
+        "@decidim/decidim-bulletin_board": "0.23.0",
+        "@decidim/voting_schemes-dummy": "0.23.0",
+        "@decidim/voting_schemes-electionguard": "0.23.0"
       }
     },
     "@decidim/eslint-config": {
@@ -19842,12 +19846,14 @@
       "requires": {}
     },
     "@decidim/voting_schemes-dummy": {
-      "version": "0.22.3",
-      "integrity": "sha512-Z5CwSUJNYW2KkoE5anAqAIwHnQHqpgGL4Xu2I7YqEn3thThlbWlY9U9Eq0O6fq7/pfBQLiAFFiBBAnCDv0HC2g=="
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-dummy/-/voting_schemes-dummy-0.23.0.tgz",
+      "integrity": "sha512-pTXJm6HsL4RmuR9TfKih8iShUk5WK6jZBUESl+T+XDXs4x60Sxi8xJ8GxUb+keTUgYG3hecYnlPez9Okc4WYqw=="
     },
     "@decidim/voting_schemes-electionguard": {
-      "version": "0.22.3",
-      "integrity": "sha512-RZn/1GO5PM6a2SuN8h/SoS4EeLYnHPWw6/tl2M26ms/Xzf1ewJIgBSiByxk4qHoqvE892rccH4+G56h6iVrIqg=="
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-electionguard/-/voting_schemes-electionguard-0.23.0.tgz",
+      "integrity": "sha512-o5/UXRc6v0Cp2BG/MtNpVAEtyNO3VdfFjJSX75E5W7G2yIu7na+D1HZyHyqIk1rgHPqdJmdg0DT7JI16fDcbXQ=="
     },
     "@decidim/webpacker": {
       "version": "file:packages/webpacker",

--- a/packages/elections/package.json
+++ b/packages/elections/package.json
@@ -10,8 +10,8 @@
   "author": "Decidim Contributors",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@decidim/decidim-bulletin_board": "0.22.3",
-    "@decidim/voting_schemes-dummy": "0.22.3",
-    "@decidim/voting_schemes-electionguard": "0.22.3"
+    "@decidim/decidim-bulletin_board": "0.23.0",
+    "@decidim/voting_schemes-dummy": "0.23.0",
+    "@decidim/voting_schemes-electionguard": "0.23.0"
   }
 }


### PR DESCRIPTION
#### :tophat: What? Why?
This updates the NPM packages that the `elections` gem relies on to the newly released versions 0.23.0.

There are no differences in the NPM packages with this version, so this is just to match the version with the Ruby gems where there is a small difference for the Ruby 3 upgrade.

#### :pushpin: Related Issues
- Related to #9133, #8452, https://github.com/decidim/decidim-bulletin-board/pull/251

#### Testing
See that CI is green.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.