### PR TITLE
Better wording when verifying an offline voter

### DIFF
--- a/decidim-elections/app/views/decidim/votings/polling_officer_zone/in_person_votes/_complete_voting.html.erb
+++ b/decidim-elections/app/views/decidim/votings/polling_officer_zone/in_person_votes/_complete_voting.html.erb
@@ -2,7 +2,11 @@
   <div class="columns">
     <% if vote_check.allowed? %>
       <div class="callout success mt-s">
-        <h5><%= t(".census_verified") %></h5>
+        <% if voted_online? %>
+          <h5><%= t(".census_verified_with_online_vote") %></h5>
+        <% else %>
+          <h5><%= t(".census_verified") %></h5>
+        <% end %>
       </div>
       <div class="row mt-sm">
         <div class="columns large-7">

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -1210,11 +1210,12 @@ en:
         in_person_votes:
           complete_voting:
             available_answers: 'Available answers:'
-            census_verified: The participant has not voted yet.
+            census_verified: This participant has not voted in person yet.
+            census_verified_with_online_vote: This participant has already voted online. If they vote in person, the previous votes will be invalidated and this will be the definitive vote.
             complete_voting: Complete voting
             identify_another: Identify another participant
             questions_title: 'They''re entitled to vote in the following questions:'
-            questions_title_voted: 'The participant has already voted online and is entitled to vote in the following questions:'
+            questions_title_voted: 'This participant has already voted online and is entitled to vote in the following questions:'
             voted: The participant has voted
           create:
             error: The vote was not registered. Please try again.

--- a/decidim-elections/spec/system/vote_in_person_spec.rb
+++ b/decidim-elections/spec/system/vote_in_person_spec.rb
@@ -32,6 +32,7 @@ describe "Polling Officer zone", type: :system do
     include_context "with test bulletin board"
 
     let(:questions_title) { "They're entitled to vote in the following questions:" }
+    let(:census_verified) { "This participant has not voted in person yet." }
 
     it "can identify a person and register their vote", :slow do
       click_link "Identify a person"
@@ -43,6 +44,7 @@ describe "Polling Officer zone", type: :system do
       click_button "Verify document"
 
       election.reload
+      expect(page).to have_content(census_verified)
       expect(page).to have_content(questions_title)
       election.questions.each do |question|
         expect(page).to have_content(translated(question.title))
@@ -74,7 +76,8 @@ describe "Polling Officer zone", type: :system do
     end
 
     it_behaves_like "a polling officer registers an in person vote" do
-      let(:questions_title) { "The participant has already voted online and is entitled to vote in the following questions:" }
+      let(:census_verified) { "This participant has already voted online. If they vote in person, the previous votes will be invalidated and this will be the definitive vote." }
+      let(:questions_title) { "This participant has already voted online and is entitled to vote in the following questions:" }
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Provides better wording to polling officers so it's easier to see that a participant has already voted online and what will happen if they submit an offline vote.

### :camera: Screenshots
Before:
![image](https://user-images.githubusercontent.com/5254/170087928-9f80be16-4a81-4d27-9e91-31d84ee1ece7.png)

After:
![image](https://user-images.githubusercontent.com/5254/170087593-81cf6d85-e582-44e4-a37f-3e8c0a60a550.png)

