### PR TITLE
Add admin log when creating, updating or deleting initiative types

### DIFF
--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
@@ -8,8 +8,9 @@ module Decidim
         # Public: Initializes the command.
         #
         # form - A form object with the params.
-        def initialize(form)
+        def initialize(form, user)
           @form = form
+          @user = user
         end
 
         # Executes the command. Broadcasts these events:
@@ -36,7 +37,9 @@ module Decidim
         attr_reader :form
 
         def create_initiative_type
-          initiative_type = InitiativesType.new(
+          initiative_type = Decidim.traceability.create!(
+            InitiativesType,
+            @user,
             organization: form.current_organization,
             title: form.title,
             description: form.description,

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
@@ -12,9 +12,10 @@ module Decidim
         #
         # initiative_type: Decidim::InitiativesType
         # form - A form object with the params.
-        def initialize(initiative_type, form)
+        def initialize(initiative_type, form, user)
           @form = form
           @initiative_type = initiative_type
+          @user = user
         end
 
         # Executes the command. Broadcasts these events:
@@ -26,13 +27,15 @@ module Decidim
         def call
           return broadcast(:invalid) if form.invalid?
 
-          initiative_type.update(attributes)
+          Decidim.traceability.perform_action!("update", initiative_type, @user) do
+            initiative_type.update(attributes)
 
-          if initiative_type.valid?
-            upate_initiatives_signature_type
-            broadcast(:ok, initiative_type)
-          else
-            broadcast(:invalid)
+            if initiative_type.valid?
+              update_initiatives_signature_type
+              broadcast(:ok, initiative_type)
+            else
+              broadcast(:invalid)
+            end
           end
         end
 
@@ -62,7 +65,7 @@ module Decidim
           )
         end
 
-        def upate_initiatives_signature_type
+        def update_initiatives_signature_type
           initiative_type.initiatives.signature_type_updatable.each do |initiative|
             initiative.update!(signature_type: initiative_type.signature_type)
           end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_types_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_types_controller.rb
@@ -55,7 +55,7 @@ module Decidim
           @form = initiative_type_form
                   .from_params(params, initiative_type: current_initiative_type)
 
-          UpdateInitiativeType.call(current_initiative_type, @form) do
+          UpdateInitiativeType.call(current_initiative_type, @form, current_user) do
             on(:ok) do
               flash[:notice] = I18n.t("decidim.initiatives.admin.initiatives_types.update.success")
               redirect_to edit_initiatives_type_path(current_initiative_type)

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_types_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_types_controller.rb
@@ -27,7 +27,7 @@ module Decidim
           enforce_permission_to :create, :initiative_type
           @form = initiative_type_form.from_params(params)
 
-          CreateInitiativeType.call(@form) do
+          CreateInitiativeType.call(@form, current_user) do
             on(:ok) do |initiative_type|
               flash[:notice] = I18n.t("decidim.initiatives.admin.initiatives_types.create.success")
               redirect_to edit_initiatives_type_path(initiative_type)

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_types_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_types_controller.rb
@@ -72,7 +72,7 @@ module Decidim
         def destroy
           enforce_permission_to :destroy, :initiative_type, initiative_type: current_initiative_type
 
-          Decidim.traceability.perform_action!("delete",current_initiative_type,current_user) do
+          Decidim.traceability.perform_action!("delete", current_initiative_type, current_user) do
             current_initiative_type.destroy!
           end
 

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_types_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_types_controller.rb
@@ -71,7 +71,10 @@ module Decidim
         # DELETE /admin/initiatives_types/:id
         def destroy
           enforce_permission_to :destroy, :initiative_type, initiative_type: current_initiative_type
-          current_initiative_type.destroy!
+
+          Decidim.traceability.perform_action!("delete",current_initiative_type,current_user) do
+            current_initiative_type.destroy!
+          end
 
           redirect_to initiatives_types_path, flash: {
             notice: I18n.t("decidim.initiatives.admin.initiatives_types.destroy.success")

--- a/decidim-initiatives/app/models/decidim/initiatives_type.rb
+++ b/decidim-initiatives/app/models/decidim/initiatives_type.rb
@@ -6,6 +6,7 @@ module Decidim
     include Decidim::HasResourcePermission
     include Decidim::TranslatableResource
     include Decidim::HasUploadValidations
+    include Decidim::Traceable
 
     translatable_fields :title, :description, :extra_fields_legal_information
 
@@ -47,6 +48,10 @@ module Decidim
 
     def mounted_params
       { host: organization.host }
+    end
+
+    def self.log_presenter_class_for(_log)
+      Decidim::Initiatives::AdminLog::InitiativesTypePresenter
     end
   end
 end

--- a/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiatives_type_presenter.rb
+++ b/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiatives_type_presenter.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module AdminLog
+      # This class holds the logic to present a `Decidim::InitiativesType`
+      # for the `AdminLog` log.
+      #
+      # Usage should be automatic and you shouldn't need to call this class
+      # directly, but here's an example:
+      #
+      #    action_log = Decidim::ActionLog.last
+      #    view_helpers # => this comes from the views
+      #    InitiativesTypePresenter.new(action_log, view_helpers).present
+      class InitiativesTypePresenter < Decidim::Log::BasePresenter
+        private
+
+        def action_string
+          case action
+          when "create", "update", "delete"
+            "decidim.initiatives.admin_log.initiatives_type.#{action}"
+          else
+            super
+          end
+        end
+
+        def diff_fields_mapping
+          {
+            description: :i18n,
+            title: :i18n,
+            extra_fields_legal_information: :i18n,
+            minimum_committee_members: :integer,
+            document_number_authorization_handler: :i18n,
+            undo_online_signatures_enabled: :boolean,
+            promoting_committee_enabled: :boolean
+          }
+        end
+
+        def diff_actions
+          super + %w(update)
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -291,6 +291,10 @@ en:
           send_to_technical_validation: "%{user_name} sent the %{resource_name} initiative to technical validation"
           unpublish: "%{user_name} discarded the %{resource_name} initiative"
           update: "%{user_name} updated the %{resource_name} initiative"
+        initiatives_type:
+          create: "%{user_name} created the %{resource_name} initiatives type"
+          delete: "%{user_name} updated the %{resource_name} initiatives type"
+          update: "%{user_name} deleted the %{resource_name} initiatives type"
       admin_states:
         accepted: Enough signatures
         created: Created

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -293,8 +293,8 @@ en:
           update: "%{user_name} updated the %{resource_name} initiative"
         initiatives_type:
           create: "%{user_name} created the %{resource_name} initiatives type"
-          delete: "%{user_name} updated the %{resource_name} initiatives type"
-          update: "%{user_name} deleted the %{resource_name} initiatives type"
+          delete: "%{user_name} deleted the %{resource_name} initiatives type"
+          update: "%{user_name} updated the %{resource_name} initiatives type"
       admin_states:
         accepted: Enough signatures
         created: Created

--- a/decidim-initiatives/spec/commands/decidim/initiatives/admin/create_initiative_type_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/admin/create_initiative_type_spec.rb
@@ -14,6 +14,7 @@ module Decidim
 
         describe "Validation failure" do
           let(:organization) { create(:organization) }
+          let(:user) { create(:user, organization: organization) }
           let!(:initiative_type) do
             build(:initiatives_type, organization: organization)
           end
@@ -27,7 +28,7 @@ module Decidim
             ActiveModel::Errors.new(initiative_type)
                                .tap { |e| e.add(:banner_image, "upload error") }
           end
-          let(:command) { described_class.new(form) }
+          let(:command) { described_class.new(form, user) }
 
           it "broadcasts invalid" do
             expect(InitiativesType).to receive(:new).at_least(:once).and_return(initiative_type)

--- a/decidim-initiatives/spec/commands/decidim/initiatives/admin/update_initiative_type_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/admin/update_initiative_type_spec.rb
@@ -14,6 +14,7 @@ module Decidim
 
         context "when validation error" do
           let(:organization) { create(:organization) }
+          let(:user) { create(:user, organization: organization) }
           let!(:initiative_type) { create(:initiatives_type, organization: organization, banner_image: banner_image) }
           let(:banner_image) { upload_test_file(Decidim::Dev.test_file("city2.jpeg", "image/jpeg")) }
           let(:form) do
@@ -22,7 +23,7 @@ module Decidim
               .with_context(current_organization: organization)
           end
 
-          let(:command) { described_class.new(initiative_type, form) }
+          let(:command) { described_class.new(initiative_type, form, user) }
 
           it "broadcasts invalid" do
             expect(initiative_type).to receive(:valid?)

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_types_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_types_controller_spec.rb
@@ -203,6 +203,18 @@ module Decidim
                 delete :destroy, params: { id: initiative_type.id }
               end.to change(InitiativesType, :count).by(0)
             end
+
+            it "traces the action", versioning: true do
+              expect(Decidim.traceability)
+                .to receive(:perform_action!)
+                      .with("delete", initiative_type, admin_user)
+                      .and_call_original
+
+              expect { delete :destroy, params: { id: initiative_type.id } }.to change(Decidim::ActionLog, :count)
+              action_log = Decidim::ActionLog.last
+              expect(action_log.action).to eq("delete")
+              expect(action_log.version).to be_present
+            end
           end
 
           context "and regular user" do

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_types_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_types_controller_spec.rb
@@ -207,8 +207,8 @@ module Decidim
             it "traces the action", versioning: true do
               expect(Decidim.traceability)
                 .to receive(:perform_action!)
-                      .with("delete", initiative_type, admin_user)
-                      .and_call_original
+                .with("delete", initiative_type, admin_user)
+                .and_call_original
 
               expect { delete :destroy, params: { id: initiative_type.id } }.to change(Decidim::ActionLog, :count)
               action_log = Decidim::ActionLog.last

--- a/decidim-initiatives/spec/shared/create_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/create_initiative_type_example.rb
@@ -65,8 +65,8 @@ shared_examples "create an initiative type" do
       it "traces the action", versioning: true do
         expect(Decidim.traceability)
           .to receive(:perform_action!)
-                .with(:create, Decidim::InitiativesType, user, {})
-                .and_call_original
+          .with(:create, Decidim::InitiativesType, user, {})
+          .and_call_original
 
         expect { command.call }.to change(Decidim::ActionLog, :count)
         action_log = Decidim::ActionLog.last

--- a/decidim-initiatives/spec/shared/update_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_type_example.rb
@@ -107,8 +107,8 @@ shared_examples "update an initiative type" do
       it "traces the action", versioning: true do
         expect(Decidim.traceability)
           .to receive(:perform_action!)
-                .with("update", initiative_type, user)
-                .and_call_original
+          .with("update", initiative_type, user)
+          .and_call_original
 
         expect { command.call }.to change(Decidim::ActionLog, :count)
         action_log = Decidim::ActionLog.last

--- a/decidim-initiatives/spec/shared/update_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_type_example.rb
@@ -2,6 +2,7 @@
 
 shared_examples "update an initiative type" do
   let(:organization) { create(:organization) }
+  let(:user) { create(:user) }
   let(:initiative_type) do
     create(:initiatives_type,
            :online_signature_enabled,
@@ -41,7 +42,7 @@ shared_examples "update an initiative type" do
       }
     end
 
-    let(:command) { described_class.new(initiative_type, form) }
+    let(:command) { described_class.new(initiative_type, form, user) }
 
     describe "when the form is not valid" do
       before do
@@ -101,6 +102,18 @@ shared_examples "update an initiative type" do
         initiative.reload
 
         expect(initiative.signature_type).to eq("online")
+      end
+
+      it "traces the action", versioning: true do
+        expect(Decidim.traceability)
+          .to receive(:perform_action!)
+                .with("update", initiative_type, user)
+                .and_call_original
+
+        expect { command.call }.to change(Decidim::ActionLog, :count)
+        action_log = Decidim::ActionLog.last
+        expect(action_log.action).to eq("update")
+        expect(action_log.version).to be_present
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
add admin log when creating, updating or deleting initiatives type

#### :pushpin: Related Issues
- Fixes the 38th, 39th and 40th tasks of #9181 

![image](https://user-images.githubusercontent.com/93646702/168771893-c17a78ea-9ac4-492f-87e7-2e142114f78d.png)
