### PR TITLE
Return 404 when there isn't a question

### DIFF
--- a/decidim-consultations/app/controllers/concerns/decidim/consultations/needs_question.rb
+++ b/decidim-consultations/app/controllers/concerns/decidim/consultations/needs_question.rb
@@ -82,6 +82,8 @@ module Decidim
         private
 
         def detect_question
+          return unless request.env["current_question"] || params[:question_slug] || params[:slug]
+
           request.env["current_question"] ||
             OrganizationQuestions.for(current_organization).find_by!(slug: params[:question_slug] || params[:slug])
         end

--- a/decidim-consultations/app/controllers/concerns/decidim/consultations/needs_question.rb
+++ b/decidim-consultations/app/controllers/concerns/decidim/consultations/needs_question.rb
@@ -83,7 +83,7 @@ module Decidim
 
         def detect_question
           request.env["current_question"] ||
-            OrganizationQuestions.for(current_organization).find_by(slug: params[:question_slug] || params[:slug])
+            OrganizationQuestions.for(current_organization).find_by!(slug: params[:question_slug] || params[:slug])
         end
 
         def detect_consultation

--- a/decidim-consultations/spec/controllers/decidim/consultations/questions_controller_spec.rb
+++ b/decidim-consultations/spec/controllers/decidim/consultations/questions_controller_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Consultations::QuestionsController, type: :controller do
+  routes { Decidim::Consultations::Engine.routes }
+
+  let(:organization) { create(:organization) }
+  let(:consultation) { create(:consultation, organization: organization) }
+  let(:question) { create(:question, consultation: consultation) }
+
+  before do
+    request.env["decidim.current_organization"] = organization
+  end
+
+  context "when there's a question" do
+    it "can access it" do
+      get :show, params: { slug: question.slug }
+
+      expect(subject).to render_template(:show)
+      expect(flash[:alert]).to be_blank
+      expect(controller.send(:current_participatory_space)).to eq question
+    end
+  end
+
+  context "when there isn't a question" do
+    it "returns 404" do
+      expect { get :show, params: { slug: "invalid-question" } }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
In some controllers, we're doing some incorrect checks when finding resources. This makes that some URLs return 500 when they should be returning 404. 

This PR fixes this for questions#show, https://try.decidim.org/questions/DOESNTEXIST 

#### :pushpin: Related Issues

- Related to #9374

#### Testing

. Go to http://localhost:3000/questions/DOESNTEXIST
. See that it returns 404 (`ActiveRecord::RecordNotFound` in development)


:hearts: Thank you!
