### PR TITLE
Move modal to body and fix condition

### DIFF
--- a/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
@@ -85,7 +85,7 @@ module Decidim
       end
 
       def iframe_embed_or_live_event_page?(meeting)
-        meeting.iframe_embed_type == ("embed_in_meeting_page" || "open_in_live_event_page")
+        %w(embed_in_meeting_page open_in_live_event_page).include? meeting.iframe_embed_type
       end
     end
   end

--- a/decidim-meetings/app/views/decidim/meetings/layouts/live_event.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/layouts/live_event.html.erb
@@ -5,10 +5,10 @@
     <%= render partial: "layouts/decidim/head" %>
     <%= javascript_pack_tag "decidim_meetings" %>
     <%= render partial: "layouts/decidim/js_configuration" %>
-    <%= render partial: "layouts/decidim/timeout_modal" %>
   </head>
 
   <body>
+    <%= render partial: "layouts/decidim/timeout_modal" %>
     <header class="meeting-polls__header">
       <% if current_user && poll %>
         <div class="flex--cc">


### PR DESCRIPTION
#### :tophat: What? Why?
In live event page timeout modal is accidentally put to [head](https://github.com/decidim/decidim/blob/develop/decidim-meetings/app/views/decidim/meetings/layouts/live_event.html.erb#L8) when it should be inside the ```<body></body>```. Also [prevent_timeout_seconds](https://github.com/decidim/decidim/blob/develop/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb#L88) returns false when embed type is "open_in_live_event_page".

#### :pushpin: Related Issues
#9070
https://github.com/decidim/decidim/commit/05b988328ca9195462e2fb6ee9fbed854fb6c2ca#r70998612

#### Testing
1. Create live event (meeting) which is open
2. Go to live event
3. ```document.querySelector("#timeoutModal").dataset.preventTimeoutSeconds``` should return something else than "0"

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
