### PR TITLE
Fix for internal links not displaying on page title

### DIFF
--- a/decidim-core/app/cells/decidim/card_m/show.erb
+++ b/decidim-core/app/cells/decidim/card_m/show.erb
@@ -9,7 +9,7 @@
       <div class="card__text">
         <div class="card__text--paragraph">
           <%= render :badge if has_badge? %>
-          <%= description %>
+          <%= Decidim::ContentProcessor.render(description, "div") %>
         </div>
       </div>
 

--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -94,11 +94,17 @@ module Decidim
       end
     end
 
+    # This method is currently being used only for Proposal and Meeting,
+    # It aims to load the presenter class, and perform some basic sanitization on the content
+    # This method should be used along side simple_format.
+    # @param resource [Object] Resource object
+    # @param method [Symbol] Method name
+    #
+    # @return ActiveSupport::SafeBuffer
     def render_sanitized_content(resource, method)
       content = present(resource).send(method, links: true, strip_tags: !safe_content?)
-      content = simple_format(content, {}, sanitize: false)
 
-      return content unless safe_content?
+      return decidim_sanitize(content, {}) unless safe_content?
 
       decidim_sanitize_editor(content)
     end

--- a/decidim-core/lib/decidim/content_parsers.rb
+++ b/decidim-core/lib/decidim/content_parsers.rb
@@ -9,5 +9,6 @@ module Decidim
     autoload :NewlineParser, "decidim/content_parsers/newline_parser"
     autoload :LinkParser, "decidim/content_parsers/link_parser"
     autoload :InlineImagesParser, "decidim/content_parsers/inline_images_parser"
+    autoload :ResourceParser, "decidim/content_parsers/resource_parser"
   end
 end

--- a/decidim-core/lib/decidim/content_parsers/resource_parser.rb
+++ b/decidim-core/lib/decidim/content_parsers/resource_parser.rb
@@ -78,7 +78,7 @@ module Decidim
 
       def find_organization(uri_host)
         current_organization = context[:current_organization]
-        current_organization.secondary_hosts.append(current_organization.host).include?(uri_host)
+        (current_organization.host == uri_host) || current_organization.secondary_hosts.include?(uri_host)
       end
 
       def url_regex

--- a/decidim-core/lib/decidim/content_parsers/resource_parser.rb
+++ b/decidim-core/lib/decidim/content_parsers/resource_parser.rb
@@ -52,6 +52,7 @@ module Decidim
       def resource_from_url_match(match)
         uri = URI.parse(match)
         return if uri.path.blank?
+        return unless find_organization(uri.host)
 
         resource_id = uri.path.split("/").last
         find_resource_by_id(resource_id)
@@ -73,6 +74,11 @@ module Decidim
           components = Component.where(participatory_space: spaces).published
           model_class.constantize.where(component: components).find_by(id: id)
         end
+      end
+
+      def find_organization(uri_host)
+        current_organization = context[:current_organization]
+        current_organization.secondary_hosts.append(current_organization.host).include?(uri_host)
       end
 
       def url_regex

--- a/decidim-core/lib/decidim/content_parsers/resource_parser.rb
+++ b/decidim-core/lib/decidim/content_parsers/resource_parser.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ContentParsers
+    # A parser that searches mentions of Resources in content.
+    #
+    # @see BaseParser Examples of how to use a content parser
+    class ResourceParser < BaseParser
+
+      # Matches a URL
+      URL_REGEX_SCHEME = '(?:http(s)?:\/\/)'
+      URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+'
+      URL_REGEX_END_CHAR = '[\d]'
+      # Matches a mentioned resource ID (~(d)+ expression)
+      ID_REGEX = /~(\d+)/
+
+
+      # Replaces found mentions matching an existing
+      # Resource with a global id for that Resource. Other mentions found that doesn't
+      # match an existing Resource are returned as they are.
+      #
+      # @return [String] the content with the valid mentions replaced by a global id.
+      def rewrite
+        rewrited_content = parse_for_urls(content)
+        parse_for_ids(rewrited_content)
+      end
+
+      private
+
+      def parse_for_urls(content)
+        content.gsub(url_regex) do |match|
+          resource = resource_from_url_match(match)
+          if resource
+            @metadata.linked_proposals << resource.id if is_proposal(resource)
+            resource.to_global_id
+          else
+            match
+          end
+        end
+      end
+
+      def parse_for_ids(content)
+        content.gsub(ID_REGEX) do |match|
+          resource = resource_from_id_match(Regexp.last_match(1))
+          if resource
+            @metadata.linked_proposals << resource.id if is_proposal(resource)
+            resource.to_global_id
+          else
+            match
+          end
+        end
+      end
+
+      def resource_from_url_match(match)
+        uri = URI.parse(match)
+        return if uri.path.blank?
+
+        resource_id = uri.path.split("/").last
+        find_resource_by_id(resource_id)
+      rescue URI::InvalidURIError
+        Rails.logger.error("#{e.message}=>#{e.backtrace}")
+        nil
+      end
+
+      def resource_from_id_match(match)
+        resource_id = match
+        find_resource_by_id(resource_id)
+      end
+
+      def find_resource_by_id(id)
+        if id.present?
+          spaces = Decidim.participatory_space_manifests.flat_map do |manifest|
+            manifest.participatory_spaces.call(context[:current_organization]).public_spaces
+          end
+          components = Component.where(participatory_space: spaces).published
+          model_class.constantize.where(component: components).find_by(id: id)
+        end
+      end
+
+      def is_proposal(resource)
+        resource.is_a?(Decidim::Proposals::Proposal)
+      end
+
+      def url_regex
+        raise "Not implemented"
+      end
+
+      def model_class
+        raise "Not implemented"
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/content_parsers/resource_parser.rb
+++ b/decidim-core/lib/decidim/content_parsers/resource_parser.rb
@@ -6,14 +6,12 @@ module Decidim
     #
     # @see BaseParser Examples of how to use a content parser
     class ResourceParser < BaseParser
-
       # Matches a URL
       URL_REGEX_SCHEME = '(?:http(s)?:\/\/)'
       URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+'
       URL_REGEX_END_CHAR = '[\d]'
       # Matches a mentioned resource ID (~(d)+ expression)
       ID_REGEX = /~(\d+)/
-
 
       # Replaces found mentions matching an existing
       # Resource with a global id for that Resource. Other mentions found that doesn't
@@ -31,7 +29,7 @@ module Decidim
         content.gsub(url_regex) do |match|
           resource = resource_from_url_match(match)
           if resource
-            @metadata.linked_proposals << resource.id if is_proposal(resource)
+            update_metadata(resource)
             resource.to_global_id
           else
             match
@@ -43,7 +41,7 @@ module Decidim
         content.gsub(ID_REGEX) do |match|
           resource = resource_from_id_match(Regexp.last_match(1))
           if resource
-            @metadata.linked_proposals << resource.id if is_proposal(resource)
+            update_metadata(resource)
             resource.to_global_id
           else
             match
@@ -77,16 +75,16 @@ module Decidim
         end
       end
 
-      def is_proposal(resource)
-        resource.is_a?(Decidim::Proposals::Proposal)
-      end
-
       def url_regex
         raise "Not implemented"
       end
 
       def model_class
         raise "Not implemented"
+      end
+
+      def update_metadata(resource)
+        # code to update metadata - needs to be overwritten
       end
     end
   end

--- a/decidim-core/lib/decidim/content_processor.rb
+++ b/decidim-core/lib/decidim/content_processor.rb
@@ -100,7 +100,8 @@ module Decidim
       simple_format(
         render_without_format(content, options),
         {},
-        wrapper_tag: wrapper_tag
+        wrapper_tag: wrapper_tag,
+        sanitize: false
       )
     end
 

--- a/decidim-core/lib/decidim/content_renderers.rb
+++ b/decidim-core/lib/decidim/content_renderers.rb
@@ -7,5 +7,6 @@ module Decidim
     autoload :UserGroupRenderer, "decidim/content_renderers/user_group_renderer"
     autoload :HashtagRenderer, "decidim/content_renderers/hashtag_renderer"
     autoload :LinkRenderer, "decidim/content_renderers/link_renderer"
+    autoload :ResourceRenderer, "decidim/content_renderers/resource_renderer"
   end
 end

--- a/decidim-core/lib/decidim/content_renderers/resource_renderer.rb
+++ b/decidim-core/lib/decidim/content_renderers/resource_renderer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ContentRenderers
+    class ResourceRenderer < BaseRenderer
+      # Matches a global id representing a Decidim::User
+
+      # Replaces found Global IDs matching an existing resource with
+      # a link to its show page. The Global IDs representing an
+      # invalid Resource are replaced with '???' string.
+      #
+      # @return [String] the content ready to display (contains HTML)
+      def render(_options = nil)
+        return content unless content.respond_to?(:gsub)
+
+        content.gsub(regex) do |resource_gid|
+          resource = GlobalID::Locator.locate(resource_gid)
+          resource.presenter.display_mention
+        rescue ActiveRecord::RecordNotFound
+          resource_id = resource_gid.split("/").last
+          "~#{resource_id}"
+        end
+      end
+
+      def regex
+        raise "Not implemented"
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
@@ -31,7 +31,7 @@ module Decidim
 
         def create_meeting!
           parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: form.current_organization).rewrite
-          parsed_description = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.description, current_organization: form.current_organization).rewrite
+          parsed_description = Decidim::ContentProcessor.parse(form.description, current_organization: form.current_organization).rewrite
           params = {
             scope: form.scope,
             category: form.category,

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
@@ -37,7 +37,7 @@ module Decidim
 
         def update_meeting!
           parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: form.current_organization).rewrite
-          parsed_description = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.description, current_organization: form.current_organization).rewrite
+          parsed_description = Decidim::ContentProcessor.parse(form.description, current_organization: form.current_organization).rewrite
 
           Decidim.traceability.update!(
             meeting,

--- a/decidim-meetings/app/commands/decidim/meetings/create_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/create_meeting.rb
@@ -31,7 +31,8 @@ module Decidim
 
       def create_meeting!
         parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: form.current_organization).rewrite
-        parsed_description = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.description, current_organization: form.current_organization).rewrite
+        parsed_description = Decidim::ContentProcessor.parse(form.description, current_organization: form.current_organization).rewrite
+
         params = {
           scope: form.scope,
           category: form.category,

--- a/decidim-meetings/app/commands/decidim/meetings/update_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/update_meeting.rb
@@ -37,7 +37,7 @@ module Decidim
 
       def update_meeting!
         parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: form.current_organization).rewrite
-        parsed_description = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.description, current_organization: form.current_organization).rewrite
+        parsed_description = Decidim::ContentProcessor.parse(form.description, current_organization: form.current_organization).rewrite
 
         Decidim.traceability.update!(
           meeting,

--- a/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
@@ -67,7 +67,7 @@ module Decidim
 
       # If the content is safe, HTML tags are sanitized, otherwise, they are stripped.
       def render_meeting_body(meeting)
-        render_sanitized_content(meeting, :description)
+        Decidim::ContentProcessor.render(render_sanitized_content(meeting, :description), "div")
       end
 
       def prevent_timeout_seconds

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -7,10 +7,19 @@ module Decidim
     #
     class MeetingPresenter < Decidim::ResourcePresenter
       include Decidim::ResourceHelper
+      include ActionView::Helpers::UrlHelper
       include Decidim::SanitizeHelper
 
       def meeting
         __getobj__
+      end
+
+      def meeting_path
+        Decidim::ResourceLocatorPresenter.new(meeting).path
+      end
+
+      def display_mention
+        link_to title, meeting_path
       end
 
       def title(links: false, html_escape: false, all_locales: false)

--- a/decidim-meetings/lib/decidim/content_parsers/meeting_parser.rb
+++ b/decidim-meetings/lib/decidim/content_parsers/meeting_parser.rb
@@ -6,7 +6,6 @@ module Decidim
     #
     # @see BaseParser Examples of how to use a content parser
     class MeetingParser < ResourceParser
-
       private
 
       def url_regex

--- a/decidim-meetings/lib/decidim/content_parsers/meeting_parser.rb
+++ b/decidim-meetings/lib/decidim/content_parsers/meeting_parser.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ContentParsers
+    # A parser that searches mentions of Meetings in content.
+    #
+    # @see BaseParser Examples of how to use a content parser
+    class MeetingParser < ResourceParser
+
+      private
+
+      def url_regex
+        %r{#{URL_REGEX_SCHEME}#{URL_REGEX_CONTENT}/meetings/#{URL_REGEX_END_CHAR}+}i
+      end
+
+      def model_class
+        "Decidim::Meetings::Meeting"
+      end
+    end
+  end
+end

--- a/decidim-meetings/lib/decidim/content_renderers/meeting_renderer.rb
+++ b/decidim-meetings/lib/decidim/content_renderers/meeting_renderer.rb
@@ -2,16 +2,16 @@
 
 module Decidim
   module ContentRenderers
-    # A renderer that searches Global IDs representing proposals in content
+    # A renderer that searches Global IDs representing meetings in content
     # and replaces it with a link to their show page.
     #
-    # e.g. gid://<APP_NAME>/Decidim::Proposals::Proposal/1
+    # e.g. gid://<APP_NAME>/Decidim::Meetings::Meeting/1
     #
     # @see BaseRenderer Examples of how to use a content renderer
-    class ProposalRenderer < ResourceRenderer
+    class MeetingRenderer < ResourceRenderer
 
       def regex
-        %r{gid://([\w-]*/Decidim::Proposals::Proposal/(\d+))}i
+        %r{gid://([\w-]*/Decidim::Meetings::Meeting/(\d+))}i
       end
     end
   end

--- a/decidim-meetings/lib/decidim/content_renderers/meeting_renderer.rb
+++ b/decidim-meetings/lib/decidim/content_renderers/meeting_renderer.rb
@@ -9,7 +9,6 @@ module Decidim
     #
     # @see BaseRenderer Examples of how to use a content renderer
     class MeetingRenderer < ResourceRenderer
-
       def regex
         %r{gid://([\w-]*/Decidim::Meetings::Meeting/(\d+))}i
       end

--- a/decidim-meetings/lib/decidim/meetings.rb
+++ b/decidim-meetings/lib/decidim/meetings.rb
@@ -29,4 +29,12 @@ module Decidim
       2.days
     end
   end
+
+  module ContentParsers
+    autoload :MeetingParser, "decidim/content_parsers/meeting_parser"
+  end
+
+  module ContentRenderers
+    autoload :MeetingRenderer, "decidim/content_renderers/meeting_renderer"
+  end
 end

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -42,6 +42,12 @@ module Decidim
         end
       end
 
+      initializer "decidim.content_processors" do |_app|
+        Decidim.configure do |config|
+          config.content_processors += [:meeting]
+        end
+      end
+
       initializer "decidim_meetings.view_hooks" do
         Decidim.view_hooks.register(:participatory_space_highlighted_elements, priority: Decidim::ViewHooks::HIGH_PRIORITY) do |view_context|
           view_context.cell("decidim/meetings/highlighted_meetings", view_context.current_participatory_space)

--- a/decidim-meetings/spec/lib/decidim/content_parsers/meeting_parser_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/content_parsers/meeting_parser_spec.rb
@@ -14,7 +14,7 @@ module Decidim
         let(:content) { "" }
 
         it "must call MeetingParser.parse" do
-          expect(described_class).to receive(:new).with(content, context).and_return(parser)
+          allow(described_class).to receive(:new).with(content, context).and_return(parser)
 
           result = Decidim::ContentProcessor.parse(content, context)
 

--- a/decidim-meetings/spec/lib/decidim/content_parsers/meeting_parser_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/content_parsers/meeting_parser_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ContentParsers
+    describe MeetingParser do
+      let(:organization) { create(:organization) }
+      let(:component) { create(:meeting_component, organization: organization) }
+      let(:context) { { current_organization: organization } }
+      let!(:parser) { Decidim::ContentParsers::MeetingParser.new(content, context) }
+
+      describe "ContentParser#parse is invoked" do
+        let(:content) { "" }
+
+        it "must call MeetingParser.parse" do
+          expect(described_class).to receive(:new).with(content, context).and_return(parser)
+
+          result = Decidim::ContentProcessor.parse(content, context)
+
+          expect(result.rewrite).to eq ""
+          expect(result.metadata[:meeting].class).to eq Decidim::ContentParsers::MeetingParser::Metadata
+        end
+      end
+
+      describe "on parse" do
+        subject { parser.rewrite }
+
+        context "when content is nil" do
+          let(:content) { nil }
+
+          it { is_expected.to eq("") }
+        end
+
+        context "when content is empty string" do
+          let(:content) { "" }
+
+          it { is_expected.to eq("") }
+        end
+
+        context "when content has no links" do
+          let(:content) { "whatever content with @mentions but no links." }
+
+          it { is_expected.to eq(content) }
+        end
+
+        context "when content links to an organization different from current" do
+          let(:meeting) { create(:meeting, component: component) }
+          let(:other_component) { create(:meeting_component, organization: create(:organization)) }
+          let(:external_meeting) { create(:meeting, component: other_component) }
+          let(:content) do
+            url = meeting_url(external_meeting)
+            "This content references meeting #{url}."
+          end
+
+          it { is_expected.to eq(content) }
+        end
+
+        context "when content has one link" do
+          let(:meeting) { create(:meeting, component: component) }
+          let(:content) do
+            url = meeting_url(meeting)
+            "This content references meeting #{url}."
+          end
+
+          it { is_expected.to eq("This content references meeting #{meeting.to_global_id}.") }
+        end
+
+        context "when content has one link that is a simple domain" do
+          let(:link) { "aaa:bbb" }
+          let(:content) do
+            "This content contains #{link} which is not a URI."
+          end
+
+          it { is_expected.to eq(content) }
+        end
+
+        context "when content has many links" do
+          let(:meeting1) { create(:meeting, component: component) }
+          let(:meeting2) { create(:meeting, component: component) }
+          let(:meeting3) { create(:meeting, component: component) }
+          let(:content) do
+            url1 = meeting_url(meeting1)
+            url2 = meeting_url(meeting2)
+            url3 = meeting_url(meeting3)
+            "This content references the following meetings: #{url1}, #{url2} and #{url3}. Great?I like them!"
+          end
+
+          it { is_expected.to eq("This content references the following meetings: #{meeting1.to_global_id}, #{meeting2.to_global_id} and #{meeting3.to_global_id}. Great?I like them!") }
+        end
+
+        context "when content has a link that is not in a meeting component" do
+          let(:meeting) { create(:meeting, component: component) }
+          let(:content) do
+            url = meeting_url(meeting).sub(%r{/meetings/}, "/something-else/")
+            "This content references a non-meeting with same ID as a meeting #{url}."
+          end
+
+          it { is_expected.to eq(content) }
+        end
+
+        context "when content has words similar to links but not links" do
+          let(:similars) do
+            %w(AA:aaa AA:sss aa:aaa aa:sss aaa:sss aaaa:sss aa:ssss aaa:ssss)
+          end
+          let(:content) do
+            "This content has similars to links: #{similars.join}. Great! Now are not treated as links"
+          end
+
+          it { is_expected.to eq(content) }
+        end
+
+        context "when meeting in content does not exist" do
+          let(:meeting) { create(:meeting, component: component) }
+          let(:url) { meeting_url(meeting) }
+          let(:content) do
+            meeting.destroy
+            "This content references meeting #{url}."
+          end
+
+          it { is_expected.to eq("This content references meeting #{url}.") }
+        end
+
+        context "when meeting is linked via ID" do
+          let(:meeting) { create(:meeting, component: component) }
+          let(:content) { "This content references meeting ~#{meeting.id}." }
+
+          it { is_expected.to eq("This content references meeting #{meeting.to_global_id}.") }
+        end
+      end
+
+      def meeting_url(meeting)
+        Decidim::ResourceLocatorPresenter.new(meeting).url
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/lib/decidim/content_renderers/meeting_renderer_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/content_renderers/meeting_renderer_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 
 module Decidim
   module ContentRenderers
-    describe ResourceRenderer do
-      let!(:renderer) { Decidim::ContentRenderers::ResourceRenderer.new(content) }
+    describe MeetingRenderer do
+      let!(:renderer) { Decidim::ContentRenderers::MeetingRenderer.new(content) }
 
       describe "on parse" do
         subject { renderer.render }
@@ -23,32 +23,32 @@ module Decidim
         end
 
         context "when content has no gids" do
-          let(:content) { "whatever content with @mentions and #hashes but no gids." }
+          let(:content) { "whatever content with @mentions but no gids." }
 
           it { is_expected.to eq(content) }
         end
 
         context "when content has one gid" do
-          let(:proposal) { create(:proposal) }
+          let(:meeting) { create(:meeting) }
           let(:content) do
-            "This content references proposal #{proposal.to_global_id}."
+            "This content references meeting #{meeting.to_global_id}."
           end
 
-          it { is_expected.to eq("This content references proposal #{resource_as_html_link(proposal)}.") }
+          it { is_expected.to eq("This content references meeting #{resource_as_html_link(meeting)}.") }
         end
 
         context "when content has many links" do
-          let(:proposal_1) { create(:proposal) }
-          let(:proposal_2) { create(:proposal) }
-          let(:proposal_3) { create(:proposal) }
+          let(:meeting_1) { create(:meeting) }
+          let(:meeting_2) { create(:meeting) }
+          let(:meeting_3) { create(:meeting) }
           let(:content) do
-            gid1 = proposal_1.to_global_id
-            gid2 = proposal_2.to_global_id
-            gid3 = proposal_3.to_global_id
+            gid1 = meeting_1.to_global_id
+            gid2 = meeting_2.to_global_id
+            gid3 = meeting_3.to_global_id
             "This content references the following proposals: #{gid1}, #{gid2} and #{gid3}. Great?I like them!"
           end
 
-          it { is_expected.to eq("This content references the following proposals: #{resource_as_html_link(proposal_1)}, #{resource_as_html_link(proposal_2)} and #{resource_as_html_link(proposal_3)}. Great?I like them!") }
+          it { is_expected.to eq("This content references the following proposals: #{resource_as_html_link(meeting_1)}, #{resource_as_html_link(meeting_2)} and #{resource_as_html_link(meeting_3)}. Great?I like them!") }
         end
       end
 

--- a/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
@@ -61,7 +61,7 @@ module Decidim
 
         def attributes
           parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: form.current_organization).rewrite
-          parsed_body = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.body, current_organization: form.current_organization).rewrite
+          parsed_body = Decidim::ContentProcessor.parse(form.body, current_organization: form.current_organization).rewrite
           {
             title: parsed_title,
             body: parsed_body,

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
@@ -59,7 +59,7 @@ module Decidim
 
         def update_proposal
           parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: form.current_organization).rewrite
-          parsed_body = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.body, current_organization: form.current_organization).rewrite
+          parsed_body = Decidim::ContentProcessor.parse(form.body, current_organization: form.current_organization).rewrite
           Decidim.traceability.update!(
             proposal,
             form.current_user,

--- a/decidim-proposals/app/commands/decidim/proposals/hashtags_methods.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/hashtags_methods.rb
@@ -13,7 +13,7 @@ module Decidim
 
       def body_with_hashtags
         @body_with_hashtags ||= begin
-          ret = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.body, current_organization: form.current_organization).rewrite.strip
+          ret = Decidim::ContentProcessor.parse(form.body, current_organization: form.current_organization).rewrite.strip
           ret += "\n#{body_extra_hashtags.strip}" unless body_extra_hashtags.empty?
           ret
         end

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -100,7 +100,7 @@ module Decidim
 
       # If the content is safe, HTML tags are sanitized, otherwise, they are stripped.
       def render_proposal_body(proposal)
-        render_sanitized_content(proposal, :body)
+        Decidim::ContentProcessor.render(render_sanitized_content(proposal, :body), "div")
       end
 
       # Returns :text_area or :editor based on the organization' settings.

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -256,6 +256,12 @@ module Decidim
         ResourceLocatorPresenter.new(self).url
       end
 
+      # Returns the presenter for this author, to be used in the views.
+      # Required by ResourceRenderer.
+      def presenter
+        Decidim::Proposals::ProposalPresenter.new(self)
+      end
+
       # Public: Overrides the `reported_attributes` Reportable concern method.
       def reported_attributes
         [:title, :body]

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_similar.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_similar.html.erb
@@ -15,7 +15,7 @@
 
       <%== cell("decidim/proposals/proposal_m", proposal).badge %>
 
-      <p><%= truncate(present(proposal).body(strip_tags: true), length: 100) %></p>
+      <p><%= strip_tags(render_proposal_body(proposal)).truncate(100) %></p>
       <%= cell "decidim/tags", proposal, context: { extra_classes: ["tags--proposal"] } %>
     </div>
   </div>

--- a/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
+++ b/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
@@ -36,6 +36,10 @@ module Decidim
       def model_class
         "Decidim::Proposals::Proposal"
       end
+
+      def update_metadata(resource)
+        @metadata.linked_proposals << resource.id
+      end
     end
   end
 end

--- a/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
+++ b/decidim-proposals/lib/decidim/content_parsers/proposal_parser.rb
@@ -12,34 +12,16 @@ module Decidim
     # Also fills a `Metadata#linked_proposals` attribute.
     #
     # @see BaseParser Examples of how to use a content parser
-    class ProposalParser < BaseParser
+    class ProposalParser < ResourceParser
       # Class used as a container for metadata
       #
       # @!attribute linked_proposals
       #   @return [Array] an array of Decidim::Proposals::Proposal mentioned in content
       Metadata = Struct.new(:linked_proposals)
 
-      # Matches a URL
-      URL_REGEX_SCHEME = '(?:http(s)?:\/\/)'
-      URL_REGEX_CONTENT = '[\w.-]+[\w\-\._~:\/?#\[\]@!\$&\'\(\)\*\+,;=.]+'
-      URL_REGEX_END_CHAR = '[\d]'
-      URL_REGEX = %r{#{URL_REGEX_SCHEME}#{URL_REGEX_CONTENT}/proposals/#{URL_REGEX_END_CHAR}+}i
-      # Matches a mentioned Proposal ID (~(d)+ expression)
-      ID_REGEX = /~(\d+)/
-
       def initialize(content, context)
         super
         @metadata = Metadata.new([])
-      end
-
-      # Replaces found mentions matching an existing
-      # Proposal with a global id for that Proposal. Other mentions found that doesn't
-      # match an existing Proposal are returned as they are.
-      #
-      # @return [String] the content with the valid mentions replaced by a global id.
-      def rewrite
-        rewrited_content = parse_for_urls(content)
-        parse_for_ids(rewrited_content)
       end
 
       # (see BaseParser#metadata)
@@ -47,54 +29,12 @@ module Decidim
 
       private
 
-      def parse_for_urls(content)
-        content.gsub(URL_REGEX) do |match|
-          proposal = proposal_from_url_match(match)
-          if proposal
-            @metadata.linked_proposals << proposal.id
-            proposal.to_global_id
-          else
-            match
-          end
-        end
+      def url_regex
+        %r{#{URL_REGEX_SCHEME}#{URL_REGEX_CONTENT}/proposals/#{URL_REGEX_END_CHAR}+}i
       end
 
-      def parse_for_ids(content)
-        content.gsub(ID_REGEX) do |match|
-          proposal = proposal_from_id_match(Regexp.last_match(1))
-          if proposal
-            @metadata.linked_proposals << proposal.id
-            proposal.to_global_id
-          else
-            match
-          end
-        end
-      end
-
-      def proposal_from_url_match(match)
-        uri = URI.parse(match)
-        return if uri.path.blank?
-
-        proposal_id = uri.path.split("/").last
-        find_proposal_by_id(proposal_id)
-      rescue URI::InvalidURIError
-        Rails.logger.error("#{e.message}=>#{e.backtrace}")
-        nil
-      end
-
-      def proposal_from_id_match(match)
-        proposal_id = match
-        find_proposal_by_id(proposal_id)
-      end
-
-      def find_proposal_by_id(id)
-        if id.present?
-          spaces = Decidim.participatory_space_manifests.flat_map do |manifest|
-            manifest.participatory_spaces.call(context[:current_organization]).public_spaces
-          end
-          components = Component.where(participatory_space: spaces).published
-          Decidim::Proposals::Proposal.where(component: components).find_by(id: id)
-        end
+      def model_class
+        "Decidim::Proposals::Proposal"
       end
     end
   end

--- a/decidim-proposals/lib/decidim/content_renderers/proposal_renderer.rb
+++ b/decidim-proposals/lib/decidim/content_renderers/proposal_renderer.rb
@@ -9,7 +9,6 @@ module Decidim
     #
     # @see BaseRenderer Examples of how to use a content renderer
     class ProposalRenderer < ResourceRenderer
-
       def regex
         %r{gid://([\w-]*/Decidim::Proposals::Proposal/(\d+))}i
       end

--- a/decidim-proposals/spec/lib/decidim/content_parsers/proposal_parser_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/content_parsers/proposal_parser_spec.rb
@@ -70,6 +70,8 @@ module Decidim
             "This content references proposal #{url}."
           end
 
+          it { is_expected.to eq(content) }
+
           it "does not recognize the proposal" do
             subject
             expect(parser.metadata.linked_proposals).to eq([])

--- a/decidim-proposals/spec/lib/decidim/content_renderers/proposal_renderer_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/content_renderers/proposal_renderer_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 
 module Decidim
   module ContentRenderers
-    describe ResourceRenderer do
-      let!(:renderer) { Decidim::ContentRenderers::ResourceRenderer.new(content) }
+    describe ProposalRenderer do
+      let!(:renderer) { Decidim::ContentRenderers::ProposalRenderer.new(content) }
 
       describe "on parse" do
         subject { renderer.render }


### PR DESCRIPTION
It can be noticed that the internal links are not displayed as a title of the page for the following items and locations:

- Proposal link in a proposal/meeting page
- Meeting link in a proposal/meeting page or in a comment

#### :tophat: What? Why?
*Please describe your pull request.*

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #9202 

#### Testing
*Describe the best way to test or validate your PR.*


### :camera: Screenshots
![Screenshot from 2022-05-03 15-23-03](https://user-images.githubusercontent.com/66411127/166637046-08e9000c-963c-4f99-91f1-92ff7c689c81.png)

![Screenshot from 2022-05-03 15-24-47](https://user-images.githubusercontent.com/66411127/166637074-a5f6ca26-f728-4351-a4e5-3ec05426997b.png)

![Screenshot from 2022-05-03 15-25-18](https://user-images.githubusercontent.com/66411127/166637092-5065ac37-01fc-40e8-9f10-4c73ea35321c.png)

![Screenshot from 2022-05-03 15-30-17](https://user-images.githubusercontent.com/66411127/166637104-eeef75e6-975e-47a8-aabd-32f2e8a36ed9.png)

![Screenshot from 2022-05-03 15-56-41](https://user-images.githubusercontent.com/66411127/166637125-5789cb60-9701-43c0-be36-3299712ec65c.png)


:hearts: Thank you!
