### PR TITLE
Ensure the census is ready when setting up an election

### DIFF
--- a/decidim-elections/app/forms/decidim/elections/admin/setup_form.rb
+++ b/decidim-elections/app/forms/decidim/elections/admin/setup_form.rb
@@ -36,8 +36,19 @@ module Decidim
             [:published, {}, election.published_at.present?],
             [:component_published, {}, election.component.published?],
             [:time_before, { hours: Decidim::Elections.setup_minimum_hours_before_start }, election.minimum_hours_before_start?],
-            [:trustees_number, { number: bulletin_board.number_of_trustees }, participatory_space_trustees_with_public_key.size >= bulletin_board.number_of_trustees]
-          ].freeze
+            [:trustees_number, { number: bulletin_board.number_of_trustees }, participatory_space_trustees_with_public_key.size >= bulletin_board.number_of_trustees],
+            census_frozen?
+          ].compact.freeze
+        end
+
+        def census_frozen?
+          return nil unless election.participatory_space.respond_to?(:vote_flow_for)
+
+          vote_flow = election.participatory_space.vote_flow_for(election)
+          return nil unless vote_flow.is_a?(Decidim::Votings::CensusVoteFlow)
+
+          census_frozen = election.participatory_space.dataset&.freeze?
+          [:census_not_frozen, {}, census_frozen]
         end
 
         def messages

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -245,6 +245,7 @@ en:
         steps:
           create_election:
             errors:
+              census_not_frozen: The census for this election must be frozen before creating the election
               component_published: The election component is <strong>not published</strong>.
               max_selections: The questions do not have a <strong>correct value for amount of answers</strong>
               minimum_answers: Questions must have <strong>at least two answers</strong>.
@@ -259,6 +260,7 @@ en:
               'false': does not have a <strong>public key</strong>
               'true': has a <strong>public key</strong>
             requirements:
+              census_not_frozen: The census is frozen.
               component_published: The election component is <strong>published</strong>.
               max_selections: All the questions have a correct value for <strong>maximum of answers</strong>.
               minimum_answers: Each question has <strong>at least 2 answers</strong>.

--- a/decidim-elections/spec/forms/decidim/elections/admin/setup_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/setup_form_spec.rb
@@ -54,6 +54,40 @@ describe Decidim::Elections::Admin::SetupForm do
     end
   end
 
+  context "when validating the census" do
+    let(:election) { create :election }
+
+    context "when the participatory space is not a voting" do
+      it "does not add errors about the census" do
+        expect(subject.errors.messages[:census_not_frozen]).to be_empty
+      end
+    end
+
+    context "when the participatory space is a voting" do
+      let(:election) { create :voting_election }
+      let(:dataset) { create :dataset, voting: election.participatory_space, status: census_status }
+
+      context "when the census is not frozen" do
+        let(:census_status) { "init_data" }
+
+        it { is_expected.to be_invalid }
+
+        it "shows errors" do
+          subject.valid?
+          expect(subject.errors.messages).to match(hash_including({ census_not_frozen: ["The census for this election must be frozen before creating the election"] }))
+        end
+      end
+
+      context "when the census is frozen" do
+        let(:census_status) { "freeze" }
+
+        it "does not add errors about the census" do
+          expect(subject.errors.messages[:census_not_frozen]).to be_empty
+        end
+      end
+    end
+  end
+
   context "when there are no trustees for the election" do
     let(:trustees) { [] }
 

--- a/decidim-elections/spec/system/admin/admin_manages_election_steps_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_election_steps_spec.rb
@@ -8,6 +8,10 @@ describe "Admin manages election steps", :slow, type: :system do
   include_context "when admin manages elections"
 
   describe "setup an election" do
+    let(:dataset) { create(:dataset, :frozen) }
+    let(:current_component) do
+      create(:elections_component, organization: organization, participatory_space: dataset.voting)
+    end
     let(:election) { create :election, :ready_for_setup, component: current_component, title: { en: "English title", es: "" } }
 
     it "performs the action successfully" do
@@ -21,6 +25,7 @@ describe "Admin manages election steps", :slow, type: :system do
         expect(page).to have_content("The election component is published.")
         expect(page).to have_content("The setup is being done at least 3 hours before the election starts.")
         expect(page).to have_content("The participatory space has at least 3 trustees with public key.")
+        expect(page).to have_content("The census is frozen.")
         expect(page).to have_content("has a public key", minimum: 2)
 
         click_button "Setup election"


### PR DESCRIPTION
#### :tophat: What? Why?

When an election belongs to a Voting we shouldn't allow setting it up if the census hasn't been properly configured.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/8800
