### PR TITLE
Add autocomplete in user account

### DIFF
--- a/decidim-core/app/views/decidim/account/_password_fields.html.erb
+++ b/decidim-core/app/views/decidim/account/_password_fields.html.erb
@@ -1,2 +1,2 @@
 <%= form.password_field :password, value: form.object.password, autocomplete: "new-password", help_text: t("devise.passwords.edit.password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH) %>
-<%= form.password_field :password_confirmation, value: form.object.password_confirmation, autocomplete: "off" %>
+<%= form.password_field :password_confirmation, value: form.object.password_confirmation, autocomplete: "new-password" %>

--- a/decidim-core/app/views/decidim/account/_password_fields.html.erb
+++ b/decidim-core/app/views/decidim/account/_password_fields.html.erb
@@ -1,2 +1,2 @@
-<%= form.password_field :password, value: form.object.password, autocomplete: "off", help_text: t("devise.passwords.edit.password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH) %>
+<%= form.password_field :password, value: form.object.password, autocomplete: "new-password", help_text: t("devise.passwords.edit.password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH) %>
 <%= form.password_field :password_confirmation, value: form.object.password_confirmation, autocomplete: "off" %>

--- a/decidim-core/app/views/decidim/account/show.html.erb
+++ b/decidim-core/app/views/decidim/account/show.html.erb
@@ -3,7 +3,7 @@
 <% content_for(:subtitle) { t("profile", scope: "layouts.decidim.user_menu") } %>
 
 <div class="row">
-  <%= decidim_form_for(@account, url: account_path, method: :put, html: { autocomplete: "off" }) do |f| %>
+  <%= decidim_form_for(@account, url: account_path, method: :put, html: { autocomplete: "on" }) do |f| %>
     <input autocomplete="off" name="hidden" type="password" style="display:none;">
     <div class="columns large-4">
       <%= f.upload :avatar %>
@@ -25,10 +25,10 @@
 
       <%= form_required_explanation %>
 
-      <%= f.text_field :name %>
-      <%= f.text_field :nickname %>
-      <%= f.email_field :email, disabled: current_user.unconfirmed_email.present? %>
-      <%= f.url_field :personal_url %>
+      <%= f.text_field :name, autocomplete: "name" %>
+      <%= f.text_field :nickname, autocomplete: "nickname" %>
+      <%= f.email_field :email, disabled: current_user.unconfirmed_email.present?, autocomplete: "email" %>
+      <%= f.url_field :personal_url, autocomplete: "url" %>
       <%= f.text_area :about, rows: 5 %>
 
       <%= f.collection_select(

--- a/decidim-core/app/views/decidim/account/show.html.erb
+++ b/decidim-core/app/views/decidim/account/show.html.erb
@@ -4,7 +4,7 @@
 
 <div class="row">
   <%= decidim_form_for(@account, url: account_path, method: :put, html: { autocomplete: "on" }) do |f| %>
-    <input autocomplete="off" name="hidden" type="password" style="display:none;">
+    <input autocomplete="current-password" class="hide" name="hidden" type="password">
     <div class="columns large-4">
       <%= f.upload :avatar %>
     </div>

--- a/decidim-core/app/views/decidim/account/show.html.erb
+++ b/decidim-core/app/views/decidim/account/show.html.erb
@@ -4,7 +4,6 @@
 
 <div class="row">
   <%= decidim_form_for(@account, url: account_path, method: :put, html: { autocomplete: "on" }) do |f| %>
-    <input autocomplete="current-password" class="hide" name="hidden" type="password">
     <div class="columns large-4">
       <%= f.upload :avatar %>
     </div>

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -94,6 +94,13 @@ module Decidim
       safe_join [label_tabs, tabs_content]
     end
 
+    def password_field(attribute, options = {})
+      field attribute, options do |opts|
+        opts[:autocomplete] ||= :off
+        method(__method__).super_method.super_method.call(attribute, opts)
+      end
+    end
+
     def translated_one_locale(type, name, locale, options = {})
       return hashtaggable_text_field(type, name, locale, options) if options.delete(:hashtaggable)
 
@@ -542,7 +549,7 @@ module Decidim
     # inputs inside the label and to automatically inject validations
     # from the object.
     #
-    # attribute    - The String name of the attribute to buidl the field.
+    # attribute    - The String name of the attribute to build the field.
     # options      - A Hash with options to build the field.
     # html_options - An optional Hash with options to pass to the html element.
     #

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -363,20 +363,6 @@ module Decidim
       end
     end
 
-    describe "checkbox" do
-      let(:output) do
-        builder.check_box :name
-      end
-
-      it "renders the checkbox before the label text" do
-        expect(output).to eq(
-          '<label for="resource_name"><input name="resource[name]" type="hidden" value="0" autocomplete="off" />' \
-          '<input type="checkbox" value="1" name="resource[name]" id="resource_name" />Name' \
-          "</label>"
-        )
-      end
-    end
-
     describe "date_field" do
       context "when the resource has errors" do
         before do

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -344,6 +344,39 @@ module Decidim
       end
     end
 
+    describe "#password_field" do
+      let(:output) do
+        builder.password_field :password, options
+      end
+      let(:options) { {} }
+
+      it "renders the input type password" do
+        expect(output).to eq('<label for="resource_password">Password<input autocomplete="off" type="password" name="resource[password]" id="resource_password" /></label>')
+      end
+
+      context "when autocomplete attribute is defined" do
+        let(:options) { { autocomplete: "new-password" } }
+
+        it "renders the input type password with given autocomplete attribute" do
+          expect(output).to eq('<label for="resource_password">Password<input autocomplete="new-password" type="password" name="resource[password]" id="resource_password" /></label>')
+        end
+      end
+    end
+
+    describe "checkbox" do
+      let(:output) do
+        builder.check_box :name
+      end
+
+      it "renders the checkbox before the label text" do
+        expect(output).to eq(
+          '<label for="resource_name"><input name="resource[name]" type="hidden" value="0" autocomplete="off" />' \
+          '<input type="checkbox" value="1" name="resource[name]" id="resource_name" />Name' \
+          "</label>"
+        )
+      end
+    end
+
     describe "date_field" do
       context "when the resource has errors" do
         before do


### PR DESCRIPTION
#### :tophat: What? Why?

Add autocomplete attributes to account form.

#### :pushpin: Related Issues

- Related to #6202

#### Testing

1. Login as user
2. Go to account form : `/account`
3. See autocomplete attributes on fields

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
