### PR TITLE
Backport "Remove 'edit link' in topbar for initiative's authors" to v0.26

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/index.html.erb
@@ -1,7 +1,7 @@
 <%
 edit_link(
   decidim_admin_initiatives.initiatives_path,
-  :list,
+  :read,
   :initiative
 )
 %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -9,9 +9,8 @@
 <%
 edit_link(
   resource_locator(current_participatory_space).edit,
-  :update,
-  :initiative,
-  initiative: current_participatory_space
+  :read,
+  :initiative
 )
 %>
 

--- a/decidim-initiatives/spec/system/edit_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/edit_initiative_spec.rb
@@ -44,6 +44,14 @@ describe "Edit initiative", type: :system do
 
     it_behaves_like "manage update"
 
+    it "doesn't show the header's edit link" do
+      visit initiative_path
+
+      within ".topbar" do
+        expect(page).not_to have_link("Edit")
+      end
+    end
+
     context "when initiative is published" do
       let(:initiative) { create(:initiative, author: user, scoped_type: scoped_type, organization: organization) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #8997 to v0.26

:hearts: Thank you!