### PR TITLE
Change docs to use decidim_system:create_admin command

### DIFF
--- a/decidim-system/README.md
+++ b/decidim-system/README.md
@@ -61,7 +61,7 @@ bin/rails console
 ```
 . Run the following instructions, changing them accordingly:
 ```ruby
-system_admin = Decidim::System::Admin.find 1                                  # for the first system admin
+system_admin = Decidim::System::Admin.order(:id).first                        # for the first system admin
 system_admin = Decidim::System::Admin.find_by_email "system@example.org"      # if you already know the email
 system_admin.password = "decidim1234567890"                                   # change for something secure
 system_admin.password_confirmation = "decidim1234567890"

--- a/decidim-system/README.md
+++ b/decidim-system/README.md
@@ -40,18 +40,17 @@ When using Decidim as multi-tenant, you should keep these in mind:
 
 ## Managing System admins
 
-Currently Decidim doesn't provide a way to create the first System Admin in a new deployment. To do it, you should open a Rails console in your application and
-create it:
+For logging in to this dashboard, you'll need to create a system admin account from your terminal:
 
-```ruby
-Decidim::System::Admin.create!(
-  email: "your-email@example.org",
-  password: "your-safe-password",
-  password_confirmation: "your-safe-password"
-)
+```bash
+bin/rails decidim_system:create_admin
 ```
 
-Once you have created your first admin you can access the system dashboard at `https://your-decidim-deployment-host/system` and login with your newly created user.
+You'll be asked for an email and a password. For security, the password will not get displayed back at you and you'll need to confirm it.
+
+Once you have created your first admin you can access the system dashboard at `/system`. For instance, if you have Decidim running at `https://example.org`, this URL would be `https://example.org/system`.
+You'll be able to login with your newly created user.
+
 From the system dashboard you can add new admins.
 
 ⚠️ If you need to reset your administrator password you'll need to do it by entering the Rails console and changing it manually. ⚠️

--- a/decidim-system/README.md
+++ b/decidim-system/README.md
@@ -55,6 +55,19 @@ From the system dashboard you can add new admins.
 
 ⚠️ If you need to reset your administrator password you'll need to do it by entering the Rails console and changing it manually. ⚠️
 
+. Open the rails console:
+```bash
+bin/rails console
+```
+. Run the following instructions, changing them accordingly:
+```ruby
+system_admin = Decidim::System::Admin.find 1                                  # for the first system admin
+system_admin = Decidim::System::Admin.find_by_email "system@example.org"      # if you already know the email
+system_admin.password = "decidim1234567890"                                   # change for something secure
+system_admin.password_confirmation = "decidim1234567890"
+system_admin.save
+```
+
 ## Managing organizations
 
 Once you have your system admin setup you can also start managing the organizations in your deploy. To do it, login at the system dashboard and create a new organization

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -86,7 +86,7 @@ Visit http://localhost:3000 to see your app running.
 
 == Configuration & setup
 
-Decidim comes pre-configured with some safe defaults, but can be changed through the `config/initializers/decidim.rb` file in your app. Check the comments there or read the comments in https://github.com/decidim/decidim/blob/develop/decidim-core/lib/decidim/core.rb[the source file] (the part with the `config_accessor` calls) for more up-to-date info.
+Decidim comes pre-configured with some safe defaults, but can be changed through xref:configure:environment_variables.adoc[Environment Variables] or the xref:configure:initializer.adoc[Initializer] file in your app.
 
 === Scheduled tasks
 

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -120,27 +120,26 @@ You can configure it with `crontab -e`, for instance if you've created your Deci
 
 === Further configuration
 
-We also have other guides on how to configure some extra components:
+We also have other guides on how to configure some extra mandatory components:
 
 * xref:services:activejob.adoc[ActiveJob]: For background jobs (like sending emails).
-* xref:services:maps.adoc[Maps]: How to enable geocoding for proposals and meetings.
+* xref:services:smtp.adoc[SMTP]: For sending emails for account registrations, password reminders, notifications, etc.
 * xref:services:social_providers.adoc[Social providers integration]: Enable sign up from social networks.
 
 == Deploy
 
-Once you've successfully deployed your app to your favorite platform, you'll need to create your `System` user. First you'll need to create your `Decidim::System` user in your production Ruby on Rails console:
+Once you've successfully deployed your app to your favorite platform, you'll need to create your `System` user. First you'll need to create your `Decidim::System` user in your terminal:
 
-[source,ruby]
+[source,console]
 ----
-email = <your email>
-password = <a secure password>
-user = Decidim::System::Admin.new(email: email, password: password, password_confirmation: password)
-user.save!
+bin/rails decidim_system:create_admin
 ----
+
+You'll be asked for an email and a password. For security, the password will not get displayed back at you and you'll need to confirm it.
 
 This will create a system user with the email and password you set. We recommend using a random password generator and saving it to a password manager, so you have a more secure login.
 
-Then, visit the `/system` dashboard and login with the email and passwords you just entered and create your organization. You're done! :tada:
+Then, visit the `/system` dashboard and login with the email and passwords you just entered and create your organization. You're done! 🎉
 
 You can check the https://github.com/decidim/decidim/tree/develop/decidim-system/README.md[`decidim-system` README file] for more info on how organizations work.
 

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -123,6 +123,7 @@ You can configure it with `crontab -e`, for instance if you've created your Deci
 We also have other guides on how to configure some extra mandatory components:
 
 * xref:services:activejob.adoc[ActiveJob]: For background jobs (like sending emails).
+* xref:services:maps.adoc[Maps]: How to enable geocoding for proposals and meetings.
 * xref:services:smtp.adoc[SMTP]: For sending emails for account registrations, password reminders, notifications, etc.
 * xref:services:social_providers.adoc[Social providers integration]: Enable sign up from social networks.
 


### PR DESCRIPTION
#### :tophat: What? Why?

Related to https://github.com/decidim/documentation/pull/102: 

> While reviewing https://github.com/decidim/decidim/pull/9349, I have seen that we didn't update the instructions to make easier the creation of the first system admin (from https://github.com/decidim/decidim/pull/8010). This PR fixed that. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/decidim/documentation/pull/102
- Related to #9349 
- Related to #8010 


:hearts: Thank you!
