### PR TITLE
Short URLs to fix long export calendar URLs

### DIFF
--- a/decidim-core/app/controllers/decidim/short_links_controller.rb
+++ b/decidim-core/app/controllers/decidim/short_links_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Redirects users with short links to the correct location on the site.
+  class ShortLinksController < Decidim::ApplicationController
+    skip_before_action :store_current_location
+
+    # The index action redirects the user to the application root in case
+    # someone tries to request the short link URL without an identifier.
+    def index
+      redirect_to decidim.root_path, status: :moved_permanently
+    end
+
+    # Redirects the user to the target URL that the short link is set to
+    # redirect to. Raises an ActionController::RoutingError in case a short link
+    # does not exist with the given identifier.
+    #
+    # @raise [ActionController::RoutingError] if a short link does not exist
+    #   with the given identifier
+    def show
+      raise ActionController::RoutingError, "Not Found" unless link
+
+      redirect_to link.target_url, status: :moved_permanently
+    end
+
+    private
+
+    # Fetches the link based on the provided identifier in the parameters.
+    #
+    # @return [Decidim::ShortLink] The short link matching the identifier
+    def link
+      @link ||= Decidim::ShortLink.find_by(identifier: params[:id])
+    end
+  end
+end

--- a/decidim-core/app/helpers/decidim/short_link_helper.rb
+++ b/decidim-core/app/helpers/decidim/short_link_helper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This helper includes some methods to help with generating short links within
+  # the Decidim engine views.
+  module ShortLinkHelper
+    # A helper method to get a short URL in the current context where this
+    # method is called from. This helper automatically fetches the "target" for
+    # the short link, suck as the component or the participatory process. This
+    # also resolves the current mounted route name to make it possible to refer
+    # to the same context when redirecting the short URL to correct full URL.
+    #
+    # @option kwargs [Boolean] :route_name the route name to which the short
+    #   link should link to
+    # @option kwargs [Float] :params the URL query parameters that should be
+    #   included in the URL where the short link redirects to
+    # @return [Decidim::ShortLink] The short link instance to link to.
+    def short_url(**kwargs)
+      target = respond_to?(:current_component) && current_component
+      target ||= respond_to?(:current_participatory_space) && current_participatory_space
+      target ||= respond_to?(:current_organization) && current_organization
+      target ||= Rails.application
+
+      mounted_engine = EngineResolver.new(_routes).mounted_name
+      ShortLink.to(target, mounted_engine, **kwargs).short_url
+    end
+  end
+end

--- a/decidim-core/app/helpers/decidim/short_link_helper.rb
+++ b/decidim-core/app/helpers/decidim/short_link_helper.rb
@@ -6,7 +6,7 @@ module Decidim
   module ShortLinkHelper
     # A helper method to get a short URL in the current context where this
     # method is called from. This helper automatically fetches the "target" for
-    # the short link, suck as the component or the participatory process. This
+    # the short link, such as the component or the participatory process. This
     # also resolves the current mounted route name to make it possible to refer
     # to the same context when redirecting the short URL to correct full URL.
     #
@@ -14,7 +14,7 @@ module Decidim
     #   link should link to
     # @option kwargs [Float] :params the URL query parameters that should be
     #   included in the URL where the short link redirects to
-    # @return [Decidim::ShortLink] The short link instance to link to.
+    # @return [String] The short URL
     def short_url(**kwargs)
       target = respond_to?(:current_component) && current_component
       target ||= respond_to?(:current_participatory_space) && current_participatory_space

--- a/decidim-core/app/models/decidim/short_link.rb
+++ b/decidim-core/app/models/decidim/short_link.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Short links are a way to reference specific locations within Decidim with
+  # shorted URLs, similar to the popular link shortening services. The original
+  # reason for creating the feature was to reference long calendar URLs in a
+  # more compact way for the URLs to be compatible with the calendar programs.
+  # When the URL is long with lots of filtering parameters included in it, it
+  # may be too long for specific 3rd party programs.
+  #
+  # This feature can be used to link to any URLs or resources in Decidim with a
+  # short reference.
+  class ShortLink < ApplicationRecord
+    belongs_to :organization, foreign_key: "decidim_organization_id", class_name: "Decidim::Organization"
+    belongs_to :target, polymorphic: true
+
+    validates :identifier, presence: true, uniqueness: true
+
+    before_validation :generate_identifier
+
+    # Finds a matching short link to the same target with exactly the same
+    # parameters if it already exists or creates a new one if it doesn't exist.
+    #
+    # @param target [ActiveRecord::Base] The target where this short link should
+    #   link to. Most of the times [Decidim::Organization], [Decidim::Component]
+    #   or some other top-level record.
+    # @param mounted_engine [String] The mounted engine helper name that will be
+    #   used to generate the link.
+    # @param route_name [String, nil] The route name to be linked to. If not
+    #   defined, the short link will be generated for the root URL for the
+    #   mounted engine.
+    # @param params [Hash] The query parameters that should be included in the
+    #   URL where this short link will redirect to.
+    # @return [Decidim::ShortLink] The short link instance to link to.
+    def self.to(target, mounted_engine, route_name: nil, params: {})
+      organization =
+        if target.is_a?(Decidim::Organization)
+          target
+        else
+          target.try(:organization)
+        end
+
+      values = {
+        organization: organization,
+        target: target,
+        mounted_engine_name: mounted_engine,
+        route_name: route_name
+      }
+      existing =
+        if params
+          where(values).find_by("params = ?::jsonb", params.to_json)
+        else
+          find_by(values.merge(params: nil))
+        end
+
+      existing || create!(values.merge(params: params))
+    end
+
+    # Creates a random unique identifier for any new links. Raises an
+    # OutOfCandidatesError if a free candidate cannot be found with 20 tries.
+    # In this situation the older records should be removed from the database.
+    #
+    # @return [String] A new unique identifier.
+    def self.unique_identifier_within(organization)
+      1.step do |n|
+        raise OutOfCandidatesError if n > 20
+
+        # A-Z, a-z and 0-9
+        # 26 + 26 + 10 = 62 possibilities per character
+        # 62^10 ≈ 8×10¹⁷ total possibilities
+        candidate = SecureRandom.alphanumeric(10)
+        next if where(organization: organization, identifier: candidate).any?
+
+        return candidate
+      end
+    end
+
+    # Overrides the route_name method to add a default route name for the "root"
+    # path in case the route name is not defined for the record.
+    #
+    # @return [String] The route name to link to.
+    def route_name
+      super || "root"
+    end
+
+    # Generates the short URL referencing this link.
+    #
+    # @return [String] The short URL that can be used to link to the target.
+    def short_url
+      EngineRouter.new("decidim", default_url_options).short_link_url(id: identifier)
+    end
+
+    # Generates the full long URL to the resource matching this short link.
+    #
+    # @return [String] The target full URL that the short link should link to.
+    def target_url
+      url_helpers.send("#{route_name}_url", **params)
+    end
+
+    private
+
+    # Generates a new identifier for new records.
+    #
+    # @return [void]
+    def generate_identifier
+      return if identifier.present?
+
+      self.identifier = self.class.unique_identifier_within(organization)
+    end
+
+    # Returns the default URL options for the organization. The participatory
+    # space and component related parameters are excluded from the
+    # default_url_options because these are also needed for the short URL
+    # generation.
+    #
+    # @return [Hash] A hash of the default URL options for the links.
+    def default_url_options
+      { host: organization&.host }.compact
+    end
+
+    # Returns the options for the URL helper call against the routes proxy.
+    # The options include the mounted params for the target, such as
+    # participatory space slug and component ID, depending what the target is.
+    #
+    # @return [Hash] The mounted options for the target record that will be used
+    #   to generate the final link.
+    def mounted_options
+      if target.respond_to?(:mounted_params)
+        target.mounted_params
+      elsif target.respond_to?(:component)
+        target.component.mounted_params.merge(id: target.id)
+      elsif target.respond_to?(:participatory_space)
+        target.participatory_space.mounted_params
+      else
+        default_url_options
+      end
+    end
+
+    # Returns the routes helpers for the target engine.
+    #
+    # @return [Decidim::EngineRouter] An instance of the engine router that will
+    #   be used to generate the links to the correct context.
+    def url_helpers
+      @url_helpers ||= EngineRouter.new(mounted_engine_name, mounted_options)
+    end
+
+    # The OutOfCandidatesError is an error class that will be raised when the
+    # short link identifiers are running out and the short link cannot be
+    # generated.
+    class OutOfCandidatesError < StandardError; end
+  end
+end

--- a/decidim-core/app/models/decidim/short_link.rb
+++ b/decidim-core/app/models/decidim/short_link.rb
@@ -125,12 +125,22 @@ module Decidim
     # @return [Hash] The mounted options for the target record that will be used
     #   to generate the final link.
     def mounted_options
-      if target.respond_to?(:mounted_params)
+      if target.is_a?(Decidim::Participable)
+        # The mounted_params method returns always e.g. participatory_space_slug
+        # assembly_slug, etc. But when we want to link to the space itself, we
+        # only need the `slug` parameter.
+        { host: target.organization.host, slug: target.slug }
+      elsif target.respond_to?(:mounted_params)
         target.mounted_params
       elsif target.respond_to?(:component)
         target.component.mounted_params.merge(id: target.id)
       elsif target.respond_to?(:participatory_space)
         target.participatory_space.mounted_params
+      elsif target.respond_to?(:slug)
+        # E.g. Decidim::StaticPage uses the slug as the `:id` parameter.
+        default_url_options.merge(id: target.slug)
+      elsif !target.is_a?(Decidim::Organization)
+        default_url_options.merge(id: target.id)
       else
         default_url_options
       end

--- a/decidim-core/app/services/decidim/engine_resolver.rb
+++ b/decidim-core/app/services/decidim/engine_resolver.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This class can be used to resolve the mounted route based on the current
+  # routes in any provided context.
+  class EngineResolver
+    # Initializes the engine resolver instance.
+    #
+    # @param current_routes [ActionDispatch::Routing::RouteSet] the route set
+    #  for the context
+    def initialize(current_routes)
+      @current_routes = current_routes
+    end
+
+    # Resolves the mounted route name for the provided context.
+    #
+    # @return [String] The resolved route name or "decidim" if it could not be
+    #   resolved
+    def mounted_name
+      return "main_app" if base_engine.routes == current_routes
+
+      route = find_mounted_route(base_engine)
+      route&.name || "decidim"
+    end
+
+    private
+
+    attr_reader :current_routes
+
+    # Provides the base engine from which the search is started from.
+    #
+    # @return [Rails::Engine] The engine to start the search from
+    def base_engine
+      Rails.application
+    end
+
+    # Finds the mounted route for current context based on the current routes.
+    #
+    # @param target_engine [Rails::Engine] The engine from which the search is
+    #   performed.
+    # @return [ActionDispatch::Journey::Route] The defined route that matches
+    #   the current context based on the current routes provided for the
+    #   initializer.
+    def find_mounted_route(target_engine)
+      target_engine.routes.set.each do |route|
+        # If the route is a dispatcher
+        # (ActionDispatch::Routing::RouteSet::Dispatcher), it won't have an
+        # engine app mapped to it in which case the app won't respond to the
+        # `routes` method.
+        next if route.dispatcher?
+        next unless route.app.app.is_a?(Class)
+        next unless route.app.app < Rails::Engine
+
+        # route.app -> ActionDispatch::Routing::Mapper::Constraints
+        # route.app.app -> the target engine
+        return route if route.app.app.routes == current_routes
+
+        # Test the sub-engines if any engines are mounted to this engine.
+        sub = find_mounted_route(route.app.app)
+        return sub if sub
+      end
+
+      nil
+    end
+  end
+end

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -177,6 +177,8 @@ Decidim::Core::Engine.routes.draw do
 
   resources :last_activities, only: [:index]
 
+  resources :short_links, only: [:index, :show], path: "s"
+
   use_doorkeeper do
     skip_controllers :applications, :authorized_applications
   end

--- a/decidim-core/db/migrate/20220524195530_create_decidim_short_links.rb
+++ b/decidim-core/db/migrate/20220524195530_create_decidim_short_links.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreateDecidimShortLinks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :decidim_short_links do |t|
+      t.references :decidim_organization, null: false, index: true
+      t.references :target, polymorphic: true, null: false, index: true
+      t.string :identifier, limit: 10, null: false
+      t.string :mounted_engine_name, index: true
+      t.string :route_name, index: true
+      t.jsonb :params
+
+      t.timestamps
+    end
+
+    add_index(
+      :decidim_short_links,
+      [:decidim_organization_id, :identifier],
+      unique: true,
+      name: "idx_decidim_short_links_organization_id_identifier"
+    )
+  end
+end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -770,4 +770,22 @@ FactoryBot.define do
   factory :reminder_delivery, class: "Decidim::ReminderDelivery" do
     reminder { create(:reminder) }
   end
+
+  factory :short_link, class: "Decidim::ShortLink" do
+    target { create(:component, manifest_name: "dummy") }
+    route_name { nil }
+    params { {} }
+
+    before(:create) do |object|
+      object.organization ||= object.target if object.target.is_a?(Decidim::Organization)
+      object.organization ||= object.target.try(:organization) || create(:organization)
+      object.identifier ||= Decidim::ShortLink.unique_identifier_within(object.organization)
+      object.mounted_engine_name ||=
+        if object.target.respond_to?(:participatory_space)
+          "decidim_#{object.target.participatory_space.underscored_name}_dummy"
+        else
+          "decidim"
+        end
+    end
+  end
 end

--- a/decidim-core/spec/controllers/short_links_controller_spec.rb
+++ b/decidim-core/spec/controllers/short_links_controller_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ShortLinksController, type: :controller do
+    routes { Decidim::Core::Engine.routes }
+
+    let(:organization) { create(:organization) }
+    let(:component) { create(:component, organization: organization) }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+    end
+
+    describe "GET /s" do
+      it "returns to the organization root path" do
+        get :index
+
+        expect(response).to redirect_to("/")
+      end
+    end
+
+    describe "GET /s/:id" do
+      let(:short_link) { create(:short_link, target: component) }
+
+      let(:params) { { id: short_link.identifier } }
+
+      it "redirects to the full URL of the short link" do
+        get :show, params: params
+
+        expect(response).to redirect_to(short_link.target_url)
+      end
+
+      context "when the link does not exist with the given identifier" do
+        let(:params) { { id: "thI5Do3SNotEx1st" } }
+
+        it "returns a 404" do
+          expect { get :show, params: params }.to raise_error(ActionController::RoutingError)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/helpers/decidim/short_link_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/short_link_helper_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ShortLinkHelper do
+    describe "#short_url" do
+      subject { helper.short_url(**kwargs) }
+
+      let(:kwargs) { { route_name: route_name, params: params }.compact }
+      let(:route_name) { nil }
+      let(:params) { nil }
+      let(:target) { create(:dummy_resource) }
+      let(:organization) { target.organization }
+
+      let(:current_routes) { mounted_helpers.public_send(mounted_engine_name).routes }
+      let(:mounted_helpers) do
+        Class.new { include Rails.application.routes.mounted_helpers }.new
+      end
+      let(:mounted_engine_name) { :decidim }
+
+      before do
+        allow(helper).to receive(:_routes).and_return(current_routes)
+      end
+
+      shared_examples "working short link" do |target_route_name|
+        let(:organization_url) { "http://#{organization.host}" }
+        let(:expected_url_pattern) { %r{^#{organization_url}/s/[a-zA-Z0-9]{10}$} }
+        let(:short_link) { Decidim::ShortLink.order(:id).last }
+
+        before do
+          expect { subject }.to change(Decidim::ShortLink, :count).by(1)
+        end
+
+        it "returns the short URL to a resource" do
+          expect(subject).to match(expected_url_pattern)
+        end
+
+        it "maps the correct attributes to the short link" do
+          expect(short_link.target).to eq(expected_target)
+          expect(short_link.organization).to eq(organization)
+          expect(short_link.mounted_engine_name).to eq(mounted_engine_name.to_s)
+          expect(short_link.route_name).to eq("root")
+          expect(short_link.params).to eq({})
+        end
+
+        context "and a route name" do
+          let(:route_name) { target_route_name }
+
+          it "maps the correct route name attribute to the short link" do
+            expect(short_link.route_name).to eq(target_route_name.to_s)
+          end
+
+          it "generates the correct target URL" do
+            expect(short_link.target_url).to eq(expected_resource_url)
+          end
+        end
+
+        context "and parameters" do
+          let(:params) { { foo: "bar", baz: "biz" } }
+
+          it "maps the correct params attribute to the short link" do
+            expect(short_link.params).to eq("baz" => "biz", "foo" => "bar")
+          end
+        end
+      end
+
+      context "with a component" do
+        let(:mounted_engine_name) { :decidim_participatory_process_dummy }
+        let(:expected_target) { target.component }
+
+        before do
+          allow(helper).to receive(:current_component).and_return(target.component)
+        end
+
+        it_behaves_like "working short link", :dummy_resources do
+          let(:expected_resource_url) { "#{organization_url}/processes/#{target.participatory_space.slug}/f/#{target.component.id}/dummy_resources" }
+        end
+      end
+
+      context "with a participatory space" do
+        let(:mounted_engine_name) { :decidim_participatory_processes }
+        let(:expected_target) { target.participatory_space }
+
+        before do
+          allow(helper).to receive(:current_participatory_space).and_return(target.participatory_space)
+        end
+
+        it_behaves_like "working short link", :participatory_process do
+          let(:expected_resource_url) { "#{organization_url}/processes/#{target.participatory_space.slug}" }
+        end
+      end
+
+      context "with an organization" do
+        let(:organization) { create(:organization) }
+        let(:target) { organization }
+        let(:expected_target) { organization }
+
+        before do
+          allow(helper).to receive(:current_organization).and_return(target)
+        end
+
+        it_behaves_like "working short link", :pages do
+          let(:expected_resource_url) { "#{organization_url}/pages" }
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/models/decidim/short_link_spec.rb
+++ b/decidim-core/spec/models/decidim/short_link_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ShortLink do
+    subject { short_link }
+
+    let(:short_link) do
+      create(
+        :short_link,
+        target: target,
+        mounted_engine_name: engine_name,
+        route_name: route_name,
+        params: params
+      )
+    end
+    let(:target) { create(:dummy_resource) }
+    let(:engine_name) { "decidim_participatory_process_dummy" }
+    let(:route_name) { "dummy_resource" }
+    let(:params) { {} }
+
+    describe ".to" do
+      subject { described_class.to(target, engine_name, route_name: route_name, params: params) }
+
+      it "creates a unique short link within the target organization" do
+        expect(subject).to be_a(described_class)
+        expect(subject.organization).to be(target.organization)
+        expect(subject.target).to be(target)
+        expect(subject.mounted_engine_name).to eq(engine_name)
+        expect(subject.route_name).to eq(route_name)
+        expect(subject.params).to eq(params)
+      end
+
+      context "with link existing for the same parameters" do
+        let(:params) { { foo: "bar" } }
+
+        # Make sure the link exists
+        before { short_link }
+
+        it "returns the existing link" do
+          expect(subject).to eq(short_link)
+        end
+      end
+    end
+
+    describe ".unique_identifier_within" do
+      subject { described_class.unique_identifier_within(organization) }
+
+      let(:organization) { create(:organization) }
+
+      it "returns a 10 character long alphanumeric string" do
+        expect(subject).to match(/[a-zA-Z0-9]{10}/)
+      end
+
+      context "when the first two identifiers are taken" do
+        let(:taken_identifier_1) { "abcDEF1234" }
+        let(:taken_identifier_2) { "GHIjkl5678" }
+        let!(:existing_link_1) { create(:short_link, target: organization, identifier: taken_identifier_1) }
+        let!(:existing_link_2) { create(:short_link, target: organization, identifier: taken_identifier_2) }
+
+        it "generates an available identifier" do
+          expect(SecureRandom).to receive(:alphanumeric).with(10).once.ordered.and_return(taken_identifier_1)
+          expect(SecureRandom).to receive(:alphanumeric).with(10).once.ordered.and_return(taken_identifier_2)
+          expect(SecureRandom).to receive(:alphanumeric).with(10).once.ordered.and_call_original
+
+          expect(subject).to match(/[a-zA-Z0-9]{10}/)
+          expect(subject).not_to eq(taken_identifier_1)
+          expect(subject).not_to eq(taken_identifier_2)
+        end
+
+        context "and the link is created for another organization" do
+          subject { described_class.unique_identifier_within(another_organization) }
+
+          let(:another_organization) { create(:organization) }
+
+          it "returns the identifier already in use in the other organization" do
+            expect(SecureRandom).to receive(:alphanumeric).with(10).once.and_return(taken_identifier_1)
+
+            expect(subject).to eq(taken_identifier_1)
+          end
+        end
+      end
+    end
+
+    describe "#route_name" do
+      it "returns the defined route name" do
+        expect(subject.route_name).to eq(route_name)
+      end
+
+      context "when the route name is not defined" do
+        let(:route_name) { nil }
+
+        it "returns the root route name" do
+          expect(subject.route_name).to eq("root")
+        end
+      end
+    end
+
+    describe "#short_url" do
+      it "returns the short URL" do
+        expect(subject.short_url).to eq("http://#{target.organization.host}/s/#{subject.identifier}")
+      end
+    end
+
+    describe "#target_url" do
+      let(:resource_url) do
+        Decidim::ResourceLocatorPresenter.new(target).url
+      end
+
+      it "returns the target URL" do
+        expect(subject.target_url).to eq(resource_url)
+      end
+
+      context "with extra parameters" do
+        let(:params) { { foo: "bar", baz: "biz" } }
+
+        it "returns the target URL with the parameters" do
+          expect(subject.target_url).to eq("#{resource_url}?baz=biz&foo=bar")
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/models/decidim/short_link_spec.rb
+++ b/decidim-core/spec/models/decidim/short_link_spec.rb
@@ -119,6 +119,36 @@ module Decidim
           expect(subject.target_url).to eq("#{resource_url}?baz=biz&foo=bar")
         end
       end
+
+      context "when the target is a participatory space" do
+        let(:target) { create(:participatory_process) }
+        let(:engine_name) { "decidim_participatory_processes" }
+        let(:route_name) { "participatory_process" }
+
+        it "returns the target URL" do
+          expect(subject.target_url).to eq("http://#{target.organization.host}/processes/#{target.slug}")
+        end
+      end
+
+      context "when the target is an organization" do
+        let(:target) { create(:organization) }
+        let(:engine_name) { "decidim" }
+        let(:route_name) { "pages" }
+
+        it "returns the target URL" do
+          expect(subject.target_url).to eq("http://#{target.host}/pages")
+        end
+      end
+
+      context "when the target is a static page" do
+        let(:target) { create(:static_page) }
+        let(:engine_name) { "decidim" }
+        let(:route_name) { "page" }
+
+        it "returns the target URL" do
+          expect(subject.target_url).to eq("http://#{target.organization.host}/pages/#{target.slug}")
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/services/decidim/engine_resolver_spec.rb
+++ b/decidim-core/spec/services/decidim/engine_resolver_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::EngineResolver do
+  subject { resolver }
+
+  let(:resolver) { described_class.new(route_set) }
+  let(:mounted_helpers) do
+    Class.new { include Rails.application.routes.mounted_helpers }.new
+  end
+  let(:route_set) { mounted_helpers.public_send(mounted_engine_name).routes }
+  let(:mounted_engine_name) { :decidim }
+
+  describe "#mounted_name" do
+    subject { resolver.mounted_name }
+
+    it "resolves the correct name for the core module" do
+      expect(subject).to eq("decidim")
+    end
+
+    context "when in the main app" do
+      let(:route_set) { Rails.application.routes }
+
+      it "resolves the main_app name" do
+        expect(subject).to eq("main_app")
+      end
+    end
+
+    context "when in a participatory process" do
+      let(:mounted_engine_name) { :decidim_participatory_processes }
+
+      it "resolves the correct name for the space" do
+        expect(subject).to eq("decidim_participatory_processes")
+      end
+    end
+
+    context "when in a component" do
+      let(:mounted_engine_name) { :decidim_participatory_process_dummy }
+
+      it "resolves the correct name for the component" do
+        expect(subject).to eq("decidim_participatory_process_dummy")
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
@@ -15,6 +15,7 @@ module Decidim
         helper Decidim::FiltersHelper
         helper Decidim::Meetings::MapHelper
         helper Decidim::ResourceHelper
+        helper Decidim::ShortLinkHelper
 
         helper_method :meetings, :search
 

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -13,6 +13,7 @@ module Decidim
 
       helper Decidim::WidgetUrlsHelper
       helper Decidim::ResourceVersionsHelper
+      helper Decidim::ShortLinkHelper
 
       helper_method :meetings, :meeting, :registration, :search
 

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/_meetings.html.erb
@@ -8,7 +8,12 @@
       <%= render partial: "decidim/shared/results_per_page" %>
     </div>
     <div class="column">
-      <%= render partial: "decidim/meetings/calendar_modal", locals: { path: calendar_url(filter: params.fetch(:filter, {}).try(:to_unsafe_hash)) } %>
+      <%= render partial: "decidim/meetings/calendar_modal", locals: {
+        path: short_url(
+          route_name: "calendar",
+          params: { filter: params.fetch(:filter, {}).try(:to_unsafe_hash) }
+        )
+      } %>
     </div>
   </div>
 

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/index.js.erb
@@ -11,6 +11,8 @@ $meetingsCount.html('<%= j(render partial: "decidim/meetings/meetings/count").st
 var $dropdownMenu = $('.dropdown.menu', $meetings);
 $dropdownMenu.foundation();
 
+$("#calendarShare").foundation(); // initialize export calendar on the page
+
 var markerData = JSON.parse('<%= escape_javascript meetings_data_for_map(search.result).to_json.html_safe %>');
 
 var $map = $("#map");
@@ -19,5 +21,3 @@ if (controller) {
   controller.clearMarkers();
   controller.addMarkers(markerData);
 }
-
-$("#calendarShare").foundation(); // initialize export calendar on the page

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -21,7 +21,12 @@
     <%= render partial: "decidim/shared/results_per_page" %>
   </div>
   <div class="column">
-    <%= render partial: "decidim/meetings/calendar_modal", locals: { path: calendar_url(filter: params.fetch(:filter, {}).try(:to_unsafe_hash)) } %>
+    <%= render partial: "decidim/meetings/calendar_modal", locals: {
+      path: short_url(
+        route_name: "calendar",
+        params: { filter: params.fetch(:filter, {}).try(:to_unsafe_hash) }
+      )
+    } %>
   </div>
 </div>
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
@@ -13,11 +13,11 @@ $dropdownMenu.foundation();
 
 var markerData = JSON.parse('<%= escape_javascript meetings_data_for_map(search.result.select(&:geocoded_and_valid?)).to_json.html_safe %>');
 
+$("#calendarShare").foundation(); // initialize export calendar on the page
+
 var $map = $("#map");
 var controller = $map.data("map-controller");
 if (controller) {
   controller.clearMarkers();
   controller.addMarkers(markerData);
 }
-
-$("#calendarShare").foundation(); // initialize export calendar on the page

--- a/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
+++ b/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
@@ -18,6 +18,9 @@ describe "Explore meeting directory", type: :system do
   end
 
   before do
+    # Required for the link to be pointing to the correct URL with the server
+    # port since the server port is not defined for the test environment.
+    allow(ActionMailer::Base).to receive(:default_url_options).and_return(port: Capybara.server_port)
     switch_to_host(organization.host)
     visit directory
   end
@@ -159,6 +162,39 @@ describe "Explore meeting directory", type: :system do
         expect(page).to have_content(online_meeting1.title["en"])
         expect(page).to have_content(online_meeting2.title["en"])
         expect(page).to have_css("#meetings-count", text: "2 MEETINGS")
+      end
+
+      it "allows linking to the filtered view using a short link" do
+        within ".with_any_type_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Online"
+        end
+
+        expect(page).to have_content(online_meeting1.title["en"])
+        expect(page).to have_content(online_meeting2.title["en"])
+        expect(page).to have_css("#meetings-count", text: "2 MEETINGS")
+
+        filter_params = CGI.parse(URI.parse(page.current_url).query)
+        base_url = "http://#{organization.host}:#{Capybara.server_port}"
+
+        click_button "Export calendar"
+        expect(page).to have_content("Calendar URL:")
+        expect(page).to have_css("#calendarShare", visible: :visible)
+        short_url = nil
+        within "#calendarShare" do
+          input = find("input#urlCalendarUrl[readonly]")
+          short_url = input.value
+          expect(short_url).to match(%r{^#{base_url}/s/[a-zA-Z0-9]{10}$})
+        end
+
+        visit short_url
+        expect(page).to have_content(online_meeting1.title["en"])
+        expect(page).to have_content(online_meeting2.title["en"])
+        expect(page).to have_css("#meetings-count", text: "2 MEETINGS")
+        expect(page).to have_current_path(/^#{directory}/)
+
+        current_params = CGI.parse(URI.parse(page.current_url).query)
+        expect(current_params).to eq(filter_params)
       end
     end
 

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -12,6 +12,9 @@ describe "Explore meetings", :slow, type: :system do
   end
 
   before do
+    # Required for the link to be pointing to the correct URL with the server
+    # port since the server port is not defined for the test environment.
+    allow(ActionMailer::Base).to receive(:default_url_options).and_return(port: Capybara.server_port)
     component_scope = create :scope, parent: participatory_process.scope
     component_settings = component["settings"]["global"].merge!(scopes_enabled: true, scope_id: component_scope.id)
     component.update!(settings: component_settings)
@@ -195,6 +198,40 @@ describe "Explore meetings", :slow, type: :system do
         end
 
         expect(page).to have_css(".card--meeting", count: 5)
+      end
+
+      it "allows linking to the filtered view using a short link" do
+        past_meeting = create(:meeting, :published, component: component, start_time: 1.day.ago)
+        visit_component
+
+        within ".with_any_date_check_boxes_tree_filter" do
+          uncheck "All"
+          check "Past"
+        end
+
+        expect(page).to have_css(".card--meeting", count: 1)
+        expect(page).to have_content(translated(past_meeting.title))
+
+        filter_params = CGI.parse(URI.parse(page.current_url).query)
+        base_url = "http://#{organization.host}:#{Capybara.server_port}"
+
+        click_button "Export calendar"
+        expect(page).to have_content("Calendar URL:")
+        expect(page).to have_css("#calendarShare", visible: :visible)
+        short_url = nil
+        within "#calendarShare" do
+          input = find("input#urlCalendarUrl[readonly]")
+          short_url = input.value
+          expect(short_url).to match(%r{^#{base_url}/s/[a-zA-Z0-9]{10}$})
+        end
+
+        visit short_url
+        expect(page).to have_css(".card--meeting", count: 1)
+        expect(page).to have_content(translated(past_meeting.title))
+        expect(page).to have_current_path(/^#{main_component_path(component)}/)
+
+        current_params = CGI.parse(URI.parse(page.current_url).query)
+        expect(current_params).to eq(filter_params)
       end
 
       it "allows filtering by scope" do


### PR DESCRIPTION
#### :tophat: What? Why?
Some calendar programs do not accept long URLs and this causes the export calendar URLs not to work properly always.

See further details from: #9116

#### :pushpin: Related Issues
- Related to #9035
- Fixes #9116
- Supersedes #9115

#### Testing
Paste the short calendar URL to your calendar program and see if it works correctly.

Also see the related comments at #9115.

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
![Short URLs for meetings directory](https://user-images.githubusercontent.com/864340/171482568-cfa774a0-3a49-40e9-8273-71d5eb9ced76.png)