### PR TITLE
Add missing events locales

### DIFF
--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -4,8 +4,8 @@ en:
     models:
       decidim/comments/comment_by_followed_user_event: Comment
       decidim/comments/comment_created_event: Comment
-      decidim/comments/reply_created_event: Comment reply
       decidim/comments/comment_upvoted_event: Comment upvoted
+      decidim/comments/reply_created_event: Comment reply
       decidim/comments/user_group_mentioned_event: Mention
       decidim/comments/user_mentioned_event: Mention
   activerecord:

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
       decidim/comments/comment_by_followed_user_event: Comment
       decidim/comments/comment_created_event: Comment
       decidim/comments/reply_created_event: Comment reply
+      decidim/comments/comment_upvoted_event: Comment upvoted
       decidim/comments/user_group_mentioned_event: Mention
       decidim/comments/user_mentioned_event: Mention
   activerecord:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
       decidim/promote_to_admin: Promoted to group admin
       decidim/removed_from_group: Removed from group
       decidim/resource_endorsed_event: Resource endorsed
+      decidim/welcome_notification_event: Welcomme message
   activerecord:
     attributes:
       decidim/user:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -36,12 +36,16 @@ en:
       decidim/demoted_membership: No longer a group admin
       decidim/gamification/badge_earned_event: Badge earned
       decidim/gamification/level_up_event: You've leveled up
+      decidim/invited_to_group_event: Invited to group
       decidim/join_request_accepted_event: Join request accepted
       decidim/join_request_rejected_event: Join request rejected
       decidim/profile_updated_event: Profile updated
       decidim/promote_to_admin: Promoted to group admin
+      decidim/promoted_to_admin_event: Promoted to group admin
       decidim/removed_from_group: Removed from group
       decidim/resource_endorsed_event: Resource endorsed
+      decidim/resource_hidden_event: Resource hidden
+      decidim/user_group_created_event: User group created
       decidim/welcome_notification_event: Welcomme message
   activerecord:
     attributes:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -46,7 +46,7 @@ en:
       decidim/resource_endorsed_event: Resource endorsed
       decidim/resource_hidden_event: Resource hidden
       decidim/user_group_created_event: User group created
-      decidim/welcome_notification_event: Welcomme message
+      decidim/welcome_notification_event: Welcome message
   activerecord:
     attributes:
       decidim/user:


### PR DESCRIPTION
#### :tophat: What? Why?
(please first excuse the poor quality of this PR which is my first ever :))

Few weeks ago I wanted to translate the first line of the notification card for the event "Welcome notification" but I didn't find the key in locales files.
Digging through the code lead me to add the locale key "welcome_notification_event" to the section related to activemodel and it worked.
Then I joined the French translation team on Crowdin but could not contribute, as the key is not present in Decidim locales files.

This PR just add some locales key related to activemodel events in order to be available in Crowdin.

### :camera: Screenshots
![decidim welcome notification event card](https://user-images.githubusercontent.com/6229909/165560519-19d40456-edd4-483a-b6f4-33aa2824b174.png)

:hearts: Thank you!
