### PR TITLE
Normalize meeting's i18n file

### DIFF
--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -312,7 +312,7 @@ en:
             select_a_meeting_type: Please select a meeting type
             select_a_registration_type: Please select a registration type
             select_an_iframe_access_level: Please select an iframe access level
-            show_embedded_iframe_help: "Only a few services allow embedding in meeting or live event from the following domains: %{domains}"
+            show_embedded_iframe_help: 'Only a few services allow embedding in meeting or live event from the following domains: %{domains}'
           index:
             title: Meetings
           new:
@@ -509,7 +509,7 @@ en:
           select_a_meeting_type: Please select a meeting type
           select_a_registration_type: Please select a registration type
           select_an_iframe_access_level: Please select an iframe access level
-          show_embedded_iframe_help: "Only a few services allow embedding in meeting or live event from the following domains: %{domains}"
+          show_embedded_iframe_help: 'Only a few services allow embedding in meeting or live event from the following domains: %{domains}'
         index:
           click_here: See all meetings
           new_meeting: New meeting


### PR DESCRIPTION
#### :tophat: What? Why?

After we've merged #9219 there's a failing job in CI in develop, regarding the normalization of the meeting's `en.yml` file. This PR fixes it. 

(It was already failing in the PR, I've missed, sorry about that :S)

#### :pushpin: Related Issues
 
- See https://github.com/decidim/decidim/runs/6426843376?check_suite_focus=true

#### Testing

[CI] Main folder should be green/passing 

:hearts: Thank you!
