### PR TITLE
Fix vote reminder email urls

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/vote_reminder_mailer/vote_reminder.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/vote_reminder_mailer/vote_reminder.html.erb
@@ -7,7 +7,7 @@
   <li>
     <%= link_to(
       translated_attribute(order.budget.title),
-      routes.budget_path(order.budget)
+      routes.budget_url(order.budget)
     ) %>
   </li>
   <% end %>
@@ -17,5 +17,5 @@
 
 <%= link_to(
   t(".email_link"),
-  routes.root_path
+  routes.root_url
 ) %>

--- a/decidim-budgets/app/views/decidim/budgets/vote_reminder_mailer/vote_reminder.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/vote_reminder_mailer/vote_reminder.html.erb
@@ -7,7 +7,7 @@
   <li>
     <%= link_to(
       translated_attribute(order.budget.title),
-      routes.budget_url(order.budget)
+      routes.budget_url(order.budget, host: @organization.host)
     ) %>
   </li>
   <% end %>
@@ -17,5 +17,5 @@
 
 <%= link_to(
   t(".email_link"),
-  routes.root_url
+  routes.root_url(host: @organization.host)
 ) %>

--- a/decidim-budgets/spec/mailers/decidim/budgets/vote_reminder_mailer_spec.rb
+++ b/decidim-budgets/spec/mailers/decidim/budgets/vote_reminder_mailer_spec.rb
@@ -26,11 +26,11 @@ module Decidim::Budgets
         end
 
         it "includes link to the budget" do
-          expect(mail).to have_link(budget.title["en"], href: router.budget_path(budget))
+          expect(mail).to have_link(budget.title["en"], href: router.budget_url(budget))
         end
 
         it "includes link to the component" do
-          expect(mail).to have_link("Go to continue voting", href: router.root_path)
+          expect(mail).to have_link("Go to continue voting", href: router.root_url)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Reminder emails in #8621 are broken (they work only locally), because they are missing hosts.
For example when link href should be ```https:///www.example.org/processes/f/13``` it's just ```/processes/f/13```

#### :pushpin: Related Issues
#8621

#### Testing
See #8621testing but inspect email links.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/162467463-4bafc3f2-2fc5-4203-9b3e-047efc373841.png)

:hearts: Thank you!
