### PR TITLE
Fix webpacker thread safety

### DIFF
--- a/decidim-core/lib/decidim/webpacker.rb
+++ b/decidim-core/lib/decidim/webpacker.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/webpacker/thread_safe_compiler"
+
 module Decidim
   module Webpacker
     autoload :Configuration, "decidim/webpacker/configuration"

--- a/decidim-core/lib/decidim/webpacker/thread_safe_compiler.rb
+++ b/decidim-core/lib/decidim/webpacker/thread_safe_compiler.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# This fixes a thread safety issue with the Webpacker compiler explained here:
+# https://github.com/rails/webpacker/issues/2801
+#
+# The fix is partly from the issue and partly from this commit at Shakapacker:
+# https://github.com/shakacode/shakapacker/commit/f2dc437ecd9914f394780d4c3150fc4a70d40f9d
+
+require "webpacker/compiler"
+
+module Decidim
+  module Webpacker
+    module ThreadSafeCompiler
+      private
+
+      def watched_files_digest
+        warn "Webpacker::Compiler.watched_paths has been deprecated. Set additional_paths in webpacker.yml instead." unless watched_paths.empty?
+        root_path = Pathname.new(File.expand_path(config.root_path))
+        expanded_paths = [*default_watched_paths, *watched_paths].map do |path|
+          root_path.join(path)
+        end
+        files = Dir[*expanded_paths].reject { |f| File.directory?(f) }
+        file_ids = files.sort.map { |f| "#{File.basename(f)}/#{Digest::SHA1.file(f).hexdigest}" }
+        Digest::SHA1.hexdigest(file_ids.join("/"))
+      end
+    end
+  end
+end
+
+Webpacker::Compiler.prepend(Decidim::Webpacker::ThreadSafeCompiler)

--- a/decidim-core/spec/lib/webpacker/compiler_spec.rb
+++ b/decidim-core/spec/lib/webpacker/compiler_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Webpacker
+  describe Compiler do
+    subject { described_class.new(webpacker) }
+
+    let(:webpacker) { Webpacker.instance }
+
+    describe "#fresh?" do
+      before { subject.compile }
+
+      it "allows multiple threads to fetch the status at the same time" do
+        threads = []
+        results = []
+        10.times { threads << Thread.new { results << subject.fresh? } }
+        threads.each(&:join)
+
+        expect(results.length).to eq(10)
+        expect(results.uniq).to match_array([true])
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
We noticed at #8452 that Webpacker is not thread safe which is hopefully the last blocker for the Ruby 3 upgrade.

This should fix Webpacker thread safety according to the discussion and instructions at:
https://github.com/rails/webpacker/issues/2801

There is a further fix for determining the full expanded paths inspired by this commit at Shakapacker:
https://github.com/shakacode/shakapacker/commit/f2dc437ecd9914f394780d4c3150fc4a70d40f9d

#### :pushpin: Related Issues
- Related to #8452, rails/webpacker#2801

#### Testing
- Ruby 2.7: Run the introduced spec and see no warnings in console.
- Ruby 3.0: Run the introduced spec and see no exceptions in the console

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.