### PR TITLE
Add edit and delete actions in InitiativeType admin table

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
@@ -14,7 +14,7 @@
 
     <div class="row">
       <div class="columns xlarge-6">
-        <%= form.upload :banner_image %>
+        <%= form.upload :banner_image, optional: false %>
       </div>
     </div>
   </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/index.html.erb
@@ -27,7 +27,29 @@
                 <%= translated_attribute initiative_type.title %></td>
               <% end %>
             <td><%= l initiative_type.created_at, format: :short %></td>
-            <td class="table-list__actions"><%= free_resource_permissions_link(initiative_type) %></td>
+            <td class="table-list__actions">
+              <% if allowed_to? :update, :initiative_type, initiative_type: initiative_type %>
+                <%= icon_link_to "pencil",
+                                 edit_initiatives_type_path(initiative_type),
+                                 t("actions.configure", scope: "decidim.admin"),
+                                 class: "action-icon--edit" %>
+              <% else %>
+                <span class="action-space icon"></span>
+              <% end %>
+
+              <%= free_resource_permissions_link(initiative_type) %>
+
+              <% if allowed_to? :destroy, :initiative_type, initiative_type: initiative_type %>
+                <%= icon_link_to "circle-x",
+                                 initiative_type,
+                                 t("actions.destroy", scope: "decidim.admin"),
+                                 class: "action-icon--remove",
+                                 method: :delete,
+                                 data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+              <% else %>
+                <span class="action-space icon"></span>
+              <% end %>
+            </td>
           <% end %>
         </tbody>
       </table>

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_scopes_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_scopes_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "InitiativeTypeScopesController", type: :system do
+describe "Admin manages initiatives types scopes", type: :system do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, :confirmed, organization: organization) }
   let(:initiatives_type) { create :initiatives_type, organization: organization }

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_spec.rb
@@ -5,24 +5,22 @@ require "spec_helper"
 describe "Admin manages initiatives types", type: :system do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+  let!(:initiatives_type) { create(:initiatives_type, organization: organization) }
 
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
+    visit decidim_admin_initiatives.initiatives_types_path
   end
 
   context "when accessing initiative types list" do
-    let!(:initiative_type) { create :initiatives_type, organization: organization }
-
-    it "Shows the initiative type data" do
-      visit decidim_admin_initiatives.initiatives_types_path
-      expect(page).to have_i18n_content(initiative_type.title)
+    it "shows the initiative type data" do
+      expect(page).to have_i18n_content(initiatives_type.title)
     end
   end
 
   context "when creating an initiative type" do
     it "creates the initiative type" do
-      visit decidim_admin_initiatives.initiatives_types_path
       click_link "New initiative type"
 
       fill_in_i18n(
@@ -50,18 +48,10 @@ describe "Admin manages initiatives types", type: :system do
   end
 
   context "when updating an initiative type" do
-    let(:initiatives_type) do
-      create(:initiatives_type,
-             :online_signature_enabled,
-             :attachments_disabled,
-             :undo_online_signatures_enabled,
-             :custom_signature_end_date_disabled,
-             :area_disabled,
-             organization: organization)
-    end
-
-    it "Updates the initiative type" do
-      visit decidim_admin_initiatives.edit_initiatives_type_path(initiatives_type)
+    it "updates the initiative type" do
+      within find("tr", text: translated(initiatives_type.title)) do
+        page.find(".action-icon--edit").click
+      end
 
       fill_in_i18n(
         :initiatives_type_title,
@@ -84,12 +74,12 @@ describe "Admin manages initiatives types", type: :system do
   end
 
   context "when deleting an initiative type" do
-    let(:initiatives_type) { create :initiatives_type, organization: organization }
-
-    it "Deletes the initiative type" do
-      visit decidim_admin_initiatives.edit_initiatives_type_path(initiatives_type)
-
-      accept_confirm { click_link "Delete" }
+    it "deletes the initiative type" do
+      within find("tr", text: translated(initiatives_type.title)) do
+        accept_confirm do
+          page.find(".action-icon--remove").click
+        end
+      end
 
       within ".callout-wrapper" do
         expect(page).to have_content("The initiative type has been successfully removed")

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "InitiativeTypesController", type: :system do
+describe "Admin manages initiatives types", type: :system do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, :confirmed, organization: organization) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

In admin's Initiative Type  we don't show the Edit and Delete icons as we already do in other sections. This PR adds them.

While working on this, I also found that the Initiative Type form didn't show an error when saving the form without adding the Banner image. This is also fixed here. 

#### :pushpin: Related Issues

- Fixes  #9150

#### Testing

##### Initiative type icons

1. Sign in as admin 
2. Create an initiative type
3. Go to the table and see that you have the actions Edit (Pencil icon) and also Delete (with the X icon) 

##### Initiative type banner image button

1. Sign in as admin 
2. Go to the /admin/initiatives_types and click on "New initiative type" button 
3. Fill the title and description
4. Click on Create button
5. See that there is an error in the banner image (before there wasn't) 

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/717367/162441610-fc9b652b-4e37-4344-af13-9d713af7d1c3.png)

:hearts: Thank you!
