### PR TITLE
Bump letter_opener_web from 1.3 to 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ group :development, :test do
 end
 
 group :development do
-  gem "letter_opener_web", "~> 1.3"
+  gem "letter_opener_web", "~> 2.0"
   gem "listen", "~> 3.1"
   gem "rubocop-faker"
   gem "spring", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -516,12 +516,13 @@ GEM
       kramdown (~> 2.0)
     launchy (2.5.0)
       addressable (~> 2.7)
-    letter_opener (1.7.0)
-      launchy (~> 2.2)
-    letter_opener_web (1.4.1)
-      actionmailer (>= 3.2)
-      letter_opener (~> 1.0)
-      railties (>= 3.2)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -848,7 +849,7 @@ DEPENDENCIES
   decidim-initiatives!
   decidim-templates!
   faker (~> 2.14)
-  letter_opener_web (~> 1.3)
+  letter_opener_web (~> 2.0)
   listen (~> 3.1)
   parallel_tests (~> 3.7)
   puma (>= 5.6.2)

--- a/decidim-generators/Gemfile
+++ b/decidim-generators/Gemfile
@@ -27,7 +27,7 @@ group :development, :test do
 end
 
 group :development do
-  gem "letter_opener_web", "~> 1.3"
+  gem "letter_opener_web", "~> 2.0"
   gem "listen", "~> 3.1"
   gem "spring", "~> 2.0"
   gem "spring-watcher-listen", "~> 2.0"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -516,12 +516,13 @@ GEM
       kramdown (~> 2.0)
     launchy (2.5.0)
       addressable (~> 2.7)
-    letter_opener (1.7.0)
-      launchy (~> 2.2)
-    letter_opener_web (1.4.1)
-      actionmailer (>= 3.2)
-      letter_opener (~> 1.0)
-      railties (>= 3.2)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -845,7 +846,7 @@ DEPENDENCIES
   decidim-initiatives!
   decidim-templates!
   faker (~> 2.14)
-  letter_opener_web (~> 1.3)
+  letter_opener_web (~> 2.0)
   listen (~> 3.1)
   puma (>= 5.0.0)
   spring (~> 2.0)

--- a/decidim-generators/lib/decidim/generators/component_templates/Gemfile.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/Gemfile.erb
@@ -18,7 +18,7 @@ end
 
 group :development do
   gem "faker", "~> 2.14"
-  gem "letter_opener_web", "~> 1.3"
+  gem "letter_opener_web", "~> 2.0"
   gem "listen", "~> 3.1"
   gem "spring", "~> 2.0"
   gem "spring-watcher-listen", "~> 2.0"

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -516,12 +516,13 @@ GEM
       kramdown (~> 2.0)
     launchy (2.5.0)
       addressable (~> 2.7)
-    letter_opener (1.7.0)
-      launchy (~> 2.2)
-    letter_opener_web (1.4.1)
-      actionmailer (>= 3.2)
-      letter_opener (~> 1.0)
-      railties (>= 3.2)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -848,7 +849,7 @@ DEPENDENCIES
   decidim-initiatives!
   decidim-templates!
   faker (~> 2.14)
-  letter_opener_web (~> 1.3)
+  letter_opener_web (~> 2.0)
   listen (~> 3.1)
   parallel_tests (~> 3.7)
   puma (>= 5.6.2)


### PR DESCRIPTION
#### :tophat: What? Why?

Bump `letter_opener_web` from `1.3` to `2.0` and `letter_opener` from `1.7` to `1.8.1`
 
#### Testing

Go to http://localhost:3000/letter_opener and see the new UI   

### :camera: Screenshots

![Selection_134](https://user-images.githubusercontent.com/717367/172322998-57c8ccdc-e909-4185-bbc7-84833ca4deb3.png)


:hearts: Thank you!
