### PR TITLE
Enforce password validation rules on system admins

### DIFF
--- a/decidim-system/app/forms/decidim/system/admin_form.rb
+++ b/decidim-system/app/forms/decidim/system/admin_form.rb
@@ -15,6 +15,8 @@ module Decidim
       validates :password, presence: true, unless: :admin_exists?
       validates :password_confirmation, presence: true, unless: :admin_exists?
 
+      validates :password, password: { email: :email }
+
       validate :email, :email_uniqueness
 
       private

--- a/decidim-system/app/models/decidim/system/admin.rb
+++ b/decidim-system/app/models/decidim/system/admin.rb
@@ -8,6 +8,8 @@ module Decidim
 
       validates :email, uniqueness: true
 
+      validates :password, password: { email: :email }
+
       private
 
       # Changes default Devise behaviour to use ActiveJob to send async emails.

--- a/decidim-system/lib/decidim/system/test/factories.rb
+++ b/decidim-system/lib/decidim/system/test/factories.rb
@@ -5,7 +5,7 @@ require "decidim/core/test/factories"
 FactoryBot.define do
   factory :admin, class: "Decidim::System::Admin" do
     sequence(:email) { |n| "admin#{n}@example.org" }
-    password { "password1234" }
-    password_confirmation { "password1234" }
+    password { "decidim123456" }
+    password_confirmation { "decidim123456" }
   end
 end

--- a/decidim-system/spec/commands/decidim/system/create_admin_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/create_admin_spec.rb
@@ -25,6 +25,23 @@ module Decidim
           end
         end
 
+        describe "when the password is too common" do
+          before do
+            create(:admin, email: "email@foo.bar")
+          end
+
+          let(:params) do
+            {
+              password: "password1234",
+              password_confirmation: "password1234"
+            }
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+        end
+
         describe "when the admin doesn't exist" do
           before do
             create(:admin, email: "email@foo.bar")
@@ -33,8 +50,8 @@ module Decidim
           let(:params) do
             {
               email: "different_email@foo.bar",
-              password: "fake123",
-              password_confirmation: "fake123"
+              password: "fake123456",
+              password_confirmation: "fake123456"
             }
           end
 

--- a/decidim-system/spec/lib/tasks/decidim_system_create_admin_spec.rb
+++ b/decidim-system/spec/lib/tasks/decidim_system_create_admin_spec.rb
@@ -38,15 +38,29 @@ describe "decidim_system:create_admin", type: :task do
     end
 
     context "when provided data is invalid" do
-      let(:email) { "invalid" }
-      let(:password_confirmation) { "invalid" }
+      context "when passwords don't match" do
+        let(:email) { "invalid" }
+        let(:password_confirmation) { "invalid" }
 
-      it "prevents creation of admin and displays validation errors" do
-        expect { task.execute }.not_to(change { Decidim::System::Admin.count })
+        it "prevents creation of admin and displays validation errors" do
+          expect { task.execute }.not_to(change { Decidim::System::Admin.count })
 
-        expect($stdout.string).to include("Some errors prevented creation of admin")
-        expect($stdout.string).to include("Email is invalid")
-        expect($stdout.string).to include("Password confirmation doesn't match Password")
+          expect($stdout.string).to include("Some errors prevented creation of admin")
+          expect($stdout.string).to include("Email is invalid")
+          expect($stdout.string).to include("Password confirmation doesn't match Password")
+        end
+      end
+
+      context "when password is too common" do
+        let(:password) { "password1234" }
+        let(:password_confirmation) { "password1234" }
+
+        it "prevents creation of admin and displays validation errors" do
+          expect { task.execute }.not_to(change { Decidim::System::Admin.count })
+
+          expect($stdout.string).to include("Some errors prevented creation of admin")
+          expect($stdout.string).to include("Password is too common")
+        end
       end
     end
   end

--- a/decidim-system/spec/system/manage_admins_spec.rb
+++ b/decidim-system/spec/system/manage_admins_spec.rb
@@ -11,43 +11,84 @@ describe "Manage admins", type: :system do
     visit decidim_system.admins_path
   end
 
-  it "creates a new admin" do
-    find(".actions .new").click
+  describe "when creating a new admin" do
+    context "with a valid password" do
+      it "is created" do
+        find(".actions .new").click
 
-    within ".new_admin" do
-      fill_in :admin_email, with: "admin@foo.bar"
-      fill_in :admin_password, with: "fake123"
-      fill_in :admin_password_confirmation, with: "fake123"
+        within ".new_admin" do
+          fill_in :admin_email, with: "admin@foo.bar"
+          fill_in :admin_password, with: "decidim123456"
+          fill_in :admin_password_confirmation, with: "decidim123456"
 
-      find("*[type=submit]").click
+          find("*[type=submit]").click
+        end
+
+        within ".success.flash" do
+          expect(page).to have_content("successfully")
+        end
+
+        within "table" do
+          expect(page).to have_content("admin@foo.bar")
+        end
+      end
     end
 
-    within ".success.flash" do
-      expect(page).to have_content("successfully")
-    end
+    context "with an invalid password" do
+      it "gives an error" do
+        find(".actions .new").click
 
-    within "table" do
-      expect(page).to have_content("admin@foo.bar")
+        within ".new_admin" do
+          fill_in :admin_email, with: "admin@foo.bar"
+          fill_in :admin_password, with: "password1234"
+          fill_in :admin_password_confirmation, with: "password1234"
+
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_css(".form-error.is-visible", text: "is too common")
+      end
     end
   end
 
-  it "updates an admin" do
-    within find("tr", text: admin.email) do
-      click_link "Edit"
+  describe "when updating an admin" do
+    context "with a valid password" do
+      it "is updated" do
+        within find("tr", text: admin.email) do
+          click_link "Edit"
+        end
+
+        within ".edit_admin" do
+          fill_in :admin_email, with: "admin@another.domain"
+
+          find("*[type=submit]").click
+        end
+
+        within ".success.flash" do
+          expect(page).to have_content("successfully")
+        end
+
+        within "table" do
+          expect(page).to have_content("admin@another.domain")
+        end
+      end
     end
 
-    within ".edit_admin" do
-      fill_in :admin_email, with: "admin@another.domain"
+    context "with an invalid password" do
+      it "gives an error" do
+        within find("tr", text: admin.email) do
+          click_link "Edit"
+        end
 
-      find("*[type=submit]").click
-    end
+        within ".edit_admin" do
+          fill_in :admin_password, with: "password1234"
+          fill_in :admin_password_confirmation, with: "password1234"
 
-    within ".success.flash" do
-      expect(page).to have_content("successfully")
-    end
+          find("*[type=submit]").click
+        end
 
-    within "table" do
-      expect(page).to have_content("admin@another.domain")
+        expect(page).to have_css(".form-error.is-visible", text: "is too common")
+      end
     end
   end
 

--- a/decidim-system/spec/system/sessions_spec.rb
+++ b/decidim-system/spec/system/sessions_spec.rb
@@ -5,8 +5,8 @@ require "spec_helper"
 describe "Sessions", type: :system do
   let!(:admin) do
     create(:admin, email: "admin@example.org",
-                   password: "123456",
-                   password_confirmation: "123456")
+                   password: "decidim123456",
+                   password_confirmation: "decidim123456")
   end
 
   before do
@@ -17,7 +17,7 @@ describe "Sessions", type: :system do
     it "lets you into the system panel" do
       within ".new_admin" do
         fill_in :admin_email, with: "admin@example.org"
-        fill_in :admin_password, with: "123456"
+        fill_in :admin_password, with: "decidim123456"
         find("*[type=submit]").click
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
As [mentioned](https://github.com/decidim/decidim/pull/9090#issuecomment-1092779100) in #9090, password validation rules aren't enforced for system admins. This PR fixes that.


#### :pushpin: Related Issues

- Related to #9090  


#### Testing

For new system users with the rake task: 
1. Run `bin/rails decidim_system:create_admin`
2. Fill email "system2@example.org" 
3. Fill password and password confirmation "password1234".
3. See "password is too common" error

For new system users with the rails console: 
1. `bin/rails console` 
2. `Decidim::System::Admin.create!(email: "system2@example.org", password: "password1234", password_confirmation: "password1234")` 
3. See "password is too common" error

For existing users through the system panel: 
1. Log in to /system
2. Go to Admins
3. Edit an admin
3. Fill password and password confirmation "password1234".
3. See "password is too common" error
  

### :camera: Screenshots
 
![Firefox_Screenshot_2022-04-29T12-29-24 027Z](https://user-images.githubusercontent.com/717367/165944480-9be86757-42be-4f7f-97cf-52dcf79f9bdb.png)

:hearts: Thank you!
