### PR TITLE
Fix validation conditions for elections setup when there are no questions

### DIFF
--- a/decidim-elections/app/forms/decidim/elections/admin/setup_form.rb
+++ b/decidim-elections/app/forms/decidim/elections/admin/setup_form.rb
@@ -31,8 +31,8 @@ module Decidim
         def validations
           @validations ||= [
             [:minimum_questions, {}, election.questions.any?],
-            [:minimum_answers, {}, election.minimum_answers?],
-            [:max_selections, {}, election.valid_questions?],
+            [:minimum_answers, {}, election.questions.any? && election.minimum_answers?],
+            [:max_selections, {}, election.questions.any? && election.valid_questions?],
             [:published, {}, election.published_at.present?],
             [:time_before, { hours: Decidim::Elections.setup_minimum_hours_before_start }, election.minimum_hours_before_start?],
             [:trustees_number, { number: bulletin_board.number_of_trustees }, participatory_space_trustees_with_public_key.size >= bulletin_board.number_of_trustees]

--- a/decidim-elections/spec/forms/decidim/elections/admin/setup_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/setup_form_spec.rb
@@ -47,6 +47,8 @@ describe Decidim::Elections::Admin::SetupForm do
       subject.valid?
       expect(subject.errors.messages).to eq({
                                               minimum_questions: ["The election <strong>must have at least one question</strong>."],
+                                              minimum_answers: ["Questions must have <strong>at least two answers</strong>."],
+                                              max_selections: ["The questions do not have a <strong>correct value for amount of answers</strong>"],
                                               published: ["The election is <strong>not published</strong>."]
                                             })
     end


### PR DESCRIPTION
When there are no answers, the checks about the answers shouldn't be green.

Fixes https://github.com/decidim/decidim/issues/9121