### PR TITLE
Fix survey activity log entries

### DIFF
--- a/decidim-surveys/app/models/decidim/surveys/survey.rb
+++ b/decidim-surveys/app/models/decidim/surveys/survey.rb
@@ -10,6 +10,8 @@ module Decidim
 
       component_manifest_name "surveys"
 
+      delegate :title, to: :questionnaire
+
       validates :questionnaire, presence: true
 
       def clean_after_publish?

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -38,7 +38,6 @@ Decidim.register_component(:surveys) do |component|
 
   component.register_resource(:survey) do |resource|
     resource.model_class_name = "Decidim::Surveys::Survey"
-    resource.searchable = true
   end
 
   component.register_stat :surveys_count do |components, start_at, end_at|

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -36,6 +36,11 @@ Decidim.register_component(:surveys) do |component|
     raise "Can't destroy this component when there are survey answers" if survey_answers_for_component.any?
   end
 
+  component.register_resource(:survey) do |resource|
+    resource.model_class_name = "Decidim::Surveys::Survey"
+    resource.searchable = true
+  end
+
   component.register_stat :surveys_count do |components, start_at, end_at|
     surveys = Decidim::Surveys::Survey.where(component: components)
     surveys = surveys.where("created_at >= ?", start_at) if start_at.present?

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -94,6 +94,17 @@ describe "Answer a survey", type: :system do
     end
   end
 
+  context "when survey has action log entry" do
+    let!(:action_log) { create(:action_log, user: user, organization: component.organization, resource: survey, component: component, participatory_space: component.participatory_space, visibility: "all") }
+    let(:router) { Decidim::EngineRouter.main_proxy(component) }
+
+    it "shows action log entry" do
+      page.visit decidim.profile_activity_path(nickname: user.nickname)
+      expect(page).to have_content("New survey at #{translated(survey.component.participatory_space.title)}")
+      expect(page).to have_link(translated(survey.questionnaire.title), href: router.survey_path(survey))
+    end
+  end
+
   def questionnaire_public_path
     main_component_path(component)
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Seeds are creating activity log entries related to surveys, but when activity feed raises error when page has activities related to survey. This happened because resource locator can't find route for the survey because it's not registered to resources manifest. 

#### :pushpin: Related Issues
- Fixes #8464

#### Testing
Follow instructions in #8464 , note that creating survey via admin panel doesn't create activity log entry that relates to survey.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/164242437-9c292d9d-60ae-423d-bb64-acdd8f87075b.png)

:hearts: Thank you!
