### PR TITLE
Fix notifications where resources are missing

### DIFF
--- a/decidim-core/app/cells/decidim/notification/show.erb
+++ b/decidim-core/app/cells/decidim/notification/show.erb
@@ -13,7 +13,7 @@
         <span class="text-small"><%= notification.event_class.constantize.model_name.human %></span>
         <br>
         <span>
-          <%= notification.event_class_instance.notification_title %>
+          <%= notification_title %>
         </span>
         <% if notification.display_resource_text? %>
           <p>

--- a/decidim-core/app/cells/decidim/notification_cell.rb
+++ b/decidim-core/app/cells/decidim/notification_cell.rb
@@ -11,6 +11,12 @@ module Decidim
       render :show
     end
 
+    def notification_title
+      notification.event_class_instance.notification_title
+    rescue StandardError
+      I18n.t("decidim.notifications.show.missing_event")
+    end
+
     private
 
     def notification

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1111,6 +1111,8 @@ en:
         translated_text: 'Automatically translated text:'
     notifications:
       no_notifications: No notifications yet.
+      show:
+        missing_event: 'Missing event: This resource is no longer available.'
     notifications_settings:
       show:
         administrators: Administrators

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1112,7 +1112,7 @@ en:
     notifications:
       no_notifications: No notifications yet.
       show:
-        missing_event: 'Missing event: This resource is no longer available.'
+        missing_event: Oops, this notification belongs to an item that is no longer available. You can discard it.
     notifications_settings:
       show:
         administrators: Administrators

--- a/decidim-core/spec/cells/decidim/notification_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/notification_cell_spec.rb
@@ -27,7 +27,7 @@ describe Decidim::NotificationCell, type: :cell do
     end
 
     it "Resource title is present" do
-      expect(my_cell.notification_title).to include("Missing event")
+      expect(my_cell.notification_title).to include("this notification belongs to an item that is no longer available")
     end
   end
 end

--- a/decidim-core/spec/cells/decidim/notification_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/notification_cell_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::NotificationCell, type: :cell do
+  subject { my_cell.call }
+
+  controller Decidim::PagesController
+  let!(:organization) { create :organization }
+  let(:user) { create :user, :confirmed, organization: organization }
+  let(:my_cell) { cell("decidim/notification", notification) }
+  let(:notification) { create :notification, user: user, resource: resource }
+  let(:component) { create(:component, manifest_name: "dummy", organization: organization) }
+  let(:resource) { create(:dummy_resource, component: component) }
+
+  context "when resource exists" do
+    it "Resource title is present" do
+      expect(my_cell.notification_title).to include("An event occured")
+    end
+  end
+
+  context "when resource is missing" do
+    before do
+      # rubocop:disable Rails/SkipsModelValidations:
+      notification.update_attribute(:decidim_resource_type, "Decidim::ParticipatoryProcessStep")
+      # rubocop:enable Rails/SkipsModelValidations:
+    end
+
+    it "Resource title is present" do
+      expect(my_cell.notification_title).to include("Missing event")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

It is pretty common for admins to experiments different configurations that generate notifications. For instance create a step, activate it, deactivated, delete it.
This kind of processes tend to leave some notifications to some users with orphan resources. The current cell that renders a notification does not has a guard clause to skip or show and alternative title for the notification when this happens, resulting in a frustrating 500 error that prevents access to the notification page.

This PR simply shows a message (we can change that @andreslucena) when a resource is missing for whatever reason. At least this way the user can simply discard the notification.

#### Testing
Create a process, create some steps in it, make sure you follow the process. Activate/deactivate some step and then delete the step. Go to notifications page, you should see a "missing event" message.

Note: this should be backported

:hearts: Thank you!
