### PR TITLE
Backport "Fix absolute urls on 'assembly member' and 'collaborative drafts' events" to v0.26

### DIFF
--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -401,7 +401,7 @@ en:
       assemblies:
         create_assembly_member:
           email_intro: An admin of the <a href="%{resource_url}">%{resource_name}</a> assembly has added you as one of its members.
-          email_outro: You have received this notification because you have been invited to an assembly. Check the <a href="%{resource_path}">assembly page</a> to contribute!
+          email_outro: You have received this notification because you have been invited to an assembly. Check the <a href="%{resource_url}">assembly page</a> to contribute!
           email_subject: You have been invited to be a member of the %{resource_name} assembly!
           notification_title: You have been registered as a member of Assembly <a href="%{resource_path}">%{resource_name}</a>. Check the <a href="%{resource_path}">assembly page</a> to contribute!
       assembly:

--- a/decidim-assemblies/spec/events/decidim/assemblies/create_assembly_member_event_spec.rb
+++ b/decidim-assemblies/spec/events/decidim/assemblies/create_assembly_member_event_spec.rb
@@ -27,7 +27,7 @@ describe Decidim::Assemblies::CreateAssemblyMemberEvent do
   describe "email_outro" do
     it "is generated correctly" do
       expect(subject.email_outro)
-        .to eq(%(You have received this notification because you have been invited to an assembly. Check the <a href="#{resource_path}">assembly page</a> to contribute!))
+        .to eq(%(You have received this notification because you have been invited to an assembly. Check the <a href="#{resource_url}">assembly page</a> to contribute!))
     end
   end
 

--- a/decidim-proposals/app/events/decidim/proposals/collaborative_draft_withdrawn_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/collaborative_draft_withdrawn_event.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Proposals
     class CollaborativeDraftWithdrawnEvent < Decidim::Events::SimpleEvent
-      i18n_attributes :author_nickname, :author_name, :author_path
+      i18n_attributes :author_nickname, :author_name, :author_path, :author_url
 
       delegate :nickname, :name, to: :author, prefix: true
 
@@ -13,6 +13,10 @@ module Decidim
 
       def author_path
         author.profile_path
+      end
+
+      def author_url
+        author.profile_url
       end
 
       private

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -226,33 +226,33 @@ en:
             email_subject: Someone left a note on proposal %{resource_title}.
             notification_title: Someone has left a note on the proposal <a href="%{resource_path}">%{resource_title}</a>. Check it out at <a href="%{admin_proposal_info_path}">the admin panel</a>
         collaborative_draft_access_accepted:
-          email_intro: '%{requester_name} has been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
-          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: '%{requester_name} has been accepted to access as a contributor of the <a href="%{resource_url}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_url}">%{resource_title}</a>.
           email_subject: "%{requester_name} has been accepted to access as a contributor of the %{resource_title}."
           notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_rejected:
-          email_intro: '%{requester_name} has been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.'
-          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: '%{requester_name} has been rejected to access as a contributor of the <a href="%{resource_url}">%{resource_title}</a> collaborative draft.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_url}">%{resource_title}</a>.
           email_subject: "%{requester_name} has been rejected to access as a contributor of the %{resource_title} collaborative draft."
           notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> has been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_requested:
-          email_intro: '%{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="%{resource_path}">%{resource_title}</a> collaborative draft page.'
-          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: '%{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="%{resource_url}">%{resource_title}</a> collaborative draft page.'
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_url}">%{resource_title}</a>.
           email_subject: "%{requester_name} requested access to contribute to %{resource_title}."
           notification_title: <a href="%{requester_path}">%{requester_name} %{requester_nickname}</a> requested access to contribute to the <a href="%{resource_path}">%{resource_title}</a> collaborative draft. Please <strong>accept or reject the request</strong>.
         collaborative_draft_access_requester_accepted:
-          email_intro: You have been accepted to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
-          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: You have been accepted to access as a contributor of the <a href="%{resource_url}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_url}">%{resource_title}</a>.
           email_subject: You have been accepted as a contributor of %{resource_title}.
           notification_title: You have been <strong>accepted to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_access_requester_rejected:
-          email_intro: You have been rejected to access as a contributor of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
-          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: You have been rejected to access as a contributor of the <a href="%{resource_url}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you requested to become a collaborator of <a href="%{resource_url}">%{resource_title}</a>.
           email_subject: You have been rejected as a contributor of %{resource_title}.
           notification_title: You have been <strong>rejected to access as a contributor</strong> of the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         collaborative_draft_withdrawn:
-          email_intro: <a href="%{author_path}">%{author_name} %{author_nickname}</a> withdrawn the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
-          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_path}">%{resource_title}</a>.
+          email_intro: <a href="%{author_url}">%{author_name} %{author_nickname}</a> withdrawn the <a href="%{resource_url}">%{resource_title}</a> collaborative draft.
+          email_outro: You have received this notification because you are a collaborator of <a href="%{resource_url}">%{resource_title}</a>.
           email_subject: "%{author_name} %{author_nickname} withdrawn the %{resource_title} collaborative draft."
           notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> <strong>withdrawn</strong> the <a href="%{resource_path}">%{resource_title}</a> collaborative draft.
         creation_enabled:

--- a/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_accepted_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_accepted_event_spec.rb
@@ -35,14 +35,14 @@ describe Decidim::Proposals::CollaborativeDraftAccessAcceptedEvent do
     describe "email_intro" do
       it "is generated correctly" do
         expect(subject.email_intro)
-          .to eq(%(#{requester_name} has been accepted to access as a contributor of the <a href="#{resource_path}">#{resource_title}</a> collaborative draft.))
+          .to eq(%(#{requester_name} has been accepted to access as a contributor of the <a href="#{resource_url}">#{resource_title}</a> collaborative draft.))
       end
     end
 
     describe "email_outro" do
       it "is generated correctly" do
         expect(subject.email_outro)
-          .to eq(%(You have received this notification because you are a collaborator of <a href="#{resource_path}">#{resource_title}</a>.))
+          .to eq(%(You have received this notification because you are a collaborator of <a href="#{resource_url}">#{resource_title}</a>.))
       end
     end
 
@@ -68,14 +68,14 @@ describe Decidim::Proposals::CollaborativeDraftAccessAcceptedEvent do
     describe "email_intro" do
       it "is generated correctly" do
         expect(subject.email_intro)
-          .to eq(%(You have been accepted to access as a contributor of the <a href="#{resource_path}">#{resource_title}</a> collaborative draft.))
+          .to eq(%(You have been accepted to access as a contributor of the <a href="#{resource_url}">#{resource_title}</a> collaborative draft.))
       end
     end
 
     describe "email_outro" do
       it "is generated correctly" do
         expect(subject.email_outro)
-          .to eq(%(You have received this notification because you requested to become a collaborator of <a href="#{resource_path}">#{resource_title}</a>.))
+          .to eq(%(You have received this notification because you requested to become a collaborator of <a href="#{resource_url}">#{resource_title}</a>.))
       end
     end
 

--- a/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_rejected_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_rejected_event_spec.rb
@@ -35,14 +35,14 @@ describe Decidim::Proposals::CollaborativeDraftAccessRejectedEvent do
     describe "email_intro" do
       it "is generated correctly" do
         expect(subject.email_intro)
-          .to eq(%(#{requester_name} has been rejected to access as a contributor of the <a href="#{resource_path}">#{resource_title}</a> collaborative draft.))
+          .to eq(%(#{requester_name} has been rejected to access as a contributor of the <a href="#{resource_url}">#{resource_title}</a> collaborative draft.))
       end
     end
 
     describe "email_outro" do
       it "is generated correctly" do
         expect(subject.email_outro)
-          .to eq(%(You have received this notification because you are a collaborator of <a href="#{resource_path}">#{resource_title}</a>.))
+          .to eq(%(You have received this notification because you are a collaborator of <a href="#{resource_url}">#{resource_title}</a>.))
       end
     end
 
@@ -68,14 +68,14 @@ describe Decidim::Proposals::CollaborativeDraftAccessRejectedEvent do
     describe "email_intro" do
       it "is generated correctly" do
         expect(subject.email_intro)
-          .to eq(%(You have been rejected to access as a contributor of the <a href="#{resource_path}">#{resource_title}</a> collaborative draft.))
+          .to eq(%(You have been rejected to access as a contributor of the <a href="#{resource_url}">#{resource_title}</a> collaborative draft.))
       end
     end
 
     describe "email_outro" do
       it "is generated correctly" do
         expect(subject.email_outro)
-          .to eq(%(You have received this notification because you requested to become a collaborator of <a href="#{resource_path}">#{resource_title}</a>.))
+          .to eq(%(You have received this notification because you requested to become a collaborator of <a href="#{resource_url}">#{resource_title}</a>.))
       end
     end
 

--- a/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_requested_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_requested_event_spec.rb
@@ -35,14 +35,14 @@ describe Decidim::Proposals::CollaborativeDraftAccessRequestedEvent do
     describe "email_intro" do
       it "is generated correctly" do
         expect(subject.email_intro)
-          .to eq(%(#{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="#{resource_path}">#{resource_title}</a> collaborative draft page.))
+          .to eq(%(#{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="#{resource_url}">#{resource_title}</a> collaborative draft page.))
       end
     end
 
     describe "email_outro" do
       it "is generated correctly" do
         expect(subject.email_outro)
-          .to eq(%(You have received this notification because you are a collaborator of <a href="#{resource_path}">#{resource_title}</a>.))
+          .to eq(%(You have received this notification because you are a collaborator of <a href="#{resource_url}">#{resource_title}</a>.))
       end
     end
 

--- a/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_withdrawn_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_withdrawn_event_spec.rb
@@ -13,6 +13,7 @@ describe Decidim::Proposals::CollaborativeDraftWithdrawnEvent do
   let(:author_id) { author.id }
   let(:author_presenter) { Decidim::UserPresenter.new(author) }
   let(:author_path) { author_presenter.profile_path }
+  let(:author_url) { author_presenter.profile_url }
   let(:author_name) { author_presenter.name }
   let(:author_nickname) { author_presenter.nickname }
   let(:extra) { { author_id: author_id } }
@@ -29,14 +30,14 @@ describe Decidim::Proposals::CollaborativeDraftWithdrawnEvent do
     describe "email_intro" do
       it "is generated correctly" do
         expect(subject.email_intro)
-          .to eq(%(<a href="#{author_path}">#{author_name} #{author_nickname}</a> withdrawn the <a href="#{resource_path}">#{resource_title}</a> collaborative draft.))
+          .to eq(%(<a href="#{author_url}">#{author_name} #{author_nickname}</a> withdrawn the <a href="#{resource_url}">#{resource_title}</a> collaborative draft.))
       end
     end
 
     describe "email_outro" do
       it "is generated correctly" do
         expect(subject.email_outro)
-          .to eq(%(You have received this notification because you are a collaborator of <a href="#{resource_path}">#{resource_title}</a>.))
+          .to eq(%(You have received this notification because you are a collaborator of <a href="#{resource_url}">#{resource_title}</a>.))
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9146 to v0.26

:hearts: Thank you!