### PR TITLE
Group creator can leave group

### DIFF
--- a/decidim-core/app/cells/decidim/profile_sidebar_cell.rb
+++ b/decidim-core/app/cells/decidim/profile_sidebar_cell.rb
@@ -64,9 +64,11 @@ module Decidim
       return false unless current_user
       return false if model.is_a?(Decidim::User)
 
-      return true if Decidim::UserGroupMembership.where(user: current_user, user_group: model, role: :member).any?
+      collection = Decidim::UserGroupMembership.where(user_group: model)
+      return false if collection.where(user: current_user).empty?
+      return true if collection.where(user: current_user, role: :member).any?
 
-      Decidim::UserGroupMembership.where(user_group: model, role: [:creator, :admin]).count > 1
+      collection.where(role: [:creator, :admin]).where.not(user: current_user).any?
     end
 
     def user_group_email_to_be_confirmed?

--- a/decidim-core/app/cells/decidim/profile_sidebar_cell.rb
+++ b/decidim-core/app/cells/decidim/profile_sidebar_cell.rb
@@ -64,11 +64,7 @@ module Decidim
       return false unless current_user
       return false if model.is_a?(Decidim::User)
 
-      collection = Decidim::UserGroupMembership.where(user_group: model)
-      return false if collection.where(user: current_user).empty?
-      return true if collection.where(user: current_user, role: :member).any?
-
-      collection.where(role: [:creator, :admin]).where.not(user: current_user).any?
+      Decidim::UserGroupMembership.where(user: current_user, user_group: model).any?
     end
 
     def user_group_email_to_be_confirmed?

--- a/decidim-core/app/cells/decidim/profile_sidebar_cell.rb
+++ b/decidim-core/app/cells/decidim/profile_sidebar_cell.rb
@@ -64,7 +64,9 @@ module Decidim
       return false unless current_user
       return false if model.is_a?(Decidim::User)
 
-      Decidim::UserGroupMembership.where(user: current_user, user_group: model).where.not(role: :creator).any?
+      return true if Decidim::UserGroupMembership.where(user: current_user, user_group: model, role: :member).any?
+
+      Decidim::UserGroupMembership.where(user_group: model, role: [:creator, :admin]).count > 1
     end
 
     def user_group_email_to_be_confirmed?

--- a/decidim-core/app/commands/decidim/leave_user_group.rb
+++ b/decidim-core/app/commands/decidim/leave_user_group.rb
@@ -36,7 +36,7 @@ module Decidim
     end
 
     def can_leave?
-      @can_leave ||= Decidim::UserGroupMembership.where(user: user, user_group: user_group).any?
+      Decidim::UserGroupMembership.where(user: user, user_group: user_group).any?
     end
 
     def last_admin?

--- a/decidim-core/app/commands/decidim/leave_user_group.rb
+++ b/decidim-core/app/commands/decidim/leave_user_group.rb
@@ -35,7 +35,7 @@ module Decidim
     end
 
     def can_leave?
-      return true if Decidim::UserGroupMembership.where(user: current_user, user_group: user_group, role: :member).any?
+      return true if Decidim::UserGroupMembership.where(user: user, user_group: user_group, role: :member).any?
 
       Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).count > 1
     end

--- a/decidim-core/app/commands/decidim/leave_user_group.rb
+++ b/decidim-core/app/commands/decidim/leave_user_group.rb
@@ -35,7 +35,9 @@ module Decidim
     end
 
     def can_leave?
-      Decidim::UserGroupMembership.where(user: user, user_group: user_group).where.not(role: :creator).any?
+      return true if Decidim::UserGroupMembership.where(user: current_user, user_group: user_group, role: :member).any?
+
+      Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).count > 1
     end
   end
 end

--- a/decidim-core/app/commands/decidim/leave_user_group.rb
+++ b/decidim-core/app/commands/decidim/leave_user_group.rb
@@ -37,7 +37,7 @@ module Decidim
     def can_leave?
       return true if Decidim::UserGroupMembership.where(user: user, user_group: user_group, role: :member).any?
 
-      Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).count > 1
+      Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).where.not(user: user).any?
     end
   end
 end

--- a/decidim-core/app/commands/decidim/leave_user_group.rb
+++ b/decidim-core/app/commands/decidim/leave_user_group.rb
@@ -35,6 +35,7 @@ module Decidim
     end
 
     def can_leave?
+      return false if Decidim::UserGroupMembership.where(user: user, user_group: user_group).empty?
       return true if Decidim::UserGroupMembership.where(user: user, user_group: user_group, role: :member).any?
 
       Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).where.not(user: user).any?

--- a/decidim-core/app/commands/decidim/leave_user_group.rb
+++ b/decidim-core/app/commands/decidim/leave_user_group.rb
@@ -20,6 +20,7 @@ module Decidim
     # Returns nothing.
     def call
       return broadcast(:invalid) unless can_leave?
+      return broadcast(:last_admin) if last_admin?
 
       leave_user_group
 
@@ -35,10 +36,13 @@ module Decidim
     end
 
     def can_leave?
-      return false if Decidim::UserGroupMembership.where(user: user, user_group: user_group).empty?
-      return true if Decidim::UserGroupMembership.where(user: user, user_group: user_group, role: :member).any?
+      @can_leave ||= Decidim::UserGroupMembership.where(user: user, user_group: user_group).any?
+    end
 
-      Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).where.not(user: user).any?
+    def last_admin?
+      return false if Decidim::UserGroupMembership.where(user_group: user_group, user: user, role: [:creator, :admin]).empty?
+
+      Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).where.not(user: user).empty?
     end
   end
 end

--- a/decidim-core/app/commands/decidim/leave_user_group.rb
+++ b/decidim-core/app/commands/decidim/leave_user_group.rb
@@ -40,9 +40,8 @@ module Decidim
     end
 
     def last_admin?
-      return false if Decidim::UserGroupMembership.where(user_group: user_group, user: user, role: [:creator, :admin]).empty?
-
-      Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).where.not(user: user).empty?
+      admin_memberships = Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin])
+      admin_memberships.length == 1 && admin_memberships.pluck(:decidim_user_id).include?(user.id)
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/groups_controller.rb
+++ b/decidim-core/app/controllers/decidim/groups_controller.rb
@@ -64,6 +64,11 @@ module Decidim
           redirect_back fallback_location: profile_path(accepted_user_group.nickname)
         end
 
+        on(:last_admin) do
+          flash[:alert] = t("groups.leave.last_admin", scope: "decidim")
+          redirect_back fallback_location: profile_path(accepted_user_group.nickname)
+        end
+
         on(:invalid) do
           flash[:alert] = t("groups.leave.error", scope: "decidim")
           redirect_back fallback_location: profile_path(accepted_user_group.nickname)

--- a/decidim-core/app/permissions/decidim/permissions.rb
+++ b/decidim-core/app/permissions/decidim/permissions.rb
@@ -148,7 +148,6 @@ module Decidim
       user_group = context.fetch(:user_group)
 
       if permission_action.action == :leave
-        # user_can_leave_group = Decidim::UserGroupMembership.where(user: user, user_group: user_group).any?
         user_can_leave_group = Decidim::UserGroupMembership.where(user: user, user_group: user_group, role: :member).any?
         user_can_leave_group ||= Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).count > 1
         return toggle_allow(user_can_leave_group)

--- a/decidim-core/app/permissions/decidim/permissions.rb
+++ b/decidim-core/app/permissions/decidim/permissions.rb
@@ -149,7 +149,7 @@ module Decidim
 
       if permission_action.action == :leave
         user_can_leave_group = Decidim::UserGroupMembership.where(user: user, user_group: user_group, role: :member).any?
-        user_can_leave_group ||= Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).count > 1
+        user_can_leave_group ||= Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).where.not(user: user).any?
         return toggle_allow(user_can_leave_group)
       end
 

--- a/decidim-core/app/permissions/decidim/permissions.rb
+++ b/decidim-core/app/permissions/decidim/permissions.rb
@@ -148,6 +148,8 @@ module Decidim
       user_group = context.fetch(:user_group)
 
       if permission_action.action == :leave
+        return toggle_allow(false) if Decidim::UserGroupMembership.where(user: user, user_group: user_group).empty?
+
         user_can_leave_group = Decidim::UserGroupMembership.where(user: user, user_group: user_group, role: :member).any?
         user_can_leave_group ||= Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).where.not(user: user).any?
         return toggle_allow(user_can_leave_group)

--- a/decidim-core/app/permissions/decidim/permissions.rb
+++ b/decidim-core/app/permissions/decidim/permissions.rb
@@ -148,7 +148,9 @@ module Decidim
       user_group = context.fetch(:user_group)
 
       if permission_action.action == :leave
-        user_can_leave_group = Decidim::UserGroupMembership.where(user: user, user_group: user_group).where.not(role: :creator).any?
+        # user_can_leave_group = Decidim::UserGroupMembership.where(user: user, user_group: user_group).any?
+        user_can_leave_group = Decidim::UserGroupMembership.where(user: user, user_group: user_group, role: :member).any?
+        user_can_leave_group ||= Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).count > 1
         return toggle_allow(user_can_leave_group)
       end
 

--- a/decidim-core/app/permissions/decidim/permissions.rb
+++ b/decidim-core/app/permissions/decidim/permissions.rb
@@ -148,10 +148,7 @@ module Decidim
       user_group = context.fetch(:user_group)
 
       if permission_action.action == :leave
-        return toggle_allow(false) if Decidim::UserGroupMembership.where(user: user, user_group: user_group).empty?
-
-        user_can_leave_group = Decidim::UserGroupMembership.where(user: user, user_group: user_group, role: :member).any?
-        user_can_leave_group ||= Decidim::UserGroupMembership.where(user_group: user_group, role: [:creator, :admin]).where.not(user: user).any?
+        user_can_leave_group = Decidim::UserGroupMembership.where(user: user, user_group: user_group).any?
         return toggle_allow(user_can_leave_group)
       end
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -927,7 +927,7 @@ en:
       no_user_groups: Doesn't belong to any group yet.
       roles:
         admin: Administrator
-        creator: Creator
+        creator: Administrator
         member: Member
       update:
         error: There was a problem updating the group

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -915,7 +915,7 @@ en:
         success: Join request successfully created. An admin will review your request before accepting you to the group.
       leave:
         error: There was a problem leaving the group
-        last_admin: You can't remove yourself from this group as you're the last administrator. Make another member an administrator in order to leave the group. 
+        last_admin: You can't remove yourself from this group as you're the last administrator. Make another member an administrator in order to leave the group.
         success: Group successfully abandoned.
       members:
         accept_or_reject_join_requests: 'The following users have applied to join this group. Accept or reject their requests:'

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -915,7 +915,7 @@ en:
         success: Join request successfully created. An admin will review your request before accepting you to the group.
       leave:
         error: There was a problem leaving the group
-        last_admin: You can't remove yourself from this group as you're the last administrator
+        last_admin: You can't remove yourself from this group as you're the last administrator. Make another member an administrator in order to leave the group. 
         success: Group successfully abandoned.
       members:
         accept_or_reject_join_requests: 'The following users have applied to join this group. Accept or reject their requests:'

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -915,6 +915,7 @@ en:
         success: Join request successfully created. An admin will review your request before accepting you to the group.
       leave:
         error: There was a problem leaving the group
+        last_admin: You can't remove yourself from this group as you're the last administrator
         success: Group successfully abandoned.
       members:
         accept_or_reject_join_requests: 'The following users have applied to join this group. Accept or reject their requests:'

--- a/decidim-core/spec/commands/decidim/leave_user_group_spec.rb
+++ b/decidim-core/spec/commands/decidim/leave_user_group_spec.rb
@@ -18,7 +18,7 @@ module Decidim
           let(:role) { :creator }
 
           it "broadcasts invalid" do
-            expect { command.call }.to broadcast(:invalid)
+            expect { command.call }.to broadcast(:last_admin)
           end
 
           context "and there is another admin in the group" do
@@ -33,7 +33,7 @@ module Decidim
             let!(:another_membership) { create(:user_group_membership, user_group: user_group, role: :member) }
 
             it "doesnt allow last admin to leave the group" do
-              expect { command.call }.to broadcast(:invalid)
+              expect { command.call }.to broadcast(:last_admin)
             end
           end
         end

--- a/decidim-core/spec/commands/decidim/leave_user_group_spec.rb
+++ b/decidim-core/spec/commands/decidim/leave_user_group_spec.rb
@@ -7,17 +7,34 @@ module Decidim
     describe LeaveUserGroup do
       describe "call" do
         let(:organization) { create(:organization) }
-        let(:membership) { create :user_group_membership, role: :admin }
+        let(:membership) { create :user_group_membership, role: role }
+        let(:role) { :admin }
         let(:user) { membership.user }
         let(:user_group) { membership.user_group }
 
         let(:command) { described_class.new(user, user_group) }
 
         context "when the user is the creator" do
-          let(:membership) { create :user_group_membership, role: :creator }
+          let(:role) { :creator }
 
           it "broadcasts invalid" do
             expect { command.call }.to broadcast(:invalid)
+          end
+
+          context "and there is another admin in the group" do
+            let!(:another_membership) { create(:user_group_membership, user_group: user_group, role: :admin) }
+
+            it "broadcasts ok" do
+              expect { command.call }.to broadcast(:ok)
+            end
+          end
+
+          context "and there is another member in the group" do
+            let!(:another_membership) { create(:user_group_membership, user_group: user_group, role: :member) }
+
+            it "doesnt allow last admin to leave the group" do
+              expect { command.call }.to broadcast(:invalid)
+            end
           end
         end
 
@@ -31,6 +48,8 @@ module Decidim
         end
 
         context "when the data is valid" do
+          let(:role) { :member }
+
           it "broadcasts ok" do
             expect { command.call }.to broadcast(:ok)
           end

--- a/decidim-core/spec/commands/decidim/leave_user_group_spec.rb
+++ b/decidim-core/spec/commands/decidim/leave_user_group_spec.rb
@@ -17,7 +17,7 @@ module Decidim
         context "when the user is the creator" do
           let(:role) { :creator }
 
-          it "broadcasts invalid" do
+          it "broadcasts last admin cant leave group" do
             expect { command.call }.to broadcast(:last_admin)
           end
 

--- a/decidim-core/spec/permissions/decidim/permissions_spec.rb
+++ b/decidim-core/spec/permissions/decidim/permissions_spec.rb
@@ -415,11 +415,15 @@ describe Decidim::Permissions do
         end
 
         context "when the user is the creator" do
-          it { is_expected.to be false }
+          it { is_expected.to be true }
         end
 
-        context "and there is another admin in the group" do
-          let!(:another_membership) { create(:user_group_membership, user_group: user_group, role: :admin) }
+        context "when the user belongs to the group" do
+          before do
+            membership = Decidim::UserGroupMembership.find_by(user: user, user_group: user_group)
+            membership.role = :admin
+            membership.save
+          end
 
           it { is_expected.to be true }
         end

--- a/decidim-core/spec/permissions/decidim/permissions_spec.rb
+++ b/decidim-core/spec/permissions/decidim/permissions_spec.rb
@@ -418,12 +418,8 @@ describe Decidim::Permissions do
           it { is_expected.to be false }
         end
 
-        context "when the user belongs to the group" do
-          before do
-            membership = Decidim::UserGroupMembership.find_by(user: user, user_group: user_group)
-            membership.role = :admin
-            membership.save
-          end
+        context "and there is another admin in the group" do
+          let!(:another_membership) { create(:user_group_membership, user_group: user_group, role: :admin) }
 
           it { is_expected.to be true }
         end

--- a/decidim-core/spec/system/user_group_leaving_spec.rb
+++ b/decidim-core/spec/system/user_group_leaving_spec.rb
@@ -20,11 +20,13 @@ describe "User group leaving", type: :system do
         expect(page).to have_no_content("Leave group")
       end
 
-      context "when there is another admin in the group" do
-        let(:another_user) { create(:user, :confirmed, organization: user.organization) }
+      context "when there is another admins in the group" do
+        let(:another_admin) { create(:user, :confirmed, organization: user.organization) }
+        let(:another_admin2) { create(:user, :confirmed, organization: user.organization) }
 
         before do
-          create :user_group_membership, user: another_user, user_group: user_group, role: :admin
+          create :user_group_membership, user: another_admin, user_group: user_group, role: :admin
+          create :user_group_membership, user: another_admin2, user_group: user_group, role: :admin
           visit decidim.profile_path(user_group.nickname)
         end
 
@@ -32,6 +34,7 @@ describe "User group leaving", type: :system do
           accept_confirm { click_link "Leave group" }
 
           expect(page).to have_content("Group successfully abandoned")
+          expect(page).not_to have_content("Leave group")
         end
       end
     end

--- a/decidim-core/spec/system/user_group_leaving_spec.rb
+++ b/decidim-core/spec/system/user_group_leaving_spec.rb
@@ -19,16 +19,39 @@ describe "User group leaving", type: :system do
       it "does not show the link to leave" do
         expect(page).to have_no_content("Leave group")
       end
+
+      context "when there is another admin in the group" do
+        let(:another_user) { create(:user, :confirmed, organization: user.organization) }
+
+        before do
+          create :user_group_membership, user: another_user, user_group: user_group, role: :admin
+          visit decidim.profile_path(user_group.nickname)
+        end
+
+        it "can leave the group" do
+          accept_confirm { click_link "Leave group" }
+
+          expect(page).to have_content("Group successfully abandoned")
+        end
+      end
     end
 
-    it "allows the user to join" do
-      create :user_group_membership, user: user, user_group: user_group, role: :admin
-      visit decidim.profile_path(user_group.nickname)
+    context "when there is two admins in the group" do
+      let(:another_user) { create(:user, :confirmed, organization: user.organization) }
 
-      accept_confirm { click_link "Leave group" }
+      before do
+        create :user_group_membership, user: user, user_group: user_group, role: :admin
+        create :user_group_membership, user: another_user, user_group: user_group, role: :admin
+      end
 
-      expect(page).to have_content("Group successfully abandoned")
-      expect(page).to have_content("Request to join group")
+      it "allows the user to leave and join back" do
+        visit decidim.profile_path(user_group.nickname)
+
+        accept_confirm { click_link "Leave group" }
+
+        expect(page).to have_content("Group successfully abandoned")
+        expect(page).to have_content("Request to join group")
+      end
     end
   end
 

--- a/decidim-core/spec/system/user_group_leaving_spec.rb
+++ b/decidim-core/spec/system/user_group_leaving_spec.rb
@@ -16,8 +16,10 @@ describe "User group leaving", type: :system do
     context "when the user is the creator" do
       let!(:user_group) { create(:user_group, users: [user], organization: user.organization) }
 
-      it "does not show the link to leave" do
-        expect(page).to have_no_content("Leave group")
+      it "cant leave group" do
+        accept_confirm { click_link "Leave group" }
+
+        expect(page).to have_content("You can't remove yourself from this group as you're the last administrator")
       end
 
       context "when there is another admins in the group" do

--- a/decidim-core/spec/system/user_group_leaving_spec.rb
+++ b/decidim-core/spec/system/user_group_leaving_spec.rb
@@ -22,13 +22,11 @@ describe "User group leaving", type: :system do
         expect(page).to have_content("You can't remove yourself from this group as you're the last administrator")
       end
 
-      context "when there is another admins in the group" do
+      context "when there is another admin in the group" do
         let(:another_admin) { create(:user, :confirmed, organization: user.organization) }
-        let(:another_admin2) { create(:user, :confirmed, organization: user.organization) }
 
         before do
           create :user_group_membership, user: another_admin, user_group: user_group, role: :admin
-          create :user_group_membership, user: another_admin2, user_group: user_group, role: :admin
           visit decidim.profile_path(user_group.nickname)
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Allow creator of a user group to leave the group when there is another admin in the group.

#### :pushpin: Related Issues
[#9177](https://github.com/decidim/decidim/issues/9177)

#### Testing
1. Create group
2. Add admin to group
3. Leave group

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/19709320/168846196-1a180c02-85dd-4d6e-ba6e-f29c386604a6.png)

![image](https://user-images.githubusercontent.com/19709320/168999535-5c55739c-bcd7-40d7-8451-543e7dbb86a0.png)

:hearts: Thank you!
