### PR TITLE
Fix rollback questionnaire answer when file is invalid

### DIFF
--- a/decidim-core/app/commands/decidim/multiple_attachments_methods.rb
+++ b/decidim-core/app/commands/decidim/multiple_attachments_methods.rb
@@ -88,6 +88,8 @@ module Decidim
     end
 
     def content_type_for(attachment)
+      return attachment.content_type if attachment.class == ActionDispatch::Http::UploadedFile
+
       blob(signed_id_for(attachment)).content_type
     end
 

--- a/decidim-core/app/commands/decidim/multiple_attachments_methods.rb
+++ b/decidim-core/app/commands/decidim/multiple_attachments_methods.rb
@@ -88,7 +88,7 @@ module Decidim
     end
 
     def content_type_for(attachment)
-      return attachment.content_type if attachment.class == ActionDispatch::Http::UploadedFile
+      return attachment.content_type if attachment.instance_of?(ActionDispatch::Http::UploadedFile)
 
       blob(signed_id_for(attachment)).content_type
     end

--- a/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
+++ b/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
@@ -43,7 +43,7 @@ module Decidim
       # of this problem.
       def reset_form_attachments
         @form.responses.each do |answer|
-          answer.errors.add(:add_documents, :needs_to_be_reattached) if answer.has_attachments?
+          answer.errors.add(:add_documents, :needs_to_be_reattached) if answer.has_attachments? || answer.has_error_in_attachments?
         end
       end
 
@@ -51,7 +51,7 @@ module Decidim
         @main_form = @form
         @errors = nil
 
-        Answer.transaction do
+        Answer.transaction(requires_new: true) do
           form.responses_by_step.flatten.select(&:display_conditions_fulfilled?).each do |form_answer|
             answer = Answer.new(
               user: @current_user,

--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -69,6 +69,10 @@ module Decidim
         question.has_attachments? && errors[:add_documents].empty? && add_documents.present?
       end
 
+      def has_error_in_attachments?
+        errors[:add_documents].present?
+      end
+
       private
 
       def mandatory_body?

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -26,6 +26,7 @@ module Decidim
           return broadcast(:invalid_form) unless registration_form.valid?
 
           return broadcast(:invalid) if answer_questionnaire == :invalid
+
           create_registration
           accept_invitation
           send_email_confirmation
@@ -52,12 +53,11 @@ module Decidim
           on(:ok) do
             return :valid
           end
-          
+
           on(:invalid) do
             return :invalid
           end
         end
-
       end
 
       def create_registration

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -25,7 +25,7 @@ module Decidim
           return broadcast(:invalid) unless can_join_meeting?
           return broadcast(:invalid_form) unless registration_form.valid?
 
-          answer_questionnaire
+          return broadcast(:invalid) if answer_questionnaire == :invalid
           create_registration
           accept_invitation
           send_email_confirmation
@@ -48,7 +48,16 @@ module Decidim
       def answer_questionnaire
         return unless questionnaire?
 
-        Decidim::Forms::AnswerQuestionnaire.call(registration_form, user, meeting.questionnaire)
+        Decidim::Forms::AnswerQuestionnaire.call(registration_form, user, meeting.questionnaire) do
+          on(:ok) do
+            return :valid
+          end
+          
+          on(:invalid) do
+            return :invalid
+          end
+        end
+
       end
 
       def create_registration

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -315,6 +315,31 @@ describe "Meeting registrations", type: :system do
           expect(page).to have_button("Submit")
         end
       end
+
+      context "when the registration form has file question and file is invalid" do
+        let!(:question) { create(:questionnaire_question, questionnaire: questionnaire, position: 0, question_type: :files) }
+
+        before do
+          login_as user, scope: :user
+        end
+
+        it "shows errors for invalid file" do
+          visit questionnaire_public_path
+
+          input_element = find("input[type='file']", visible: :all)
+          input_element.attach_file(Decidim::Dev.asset("verify_user_groups.csv"))
+
+          expect(page).to have_field("public_participation", checked: false)
+          find(".tos-agreement").set(true)
+          click_button "Submit"
+
+          within ".confirm-modal-footer" do
+            find("a.button[data-confirm-ok]").click
+          end
+
+          expect(page).to have_content("Needs to be reattached")
+        end
+      end
     end
 
     context "and the user is going to the meeting" do


### PR DESCRIPTION
#### :tophat: What? Why?

In questionnaires, if there is a question to upload a file and it has an invalid content type, the answer is also saved, but the file has not been saved as it is invalid.

Changes:

- Indicate the content type correctly if it is an UploadedFile, this was failing.
- Added `add_documents` error if the attachment has an error and could not be created.
- The transaction now rollback if the attachment is invalid.
- The answer_questionnaire has been checked to be correct, otherwise the answer and what comes after it should not be saved.

#### Testing
1. Go to any questionnaire
2. Try to upload any file invalid (per example: a presentation (.odp))
3. Check that you can't send answers and you must see errors in form.

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots

![Captura de pantalla de 2022-05-25 12-25-26](https://user-images.githubusercontent.com/75725233/170249792-ecef092c-7007-4306-af63-99ec5734d64d.png)


:hearts: Thank you!
