### PR TITLE
Only show that the code can be requested via SMS if its true

### DIFF
--- a/decidim-elections/app/views/decidim/votings/votings/check_census.html.erb
+++ b/decidim-elections/app/views/decidim/votings/votings/check_census.html.erb
@@ -22,7 +22,11 @@ edit_link(
           <p>
             <%= t("decidim.votings.votings.check_census.success.info") %>
             <button type="button" class="link" data-open="access-code-modal">
+              <% if Decidim.sms_gateway_service.to_s.safe_constantize %>
+              <%= t("decidim.votings.votings.check_census.success.access_link_with_sms") %>
+              <% else %>
               <%= t("decidim.votings.votings.check_census.success.access_link") %>
+              <% end %>
             </button>
           </p>
         </div>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -1308,7 +1308,8 @@ en:
           form_title: 'Fill the following form to check your census data:'
           invalid: There was a problem checking the census.
           success:
-            access_link: via SMS or email.
+            access_link: via email.
+            access_link_with_sms: via SMS or email.
             info: You should have received your Access Code by postal mail already. In case, you don't have it, you can request it here
             title: Your census data is correct!
           title: Can I vote?

--- a/decidim-elections/spec/system/check_census_spec.rb
+++ b/decidim-elections/spec/system/check_census_spec.rb
@@ -69,9 +69,36 @@ describe "Check Census", type: :system do
       end
     end
 
-    it "shows instructions to ask for access code again" do
+    it "shows instructions to ask for access code again, mentioning email and SMS" do
       within ".wrapper" do
         expect(page).to have_content("You should have received your Access Code by postal mail already. In case, you don't have it, you can request it here via SMS or email")
+      end
+    end
+  end
+
+  context "when census data is correct but there is no SMS gateway configured" do
+    before do
+      Decidim.sms_gateway_service = "FooBar"
+
+      visit decidim_votings.voting_check_census_path(voting)
+      within ".card__content" do
+        select("DNI", from: "Document type")
+        fill_in "Document number", with: "12345678X"
+        fill_in "Postal code", with: "04001"
+        fill_in "Day", with: "11"
+        fill_in "Month", with: "05"
+        fill_in "Year", with: "1980"
+        find("*[type=submit]").click
+      end
+    end
+
+    after do
+      Decidim.sms_gateway_service = "Decidim::Verifications::Sms::ExampleGateway"
+    end
+
+    it "shows instructions to ask for access code again, mentioning only email" do
+      within ".wrapper" do
+        expect(page).to have_content("You should have received your Access Code by postal mail already. In case, you don't have it, you can request it here via email")
       end
     end
   end


### PR DESCRIPTION
If there is no SMS gateway, we shouldn't mention that the code can be requested by SMS.