### PR TITLE
Clarify unregistered answers on surveys behavior

### DIFF
--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -31,7 +31,7 @@ en:
           step:
             allow_answers: Allow answers
             allow_unregistered: Allow unregistered users to answer the survey
-            allow_unregistered_help: If active, no login will be required in order to answer the survey. This may lead to poor or unreliable data and it will be more vulnerable to automated attacks. Use with caution!
+            allow_unregistered_help: 'If active, no login will be required in order to answer the survey. This may lead to poor or unreliable data and it will be more vulnerable to automated attacks. Use with caution! Mind that a participant could answer the same survey multiple times, by using different browsers or the "private browsing" feature of her web browser.'
             announcement: Announcement
     events:
       surveys:

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -31,7 +31,7 @@ en:
           step:
             allow_answers: Allow answers
             allow_unregistered: Allow unregistered users to answer the survey
-            allow_unregistered_help: 'If active, no login will be required in order to answer the survey. This may lead to poor or unreliable data and it will be more vulnerable to automated attacks. Use with caution! Mind that a participant could answer the same survey multiple times, by using different browsers or the "private browsing" feature of her web browser.'
+            allow_unregistered_help: If active, no login will be required in order to answer the survey. This may lead to poor or unreliable data and it will be more vulnerable to automated attacks. Use with caution! Mind that a participant could answer the same survey multiple times, by using different browsers or the "private browsing" feature of her web browser.
             announcement: Announcement
     events:
       surveys:


### PR DESCRIPTION
#### :tophat: What? Why?

This PR clarifies the behavior of the 'allow unregistered answers' setting in the surveys component, as talked in #7438. 

Mind that there are other topics talked there (about how to improve the fingerprinting, if it should be done with IP addresses, it there is other use cases for making multiple answers in the same browser, etc). All of those use cases and changes should need to be proposed as a new feature. 

At least the original bug report was actually about a clarification on how this feature worked, so the best solution that I could get is to clarify this too in the admin dashboard.  

#### :pushpin: Related Issues
 
- Fixes #7438 

#### Testing

1. Sign in as admin
2. Go to the survey component settings
 
### :camera: Screenshots

![image](https://user-images.githubusercontent.com/717367/165923408-b2adb4a2-c2c7-4d18-bc38-1a236d39851a.png)


:hearts: Thank you!
