### PR TITLE
Add admin log when creating, deleting, duplicating and updating templates

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -316,6 +316,7 @@ ignore_unused:
   - decidim.assemblies.admin.assembly_members.form.explanation
   - decidim.assemblies.admin.assembly_members.form.image_guide
   - decidim.assemblies.admin.assembly_members.form.non_user_avatar_help
+  - decidim.templates.admin_log.*
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/decidim-templates/app/commands/decidim/templates/admin/copy_questionnaire_template.rb
+++ b/decidim-templates/app/commands/decidim/templates/admin/copy_questionnaire_template.rb
@@ -10,8 +10,9 @@ module Decidim
         # Public: Initializes the command.
         #
         # template - A template we want to duplicate
-        def initialize(template)
+        def initialize(template, user)
           @template = template
+          @user = user
         end
 
         # Executes the command. Broadcasts these events:
@@ -23,9 +24,11 @@ module Decidim
         def call
           return broadcast(:invalid) unless @template.valid?
 
-          Template.transaction do
-            copy_template
-            copy_questionnaire_questions(@template.templatable, @copied_template.templatable)
+          Decidim.traceability.perform_action!("duplicate", @template, @user) do
+            Template.transaction do
+              copy_template
+              copy_questionnaire_questions(@template.templatable, @copied_template.templatable)
+            end
           end
 
           broadcast(:ok, @copied_template)

--- a/decidim-templates/app/controllers/decidim/templates/admin/questionnaire_templates_controller.rb
+++ b/decidim-templates/app/controllers/decidim/templates/admin/questionnaire_templates_controller.rb
@@ -54,7 +54,7 @@ module Decidim
         def copy
           enforce_permission_to :copy, :template
 
-          CopyQuestionnaireTemplate.call(template) do
+          CopyQuestionnaireTemplate.call(template, current_user) do
             on(:ok) do
               flash[:notice] = I18n.t("templates.copy.success", scope: "decidim.admin")
               redirect_to action: :index

--- a/decidim-templates/app/models/decidim/templates/template.rb
+++ b/decidim-templates/app/models/decidim/templates/template.rb
@@ -11,6 +11,8 @@
 module Decidim
   module Templates
     class Template < ApplicationRecord
+      include Decidim::Traceable
+
       belongs_to :organization,
                  foreign_key: "decidim_organization_id",
                  class_name: "Decidim::Organization"
@@ -27,6 +29,10 @@ module Decidim
 
       def destroy_templatable
         templatable.destroy
+      end
+
+      def self.log_presenter_class_for(_log)
+        Decidim::Templates::AdminLog::TemplatePresenter
       end
     end
   end

--- a/decidim-templates/app/presenters/decidim/templates/admin_log/template_presenter.rb
+++ b/decidim-templates/app/presenters/decidim/templates/admin_log/template_presenter.rb
@@ -24,7 +24,7 @@ module Decidim
 
         def action_string
           case action
-          when "create","update","delete"
+          when "create", "update", "delete", "duplicate"
             "decidim.templates.admin_log.template.#{action}"
           else
             super

--- a/decidim-templates/app/presenters/decidim/templates/admin_log/template_presenter.rb
+++ b/decidim-templates/app/presenters/decidim/templates/admin_log/template_presenter.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Templates
+    module AdminLog
+      # This class holds the logic to present a `Decidim::Template`
+      # for the `AdminLog` log.
+      #
+      # Usage should be automatic and you shouldn't need to call this class
+      # directly, but here's an example:
+      #
+      #    action_log = Decidim::ActionLog.last
+      #    view_helpers # => this comes from the views
+      #    TemplatePresenter.new(action_log, view_helpers).present
+      class TemplatePresenter < Decidim::Log::BasePresenter
+        private
+
+        def diff_fields_mapping
+          {
+            name: :i18n,
+            description: :i18n
+          }
+        end
+
+        def action_string
+          case action
+          when "create","update","delete"
+            "decidim.templates.admin_log.template.#{action}"
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-templates/config/locales/en.yml
+++ b/decidim-templates/config/locales/en.yml
@@ -66,9 +66,9 @@ en:
             tos_agreement: By participating you accept its Terms of Service
       admin_log:
         template:
-          create: "%{user_name} created the %{resource_name} template"
-          delete: "%{user_name} deleted the %{resource_name} template"
+          create: "%{user_name} created the %{resource_name} questionnaire template"
+          delete: "%{user_name} deleted the %{resource_name} questionnaire template"
           duplicate: "%{user_name} duplicated the %{resource_name} questionnaire template"
-          update: "%{user_name} updated the %{resource_name} template"
+          update: "%{user_name} updated the %{resource_name} questionnaire template"
       template_types:
         questionnaires: Questionnaires

--- a/decidim-templates/config/locales/en.yml
+++ b/decidim-templates/config/locales/en.yml
@@ -64,5 +64,11 @@ en:
             current_step: Step %{step}
             of_total_steps: of %{total_steps}
             tos_agreement: By participating you accept its Terms of Service
+      admin_log:
+        template:
+          create: "%{user_name} created the %{resource_name} template"
+          delete: "%{user_name} deleted the %{resource_name} template"
+          update: "%{user_name} updated the %{resource_name} template"
       template_types:
         questionnaires: Questionnaires
+

--- a/decidim-templates/config/locales/en.yml
+++ b/decidim-templates/config/locales/en.yml
@@ -45,8 +45,7 @@ en:
         questionnaire_templates:
           choose:
             create_from_template: Create from template
-            description: You are about to create a new questionnaire. You may choose
-              a predefined template and modify it afterwards.
+            description: You are about to create a new questionnaire. You may choose a predefined template and modify it afterwards.
             label: Choose template
             placeholder: Choose template
             skip_template: Skip

--- a/decidim-templates/config/locales/en.yml
+++ b/decidim-templates/config/locales/en.yml
@@ -68,6 +68,7 @@ en:
         template:
           create: "%{user_name} created the %{resource_name} template"
           delete: "%{user_name} deleted the %{resource_name} template"
+          duplicate: "%{user_name} duplicated the %{resource_name} questionnaire template"
           update: "%{user_name} updated the %{resource_name} template"
       template_types:
         questionnaires: Questionnaires

--- a/decidim-templates/config/locales/en.yml
+++ b/decidim-templates/config/locales/en.yml
@@ -45,7 +45,8 @@ en:
         questionnaire_templates:
           choose:
             create_from_template: Create from template
-            description: You are about to create a new questionnaire. You may choose a predefined template and modify it afterwards.
+            description: You are about to create a new questionnaire. You may choose
+              a predefined template and modify it afterwards.
             label: Choose template
             placeholder: Choose template
             skip_template: Skip
@@ -72,4 +73,3 @@ en:
           update: "%{user_name} updated the %{resource_name} template"
       template_types:
         questionnaires: Questionnaires
-

--- a/decidim-templates/spec/commands/decidim/templates/admin/create_questionnaire_template_spec.rb
+++ b/decidim-templates/spec/commands/decidim/templates/admin/create_questionnaire_template_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Templates
+    module Admin
+      describe CreateQuestionnaireTemplate do
+        subject { described_class.new(form) }
+
+        let(:organization) { create :organization }
+        let(:user) { create :user, :admin, :confirmed, organization: organization }
+
+        let(:form) do
+          instance_double(
+            TemplateForm,
+            invalid?: invalid,
+            valid?: !invalid,
+            current_user: user,
+            current_organization: organization,
+            name: "name",
+            description: "description"
+          )
+        end
+        let(:invalid) { false }
+
+        context "when the form is not valid" do
+          let(:invalid) { true }
+
+          it "is not valid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when the form is valid" do
+          it "broadcasts ok" do
+            expect { subject.call }.to broadcast(:ok)
+          end
+
+          it "create a new template for the organization" do
+            expect { subject.call }.to change { Decidim::Templates::Template.all.count }.by(1)
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:perform_action!)
+              .with(:create, Decidim::Templates::Template, user, {})
+              .and_call_original
+
+            expect { subject.call }.to change(Decidim::ActionLog, :count)
+            action_log = Decidim::ActionLog.last
+            expect(action_log.version).to be_present
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-templates/spec/commands/decidim/templates/admin/destroy_template_spec.rb
+++ b/decidim-templates/spec/commands/decidim/templates/admin/destroy_template_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Templates
+    module Admin
+      describe DestroyTemplate do
+        subject { described_class.new(template, user) }
+
+        let(:organization) { create :organization }
+        let(:user) { create :user, :admin, :confirmed, organization: organization }
+        let(:template) { create :questionnaire_template, organization: organization }
+
+        it "broadcasts ok" do
+          expect { subject.call }.to broadcast(:ok)
+        end
+
+        it "destroy the template" do
+          subject.call
+          expect { template.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it "traces the action", versioning: true do
+          expect(Decidim.traceability)
+            .to receive(:perform_action!)
+            .with(:delete, template, user)
+            .and_call_original
+
+          expect { subject.call }.to change(Decidim::ActionLog, :count)
+          action_log = Decidim::ActionLog.last
+          expect(action_log.version).to be_present
+        end
+      end
+    end
+  end
+end

--- a/decidim-templates/spec/commands/decidim/templates/admin/update_template_spec.rb
+++ b/decidim-templates/spec/commands/decidim/templates/admin/update_template_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Templates
+    module Admin
+      describe UpdateTemplate do
+        subject { described_class.new(template, form, user) }
+
+        let(:organization) { create :organization }
+        let(:user) { create :user, :admin, :confirmed, organization: organization }
+        let(:template) { create :questionnaire_template, organization: organization }
+        let(:name) { "test" }
+        let(:description) { "description" }
+
+        let(:form) do
+          instance_double(
+            TemplateForm,
+            invalid?: invalid,
+            valid?: !invalid,
+            current_user: user,
+            current_organization: organization,
+            name: name,
+            description: description
+          )
+        end
+        let(:invalid) { false }
+
+        context "when the form is not valid" do
+          let(:invalid) { true }
+
+          it "is not valid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when the form is valid" do
+          it "broadcasts ok" do
+            expect { subject.call }.to broadcast(:ok)
+          end
+
+          it "update the template" do
+            subject.call
+            expect(template.name).to eq(name)
+            expect(template.description).to eq(description)
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:perform_action!)
+              .with(:update, template, user, {})
+              .and_call_original
+
+            expect { subject.call }.to change(Decidim::ActionLog, :count)
+            action_log = Decidim::ActionLog.last
+            expect(action_log.version).to be_present
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
add admin log when duplicating a template
add presenters to template admin log

#### :pushpin: Related Issues
- Fixes the last task of #9181
![image](https://user-images.githubusercontent.com/93646702/170281291-3d889bf3-b4a1-40a5-9c83-90bfb135763a.png)
