### PR TITLE
add order of initiatives

### DIFF
--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiatives_settings.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiatives_settings.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      # A command with all the business logic when updating initiatives
+      # settings in admin area.
+      class UpdateInitiativesSettings < Decidim::Command
+        # Public: Initializes the command.
+        #
+        # initiatives_settings - A initiatives settings object to update.
+        # form - A form object with the params.
+        def initialize(initiatives_settings, form)
+          @initiatives_settings = initiatives_settings
+          @form = form
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form or initiatives_settings isn't valid and we couldn't proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) if form.invalid? || initiatives_settings.invalid?
+
+          update_initiatives_settings!
+
+          broadcast(:ok)
+        end
+
+        private
+
+        attr_reader :form, :initiatives_settings
+
+        def update_initiatives_settings!
+          Decidim.traceability.update!(
+            @initiatives_settings,
+            form.current_user,
+            initiatives_order: form.initiatives_order
+          )
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/controllers/concerns/decidim/initiatives/orderable.rb
+++ b/decidim-initiatives/app/controllers/concerns/decidim/initiatives/orderable.rb
@@ -37,6 +37,14 @@ module Decidim
             initiatives.order_randomly(random_seed)
           end
         end
+
+        def order
+          @order ||= detect_order(params[:order]) || current_initiatives_settings.initiatives_order || default_order
+        end
+
+        def current_initiatives_settings
+          Decidim::InitiativesSettings.find_or_create_by!(decidim_organization_id: current_organization.id)
+        end
       end
     end
   end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_settings_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_settings_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      # Controller used to manage the initiatives settings for the current
+      # organization.
+      class InitiativesSettingsController < Decidim::Initiatives::Admin::ApplicationController
+        layout "decidim/admin/initiatives"
+
+        # GET /admin/initiatives_settings/edit
+        def edit
+          enforce_permission_to :update, :initiatives_settings, initiatives_settings: current_initiatives_settings
+          @form = initiatives_settings_form.from_model(current_initiatives_settings)
+        end
+
+        # PUT /admin/initiatives_settings
+        def update
+          enforce_permission_to :update, :initiatives_settings, initiatives_settings: current_initiatives_settings
+
+          @form = initiatives_settings_form
+                  .from_params(params, initiatives_settings: current_initiatives_settings)
+
+          UpdateInitiativesSettings.call(current_initiatives_settings, @form) do
+            on(:ok) do
+              flash[:notice] = I18n.t("initiatives_settings.update.success", scope: "decidim.admin")
+              redirect_to edit_initiatives_setting_path
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("initiatives_settings.update.error", scope: "decidim.admin")
+              render :edit
+            end
+          end
+        end
+
+        private
+
+        def current_initiatives_settings
+          @current_initiatives_settings ||= Decidim::InitiativesSettings.find_or_create_by!(decidim_organization_id: current_organization.id)
+        end
+
+        def initiatives_settings_form
+          form(Decidim::Initiatives::Admin::InitiativesSettingsForm)
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiatives_settings_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiatives_settings_form.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      # A form object used to create initiatives settings from the admin dashboard.
+      class InitiativesSettingsForm < Form
+        mimic :initiatives_settings
+
+        attribute :initiatives_order, String
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/models/decidim/initiatives_settings.rb
+++ b/decidim-initiatives/app/models/decidim/initiatives_settings.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Initiatives setting.
+  class InitiativesSettings < ApplicationRecord
+    include Decidim::Traceable
+    include Decidim::Loggable
+
+    belongs_to :organization,
+               foreign_key: "decidim_organization_id",
+               class_name: "Decidim::Organization"
+
+    def self.log_presenter_class_for(_log)
+      Decidim::Initiatives::AdminLog::InitiativesSettingsPresenter
+    end
+  end
+end

--- a/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
@@ -19,6 +19,7 @@ module Decidim
             initiative_committee_action?
             initiative_user_action?
             attachment_action?
+            initiatives_settings_action?
 
             return permission_action
           end
@@ -36,6 +37,7 @@ module Decidim
           initiative_committee_action?
           initiative_admin_user_action?
           initiative_export_action?
+          initiatives_settings_action?
           moderator_action?
           allow! if permission_action.subject == :attachment
 
@@ -161,6 +163,13 @@ module Decidim
 
         def initiative_export_action?
           allow! if permission_action.subject == :initiatives && permission_action.action == :export
+        end
+
+        def initiatives_settings_action?
+          return unless permission_action.action == :update &&
+                        permission_action.subject == :initiatives_settings
+
+          toggle_allow(user.admin?)
         end
 
         def moderator_action?

--- a/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiatives_settings_presenter.rb
+++ b/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiatives_settings_presenter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module AdminLog
+      # This class holds the logic to present a `Decidim::InitiativesSettings`
+      # for the `AdminLog` log.
+      #
+      # Usage should be automatic and you shouldn't need to call this class
+      # directly, but here's an example:
+      #
+      #    action_log = Decidim::ActionLog.last
+      #    view_helpers # => this comes from the views
+      #    InitiativesSettingsPresenter.new(action_log, view_helpers).present
+      class InitiativesSettingsPresenter < Decidim::Log::BasePresenter
+        private
+
+        def action_string
+          case action
+          when "update"
+            "decidim.initiatives.admin_log.initiatives_settings.#{action}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_settings/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_settings/_form.html.erb
@@ -1,0 +1,10 @@
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title"><%= t(".title") %></h2>
+  </div>
+  <div class="card-section">
+    <div class="row column">
+      <%= form.select :initiatives_order, [[t(".random"),"random"],[t(".date"),"recent"],[t(".signatures"),"most_voted"],[t(".comments"),"most_commented"],[t(".publication_date"),"recently_published"]] %>
+   </div>
+  </div>
+</div>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_settings/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_settings/edit.html.erb
@@ -1,0 +1,6 @@
+<%= decidim_form_for(@form, html: { class: "form edit_initiatives_settings" }, url: initiatives_setting_path, method: :put) do |f| %>
+  <%= render partial: "form", object: f %>
+  <div class="button--double form-general-submit">
+    <%= f.submit t(".update") %>
+  </div>
+<% end %>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -1,4 +1,5 @@
 ---
+
 en:
   activemodel:
     attributes:
@@ -85,12 +86,16 @@ en:
             label: Type
         search_placeholder:
           title_or_description_or_id_string_or_author_name_or_author_nickname_cont: Search %{collection} by title, description, ID or author name.
+      initiatives_settings:
+        update:
+          success: "The initiatives settings have been successfully updated"
       menu:
         attachments: Attachments
         committee_members: Committee members
         components: Components
         information: Information
         initiatives: Initiatives
+        initiatives_settings: Settings
         initiatives_types: Initiative types
         moderations: Moderations
       models:
@@ -242,6 +247,16 @@ en:
           update:
             error: An error has occurred
             success: The initiative has been successfully updated
+        initiatives_settings:
+          edit:
+            update: "Update"
+          form:
+            title: "Settings for initiatives"
+            random: "Random"
+            date: "Most recent"
+            signatures: "Most signed"
+            comments: "Most commented"
+            publication_date: "Most recently published"
         initiatives_type_scopes:
           create:
             error: An error has occurred
@@ -291,6 +306,8 @@ en:
           send_to_technical_validation: "%{user_name} sent the %{resource_name} initiative to technical validation"
           unpublish: "%{user_name} discarded the %{resource_name} initiative"
           update: "%{user_name} updated the %{resource_name} initiative"
+        initiatives_settings:
+          update: "%{user_name} updated the initiatives settings"
         initiatives_type:
           create: "%{user_name} created the %{resource_name} initiatives type"
           delete: "%{user_name} deleted the %{resource_name} initiatives type"

--- a/decidim-initiatives/db/migrate/20220527130640_create_decidim_initiatives_settings.rb
+++ b/decidim-initiatives/db/migrate/20220527130640_create_decidim_initiatives_settings.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreateDecidimInitiativesSettings < ActiveRecord::Migration[5.2]
+  def change
+    create_table :decidim_initiatives_settings do |t|
+      t.string :initiatives_order, default: "random"
+      t.references :decidim_organization, foreign_key: true, index: true
+    end
+  end
+end

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -19,6 +19,8 @@ module Decidim
           resources :initiatives_type_scopes, except: [:index, :show]
         end
 
+        resources :initiatives_settings, only: [:edit, :update], controller: "initiatives_settings"
+
         resources :initiatives, only: [:index, :edit, :update], param: :slug do
           member do
             get :send_to_technical_validation
@@ -159,6 +161,16 @@ module Decidim
                         decidim_admin_initiatives.initiatives_types_path,
                         active: is_active_link?(decidim_admin_initiatives.initiatives_types_path),
                         if: allowed_to?(:manage, :initiative_type)
+
+          menu.add_item :initiatives_settings,
+                        I18n.t("menu.initiatives_settings", scope: "decidim.admin"),
+                        decidim_admin_initiatives.edit_initiatives_setting_path(
+                          Decidim::InitiativesSettings.find_or_create_by!(
+                            decidim_organization_id: current_organization.id
+                          )
+                        ),
+                        active: is_active_link?(decidim_admin_initiatives.edit_initiatives_setting_path(Decidim::InitiativesSettings.find_or_create_by!(decidim_organization_id: current_organization.id))),
+                        if: allowed_to?(:update, :initiatives_settings)
         end
       end
     end

--- a/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
@@ -271,4 +271,25 @@ FactoryBot.define do
       state { "rejected" }
     end
   end
+
+  factory :initiatives_settings, class: "Decidim::InitiativesSettings" do
+    initiatives_order { "random" }
+    organization
+
+    trait :most_recent do
+      initiatives_order { "date" }
+    end
+
+    trait :most_signed do
+      initiatives_order { "signatures" }
+    end
+
+    trait :most_commented do
+      initiatives_order { "comments" }
+    end
+
+    trait :most_recently_published do
+      initiatives_order { "publication_date" }
+    end
+  end
 end

--- a/decidim-initiatives/spec/commands/decidim/initiatives/admin/update_initiatives_settings_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/admin/update_initiatives_settings_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    module Admin
+      describe UpdateInitiativesSettings do
+        subject { described_class.new(initiatives_settings, form) }
+
+        let(:organization) { create :organization }
+        let(:user) { create :user, :admin, :confirmed, organization: organization }
+        let(:initiatives_settings) { create :initiatives_settings, organization: organization }
+        let(:initiatives_order) { "date" }
+        let(:form) do
+          double(
+            invalid?: invalid,
+            current_user: user,
+            initiatives_order: initiatives_order
+          )
+        end
+        let(:invalid) { false }
+
+        context "when the form is not valid" do
+          let(:invalid) { true }
+
+          it "is not valid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when the form is valid" do
+          it "broadcasts ok" do
+            expect { subject.call }.to broadcast(:ok)
+          end
+
+          it "updates the initiatives settings" do
+            subject.call
+            expect(initiatives_settings.initiatives_order).to eq(initiatives_order)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_settings_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_settings_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    module Admin
+      describe InitiativesSettingsController, type: :controller do
+        routes { Decidim::Initiatives::AdminEngine.routes }
+
+        let(:organization) { create(:organization) }
+        let(:current_user) { create(:user, :confirmed, :admin, organization: organization) }
+        let!(:initiatives_settings) { create(:initiatives_settings, organization: organization) }
+
+        before do
+          request.env["decidim.current_organization"] = organization
+          sign_in current_user
+        end
+
+        describe "PATCH update" do
+          let(:initiatives_settings_params) do
+            {
+              initiatives_order: initiatives_settings.initiatives_order
+            }
+          end
+
+          it "updates the initiatives settings" do
+            patch :update, params: { id: initiatives_settings.id, initiatives_settings: initiatives_settings_params }
+
+            expect(response).to redirect_to edit_initiatives_setting_path
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
@@ -20,6 +20,18 @@ describe Decidim::Initiatives::InitiativesController, type: :controller do
       expect(subject.helpers.initiatives).not_to include(created_initiative)
     end
 
+    context "when no order is given" do
+      let(:voted_initiative) { create(:initiative, organization: organization) }
+      let!(:vote) { create(:initiative_user_vote, initiative: voted_initiative) }
+      let!(:initiatives_settings) { create(:initiatives_settings, :most_signed) }
+
+      it "return in the default order" do
+        get :index, params: { order: "most_voted" }
+
+        expect(subject.helpers.initiatives.first).to eq(voted_initiative)
+      end
+    end
+
     context "when order by most_voted" do
       let(:voted_initiative) { create(:initiative, organization: organization) }
       let!(:vote) { create(:initiative_user_vote, initiative: voted_initiative) }

--- a/decidim-initiatives/spec/forms/admin/initiatives_settings_form_spec.rb
+++ b/decidim-initiatives/spec/forms/admin/initiatives_settings_form_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    module Admin
+      describe InitiativesSettingsForm do
+        subject { described_class.from_params(attributes).with_context(current_organization: organization) }
+
+        let(:organization) { create :organization }
+        let(:initiatives_order) { "date" }
+
+        let(:attributes) do
+          {
+            "initiatives_order" => initiatives_order
+          }
+        end
+
+        context "when everything is OK" do
+          it { is_expected.to be_valid }
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/models/decidim/initiatives_settings_spec.rb
+++ b/decidim-initiatives/spec/models/decidim/initiatives_settings_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe InitiativesSettings do
+    subject(:initiatives_settings) { create(:initiatives_settings) }
+
+    it { is_expected.to be_valid }
+
+    it "overwrites the log presenter" do
+      expect(described_class.log_presenter_class_for(:foo))
+        .to eq Decidim::Initiatives::AdminLog::InitiativesSettingsPresenter
+    end
+
+    context "without organization" do
+      before do
+        initiatives_settings.organization = nil
+      end
+
+      it { is_expected.to be_invalid }
+    end
+  end
+end

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/admin/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/admin/permissions_spec.rb
@@ -10,6 +10,7 @@ describe Decidim::Initiatives::Admin::Permissions do
   let(:initiative) { create :initiative, organization: organization }
   let(:context) { { initiative: initiative } }
   let(:permission_action) { Decidim::PermissionAction.new(**action) }
+  let(:initiatives_settings) { create :initiatives_settings, organization: organization }
   let(:action) do
     { scope: :admin, action: action_name, subject: action_subject }
   end
@@ -238,6 +239,13 @@ describe Decidim::Initiatives::Admin::Permissions do
         it { is_expected.to be true }
       end
 
+      context "when reading a initiatives settings" do
+        let(:action_subject) { :initiatives_settings }
+        let(:action_name) { :update }
+
+        it { is_expected.to be false }
+      end
+
       context "when any other action" do
         let(:action_name) { :foo }
 
@@ -461,6 +469,13 @@ describe Decidim::Initiatives::Admin::Permissions do
           it { is_expected.to be false }
         end
       end
+    end
+
+    context "when reading a initiatives settings" do
+      let(:action_subject) { :initiatives_settings }
+      let(:action_name) { :update }
+
+      it { is_expected.to be true }
     end
   end
 

--- a/decidim-initiatives/spec/presenters/decidim/initiatives/admin_log/initiatives_settings_presenter_spec.rb
+++ b/decidim-initiatives/spec/presenters/decidim/initiatives/admin_log/initiatives_settings_presenter_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    module AdminLog
+      describe InitiativesSettingsPresenter, type: :helper do
+        subject { described_class.new(action_log, helper) }
+
+        let(:action_log) do
+          create(
+            :action_log,
+            action: action
+          )
+        end
+        let(:action) { :update }
+
+        before do
+          helper.extend(Decidim::ApplicationHelper)
+          helper.extend(Decidim::TranslationsHelper)
+        end
+
+        describe "#present" do
+          context "when the setting is updated" do
+            it "shows the settings has been updated" do
+              expect(subject.present).to include("updated the initiatives settings")
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
add a way to define defaut order of initiatives

#### :pushpin: Related Issues
related to [this meta proposal](https://meta.decidim.org/processes/roadmap/f/122/proposals/16983)

#### Testing
- go to the initiatives administration
- click on settings
- change the default order
- go to initiatives
- see the default order has changed

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
