### PR TITLE
Add geocoding to budgets projects

### DIFF
--- a/decidim-budgets/app/commands/decidim/budgets/admin/create_project.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/create_project.rb
@@ -47,7 +47,7 @@ module Decidim
             budget_amount: form.budget_amount,
             address: form.address,
             latitude: form.latitude,
-            longitude: form.longitude,
+            longitude: form.longitude
           }
 
           @project = Decidim.traceability.create!(

--- a/decidim-budgets/app/commands/decidim/budgets/admin/create_project.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/create_project.rb
@@ -44,7 +44,10 @@ module Decidim
             category: form.category,
             title: form.title,
             description: form.description,
-            budget_amount: form.budget_amount
+            budget_amount: form.budget_amount,
+            address: form.address,
+            latitude: form.latitude,
+            longitude: form.longitude,
           }
 
           @project = Decidim.traceability.create!(

--- a/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
@@ -48,7 +48,10 @@ module Decidim
             description: original_proposal.body,
             budget_amount: budget_for(original_proposal),
             category: original_proposal.category,
-            scope: original_proposal.scope
+            scope: original_proposal.scope,
+            address: original_proposal.address,
+            latitude: original_proposal.latitude,
+            longitude: original_proposal.longitude
           }
 
           @project = Decidim.traceability.create!(

--- a/decidim-budgets/app/commands/decidim/budgets/admin/update_project.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/update_project.rb
@@ -56,7 +56,7 @@ module Decidim
             selected_at: selected_at,
             address: form.address,
             latitude: form.latitude,
-            longitude: form.longitude,
+            longitude: form.longitude
           )
         end
 

--- a/decidim-budgets/app/commands/decidim/budgets/admin/update_project.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/update_project.rb
@@ -53,7 +53,10 @@ module Decidim
             title: form.title,
             description: form.description,
             budget_amount: form.budget_amount,
-            selected_at: selected_at
+            selected_at: selected_at,
+            address: form.address,
+            latitude: form.latitude,
+            longitude: form.longitude,
           )
         end
 

--- a/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
@@ -33,7 +33,7 @@ module Decidim
       end
 
       def all_geocoded_projects
-        @all_geocoded_projects ||= @projects.geocoded
+        @all_geocoded_projects ||= projects.geocoded
       end
 
       def project

--- a/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
@@ -8,7 +8,7 @@ module Decidim
       include NeedsCurrentOrder
       include Decidim::Budgets::Orderable
 
-      helper_method :projects, :project, :budget
+      helper_method :projects, :project, :budget, :all_geocoded_projects
 
       def index
         raise ActionController::RoutingError, "Not Found" unless budget
@@ -30,6 +30,10 @@ module Decidim
 
         @projects = search.result.page(params[:page]).per(current_component.settings.projects_per_page)
         @projects = reorder(@projects)
+      end
+
+      def all_geocoded_projects
+        @all_geocoded_projects ||= @projects.geocoded
       end
 
       def project

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
@@ -29,7 +29,6 @@ module Decidim
         validates :description, translatable_presence: true
         validates :budget_amount, presence: true, numericality: { greater_than: 0 }
         validates :address, geocoding: true, if: ->(form) { form.has_address? && !form.geocoded? }
-        validates :address, presence: true, if: ->(form) { form.has_address? }
         validates :category, presence: true, if: ->(form) { form.decidim_category_id.present? }
         validates :scope, presence: true, if: ->(form) { form.decidim_scope_id.present? }
         validates :decidim_scope_id, scope_belongs_to_component: true, if: ->(form) { form.decidim_scope_id.present? }
@@ -50,8 +49,8 @@ module Decidim
 
         def proposals
           @proposals ||= Decidim.find_resource_manifest(:proposals).try(:resource_scope, current_component)
-                           &.where(id: proposal_ids)
-                           &.order(title: :asc)
+                         &.where(id: proposal_ids)
+                         &.order(title: :asc)
         end
 
         def geocoding_enabled?
@@ -80,7 +79,7 @@ module Decidim
           @category ||= categories.find_by(id: decidim_category_id)
         end
 
-        # Finds the Scope from the given decidim_scope_id,uses the component scope if missing.
+        # Finds the Scope from the given decidim_scope_id, uses the component scope if missing.
         #
         # Returns a Decidim::Scope
         def scope
@@ -98,7 +97,7 @@ module Decidim
 
         # This method will add an error to the `attachment` field only if there's
         # any error in any other field. This is needed because when the form has
-        # an error,the attachment is lost,so we need a way to inform the user of
+        # an error, the attachment is lost, so we need a way to inform the user of
         # this problem.
         def notify_missing_attachment_if_errored
           errors.add(:add_photos, :needs_to_be_reattached) if errors.any? && add_photos.present?

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
@@ -16,7 +16,6 @@ module Decidim
         attribute :address, String
         attribute :latitude, Float
         attribute :longitude, Float
-        attribute :has_address, Boolean
         attribute :budget_amount, Integer
         attribute :decidim_scope_id, Integer
         attribute :decidim_category_id, Integer
@@ -59,15 +58,7 @@ module Decidim
           Decidim::Map.available?(:geocoding) && current_component.settings.geocoding_enabled?
         end
 
-        def address
-          return unless has_address
-
-          super
-        end
-
         def has_address?
-          return unless has_address
-
           geocoding_enabled? && address.present?
         end
 

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
@@ -10,36 +10,37 @@ module Decidim
         include TranslationsHelper
         include Decidim::ApplicationHelper
 
-        translatable_attribute :title,String
-        translatable_attribute :description,String
+        translatable_attribute :title, String
+        translatable_attribute :description, String
 
-        attribute :address,String
-        attribute :latitude,Float
-        attribute :longitude,Float
-        attribute :budget_amount,Integer
-        attribute :decidim_scope_id,Integer
-        attribute :decidim_category_id,Integer
-        attribute :proposal_ids,Array[Integer]
-        attribute :attachment,AttachmentForm
-        attribute :selected,Boolean
+        attribute :address, String
+        attribute :latitude, Float
+        attribute :longitude, Float
+        attribute :budget_amount, Integer
+        attribute :decidim_scope_id, Integer
+        attribute :decidim_category_id, Integer
+        attribute :proposal_ids, Array[Integer]
+        attribute :attachment, AttachmentForm
+        attribute :selected, Boolean
 
         attachments_attribute :photos
 
-        validates :title,translatable_presence: true
-        validates :description,translatable_presence: true
-        validates :budget_amount,presence: true,numericality: { greater_than: 0 }
-        validates :address,geocoding: true,if: ->(form) { form.has_address? && !form.geocoded? }
-        validates :address,presence: true,if: ->(form) { form.has_address? }
-        validates :category,presence: true,if: ->(form) { form.decidim_category_id.present? }
-        validates :scope,presence: true,if: ->(form) { form.decidim_scope_id.present? }
-        validates :decidim_scope_id,scope_belongs_to_component: true,if: ->(form) { form.decidim_scope_id.present? }
+        validates :title, translatable_presence: true
+        validates :description, translatable_presence: true
+        validates :budget_amount, presence: true, numericality: { greater_than: 0 }
+        validates :address, geocoding: true, if: ->(form) { form.has_address? && !form.geocoded? }
+        validates :address, presence: true, if: ->(form) { form.has_address? }
+        validates :category, presence: true, if: ->(form) { form.decidim_category_id.present? }
+        validates :scope, presence: true, if: ->(form) { form.decidim_scope_id.present? }
+        validates :decidim_scope_id, scope_belongs_to_component: true, if: ->(form) { form.decidim_scope_id.present? }
 
         validate :notify_missing_attachment_if_errored
 
-        delegate :categories,to: :current_component
-        alias :component :current_component
+        delegate :categories, to: :current_component
+        alias component current_component
 
-        def map_model(model) self.proposal_ids = model.linked_resources(:proposals,"included_proposals").pluck(:id)
+        def map_model(model)
+          self.proposal_ids = model.linked_resources(:proposals, "included_proposals").pluck(:id)
           self.selected = model.selected?
 
           return unless model.categorization
@@ -48,7 +49,7 @@ module Decidim
         end
 
         def proposals
-          @proposals ||= Decidim.find_resource_manifest(:proposals).try(:resource_scope,current_component)
+          @proposals ||= Decidim.find_resource_manifest(:proposals).try(:resource_scope, current_component)
                            &.where(id: proposal_ids)
                            &.order(title: :asc)
         end
@@ -57,34 +58,40 @@ module Decidim
           Decidim::Map.available?(:geocoding) && current_component.settings.geocoding_enabled?
         end
 
-        def has_address? geocoding_enabled? && address.present?
+        def has_address?
+          geocoding_enabled? && address.present?
         end
 
-        def geocoded? latitude.present? && longitude.present?
+        def geocoded?
+          latitude.present? && longitude.present?
         end
 
         # Finds the Budget from the decidim_budgets_budget_id.
         #
         # Returns a Decidim::Budgets:Budget
-        def budget @budget ||= context[:budget]
+        def budget
+          @budget ||= context[:budget]
         end
 
         # Finds the Category from the decidim_category_id.
         #
         # Returns a Decidim::Category
-        def category @category ||= categories.find_by(id: decidim_category_id)
+        def category
+          @category ||= categories.find_by(id: decidim_category_id)
         end
 
         # Finds the Scope from the given decidim_scope_id,uses the component scope if missing.
         #
         # Returns a Decidim::Scope
-        def scope @scope ||= @attributes["decidim_scope_id"].value ? current_component.scopes.find_by(id: @attributes["decidim_scope_id"].value) : current_component.scope
+        def scope
+          @scope ||= @attributes["decidim_scope_id"].value ? current_component.scopes.find_by(id: @attributes["decidim_scope_id"].value) : current_component.scope
         end
 
         # Scope identifier
         #
         # Returns the scope identifier related to the project
-        def decidim_scope_id super || scope&.id
+        def decidim_scope_id
+          super || scope&.id
         end
 
         private
@@ -93,7 +100,8 @@ module Decidim
         # any error in any other field. This is needed because when the form has
         # an error,the attachment is lost,so we need a way to inform the user of
         # this problem.
-        def notify_missing_attachment_if_errored errors.add(:add_photos,:needs_to_be_reattached) if errors.any? && add_photos.present?
+        def notify_missing_attachment_if_errored
+          errors.add(:add_photos, :needs_to_be_reattached) if errors.any? && add_photos.present?
         end
       end
     end

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
@@ -10,37 +10,36 @@ module Decidim
         include TranslationsHelper
         include Decidim::ApplicationHelper
 
-        translatable_attribute :title, String
-        translatable_attribute :description, String
+        translatable_attribute :title,String
+        translatable_attribute :description,String
 
-        attribute :address, String
-        attribute :latitude, Float
-        attribute :longitude, Float
-        attribute :budget_amount, Integer
-        attribute :decidim_scope_id, Integer
-        attribute :decidim_category_id, Integer
-        attribute :proposal_ids, Array[Integer]
-        attribute :attachment, AttachmentForm
-        attribute :selected, Boolean
+        attribute :address,String
+        attribute :latitude,Float
+        attribute :longitude,Float
+        attribute :budget_amount,Integer
+        attribute :decidim_scope_id,Integer
+        attribute :decidim_category_id,Integer
+        attribute :proposal_ids,Array[Integer]
+        attribute :attachment,AttachmentForm
+        attribute :selected,Boolean
 
         attachments_attribute :photos
 
-        validates :title, translatable_presence: true
-        validates :description, translatable_presence: true
-        validates :budget_amount, presence: true, numericality: { greater_than: 0 }
-        validates :address, geocoding: true, if: ->(form) { form.has_address? && !form.geocoded? }
-        validates :address, presence: true, if: ->(form) { form.has_address? }
-        validates :category, presence: true, if: ->(form) { form.decidim_category_id.present? }
-        validates :scope, presence: true, if: ->(form) { form.decidim_scope_id.present? }
-        validates :decidim_scope_id, scope_belongs_to_component: true, if: ->(form) { form.decidim_scope_id.present? }
+        validates :title,translatable_presence: true
+        validates :description,translatable_presence: true
+        validates :budget_amount,presence: true,numericality: { greater_than: 0 }
+        validates :address,geocoding: true,if: ->(form) { form.has_address? && !form.geocoded? }
+        validates :address,presence: true,if: ->(form) { form.has_address? }
+        validates :category,presence: true,if: ->(form) { form.decidim_category_id.present? }
+        validates :scope,presence: true,if: ->(form) { form.decidim_scope_id.present? }
+        validates :decidim_scope_id,scope_belongs_to_component: true,if: ->(form) { form.decidim_scope_id.present? }
 
         validate :notify_missing_attachment_if_errored
 
-        delegate :categories, to: :current_component
+        delegate :categories,to: :current_component
         alias :component :current_component
 
-        def map_model(model)
-          self.proposal_ids = model.linked_resources(:proposals, "included_proposals").pluck(:id)
+        def map_model(model) self.proposal_ids = model.linked_resources(:proposals,"included_proposals").pluck(:id)
           self.selected = model.selected?
 
           return unless model.categorization
@@ -49,59 +48,52 @@ module Decidim
         end
 
         def proposals
-          @proposals ||= Decidim.find_resource_manifest(:proposals).try(:resource_scope, current_component)
-                         &.where(id: proposal_ids)
-                         &.order(title: :asc)
+          @proposals ||= Decidim.find_resource_manifest(:proposals).try(:resource_scope,current_component)
+                           &.where(id: proposal_ids)
+                           &.order(title: :asc)
         end
 
         def geocoding_enabled?
           Decidim::Map.available?(:geocoding) && current_component.settings.geocoding_enabled?
         end
 
-        def has_address?
-          geocoding_enabled? && address.present?
+        def has_address? geocoding_enabled? && address.present?
         end
 
-        def geocoded?
-          latitude.present? && longitude.present?
+        def geocoded? latitude.present? && longitude.present?
         end
 
         # Finds the Budget from the decidim_budgets_budget_id.
         #
         # Returns a Decidim::Budgets:Budget
-        def budget
-          @budget ||= context[:budget]
+        def budget @budget ||= context[:budget]
         end
 
         # Finds the Category from the decidim_category_id.
         #
         # Returns a Decidim::Category
-        def category
-          @category ||= categories.find_by(id: decidim_category_id)
+        def category @category ||= categories.find_by(id: decidim_category_id)
         end
 
-        # Finds the Scope from the given decidim_scope_id, uses the component scope if missing.
+        # Finds the Scope from the given decidim_scope_id,uses the component scope if missing.
         #
         # Returns a Decidim::Scope
-        def scope
-          @scope ||= @attributes["decidim_scope_id"].value ? current_component.scopes.find_by(id: @attributes["decidim_scope_id"].value) : current_component.scope
+        def scope @scope ||= @attributes["decidim_scope_id"].value ? current_component.scopes.find_by(id: @attributes["decidim_scope_id"].value) : current_component.scope
         end
 
         # Scope identifier
         #
         # Returns the scope identifier related to the project
-        def decidim_scope_id
-          super || scope&.id
+        def decidim_scope_id super || scope&.id
         end
 
         private
 
         # This method will add an error to the `attachment` field only if there's
         # any error in any other field. This is needed because when the form has
-        # an error, the attachment is lost, so we need a way to inform the user of
+        # an error,the attachment is lost,so we need a way to inform the user of
         # this problem.
-        def notify_missing_attachment_if_errored
-          errors.add(:add_photos, :needs_to_be_reattached) if errors.any? && add_photos.present?
+        def notify_missing_attachment_if_errored errors.add(:add_photos,:needs_to_be_reattached) if errors.any? && add_photos.present?
         end
       end
     end

--- a/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
+++ b/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
@@ -104,19 +104,6 @@ module Decidim
           )
       end
 
-      def project_preview_data_for_map(project)
-        {
-          type: "drag-marker",
-          marker: project.slice(
-            :latitude,
-            :longitude,
-            :address
-          ).merge(
-            icon: icon("project", width: 40, height: 70, remove_icon_class: true)
-          )
-        }
-      end
-
       def has_position?(project)
         return if project.address.blank?
 

--- a/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
+++ b/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
@@ -5,6 +5,7 @@ module Decidim
     # A helper to render order and budgets actions
     module ProjectsHelper
       include Decidim::ApplicationHelper
+      include Decidim::MapHelper
 
       # Render a budget as a currency
       #

--- a/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
+++ b/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
@@ -99,7 +99,7 @@ module Decidim
           .merge(
             title: decidim_html_escape(translated_attribute(project.title)),
             description: html_truncate(decidim_sanitize_editor(translated_attribute(project.description)), length: 100),
-            icon: icon("projects", width: 40, height: 70, remove_icon_class: true),
+            icon: icon("project", width: 40, height: 70, remove_icon_class: true),
             link: ::Decidim::ResourceLocatorPresenter.new([project.budget, project]).path
           )
       end
@@ -112,7 +112,7 @@ module Decidim
             :longitude,
             :address
           ).merge(
-            icon: icon("projects", width: 40, height: 70, remove_icon_class: true)
+            icon: icon("project", width: 40, height: 70, remove_icon_class: true)
           )
         }
       end

--- a/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
+++ b/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
@@ -4,6 +4,8 @@ module Decidim
   module Budgets
     # A helper to render order and budgets actions
     module ProjectsHelper
+      include Decidim::ApplicationHelper
+
       # Render a budget as a currency
       #
       # budget - A integer to represent a budget
@@ -79,6 +81,45 @@ module Decidim
         else
           t(".vote_threshold_percent_rule.description", minimum_budget: budget_to_currency(current_order.minimum_budget))
         end
+      end
+
+      # Serialize a collection of geocoded projects to be used by the dynamic map component
+      #
+      # geocoded_projects - A collection of geocoded projects
+      def projects_data_for_map(geocoded_projects)
+        geocoded_projects.map do |project|
+          project_data_for_map(project)
+        end
+      end
+
+      def project_data_for_map(project)
+        project
+          .slice(:latitude, :longitude, :address)
+          .merge(
+            title: decidim_html_escape(translated_attribute(project.title)),
+            description: html_truncate(decidim_sanitize_editor(translated_attribute(project.description)), length: 100),
+            icon: icon("projects", width: 40, height: 70, remove_icon_class: true),
+            link: ::Decidim::ResourceLocatorPresenter.new([project.budget, project]).path
+          )
+      end
+
+      def project_preview_data_for_map(project)
+        {
+          type: "drag-marker",
+          marker: project.slice(
+            :latitude,
+            :longitude,
+            :address
+          ).merge(
+            icon: icon("projects", width: 40, height: 70, remove_icon_class: true)
+          )
+        }
+      end
+
+      def has_position?(project)
+        return if project.address.blank?
+
+        project.latitude.present? && project.longitude.present?
       end
     end
   end

--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -34,6 +34,8 @@ module Decidim
       scope :selected, -> { where.not(selected_at: nil) }
       scope :not_selected, -> { where(selected_at: nil) }
 
+      geocoded_by :address
+
       scope_search_multi :with_any_status, [:selected, :not_selected]
 
       searchable_fields(

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/_form.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/_form.html.erb
@@ -18,6 +18,12 @@
       <%= form.number_field :budget_amount %>
     </div>
 
+    <% if @form.geocoding_enabled? %>
+      <div class="row column">
+        <%= form.geocoding_field :address %>
+      </div>
+    <% end %>
+
     <% if current_component.has_subscopes? %>
       <div class="row column">
         <%= scopes_picker_field form, :decidim_scope_id, root: budget.scope %>

--- a/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
@@ -5,6 +5,31 @@
 
 <div class="voting-wrapper">
   <div class="row columns">
+    <% if component_settings.geocoding_enabled? %>
+      <%= dynamic_map_for projects_data_for_map(all_geocoded_projects) do %>
+        <template id="marker-popup">
+          <div class="map-info__content">
+            <h3>${title}</h3>
+            <div id="bodyContent">
+              <p>{{html body}}</p>
+              <div class="map__date-address">
+                <div class="address card__extra">
+                  <div class="address__icon">{{html icon}}</div>
+                  <div class="address__details">
+                    <span>${address}</span><br>
+                  </div>
+                </div>
+              </div>
+              <div class="map-info__button">
+                <a href="${link}" class="button button--sc">
+                  <%= t(".view_project") %>
+                </a>
+              </div>
+            </div>
+          </div>
+        </template>
+      <% end %>
+    <% end %>
     <% if voting_finished? %>
       <h2 class="heading2">
         <%= t("decidim.budgets.projects.projects_for", name: translated_attribute(budget.title)) %>

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -55,6 +55,9 @@ edit_link(
     </div>
     <div class="columns mediumlarge-8 mediumlarge-pull-4">
       <div class="section">
+        <% if component_settings.geocoding_enabled? && project.geocoded? %>
+          <%= render partial: "decidim/shared/static_map", locals: { icon_name: "projects", geolocalizable: project } %>
+        <% end %>
         <%= cell("decidim/budgets/project_selected_status", project, as_label: true) %>
         <%= decidim_sanitize_editor translated_attribute project.description %>
         <%= cell "decidim/budgets/project_tags", project, context: { extra_classes: ["tags--project"] } %>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -1,4 +1,5 @@
 ---
+
 en:
   activemodel:
     attributes:
@@ -196,6 +197,8 @@ en:
           voted_on_space: You have voted on the %{budget_name} budget for the %{space_name} participatory space.
           voted_on_space_with_scope: You have voted on the %{budget_name} budget for the %{space_name} participatory space on %{scope_name} (%{scope_type}).
       projects:
+        index:
+          view_project: View project
         budget_confirm:
           are_you_sure: If you change your mind, you can change your vote later.
           cancel: Cancel

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -1,5 +1,4 @@
 ---
-
 en:
   activemodel:
     attributes:
@@ -197,8 +196,6 @@ en:
           voted_on_space: You have voted on the %{budget_name} budget for the %{space_name} participatory space.
           voted_on_space_with_scope: You have voted on the %{budget_name} budget for the %{space_name} participatory space on %{scope_name} (%{scope_type}).
       projects:
-        index:
-          view_project: View project
         budget_confirm:
           are_you_sure: If you change your mind, you can change your vote later.
           cancel: Cancel
@@ -263,6 +260,8 @@ en:
           filter: Filter
           filter_by: Filter by
           unfold: Unfold
+        index:
+          view_project: View project
         order_progress:
           vote: Vote
         order_selected_projects:

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -317,6 +317,7 @@ en:
               errors:
                 budget_voting_rule_only_one: Only one voting rule must be enabled
                 budget_voting_rule_required: One voting rule is required
+            geocoding_enabled: Geocoding enabled
             landing_page_content: Budgets landing page
             more_information_modal: More information modal
             projects_per_page: Projects per page

--- a/decidim-budgets/db/migrate/20220428072638_add_geolocalization_fields_to_projects.rb
+++ b/decidim-budgets/db/migrate/20220428072638_add_geolocalization_fields_to_projects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGeolocalizationFieldsToProjects < ActiveRecord::Migration[6.1]
   def change
     add_column :decidim_budgets_projects, :address, :text

--- a/decidim-budgets/db/migrate/20220428072638_add_geolocalization_fields_to_projects.rb
+++ b/decidim-budgets/db/migrate/20220428072638_add_geolocalization_fields_to_projects.rb
@@ -1,0 +1,7 @@
+class AddGeolocalizationFieldsToProjects < ActiveRecord::Migration[6.1]
+  def change
+    add_column :decidim_budgets_projects, :address, :text
+    add_column :decidim_budgets_projects, :latitude, :float
+    add_column :decidim_budgets_projects, :longitude, :float
+  end
+end

--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -90,6 +90,7 @@ Decidim.register_component(:budgets) do |component|
     settings.attribute :vote_selected_projects_maximum, type: :integer, default: 1
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :comments_max_length, type: :integer, required: false
+    settings.attribute :geocoding_enabled, type: :boolean, default: false
     settings.attribute :resources_permissions_enabled, type: :boolean, default: true
     settings.attribute :announcement, type: :text, translated: true, editor: true
 

--- a/decidim-budgets/lib/decidim/budgets/test/factories.rb
+++ b/decidim-budgets/lib/decidim/budgets/test/factories.rb
@@ -12,6 +12,14 @@ FactoryBot.define do
     manifest_name { :budgets }
     participatory_space { create(:participatory_process, :with_steps, organization: organization) }
 
+    trait :with_geocoding_enabled do
+      settings do
+        {
+          geocoding_enabled: true
+        }
+      end
+    end
+
     trait :with_vote_threshold_percent do
       transient do
         vote_rule_threshold_percent_enabled { true }
@@ -120,6 +128,9 @@ FactoryBot.define do
   factory :project, class: "Decidim::Budgets::Project" do
     title { generate_localized_title }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    address { "#{Faker::Address.street_name}, #{Faker::Address.city}" }
+    latitude { Faker::Address.latitude }
+    longitude { Faker::Address.longitude }
     budget_amount { Faker::Number.number(digits: 8) }
     budget { create(:budget) }
 

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/create_project_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/create_project_spec.rb
@@ -82,13 +82,13 @@ module Decidim::Budgets
       it "traces the action", versioning: true do
         expect(Decidim.traceability)
           .to receive(:create!)
-                .with(
-                  Decidim::Budgets::Project,
-                  current_user,
-                  hash_including(:scope, :category, :budget, :title, :description, :budget_amount),
-                  visibility: "all"
-                )
-                .and_call_original
+          .with(
+            Decidim::Budgets::Project,
+            current_user,
+            hash_including(:scope, :category, :budget, :title, :description, :budget_amount),
+            visibility: "all"
+          )
+          .and_call_original
 
         expect { subject.call }.to change(Decidim::ActionLog, :count)
         action_log = Decidim::ActionLog.last

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/update_project_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/update_project_spec.rb
@@ -76,12 +76,12 @@ module Decidim::Budgets
       it "traces the action", versioning: true do
         expect(Decidim.traceability)
           .to receive(:update!)
-                .with(
-                  project,
-                  current_user,
-                  hash_including(:scope, :category, :title, :description, :budget_amount)
-                )
-                .and_call_original
+          .with(
+            project,
+            current_user,
+            hash_including(:scope, :category, :title, :description, :budget_amount)
+          )
+          .and_call_original
 
         expect { subject.call }.to change(Decidim::ActionLog, :count)
         action_log = Decidim::ActionLog.last

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/update_project_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/update_project_spec.rb
@@ -15,6 +15,9 @@ module Decidim::Budgets
     let(:current_user) { create :user, :admin, :confirmed, organization: organization }
     let(:uploaded_photos) { [] }
     let(:selected) { nil }
+    let(:address) { "something" }
+    let(:latitude) { 40.1234 }
+    let(:longitude) { 2.1234 }
     let(:current_photos) { [] }
     let(:proposal_component) do
       create(:component, manifest_name: :proposals, participatory_space: participatory_process)
@@ -38,7 +41,10 @@ module Decidim::Budgets
         category: category,
         selected: selected,
         photos: current_photos,
-        add_photos: uploaded_photos
+        add_photos: uploaded_photos,
+        address: address,
+        latitude: latitude,
+        longitude: longitude
       )
     end
     let(:invalid) { false }
@@ -70,16 +76,36 @@ module Decidim::Budgets
       it "traces the action", versioning: true do
         expect(Decidim.traceability)
           .to receive(:update!)
-          .with(
-            project,
-            current_user,
-            hash_including(:scope, :category, :title, :description, :budget_amount)
-          )
-          .and_call_original
+                .with(
+                  project,
+                  current_user,
+                  hash_including(:scope, :category, :title, :description, :budget_amount)
+                )
+                .and_call_original
 
         expect { subject.call }.to change(Decidim::ActionLog, :count)
         action_log = Decidim::ActionLog.last
         expect(action_log.version).to be_present
+      end
+
+      context "when geocoding is enabled" do
+        let(:current_component) { create :budgets_component, :with_geocoding_enabled, participatory_space: participatory_process }
+
+        context "when the address is present" do
+          let(:address) { "Some address" }
+
+          before do
+            stub_geocoding(address, [latitude, longitude])
+          end
+
+          it "sets the latitude and longitude" do
+            subject.call
+            project = Decidim::Budgets::Project.last
+
+            expect(project.latitude).to eq(latitude)
+            expect(project.longitude).to eq(longitude)
+          end
+        end
       end
 
       it "links proposals" do

--- a/decidim-budgets/spec/controller/decidim/budgets/projects_controller_spec.rb
+++ b/decidim-budgets/spec/controller/decidim/budgets/projects_controller_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Budgets
+    describe ProjectsController, type: :controller do
+      routes { Decidim::Budgets::Engine.routes }
+
+      let(:user) { create(:user, :confirmed, organization: component.organization) }
+      let!(:budget) { create(:budget, component: component) }
+
+      before do
+        request.env["decidim.current_organization"] = component.organization
+        request.env["decidim.current_participatory_space"] = component.participatory_space
+        request.env["decidim.current_component"] = component
+        sign_in user
+      end
+
+      describe "GET index" do
+        let(:component) { create(:budgets_component, :with_geocoding_enabled) }
+
+        it "sets two different collections" do
+          geocoded_projects = create_list :project, 10, budget: budget, latitude: 1.1, longitude: 2.2
+          _non_geocoded_projects = create_list :project, 2, budget: budget, latitude: nil, longitude: nil
+
+          get :index, params: { budget_id: budget.id }
+          expect(response).to have_http_status(:ok)
+          expect(subject).to render_template(:index)
+
+          expect(subject.send(:projects).count).to eq 12
+          expect(subject.send(:all_geocoded_projects)).to match_array(geocoded_projects)
+        end
+      end
+    end
+  end
+end

--- a/decidim-budgets/spec/forms/decidim/budgets/admin/project_form_spec.rb
+++ b/decidim-budgets/spec/forms/decidim/budgets/admin/project_form_spec.rb
@@ -33,7 +33,6 @@ module Decidim::Budgets
     let(:latitude) { 40.1234 }
     let(:longitude) { 2.1234 }
     let(:address) { nil }
-    let(:has_address) { false }
     let(:attributes) do
       {
         decidim_scope_id: scope_id,
@@ -42,8 +41,7 @@ module Decidim::Budgets
         description_en: description[:en],
         budget_amount: budget_amount,
         selected: selected,
-        address: address,
-        has_address: has_address,
+        address: address
       }
     end
 
@@ -53,9 +51,6 @@ module Decidim::Budgets
 
     context "when geocoding is enabled" do
       let(:current_component) { create :budgets_component, :with_geocoding_enabled, participatory_space: participatory_process }
-
-      context "when the has address checkbox is checked" do
-        let(:has_address) { true }
 
         context "when the address is not present" do
           it "does not store the coordinates" do
@@ -78,7 +73,6 @@ module Decidim::Budgets
             expect(subject.latitude).to eq(latitude)
             expect(subject.longitude).to eq(longitude)
           end
-        end
       end
     end
 

--- a/decidim-budgets/spec/forms/decidim/budgets/admin/project_form_spec.rb
+++ b/decidim-budgets/spec/forms/decidim/budgets/admin/project_form_spec.rb
@@ -52,27 +52,27 @@ module Decidim::Budgets
     context "when geocoding is enabled" do
       let(:current_component) { create :budgets_component, :with_geocoding_enabled, participatory_space: participatory_process }
 
-        context "when the address is not present" do
-          it "does not store the coordinates" do
-            expect(subject).to be_valid
-            expect(subject.address).to be(nil)
-            expect(subject.latitude).to be(nil)
-            expect(subject.longitude).to be(nil)
-          end
+      context "when the address is not present" do
+        it "does not store the coordinates" do
+          expect(subject).to be_valid
+          expect(subject.address).to be(nil)
+          expect(subject.latitude).to be(nil)
+          expect(subject.longitude).to be(nil)
+        end
+      end
+
+      context "when the address is present" do
+        let(:address) { "Some address" }
+
+        before do
+          stub_geocoding(address, [latitude, longitude])
         end
 
-        context "when the address is present" do
-          let(:address) { "Some address" }
-
-          before do
-            stub_geocoding(address, [latitude, longitude])
-          end
-
-          it "validates the address and store its coordinates" do
-            expect(subject).to be_valid
-            expect(subject.latitude).to eq(latitude)
-            expect(subject.longitude).to eq(longitude)
-          end
+        it "validates the address and store its coordinates" do
+          expect(subject).to be_valid
+          expect(subject.latitude).to eq(latitude)
+          expect(subject.longitude).to eq(longitude)
+        end
       end
     end
 

--- a/decidim-budgets/spec/forms/decidim/budgets/admin/project_form_spec.rb
+++ b/decidim-budgets/spec/forms/decidim/budgets/admin/project_form_spec.rb
@@ -55,9 +55,9 @@ module Decidim::Budgets
       context "when the address is not present" do
         it "does not store the coordinates" do
           expect(subject).to be_valid
-          expect(subject.address).to be(nil)
-          expect(subject.latitude).to be(nil)
-          expect(subject.longitude).to be(nil)
+          expect(subject.address).to be_nil
+          expect(subject.latitude).to be_nil
+          expect(subject.longitude).to be_nil
         end
       end
 

--- a/decidim-budgets/spec/forms/decidim/budgets/admin/project_form_spec.rb
+++ b/decidim-budgets/spec/forms/decidim/budgets/admin/project_form_spec.rb
@@ -30,6 +30,10 @@ module Decidim::Budgets
     let(:category) { create :category, participatory_space: participatory_process }
     let(:category_id) { category.id }
     let(:selected) { nil }
+    let(:latitude) { 40.1234 }
+    let(:longitude) { 2.1234 }
+    let(:address) { nil }
+    let(:has_address) { false }
     let(:attributes) do
       {
         decidim_scope_id: scope_id,
@@ -37,13 +41,46 @@ module Decidim::Budgets
         title_en: title[:en],
         description_en: description[:en],
         budget_amount: budget_amount,
-        selected: selected
+        selected: selected,
+        address: address,
+        has_address: has_address,
       }
     end
 
     it_behaves_like "a scopable resource"
 
     it { is_expected.to be_valid }
+
+    context "when geocoding is enabled" do
+      let(:current_component) { create :budgets_component, :with_geocoding_enabled, participatory_space: participatory_process }
+
+      context "when the has address checkbox is checked" do
+        let(:has_address) { true }
+
+        context "when the address is not present" do
+          it "does not store the coordinates" do
+            expect(subject).to be_valid
+            expect(subject.address).to be(nil)
+            expect(subject.latitude).to be(nil)
+            expect(subject.longitude).to be(nil)
+          end
+        end
+
+        context "when the address is present" do
+          let(:address) { "Some address" }
+
+          before do
+            stub_geocoding(address, [latitude, longitude])
+          end
+
+          it "validates the address and store its coordinates" do
+            expect(subject).to be_valid
+            expect(subject.latitude).to eq(latitude)
+            expect(subject.longitude).to eq(longitude)
+          end
+        end
+      end
+    end
 
     describe "when title is missing" do
       let(:title) { { en: nil } }

--- a/decidim-budgets/spec/helpers/decidim/budgets/projects_helper_spec.rb
+++ b/decidim-budgets/spec/helpers/decidim/budgets/projects_helper_spec.rb
@@ -29,20 +29,6 @@ module Decidim
         end
       end
 
-      describe "#project_preview_data_for_map" do
-        subject { helper.project_preview_data_for_map(project) }
-
-        let(:marker) { subject[:marker] }
-
-        it "returns preview data" do
-          expect(subject[:type]).to eq("drag-marker")
-          expect(marker["latitude"]).to eq(latitude)
-          expect(marker["longitude"]).to eq(longitude)
-          expect(marker["address"]).to eq(address)
-          expect(marker["icon"]).to match(/<svg.+/)
-        end
-      end
-
       describe "#project_data_for_map" do
         subject { helper.project_data_for_map(project) }
 

--- a/decidim-budgets/spec/helpers/decidim/budgets/projects_helper_spec.rb
+++ b/decidim-budgets/spec/helpers/decidim/budgets/projects_helper_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Budgets
+    describe ProjectsHelper do
+      include Decidim::LayoutHelper
+
+      let!(:organization) { create(:organization) }
+      let!(:budgets_component) { create(:budgets_component, :with_geocoding_enabled, organization: organization) }
+      let(:budget) { create(:budget, component: budgets_component) }
+      let!(:user) { create(:user, organization: organization) }
+      let!(:projects) { create_list(:project, 5, budget: budget, address: address, latitude: latitude, longitude: longitude, component: budgets_component) }
+      let!(:project) { projects.first }
+      let(:address) { "Carrer Pic de Peguera 15, 17003 Girona" }
+      let(:latitude) { 40.1234 }
+      let(:longitude) { 2.1234 }
+
+      describe "#has_position?" do
+        subject { helper.has_position?(project) }
+
+        it { is_expected.to be_truthy }
+
+        context "when project is not geocoded" do
+          let!(:projects) { create_list(:project, 5, budget: budget, address: address, latitude: nil, longitude: nil, component: budgets_component) }
+
+          it { is_expected.to be_falsey }
+        end
+      end
+
+      describe "#project_preview_data_for_map" do
+        subject { helper.project_preview_data_for_map(project) }
+
+        let(:marker) { subject[:marker] }
+
+        it "returns preview data" do
+          expect(subject[:type]).to eq("drag-marker")
+          expect(marker["latitude"]).to eq(latitude)
+          expect(marker["longitude"]).to eq(longitude)
+          expect(marker["address"]).to eq(address)
+          expect(marker["icon"]).to match(/<svg.+/)
+        end
+      end
+
+      describe "#project_data_for_map" do
+        subject { helper.project_data_for_map(project) }
+
+        let(:fake_description) { "<script>alert(\"HEY\")</script> This is my long, but still super interesting, description of my also long, but also super interesting, project. Check it out!" }
+        let(:fake_title) { "<script>alert(\"HEY\")</script> This is my title" }
+
+        it "returns preview data" do
+          allow(project).to receive(:description).and_return(en: fake_description)
+          allow(project).to receive(:title).and_return(en: fake_title)
+
+          expect(subject["latitude"]).to eq(latitude)
+          expect(subject["longitude"]).to eq(longitude)
+          expect(subject["address"]).to eq(address)
+          expect(subject["title"]).to eq("&lt;script&gt;alert(&quot;HEY&quot;)&lt;/script&gt; This is my title")
+          expect(subject["description"]).to eq("<div class=\"ql-editor ql-reset-decidim\">alert(&quot;HEY&quot;) This is my long, but still super interesting, description of my also long, but also sup...</div>")
+          expect(subject["link"]).to eq(::Decidim::ResourceLocatorPresenter.new([project.budget, project]).path)
+          expect(subject["icon"]).to match(/<svg.+/)
+        end
+      end
+
+      describe "#projects_data_for_map" do
+        subject { helper.projects_data_for_map(projects) }
+
+        it "returns preview data" do
+          expect(subject.length).to eq(5)
+        end
+      end
+    end
+  end
+end

--- a/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
+++ b/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
@@ -56,7 +56,7 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
 
       it "updates the component" do
         expect do
-          Decidim::Admin::UpdateComponent.call(form, component)
+          Decidim::Admin::UpdateComponent.call(form, component, current_user)
         end.to broadcast(:ok)
       end
     end

--- a/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
+++ b/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
@@ -27,6 +27,7 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
     let(:percent) { 70 }
     let(:minimum_enabled) { false }
     let(:projects_enabled) { false }
+    let(:geocoding_enabled) { false }
     let(:minimum_number) { 3 }
     let(:maximum_number) { 6 }
 
@@ -39,12 +40,25 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
         vote_minimum_budget_projects_number: minimum_number,
         vote_rule_selected_projects_enabled: projects_enabled,
         vote_selected_projects_minimum: minimum_number,
-        vote_selected_projects_maximum: maximum_number
+        vote_selected_projects_maximum: maximum_number,
+        geocoding_enabled: geocoding_enabled
       }
     end
 
     def new_settings(name, data)
       Decidim::Component.build_settings(manifest, name, data, organization)
+    end
+
+    describe "with geocoding enabled" do
+      let(:geocoding_enabled) { true }
+      # One budget rule must me activated
+      let(:percent_enabled) { true }
+
+      it "updates the component" do
+        expect do
+          Decidim::Admin::UpdateComponent.call(form, component)
+        end.to broadcast(:ok)
+      end
     end
 
     describe "with minimum projects number to vote" do

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -22,6 +22,7 @@ shared_examples "manage projects" do
       before do
         stub_geocoding(address, [latitude, longitude])
         current_component.update!(settings: { geocoding_enabled: true })
+        visit current_path
       end
 
       it "creates a new project" do
@@ -39,8 +40,7 @@ shared_examples "manage projects" do
           project = Decidim::Budgets::Project.last
 
           expect(page).to have_content("Make decidim great again")
-          expect(translated(project.body)).to eq("<p>Decidim is great but it can be better</p>")
-          expect(project.scope).to eq(scope)
+          expect(translated(project.description)).to eq("<p>Decidim is great but it can be better</p>")
         end
       end
 

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -54,6 +54,7 @@ shared_examples "manage projects" do
         let(:geocoded_address_coordinates) { [latitude, longitude] }
 
         before do
+          stub_geocoding(address, [latitude, longitude])
           within ".new_project" do
             fill_in_i18n :project_title, "#project-title-tabs", en: "Make decidim great again"
             fill_in_i18n_editor :project_description, "#project-description-tabs", en: "Decidim is great but it can be better"

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -14,6 +14,55 @@ shared_examples "manage projects" do
       expect(page).to have_content("Choose proposals")
     end
 
+    context "when geocoding is enabled", :serves_geocoding_autocomplete do
+      let(:address) { "Some address" }
+      let(:latitude) { 40.1234 }
+      let(:longitude) { 2.1234 }
+
+      before do
+        stub_geocoding(address, [latitude, longitude])
+        current_component.update!(settings: { geocoding_enabled: true })
+      end
+
+      it "creates a new project" do
+        within ".new_project" do
+          fill_in_i18n :project_title, "#project-title-tabs", en: "Make decidim great again"
+          fill_in_i18n_editor :project_description, "#project-description-tabs", en: "Decidim is great but it can be better"
+          fill_in :project_address, with: address
+          fill_in :project_budget_amount, with: 1234
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_admin_callout("successfully")
+
+        within "table" do
+          project = Decidim::Budgets::Project.last
+
+          expect(page).to have_content("Make decidim great again")
+          expect(translated(project.body)).to eq("<p>Decidim is great but it can be better</p>")
+          expect(project.scope).to eq(scope)
+        end
+      end
+
+      it_behaves_like(
+        "a record with front-end geocoding address field",
+        Decidim::Budgets::Project,
+        within_selector: ".new_project",
+        address_field: :project_address
+      ) do
+        let(:geocoded_address_value) { address }
+        let(:geocoded_address_coordinates) { [latitude, longitude] }
+
+        before do
+          within ".new_project" do
+            fill_in_i18n :project_title, "#project-title-tabs", en: "Make decidim great again"
+            fill_in_i18n_editor :project_description, "#project-description-tabs", en: "Decidim is great but it can be better"
+            fill_in :project_budget_amount, with: 1234
+          end
+        end
+      end
+    end
+
     context "when proposal linking is disabled" do
       before do
         allow(Decidim::Budgets).to receive(:enable_proposal_linking).and_return(false)

--- a/decidim-budgets/spec/system/explore_projects_spec.rb
+++ b/decidim-budgets/spec/system/explore_projects_spec.rb
@@ -129,46 +129,6 @@ describe "Explore projects", :slow, type: :system do
       end
     end
 
-    context "when geocoding is enabled" do
-      before do
-        component.update!(settings: { geocoding_enabled: true })
-
-        allow(Decidim.config).to receive(:maps).and_return({
-                                                             provider: :here,
-                                                             api_key: Rails.application.secrets.maps[:api_key],
-                                                             static: { url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview" }
-                                                           })
-        # To make sure there are 5 points distinct
-        projects[0].update!(latitude: -10)
-        projects[0].update!(longitude: -10)
-        projects[1].update!(latitude: -10)
-        projects[1].update!(longitude: 10)
-        projects[2].update!(latitude: 0)
-        projects[2].update!(longitude: 0)
-        projects[3].update!(latitude: 10)
-        projects[3].update!(longitude: -10)
-        projects[4].update!(latitude: 10)
-        projects[4].update!(longitude: 10)
-
-        visit_budget
-      end
-
-      it "displays a map with the projects", :slow do
-        expect(page).to have_selector("div[data-decidim-map]")
-        expect(find("div[data-decidim-map]")["data-decidim-map"]).to have_content("latitude", count: 5)
-        expect(page).to have_selector(".leaflet-marker-icon", count: 5)
-      end
-
-      it "can be clicked", :slow do
-        find(".leaflet-marker-icon[title='#{project.title["en"]}']").click
-        within ".leaflet-popup-content-wrapper" do
-          expect(page).to have_content(project.title["en"])
-          find(".button--sc").click
-        end
-        expect(page).to have_content(project.address)
-      end
-    end
-
     context "when directly accessing from URL with an invalid budget id" do
       it_behaves_like "a 404 page" do
         let(:target_path) { decidim_budgets.budget_projects_path(99_999_999) }

--- a/decidim-budgets/spec/system/explore_projects_spec.rb
+++ b/decidim-budgets/spec/system/explore_projects_spec.rb
@@ -129,6 +129,46 @@ describe "Explore projects", :slow, type: :system do
       end
     end
 
+    context "when geocoding is enabled" do
+      before do
+        component.update!(settings: { geocoding_enabled: true })
+
+        allow(Decidim.config).to receive(:maps).and_return({
+                                                             provider: :here,
+                                                             api_key: Rails.application.secrets.maps[:api_key],
+                                                             static: { url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview" }
+                                                           })
+        # To make sure there are 5 points distinct
+        projects[0].update!(latitude: -10)
+        projects[0].update!(longitude: -10)
+        projects[1].update!(latitude: -10)
+        projects[1].update!(longitude: 10)
+        projects[2].update!(latitude: 0)
+        projects[2].update!(longitude: 0)
+        projects[3].update!(latitude: 10)
+        projects[3].update!(longitude: -10)
+        projects[4].update!(latitude: 10)
+        projects[4].update!(longitude: 10)
+
+        visit_budget
+      end
+
+      it "displays a map with the projects" do
+        expect(page).to have_selector("div[data-decidim-map]")
+        expect(find("div[data-decidim-map]")["data-decidim-map"]).to have_content("latitude", count: 5)
+        expect(page).to have_selector(".leaflet-marker-icon", count: 5)
+      end
+
+      it "can be clicked" do
+        find(".leaflet-marker-icon[title='#{project.title["en"]}']").click
+        within ".leaflet-popup-content-wrapper" do
+          expect(page).to have_content(project.title["en"])
+          find(".button--sc").click
+        end
+        expect(page).to have_content(project.address)
+      end
+    end
+
     context "when directly accessing from URL with an invalid budget id" do
       it_behaves_like "a 404 page" do
         let(:target_path) { decidim_budgets.budget_projects_path(99_999_999) }

--- a/decidim-budgets/spec/system/explore_projects_spec.rb
+++ b/decidim-budgets/spec/system/explore_projects_spec.rb
@@ -153,13 +153,13 @@ describe "Explore projects", :slow, type: :system do
         visit_budget
       end
 
-      it "displays a map with the projects" do
+      it "displays a map with the projects", :slow do
         expect(page).to have_selector("div[data-decidim-map]")
         expect(find("div[data-decidim-map]")["data-decidim-map"]).to have_content("latitude", count: 5)
         expect(page).to have_selector(".leaflet-marker-icon", count: 5)
       end
 
-      it "can be clicked" do
+      it "can be clicked", :slow do
         find(".leaflet-marker-icon[title='#{project.title["en"]}']").click
         within ".leaflet-popup-content-wrapper" do
           expect(page).to have_content(project.title["en"])


### PR DESCRIPTION
#### :tophat: What? Why?
Participatory budget are often made by cities, and a lot of projects have a specific location in the city. The idea here is to allow administrators to add an address on projects so they can me displayed in a map on Budget component. This helps users to easily access projects of their neighbourhood.

Describe the solution you'd like

As an admin, I'd like to be able to enable geocoding on the Budget component.

Add a config flag in Budgets component configuration that allows the admin to enable/disable projects geocoding.
As an admin, I'd like to be able to add an address on the project I'm creating or editing.

Add an address field with geocoder in project creation & edition page. ([https://imgur.com/Dt2j5aR (External link)](https://imgur.com/Dt2j5aR))
As an admin, I'd like to be able to see the map preview on projects index in BO.

Add a "Map" column to display the map preview on projects index in BO (https://imgur.com/MdGtTBq (External link))
As a user, I'd like to see a map displaying geocoded projects on the projects index.

Show a map on projects index to display geocoded projects (ex here : https://imgur.com/34jVIGo (External link))
As a user, I'd like to see the address and the map preview on the project page.

As for meetings and proposals, add a card on project page to display address infos and map preview

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #9109

#### Testing
* Create a project with an address
* Activate geocoding
* See maps with pin points

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
Configuration in Budgets configuration
<img width="1068" alt="Capture d’écran 2022-05-10 à 16 23 09" src="https://user-images.githubusercontent.com/20232956/168726310-06b96e1e-dc2f-47a7-9b34-1e463c5ed943.png">

When geocoding is enabled and there is a project with an address, a pin is displayed on the map
<img width="1236" alt="Capture d’écran 2022-05-11 à 09 37 30" src="https://user-images.githubusercontent.com/20232956/168726337-de6af08b-438e-4cca-86a8-1f2921b8baa4.png">

When geocoding is enabled,a map is displayed on the projects index
<img width="1200" alt="Capture d’écran 2022-05-11 à 09 40 23" src="https://user-images.githubusercontent.com/20232956/168726468-c20ec0bb-35e1-4074-958b-cfad0cd73c81.png">

As for proposals, the card with address is displayed
<img width="1207" alt="Capture d’écran 2022-05-11 à 09 43 46" src="https://user-images.githubusercontent.com/20232956/168726490-199e25f2-c89f-48c1-b6b9-04dec95cda68.png">


:hearts: Thank you!
