### PR TITLE
Return 404 when there isn't a consultation

### DIFF
--- a/decidim-consultations/app/controllers/concerns/decidim/consultations/needs_consultation.rb
+++ b/decidim-consultations/app/controllers/concerns/decidim/consultations/needs_consultation.rb
@@ -38,7 +38,7 @@ module Decidim
 
         def detect_consultation
           request.env["current_consultation"] ||
-            organization_consultations.find_by(slug: params[:consultation_slug] || params[:slug])
+            organization_consultations.find_by!(slug: params[:consultation_slug] || params[:slug])
         end
 
         def organization_consultations

--- a/decidim-consultations/spec/controllers/decidim/consultations/consultations_controller_spec.rb
+++ b/decidim-consultations/spec/controllers/decidim/consultations/consultations_controller_spec.rb
@@ -3,7 +3,29 @@
 require "spec_helper"
 
 describe Decidim::Consultations::ConsultationsController, type: :controller do
-  it "does not raise error to call current_participatory_space" do
-    expect { controller.send(:current_participatory_space) }.not_to raise_error
+  routes { Decidim::Consultations::Engine.routes }
+
+  let(:organization) { create(:organization) }
+  let(:consultation) { create(:consultation, organization: organization) }
+
+  before do
+    request.env["decidim.current_organization"] = organization
+  end
+
+  context "when there's a consultation" do
+    it "can access it" do
+      get :show, params: { slug: consultation.slug }
+
+      expect(subject).to render_template(:show)
+      expect(flash[:alert]).to be_blank
+      expect(controller.send(:current_participatory_space)).to eq consultation
+    end
+  end
+
+  context "when there isn't a consultation" do
+    it "returns 404" do
+      expect { get :show, params: { slug: "invalid-consultation" } }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

In some controllers, we're doing some incorrect checks when finding resources. This makes that some URLs return 500 when they should be returning 404. 

This PR fixes this for consultations#show, https://try.decidim.org/consultations/DOESNTEXIST 

#### Testing

. Go to http://localhost:3000/consultations/DOESNTEXIST
. See that it returns 404 (`ActiveRecord::RecordNotFound` in development)

:hearts: Thank you!
