### PR TITLE
Add admin log when managing assemblies

### DIFF
--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
@@ -10,9 +10,10 @@ module Decidim
         #
         # form - A form object with the params.
         # assembly - An assembly we want to duplicate
-        def initialize(form, assembly)
+        def initialize(form, assembly, user)
           @form = form
           @assembly = assembly
+          @user = user
         end
 
         # Executes the command. Broadcasts these events:
@@ -24,11 +25,13 @@ module Decidim
         def call
           return broadcast(:invalid) if form.invalid?
 
-          Assembly.transaction do
-            copy_assembly
-            copy_assembly_attachments
-            copy_assembly_categories if @form.copy_categories?
-            copy_assembly_components if @form.copy_components?
+          Decidim.traceability.perform_action!("duplicate",@assembly,@user) do
+            Assembly.transaction do
+              copy_assembly
+              copy_assembly_attachments
+              copy_assembly_categories if @form.copy_categories?
+              copy_assembly_components if @form.copy_components?
+            end
           end
 
           broadcast(:ok, @copied_assembly)

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
@@ -25,7 +25,7 @@ module Decidim
         def call
           return broadcast(:invalid) if form.invalid?
 
-          Decidim.traceability.perform_action!("duplicate",@assembly,@user) do
+          Decidim.traceability.perform_action!("duplicate", @assembly, @user) do
             Assembly.transaction do
               copy_assembly
               copy_assembly_attachments

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/import_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/import_assembly.rb
@@ -10,8 +10,9 @@ module Decidim
         #
         # form - A form object with the params.
         # assembly - An assembly we want to duplicate
-        def initialize(form)
+        def initialize(form, user)
           @form = form
+          @user = user
         end
 
         # Executes the command. Broadcasts these events:
@@ -38,11 +39,14 @@ module Decidim
         def import_assembly
           importer = Decidim::Assemblies::AssemblyImporter.new(form.current_organization, form.current_user)
           assemblies.each do |original_assembly|
-            @imported_assembly = importer.import(original_assembly, form.current_user, title: form.title, slug: form.slug)
-            importer.import_assemblies_type(original_assembly["decidim_assemblies_type_id"])
-            importer.import_categories(original_assembly["assembly_categories"]) if form.import_categories?
-            importer.import_folders_and_attachments(original_assembly["attachments"]) if form.import_attachments?
-            importer.import_components(original_assembly["components"]) if form.import_components?
+            Decidim.traceability.perform_action!("import",Assembly,@user) do ||
+              @imported_assembly = importer.import(original_assembly, form.current_user, title: form.title, slug: form.slug)
+              importer.import_assemblies_type(original_assembly["decidim_assemblies_type_id"])
+              importer.import_categories(original_assembly["assembly_categories"]) if form.import_categories?
+              importer.import_folders_and_attachments(original_assembly["attachments"]) if form.import_attachments?
+              importer.import_components(original_assembly["components"]) if form.import_components?
+              @imported_assembly
+            end
           end
         end
 

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/import_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/import_assembly.rb
@@ -39,7 +39,7 @@ module Decidim
         def import_assembly
           importer = Decidim::Assemblies::AssemblyImporter.new(form.current_organization, form.current_user)
           assemblies.each do |original_assembly|
-            Decidim.traceability.perform_action!("import",Assembly,@user) do ||
+            Decidim.traceability.perform_action!("import", Assembly, @user) do
               @imported_assembly = importer.import(original_assembly, form.current_user, title: form.title, slug: form.slug)
               importer.import_assemblies_type(original_assembly["decidim_assemblies_type_id"])
               importer.import_categories(original_assembly["assembly_categories"]) if form.import_categories?

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
@@ -17,7 +17,7 @@ module Decidim
           enforce_permission_to :create, :assembly
           @form = form(AssemblyCopyForm).from_params(params)
 
-          CopyAssembly.call(@form, current_assembly) do
+          CopyAssembly.call(@form, current_assembly, current_user) do
             on(:ok) do
               flash[:notice] = I18n.t("assemblies_copies.create.success", scope: "decidim.admin")
               redirect_to assemblies_path(parent_id: current_assembly.parent_id)

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_imports_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_imports_controller.rb
@@ -13,7 +13,7 @@ module Decidim
           enforce_permission_to :import, :assembly
           @form = form(AssemblyImportForm).from_params(params)
 
-          ImportAssembly.call(@form) do
+          ImportAssembly.call(@form, current_user) do
             on(:ok) do
               flash[:notice] = I18n.t("assembly_imports.create.success", scope: "decidim.admin")
               redirect_to assemblies_path

--- a/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assembly_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assembly_presenter.rb
@@ -63,7 +63,7 @@ module Decidim
 
         def action_string
           case action
-          when "create", "publish", "unpublish", "update"
+          when "create", "publish", "unpublish", "update", "duplicate", "export", "import"
             "decidim.admin_log.assembly.#{action}"
           else
             super

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -243,6 +243,9 @@ en:
     admin_log:
       assembly:
         create: "%{user_name} created the %{resource_name} assembly"
+        duplicate: "%{user_name} duplicated the %{resource_name} assembly"
+        export: "%{user_name} exported the %{resource_name} assembly"
+        import: "%{user_name} imported the %{resource_name} assembly"
         publish: "%{user_name} published the %{resource_name} assembly"
         unpublish: "%{user_name} unpublished the %{resource_name} assembly"
         update: "%{user_name} updated the %{resource_name} assembly"

--- a/decidim-assemblies/spec/commands/copy_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/copy_assembly_spec.rb
@@ -4,9 +4,10 @@ require "spec_helper"
 
 module Decidim::Assemblies
   describe Admin::CopyAssembly do
-    subject { described_class.new(form, assembly) }
+    subject { described_class.new(form, assembly, user) }
 
     let(:organization) { create :organization }
+    let(:user) { create :user, organization: organization }
     let(:scope) { create :scope, organization: organization }
     let(:errors) { double.as_null_object }
     let!(:assembly) { create :assembly }
@@ -66,6 +67,18 @@ module Decidim::Assemblies
 
       it "broadcasts ok" do
         expect { subject.call }.to broadcast(:ok)
+      end
+
+      it "traces the action", versioning: true do
+        expect(Decidim.traceability)
+          .to receive(:perform_action!)
+                .with("duplicate", Decidim::Assembly, user)
+                .and_call_original
+
+        expect { subject.call }.to change(Decidim::ActionLog, :count)
+        action_log = Decidim::ActionLog.last
+        expect(action_log.action).to eq("duplicate")
+        expect(action_log.version).to be_present
       end
     end
 

--- a/decidim-assemblies/spec/commands/copy_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/copy_assembly_spec.rb
@@ -72,8 +72,8 @@ module Decidim::Assemblies
       it "traces the action", versioning: true do
         expect(Decidim.traceability)
           .to receive(:perform_action!)
-                .with("duplicate", Decidim::Assembly, user)
-                .and_call_original
+          .with("duplicate", Decidim::Assembly, user)
+          .and_call_original
 
         expect { subject.call }.to change(Decidim::ActionLog, :count)
         action_log = Decidim::ActionLog.last

--- a/decidim-assemblies/spec/commands/decidim/assemblies/admin/import_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/decidim/assemblies/admin/import_assembly_spec.rb
@@ -56,7 +56,7 @@ module Decidim::Assemblies::Admin
 
       it "traces the action", versioning: true do
         expect(Decidim.traceability)
-          .to receive(:perform_action!).exactly(2).times
+          .to receive(:perform_action!).twice
                                        .and_call_original
 
         expect { subject.call }.to change(Decidim::ActionLog, :count)

--- a/decidim-assemblies/spec/commands/decidim/assemblies/admin/import_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/decidim/assemblies/admin/import_assembly_spec.rb
@@ -4,9 +4,10 @@ require "spec_helper"
 
 module Decidim::Assemblies::Admin
   describe ImportAssembly do
-    subject { described_class.new(form) }
+    subject { described_class.new(form, user) }
 
     let(:organization) { create :organization }
+    let(:user) { create :user, organization: organization }
     let!(:document_file) { IO.read(Decidim::Dev.asset(document_name)) }
     let(:form_doc) do
       instance_double(File,
@@ -51,6 +52,17 @@ module Decidim::Assemblies::Admin
         expect(imported_assembly.title["en"]).to eq("title")
         expect(imported_assembly).not_to be_published
         expect(imported_assembly.organization).to eq(organization)
+      end
+
+      it "traces the action", versioning: true do
+        expect(Decidim.traceability)
+          .to receive(:perform_action!).exactly(2).times
+                                       .and_call_original
+
+        expect { subject.call }.to change(Decidim::ActionLog, :count)
+        action_log = Decidim::ActionLog.last
+        expect(action_log.action).to eq("import")
+        expect(action_log.version).to be_present
       end
     end
 

--- a/decidim-assemblies/spec/controllers/admin/assembly_exports_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/admin/assembly_exports_controller_spec.rb
@@ -35,8 +35,8 @@ module Decidim
           it "traces the action", versioning: true do
             expect(Decidim.traceability)
               .to receive(:perform_action!)
-                    .with("export", assembly, user)
-                    .and_call_original
+              .with("export", assembly, user)
+              .and_call_original
 
             expect { post(:create, params: params) }.to change(Decidim::ActionLog, :count)
             action_log = Decidim::ActionLog.last

--- a/decidim-assemblies/spec/controllers/admin/assembly_exports_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/admin/assembly_exports_controller_spec.rb
@@ -31,6 +31,18 @@ module Decidim
 
             post(:create, params: params)
           end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:perform_action!)
+                    .with("export", assembly, user)
+                    .and_call_original
+
+            expect { post(:create, params: params) }.to change(Decidim::ActionLog, :count)
+            action_log = Decidim::ActionLog.last
+            expect(action_log.action).to eq("export")
+            expect(action_log.version).to be_present
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
add admin log when importing, exporting or duplicating an assembly

#### :pushpin: Related Issues
- Fixes the 36th, 37th and 38th task of #9181 

![image](https://user-images.githubusercontent.com/93646702/169258554-aa61e7f2-de3e-48fb-b914-58380ccb78be.png)
