### PR TITLE
Fix newsletters and Decidim Votings

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/newsletters_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/newsletters_helper.rb
@@ -102,7 +102,7 @@ module Decidim
                                                               .find_participatory_space_manifest(manifest_name)
                                                               .participatory_spaces.call(current_organization)
                                                               .published
-                                                              .sort_by { |space| [space.closed? ? 1 : 0, space.title[current_locale]] }
+                                                              .sort_by { |space| [space.try(:closed?) ? 1 : 0, space.title[current_locale]] }
       end
 
       def spaces_user_can_admin

--- a/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
+++ b/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
@@ -51,11 +51,12 @@ module Decidim
         @spaces ||= @form.participatory_space_types.map do |type|
           next if type.ids.blank?
 
-          object_class = "Decidim::#{type.manifest_name.classify}"
+          object_class = Decidim.participatory_space_registry.find(type.manifest_name).model_class_name.constantize
+
           if type.ids.include?("all")
-            object_class.constantize.where(organization: @organization)
+            object_class.where(organization: @organization)
           else
-            object_class.constantize.where(id: type.ids.reject(&:blank?))
+            object_class.where(id: type.ids.reject(&:blank?))
           end
         end.flatten.compact
       end

--- a/decidim-admin/spec/queries/newsletter_recipients_spec.rb
+++ b/decidim-admin/spec/queries/newsletter_recipients_spec.rb
@@ -110,7 +110,10 @@ module Decidim::Admin
               "ids" => [] },
             { "id" => nil,
               "manifest_name" => "initiatives",
-              "ids" => [] }
+              "ids" => [] },
+            { "id" => nil,
+              "manifest_name" => "votings",
+              "ids" => [component.participatory_space.id.to_s] }
           ]
         end
 

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -59,6 +59,9 @@ en:
       decidim/elections/question:
         one: Question
         other: Questions
+      decidim/voting:
+        one: Voting
+        other: Votings
       decidim/votings/census/dataset:
         one: Dataset
         other: Datasets


### PR DESCRIPTION
#### :tophat: What? Why?

Makes `Decidim::Votings` compatible with newsletters. Instead of constantizing the value of the manifest name, it uses the participatory space registry to find the manifest, and from there, use the specified model class.

Also includes the changes made by @andreslucena at https://github.com/decidim/decidim/compare/fix/votings-newsletter

#### :pushpin: Related Issues
- Fixes #8700
