### PR TITLE
Project budget amount is less than total budget

### DIFF
--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -148,7 +148,7 @@ Decidim.register_component(:budgets) do |component|
           description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
             Decidim::Faker::Localized.paragraph(sentence_count: 3)
           end,
-          budget_amount: Faker::Number.number(digits: 8)
+          budget_amount: Faker::Number.between(from: Integer(budget.total_budget * 0.7), to: budget.total_budget)
         )
 
         attachment_collection = Decidim::AttachmentCollection.create!(


### PR DESCRIPTION
#### :tophat: What? Why?
Seeds can be so annoying currently: They don't include votes (budget orders) and when user wants to create vote, it might be impossible because every project can have budget amount higher than total budget. 

#### Testing
1. Create development app
2. Sign in 
3. Go to budgets component and vote in some budget

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/164246167-e42cbbad-9ed1-430f-afd2-7adf1cec225b.png)

:hearts: Thank you!
