### PR TITLE
Add hyperlink to title in admin dashboard meetings listing

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -48,7 +48,11 @@
                 <%= meeting.id %><br>
               </td>
               <td>
-                <%= present(meeting).title %><br>
+                <%= link_to(
+                      decidim_html_escape(present(meeting).title).html_safe,
+                      resource_locator(meeting).url,
+                      target: "_blank"
+                    ) %><br>
               </td>
               <td>
                 <% if meeting.start_time %>

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -28,6 +28,12 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
       expect(page).to have_selector("tbody tr:last-child", text: Decidim::Meetings::MeetingPresenter.new(old_meeting).title)
     end
 
+    it "displays the title with link to the meeting's public page" do
+      visit current_path
+
+      expect(page).to have_link(translated(meeting.title), href: resource_locator(meeting).url)
+    end
+
     it "allows to publish/unpublish meetings" do
       visit current_path
 


### PR DESCRIPTION
#### :tophat: What? Why?
At the moment, in admin dashboard - pick a topic - proposal or meeting component, it can be noticed that the tile of the proposals are hyperlinked and take the user to the proposal page with details but the meetings are not hyperlinked within the list.
The expected behavior is to have a link added to the meeting's title that will be a redirect tot the public page (like "Preview" action).

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #9393

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
