### PR TITLE
Harmonize permissions behavior when creating a meeting in private space

### DIFF
--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -72,6 +72,8 @@ module Decidim
       end
 
       def can_create_meetings?
+        return false if user.admin?
+
         component_settings&.creation_enabled_for_participants? && public_space_or_member?
       end
 

--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -72,7 +72,19 @@ module Decidim
       end
 
       def can_create_meetings?
-        component_settings&.creation_enabled_for_participants?
+        component_settings&.creation_enabled_for_participants? && public_space_or_member?
+      end
+
+      def public_space_or_member?
+        participatory_space = context[:current_component].participatory_space
+
+        participatory_space.private_space? ? space_member?(participatory_space, user) : true
+      end
+
+      def space_member?(participatory_space, user)
+        return false unless user
+
+        participatory_space.admins.exists?(user.id) || participatory_space.participatory_space_private_users.exists?(decidim_user_id: user.id)
       end
 
       def can_update_meeting?

--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -72,8 +72,6 @@ module Decidim
       end
 
       def can_create_meetings?
-        return false if user.admin?
-
         component_settings&.creation_enabled_for_participants? && public_space_or_member?
       end
 
@@ -83,10 +81,11 @@ module Decidim
         participatory_space.private_space? ? space_member?(participatory_space, user) : true
       end
 
+      # Neither platform admins, nor space admins should be able to create meetings from the public side.
       def space_member?(participatory_space, user)
         return false unless user
 
-        participatory_space.admins.exists?(user.id) || participatory_space.participatory_space_private_users.exists?(decidim_user_id: user.id)
+        participatory_space.participatory_space_private_users.exists?(decidim_user_id: user.id)
       end
 
       def can_update_meeting?

--- a/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
+++ b/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
@@ -222,6 +222,12 @@ describe Decidim::Meetings::Permissions do
         it { is_expected.to be false }
       end
 
+      context "when user is admin" do
+        let(:user) { admin_user }
+
+        it { is_expected.to be false }
+      end
+
       context "when user is a space admin" do
         before do
           create(:participatory_process_user_role, user: user, participatory_process: participatory_space)

--- a/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
+++ b/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
@@ -222,10 +222,20 @@ describe Decidim::Meetings::Permissions do
         it { is_expected.to be false }
       end
 
-      context "when user is admin" do
+      context "when user is admin and not a member" do
         let(:user) { admin_user }
 
         it { is_expected.to be false }
+      end
+
+      context "when user is admin but is a member" do
+        let(:user) { admin_user }
+
+        before do
+          create(:participatory_space_private_user, user: user, privatable_to: participatory_space)
+        end
+
+        it { is_expected.to be true }
       end
 
       context "when user is a space admin" do
@@ -233,7 +243,7 @@ describe Decidim::Meetings::Permissions do
           create(:participatory_process_user_role, user: user, participatory_process: participatory_space)
         end
 
-        it { is_expected.to be true }
+        it { is_expected.to be false }
       end
 
       context "when user is a space private participant" do

--- a/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
+++ b/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
@@ -5,8 +5,9 @@ require "spec_helper"
 describe Decidim::Meetings::Permissions do
   subject { described_class.new(user, permission_action, context).permissions.allowed? }
 
-  let(:user) { create :user, organization: meeting_component.organization }
-  let(:admin_user) { create :user, :admin, organization: meeting_component.organization }
+  let(:participatory_space) { create(:participatory_process, :with_steps) }
+  let(:user) { create :user, organization: participatory_space.organization }
+  let(:admin_user) { create :user, :admin, organization: participatory_space.organization }
   let(:context) do
     {
       current_component: meeting_component,
@@ -18,7 +19,7 @@ describe Decidim::Meetings::Permissions do
   let(:component_settings) do
     double(creation_enabled_for_participants?: true)
   end
-  let(:meeting_component) { create :meeting_component }
+  let(:meeting_component) { create :meeting_component, participatory_space: participatory_space }
   let(:meeting) { create :meeting, component: meeting_component }
   let(:permission_action) { Decidim::PermissionAction.new(**action) }
   let(:poll) { create :poll, meeting: meeting }
@@ -207,8 +208,35 @@ describe Decidim::Meetings::Permissions do
       { scope: :public, action: :create, subject: :meeting }
     end
 
-    context "when setting is enabled" do
+    context "when space is public and setting is enabled" do
       it { is_expected.to be true }
+    end
+
+    context "when space is private and setting is enabled" do
+      let(:participatory_space) { create(:participatory_process, :with_steps, private_space: true) }
+      let(:component_settings) do
+        double(creation_enabled_for_participants?: true)
+      end
+
+      context "when user is not a member" do
+        it { is_expected.to be false }
+      end
+
+      context "when user is a space admin" do
+        before do
+          create(:participatory_process_user_role, user: user, participatory_process: participatory_space)
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context "when user is a space private participant" do
+        before do
+          create(:participatory_space_private_user, user: user, privatable_to: participatory_space)
+        end
+
+        it { is_expected.to be true }
+      end
     end
 
     context "when setting is disabled" do


### PR DESCRIPTION
#### :tophat: What? Why?
When on a meetings component participants have the possibility to create meetings if enabled. When the space where the meetings component lives on is a private space the "New meeting" button always appear, for space members and for non space members.

This PR fixes this situation by adding the corresponding permissions:

- Non members of the private space won't be able to create meetings from the public side.
- This includes Platform admins and space admins. They are not allowed to create meetings neither.
- Only members of the private space will able to create meetings from the public side.
- On public spaces everybody is able to create Meetings from the public side.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
- Create a private & transparent participatory space
- Publish a meetings component and enable creation for participants
- Login as a user that is not member of the participatory space
- Visit the public meetings component
- The "New meeting" button should

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![image](https://user-images.githubusercontent.com/199462/171561619-011afd03-875e-4938-a04b-bd167928d5be.png)


:hearts: Thank you!
