### PR TITLE
Backport 'Do not send upcoming meeting notification for hidden or withdrawn meetings' to v0.26

### DIFF
--- a/decidim-meetings/app/jobs/decidim/meetings/upcoming_meeting_notification_job.rb
+++ b/decidim-meetings/app/jobs/decidim/meetings/upcoming_meeting_notification_job.rb
@@ -7,7 +7,10 @@ module Decidim
 
       def perform(meeting_id, checksum)
         meeting = Decidim::Meetings::Meeting.find(meeting_id)
-        send_notification(meeting) if verify_checksum(meeting, checksum)
+        return if meeting.hidden? || meeting.withdrawn?
+        return unless verify_checksum(meeting, checksum)
+
+        send_notification(meeting)
       end
 
       def self.generate_checksum(meeting)

--- a/decidim-meetings/spec/jobs/decidim/meetings/upcoming_meeting_notification_job_spec.rb
+++ b/decidim-meetings/spec/jobs/decidim/meetings/upcoming_meeting_notification_job_spec.rb
@@ -39,4 +39,26 @@ describe Decidim::Meetings::UpcomingMeetingNotificationJob do
       subject.perform_now(meeting.id, checksum)
     end
   end
+
+  context "when the meeting is hidden" do
+    let!(:moderation) { create(:moderation, reportable: meeting, report_count: 1, hidden_at: Time.current) }
+
+    it "doesn't notify the upcoming meeting" do
+      expect(Decidim::EventsManager)
+        .not_to receive(:publish)
+
+      subject.perform_now(meeting.id, checksum)
+    end
+  end
+
+  context "when the meeting is withdrawn" do
+    let(:meeting) { create :meeting, :withdrawn, start_time: start_time }
+
+    it "doesn't notify the upcoming meeting" do
+      expect(Decidim::EventsManager)
+        .not_to receive(:publish)
+
+      subject.perform_now(meeting.id, checksum)
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9134 to v0.26

:hearts: Thank you!