### PR TITLE
Make conference's partners logos always mandatory

### DIFF
--- a/decidim-conferences/app/forms/decidim/conferences/admin/partner_form.rb
+++ b/decidim-conferences/app/forms/decidim/conferences/admin/partner_form.rb
@@ -17,7 +17,7 @@ module Decidim
         attribute :remove_logo, Boolean, default: false
 
         validates :name, :partner_type, presence: true, if: ->(form) { form.logo.present? }
-        validates :logo, presence: true, unless: :persisted?
+        validates :logo, presence: true
         validates :logo, passthru: {
           to: Decidim::Conferences::Partner,
           with: {

--- a/decidim-conferences/app/forms/decidim/conferences/admin/partner_form.rb
+++ b/decidim-conferences/app/forms/decidim/conferences/admin/partner_form.rb
@@ -14,10 +14,9 @@ module Decidim
         attribute :partner_type, String
         attribute :weight, Integer, default: 0
         attribute :logo
-        attribute :remove_logo, Boolean, default: false
 
         validates :name, :partner_type, presence: true, if: ->(form) { form.logo.present? }
-        validates :logo, presence: true
+        validates :logo, presence: true, unless: :persisted?
         validates :logo, passthru: {
           to: Decidim::Conferences::Partner,
           with: {

--- a/decidim-conferences/app/views/decidim/conferences/admin/partners/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/partners/_form.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <div class="row column">
-      <%= form.upload :logo, optional: @form.persisted? %>
+      <%= form.upload :logo, optional: false %>
     </div>
   </div>
 </div>

--- a/decidim-conferences/spec/commands/create_partner_spec.rb
+++ b/decidim-conferences/spec/commands/create_partner_spec.rb
@@ -27,8 +27,7 @@ module Decidim::Conferences
           weight: 1,
           partner_type: partner_type,
           link: Faker::Internet.url,
-          logo: logo,
-          remove_logo: false
+          logo: logo
         }
       }
     end

--- a/decidim-conferences/spec/commands/update_partner_spec.rb
+++ b/decidim-conferences/spec/commands/update_partner_spec.rb
@@ -24,8 +24,7 @@ module Decidim::Conferences
           weight: 2,
           partner_type: "collaborator",
           link: Faker::Internet.url,
-          logo: logo,
-          remove_logo: false
+          logo: logo
         }
       }
     end

--- a/decidim-conferences/spec/forms/partner_form_spec.rb
+++ b/decidim-conferences/spec/forms/partner_form_spec.rb
@@ -42,6 +42,12 @@ module Decidim
           it { is_expected.to be_invalid }
         end
 
+        context "when logo is missing" do
+          let(:logo) { nil }
+
+          it { is_expected.to be_invalid }
+        end
+
         context "when weight is missing" do
           let(:weight) { nil }
 


### PR DESCRIPTION
#### :tophat: What? Why?

You can delete a conference's partners logo after it was created. This wasn't intended, so this PR fixes it and makes the logo always mandatory. 

**Steps to reproduce the behavior:** 

1. Sign in as admin
2. Go to admin dashboard -> conferences -> select a conference -> partners -> create a new partner
3. Put a name and save it without a logo
4. Save it
5. See that it doesn't allow you to save it. 
6. Upload a logo
7. Save it
8. Edit the partner
9. Delete its logo
10. Save it

It shouldn't allow deleting it. 

#### :pushpin: Related Issues

- Related to #9045  

#### Testing

1. Sign in as admin
2. Go to admin dashboard -> conferences -> select a conference -> partners -> create a new partner
3. Put a name and save it without a logo
4. Save it
5. See that it doesn't allow you to save it. 
6. Upload a logo
7. Save it
8. Edit the partner
9. Delete its logo
4. See that it doesn't allow you to save it. 
 
:hearts: Thank you!
