### PR TITLE
Fix keyword arguments in the change nickname event and fixing task

### DIFF
--- a/decidim-core/app/events/decidim/change_nickname_event.rb
+++ b/decidim-core/app/events/decidim/change_nickname_event.rb
@@ -9,7 +9,7 @@ module Decidim
     i18n_attributes :link_to_account_settings
 
     def notification_title
-      I18n.t("decidim.events.nickname_event.notification_body", i18n_options).to_s.html_safe
+      I18n.t("decidim.events.nickname_event.notification_body", **i18n_options).to_s.html_safe
     end
 
     def i18n_options

--- a/decidim-core/lib/tasks/upgrade/decidim_fix_nickname_uniqueness.rake
+++ b/decidim-core/lib/tasks/upgrade/decidim_fix_nickname_uniqueness.rake
@@ -34,12 +34,12 @@ namespace :decidim do
     private
 
     def send_notification_to(user)
-      Decidim::EventsManager.publish({
-                                       event: "decidim.events.nickname_event",
-                                       event_class: Decidim::ChangeNicknameEvent,
-                                       affected_users: [user],
-                                       resource: user
-                                     })
+      Decidim::EventsManager.publish(
+        event: "decidim.events.nickname_event",
+        event_class: Decidim::ChangeNicknameEvent,
+        affected_users: [user],
+        resource: user
+      )
     end
 
     def update_user_nickname(user, new_nickname)


### PR DESCRIPTION
#### :tophat: What? Why?
After merging #8792 the build is broken because it was developed against Ruby 2.7 and meanwhile we merged Ruby 3.

This should fix the keyword argument issues introduced by that PR.

#### :pushpin: Related Issues
- Related to #8792

#### Testing
See the CI green or:

```bash
$ cd decidim-core
$ bundle exec rspec spec/events/decidim/change_nickname_event_spec.rb
$ bundle exec rspec spec/tasks/decidim_tasks_fix_nickname_uniqueness_spec.rb
```

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.