### PR TITLE
Fix proposals creation with Participatory Texts 

### DIFF
--- a/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
@@ -120,7 +120,10 @@ module Decidim
 
         # Proposals can only be created from the admin when the
         # corresponding setting is enabled.
+        # This setting is incompatible with participatory texts.
         def can_create_proposal_from_admin?
+          return disallow! if participatory_texts_are_enabled? && permission_action.subject == :proposal
+
           toggle_allow(admin_creation_is_enabled?) if permission_action.subject == :proposal
         end
 

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -198,7 +198,7 @@ en:
             automatic_hashtags: Hashtags added to all proposals
             comments_blocked: Comments blocked
             creation_enabled: Participants can create proposals
-            creation_enabled_readonly: You have enabled Participatory Texts, so you cannot create proposals manually. To create a new participatory text click in the Participatory Texts button.
+            creation_enabled_readonly: This setting is disabled when you activate the Participatory Texts functionality. To upload proposals as participatory text click on the Participatory Texts button and follow the instructions.
             default_sort_order: Default proposal sorting
             default_sort_order_help: Default it means that if the supports are enabled, the proposals will be shown sorted by random, and if the supports are blocked, then they will be sorted by the most supported.
             default_sort_order_options:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -198,6 +198,7 @@ en:
             automatic_hashtags: Hashtags added to all proposals
             comments_blocked: Comments blocked
             creation_enabled: Participants can create proposals
+            creation_enabled_readonly: You have enabled Participatory Texts, so you cannot create proposals manually. To create a new participatory text click in the Participatory Texts button.
             default_sort_order: Default proposal sorting
             default_sort_order_help: Default it means that if the supports are enabled, the proposals will be shown sorted by random, and if the supports are blocked, then they will be sorted by the most supported.
             default_sort_order_options:

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -66,7 +66,7 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :votes_blocked, type: :boolean
     settings.attribute :votes_hidden, type: :boolean, default: false
     settings.attribute :comments_blocked, type: :boolean, default: false
-    settings.attribute :creation_enabled, type: :boolean
+    settings.attribute :creation_enabled, type: :boolean, readonly: ->(context) { context[:component].settings[:participatory_texts_enabled] }
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
     settings.attribute :default_sort_order, type: :select, include_blank: true, choices: -> { POSSIBLE_SORT_ORDERS }
     settings.attribute :publish_answers_immediately, type: :boolean, default: true

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -68,9 +68,9 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :comments_blocked, type: :boolean, default: false
     settings.attribute :creation_enabled, type: :boolean, readonly: ->(context) { context[:component].settings[:participatory_texts_enabled] }
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
-    settings.attribute :default_sort_order, type: :select, include_blank: true, choices: -> { POSSIBLE_SORT_ORDERS }
     settings.attribute :publish_answers_immediately, type: :boolean, default: true
     settings.attribute :answers_with_costs, type: :boolean, default: false
+    settings.attribute :default_sort_order, type: :select, include_blank: true, choices: -> { POSSIBLE_SORT_ORDERS }
     settings.attribute :amendment_creation_enabled, type: :boolean, default: true
     settings.attribute :amendment_reaction_enabled, type: :boolean, default: true
     settings.attribute :amendment_promotion_enabled, type: :boolean, default: true

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -142,6 +142,18 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
         visit edit_component_path
       end
 
+      context "when it's enabled" do
+        before do
+          component.update(settings: { participatory_texts_enabled: true })
+          visit edit_component_path
+        end
+
+        it "does NOT allow creating new proposals with the proposal form" do
+          expect(page.find(".creation_enabled_container")[:class]).to include("readonly")
+          expect(page).to have_content("You have enabled Participatory Texts, so you cannot create proposals manually. To create a new participatory text click in the Participatory Texts button.")
+        end
+      end
+
       context "when there are no proposals for the component" do
         it "allows to check the setting" do
           expect(participatory_texts_enabled_container[:class]).not_to include("readonly")

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -150,7 +150,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
 
         it "does NOT allow creating new proposals with the proposal form" do
           expect(page.find(".creation_enabled_container")[:class]).to include("readonly")
-          expect(page).to have_content("You have enabled Participatory Texts, so you cannot create proposals manually. To create a new participatory text click in the Participatory Texts button.")
+          expect(page).to have_content("This setting is disabled when you activate the Participatory Texts functionality. To upload proposals as participatory text click on the Participatory Texts button and follow the instructions.")
         end
       end
 

--- a/decidim-proposals/spec/permissions/decidim/proposals/admin/permissions_spec.rb
+++ b/decidim-proposals/spec/permissions/decidim/proposals/admin/permissions_spec.rb
@@ -34,7 +34,7 @@ describe Decidim::Proposals::Admin::Permissions do
   let(:creation_enabled?) { true }
   let(:official_proposals_enabled?) { true }
   let(:component_settings_proposal_answering_enabled?) { true }
-  let(:component_settings_participatory_texts_enabled?) { true }
+  let(:component_settings_participatory_texts_enabled?) { false }
   let(:current_settings_proposal_answering_enabled?) { true }
   let(:current_settings_publish_answers_immediately?) { true }
   let(:permission_action) { Decidim::PermissionAction.new(**action) }
@@ -138,6 +138,12 @@ describe Decidim::Proposals::Admin::Permissions do
 
       it { is_expected.to be false }
     end
+
+    context "when participatory texts is enabled" do
+      let(:component_settings_participatory_texts_enabled?) { true }
+
+      it { is_expected.to be false }
+    end
   end
 
   describe "proposal edition" do
@@ -232,6 +238,7 @@ describe Decidim::Proposals::Admin::Permissions do
   end
 
   describe "manage participatory texts" do
+    let(:component_settings_participatory_texts_enabled?) { true }
     let(:action) do
       { scope: :admin, action: :manage, subject: :participatory_texts }
     end


### PR DESCRIPTION
#### :tophat: What? Why?

There's a problem when having "Participatory texts enabled" and "Participants can create proposals" enabled at the same time: an admin can create a new proposal through the form, even though the Participatory Texts feature is designed with the importer in mind. 
    
This PR fixes this in two ways:    
    
1. Changing the permission so we don't show the "New proposal" button when "Participatory texts enabled" is checked.    
2. When checking "Participatory texts enabled" we show the "Participants can create proposals" disabled with an error message explaining to the admin why is that.    
    
I've also reordered the settings as we had this (showing only relevant settings):    
    
* creation_enabled              - Creation    
* proposal_answering_enabled    - Answers    
* default_sort_order            - Order    
* publish_answers_immediately   - Answers    
* answers_with_costs            - Answers    
    
It makes more sense if all the Answers related settings are together:    
    
* creation_enabled              - Creation    
* proposal_answering_enabled    - Answers    
* publish_answers_immediately   - Answers    
* answers_with_costs            - Answers    
* default_sort_order            - Order    

#### :pushpin: Related Issues
 
- Fixes #8765

#### Testing

1. Create a new proposal component in a space
2. Enable the following settings: "Participatory texts enabled" and "Participants can create proposals"
3. Edit the proposals component configuration. See that the "Participants can create proposals" is disabled, read only and with a help text. 
4. Go to the proposals management page. See that you don't have the "New proposal button"

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/717367/171132296-beadde4e-da13-41a8-997c-f12116e9af24.png)

:hearts: Thank you!
