### PR TITLE
Fix hashtag parsing on URLs with fragments

### DIFF
--- a/decidim-core/lib/decidim/content_parsers/hashtag_parser.rb
+++ b/decidim-core/lib/decidim/content_parsers/hashtag_parser.rb
@@ -18,7 +18,7 @@ module Decidim
 
       # Matches a hashtag if it starts with a letter or number
       # and only contains letters, numbers or underscores.
-      HASHTAG_REGEX = /\B#([[:alnum:]](?:[[:alnum:]]|_)*)\b/i.freeze
+      HASHTAG_REGEX = /\s\K\B#([[:alnum:]](?:[[:alnum:]]|_)*)\b/i.freeze
 
       # Replaces hashtags name with new or existing hashtags models global ids.
       #

--- a/decidim-core/spec/content_parsers/decidim/hashtag_parser_spec.rb
+++ b/decidim-core/spec/content_parsers/decidim/hashtag_parser_spec.rb
@@ -89,5 +89,26 @@ module Decidim
 
       it_behaves_like "find and stores the hashtags references"
     end
+
+    context "when content contains an URL with a fragment (aka anchored link)" do
+      let(:hashtag) { Decidim::Hashtag.find_by(organization: organization, name: name) }
+      let(:content) { "You can add an URL and this shouldn't be parsed http://www.example.org/path##{hashtag.name}" }
+      let(:parsed_content) { "You can add an URL and this shouldn't be parsed http://www.example.org/path#fragment" }
+
+      it "doesn't find the hashtag" do
+        expect(parser.metadata).to be_a(Decidim::ContentParsers::HashtagParser::Metadata)
+        expect(parser.metadata.hashtags).to eq([])
+      end
+
+      context "when written with an slash before the fragmnent" do
+        let(:content) { "You can add an URL and this shouldn't be parsed http://www.example.org/path/#fragment" }
+        let(:parsed_content) { "You can add an URL and this shouldn't be parsed http://www.example.org/path/#fragment" }
+
+        it "doesn't find the hashtag" do
+          expect(parser.metadata).to be_a(Decidim::ContentParsers::HashtagParser::Metadata)
+          expect(parser.metadata.hashtags).to eq([])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

When there's a proposal with a body with a URL with a fragment, the Hashtag parser thinks that this is hashtag and links it like that (/search?term=%23fragment). This PR fixes that. 

#### :pushpin: Related Issues
 
- Fixes #5951

#### Testing

Create a proposal with a URL like http://www.example.org/path/#fragment  

(Mind that for trying this out locally you should stop the rails' server, edit the proposal and modify the body). 

### :camera: Screenshots

#### Before

![image](https://user-images.githubusercontent.com/717367/166414332-02d657cd-26a5-4fa6-9b0f-09d4a0f40d75.png)


#### After


![image](https://user-images.githubusercontent.com/717367/166414350-27056d37-2e10-4f5d-a01a-43067b2ffe17.png)

:hearts: Thank you!
