### PR TITLE
Homepage optimization: tune images' caches and query includes

### DIFF
--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
@@ -22,6 +22,7 @@ module Decidim
           @highlighted_assemblies ||= OrganizationPrioritizedAssemblies
                                       .new(current_organization, current_user)
                                       .query
+                                      .with_attached_hero_image
                                       .includes([:organization])
                                       .limit(max_results)
         end

--- a/decidim-conferences/app/queries/decidim/conferences/organization_prioritized_conferences.rb
+++ b/decidim-conferences/app/queries/decidim/conferences/organization_prioritized_conferences.rb
@@ -14,7 +14,7 @@ module Decidim
         Decidim::Query.merge(
           OrganizationPublishedConferences.new(@organization, @user),
           PrioritizedConferences.new
-        ).query
+        ).query.with_attached_hero_image
       end
     end
   end

--- a/decidim-core/lib/decidim/has_attachments.rb
+++ b/decidim-core/lib/decidim/has_attachments.rb
@@ -26,14 +26,14 @@ module Decidim
       #
       # Returns an Array<Attachment>
       def photos
-        @photos ||= attachments.order(:weight).select(&:photo?)
+        @photos ||= attachments.with_attached_file.order(:weight).select(&:photo?)
       end
 
       # All the attachments that are documents for this model.
       #
       # Returns an Array<Attachment>
       def documents
-        @documents ||= attachments.order(:weight).includes(:attachment_collection).select(&:document?)
+        @documents ||= attachments.with_attached_file.order(:weight).includes(:attachment_collection).select(&:document?)
       end
 
       # All the attachments that are documents for this model that has a collection.

--- a/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_meetings_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/content_blocks/upcoming_meetings_cell.rb
@@ -14,7 +14,7 @@ module Decidim
 
         def upcoming_meetings
           @upcoming_meetings ||= Decidim::Meetings::Meeting
-                                 .includes(component: :participatory_space)
+                                 .includes(:author, component: :participatory_space)
                                  .where(component: meeting_components)
                                  .visible_for(current_user)
                                  .published

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell.rb
@@ -51,7 +51,7 @@ module Decidim
                                          OrganizationPublishedParticipatoryProcesses.new(current_organization, current_user) |
                                          HighlightedParticipatoryProcesses.new |
                                          FilteredParticipatoryProcesses.new("active")
-                                       ).query.includes([:organization]).limit(highlighted_processes_max_results)
+                                       ).query.with_attached_hero_image.includes([:organization, :hero_image_attachment]).limit(highlighted_processes_max_results)
                                      end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds some eager loadings to improve performance of homepage

The main performance improvement has been made by caching some heavy content blocks, the times without caching are very high. The effect of this PR is rather small.

##### Metrics

Data obtained from appsignal data of staging applicaction.Time in ms.

The main improvement is observed in the times of action_view. After caching the action_view times of the cells are not present

*Before optimization*

Without caching the times are very high:

  | Mean | Sample 1 | Sample 2 | Sample 3 | Sample 4 | Sample 5
-- | -- | -- | -- | -- | -- | --
action_view | 1320 | 1320 | 1400 | 1290 | 1240 | 1350
active_record | 157,8 | 169 | 176 | 146 | 139 | 159
active_support | 49,6 | 89 | 40 | 41 | 37 | 41
action_controller | 19 | 20 | 18 | 20 | 19 | 18
cells | 5,8 | 6 | 7 | 5 | 5 | 6

ActionView partials render times:  

  | Mean | Sample 1 | Sample 2 | Sample 3 | Sample 4 | Sample 5
-- | -- | -- | -- | -- | -- | --
last_activity content block | 943,2 | 938 | 922 | 962 | 898 | 996
stats content block | 147,4 | 164 | 145 | 144 | 132 | 152
upcoming_meetings content block | 50 | 56 | 47 | 53 | 44 | 50


Using cached content blocks:


  | Mean | Sample 1 | Sample 2 | Sample 3 | Sample 4 | Sample 5
-- | -- | -- | -- | -- | -- | --
action_view | 472 | 664 | 422 | 457 | 390 | 427
active_record | 87 | 101 | 80 | 110 | 71 | 73
action_controller | 6,8 | 7 | 8 | 6 | 7 | 6
active_support | 2 | 2 | 2 | 2 | 2 | 2
cells | 1,6 | 2 | 2 | 2 | 1 | 1

The times of the content blocks with action_view disappear because they are cached


*After optimization*
(The content blocks remain cached)

  | Mean | Sample 1 | Sample 2 | Sample 3 | Sample 4 | Sample 5
-- | -- | -- | -- | -- | -- | --
action_view | 423,2 | 413 | 374 | 387 | 421 | 521
active_record | 111,6 | 140 | 66 | 109 | 132 | 111
action_controller | 7,4 | 7 | 7 | 7 | 10 | 6
active_support | 2,4 | 2 | 2 | 2 | 3 | 3
cells | 1,6 | 1 | 1 | 2 | 2 | 2


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #8471

:hearts: Thank you!
