### PR TITLE
Fix regular expression on census check

### DIFF
--- a/decidim-elections/app/views/decidim/votings/votings/check_census.html.erb
+++ b/decidim-elections/app/views/decidim/votings/votings/check_census.html.erb
@@ -27,7 +27,7 @@ edit_link(
           </p>
         </div>
         <% if datum.email.present? || datum.mobile_phone_number.present? %>
-          <%= render partial: "access_code_modal", locals: { datum: datum, email: datum.email ? datum.email.gsub!(/.{4}(?=@)/,"****") : "", sms: datum.mobile_phone_number ? datum.mobile_phone_number.gsub!(/.{3}\d$/,"***") : "" } %>
+          <%= render partial: "access_code_modal", locals: { datum: datum, email: datum.email ? datum.email.gsub!(/.+(?=@)/,"****") : "", sms: datum.mobile_phone_number ? datum.mobile_phone_number.gsub!(/.{3}\d$/,"***") : "" } %>
         <% end %>
       <% elsif not_found %>
         <div class="verify-census-error callout alert mt-s">

--- a/decidim-elections/app/views/decidim/votings/votings/check_census.html.erb
+++ b/decidim-elections/app/views/decidim/votings/votings/check_census.html.erb
@@ -27,7 +27,7 @@ edit_link(
           </p>
         </div>
         <% if datum.email.present? || datum.mobile_phone_number.present? %>
-          <%= render partial: "access_code_modal", locals: { datum: datum, email: datum.email ? datum.email.gsub!(/.+(?=@)/,"****") : "", sms: datum.mobile_phone_number ? datum.mobile_phone_number.gsub!(/.{3}\d$/,"***") : "" } %>
+          <%= render partial: "access_code_modal", locals: { datum: datum, email: datum.email ? datum.email.gsub!(/^.+@/,"****@") : "", sms: datum.mobile_phone_number ? datum.mobile_phone_number.gsub!(/.{3}\d$/,"***") : "" } %>
         <% end %>
       <% elsif not_found %>
         <div class="verify-census-error callout alert mt-s">

--- a/decidim-elections/spec/system/check_census_spec.rb
+++ b/decidim-elections/spec/system/check_census_spec.rb
@@ -13,7 +13,7 @@ describe "Check Census", type: :system do
   end
   let!(:user) { create :user, :confirmed, organization: organization }
   let(:mobile_phone_number) { "123456789" }
-  let(:email) { "census_email@example.com" }
+  let(:email) { "foo@example.com" }
   let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
 
   before do
@@ -95,6 +95,7 @@ describe "Check Census", type: :system do
         click_button "via SMS or email"
 
         expect(page).to have_content("Get Access Code")
+        expect(page).to have_content("****@example.com")
 
         click_button "Send by email to"
 

--- a/decidim-elections/spec/system/check_census_spec.rb
+++ b/decidim-elections/spec/system/check_census_spec.rb
@@ -95,9 +95,8 @@ describe "Check Census", type: :system do
         click_button "via SMS or email"
 
         expect(page).to have_content("Get Access Code")
-        expect(page).to have_content("****@example.com")
 
-        click_button "Send by email to"
+        click_button "Send by email to ****@example.com"
 
         callout = find(:xpath, '//*[@id="content"]/div[1]')
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes a regular expression which wouldn't match emails shorter than 4 characters before the `@` symbol. This changes it, allowing any amount of characters (as far as it's not empty).

#### :pushpin: Related Issues
- Related to #8657

#### Testing
When checking the census, use an e-mail like `foo@bar.com`.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*None*