### PR TITLE
Fix ActionLog when a ballot style is deleted

### DIFF
--- a/decidim-elections/app/commands/decidim/votings/admin/destroy_ballot_style.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/destroy_ballot_style.rb
@@ -30,7 +30,7 @@ module Decidim
             :delete,
             ballot_style,
             current_user,
-            visibility: "all"
+            { visibility: "all", code: ballot_style.code }
           ) do
             ballot_style.destroy!
           end

--- a/decidim-elections/app/presenters/decidim/votings/admin_log/ballot_style_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/votings/admin_log/ballot_style_presenter.rb
@@ -17,8 +17,12 @@ module Decidim
 
         def i18n_params
           super.merge(
-            ballot_style_code: action_log.resource.code
+            ballot_style_code: ballot_style_code.to_s
           )
+        end
+
+        def ballot_style_code
+          action_log&.resource&.code || action_log.extra["code"]
         end
 
         def action_string

--- a/decidim-elections/spec/commands/decidim/votings/admin/destroy_ballot_style_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/admin/destroy_ballot_style_spec.rb
@@ -32,12 +32,13 @@ module Decidim
           it "traces the action", versioning: true do
             expect(Decidim.traceability)
               .to receive(:perform_action!)
-              .with(:delete, ballot_style, user, visibility: "all")
+              .with(:delete, ballot_style, user, { visibility: "all", code: ballot_style.code })
               .and_call_original
 
             expect { subject.call }.to change(Decidim::ActionLog, :count)
             action_log = Decidim::ActionLog.last
             expect(action_log.action).to eq("delete")
+            expect(action_log.extra["code"]).to eq(ballot_style.code)
           end
         end
       end

--- a/decidim-elections/spec/presenters/decidim/votings/admin_log/ballot_style_presenter_spec.rb
+++ b/decidim-elections/spec/presenters/decidim/votings/admin_log/ballot_style_presenter_spec.rb
@@ -11,7 +11,8 @@ module Decidim
       create(
         :action_log,
         action: action,
-        resource: resource
+        resource: resource,
+        extra_data: { code: resource.code }
       )
     end
 
@@ -41,6 +42,11 @@ module Decidim
 
       context "when the ballot style is deleted" do
         let(:action) { :delete }
+
+        before do
+          resource.destroy!
+          action_log.reload
+        end
 
         it "shows that the ballot style has been created" do
           expect(subject.present).to include(resource.code)


### PR DESCRIPTION
#### :tophat: What? Why?

We were relying on the ballot style being present with the audit log. With this change, when destroying a ballot style we'll persist the necessary data for the action log.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/9147