### PR TITLE
Correctly show trustees and votings menu

### DIFF
--- a/decidim-elections/app/permissions/decidim/votings/admin/permissions.rb
+++ b/decidim-elections/app/permissions/decidim/votings/admin/permissions.rb
@@ -15,7 +15,6 @@ module Decidim
             return permission_action
           end
 
-          user_can_enter_space_area?
           allowed_read_participatory_space?
           allowed_voting_action?
 
@@ -23,14 +22,6 @@ module Decidim
         end
 
         private
-
-        def user_can_enter_space_area?
-          return unless permission_action.action == :enter &&
-                        permission_action.subject == :space_area &&
-                        context.fetch(:space_name, nil) == :votings
-
-          allow!
-        end
 
         def read_admin_dashboard_action?
           permission_action.action == :read &&

--- a/decidim-elections/app/permissions/decidim/votings/admin/permissions.rb
+++ b/decidim-elections/app/permissions/decidim/votings/admin/permissions.rb
@@ -8,6 +8,9 @@ module Decidim
           return permission_action unless user
           return user_allowed_to_read_admin_dashboard? if read_admin_dashboard_action?
           return permission_action unless permission_action.scope == :admin
+
+          user_can_enter_space_area?
+
           return permission_action if voting && !voting.is_a?(Decidim::Votings::Voting)
 
           unless user_can_read_votings_admin_dashboard?
@@ -22,6 +25,14 @@ module Decidim
         end
 
         private
+
+        def user_can_enter_space_area?
+          return unless permission_action.action == :enter &&
+                        permission_action.subject == :space_area &&
+                        context.fetch(:space_name, nil) == :votings
+
+          allow!
+        end
 
         def read_admin_dashboard_action?
           permission_action.action == :read &&

--- a/decidim-elections/lib/decidim/elections/admin_engine.rb
+++ b/decidim-elections/lib/decidim/elections/admin_engine.rb
@@ -64,7 +64,7 @@ module Decidim
             menu.add_item :trustees,
                           I18n.t("trustees", scope: "decidim.elections.admin.menu"),
                           link,
-                          if: allowed_to?(:manage, :trustees) || has_election_components && current_user.admin?,
+                          if: has_election_components && (allowed_to?(:manage, :trustees) || current_user.admin?),
                           position: 100,
                           active: is_active_link?(link)
           end

--- a/decidim-elections/lib/decidim/elections/admin_engine.rb
+++ b/decidim-elections/lib/decidim/elections/admin_engine.rb
@@ -58,11 +58,14 @@ module Decidim
             next unless component
 
             link = Decidim::EngineRouter.admin_proxy(component).trustees_path(locale: I18n.locale)
+
+            has_election_components = current_participatory_space.components.select { |c| c.manifest_name == "elections" }.any?
+
             menu.add_item :trustees,
                           I18n.t("trustees", scope: "decidim.elections.admin.menu"),
                           link,
+                          if: allowed_to?(:manage, :trustees) || has_election_components && current_user.admin?,
                           position: 100,
-                          if: allowed_to?(:manage, :trustees),
                           active: is_active_link?(link)
           end
         end

--- a/decidim-elections/lib/decidim/votings/admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/admin_engine.rb
@@ -74,8 +74,7 @@ module Decidim
                         decidim_admin_votings.votings_path,
                         icon_name: "comment-square",
                         position: 2.6,
-                        active: :inclusive,
-                        if: allowed_to?(:enter, :space_area, space_name: :votings)
+                        active: :inclusive
         end
       end
 

--- a/decidim-elections/lib/decidim/votings/admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/admin_engine.rb
@@ -74,7 +74,8 @@ module Decidim
                         decidim_admin_votings.votings_path,
                         icon_name: "comment-square",
                         position: 2.6,
-                        active: :inclusive
+                        active: :inclusive,
+                        if: allowed_to?(:enter, :space_area, space_name: :votings)
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This will correctly show the trustees menu when the current participatory space has an elections components. The code for votings has also been corrected as they should always be visible.

#### :pushpin: Related Issues
*None*

#### Testing
Go to a "votings" participatory space with an elections component. You should see a "trustee" option on the admin.

#### :clipboard: Checklist
- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

<img width="1498" alt="image" src="https://user-images.githubusercontent.com/111746/164982374-ca3ab519-ace8-4d7f-a645-d4a4cef10d3f.png">
