### PR TITLE
Fix 'Duplicate branch' lint offense in budgets

### DIFF
--- a/decidim-budgets/app/permissions/decidim/budgets/admin/permissions.rb
+++ b/decidim-budgets/app/permissions/decidim/budgets/admin/permissions.rb
@@ -19,23 +19,17 @@ module Decidim
             end
           when :project, :projects
             case permission_action.action
-            when :create, :import_proposals
+            when :create, :import_proposals, :project_category
               permission_action.allow!
             when :update, :destroy
               permission_action.allow! if project.present?
-            when :project_category
-              permission_action.allow!
             end
           when :order
             case permission_action.action
             when :remind
               permission_action.allow!
             end
-          when :project_category
-            permission_action.allow!
-          when :project_scope
-            permission_action.allow!
-          when :project_selected
+          when :project_category, :project_scope, :project_selected
             permission_action.allow!
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?

There's a CI flow failing in develop for some changes done Friday, regarding the changes to Rubocop configuration and a new feature in Budgets (#8986). 

> Offenses:
> 
> decidim-budgets/app/permissions/decidim/budgets/admin/permissions.rb:26:13: W: Lint/DuplicateBranch: Duplicate branch body detected.
>             when :project_category ...
>             ^^^^^^^^^^^^^^^^^^^^^^
> decidim-budgets/app/permissions/decidim/budgets/admin/permissions.rb:36:11: W: Lint/DuplicateBranch: Duplicate branch body detected.
>           when :project_scope ...
>           ^^^^^^^^^^^^^^^^^^^
> decidim-budgets/app/permissions/decidim/budgets/admin/permissions.rb:38:11: W: Lint/DuplicateBranch: Duplicate branch body detected.
>           when :project_selected ...
>           ^^^^^^^^^^^^^^^^^^^^^^

This PR fixes it.  

(It's difficult to detect this before merging. We could ask for people to merge when we do this kind of changes, but that could be too cumbersome/with little value and we of course can always fix it after, as this PR).  

#### :pushpin: Related Issues

- See https://github.com/decidim/decidim/runs/6426844156?check_suite_focus=true

#### Testing

"[CI] Lint code" should be passing/green.

:hearts: Thank you!
