### PR TITLE
Fix Leaflet trying to load "infinite amount of tiles"

### DIFF
--- a/decidim-core/app/packs/src/decidim/map/controller/static.js
+++ b/decidim-core/app/packs/src/decidim/map/controller/static.js
@@ -16,6 +16,12 @@ export default class MapStaticController extends MapController {
       this.map.tap.disable();
     }
 
+    if (this.config.zoom) {
+      this.map.setZoom(this.config.zoom);
+    } else {
+      this.map.setZoom(15);
+    }
+
     if (this.config.latitude && this.config.longitude) {
       const coordinates = [this.config.latitude, this.config.longitude];
 
@@ -26,11 +32,6 @@ export default class MapStaticController extends MapController {
         title: this.config.title
       }).addTo(this.map);
       marker._icon.removeAttribute("tabindex");
-    }
-    if (this.config.zoom) {
-      this.map.setZoom(this.config.zoom);
-    } else {
-      this.map.setZoom(15);
     }
 
     if (this.config.link) {


### PR DESCRIPTION
#### :tophat: What? Why?
While testing #9156 I noticed that when we display the static map through Leaflet, there is the following error displayed in the developer console:

```
Uncaught Error: Attempted to load an infinite number of tiles
    at NewClass._update (leaflet-src.js:11068:1)
    at NewClass._setView (leaflet-src.js:10977:1)
    at NewClass._resetView (leaflet-src.js:10935:1)
    at NewClass.onAdd (leaflet-src.js:10572:1)
    at NewClass.onAdd (leaflet-tilelayer-here.js:115:1)
    at NewClass._layerAdd (leaflet-src.js:6487:1)
    at NewClass.fire (leaflet-src.js:593:1)
    at NewClass._resetView (leaflet-src.js:4117:1)
    at NewClass.setView (leaflet-src.js:3164:1)
    at NewClass.panTo (leaflet-src.js:3266:1)
```

After further investigation, the reason seems to be when we try to `setView` before defining a zoom value as explained here:
https://github.com/Leaflet/Leaflet/issues/6416#issuecomment-491980254

> This usually happens when you setView the first time without defining zoom or defining zoom incorrectly

So, moving the `setZoom` call before the `panTo` call seems to fix this issue.

#### :pushpin: Related Issues
- Related to Leaflet/Leaflet#6416

#### Testing
Configure the static maps to be displayed through leaflet with the following configuration at `config/initializers/decidim.rb`:

```ruby
  # Leave out the "static" config in which case Leaflet will be used as a fallback
  config.maps = {
     provider: :here,
     api_key: Rails.application.secrets.maps[:dynamic_api_key]
  }
```

After this:

- Make sure you have `MAPS_API_KEY` defined in your environment configs
- Enable geocoding for the proposals component
- Create one proposal with address and latitude/longitude assigned to it
- Go to the proposal preview or show view and see there are no errors in the developer console

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.