### PR TITLE
Add missing translation keys proposals import and proposals picker

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
@@ -7,7 +7,7 @@
 
       <div class="card-section">
         <div class="row column">
-          <%= f.select :origin_component_id, @form.origin_components_collection, prompt: t(".select_component") %>
+          <%= f.select :origin_component_id, @form.origin_components_collection, prompt: t(".select_component"), label: t(".origin_component_id") %>
         </div>
         <% if current_component.scopes_enabled? %>
           <div class="row column">
@@ -15,10 +15,10 @@
           </div>
         <% end %>
         <div class="row column">
-          <%= f.number_field :default_budget %>
+          <%= f.number_field :default_budget, label: t(".default_budget") %>
         </div>
         <div class="row column">
-          <%= f.check_box :import_all_accepted_proposals %>
+          <%= f.check_box :import_all_accepted_proposals, label: t(".import_all_accepted_proposals") %>
         </div>
       </div>
     </div>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -17,6 +17,8 @@ en:
         proposal_ids: Related proposals
         selected: Selected for implementation
         title: Title
+      proposals_import:
+        scope_id: Scope
   activerecord:
     models:
       decidim/budgets/project:
@@ -127,7 +129,10 @@ en:
             success: "%{number} proposals successfully imported into projects"
           new:
             create: Import proposals to projects
+            default_budget: Default budget
+            import_all_accepted_proposals: Import all accepted proposals
             no_components: There are no other proposal components in this participatory space to import the proposals into projects.
+            origin_component_id: Origin component
             select_component: Please select a component
             title: Import proposals
         reminders:

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -13,8 +13,8 @@ en:
         decidim_category_id: Category
         decidim_scope_id: Scope
         description: Description
-        proposals: Proposals
         proposal_ids: Related proposals
+        proposals: Proposals
         selected: Selected for implementation
         title: Title
       proposals_import:

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
         decidim_category_id: Category
         decidim_scope_id: Scope
         description: Description
+        proposals: Proposals
         proposal_ids: Related proposals
         selected: Selected for implementation
         title: Title


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds some missing translation keys for the proposals picker and proposals import on budgets. 

#### :pushpin: Related Issues

- Fixes #9342
- Fixes #9345

#### Testing

##### For Import proposals form

1. Create a process
2. Add a Proposal functionality and add a Proposal into it
3. Add a Budget functionality with Scopes enabled and add a Budget into it
4. For this new Budget, click on the Manage projects
5. Click on Import proposal to project
6. Change the added locales in `config/locales/en.yml`

##### For proposals picker on project form

1. Create a Process
2. Add a Proposal component into this process and create a Proposal into it
3. Add a Budget component into this process and create a Budget into it
4. On this Budget click on Manage projects then click on New Project button

:hearts: Thank you!
