### PR TITLE
Fix registration type field highlighted in admin meeting creation form

### DIFF
--- a/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
@@ -114,7 +114,7 @@ $(() => {
       toggleDependsOnSelect($target, $meetingRegistrationUrl, "on_different_platform");
     });
 
-    $meetingRegistrationType.trigger("change");
+    toggleDependsOnSelect($meetingRegistrationType, $meetingRegistrationUrl, "on_different_platform");
 
     const $meetingTypeOfMeeting = $form.find("#meeting_type_of_meeting");
     const $meetingOnlineFields = $form.find(".field[data-meeting-type='online']");

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -429,6 +429,14 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
       end
     end
 
+    it "doesn't display error message when opening meeting's create form" do
+      find(".card-title a.button").click
+
+      within "label[for='meeting_registration_type']" do
+        expect(page).to have_no_content("There's an error in this field.")
+      end
+    end
+
     it "creates a new meeting", :slow do
       find(".card-title a.button").click
 


### PR DESCRIPTION
#### :tophat: What? Why?

Registration type field is already highlighted upon creating a meeting via admin

#### :pushpin: Related Issues

- Fixes #9159

#### Testing

- Login as admin
- Navigate to create meeting
- Observe the form

:hearts: Thank you!
