### PR TITLE
Add test for offline content serving

### DIFF
--- a/decidim-core/spec/system/pwa_features_spec.rb
+++ b/decidim-core/spec/system/pwa_features_spec.rb
@@ -16,17 +16,11 @@ describe "PWA features", type: :system do
       visit decidim.root_path
       expect(page).to have_content("Home")
 
-      page.driver.browser.network_conditions = { offline: true }
-
-      # Wait for the browser to be offline
-      sleep 1
-
-      visit decidim.root_path
-      expect(page).to have_content("Home")
-      expect(page).to have_content("Your network is offline. This is a previously cached version of the page you're visiting, perhaps the content is not up to date.")
-
-      # Restore the network conditions
-      page.driver.browser.network_conditions = { offline: false }
+      with_browser_in_offline_mode do
+        visit decidim.root_path
+        expect(page).to have_content("Home")
+        expect(page).to have_content("Your network is offline. This is a previously cached version of the page you're visiting, perhaps the content is not up to date.")
+      end
     end
   end
 end

--- a/decidim-core/spec/system/pwa_features_spec.rb
+++ b/decidim-core/spec/system/pwa_features_spec.rb
@@ -24,6 +24,9 @@ describe "PWA features", type: :system do
       visit decidim.root_path
       expect(page).to have_content("Home")
       expect(page).to have_content("Your network is offline. This is a previously cached version of the page you're visiting, perhaps the content is not up to date.")
+
+      # Restore the network conditions
+      page.driver.browser.network_conditions = { offline: false }
     end
   end
 end

--- a/decidim-core/spec/system/pwa_features_spec.rb
+++ b/decidim-core/spec/system/pwa_features_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "PWA features", type: :system do
+  let(:organization) { create(:organization, host: "pwa.lvh.me") }
+
+  before do
+    driven_by(:pwa_chrome)
+    switch_to_host(organization.host)
+  end
+
+  describe "offline navigation" do
+    it "shows the account form when clicking on the menu" do
+      # Cache the homepage
+      visit decidim.root_path
+      expect(page).to have_content("Home")
+
+      page.driver.browser.network_conditions = { offline: true }
+
+      # Wait for the browser to be offline
+      sleep 1
+
+      visit decidim.root_path
+      expect(page).to have_content("Home")
+      expect(page).to have_content("Your network is offline. This is a previously cached version of the page you're visiting, perhaps the content is not up to date.")
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/network_conditions_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/network_conditions_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module NetworkConditionsHelpers
+  def with_browser_in_offline_mode
+    page.driver.browser.network_conditions = { offline: true }
+
+    # Wait for the browser to be offline
+    sleep 1
+
+    yield
+
+    page.driver.browser.network_conditions = { offline: false }
+  end
+end
+
+RSpec.configure do |config|
+  config.include NetworkConditionsHelpers, type: :system
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR complements the PWA test coverage with a test that checks that cached content by the service worker is used when the browser is offline, and that the user is warned with a message indicating that the page is offline.

#### :pushpin: Related Issues

- Related to [#8594](https://github.com/decidim/decidim/pull/8594)

#### Testing

It's a test, so I guess the test should be green.

:hearts: Thank you!
