### PR TITLE
Return 404 when there isn't a voting in elections_log

### DIFF
--- a/decidim-elections/app/controllers/decidim/votings/votings_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/votings_controller.rb
@@ -107,6 +107,8 @@ module Decidim
       end
 
       def elections
+        raise ActionController::RoutingError, "Not Found" unless current_participatory_space
+
         Decidim::Elections::Election.where(component: current_participatory_space.components).where.not(bb_status: nil)
       end
 

--- a/decidim-elections/spec/controllers/decidim/votings/votings_controller_spec.rb
+++ b/decidim-elections/spec/controllers/decidim/votings/votings_controller_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Votings::VotingsController, type: :controller do
+  routes { Decidim::Votings::Engine.routes }
+
+  let(:organization) { create(:organization) }
+  let(:voting) { create(:voting, organization: organization) }
+
+  before do
+    request.env["decidim.current_organization"] = organization
+  end
+
+  describe "GET show" do
+    context "when there's a voting" do
+      it "can access it" do
+        get :show, params: { slug: voting.slug }
+        expect(subject).to render_template(:show)
+        expect(flash[:alert]).to be_blank
+        expect(controller.send(:current_participatory_space)).to eq voting
+      end
+    end
+
+    context "when there isn't a voting" do
+      it "returns 404" do
+        expect { get :show, params: { slug: "invalid-voting" } }
+          .to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+
+  describe "GET elections_log" do
+    context "when there's a voting" do
+      it "can access it" do
+        get :elections_log, params: { voting_slug: voting.slug }
+        expect(subject).to render_template(:elections_log)
+        expect(flash[:alert]).to be_blank
+        expect(controller.send(:current_participatory_space)).to eq voting
+      end
+    end
+
+    context "when there isn't a voting" do
+      it "returns 404" do
+        expect { get :elections_log, params: { voting_slug: "invalid-voting" } }
+          .to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

In some controllers, we're doing some incorrect checks when finding resources. This makes that some URLs return 500 when they should be returning 404. 

This PR fixes this for votings#elections_log, https://try.decidim.org/votings/DOESNTEXIST/elections_log

#### Testing

. Go to http://localhost:3000/votings/DOESNTEXIST/elections_log
. See that it returns 404 (`Not Found` in development)

:hearts: Thank you!
