### PR TITLE
Fix agenda_item association with agenda

### DIFF
--- a/decidim-meetings/app/models/decidim/meetings/agenda_item.rb
+++ b/decidim-meetings/app/models/decidim/meetings/agenda_item.rb
@@ -11,7 +11,7 @@ module Decidim
 
       translatable_fields :title, :description
 
-      belongs_to :agenda, -> { order(:position) }, foreign_key: "decidim_agenda_id", class_name: "Decidim::Meetings::Agenda"
+      belongs_to :agenda, -> { joins(:agenda_items).order(:position) }, foreign_key: "decidim_agenda_id", class_name: "Decidim::Meetings::Agenda"
 
       has_many :agenda_item_children, foreign_key: "parent_id", class_name: "Decidim::Meetings::AgendaItem", inverse_of: :parent, dependent: :destroy
       belongs_to :parent, class_name: "Decidim::Meetings::AgendaItem", inverse_of: :agenda_item_children, optional: true

--- a/decidim-meetings/app/models/decidim/meetings/agenda_item.rb
+++ b/decidim-meetings/app/models/decidim/meetings/agenda_item.rb
@@ -11,7 +11,7 @@ module Decidim
 
       translatable_fields :title, :description
 
-      belongs_to :agenda, -> { joins(:agenda_items).order(:position) }, foreign_key: "decidim_agenda_id", class_name: "Decidim::Meetings::Agenda"
+      belongs_to :agenda, foreign_key: "decidim_agenda_id", class_name: "Decidim::Meetings::Agenda"
 
       has_many :agenda_item_children, foreign_key: "parent_id", class_name: "Decidim::Meetings::AgendaItem", inverse_of: :parent, dependent: :destroy
       belongs_to :parent, class_name: "Decidim::Meetings::AgendaItem", inverse_of: :agenda_item_children, optional: true

--- a/decidim-meetings/spec/models/decidim/meetings/agenda_item_spec.rb
+++ b/decidim-meetings/spec/models/decidim/meetings/agenda_item_spec.rb
@@ -30,6 +30,7 @@ module Decidim
 
       it "has an associated agenda" do
         expect(agenda_item.agenda).to be_a(Decidim::Meetings::Agenda)
+        expect(Decidim::Meetings::AgendaItem.last.agenda).to be_a(Decidim::Meetings::Agenda)
       end
 
       describe ".first_class" do


### PR DESCRIPTION

#### :tophat: What? Why?
In some circumstances like Decidim::Meetings::AgendaItem.last.agenda the
query fails because the association sets an order by position which is
in the agenda items table but the join with agendas table is not
specified

This error happens when the decidim:active_storage_migrations:migrate_inline_images_to_active_storage task is executed and there are existing agenda items (the description can contain inline images)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing

I have added a test

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
