### PR TITLE
Don't show deleted resources in last activities 

### DIFF
--- a/decidim-comments/lib/decidim/comments/test/factories.rb
+++ b/decidim-comments/lib/decidim/comments/test/factories.rb
@@ -19,6 +19,11 @@ FactoryBot.define do
       comment.body = Decidim::ContentProcessor.parse_with_processor(:hashtag, comment.body, current_organization: comment.root_commentable.organization).rewrite
     end
 
+    trait :deleted do
+      created_at { 1.day.ago }
+      deleted_at { 1.hour.ago }
+    end
+
     trait :comment_on_comment do
       author { build(:user, organization: root_commentable.organization) }
       commentable do

--- a/decidim-comments/spec/cells/decidim/comments/comment_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comment_cell_spec.rb
@@ -35,7 +35,7 @@ module Decidim::Comments
       end
 
       context "when deleted" do
-        let(:comment) { create(:comment, commentable: commentable, deleted_at: 1.hour.ago, created_at: 1.day.ago) }
+        let(:comment) { create(:comment, :deleted, commentable: commentable) }
 
         it "renders the card with a deletion message and replies" do
           expect(subject).to have_css("#comment_#{comment.id}")

--- a/decidim-core/app/models/decidim/action_log.rb
+++ b/decidim-core/app/models/decidim/action_log.rb
@@ -219,6 +219,7 @@ module Decidim
     def visible_for?(user)
       return false if resource_lazy.blank?
       return false if participatory_space_lazy.blank?
+      return false if resource_lazy.respond_to?(:deleted?) && resource_lazy.deleted?
       return false if resource_lazy.respond_to?(:hidden?) && resource_lazy.hidden?
       return false if resource_lazy.respond_to?(:can_participate?) && !resource_lazy.can_participate?(user)
 

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -38,7 +38,7 @@ describe "Last activity", type: :system do
     switch_to_host organization.host
   end
 
-  describe "accessing the last activity page" do
+  describe "accessing the homepage with the last activity content block enabled" do
     before do
       page.visit decidim.root_path
     end

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -54,6 +54,16 @@ describe "Last activity", type: :system do
       expect(page).to have_no_content(another_comment.translated_body)
     end
 
+    context "when there is a deleted comment" do
+      let(:comment) { create(:comment, body: "This is deleted", deleted_at: 1.hour.ago, created_at: 1.day.ago) }
+
+      it "isn't shown" do
+        within "#last_activity" do
+          expect(page).to_not have_content("This is deleted")
+        end
+      end
+    end
+
     context "when viewing all activities" do
       before do
         within "#last_activity" do

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -59,7 +59,7 @@ describe "Last activity", type: :system do
 
       it "isn't shown" do
         within "#last_activity" do
-          expect(page).to_not have_content("This is deleted")
+          expect(page).not_to have_content("This is deleted")
         end
       end
     end

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -44,7 +44,7 @@ describe "Last activity", type: :system do
     end
 
     it "displays the activities at the home page" do
-      within ".upcoming-events" do
+      within "#last_activity" do
         expect(page).to have_css(".card--activity", count: 3)
       end
     end
@@ -56,7 +56,7 @@ describe "Last activity", type: :system do
 
     context "when viewing all activities" do
       before do
-        within ".upcoming-events" do
+        within "#last_activity" do
           click_link "View all"
         end
       end

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -55,7 +55,7 @@ describe "Last activity", type: :system do
     end
 
     context "when there is a deleted comment" do
-      let(:comment) { create(:comment, body: "This is deleted", deleted_at: 1.hour.ago, created_at: 1.day.ago) }
+      let(:comment) { create(:comment, :deleted, body: "This is deleted") }
 
       it "isn't shown" do
         within "#last_activity" do


### PR DESCRIPTION
#### :tophat: What? Why?

When someone makes a comment and deletes it, it's still accessible on the Last Activity content block of the homepage. This PR fixes that. 

#### :pushpin: Related Issues
 
- Fixes #9289

#### Testing

1.    Log in and create a comment
2.   Delete it
3.    Go to the homepage and look for the Last Activity block

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/717367/168091311-cd1ed980-b66f-4c75-a2bd-42559ba96ab6.png)

(This currently in [Metadecidim homepage](https://meta.decidim.org/))

:hearts: Thank you!
