### PR TITLE
Offer more information to the user when a question fails to create

### DIFF
--- a/decidim-elections/app/commands/decidim/elections/admin/create_question.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/create_question.rb
@@ -12,9 +12,11 @@ module Decidim
 
         # Creates the question if valid.
         #
-        # Broadcasts :ok if successful, :invalid otherwise.
+        # Broadcasts :ok if successful, :ongoing_election if the
+        # election already started, and :invalid otherwise.
         def call
           return broadcast(:invalid) if invalid?
+          return broadcast(:election_ongoing) if election_started?
 
           create_question!
 
@@ -26,7 +28,11 @@ module Decidim
         attr_reader :form, :question
 
         def invalid?
-          form.election.started? || form.invalid?
+          form.invalid?
+        end
+
+        def election_started?
+          form.election.started?
         end
 
         def create_question!

--- a/decidim-elections/app/controllers/decidim/elections/admin/questions_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/questions_controller.rb
@@ -26,6 +26,11 @@ module Decidim
               flash.now[:alert] = I18n.t("questions.create.invalid", scope: "decidim.elections.admin")
               render action: "new"
             end
+
+            on(:election_ongoing) do
+              flash.now[:alert] = I18n.t("questions.create.election_ongoing", scope: "decidim.elections.admin")
+              render action: "new"
+            end
           end
         end
 

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -226,7 +226,8 @@ en:
             title: Import proposals
         questions:
           create:
-            invalid: There was a problem creating this question
+            invalid: The question is not valid. Please review the form
+            election_ongoing: You can't create a question for an ongoing election
             success: Question successfully created
           destroy:
             invalid: There was a problem deleting this question

--- a/decidim-elections/spec/commands/decidim/elections/admin/create_question_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/create_question_spec.rb
@@ -71,7 +71,7 @@ describe Decidim::Elections::Admin::CreateQuestion do
     let(:election) { create :election, :started }
 
     it "is not valid" do
-      expect { subject.call }.to broadcast(:invalid)
+      expect { subject.call }.to broadcast(:election_ongoing)
     end
   end
 end


### PR DESCRIPTION
When a question can't be created in an election, it could be because the election already started, or because the question itself is invalid. This PR distinguishes between the two cases with different error messages.