### PR TITLE
Fix typo in meeting's copy calendar string

### DIFF
--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -394,7 +394,7 @@ en:
         calendar_url: Calendar URL
         close_window: Close window
         copy_calendar_url: Copy
-        copy_calendar_url_clarification: Copy clendar url to clipboard
+        copy_calendar_url_clarification: Copy calendar url to clipboard
         copy_calendar_url_copied: Copied!
         copy_calendar_url_description: You can see all the published meetings in your calendar application or provider. Copy and paste this URL in your calendar using the "Add new calendar from an URL" option.
         copy_calendar_url_explanation: Please note that you're exporting a selection of meetings, as there are active filters. If you wish to export them all, reset all filters first.


### PR DESCRIPTION
#### :tophat: What? Why?

There's a typo in a string. This PR fixes it. 

#### :pushpin: Related Issues
 
- Comes from a Crowdin comment made by @ahukkanen 
https://crowdin.com/translate/decidim/2680/en-fi?filter=basic&value=0#229800
 

:hearts: Thank you!
