### PR TITLE
Configure online meetings embedded services with ENV vars

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -367,6 +367,9 @@ end
 if Decidim.module_installed? :meetings
   Decidim::Meetings.configure do |config|
     config.upcoming_meeting_notification = Rails.application.secrets.dig(:decidim, :meetings, :upcoming_meeting_notification).to_i.days
+    if Rails.application.secrets.dig(:decidim, :meetings, :embeddable_services).present?
+      config.embeddable_services = Rails.application.secrets.dig(:decidim, :meetings, :embeddable_services)
+    end
     unless Rails.application.secrets.dig(:decidim, :meetings, :enable_proposal_linking) == "auto"
       config.enable_proposal_linking = Rails.application.secrets.dig(:decidim, :meetings, :enable_proposal_linking).present?
     end

--- a/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
@@ -52,6 +52,7 @@ decidim_default: &decidim_default
   meetings:
     upcoming_meeting_notification: <%%= Decidim::Env.new("MEETINGS_UPCOMING_MEETING_NOTIFICATION", 2).to_i %>
     enable_proposal_linking: <%%= Decidim::Env.new("MEETINGS_ENABLE_PROPOSAL_LINKING", "auto").default_or_present_if_exists.to_s %>
+    embeddable_services: <%%= Decidim::Env.new("MEETINGS_EMBEDDABLE_SERVICES").to_array.to_json %>
   budgets:
     enable_proposal_linking: <%%= Decidim::Env.new("BUDGETS_ENABLE_PROPOSAL_LINKING", "auto").default_or_present_if_exists.to_s %>
   accountability:

--- a/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
@@ -52,7 +52,7 @@ decidim_default: &decidim_default
   meetings:
     upcoming_meeting_notification: <%%= Decidim::Env.new("MEETINGS_UPCOMING_MEETING_NOTIFICATION", 2).to_i %>
     enable_proposal_linking: <%%= Decidim::Env.new("MEETINGS_ENABLE_PROPOSAL_LINKING", "auto").default_or_present_if_exists.to_s %>
-    embeddable_services: <%%= Decidim::Env.new("MEETINGS_EMBEDDABLE_SERVICES").to_array.to_json %>
+    embeddable_services: <%%= Decidim::Env.new("MEETINGS_EMBEDDABLE_SERVICES").to_array(separator: " ").to_json %>
   budgets:
     enable_proposal_linking: <%%= Decidim::Env.new("BUDGETS_ENABLE_PROPOSAL_LINKING", "auto").default_or_present_if_exists.to_s %>
   accountability:

--- a/decidim-generators/lib/decidim/generators/test/generator_examples.rb
+++ b/decidim-generators/lib/decidim/generators/test/generator_examples.rb
@@ -181,6 +181,7 @@ shared_context "with application env vars" do
       "PROPOSALS_PROCESS_GROUP_HIGHLIGHTED_PROPOSALS_LIMIT" => "5",
       "MEETINGS_UPCOMING_MEETING_NOTIFICATION" => "3",
       "MEETINGS_ENABLE_PROPOSAL_LINKING" => "false",
+      "MEETINGS_EMBEDDABLE_SERVICES" => "www.youtube.com www.twitch.tv meet.jit.si 8x8.vc",
       "BUDGETS_ENABLE_PROPOSAL_LINKING" => "false",
       "ACCOUNTABILITY_ENABLE_PROPOSAL_LINKING" => "false",
       "CONSULTATIONS_STATS_CACHE_EXPIRATION_TIME" => "7",
@@ -303,6 +304,7 @@ shared_examples_for "an application with configurable env vars" do
       %w(decidim proposals process_group_highlighted_proposals_limit) => 3,
       %w(decidim meetings upcoming_meeting_notification) => 2,
       %w(decidim meetings enable_proposal_linking) => "auto",
+      %w(decidim meetings embeddable_services) => [],
       %w(decidim budgets enable_proposal_linking) => "auto",
       %w(decidim accountability enable_proposal_linking) => "auto",
       %w(decidim consultations stats_cache_expiration_time) => 5,
@@ -401,6 +403,7 @@ shared_examples_for "an application with configurable env vars" do
       %w(decidim proposals process_group_highlighted_proposals_limit) => 5,
       %w(decidim meetings upcoming_meeting_notification) => 3,
       %w(decidim meetings enable_proposal_linking) => false,
+      %w(decidim meetings embeddable_services) => %w(www.youtube.com www.twitch.tv meet.jit.si 8x8.vc),
       %w(decidim budgets enable_proposal_linking) => false,
       %w(decidim accountability enable_proposal_linking) => false,
       %w(decidim consultations stats_cache_expiration_time) => 7,
@@ -608,14 +611,16 @@ shared_examples_for "an application with configurable env vars" do
   let(:meetings_initializer_off) do
     {
       "upcoming_meeting_notification" => 172_800, # 2.days
-      "enable_proposal_linking" => true
+      "enable_proposal_linking" => true,
+      "embeddable_services" => %w(www.youtube.com www.twitch.tv meet.jit.si)
     }
   end
 
   let(:meetings_initializer_on) do
     {
       "upcoming_meeting_notification" => 259_200, # 3.days
-      "enable_proposal_linking" => false
+      "enable_proposal_linking" => false,
+      "embeddable_services" => %w(www.youtube.com www.twitch.tv meet.jit.si 8x8.vc)
     }
   end
 

--- a/decidim-meetings/app/services/decidim/meetings/meeting_iframe_embedder.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meeting_iframe_embedder.rb
@@ -30,7 +30,7 @@ module Decidim
       def embeddable?
         return nil if parsed_online_meeting_uri.nil?
 
-        EMBEDDABLE_SERVICES.include?(parsed_online_meeting_uri.host)
+        embeddable_services.include?(parsed_online_meeting_uri.host)
       end
 
       def embed_code(request_host)
@@ -48,9 +48,11 @@ module Decidim
 
       private
 
-      EMBEDDABLE_SERVICES = %( www.youtube.com www.twitch.tv meet.jit.si )
-
       attr_accessor :online_meeting_service_url
+
+      def embeddable_services
+        @embeddable_services ||= Meetings.embeddable_services
+      end
 
       # Youtube transformation consists on:
       # 1. extract the video id from the parameter v

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -43,7 +43,7 @@
         <%= form.select :iframe_embed_type,
           @form.iframe_embed_type_select,
           { multiple: false } %>
-        <p class="help-text"><%= t(".show_embedded_iframe_help") %></p>
+        <p class="help-text"><%= t(".show_embedded_iframe_help", domains: Decidim::Meetings.embeddable_services&.join(" ")) %></p>
       </div>
 
       <div class="row column field iframe-fields--access-level" data-meeting-type="online-access-level">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_form.html.erb
@@ -38,7 +38,7 @@
     <%= form.select :iframe_embed_type,
       @form.iframe_embed_type_select,
       { multiple: false } %>
-    <p class="help-text"><%= t(".show_embedded_iframe_help") %></p>
+    <p class="help-text"><%= t(".show_embedded_iframe_help", domains: Decidim::Meetings.embeddable_services&.join(" ")) %></p>
   </div>
 
   <div class="field iframe-fields--access-level" id="meeting_iframe_embed_type" data-meeting-type="online-access-level">

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -312,7 +312,7 @@ en:
             select_a_meeting_type: Please select a meeting type
             select_a_registration_type: Please select a registration type
             select_an_iframe_access_level: Please select an iframe access level
-            show_embedded_iframe_help: Only a few services allow embedding in meeting or live event (YouTube, Twitch and Jitsi)
+            show_embedded_iframe_help: "Only a few services allow embedding in meeting or live event from the following domains: %{domains}"
           index:
             title: Meetings
           new:
@@ -509,7 +509,7 @@ en:
           select_a_meeting_type: Please select a meeting type
           select_a_registration_type: Please select a registration type
           select_an_iframe_access_level: Please select an iframe access level
-          show_embedded_iframe_help: Only a few services allow embedding in meeting or live event (YouTube, Twitch and Jitsi)
+          show_embedded_iframe_help: "Only a few services allow embedding in meeting or live event from the following domains: %{domains}"
         index:
           click_here: See all meetings
           new_meeting: New meeting

--- a/decidim-meetings/lib/decidim/meetings.rb
+++ b/decidim-meetings/lib/decidim/meetings.rb
@@ -28,5 +28,9 @@ module Decidim
     config_accessor :upcoming_meeting_notification do
       2.days
     end
+
+    config_accessor :embeddable_services do
+      %w(www.youtube.com www.twitch.tv meet.jit.si)
+    end
   end
 end

--- a/decidim-meetings/spec/services/meeting_iframe_embedder_spec.rb
+++ b/decidim-meetings/spec/services/meeting_iframe_embedder_spec.rb
@@ -79,7 +79,7 @@ module Decidim
           it "is not embeddable" do
             expect(subject).not_to be_embeddable
           end
-  
+
           context "and emebeddable services are customized" do
             let(:services) { %w(www.youtube.com www.twitch.tv meet.jit.si example.org) }
 

--- a/decidim-meetings/spec/services/meeting_iframe_embedder_spec.rb
+++ b/decidim-meetings/spec/services/meeting_iframe_embedder_spec.rb
@@ -8,6 +8,11 @@ module Decidim
       subject { described_class.new(url) }
 
       let(:request_host) { "decidim.org" }
+      let(:services) { %w(www.youtube.com www.twitch.tv meet.jit.si) }
+
+      before do
+        allow(Decidim::Meetings).to receive(:embeddable_services).and_return services
+      end
 
       describe "#embed_transformed_url" do
         context "with a valid youtube URL" do
@@ -73,6 +78,14 @@ module Decidim
 
           it "is not embeddable" do
             expect(subject).not_to be_embeddable
+          end
+  
+          context "and emebeddable services are customized" do
+            let(:services) { %w(www.youtube.com www.twitch.tv meet.jit.si example.org) }
+
+            it "is not embeddable" do
+              expect(subject).to be_embeddable
+            end
           end
         end
       end

--- a/docs/modules/configure/pages/environment_variables.adoc
+++ b/docs/modules/configure/pages/environment_variables.adoc
@@ -711,6 +711,11 @@ Using a very high number (ie: 0.99) can effectively deactivate the comparison st
 |auto
 |No
 
+|MEETINGS_EMBEDDABLE_SERVICES
+|A list (separated by spaces) of allowed services that can be embedded in a iframe when creating an online meeting.
+|www.youtube.com www.twitch.tv meet.jit.si
+|No
+
 |BUDGETS_ENABLE_PROPOSAL_LINKING
 |If true, enables several relationships between budgets and proposals. By default is active if Proposals are active (which is true always at the moment).
 


### PR DESCRIPTION
#### :tophat: What? Why?
- [x] add configuration var for embeddable services in meetings
- [x] add ENV var for embeddable meetings

Since the introduccion of the online meetings it is possible to embed an iframe with a link for an external video service (Jit.si, etc). However the list of allowed services was hardcoded to only `www.youtube.com www.twitch.tv meet.jit.si`.

This adds a configurable accessor into the Meetings module and a generic ENV var (`MEETING_EMBEDDABLE_SERVICES`) to allow system maintainers to configure this.

Note that a nice follow up for this could be to allow system admins to configure this in /system. 

#### Testing
Use the ENV var `MEETING_EMBEDDABLE_SERVICES` to add alternatives to the default allowed services.
 
#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
