### PR TITLE
Add an option to hide the "Can I vote?" page

### DIFF
--- a/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/header_cell.rb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/header_cell.rb
@@ -74,7 +74,7 @@ module Decidim
                   url: decidim_votings.voting_path(current_participatory_space),
                   active: is_active_link?(decidim_votings.voting_path(current_participatory_space), :exclusive)
                 },
-                if current_participatory_space.dataset.present?
+                if current_participatory_space.check_census_enabled?
                   {
                     name: t("layouts.decidim.voting_navigation.check_census"),
                     url: decidim_votings.voting_check_census_path(current_participatory_space),

--- a/decidim-elections/app/commands/decidim/votings/admin/create_voting.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/create_voting.rb
@@ -51,7 +51,8 @@ module Decidim
             banner_image: form.banner_image,
             introductory_image: form.introductory_image,
             voting_type: form.voting_type,
-            census_contact_information: form.census_contact_information
+            census_contact_information: form.census_contact_information,
+            hide_can_i_vote: form.hide_can_i_vote
           )
         end
       end

--- a/decidim-elections/app/commands/decidim/votings/admin/create_voting.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/create_voting.rb
@@ -52,7 +52,7 @@ module Decidim
             introductory_image: form.introductory_image,
             voting_type: form.voting_type,
             census_contact_information: form.census_contact_information,
-            hide_can_i_vote: form.hide_can_i_vote
+            show_check_census: form.show_check_census
           )
         end
       end

--- a/decidim-elections/app/commands/decidim/votings/admin/update_voting.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/update_voting.rb
@@ -68,7 +68,7 @@ module Decidim
             promoted: form.promoted,
             voting_type: form.voting_type,
             census_contact_information: form.census_contact_information,
-            hide_can_i_vote: form.hide_can_i_vote
+            show_check_census: form.show_check_census
           }.merge(attachment_attributes(*image_fields))
         end
       end

--- a/decidim-elections/app/commands/decidim/votings/admin/update_voting.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/update_voting.rb
@@ -67,7 +67,8 @@ module Decidim
             scope: form.scope,
             promoted: form.promoted,
             voting_type: form.voting_type,
-            census_contact_information: form.census_contact_information
+            census_contact_information: form.census_contact_information,
+            hide_can_i_vote: form.hide_can_i_vote
           }.merge(attachment_attributes(*image_fields))
         end
       end

--- a/decidim-elections/app/controllers/decidim/votings/votings_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/votings_controller.rb
@@ -49,11 +49,15 @@ module Decidim
       end
 
       def show_check_census
+        raise ActionController::RoutingError, "Not Found" unless current_participatory_space.check_census_enabled?
+
         @form = form(Census::CheckForm).instance
         render :check_census, locals: { success: false, not_found: false }
       end
 
       def check_census
+        raise ActionController::RoutingError, "Not Found" unless current_participatory_space.check_census_enabled?
+
         @form = form(Census::CheckForm).from_params(params).with_context(
           current_participatory_space: current_participatory_space
         )

--- a/decidim-elections/app/forms/decidim/votings/admin/voting_form.rb
+++ b/decidim-elections/app/forms/decidim/votings/admin/voting_form.rb
@@ -20,6 +20,7 @@ module Decidim
         attribute :introductory_image
         attribute :voting_type, String
         attribute :census_contact_information, String
+        attribute :hide_can_i_vote, Boolean, default: false
 
         validates :title, translatable_presence: true
         validates :description, translatable_presence: true

--- a/decidim-elections/app/forms/decidim/votings/admin/voting_form.rb
+++ b/decidim-elections/app/forms/decidim/votings/admin/voting_form.rb
@@ -20,7 +20,7 @@ module Decidim
         attribute :introductory_image
         attribute :voting_type, String
         attribute :census_contact_information, String
-        attribute :hide_can_i_vote, Boolean, default: false
+        attribute :show_check_census, Boolean, default: false
 
         validates :title, translatable_presence: true
         validates :description, translatable_presence: true

--- a/decidim-elections/app/models/decidim/votings/voting.rb
+++ b/decidim-elections/app/models/decidim/votings/voting.rb
@@ -139,7 +139,7 @@ module Decidim
       end
 
       def check_census_enabled?
-        dataset.present? && !hide_can_i_vote?
+        dataset.present? && show_check_census?
       end
 
       def elections

--- a/decidim-elections/app/models/decidim/votings/voting.rb
+++ b/decidim-elections/app/models/decidim/votings/voting.rb
@@ -138,6 +138,10 @@ module Decidim
         ballot_styles.exists?
       end
 
+      def check_census_enabled?
+        dataset.present? && !hide_can_i_vote?
+      end
+
       def elections
         Decidim::Elections::Election.where(component: components)
       end

--- a/decidim-elections/app/views/decidim/votings/admin/votings/_form.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/votings/_form.html.erb
@@ -45,6 +45,15 @@
     </div>
 
     <div class="row">
+      <div class="columns xlarge-6 hide_can_i_vote">
+        <%= form.check_box :hide_can_i_vote %>
+        <p class="help-text">
+          <%== t(".hide_can_i_vote_help") %>
+        </p>
+      </div>
+    </div>
+
+    <div class="row">
       <div class="columns xlarge-6 census_contact_information">
         <%= form.text_field :census_contact_information, label: t(".census_contact_information") %>
         <p class="help-text">

--- a/decidim-elections/app/views/decidim/votings/admin/votings/_form.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/votings/_form.html.erb
@@ -45,10 +45,10 @@
     </div>
 
     <div class="row">
-      <div class="columns xlarge-6 hide_can_i_vote">
-        <%= form.check_box :hide_can_i_vote %>
+      <div class="columns xlarge-6 show_check_census">
+        <%= form.check_box :show_check_census %>
         <p class="help-text">
-          <%== t(".hide_can_i_vote_help") %>
+          <%== t(".show_check_census_help") %>
         </p>
       </div>
     </div>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
       voting:
         end_time: Voting ends
         start_time: Voting begins
+        hide_can_i_vote: Hide "Can I vote?"
     errors:
       models:
         answer:
@@ -998,6 +999,7 @@ en:
             banner_image: Banner image
             census_contact_information: Census contact information
             census_contact_information_help: This contact information is for a participant who wants to report issues with the census. It can be an email address, a contact form on another site, a survey for visitors, etc.
+            hide_can_i_vote_help: Whether to show the "Can I vote?" link at the public votings menu
             introductory_image: Introductory image
             promoted: Promoted
             select_a_voting_type: Please select a voting type

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -22,10 +22,10 @@ en:
         census_contact_information: Census contact information
         description: Description
         end_time: Voting ends
-        hide_can_i_vote: Hide "Can I vote?"
         introductory_image: Introductory image
         promoted: Promoted
         scope: Scope
+        show_check_census: Show "check census" page
         start_time: Voting begins
         title: Title
         voting_type: Voting type
@@ -1007,10 +1007,10 @@ en:
             banner_image: Banner image
             census_contact_information: Census contact information
             census_contact_information_help: This contact information is for a participant who wants to report issues with the census. It can be an email address, a contact form on another site, a survey for visitors, etc.
-            hide_can_i_vote_help: Whether to show the "Can I vote?" link at the public votings menu
             introductory_image: Introductory image
             promoted: Promoted
             select_a_voting_type: Please select a voting type
+            show_check_census_help: Whether to show the "Can I vote?" link at the public votings menu
             slug: Slug
             slug_help: 'URL slugs are used to generate the URLs that point to this voting. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
             title: Title

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -18,9 +18,17 @@ en:
         min_selections: None of the above option
         title: Title
       voting:
+        banner_image: Banner image
+        census_contact_information: Census contact information
+        description: Description
         end_time: Voting ends
-        start_time: Voting begins
         hide_can_i_vote: Hide "Can I vote?"
+        introductory_image: Introductory image
+        promoted: Promoted
+        scope: Scope
+        start_time: Voting begins
+        title: Title
+        voting_type: Voting type
     errors:
       models:
         answer:

--- a/decidim-elections/db/migrate/20220424121541_add_hide_can_i_vote_to_votings.rb
+++ b/decidim-elections/db/migrate/20220424121541_add_hide_can_i_vote_to_votings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHideCanIVoteToVotings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :decidim_votings_votings, :hide_can_i_vote, :boolean, default: false
+  end
+end

--- a/decidim-elections/db/migrate/20220424121541_add_hide_can_i_vote_to_votings.rb
+++ b/decidim-elections/db/migrate/20220424121541_add_hide_can_i_vote_to_votings.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddHideCanIVoteToVotings < ActiveRecord::Migration[6.1]
-  def change
-    add_column :decidim_votings_votings, :hide_can_i_vote, :boolean, default: false
-  end
-end

--- a/decidim-elections/db/migrate/20220424121541_add_show_check_census_to_votings.rb
+++ b/decidim-elections/db/migrate/20220424121541_add_show_check_census_to_votings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddShowCheckCensusToVotings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :decidim_votings_votings, :show_check_census, :boolean, default: true
+  end
+end

--- a/decidim-elections/lib/decidim/votings/test/factories.rb
+++ b/decidim-elections/lib/decidim/votings/test/factories.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
     introductory_image { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
     voting_type { "hybrid" }
     census_contact_information { nil }
+    hide_can_i_vote { false }
 
     trait :unpublished do
       published_at { nil }

--- a/decidim-elections/lib/decidim/votings/test/factories.rb
+++ b/decidim-elections/lib/decidim/votings/test/factories.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
     introductory_image { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
     voting_type { "hybrid" }
     census_contact_information { nil }
-    hide_can_i_vote { false }
+    show_check_census { true }
 
     trait :unpublished do
       published_at { nil }

--- a/decidim-elections/spec/commands/decidim/votings/admin/create_voting_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/admin/create_voting_spec.rb
@@ -26,7 +26,8 @@ module Decidim
             introductory_image: nil,
             promoted: promoted,
             voting_type: voting_type,
-            census_contact_information: census_contact_information
+            census_contact_information: census_contact_information,
+            hide_can_i_vote: hide_can_i_vote
           )
         end
 
@@ -40,6 +41,7 @@ module Decidim
         let(:promoted) { true }
         let(:voting_type) { "online" }
         let(:census_contact_information) { nil }
+        let(:hide_can_i_vote) { false }
 
         let(:voting) { Decidim::Votings::Voting.last }
 
@@ -62,6 +64,7 @@ module Decidim
           expect(voting.organization).to eq organization
           expect(voting.promoted).to eq promoted
           expect(voting.voting_type).to eq voting_type
+          expect(voting.hide_can_i_vote).to eq hide_can_i_vote
         end
 
         it "traces the action", versioning: true do

--- a/decidim-elections/spec/commands/decidim/votings/admin/create_voting_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/admin/create_voting_spec.rb
@@ -27,7 +27,7 @@ module Decidim
             promoted: promoted,
             voting_type: voting_type,
             census_contact_information: census_contact_information,
-            hide_can_i_vote: hide_can_i_vote
+            show_check_census: show_check_census
           )
         end
 
@@ -41,7 +41,7 @@ module Decidim
         let(:promoted) { true }
         let(:voting_type) { "online" }
         let(:census_contact_information) { nil }
-        let(:hide_can_i_vote) { false }
+        let(:show_check_census) { true }
 
         let(:voting) { Decidim::Votings::Voting.last }
 
@@ -64,7 +64,7 @@ module Decidim
           expect(voting.organization).to eq organization
           expect(voting.promoted).to eq promoted
           expect(voting.voting_type).to eq voting_type
-          expect(voting.hide_can_i_vote).to eq hide_can_i_vote
+          expect(voting.show_check_census).to eq show_check_census
         end
 
         it "traces the action", versioning: true do

--- a/decidim-elections/spec/system/check_census_spec.rb
+++ b/decidim-elections/spec/system/check_census_spec.rb
@@ -36,6 +36,18 @@ describe "Check Census", type: :system do
     end
   end
 
+  context "when the page has been hidden" do
+    before do
+      voting.update!(hide_can_i_vote: true)
+    end
+
+    it "returns a not found page" do
+      visit decidim_votings.voting_path(voting)
+
+      expect(page).not_to have_content("CAN I VOTE?")
+    end
+  end
+
   context "when census data is correct" do
     before do
       visit decidim_votings.voting_check_census_path(voting)

--- a/decidim-elections/spec/system/check_census_spec.rb
+++ b/decidim-elections/spec/system/check_census_spec.rb
@@ -38,7 +38,7 @@ describe "Check Census", type: :system do
 
   context "when the page has been hidden" do
     before do
-      voting.update!(hide_can_i_vote: true)
+      voting.update!(show_check_census: false)
     end
 
     it "returns a not found page" do


### PR DESCRIPTION
#### :tophat: What? Why?

Adds an option to the votings form to be able to hide the "Can I vote?" page, this was requested after the running the simulation on the evote module.

Also adds missing translations for the votings form.

### :camera: Screenshots
<img width="1078" alt="image" src="https://user-images.githubusercontent.com/5254/164981929-1832a207-c023-4dcc-a239-e0d1ce657d65.png">

