### PR TITLE
Add configuration option for initiative type to deactivate comments

### DIFF
--- a/decidim-core/app/cells/decidim/author_cell.rb
+++ b/decidim-core/app/cells/decidim/author_cell.rb
@@ -102,7 +102,7 @@ module Decidim
     end
 
     def commentable?
-      from_context && from_context.class.include?(Decidim::Comments::Commentable)
+      from_context && from_context.class.include?(Decidim::Comments::Commentable) && from_context.try(:commentable?)
     end
 
     def endorsable?

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
@@ -41,6 +41,7 @@ module Decidim
             title: form.title,
             description: form.description,
             signature_type: form.signature_type,
+            comments_enabled: form.comments_enabled,
             attachments_enabled: form.attachments_enabled,
             undo_online_signatures_enabled: form.undo_online_signatures_enabled,
             custom_signature_end_date_enabled: form.custom_signature_end_date_enabled,

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
@@ -46,6 +46,7 @@ module Decidim
             description: form.description,
             signature_type: form.signature_type,
             attachments_enabled: form.attachments_enabled,
+            comments_enabled: form.comments_enabled,
             undo_online_signatures_enabled: form.undo_online_signatures_enabled,
             custom_signature_end_date_enabled: form.custom_signature_end_date_enabled,
             area_enabled: form.area_enabled,

--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_type_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_type_form.rb
@@ -18,6 +18,7 @@ module Decidim
         attribute :undo_online_signatures_enabled, Boolean
         attribute :attachments_enabled, Boolean
         attribute :custom_signature_end_date_enabled, Boolean
+        attribute :comments_enabled, Boolean
         attribute :area_enabled, Boolean
         attribute :child_scope_threshold_enabled, Boolean
         attribute :only_global_scope_enabled, Boolean

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -178,6 +178,11 @@ module Decidim
       type.attached_uploader(:banner_image)
     end
 
+    # Public: Whether the object's comments are visible or not.
+    def commentable?
+      type.comments_enabled?
+    end
+
     # Public: Check if an initiative has been created by an individual person.
     # If it's false, then it has been created by an authorized organization.
     #

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
@@ -65,6 +65,10 @@
     </div>
 
     <div class="row column">
+      <%= form.check_box :comments_enabled %>
+    </div>
+
+    <div class="row column">
       <%= form.check_box :collect_user_extra_fields %>
     </div>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -40,7 +40,9 @@ edit_link(
               <%= render partial: "vote_cabin", locals: { initiative: current_initiative } %>
             </div>
           <% end %>
-          <%= render partial: "interactions" %>
+          <% if current_initiative.type.comments_enabled %>
+            <%= render partial: "interactions" %>
+          <% end %> %>
         <% else %>
           <%= link_to t(".edit"),
               edit_initiative_path(current_initiative),

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -90,4 +90,4 @@ edit_link(
   </div>
 </div>
 
-<%= comments_for current_initiative if current_initiative.published? %>
+<%= comments_for current_initiative if current_initiative.type.comments_enabled && current_initiative.published? %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -92,4 +92,4 @@ edit_link(
   </div>
 </div>
 
-<%= comments_for current_initiative if current_initiative.type.comments_enabled && current_initiative.published? %>
+<%= comments_for current_initiative if current_initiative.commentable? && current_initiative.published? %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -42,7 +42,7 @@ edit_link(
           <% end %>
           <% if current_initiative.type.comments_enabled %>
             <%= render partial: "interactions" %>
-          <% end %> %>
+          <% end %>
         <% else %>
           <%= link_to t(".edit"),
               edit_initiative_path(current_initiative),

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -40,7 +40,7 @@ edit_link(
               <%= render partial: "vote_cabin", locals: { initiative: current_initiative } %>
             </div>
           <% end %>
-          <% if current_initiative.type.comments_enabled %>
+          <% if current_initiative.commentable? %>
             <%= render partial: "interactions" %>
           <% end %>
         <% else %>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
         banner_image: Banner image
         child_scope_threshold_enabled: Enable child scope signatures
         collect_user_extra_fields: Collect participant personal data on signature
+        comments_enabled: Enable comments
         custom_signature_end_date_enabled: Enable authors to choose the end of signature collection period
         description: Description
         document_number_authorization_handler: Authorization to verify document number on signatures

--- a/decidim-initiatives/db/migrate/20220518053612_add_comments_enabled_to_initiative_types.rb
+++ b/decidim-initiatives/db/migrate/20220518053612_add_comments_enabled_to_initiative_types.rb
@@ -1,0 +1,5 @@
+class AddCommentsEnabledToInitiativeTypes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :decidim_initiatives_types, :comments_enabled, :boolean, null: false, default: true
+  end
+end

--- a/decidim-initiatives/db/migrate/20220518053612_add_comments_enabled_to_initiative_types.rb
+++ b/decidim-initiatives/db/migrate/20220518053612_add_comments_enabled_to_initiative_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCommentsEnabledToInitiativeTypes < ActiveRecord::Migration[6.1]
   def change
     add_column :decidim_initiatives_types, :comments_enabled, :boolean, null: false, default: true

--- a/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
@@ -25,6 +25,11 @@ FactoryBot.define do
     minimum_committee_members { 3 }
     child_scope_threshold_enabled { false }
     only_global_scope_enabled { false }
+    comments_enabled { true }
+
+    trait :with_comments_disabled do
+      comments_enabled { false }
+    end
 
     trait :attachments_enabled do
       attachments_enabled { true }

--- a/decidim-initiatives/spec/cells/decidim/initiatives/initiative_m_cell_spec.rb
+++ b/decidim-initiatives/spec/cells/decidim/initiatives/initiative_m_cell_spec.rb
@@ -11,7 +11,8 @@ module Decidim::Initiatives
     let(:my_cell) { cell("decidim/initiatives/initiative_m", initiative, context: { show_space: show_space }) }
     let(:cell_html) { my_cell.call }
     let(:state) { :published }
-    let!(:initiative) { create(:initiative, hashtag: "my_hashtag", state: state) }
+    let(:organization) { create(:organization) }
+    let!(:initiative) { create(:initiative, organization: organization, hashtag: "my_hashtag", state: state) }
     let(:user) { create :user, organization: initiative.organization }
 
     before do
@@ -75,6 +76,19 @@ module Decidim::Initiatives
         let(:state) { :discarded }
 
         it_behaves_like "card does not show signatures"
+      end
+
+      context "when comments are disabled on inititiative type" do
+        let!(:initiative) { create(:initiative, hashtag: "my_hashtag", state: state) }
+
+        before do
+          allow(initiative.type).to receive(:comments_enabled?).and_return(false)
+        end
+
+        it "does not render comments" do
+          expect(subject).not_to have_css(".comments_count_status")
+          expect(subject).not_to have_content("0 comments")
+        end
       end
     end
   end

--- a/decidim-initiatives/spec/forms/admin/initiative_type_form_spec.rb
+++ b/decidim-initiatives/spec/forms/admin/initiative_type_form_spec.rb
@@ -13,6 +13,7 @@ module Decidim
         let(:title) { Decidim::Faker::Localized.sentence(word_count: 5) }
         let(:promoting_committee_enabled) { true }
         let(:minimum_committee_members) { 5 }
+        let(:comments_enabled) { true }
         let(:attributes) do
           {
             title: title,
@@ -22,6 +23,7 @@ module Decidim
             custom_signature_end_date_enabled: true,
             undo_online_signatures_enabled: false,
             area_enabled: false,
+            comments_enabled: comments_enabled,
             promoting_committee_enabled: promoting_committee_enabled,
             minimum_committee_members: minimum_committee_members,
             banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg")
@@ -58,6 +60,12 @@ module Decidim
           it "sets 0 as minimum committee members" do
             expect(subject.minimum_committee_members).to eq(0)
           end
+        end
+
+        context "when comments are disabled" do
+          let(:comments_enabled) { false }
+
+          it { is_expected.to be_valid }
         end
       end
     end

--- a/decidim-initiatives/spec/shared/create_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/create_initiative_type_example.rb
@@ -22,6 +22,7 @@ shared_examples "create an initiative type" do
         undo_online_signatures_enabled: true,
         custom_signature_end_date_enabled: true,
         area_enabled: true,
+        comments_enabled: true,
         promoting_committee_enabled: true,
         minimum_committee_members: 7,
         banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg"),

--- a/decidim-initiatives/spec/shared/update_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_type_example.rb
@@ -30,6 +30,7 @@ shared_examples "update an initiative type" do
         undo_online_signatures_enabled: false,
         custom_signature_end_date_enabled: true,
         area_enabled: true,
+        comments_enabled: true,
         promoting_committee_enabled: true,
         minimum_committee_members: 7,
         banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg"),

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_spec.rb
@@ -64,6 +64,7 @@ describe "Admin manages initiatives types", type: :system do
       uncheck "Enable participants to undo their online signatures"
       check "Enable authors to choose the end of signature collection period"
       check "Enable authors to choose the area for their initiative"
+      uncheck "Enable comments"
 
       click_button "Update"
 

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -100,6 +100,7 @@ describe "Initiative", type: :system do
 
       it "has comments" do
         expect(page).to have_css(".comments")
+        expect(page).to have_content("0 comments")
       end
 
       context "when comments are disabled" do
@@ -117,6 +118,7 @@ describe "Initiative", type: :system do
 
         it "does not have comments" do
           expect(page).not_to have_css(".comments")
+          expect(page).not_to have_content("0 comments")
         end
       end
     end

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -98,9 +98,9 @@ describe "Initiative", type: :system do
 
       it_behaves_like "has attachments"
 
-      it "has comments" do
+      it "displays comments section" do
         expect(page).to have_css(".comments")
-        expect(page).to have_content("0 comments")
+        expect(page).to have_content("0 Comments")
       end
 
       context "when comments are disabled" do
@@ -118,7 +118,7 @@ describe "Initiative", type: :system do
 
         it "does not have comments" do
           expect(page).not_to have_css(".comments")
-          expect(page).not_to have_content("0 comments")
+          expect(page).not_to have_content("0 Comments")
         end
       end
     end

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -97,6 +97,28 @@ describe "Initiative", type: :system do
       end
 
       it_behaves_like "has attachments"
+
+      it "has comments" do
+        expect(page).to have_css(".comments")
+      end
+
+      context "when comments are disabled" do
+        let(:base_initiative) do
+          create(:initiative, organization: organization, state: state, scoped_type: scoped_type)
+        end
+
+        let(:scoped_type) do
+          create(:initiatives_type_scope,
+                 type: create(:initiatives_type,
+                              :with_comments_disabled,
+                              organization: organization,
+                              signature_type: "online"))
+        end
+
+        it "does not have comments" do
+          expect(page).not_to have_css(".comments")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Configuration option for initiative type to desactivate comments

#### :pushpin: Related Issues
- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/14863

#### Testing
* Edit initiative type
* Uncheck comments enabled
* Visti index and show

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
<img width="1092" alt="Capture d’écran 2022-05-18 à 12 06 48" src="https://user-images.githubusercontent.com/20232956/169014836-40b0eeac-0ae8-4f02-a70f-8cf17e03471a.png">
<img width="1399" alt="Capture d’écran 2022-05-18 à 12 07 06" src="https://user-images.githubusercontent.com/20232956/169014853-3b2c4f3f-7e70-4719-ad58-c5698a2826f1.png">
<img width="947" alt="Capture d’écran 2022-05-18 à 12 07 17" src="https://user-images.githubusercontent.com/20232956/169014858-faf79f4c-4800-4d8e-bd06-3dad5b052327.png">

