### PR TITLE
Add admin log when creating, updating or deleting accountability's status

### DIFF
--- a/decidim-accountability/app/commands/decidim/accountability/admin/create_status.rb
+++ b/decidim-accountability/app/commands/decidim/accountability/admin/create_status.rb
@@ -6,8 +6,9 @@ module Decidim
       # This command is executed when the user creates a Status from the admin
       # panel.
       class CreateStatus < Decidim::Command
-        def initialize(form)
+        def initialize(form, user)
           @form = form
+          @user = user
         end
 
         # Creates the status if valid.
@@ -28,7 +29,9 @@ module Decidim
         attr_reader :status
 
         def create_status
-          @status = Status.create!(
+          @status = Decidim.traceability.create!(
+            Status,
+            @user,
             component: @form.current_component,
             key: @form.key,
             name: @form.name,

--- a/decidim-accountability/app/commands/decidim/accountability/admin/update_status.rb
+++ b/decidim-accountability/app/commands/decidim/accountability/admin/update_status.rb
@@ -10,9 +10,10 @@ module Decidim
         #
         # form - The form from which to get the data.
         # status - The current instance of the status to be updated.
-        def initialize(form, status)
+        def initialize(form, status, user)
           @form = form
           @status = status
+          @user = user
         end
 
         # Updates the status if valid.
@@ -33,7 +34,9 @@ module Decidim
         attr_reader :status, :form
 
         def update_status
-          status.update!(
+          Decidim.traceability.update!(
+            status,
+            @user,
             key: @form.key,
             name: @form.name,
             description: @form.description,

--- a/decidim-accountability/app/controllers/decidim/accountability/admin/statuses_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/statuses_controller.rb
@@ -18,7 +18,7 @@ module Decidim
 
           @form = form(StatusForm).from_params(params)
 
-          CreateStatus.call(@form) do
+          CreateStatus.call(@form, current_user) do
             on(:ok) do
               flash[:notice] = I18n.t("statuses.create.success", scope: "decidim.accountability.admin")
               redirect_to statuses_path

--- a/decidim-accountability/app/controllers/decidim/accountability/admin/statuses_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/statuses_controller.rb
@@ -58,7 +58,9 @@ module Decidim
         def destroy
           enforce_permission_to :destroy, :status, status: status
 
-          status.destroy!
+          Decidim.traceability.perform_action!("delete", status, current_user) do
+            status.destroy!
+          end
 
           flash[:notice] = I18n.t("statuses.destroy.success", scope: "decidim.accountability.admin")
 

--- a/decidim-accountability/app/controllers/decidim/accountability/admin/statuses_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/statuses_controller.rb
@@ -42,7 +42,7 @@ module Decidim
 
           @form = form(StatusForm).from_params(params)
 
-          UpdateStatus.call(@form, status) do
+          UpdateStatus.call(@form, status, current_user) do
             on(:ok) do
               flash[:notice] = I18n.t("statuses.update.success", scope: "decidim.accountability.admin")
               redirect_to statuses_path

--- a/decidim-accountability/app/models/decidim/accountability/status.rb
+++ b/decidim-accountability/app/models/decidim/accountability/status.rb
@@ -8,6 +8,7 @@ module Decidim
       include Decidim::HasComponent
       include Decidim::TranslatableResource
       include Decidim::FilterableResource
+      include Decidim::Traceable
 
       component_manifest_name "accountability"
 
@@ -20,6 +21,10 @@ module Decidim
 
       # Allow ransacker to search for a key in a hstore column (`name`.`en`)
       ransacker_i18n :name
+
+      def self.log_presenter_class_for(_log)
+        Decidim::Accountability::AdminLog::StatusPresenter
+      end
     end
   end
 end

--- a/decidim-accountability/app/presenters/decidim/accountability/admin_log/status_presenter.rb
+++ b/decidim-accountability/app/presenters/decidim/accountability/admin_log/status_presenter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Accountability
+    module AdminLog
+      # This class holds the logic to present a `Decidim::Accountability::Status`
+      # for the `AdminLog` log.
+      #
+      # Usage should be automatic and you shouldn't need to call this class
+      # directly, but here's an example:
+      #
+      #    action_log = Decidim::ActionLog.last
+      #    view_helpers # => this comes from the views
+      #    StatusPresenter.new(action_log, view_helpers).present
+      class StatusPresenter < Decidim::Log::BasePresenter
+        private
+
+        def action_string
+          case action
+          when "create", "delete", "update"
+            "decidim.accountability.admin_log.status.#{action}"
+          else
+            super
+          end
+        end
+
+        def diff_fields_mapping
+          {
+            key: :string,
+            name: :i18n,
+            description: :i18n,
+            progress: :integer
+          }
+        end
+      end
+    end
+  end
+end

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -123,6 +123,10 @@ en:
           create: "%{user_name} created result %{resource_name} in %{space_name}"
           delete: "%{user_name} deleted the %{resource_name} result in %{space_name}"
           update: "%{user_name} updated result %{resource_name} in %{space_name}"
+        status:
+          create: "%{user_name} created the %{resource_name} status"
+          delete: "%{user_name} deleted the %{resource_name} status"
+          update: "%{user_name} updated the %{resource_name} status"
         value_types:
           parent_presenter:
             not_found: 'The parent was not found on the database (ID: %{id})'

--- a/decidim-accountability/spec/commands/admin/create_status_spec.rb
+++ b/decidim-accountability/spec/commands/admin/create_status_spec.rb
@@ -4,9 +4,10 @@ require "spec_helper"
 
 module Decidim::Accountability
   describe Admin::CreateStatus do
-    subject { described_class.new(form) }
+    subject { described_class.new(form, user) }
 
     let(:organization) { create :organization, available_locales: [:en] }
+    let(:user) { create(:user, organization: organization) }
     let(:participatory_process) { create :participatory_process, organization: organization }
     let(:current_component) { create :component, manifest_name: "accountability", participatory_space: participatory_process }
 
@@ -60,6 +61,18 @@ module Decidim::Accountability
       it "sets the progress" do
         subject.call
         expect(status.progress).to eq progress
+      end
+
+      it "traces the action", versioning: true do
+        expect(Decidim.traceability)
+          .to receive(:perform_action!)
+          .with(:create, Decidim::Accountability::Status, user, {})
+          .and_call_original
+
+        expect { subject.call }.to change(Decidim::ActionLog, :count)
+        action_log = Decidim::ActionLog.last
+        expect(action_log.action).to eq("create")
+        expect(action_log.version).to be_present
       end
     end
   end

--- a/decidim-accountability/spec/commands/admin/update_status_spec.rb
+++ b/decidim-accountability/spec/commands/admin/update_status_spec.rb
@@ -4,9 +4,10 @@ require "spec_helper"
 
 module Decidim::Accountability
   describe Admin::UpdateStatus do
-    subject { described_class.new(form, status) }
+    subject { described_class.new(form, status, user) }
 
     let(:organization) { create :organization, available_locales: [:en] }
+    let(:user) { create :user, organization: organization }
     let(:participatory_process) { create :participatory_process, organization: organization }
     let(:current_component) { create :accountability_component, participatory_space: participatory_process }
 
@@ -55,6 +56,18 @@ module Decidim::Accountability
       it "sets the progress" do
         subject.call
         expect(status.progress).to eq progress
+      end
+
+      it "traces the action", versioning: true do
+        expect(Decidim.traceability)
+          .to receive(:perform_action!)
+                .with(:update, status, user, {})
+                .and_call_original
+
+        expect { subject.call }.to change(Decidim::ActionLog, :count)
+        action_log = Decidim::ActionLog.last
+        expect(action_log.action).to eq("update")
+        expect(action_log.version).to be_present
       end
     end
   end

--- a/decidim-accountability/spec/commands/admin/update_status_spec.rb
+++ b/decidim-accountability/spec/commands/admin/update_status_spec.rb
@@ -61,8 +61,8 @@ module Decidim::Accountability
       it "traces the action", versioning: true do
         expect(Decidim.traceability)
           .to receive(:perform_action!)
-                .with(:update, status, user, {})
-                .and_call_original
+          .with(:update, status, user, {})
+          .and_call_original
 
         expect { subject.call }.to change(Decidim::ActionLog, :count)
         action_log = Decidim::ActionLog.last


### PR DESCRIPTION
#### :tophat: What? Why?
add admin log when creating, updating or deleting accountability status

#### :pushpin: Related Issues
- Fixes the 20th, 21st and 22nd task of #9181 

![image](https://user-images.githubusercontent.com/93646702/169038145-e024e16a-6f86-485c-a09b-3b041f7f0c01.png)
