### PR TITLE
Add admin log when creating, updating or deleting attachment collections

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_attachment_collection.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_attachment_collection.rb
@@ -36,7 +36,7 @@ module Decidim
         Decidim.traceability.create!(
           AttachmentCollection,
           @user,
-          params
+          attributes
         )
       end
 

--- a/decidim-admin/app/commands/decidim/admin/create_attachment_collection.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_attachment_collection.rb
@@ -9,9 +9,10 @@ module Decidim
       #
       # form - A form object with the params.
       # collection_for - The ActiveRecord::Base that will hold the collection
-      def initialize(form, collection_for)
+      def initialize(form, collection_for, user)
         @form = form
         @collection_for = collection_for
+        @user = user
       end
 
       # Executes the command. Broadcasts these events:
@@ -32,12 +33,20 @@ module Decidim
       attr_reader :form
 
       def create_attachment_collection
-        AttachmentCollection.create!(
+        Decidim.traceability.create!(
+          AttachmentCollection,
+          @user,
+          params
+        )
+      end
+
+      def params
+        {
           name: form.name,
           weight: form.weight,
           description: form.description,
           collection_for: @collection_for
-        )
+        }
       end
     end
   end

--- a/decidim-admin/app/commands/decidim/admin/create_attachment_collection.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_attachment_collection.rb
@@ -40,7 +40,7 @@ module Decidim
         )
       end
 
-      def params
+      def attributes
         {
           name: form.name,
           weight: form.weight,

--- a/decidim-admin/app/commands/decidim/admin/update_attachment_collection.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_attachment_collection.rb
@@ -8,9 +8,10 @@ module Decidim
       #
       # attachment_collection - The AttachmentCollection to update
       # form - A form object with the params.
-      def initialize(attachment_collection, form)
+      def initialize(attachment_collection, form, user)
         @attachment_collection = attachment_collection
         @form = form
+        @user = user
       end
 
       # Executes the command. Broadcasts these events:
@@ -31,7 +32,11 @@ module Decidim
       attr_reader :form
 
       def update_attachment_collection
-        @attachment_collection.update!(attributes)
+        Decidim.traceability.update!(
+          @attachment_collection,
+          @user,
+          attributes
+        )
       end
 
       def attributes

--- a/decidim-admin/app/controllers/decidim/admin/concerns/has_attachment_collections.rb
+++ b/decidim-admin/app/controllers/decidim/admin/concerns/has_attachment_collections.rb
@@ -31,7 +31,7 @@ module Decidim
             enforce_permission_to :create, :attachment_collection
             @form = form(AttachmentCollectionForm).from_params(params, collection_for: collection_for)
 
-            CreateAttachmentCollection.call(@form, collection_for) do
+            CreateAttachmentCollection.call(@form, collection_for, current_user) do
               on(:ok) do
                 flash[:notice] = I18n.t("attachment_collections.create.success", scope: "decidim.admin")
                 redirect_to action: :index
@@ -56,7 +56,7 @@ module Decidim
             enforce_permission_to :update, :attachment_collection, attachment_collection: @attachment_collection
             @form = form(AttachmentCollectionForm).from_params(params, collection_for: collection_for)
 
-            UpdateAttachmentCollection.call(@attachment_collection, @form) do
+            UpdateAttachmentCollection.call(@attachment_collection, @form, current_user) do
               on(:ok) do
                 flash[:notice] = I18n.t("attachment_collections.update.success", scope: "decidim.admin")
                 redirect_to action: :index
@@ -78,7 +78,10 @@ module Decidim
           def destroy
             @attachment_collection = collection.find(params[:id])
             enforce_permission_to :destroy, :attachment_collection, attachment_collection: @attachment_collection
-            @attachment_collection.destroy!
+
+            Decidim.traceability.perform_action!("delete",@attachment_collection,current_user) do
+              @attachment_collection.destroy!
+            end
 
             flash[:notice] = I18n.t("attachment_collections.destroy.success", scope: "decidim.admin")
 

--- a/decidim-admin/app/controllers/decidim/admin/concerns/has_attachment_collections.rb
+++ b/decidim-admin/app/controllers/decidim/admin/concerns/has_attachment_collections.rb
@@ -79,7 +79,7 @@ module Decidim
             @attachment_collection = collection.find(params[:id])
             enforce_permission_to :destroy, :attachment_collection, attachment_collection: @attachment_collection
 
-            Decidim.traceability.perform_action!("delete",@attachment_collection,current_user) do
+            Decidim.traceability.perform_action!("delete", @attachment_collection, current_user) do
               @attachment_collection.destroy!
             end
 

--- a/decidim-admin/lib/decidim/admin/test/commands/create_attachment_collection_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/commands/create_attachment_collection_examples.rb
@@ -60,8 +60,8 @@ module Decidim
           it "traces the action", versioning: true do
             expect(Decidim.traceability)
               .to receive(:perform_action!)
-                    .with(:create, Decidim::AttachmentCollection, user, {})
-                    .and_call_original
+              .with(:create, Decidim::AttachmentCollection, user, {})
+              .and_call_original
 
             expect { command.call }.to change(Decidim::ActionLog, :count)
             action_log = Decidim::ActionLog.last

--- a/decidim-admin/lib/decidim/admin/test/commands/create_attachment_collection_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/commands/create_attachment_collection_examples.rb
@@ -7,6 +7,7 @@ module Decidim
     shared_examples_for "CreateAttachmentCollection command" do
       describe "call" do
         let(:organization) { create(:organization) }
+        let(:user) { create(:user, organization: organization) }
         let(:form_params) do
           {
             "attachment_collection" => {
@@ -27,7 +28,7 @@ module Decidim
             current_organization: organization
           )
         end
-        let(:command) { described_class.new(form, collection_for) }
+        let(:command) { described_class.new(form, collection_for, user) }
 
         describe "when the form is not valid" do
           before do
@@ -54,6 +55,18 @@ module Decidim
             expect do
               command.call
             end.to change(collection_for.attachment_collections, :count).by(1)
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:perform_action!)
+                    .with(:create, Decidim::AttachmentCollection, user, {})
+                    .and_call_original
+
+            expect { command.call }.to change(Decidim::ActionLog, :count)
+            action_log = Decidim::ActionLog.last
+            expect(action_log.action).to eq("create")
+            expect(action_log.version).to be_present
           end
         end
       end

--- a/decidim-admin/lib/decidim/admin/test/commands/update_attachment_collection_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/commands/update_attachment_collection_examples.rb
@@ -7,6 +7,7 @@ module Decidim
     shared_examples_for "UpdateAttachmentCollection command" do
       describe "call" do
         let(:organization) { create(:organization) }
+        let(:user) { create(:user, organization: organization) }
         let(:attachment_collection) { create(:attachment_collection, collection_for: collection_for) }
         let(:form_params) do
           {
@@ -28,7 +29,7 @@ module Decidim
             current_organization: organization
           )
         end
-        let(:command) { described_class.new(attachment_collection, form) }
+        let(:command) { described_class.new(attachment_collection, form, user) }
 
         describe "when the form is not valid" do
           before do
@@ -57,6 +58,18 @@ module Decidim
             attachment_collection.reload
 
             expect(translated(attachment_collection.name)).to eq("New title")
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:perform_action!)
+                    .with(:update, Decidim::AttachmentCollection, user, {})
+                    .and_call_original
+
+            expect { command.call }.to change(Decidim::ActionLog, :count)
+            action_log = Decidim::ActionLog.last
+            expect(action_log.action).to eq("update")
+            expect(action_log.version).to be_present
           end
         end
       end

--- a/decidim-admin/lib/decidim/admin/test/commands/update_attachment_collection_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/commands/update_attachment_collection_examples.rb
@@ -63,8 +63,8 @@ module Decidim
           it "traces the action", versioning: true do
             expect(Decidim.traceability)
               .to receive(:perform_action!)
-                    .with(:update, Decidim::AttachmentCollection, user, {})
-                    .and_call_original
+              .with(:update, Decidim::AttachmentCollection, user, {})
+              .and_call_original
 
             expect { command.call }.to change(Decidim::ActionLog, :count)
             action_log = Decidim::ActionLog.last

--- a/decidim-core/app/models/decidim/attachment_collection.rb
+++ b/decidim-core/app/models/decidim/attachment_collection.rb
@@ -4,6 +4,7 @@ module Decidim
   # Categories serve as a taxonomy for attachments to use for while in the
   # context of a participatory space.
   class AttachmentCollection < ApplicationRecord
+    include Traceable
     include Decidim::TranslatableResource
 
     translatable_fields :name, :description
@@ -14,6 +15,10 @@ module Decidim
 
     def unused?
       attachments.empty?
+    end
+
+    def self.log_presenter_class_for(_log)
+      Decidim::AdminLog::AttachmentCollectionPresenter
     end
   end
 end

--- a/decidim-core/app/presenters/decidim/admin_log/attachment_collection_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/attachment_collection_presenter.rb
@@ -10,7 +10,7 @@ module Decidim
     #
     #    action_log = Decidim::ActionLog.last
     #    view_helpers # => this comes from the views
-    #    ComponentPresenter.new(action_log, view_helpers).present
+    #    AttachmentCollectionPresenter.new(action_log, view_helpers).present
     class AttachmentCollectionPresenter < Decidim::Log::BasePresenter
       private
 

--- a/decidim-core/app/presenters/decidim/admin_log/attachment_collection_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/attachment_collection_presenter.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module AdminLog
-    # This class holds the logic to present a `Decidim::Component`
+    # This class holds the logic to present a `Decidim::AttachmentCollection`
     # for the `AdminLog` log.
     #
     # Usage should be automatic and you shouldn't need to call this class

--- a/decidim-core/app/presenters/decidim/admin_log/attachment_collection_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/attachment_collection_presenter.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AdminLog
+    # This class holds the logic to present a `Decidim::Component`
+    # for the `AdminLog` log.
+    #
+    # Usage should be automatic and you shouldn't need to call this class
+    # directly, but here's an example:
+    #
+    #    action_log = Decidim::ActionLog.last
+    #    view_helpers # => this comes from the views
+    #    ComponentPresenter.new(action_log, view_helpers).present
+    class AttachmentCollectionPresenter < Decidim::Log::BasePresenter
+      private
+
+      def diff_fields_mapping
+        {
+          name: :i18n,
+          description: :i18n,
+          weight: :integer
+        }
+      end
+
+      def action_string
+        case action
+        when "create", "delete", "update"
+          "decidim.admin_log.attachment_collection.#{action}"
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -155,6 +155,10 @@ en:
         create: "%{user_name} created the %{resource_name} area"
         delete: "%{user_name} deleted the %{resource_name} area"
         update: "%{user_name} updated the %{resource_name} area"
+      attachment_collection:
+        create: "%{user_name} created the %{resource_name} attachment collection"
+        delete: "%{user_name} deleted the %{resource_name} attachment collection"
+        update: "%{user_name} updated the %{resource_name} attachment collection"
       component:
         create: "%{user_name} added the %{resource_name} component to the %{space_name} space"
         delete: "%{user_name} removed the %{resource_name} component from the %{space_name} space"


### PR DESCRIPTION
#### :tophat: What? Why?
add admin log when creating, updating or deleting attachment collections

#### :pushpin: Related Issues
- Fixes the 7th, 8th and 9th task of #9181 

![image](https://user-images.githubusercontent.com/93646702/167454250-f9af877a-7dd8-4d70-a547-8fdd69b80d16.png)
