### PR TITLE
Fix contradictory form errors on survey form

### DIFF
--- a/decidim-forms/app/views/decidim/forms/questionnaires/_answer.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/_answer.html.erb
@@ -30,7 +30,9 @@
 
   <%= answer_form.hidden_field :question_id %>
 
-  <small class="form-error max-choices-alert"><%= t(".max_choices_alert") %></small>
+  <% if answer.question.max_choices %>
+    <small class="form-error max-choices-alert"><%= t(".max_choices_alert") %></small>
+  <% end %>
 
   <% answer.errors.full_messages.each do |msg| %>
     <small class="form-error is-visible"><%= msg %></small>

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -242,7 +242,7 @@ shared_examples_for "has questionnaire" do
       it "shows errors without submitting the form" do
         expect(page).to have_no_selector ".alert.flash"
         different_error = I18n.t("decidim.forms.questionnaires.answer.max_choices_alert")
-        expect(different_error).to be_present
+        expect(different_error).to eq("There are too many choices selected")
         expect(page).not_to have_content(different_error)
 
         expect(page).to have_content("can't be blank")

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -241,6 +241,9 @@ shared_examples_for "has questionnaire" do
 
       it "shows errors without submitting the form" do
         expect(page).to have_no_selector ".alert.flash"
+        different_error = I18n.t("decidim.forms.questionnaires.answer.max_choices_alert")
+        expect(different_error).to be_present
+        expect(page).not_to have_content(different_error)
 
         expect(page).to have_content("can't be blank")
       end


### PR DESCRIPTION
#### :tophat: What? Why?
After leaving mandatory sort answer field in survey blank, it gives two contradictory erros: "Body can't be blank" and "There are too many choices selected" which doesn't make any sense for normal people (or even to me).

#### :pushpin: Related Issues
- Fixes #9005

#### Testing
1. Create survey with mandatory short answer field and matrix with max choices
2. Go to survey's page, click sort answer input and press tab
3. Select more options than max choices from the matrix

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/164735750-7eb473d9-f865-4131-b646-e662ec418935.png)

:hearts: Thank you!
