### PR TITLE
Make sure component is published when starting an election

### DIFF
--- a/decidim-elections/app/forms/decidim/elections/admin/setup_form.rb
+++ b/decidim-elections/app/forms/decidim/elections/admin/setup_form.rb
@@ -34,6 +34,7 @@ module Decidim
             [:minimum_answers, {}, election.minimum_answers?],
             [:max_selections, {}, election.valid_questions?],
             [:published, {}, election.published_at.present?],
+            [:component_published, {}, election.component.published?],
             [:time_before, { hours: Decidim::Elections.setup_minimum_hours_before_start }, election.minimum_hours_before_start?],
             [:trustees_number, { number: bulletin_board.number_of_trustees }, participatory_space_trustees_with_public_key.size >= bulletin_board.number_of_trustees]
           ].freeze

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -246,6 +246,7 @@ en:
         steps:
           create_election:
             errors:
+              component_published: The election component is <strong>not published</strong>.
               max_selections: The questions do not have a <strong>correct value for amount of answers</strong>
               minimum_answers: Questions must have <strong>at least two answers</strong>.
               minimum_questions: The election <strong>must have at least one question</strong>.

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -263,6 +263,7 @@ en:
               minimum_answers: Each question has <strong>at least 2 answers</strong>.
               minimum_questions: The election has <strong>at least 1 question</strong>.
               published: The election is <strong>published</strong>.
+              component_published: The election component is <strong>published</strong>.
               time_before: The setup is being done <strong>at least %{hours} hours</strong> before the election starts.
               trustees_number: The participatory space has <strong>at least %{number} trustees with public key</strong>.
             submit: Setup election

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -259,11 +259,11 @@ en:
               'false': does not have a <strong>public key</strong>
               'true': has a <strong>public key</strong>
             requirements:
+              component_published: The election component is <strong>published</strong>.
               max_selections: All the questions have a correct value for <strong>maximum of answers</strong>.
               minimum_answers: Each question has <strong>at least 2 answers</strong>.
               minimum_questions: The election has <strong>at least 1 question</strong>.
               published: The election is <strong>published</strong>.
-              component_published: The election component is <strong>published</strong>.
               time_before: The setup is being done <strong>at least %{hours} hours</strong> before the election starts.
               trustees_number: The participatory space has <strong>at least %{number} trustees with public key</strong>.
             submit: Setup election

--- a/decidim-elections/spec/forms/decidim/elections/admin/setup_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/setup_form_spec.rb
@@ -28,14 +28,16 @@ describe Decidim::Elections::Admin::SetupForm do
   it { is_expected.to be_valid }
 
   it "shows messages" do
-    expect(subject.messages).to eq({
-                                     max_selections: "All the questions have a correct value for <strong>maximum of answers</strong>.",
-                                     minimum_answers: "Each question has <strong>at least 2 answers</strong>.",
-                                     minimum_questions: "The election has <strong>at least 1 question</strong>.",
-                                     published: "The election is <strong>published</strong>.",
-                                     time_before: "The setup is being done <strong>at least 3 hours</strong> before the election starts.",
-                                     trustees_number: "The participatory space has <strong>at least 3 trustees with public key</strong>."
-                                   })
+    expect(subject.messages).to match(
+      hash_including({
+                       max_selections: "All the questions have a correct value for <strong>maximum of answers</strong>.",
+                       minimum_answers: "Each question has <strong>at least 2 answers</strong>.",
+                       minimum_questions: "The election has <strong>at least 1 question</strong>.",
+                       published: "The election is <strong>published</strong>.",
+                       time_before: "The setup is being done <strong>at least 3 hours</strong> before the election starts.",
+                       trustees_number: "The participatory space has <strong>at least 3 trustees with public key</strong>."
+                     })
+    )
   end
 
   context "when the election is not ready for the setup" do

--- a/decidim-elections/spec/system/admin/admin_manages_election_steps_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_election_steps_spec.rb
@@ -18,6 +18,7 @@ describe "Admin manages election steps", :slow, type: :system do
         expect(page).to have_content("Each question has at least 2 answers.")
         expect(page).to have_content("All the questions have a correct value for maximum of answers.")
         expect(page).to have_content("The election is published.")
+        expect(page).to have_content("The election component is published.")
         expect(page).to have_content("The setup is being done at least 3 hours before the election starts.")
         expect(page).to have_content("The participatory space has at least 3 trustees with public key.")
         expect(page).to have_content("has a public key", minimum: 2)


### PR DESCRIPTION
#### :tophat: What? Why?
Add check to make sure the election component is published before the election can start.

#### :pushpin: Related Issues
https://github.com/decidim/decidim/issues/9129

#### Testing
*None*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![image](https://user-images.githubusercontent.com/111746/170088088-ae33a11c-b3d1-4c10-8116-f61d89134020.png)
