### PR TITLE
Fix email subject when resource title has special characters

### DIFF
--- a/decidim-assemblies/spec/events/decidim/role_assigned_to_assembly_event_spec.rb
+++ b/decidim-assemblies/spec/events/decidim/role_assigned_to_assembly_event_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe Decidim::RoleAssignedToAssemblyEvent do
   include_context "when a simple event"
 
-  let(:resource) { create :assembly }
+  let(:resource) { create :assembly, title: { en: "It's my assembly" } }
   let(:event_name) { "decidim.events.assembly.role_assigned" }
   let(:role) { create :assembly_user_role, user: user, assembly: resource, role: :admin }
   let(:extra) { { role: role } }

--- a/decidim-conferences/spec/events/decidim/conferences/conference_role_assigned_event_spec.rb
+++ b/decidim-conferences/spec/events/decidim/conferences/conference_role_assigned_event_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe Decidim::Conferences::ConferenceRoleAssignedEvent do
   include_context "when a simple event"
 
-  let(:resource) { create :conference }
+  let(:resource) { create :conference, title: { en: "It's my conference" } }
   let(:event_name) { "decidim.events.conferences.role_assigned" }
   let(:role) { create :conference_user_role, user: user, conference: resource, role: :admin }
   let(:extra) { { role: role } }

--- a/decidim-core/lib/decidim/events/simple_event.rb
+++ b/decidim-core/lib/decidim/events/simple_event.rb
@@ -34,10 +34,10 @@ module Decidim
       end
 
       def email_subject
-        I18n.t("email_subject", **updated_options).html_safe
+        I18n.t("email_subject", **email_subject_i18n_options).html_safe
       end
 
-      def updated_options
+      def email_subject_i18n_options
         sanitized_values = { resource_title: decidim_sanitize(resource_title) }
         sanitized_values[:mentioned_proposal_title] = decidim_sanitize(mentioned_proposal_title) if i18n_options.has_key?(:mentioned_proposal_title)
         i18n_options.merge(sanitized_values)

--- a/decidim-core/lib/decidim/events/simple_event.rb
+++ b/decidim-core/lib/decidim/events/simple_event.rb
@@ -34,7 +34,13 @@ module Decidim
       end
 
       def email_subject
-        decidim_sanitize(I18n.t("email_subject", **i18n_options)).html_safe
+        I18n.t("email_subject", **updated_options).html_safe
+      end
+
+      def updated_options
+        sanitized_values = { resource_title: decidim_sanitize(resource_title) }
+        sanitized_values[:mentioned_proposal_title] = decidim_sanitize(mentioned_proposal_title) if i18n_options.has_key?(:mentioned_proposal_title)
+        i18n_options.merge(sanitized_values)
       end
 
       def email_intro

--- a/decidim-core/lib/decidim/events/simple_event.rb
+++ b/decidim-core/lib/decidim/events/simple_event.rb
@@ -34,7 +34,7 @@ module Decidim
       end
 
       def email_subject
-        I18n.t("email_subject", **i18n_options).html_safe
+        decidim_sanitize(I18n.t("email_subject", **i18n_options)).html_safe
       end
 
       def email_intro
@@ -72,7 +72,7 @@ module Decidim
       def i18n_options
         default_i18n_options.merge(event_interpolations).transform_values do |value|
           if value.is_a?(String)
-            decidim_sanitize(decidim_html_escape(value))
+            decidim_html_escape(value)
           else
             value
           end

--- a/decidim-core/lib/decidim/events/simple_event.rb
+++ b/decidim-core/lib/decidim/events/simple_event.rb
@@ -72,7 +72,7 @@ module Decidim
       def i18n_options
         default_i18n_options.merge(event_interpolations).transform_values do |value|
           if value.is_a?(String)
-            decidim_html_escape(value)
+            decidim_sanitize(decidim_html_escape(value))
           else
             value
           end

--- a/decidim-core/spec/lib/events/simple_event_spec.rb
+++ b/decidim-core/spec/lib/events/simple_event_spec.rb
@@ -20,7 +20,7 @@ module Decidim
 
       it "escapes the HTML tags from the i18n options" do
         expect(subject.i18n_options[:resource_title])
-          .to eq "&lt;script&gt;alert('Hey');&lt;/script&gt;"
+          .to eq "&lt;script&gt;alert(&#39;Hey&#39;);&lt;/script&gt;"
       end
     end
   end

--- a/decidim-core/spec/lib/events/simple_event_spec.rb
+++ b/decidim-core/spec/lib/events/simple_event_spec.rb
@@ -20,7 +20,7 @@ module Decidim
 
       it "escapes the HTML tags from the i18n options" do
         expect(subject.i18n_options[:resource_title])
-          .to eq "&lt;script&gt;alert(&#39;Hey&#39;);&lt;/script&gt;"
+          .to eq "&lt;script&gt;alert('Hey');&lt;/script&gt;"
       end
     end
   end

--- a/decidim-debates/spec/events/decidim/debates/create_debate_event_spec.rb
+++ b/decidim-debates/spec/events/decidim/debates/create_debate_event_spec.rb
@@ -7,12 +7,12 @@ describe Decidim::Debates::CreateDebateEvent do
 
   include_context "when a simple event"
 
-  let(:resource) { create :debate, :participant_author }
+  let(:resource) { create :debate, :participant_author, title: { en: "It's my debate" } }
   let(:space) { resource.participatory_space }
   let(:event_name) { "decidim.events.debates.debate_created" }
   let(:space_path) { resource_locator(space).path }
   let(:extra) { { type: type.to_s } }
-  let(:debate_title) { decidim_sanitize(decidim_html_escape(translated(resource.title))) }
+  let(:debate_title) { decidim_html_escape(translated(resource.title)) }
 
   describe "resource_text" do
     let(:type) { "" }
@@ -30,7 +30,7 @@ describe Decidim::Debates::CreateDebateEvent do
 
     describe "email_subject" do
       it "is generated correctly" do
-        expect(subject.email_subject).to eq("New debate \"#{debate_title}\" by @#{author.nickname}")
+        expect(subject.email_subject).to eq("New debate \"#{decidim_sanitize(debate_title)}\" by @#{author.nickname}")
       end
     end
 
@@ -67,7 +67,7 @@ describe Decidim::Debates::CreateDebateEvent do
 
     describe "email_subject" do
       it "is generated correctly" do
-        expect(subject.email_subject).to eq("New debate \"#{debate_title}\" on #{translated(space.title)}")
+        expect(subject.email_subject).to eq("New debate \"#{decidim_sanitize(debate_title)}\" on #{translated(space.title)}")
       end
     end
 

--- a/decidim-debates/spec/events/decidim/debates/create_debate_event_spec.rb
+++ b/decidim-debates/spec/events/decidim/debates/create_debate_event_spec.rb
@@ -12,7 +12,7 @@ describe Decidim::Debates::CreateDebateEvent do
   let(:event_name) { "decidim.events.debates.debate_created" }
   let(:space_path) { resource_locator(space).path }
   let(:extra) { { type: type.to_s } }
-  let(:debate_title) { decidim_html_escape(translated(resource.title)) }
+  let(:debate_title) { decidim_sanitize(decidim_html_escape(translated(resource.title))) }
 
   describe "resource_text" do
     let(:type) { "" }

--- a/decidim-meetings/spec/events/decidim/meetings/close_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/close_meeting_event_spec.rb
@@ -3,12 +3,19 @@
 require "spec_helper"
 
 describe Decidim::Meetings::CloseMeetingEvent do
-  let(:resource) { create :meeting }
+  let(:resource) { create :meeting, title: { en: "It's my overdue meeting" } }
+  let(:resource_title) { translated(resource.title) }
   let(:event_name) { "decidim.events.meetings.meeting_closed" }
 
   include_context "when a simple event"
   it_behaves_like "a simple event"
   it_behaves_like "a translated meeting event"
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("The \"#{resource_title}\" meeting was closed")
+    end
+  end
 
   describe "resource_text" do
     it "returns the meeting description" do

--- a/decidim-meetings/spec/events/decidim/meetings/meeting_registrations_enabled_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/meeting_registrations_enabled_event_spec.rb
@@ -3,12 +3,19 @@
 require "spec_helper"
 
 describe Decidim::Meetings::MeetingRegistrationsEnabledEvent do
-  let(:resource) { create :meeting }
+  let(:resource) { create :meeting, title: { en: "It's my meeting" } }
+  let(:resource_title) { translated(resource.title) }
   let(:event_name) { "decidim.events.meetings.registrations_enabled" }
 
   include_context "when a simple event"
   it_behaves_like "a simple event"
   it_behaves_like "a translated meeting event"
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("The \"#{resource_title}\" meeting has enabled registrations.")
+    end
+  end
 
   describe "resource_text" do
     it "returns the meeting description" do

--- a/decidim-meetings/spec/events/decidim/meetings/upcoming_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/upcoming_meeting_event_spec.rb
@@ -3,12 +3,19 @@
 require "spec_helper"
 
 describe Decidim::Meetings::UpcomingMeetingEvent do
-  let(:resource) { create :meeting }
+  let(:resource) { create :meeting, title: { en: "It's my meeting" } }
+  let(:resource_title) { translated(resource.title) }
   let(:event_name) { "decidim.events.meetings.upcoming_meeting" }
 
   include_context "when a simple event"
   it_behaves_like "a simple event"
   it_behaves_like "a translated meeting event"
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("The \"#{resource_title}\" meeting will start in less than 48h.")
+    end
+  end
 
   describe "resource_text" do
     it "returns the meeting description" do

--- a/decidim-meetings/spec/events/decidim/meetings/update_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/update_meeting_event_spec.rb
@@ -3,12 +3,19 @@
 require "spec_helper"
 
 describe Decidim::Meetings::UpdateMeetingEvent do
-  let(:resource) { create :meeting }
+  let(:resource) { create :meeting, title: { en: "It's my meeting" } }
+  let(:resource_title) { translated(resource.title) }
   let(:event_name) { "decidim.events.meetings.meeting_updated" }
 
   include_context "when a simple event"
   it_behaves_like "a simple event"
   it_behaves_like "a translated meeting event"
+
+  describe "email_subject" do
+    it "is generated correctly" do
+      expect(subject.email_subject).to eq("The \"#{resource_title}\" meeting was updated")
+    end
+  end
 
   describe "resource_text" do
     it "returns the meeting description" do

--- a/decidim-proposals/spec/events/decidim/proposals/admin/proposal_note_created_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/admin/proposal_note_created_event_spec.rb
@@ -14,6 +14,8 @@ describe Decidim::Proposals::Admin::ProposalNoteCreatedEvent do
   it_behaves_like "a simple event"
 
   describe "email_subject" do
+    let(:resource) { create :proposal, title: { en: "It's my proposal" } }
+
     it "is generated correctly" do
       expect(subject.email_subject).to eq("Someone left a note on proposal #{resource_title}.")
     end

--- a/decidim-proposals/spec/events/decidim/proposals/admin/update_proposal_category_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/admin/update_proposal_category_event_spec.rb
@@ -4,7 +4,6 @@ require "spec_helper"
 
 describe Decidim::Proposals::Admin::UpdateProposalCategoryEvent do
   let(:resource) { create :proposal, title: "It's my super proposal" }
-  let(:resource_title) { translated(resource.title) }
   let(:event_name) { "decidim.events.proposals.proposal_update_category" }
 
   include_context "when a simple event"
@@ -12,14 +11,14 @@ describe Decidim::Proposals::Admin::UpdateProposalCategoryEvent do
 
   describe "email_subject" do
     it "is generated correctly" do
-      expect(subject.email_subject).to eq("The #{resource_title} proposal category has been updated")
+      expect(subject.email_subject).to eq("The #{translated(resource.title)} proposal category has been updated")
     end
   end
 
   describe "email_intro" do
     it "is generated correctly" do
       expect(subject.email_intro)
-        .to eq("An admin has updated the category of your proposal \"#{resource_title}\", check it out in this page:")
+        .to eq("An admin has updated the category of your proposal \"#{decidim_html_escape(translated(resource.title))}\", check it out in this page:")
     end
   end
 
@@ -33,7 +32,7 @@ describe Decidim::Proposals::Admin::UpdateProposalCategoryEvent do
   describe "notification_title" do
     it "is generated correctly" do
       expect(subject.notification_title)
-        .to include("The <a href=\"#{resource_path}\">#{resource_title}</a> proposal category has been updated by an admin.")
+        .to include("The <a href=\"#{resource_path}\">#{decidim_html_escape(translated(resource.title))}</a> proposal category has been updated by an admin.")
     end
   end
 end

--- a/decidim-proposals/spec/events/decidim/proposals/admin/update_proposal_category_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/admin/update_proposal_category_event_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Decidim::Proposals::Admin::UpdateProposalCategoryEvent do
-  let(:resource) { create :proposal, title: "My super proposal" }
+  let(:resource) { create :proposal, title: "It's my super proposal" }
   let(:resource_title) { translated(resource.title) }
   let(:event_name) { "decidim.events.proposals.proposal_update_category" }
 

--- a/decidim-proposals/spec/events/decidim/proposals/admin/update_proposal_scope_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/admin/update_proposal_scope_event_spec.rb
@@ -12,14 +12,14 @@ describe Decidim::Proposals::Admin::UpdateProposalScopeEvent do
 
   describe "email_subject" do
     it "is generated correctly" do
-      expect(subject.email_subject).to eq("The #{resource_title} proposal scope has been updated")
+      expect(subject.email_subject).to eq("The #{decidim_sanitize(resource_title)} proposal scope has been updated")
     end
   end
 
   describe "email_intro" do
     it "is generated correctly" do
       expect(subject.email_intro)
-        .to eq("An admin has updated the scope of your proposal \"#{resource_title}\", check it out in this page:")
+        .to eq("An admin has updated the scope of your proposal \"#{decidim_html_escape(resource_title)}\", check it out in this page:")
     end
   end
 
@@ -33,7 +33,7 @@ describe Decidim::Proposals::Admin::UpdateProposalScopeEvent do
   describe "notification_title" do
     it "is generated correctly" do
       expect(subject.notification_title)
-        .to include("The <a href=\"#{resource_path}\">#{resource_title}</a> proposal scope has been updated by an admin.")
+        .to include("The <a href=\"#{resource_path}\">#{decidim_html_escape(resource_title)}</a> proposal scope has been updated by an admin.")
     end
   end
 end

--- a/decidim-proposals/spec/events/decidim/proposals/admin/update_proposal_scope_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/admin/update_proposal_scope_event_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Decidim::Proposals::Admin::UpdateProposalScopeEvent do
-  let(:resource) { create :proposal, title: "My super proposal" }
+  let(:resource) { create :proposal, title: "It's my super proposal" }
   let(:resource_title) { translated(resource.title) }
   let(:event_name) { "decidim.events.proposals.proposal_update_scope" }
 

--- a/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_accepted_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_accepted_event_spec.rb
@@ -35,21 +35,21 @@ describe Decidim::Proposals::CollaborativeDraftAccessAcceptedEvent do
     describe "email_intro" do
       it "is generated correctly" do
         expect(subject.email_intro)
-          .to eq(%(#{requester_name} has been accepted to access as a contributor of the <a href="#{resource_url}">#{resource_title}</a> collaborative draft.))
+          .to eq(%(#{requester_name} has been accepted to access as a contributor of the <a href="#{resource_url}">#{decidim_html_escape(resource_title)}</a> collaborative draft.))
       end
     end
 
     describe "email_outro" do
       it "is generated correctly" do
         expect(subject.email_outro)
-          .to eq(%(You have received this notification because you are a collaborator of <a href="#{resource_url}">#{resource_title}</a>.))
+          .to eq(%(You have received this notification because you are a collaborator of <a href="#{resource_url}">#{decidim_html_escape(resource_title)}</a>.))
       end
     end
 
     describe "notification_title" do
       it "is generated correctly" do
         expect(subject.notification_title)
-          .to include(%(<a href="#{requester_path}">#{requester_name} #{requester_nickname}</a> has been <strong>accepted to access as a contributor</strong> of the <a href="#{resource_path}">#{resource_title}</a> collaborative draft.))
+          .to include(%(<a href="#{requester_path}">#{requester_name} #{requester_nickname}</a> has been <strong>accepted to access as a contributor</strong> of the <a href="#{resource_path}">#{decidim_html_escape(resource_title)}</a> collaborative draft.))
       end
     end
   end
@@ -68,21 +68,21 @@ describe Decidim::Proposals::CollaborativeDraftAccessAcceptedEvent do
     describe "email_intro" do
       it "is generated correctly" do
         expect(subject.email_intro)
-          .to eq(%(You have been accepted to access as a contributor of the <a href="#{resource_url}">#{resource_title}</a> collaborative draft.))
+          .to eq(%(You have been accepted to access as a contributor of the <a href="#{resource_url}">#{decidim_html_escape(resource_title)}</a> collaborative draft.))
       end
     end
 
     describe "email_outro" do
       it "is generated correctly" do
         expect(subject.email_outro)
-          .to eq(%(You have received this notification because you requested to become a collaborator of <a href="#{resource_url}">#{resource_title}</a>.))
+          .to eq(%(You have received this notification because you requested to become a collaborator of <a href="#{resource_url}">#{decidim_html_escape(resource_title)}</a>.))
       end
     end
 
     describe "notification_title" do
       it "is generated correctly" do
         expect(subject.notification_title)
-          .to eq(%(You have been <strong>accepted to access as a contributor</strong> of the <a href="#{resource_path}">#{resource_title}</a> collaborative draft.))
+          .to eq(%(You have been <strong>accepted to access as a contributor</strong> of the <a href="#{resource_path}">#{decidim_html_escape(resource_title)}</a> collaborative draft.))
       end
     end
   end

--- a/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_accepted_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_accepted_event_spec.rb
@@ -6,7 +6,7 @@ describe Decidim::Proposals::CollaborativeDraftAccessAcceptedEvent do
   include_context "when a simple event"
 
   let(:event_name) { "decidim.events.proposals.collaborative_draft_access_accepted" }
-  let(:resource) { create :collaborative_draft, title: "My collaborative draft" }
+  let(:resource) { create :collaborative_draft, title: "It's my collaborative draft" }
   let(:resource_path) { Decidim::ResourceLocatorPresenter.new(resource).path }
   let(:resource_title) { resource.title }
   let(:author) { resource.authors.first }

--- a/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_rejected_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_rejected_event_spec.rb
@@ -8,7 +8,7 @@ describe Decidim::Proposals::CollaborativeDraftAccessRejectedEvent do
   let(:event_name) { "decidim.events.proposals.collaborative_draft_access_rejected" }
   let(:resource) { create :collaborative_draft, title: "It's my collaborative draft" }
   let(:resource_path) { Decidim::ResourceLocatorPresenter.new(resource).path }
-  let(:resource_title) { resource.title }
+  let(:resource_title) { decidim_html_escape(resource.title) }
   let(:author) { resource.authors.first }
   let(:author_id) { author.id }
   let(:author_presenter) { Decidim::UserPresenter.new(author) }
@@ -28,7 +28,7 @@ describe Decidim::Proposals::CollaborativeDraftAccessRejectedEvent do
 
     describe "email_subject" do
       it "is generated correctly" do
-        expect(subject.email_subject).to eq("#{requester_name} has been rejected to access as a contributor of the #{resource_title} collaborative draft.")
+        expect(subject.email_subject).to eq("#{requester_name} has been rejected to access as a contributor of the #{translated(resource.title)} collaborative draft.")
       end
     end
 
@@ -61,7 +61,7 @@ describe Decidim::Proposals::CollaborativeDraftAccessRejectedEvent do
 
     describe "email_subject" do
       it "is generated correctly" do
-        expect(subject.email_subject).to eq("You have been rejected as a contributor of #{resource_title}.")
+        expect(subject.email_subject).to eq("You have been rejected as a contributor of #{translated(resource.title)}.")
       end
     end
 

--- a/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_rejected_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_rejected_event_spec.rb
@@ -6,7 +6,7 @@ describe Decidim::Proposals::CollaborativeDraftAccessRejectedEvent do
   include_context "when a simple event"
 
   let(:event_name) { "decidim.events.proposals.collaborative_draft_access_rejected" }
-  let(:resource) { create :collaborative_draft, title: "My collaborative draft" }
+  let(:resource) { create :collaborative_draft, title: "It's my collaborative draft" }
   let(:resource_path) { Decidim::ResourceLocatorPresenter.new(resource).path }
   let(:resource_title) { resource.title }
   let(:author) { resource.authors.first }

--- a/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_requested_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_requested_event_spec.rb
@@ -35,21 +35,21 @@ describe Decidim::Proposals::CollaborativeDraftAccessRequestedEvent do
     describe "email_intro" do
       it "is generated correctly" do
         expect(subject.email_intro)
-          .to eq(%(#{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="#{resource_url}">#{resource_title}</a> collaborative draft page.))
+          .to eq(%(#{requester_name} requested access as a contributor. You can <strong>accept or reject the request</strong> from the <a href="#{resource_url}">#{decidim_html_escape(resource_title)}</a> collaborative draft page.))
       end
     end
 
     describe "email_outro" do
       it "is generated correctly" do
         expect(subject.email_outro)
-          .to eq(%(You have received this notification because you are a collaborator of <a href="#{resource_url}">#{resource_title}</a>.))
+          .to eq(%(You have received this notification because you are a collaborator of <a href="#{resource_url}">#{decidim_html_escape(resource_title)}</a>.))
       end
     end
 
     describe "notification_title" do
       it "is generated correctly" do
         expect(subject.notification_title)
-          .to include(%(<a href="#{requester_path}">#{requester_name} #{requester_nickname}</a> requested access to contribute to the <a href="#{resource_path}">#{resource_title}</a> collaborative draft. Please <strong>accept or reject the request</strong>.))
+          .to include(%(<a href="#{requester_path}">#{requester_name} #{requester_nickname}</a> requested access to contribute to the <a href="#{resource_path}">#{decidim_html_escape(resource_title)}</a> collaborative draft. Please <strong>accept or reject the request</strong>.))
       end
     end
   end

--- a/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_requested_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_access_requested_event_spec.rb
@@ -6,7 +6,7 @@ describe Decidim::Proposals::CollaborativeDraftAccessRequestedEvent do
   include_context "when a simple event"
 
   let(:event_name) { "decidim.events.proposals.collaborative_draft_access_requested" }
-  let(:resource) { create :collaborative_draft, title: "My collaborative draft" }
+  let(:resource) { create :collaborative_draft, title: "It's my collaborative draft" }
   let(:resource_path) { Decidim::ResourceLocatorPresenter.new(resource).path }
   let(:resource_title) { resource.title }
   let(:author) { resource.authors.first }

--- a/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_withdrawn_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_withdrawn_event_spec.rb
@@ -8,7 +8,7 @@ describe Decidim::Proposals::CollaborativeDraftWithdrawnEvent do
   let(:event_name) { "decidim.events.proposals.collaborative_draft_withdrawn" }
   let(:resource) { create :collaborative_draft, title: "It's my collaborative draft" }
   let(:resource_path) { Decidim::ResourceLocatorPresenter.new(resource).path }
-  let(:resource_title) { resource.title }
+  let(:resource_title) { decidim_html_escape(resource.title) }
   let(:author) { resource.authors.first }
   let(:author_id) { author.id }
   let(:author_presenter) { Decidim::UserPresenter.new(author) }
@@ -23,7 +23,7 @@ describe Decidim::Proposals::CollaborativeDraftWithdrawnEvent do
 
     describe "email_subject" do
       it "is generated correctly" do
-        expect(subject.email_subject).to eq("#{author_name} #{author_nickname} withdrawn the #{resource_title} collaborative draft.")
+        expect(subject.email_subject).to eq("#{author_name} #{author_nickname} withdrawn the #{decidim_sanitize(resource_title)} collaborative draft.")
       end
     end
 

--- a/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_withdrawn_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/collaborative_draft_withdrawn_event_spec.rb
@@ -6,7 +6,7 @@ describe Decidim::Proposals::CollaborativeDraftWithdrawnEvent do
   include_context "when a simple event"
 
   let(:event_name) { "decidim.events.proposals.collaborative_draft_withdrawn" }
-  let(:resource) { create :collaborative_draft, title: "My collaborative draft" }
+  let(:resource) { create :collaborative_draft, title: "It's my collaborative draft" }
   let(:resource_path) { Decidim::ResourceLocatorPresenter.new(resource).path }
   let(:resource_title) { resource.title }
   let(:author) { resource.authors.first }

--- a/decidim-proposals/spec/events/decidim/proposals/proposal_mentioned_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/proposal_mentioned_event_spec.rb
@@ -34,13 +34,13 @@ describe Decidim::Proposals::ProposalMentionedEvent do
 
   describe "email_subject" do
     it "is generated correctly" do
-      expect(subject.email_subject).to eq("Your proposal \"#{translated(mentioned_proposal.title)}\" has been mentioned")
+      expect(subject.email_subject).to eq("Your proposal \"#{decidim_sanitize(translated(mentioned_proposal.title))}\" has been mentioned")
     end
   end
 
   context "with content" do
     let(:content) do
-      "Your proposal \"#{translated(mentioned_proposal.title)}\" has been mentioned " \
+      "Your proposal \"#{decidim_html_escape(translated(mentioned_proposal.title))}\" has been mentioned " \
         "<a href=\"#{resource_url}\">in this space</a> in the comments."
     end
 

--- a/decidim-proposals/spec/events/decidim/proposals/proposal_mentioned_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/proposal_mentioned_event_spec.rb
@@ -10,7 +10,7 @@ describe Decidim::Proposals::ProposalMentionedEvent do
   let(:author) { create :user, organization: organization }
 
   let(:source_proposal) { create :proposal, component: create(:proposal_component, organization: organization), title: "Proposal A" }
-  let(:mentioned_proposal) { create :proposal, component: create(:proposal_component, organization: organization), title: "Proposal B" }
+  let(:mentioned_proposal) { create :proposal, component: create(:proposal_component, organization: organization), title: "It's proposal B" }
   let(:resource) { source_proposal }
   let(:extra) do
     {

--- a/decidim-proposals/spec/events/decidim/proposals/publish_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/publish_proposal_event_spec.rb
@@ -22,6 +22,14 @@ module Decidim
       end
 
       describe "email_subject" do
+        context "when resource title contains apostrophes" do
+          let(:resource) { create :proposal, title: "It's a nice proposal" }
+
+          it "is generated correctly" do
+            expect(subject.email_subject).to eq("New proposal \"#{resource_title}\" by @#{author.nickname}")
+          end
+        end
+
         it "is generated correctly" do
           expect(subject.email_subject).to eq("New proposal \"#{resource_title}\" by @#{author.nickname}")
         end

--- a/decidim-proposals/spec/events/decidim/proposals/rejected_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/rejected_proposal_event_spec.rb
@@ -19,21 +19,21 @@ describe Decidim::Proposals::RejectedProposalEvent do
   describe "email_intro" do
     it "is generated correctly" do
       expect(subject.email_intro)
-        .to eq("The proposal \"#{resource_title}\" has been rejected. You can read the answer in this page:")
+        .to eq("The proposal \"#{decidim_html_escape(resource_title)}\" has been rejected. You can read the answer in this page:")
     end
   end
 
   describe "email_outro" do
     it "is generated correctly" do
       expect(subject.email_outro)
-        .to eq("You have received this notification because you are following \"#{resource_title}\". You can unfollow it from the previous link.")
+        .to eq("You have received this notification because you are following \"#{decidim_html_escape(resource_title)}\". You can unfollow it from the previous link.")
     end
   end
 
   describe "notification_title" do
     it "is generated correctly" do
       expect(subject.notification_title)
-        .to include("The <a href=\"#{resource_path}\">#{resource_title}</a> proposal has been rejected")
+        .to include("The <a href=\"#{resource_path}\">#{decidim_html_escape(resource_title)}</a> proposal has been rejected")
     end
   end
 

--- a/decidim-proposals/spec/events/decidim/proposals/rejected_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/rejected_proposal_event_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Decidim::Proposals::RejectedProposalEvent do
-  let(:resource) { create :proposal, :with_answer, title: "My super proposal" }
+  let(:resource) { create :proposal, :with_answer, title: "It's my super proposal" }
   let(:resource_title) { translated(resource.title) }
   let(:event_name) { "decidim.events.proposals.proposal_rejected" }
 


### PR DESCRIPTION
#### :tophat: What? Why?
When an event is sent by email (ex. create/update new proposal/meeting), if the resource title has diacritics or apostrophes, then characters are badly encoded.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #9391
- Related to #7827 

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
