### PR TITLE
Cache highlighted resources for components cells

### DIFF
--- a/decidim-accountability/app/cells/decidim/accountability/highlighted_results_for_component_cell.rb
+++ b/decidim-accountability/app/cells/decidim/accountability/highlighted_results_for_component_cell.rb
@@ -40,7 +40,7 @@ module Decidim
         hash.join(Decidim.cache_key_separator)
       end
 
-      def expiry_time
+      def cache_expiry_time
         10.minutes
       end
     end

--- a/decidim-accountability/app/cells/decidim/accountability/highlighted_results_for_component_cell.rb
+++ b/decidim-accountability/app/cells/decidim/accountability/highlighted_results_for_component_cell.rb
@@ -31,6 +31,14 @@ module Decidim
       def results_count
         @results_count ||= results.count
       end
+
+      def cache_hash
+        hash = []
+        hash << "decidim/Accountability/highlighted_results_for_component"
+        hash << results.cache_key_with_version
+        hash << I18n.locale.to_s
+        hash.join(Decidim.cache_key_separator)
+      end
     end
   end
 end

--- a/decidim-accountability/app/cells/decidim/accountability/highlighted_results_for_component_cell.rb
+++ b/decidim-accountability/app/cells/decidim/accountability/highlighted_results_for_component_cell.rb
@@ -34,10 +34,14 @@ module Decidim
 
       def cache_hash
         hash = []
-        hash << "decidim/Accountability/highlighted_results_for_component"
+        hash << "decidim/accountability/highlighted_results_for_component"
         hash << results.cache_key_with_version
         hash << I18n.locale.to_s
         hash.join(Decidim.cache_key_separator)
+      end
+
+      def expiry_time
+        10.minutes
       end
     end
   end

--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
@@ -6,10 +6,6 @@ module Decidim
       class HighlightedAssembliesCell < Decidim::ViewModel
         delegate :current_user, to: :controller
 
-        cache :show, expires_in: 10.minutes, if: :perform_caching? do
-          cache_hash
-        end
-
         def show
           render if highlighted_assemblies.any?
         end
@@ -40,6 +36,10 @@ module Decidim
           hash = []
           hash.push(I18n.locale)
           hash.join(Decidim.cache_key_separator)
+        end
+
+        def expiry_time
+          10.minutes
         end
       end
     end

--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
@@ -38,7 +38,7 @@ module Decidim
           hash.join(Decidim.cache_key_separator)
         end
 
-        def expiry_time
+        def cache_expiry_time
           10.minutes
         end
       end

--- a/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
@@ -30,7 +30,7 @@ module Decidim
           hash.join(Decidim.cache_key_separator)
         end
 
-        def expiry_time
+        def cache_expiry_time
           10.minutes
         end
       end

--- a/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
@@ -6,10 +6,6 @@ module Decidim
       class HighlightedConferencesCell < Decidim::ViewModel
         delegate :current_user, to: :controller
 
-        cache :show, expires_in: 10.minutes, if: :perform_caching? do
-          cache_hash
-        end
-
         def show
           render if highlighted_conferences.any?
         end
@@ -32,6 +28,10 @@ module Decidim
           hash = []
           hash.push(I18n.locale)
           hash.join(Decidim.cache_key_separator)
+        end
+
+        def expiry_time
+          10.minutes
         end
       end
     end

--- a/decidim-core/app/cells/decidim/content_blocks/stats_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/stats_cell.rb
@@ -3,10 +3,6 @@
 module Decidim
   module ContentBlocks
     class StatsCell < Decidim::ViewModel
-      cache :show, expires_in: 10.minutes, if: :perform_caching? do
-        cache_hash
-      end
-
       def stats
         @stats ||= HomeStatsPresenter.new(organization: current_organization)
       end
@@ -17,6 +13,10 @@ module Decidim
         hash = []
         hash.push(I18n.locale)
         hash.join(Decidim.cache_key_separator)
+      end
+
+      def expiry_time
+        10.minutes
       end
     end
   end

--- a/decidim-core/app/cells/decidim/content_blocks/stats_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/stats_cell.rb
@@ -15,7 +15,7 @@ module Decidim
         hash.join(Decidim.cache_key_separator)
       end
 
-      def expiry_time
+      def cache_expiry_time
         10.minutes
       end
     end

--- a/decidim-core/lib/decidim/view_model.rb
+++ b/decidim-core/lib/decidim/view_model.rb
@@ -19,7 +19,7 @@ module Decidim
 
     delegate :current_organization, to: :controller
 
-    cache :show, if: :perform_caching? do
+    cache :show, if: :perform_caching?, expires_in: :expiry_time do
       cache_hash
     end
 
@@ -57,6 +57,10 @@ module Decidim
     end
 
     def cache_hash
+      nil
+    end
+
+    def expiry_time
       nil
     end
 

--- a/decidim-core/lib/decidim/view_model.rb
+++ b/decidim-core/lib/decidim/view_model.rb
@@ -19,7 +19,7 @@ module Decidim
 
     delegate :current_organization, to: :controller
 
-    cache :show, if: :perform_caching?, expires_in: :expiry_time do
+    cache :show, if: :perform_caching?, expires_in: :cache_expiry_time do
       cache_hash
     end
 
@@ -60,7 +60,7 @@ module Decidim
       nil
     end
 
-    def expiry_time
+    def cache_expiry_time
       nil
     end
 

--- a/decidim-elections/app/cells/decidim/votings/content_blocks/highlighted_votings_cell.rb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/highlighted_votings_cell.rb
@@ -36,7 +36,7 @@ module Decidim
           hash.join(Decidim.cache_key_separator)
         end
 
-        def expiry_time
+        def cache_expiry_time
           10.minutes
         end
       end

--- a/decidim-elections/app/cells/decidim/votings/content_blocks/highlighted_votings_cell.rb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/highlighted_votings_cell.rb
@@ -6,10 +6,6 @@ module Decidim
       class HighlightedVotingsCell < Decidim::ViewModel
         delegate :current_user, to: :controller
 
-        cache :show, expires_in: 10.minutes, if: :perform_caching? do
-          cache_hash
-        end
-
         def show
           render if highlighted_votings.any?
         end
@@ -38,6 +34,10 @@ module Decidim
           hash = []
           hash.push(I18n.locale)
           hash.join(Decidim.cache_key_separator)
+        end
+
+        def expiry_time
+          10.minutes
         end
       end
     end

--- a/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component_cell.rb
@@ -44,6 +44,15 @@ module Decidim
       def upcoming_meetings_count
         @upcoming_meetings_count ||= meetings.upcoming.count
       end
+
+      def cache_hash
+        hash = []
+        hash << "decidim/meetings/highlighted_meetings_for_component"
+        hash << meetings.cache_key_with_version
+        hash.push(current_user.try(:id))
+        hash << I18n.locale.to_s
+        hash.join(Decidim.cache_key_separator)
+      end
     end
   end
 end

--- a/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component_cell.rb
@@ -29,6 +29,14 @@ module Decidim
       def proposals_count
         @proposals_count ||= proposals.count
       end
+
+      def cache_hash
+        hash = []
+        hash << "decidim/proposals/highlighted_proposals_for_component"
+        hash << proposals.cache_key_with_version
+        hash << I18n.locale.to_s
+        hash.join(Decidim.cache_key_separator)
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

* This PR improves performance of participatory processes show action by caching all highlighted resources associated to components defined in the participatory space
* It also adds a small refactor to allow to define an expiry_time on cells in a similar way to how a cache_hash is defined. By default expiry_time is nil which means no expiration
* Some cached cells have an expiry time of 10 minutes because they have a random factor

##### Metrics

Data obtained from appsignal data of staging applicaction, with a participatory space created with seeds. Time in ms.

The main improvement is observed in the times of action_view. After caching the action_view times of the cells are not present

*Before optimization*

  | Mean | Sample 1 | Sample 2 | Sample 3 | Sample 4 | Sample 5
-- | -- | -- | -- | -- | -- | --
action_view | 425,4 | 515 | 391 | 408 | 371 | 442
active_record | 127,4 | 155 | 151 | 97 | 105 | 129
action_controller | 11,2 | 14 | 11 | 9 | 8 | 14
active_support | 3,8 | 10 | 3 | 2 | 2 | 2
cells | 1,6 | 3 | 1 | 1 | 1 | 2


ActionView cells renders times:

   | Mean | Sample 1 | Sample 2 | Sample 3 | Sample 4 | Sample 5
-- | -- | -- | -- | -- | -- | --
highlighted_proposals cell | 119,6 | 223 | 118 | 75 | 79 | 103
accountability highlighted results | 34,8 | 45 | 29 | 28 | 33 | 39

*After optimization*

  | Mean | Sample 1 | Sample 2 | Sample 3 | Sample 4 | Sample 5
-- | -- | -- | -- | -- | -- | --
action_view | 317,4 | 242 | 347 | 295 | 329 | 374
active_record | 83 | 61 | 78 | 77 | 92 | 107
action_controller | 10,6 | 9 | 10 | 13 | 10 | 11
active_support | 0,82 | 0,7 | 1 | 0,8 | 0,8 | 0,8
cells | 0,72 | 0,5 | 0,8 | 0,7 | 0,8 | 0,8



#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #8471

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
