### PR TITLE
Add help text when verifying your vote

### DIFF
--- a/decidim-elections/app/views/decidim/elections/votes/verify.html.erb
+++ b/decidim-elections/app/views/decidim/elections/votes/verify.html.erb
@@ -54,6 +54,7 @@
 
             <input type="text" class="vote-identifier" name="vote-identifier" value="<%= params[:vote_id].gsub("_","") %>">
           </label>
+          <p class="help-text"><%= t("decidim.elections.votes.verify.form.vote_identifier_help") %></p>
           <div>
             <%= link_to(
               "#",

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -680,6 +680,7 @@ en:
             back: Back to the platform
             submit: Check
             vote_identifier: 'Identifier code:'
+            vote_identifier_help: This is the identifier that was given to you after you cast your vote (not the code to enter the voting booth).
           header:
             title: Verify your vote
           success:


### PR DESCRIPTION
#### :tophat: What? Why?

Adds a help text to let the users know which code should they use when verifying their cast vote.

### :camera: Screenshots
<img width="895" alt="image" src="https://user-images.githubusercontent.com/5254/164974672-2a1b06aa-9bf1-4ad8-bb8d-504192cf2180.png">


