### PR TITLE
Load comments with ajax

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comment_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comment_cell.rb
@@ -186,11 +186,11 @@ module Decidim
       end
 
       def has_replies?
-        model.comment_threads.includes(:moderation).collect { |c| !c.deleted? && !c.hidden? }.any?
+        model.comment_threads.not_hidden.not_deleted.exists?
       end
 
       def has_replies_in_children?
-        has_replies? || model.comment_threads.includes(:moderation).collect { |t| t.comment_threads.includes(:moderation).collect { |c| !c.deleted? && !c.hidden? }.any? }.any?
+        model.descendants.where(decidim_commentable_type: "Decidim::Comments::Comment").not_hidden.not_deleted.exists?
       end
 
       # action_authorization_button expects current_component to be available

--- a/decidim-comments/app/cells/decidim/comments/comments/comments_loading.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/comments_loading.erb
@@ -1,0 +1,4 @@
+<div class="callout primary loading-comments">
+  <p><%= t("decidim.components.comments.loading") %></p>
+</div>
+

--- a/decidim-comments/app/cells/decidim/comments/comments/comments_loading.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/comments_loading.erb
@@ -1,4 +1,3 @@
 <div class="callout primary loading-comments">
   <p><%= t("decidim.components.comments.loading") %></p>
 </div>
-

--- a/decidim-comments/app/cells/decidim/comments/comments/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/show.erb
@@ -16,6 +16,7 @@
       <%= single_comment_warning %>
       <%= blocked_comments_warning %>
       <div class="comment-threads">
+        <%= comments_loading %>
         <% comments.each do |comment| %>
           <%= cell("decidim/comments/comment_thread", comment, order: order) %>
         <% end %>

--- a/decidim-comments/app/cells/decidim/comments/comments_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comments_cell.rb
@@ -22,6 +22,12 @@ module Decidim
         render :single_comment_warning
       end
 
+      def comments_loading
+        return if single_comment?
+
+        render :comments_loading
+      end
+
       def blocked_comments_warning
         return unless comments_blocked?
         return unless user_comments_blocked?

--- a/decidim-comments/app/cells/decidim/comments/comments_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comments_cell.rb
@@ -43,11 +43,7 @@ module Decidim
       end
 
       def comments
-        if single_comment?
-          [single_comment]
-        else
-          SortedComments.for(model, order_by: order)
-        end
+        single_comment? ? [single_comment] : []
       end
 
       def comments_count
@@ -97,15 +93,8 @@ module Decidim
           commentableGid: model.to_signed_global_id.to_s,
           commentsUrl: decidim_comments.comments_path,
           rootDepth: root_depth,
-          lastCommentId: last_comment_id,
           order: order
         }
-      end
-
-      def last_comment_id
-        Decidim::Comments::Comment.where(
-          root_commentable: model
-        ).order(:id).pluck(:id).last
       end
 
       def single_comment?

--- a/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
+++ b/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
@@ -23,6 +23,12 @@ module Decidim
           order_by: order,
           after: params.fetch(:after, 0).to_i
         )
+        @comments = @comments.reject do |comment|
+          next if comment.depth < 1
+          next if !comment.deleted? && !comment.hidden?
+
+          comment.commentable.descendants.where(decidim_commentable_type: "Decidim::Comments::Comment").not_hidden.not_deleted.blank?
+        end
         @comments_count = commentable.comments_count
 
         respond_to do |format|

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -16,6 +16,7 @@ module Decidim
       include Decidim::Searchable
       include Decidim::TranslatableResource
       include Decidim::TranslatableAttributes
+      include Decidim::ActsAsTree
 
       # Limit the max depth of a comment tree. If C is a comment and R is a reply:
       # C          (depth 0)
@@ -26,6 +27,8 @@ module Decidim
       MAX_DEPTH = 3
 
       translatable_fields :body
+
+      parent_item_foreign_key :decidim_commentable_id
 
       belongs_to :commentable, foreign_key: "decidim_commentable_id", foreign_type: "decidim_commentable_type", polymorphic: true
       belongs_to :root_commentable, foreign_key: "decidim_root_commentable_id", foreign_type: "decidim_root_commentable_type", polymorphic: true, touch: true

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -93,7 +93,6 @@ export default class CommentsComponent {
     const $comment = $(replyHtml);
     const $replies = $(`#comment-${commentId}-replies`);
     this._addComment($replies, $comment);
-    $replies.siblings(".comment__additionalreply").removeClass("hide");
     this._finalizeCommentCreation($parent, fromCurrentUser);
   }
 

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -170,7 +170,10 @@ export default class CommentsComponent {
     $target.append($container);
     $container.foundation();
     this._initializeComments($container);
-    createCharacterCounter($(".add-comment textarea", $container));
+    let $newCommentTextarea = $(".add-comment textarea", $container);
+    if ($newCommentTextarea.length) {
+      createCharacterCounter();
+    }
     $container.find('a[target="_blank"]').each((_i, elem) => {
       const $link = $(elem);
       $link.data("external-link", new ExternalLink($link));

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -26,6 +26,7 @@ export default class CommentsComponent {
     this.lastCommentId = config.lastCommentId;
     this.pollingInterval = config.pollingInterval || 15000;
     this.singleComment = config.singleComment;
+    this.toggleTranslations = config.toggleTranslations;
     this.id = this.$element.attr("id") || this._getUID();
     this.mounted = false;
   }
@@ -144,7 +145,8 @@ export default class CommentsComponent {
         data: new URLSearchParams({
           "commentable_gid": this.commentableGid,
           "root_depth": this.rootDepth,
-          "order": this.order
+          "order": this.order,
+          ...(this.toggleTranslations && { "toggle_translations": this.toggleTranslations })
         }),
         success: this._pollComments()
       })
@@ -221,7 +223,8 @@ export default class CommentsComponent {
           "commentable_gid": this.commentableGid,
           "root_depth": this.rootDepth,
           "order": this.order,
-          "after": this.lastCommentId
+          "after": this.lastCommentId,
+          ...(this.toggleTranslations && { "toggle_translations": this.toggleTranslations })
         }),
         success: this._pollComments()
       })

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -93,6 +93,7 @@ export default class CommentsComponent {
     const $comment = $(replyHtml);
     const $replies = $(`#comment-${commentId}-replies`);
     this._addComment($replies, $comment);
+    $replies.siblings(".comment__additionalreply").removeClass("hide");
     this._finalizeCommentCreation($parent, fromCurrentUser);
   }
 

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -23,6 +23,7 @@ export default class CommentsComponent {
     this.order = config.order;
     this.lastCommentId = config.lastCommentId;
     this.pollingInterval = config.pollingInterval || 15000;
+    this.singleComment = config.singleComment;
     this.id = this.$element.attr("id") || this._getUID();
     this.mounted = false;
   }
@@ -134,7 +135,18 @@ export default class CommentsComponent {
       }
     });
 
-    this._pollComments();
+    if (!this.singleComment) {
+      Rails.ajax({
+        url: this.commentsUrl,
+        type: "GET",
+        data: new URLSearchParams({
+          "commentable_gid": this.commentableGid,
+          "root_depth": this.rootDepth,
+          "order": this.order
+        }),
+        success: this._pollComments()
+      })
+    }
   }
 
   /**

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -170,10 +170,7 @@ export default class CommentsComponent {
     $target.append($container);
     $container.foundation();
     this._initializeComments($container);
-    let $newCommentTextarea = $(".add-comment textarea", $container);
-    if ($newCommentTextarea.length) {
-      createCharacterCounter();
-    }
+    createCharacterCounter($(".add-comment textarea", $container));
     $container.find('a[target="_blank"]').each((_i, elem) => {
       const $link = $(elem);
       $link.data("external-link", new ExternalLink($link));

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -139,17 +139,7 @@ export default class CommentsComponent {
     });
 
     if (!this.singleComment) {
-      Rails.ajax({
-        url: this.commentsUrl,
-        type: "GET",
-        data: new URLSearchParams({
-          "commentable_gid": this.commentableGid,
-          "root_depth": this.rootDepth,
-          "order": this.order,
-          ...(this.toggleTranslations && { "toggle_translations": this.toggleTranslations })
-        }),
-        success: this._pollComments()
-      })
+      this._fetchComments();
     }
   }
 
@@ -216,19 +206,30 @@ export default class CommentsComponent {
     this._stopPolling();
 
     this.pollTimeout = setTimeout(() => {
-      Rails.ajax({
-        url: this.commentsUrl,
-        type: "GET",
-        data: new URLSearchParams({
-          "commentable_gid": this.commentableGid,
-          "root_depth": this.rootDepth,
-          "order": this.order,
-          "after": this.lastCommentId,
-          ...(this.toggleTranslations && { "toggle_translations": this.toggleTranslations })
-        }),
-        success: this._pollComments()
-      })
+      this._fetchComments();
     }, this.pollingInterval);
+  }
+
+  /**
+   * Sends an ajax request based on current
+   * params to get comments for the component
+   * @private
+   * @returns {Void} - Returns nothing
+   */
+  _fetchComments() {
+    Rails.ajax({
+      url: this.commentsUrl,
+      type: "GET",
+      data: new URLSearchParams({
+        "commentable_gid": this.commentableGid,
+        "root_depth": this.rootDepth,
+        "order": this.order,
+        "after": this.lastCommentId,
+        ...(this.toggleTranslations && { "toggle_translations": this.toggleTranslations }),
+        ...(this.lastCommentId && { "after": this.lastCommentId })
+      }),
+      success: this._pollComments()
+    })
   }
 
   /**

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -40,6 +40,9 @@ export default class CommentsComponent {
     if (this.$element.length > 0 && !this.mounted) {
       this.mounted = true;
       this._initializeComments(this.$element);
+      if (!this.singleComment) {
+        this._fetchComments();
+      }
 
       $(".order-by__dropdown .is-submenu-item a", this.$element).on("click.decidim-comments", () => this._onInitOrder());
     }
@@ -137,10 +140,6 @@ export default class CommentsComponent {
         $text.get(0).addEventListener("emoji.added", this._onTextInput);
       }
     });
-
-    if (!this.singleComment) {
-      this._fetchComments();
-    }
   }
 
   /**

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -1,4 +1,6 @@
 /* eslint id-length: ["error", { "exceptions": ["$"] }] */
+/* eslint max-lines: ["error", {"max": 350, "skipBlankLines": true}] */
+
 
 /**
  * A plain Javascript component that handles the comments.

--- a/decidim-comments/app/views/decidim/comments/comments/index.js.erb
+++ b/decidim-comments/app/views/decidim/comments/comments/index.js.erb
@@ -4,6 +4,7 @@
   var $comments = $("#" + rootCommentableId);
   var component = $comments.data("comments");
 
+  $(".loading-comments").addClass("hide");
 <% @comments.each do |comment| %>
   var commentId = <%= comment.id.to_json %>;
   var commentHtml = '<%== j(render comment).strip %>';

--- a/decidim-comments/app/views/decidim/comments/comments/reload.js.erb
+++ b/decidim-comments/app/views/decidim/comments/comments/reload.js.erb
@@ -6,6 +6,7 @@
   component.unmountComponent();
 
   var commentsHtml = '<%== j(render partial: "comments").strip %>';
+  $(".loading-comments").addClass("hide");
   $comments.replaceWith(commentsHtml);
 
   $comments = $("#" + rootCommentableId);

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -19,7 +19,7 @@ module Decidim::Comments
       it "renders the thread" do
         expect(subject).to have_css(".section-heading", text: "1 comment")
         expect(subject).to have_css(".callout.primary.loading-comments p", text: "Loading comments ...")
-        expect(subject).to have_content(comment.body.values.first)
+        expect(subject).to have_no_content(comment.body.values.first)
         expect(subject).to have_css(".add-comment")
         expect(subject).to have_content("Sign in with your account or sign up to add your comment.")
 

--- a/decidim-core/app/packs/src/decidim/input_character_counter.js
+++ b/decidim-core/app/packs/src/decidim/input_character_counter.js
@@ -274,7 +274,7 @@ export default class InputCharacterCounter {
 }
 
 const createCharacterCounter = ($input) => {
-  if ($input !== undefined && $input.length) {
+  if (typeof $input !== "undefined" && $input.length) {
     $input.data("remaining-characters-counter", new InputCharacterCounter($input));
   }
 }

--- a/decidim-core/app/packs/src/decidim/input_character_counter.js
+++ b/decidim-core/app/packs/src/decidim/input_character_counter.js
@@ -274,7 +274,9 @@ export default class InputCharacterCounter {
 }
 
 const createCharacterCounter = ($input) => {
-  $input.data("remaining-characters-counter", new InputCharacterCounter($input));
+  if ($input !== undefined && $input.length) {
+    $input.data("remaining-characters-counter", new InputCharacterCounter($input));
+  }
 }
 
 $(() => {

--- a/decidim-core/lib/decidim/acts_as_tree.rb
+++ b/decidim-core/lib/decidim/acts_as_tree.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ActsAsTree
+    extend ActiveSupport::Concern
+
+    included do
+      @parent_item_foreign_key = :parent_id
+    end
+
+    class_methods do
+      def parent_item_foreign_key(name = nil)
+        return @parent_item_foreign_key unless name
+
+        @parent_item_foreign_key = name
+      end
+
+      def tree_for(item)
+        where(Arel.sql("#{table_name}.id IN (#{tree_sql_for(item)})")).order("#{table_name}.id")
+      end
+
+      def tree_sql_for(item)
+        <<-SQL.squish
+        WITH RECURSIVE search_tree(id, path) AS (
+          SELECT id, ARRAY[id]
+          FROM #{table_name}
+          WHERE id = #{item.id}
+            UNION ALL
+          SELECT #{table_name}.id, path || #{table_name}.id
+            FROM search_tree
+          JOIN #{table_name} ON #{table_name}.#{parent_item_foreign_key} = search_tree.id
+            WHERE NOT #{table_name}.id = ANY(path)
+        )
+        SELECT id FROM search_tree ORDER BY path
+        SQL
+      end
+    end
+
+    def descendants
+      @descendants ||= self_and_descendants.where.not(id: id)
+    end
+
+    def self_and_descendants
+      @self_and_descendants ||= self.class.tree_for(self)
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -9,6 +9,7 @@ module Decidim
   autoload :Env, "decidim/env"
   autoload :Deprecations, "decidim/deprecations"
   autoload :ActsAsAuthor, "decidim/acts_as_author"
+  autoload :ActsAsTree, "decidim/acts_as_tree"
   autoload :TranslatableAttributes, "decidim/translatable_attributes"
   autoload :TranslatableResource, "decidim/translatable_resource"
   autoload :JsonbAttributes, "decidim/jsonb_attributes"


### PR DESCRIPTION
#### :tophat: What? Why?

This PR avoids loading all comments in the comments cell and loads them using javascript instead. In this way pages containing comments like the proposals or meetings show pages are loaded with similar times regardless of the number of comments they may contain.

##### Metrics

Data obtained from appsignal data of staging applicaction, with the show page of a meeting with 6 comments. Time in ms.

The time to load the comments partial (with a loading comments message initially) is significantly reduced.

*Before optimization*

  | Mean | Sample 1 | Sample 2 | Sample 3 | Sample 4 | Sample 5
-- | -- | -- | -- | -- | -- | --
action_view | 451,2 | 396 | 463 | 443 | 507 | 447
active_record | 97,2 | 76 | 131 | 83 | 104 | 92
action_controller | 24,4 | 21 | 33 | 17 | 19 | 32
active_support | 1,2 | 1 | 1 | 1 | 2 | 1
cells | 1 | 1 | 1 | 1 | 1 | 1

Partials loading time:

  | Mean | Sample 1 | Sample 2 | Sample 3 | Sample 4 | Sample 5
-- | -- | -- | -- | -- | -- | --
comments | 206,8 | 196 | 187 | 207 | 228 | 216


*After optimization*

action_view | 245,4 | 200 | 208 | 321 | 296 | 202
-- | -- | -- | -- | -- | -- | --
active_record | 59 | 36 | 36 | 91 | 91 | 41
action_controller | 19,4 | 17 | 16 | 20 | 23 | 21
active_support | 0,52 | 0,5 | 0,5 | 0,5 | 0,6 | 0,5
cells | 0,32 | 0,3 | 0,3 | 0,3 | 0,4 | 0,3

Partials loading time:

  | Mean | Sample 1 | Sample 2 | Sample 3 | Sample 4 | Sample 5
-- | -- | -- | -- | -- | -- | --
comments | 12,4 | 11 | 9 | 18 | 16 | 8





#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #8471

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
