### PR TITLE
Add admin log when updating the meeting questionnaire

### DIFF
--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
@@ -21,12 +21,14 @@ module Decidim
         def call
           return broadcast(:invalid) if @form.invalid?
 
-          Decidim::Meetings::Questionnaire.transaction do
-            create_questionnaire_for
-            create_questionaire
-            if @questionnaire.questions_editable?
-              update_questionnaire_questions
-              delete_answers
+          Decidim.traceability.perform_action!("update",@questionnaire,@form.current_user) do
+            Decidim::Meetings::Questionnaire.transaction do
+              create_questionnaire_for
+              create_questionaire
+              if @questionnaire.questions_editable?
+                update_questionnaire_questions
+                delete_answers
+              end
             end
           end
 

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
@@ -21,7 +21,7 @@ module Decidim
         def call
           return broadcast(:invalid) if @form.invalid?
 
-          Decidim.traceability.perform_action!("update",Decidim::Meetings::Questionnaire,@form.current_user, { meeting: @questionnaire.questionnaire_for.try(:meeting) }) do
+          Decidim.traceability.perform_action!("update", Decidim::Meetings::Questionnaire, @form.current_user, { meeting: @questionnaire.questionnaire_for.try(:meeting) }) do
             Decidim::Meetings::Questionnaire.transaction do
               create_questionnaire_for
               create_questionaire

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
@@ -21,7 +21,7 @@ module Decidim
         def call
           return broadcast(:invalid) if @form.invalid?
 
-          Decidim.traceability.perform_action!("update",@questionnaire,@form.current_user) do
+          Decidim.traceability.perform_action!("update",Decidim::Meetings::Questionnaire,@form.current_user, { meeting: @questionnaire.questionnaire_for.try(:meeting) }) do
             Decidim::Meetings::Questionnaire.transaction do
               create_questionnaire_for
               create_questionaire
@@ -29,6 +29,7 @@ module Decidim
                 update_questionnaire_questions
                 delete_answers
               end
+              @questionnaire
             end
           end
 

--- a/decidim-meetings/app/models/decidim/meetings/questionnaire.rb
+++ b/decidim-meetings/app/models/decidim/meetings/questionnaire.rb
@@ -4,6 +4,8 @@ module Decidim
   module Meetings
     # The data store for a Questionnaire in the Decidim::Meetings component.
     class Questionnaire < Meetings::ApplicationRecord
+      include Decidim::Traceable
+
       belongs_to :questionnaire_for, polymorphic: true
 
       has_many :questions, -> { order(:position) }, class_name: "Question", foreign_key: "decidim_questionnaire_id", dependent: :destroy
@@ -17,6 +19,10 @@ module Decidim
 
       def all_questions_unpublished?
         questions.all?(&:unpublished?)
+      end
+
+      def self.log_presenter_class_for(_log)
+        Decidim::Meetings::AdminLog::QuestionnairePresenter
       end
     end
   end

--- a/decidim-meetings/app/presenters/decidim/meetings/admin_log/questionnaire_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/admin_log/questionnaire_presenter.rb
@@ -28,8 +28,6 @@ module Decidim
           @resource_presenter ||= Decidim::Log::ResourcePresenter.new(action_log.resource.questionnaire_for.meeting, h, action_log.resource.questionnaire_for.meeting)
         end
 
-        # Tries to use the attendee name from the invitation (resource).
-        # If invitation does not exist anymore use the one in extras.
         def i18n_params
           super.merge(
             meeting_name: resource_presenter.try(:present)

--- a/decidim-meetings/app/presenters/decidim/meetings/admin_log/questionnaire_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/admin_log/questionnaire_presenter.rb
@@ -24,12 +24,15 @@ module Decidim
           end
         end
 
+        def resource_presenter
+          @resource_presenter ||= Decidim::Log::ResourcePresenter.new(action_log.resource.questionnaire_for.meeting, h, action_log.resource.questionnaire_for.meeting)
+        end
+
         # Tries to use the attendee name from the invitation (resource).
         # If invitation does not exist anymore use the one in extras.
         def i18n_params
-          meeting_name = action_log.resource.meeting
           super.merge(
-            meeting_name: meeting_name
+            meeting_name: resource_presenter.try(:present)
           )
         end
       end

--- a/decidim-meetings/app/presenters/decidim/meetings/admin_log/questionnaire_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/admin_log/questionnaire_presenter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    module AdminLog
+      # This class holds the logic to present a `Decidim::Meetings::Questionnaire`
+      # for the `AdminLog` log.
+      #
+      # Usage should be automatic and you shouldn't need to call this class
+      # directly, but here's an example:
+      #
+      #    action_log = Decidim::ActionLog.last
+      #    view_helpers # => this comes from the views
+      #    InvitePresenter.new(action_log, view_helpers).present
+      class QuestionnairePresenter < Decidim::Log::BasePresenter
+        private
+
+        def action_string
+          case action
+          when "update"
+            "decidim.meetings.admin_log.questionnaire.#{action}"
+          else
+            super
+          end
+        end
+
+        # Tries to use the attendee name from the invitation (resource).
+        # If invitation does not exist anymore use the one in extras.
+        def i18n_params
+          meeting_name = action_log.resource.meeting
+          super.merge(
+            meeting_name: meeting_name
+          )
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/presenters/decidim/meetings/admin_log/questionnaire_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/admin_log/questionnaire_presenter.rb
@@ -11,7 +11,7 @@ module Decidim
       #
       #    action_log = Decidim::ActionLog.last
       #    view_helpers # => this comes from the views
-      #    InvitePresenter.new(action_log, view_helpers).present
+      #    QuestionnairePresenter.new(action_log, view_helpers).present
       class QuestionnairePresenter < Decidim::Log::BasePresenter
         private
 

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -384,7 +384,7 @@ en:
             organizer_presenter:
               not_found: 'The organizer was not found on the database (ID: %{id})'
         questionnaire:
-          update: "%{user_name} updated the %{resource_name} questionnaire of the %{meeting_name} meeting"
+          update: "%{user_name} updated the questionnaire for the %{meeting_name} meeting"
       application_helper:
         filter_category_values:
           all: All

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -383,6 +383,8 @@ en:
           value_types:
             organizer_presenter:
               not_found: 'The organizer was not found on the database (ID: %{id})'
+        questionnaire:
+          update: "%{user_name} updated the %{resource_name} questionnaire of the %{meeting_name} meeting"
       application_helper:
         filter_category_values:
           all: All

--- a/decidim-meetings/spec/commands/admin/update_questionnaire_spec.rb
+++ b/decidim-meetings/spec/commands/admin/update_questionnaire_spec.rb
@@ -79,7 +79,7 @@ module Decidim
         let(:command) { described_class.new(form, questionnaire) }
 
         context "with a persisted poll and questionnaire" do
-          let(:poll) { create(:poll) }
+          let(:poll) { create(:poll, meeting: meeting) }
           let(:questionnaire) { create(:meetings_poll_questionnaire, questionnaire_for: poll) }
 
           describe "when the form is invalid" do
@@ -114,15 +114,16 @@ module Decidim
               expect(questionnaire.questions[1].max_choices).to eq(2)
             end
 
-            it "traces the action" do
+            it "traces the action", versioning: true do
               expect(Decidim.traceability)
                 .to receive(:perform_action!)
-                      .with("update", Decidim::Meetings::Questionnaire, Decidim::User)
+                      .with("update", Decidim::Meetings::Questionnaire, user, {meeting: meeting})
                       .and_call_original
 
               expect { command.call }.to change(Decidim::ActionLog, :count)
               action_log = Decidim::ActionLog.last
               expect(action_log.action).to eq("update")
+              expect(action_log.version).to be_present()
             end
           end
 

--- a/decidim-meetings/spec/commands/admin/update_questionnaire_spec.rb
+++ b/decidim-meetings/spec/commands/admin/update_questionnaire_spec.rb
@@ -117,13 +117,13 @@ module Decidim
             it "traces the action", versioning: true do
               expect(Decidim.traceability)
                 .to receive(:perform_action!)
-                      .with("update", Decidim::Meetings::Questionnaire, user, {meeting: meeting})
-                      .and_call_original
+                .with("update", Decidim::Meetings::Questionnaire, user, { meeting: meeting })
+                .and_call_original
 
               expect { command.call }.to change(Decidim::ActionLog, :count)
               action_log = Decidim::ActionLog.last
               expect(action_log.action).to eq("update")
-              expect(action_log.version).to be_present()
+              expect(action_log.version).to be_present
             end
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?
add admin log when updating/creating/removing some questions in the questionnaire for a meeting

#### :pushpin: Related Issues
- Fixes the 6th in #9181 

![image](https://user-images.githubusercontent.com/93646702/167385729-990c1c30-9f1c-450c-ab94-74815cd0cee6.png)