### PR TITLE
Fix flaky factory when the user's sequence name arrives to 1234

### DIFF
--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -17,8 +17,8 @@ FactoryBot.define do
     "#{Faker::Lorem.sentence(word_count: 3)} #{n}".delete("'")
   end
 
-  sequence(:name) do |n|
-    "#{Faker::Name.name} #{n}".delete("'")
+  sequence(:name) do |_|
+    Faker::Name.name.delete("'")
   end
 
   sequence(:nickname) do |n|


### PR DESCRIPTION
#### :tophat: What? Why?

On #9164 it was detected a [flaky spec](https://github.com/decidim/decidim/runs/6026860434?check_suite_focus=true ) that comes from a seed related to #9090. 

The culprit is the sequence name, when it arrives to 1234 and the password validation kicks in. 

This PR fixes it by removing this sequence in the name. 

#### :pushpin: Related Issues
 
- Related to #9090 

#### Testing

To test  the failing, you can do it with this script:

```ruby
require "faker"
require "factory_bot"
require "decidim/core/test/factories"

FactoryBot.define do
  factory :user2, class: "Decidim::User" do
    email { "user#{rand(100..10000)}@example.org" } # Changed to skip email already taken validation
    password { "decidim123456" }
    password_confirmation { password }
    name { "#{Faker::Name.name} 1234".delete("'") } # Here's the problem if n arrives to 1234
    nickname { generate(:nickname) }
    organization { Decidim::Organization.first } # Changed to skip organization already taken validation
    tos_agreement { "1" }
  end 
end

FactoryBot.create :user2
```

:hearts: Thank you!
