### PR TITLE
Seperate messages for file dimensions and size

### DIFF
--- a/decidim-assemblies/spec/commands/create_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_spec.rb
@@ -137,7 +137,7 @@ module Decidim::Assemblies
 
       it "broadcasts invalid" do
         expect { subject.call }.to broadcast(:invalid)
-        expect(form.errors.messages[:hero_image]).to contain_exactly("The image is too big")
+        expect(form.errors.messages[:hero_image]).to contain_exactly("File resolution is too large")
       end
     end
 

--- a/decidim-assemblies/spec/commands/update_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/update_assembly_spec.rb
@@ -120,7 +120,7 @@ module Decidim::Assemblies
 
         it "broadcasts invalid" do
           expect { command.call }.to broadcast(:invalid)
-          expect(form.errors.messages[:hero_image]).to contain_exactly("The image is too big")
+          expect(form.errors.messages[:hero_image]).to contain_exactly("File resolution is too large")
         end
       end
 

--- a/decidim-core/app/uploaders/decidim/cw/attachment_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/cw/attachment_uploader.rb
@@ -47,7 +47,7 @@ module Decidim::Cw
       return unless image?(self)
 
       manipulate! do |image|
-        raise CarrierWave::IntegrityError, I18n.t("carrierwave.errors.image_too_big") if image.dimensions.any? { |dimension| dimension > max_image_height_or_width }
+        raise CarrierWave::IntegrityError, I18n.t("carrierwave.errors.file_resolution_too_large") if image.dimensions.any? { |dimension| dimension > max_image_height_or_width }
 
         image
       end

--- a/decidim-core/app/uploaders/decidim/cw/image_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/cw/image_uploader.rb
@@ -48,14 +48,14 @@ module Decidim::Cw
     # See https://hackerone.com/reports/390
     def validate_dimensions
       manipulate! do |image|
-        validation_error!(I18n.t("carrierwave.errors.image_too_big")) if image.dimensions.any? { |dimension| dimension > max_image_height_or_width }
+        validation_error!(I18n.t("carrierwave.errors.file_resolution_too_large")) if image.dimensions.any? { |dimension| dimension > max_image_height_or_width }
         image
       end
     end
 
     def validate_size
       manipulate! do |image|
-        validation_error!(I18n.t("carrierwave.errors.image_too_big")) if image.size > maximum_upload_size
+        validation_error!(I18n.t("carrierwave.errors.file_too_large")) if image.size > maximum_upload_size
         image
       end
     end

--- a/decidim-core/app/validators/uploader_image_dimensions_validator.rb
+++ b/decidim-core/app/validators/uploader_image_dimensions_validator.rb
@@ -28,7 +28,7 @@ class UploaderImageDimensionsValidator < ActiveModel::Validations::FileContentTy
     return unless uploader.validable_dimensions
     return if (image = extract_image(file)).blank?
 
-    record.errors.add attribute, I18n.t("carrierwave.errors.image_too_big") if image.dimensions.any? { |dimension| dimension > uploader.max_image_height_or_width }
+    record.errors.add attribute, I18n.t("carrierwave.errors.file_resolution_too_large") if image.dimensions.any? { |dimension| dimension > uploader.max_image_height_or_width }
   end
 
   def extract_image(file)

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -69,6 +69,8 @@ en:
     'true': 'Yes'
   carrierwave:
     errors:
+      file_resolution_too_large: File resolution is too large
+      file_too_large: File size is too large
       image_too_big: The image is too big
       not_inside_organization: The file is not attached to any organization
   date:
@@ -771,6 +773,7 @@ en:
           message_2: The service crops the image.
       file_validation:
         allowed_file_extensions: 'Allowed file extensions: %{extensions}'
+        max_file_dimension: 'Maximum file dimensions: %{resolution} pixels'
         max_file_size: 'Maximum file size: %{megabytes}MB'
       upload:
         labels:
@@ -780,7 +783,7 @@ en:
           cancel: Cancel
           edit_image: Edit image
           error: Error!
-          file_too_big: 'File is too big! Maximun file size: %{megabytes}MB'
+          file_too_big: 'File size is too large! Maximun file size: %{megabytes}MB'
           remove: Remove
           replace: Replace
           save: Save

--- a/decidim-core/lib/decidim/file_validator_humanizer.rb
+++ b/decidim-core/lib/decidim/file_validator_humanizer.rb
@@ -43,6 +43,14 @@ module Decidim
         )
       end
 
+      if (file_dimensions = max_file_dimensions)
+        messages << I18n.t(
+          "max_file_dimension",
+          resolution: file_dimensions,
+          scope: "decidim.forms.file_validation"
+        )
+      end
+
       if (extensions = extension_allowlist)
         messages << I18n.t(
           "allowed_file_extensions",
@@ -79,6 +87,12 @@ module Decidim
       lte.call(passthru_record) if lte.respond_to?(:call)
     end
     # rubocop: enable Metrics/CyclomaticComplexity
+
+    def max_file_dimensions
+      return unless uploader.respond_to?(:max_image_height_or_width)
+
+      "#{uploader.max_image_height_or_width}x#{uploader.max_image_height_or_width}"
+    end
 
     def extension_allowlist
       return unless uploader.respond_to?(:extension_allowlist, true)

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -50,7 +50,7 @@ describe "Account", type: :system do
           input_element = find("input[type='file']", visible: :all)
           input_element.attach_file(Decidim::Dev.asset("5000x5000.png"))
 
-          expect(page).to have_content("The image is too big", count: 1)
+          expect(page).to have_content("File resolution is too large", count: 1)
           expect(page).to have_css(".upload-errors .form-error", count: 1)
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently image uploads doesn't give any guidance about accepted file resolution, here we add guidance. Also error message when trying to upload image with too big resolution is currently ambiguous: "File too big".

#### :pushpin: Related Issues
#9157

#### Testing
Try to upload images (e.g. identity document, new proposal, hero image)

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/163220518-e2e2c5cb-d381-46d5-bded-eb905c51c722.png)

:hearts: Thank you!
