### PR TITLE
Fix instructions for documentation 

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -36,20 +36,7 @@ If you want to try changes in this folder and how it'd be shown in https://docs.
 . Build the antora playbook
 . Open the generated website with your web browser
 
-In detail each one of these steps are:
-
-[source,bash]
-----
-# 1. Clone the repository
-git clone https://github.com/decidim/documentation
-# 2. Install dependencies
-npm
-# 3. Change the antora-playbook.yml url key in source
-# 4. Build the antora playbook
-npm run build
-# 5. Open the generated website with your web browser
-xdg-open build/site/index.html
-----
+For instructions on how to clone the repository, install dependencies, build the antora playbook and open the generated webiste, see https://github.com/decidim/documentation[Decidim's documentation repository README file].
 
 Regarding "3. Change the antora-playbook.yml url key in source", if this is the configuration at antora-playbook.yml:
 

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -56,6 +56,8 @@ Then the result would be:
      branches: develop
 ----
 
+If building locally doesn't show any change, then check also that the branch corresponds with the one that you're working locally.
+
 == Add a new link in the sidebar
 
 For adding a new link in the sidebar you need to add it in https://raw.githubusercontent.com/decidim/documentation/master/en/modules/ROOT/nav.adoc[nav.adoc file]


### PR DESCRIPTION
#### :tophat: What? Why?

While working with the docs, I saw that we've had some old instructions on how to build the Antora website locally. I prefer to have these instructions in a single place, the README of the [decidim/documentation](https://github.com/decidim/documentation[) project, so this PR does that. 

This PR is from a few months ago, I forgot to send the PR. I think it still makes sense.

:hearts: Thank you!
