### PR TITLE
External link improvements

### DIFF
--- a/decidim-core/app/packs/src/decidim/external_link.js
+++ b/decidim-core/app/packs/src/decidim/external_link.js
@@ -42,13 +42,24 @@ export default class ExternalLink {
       return;
     }
 
-    this.$link.addClass("external-link-container");
+    let $target = this.$link;
+    if (this.$link[0].hasAttribute("data-external-link-target")) {
+      $target = $(this.$link.data("external-link-target"), this.$link);
+      if ($target.length < 1) {
+        $target = this.$link;
+      }
+    }
+
+    $target.addClass("external-link-container");
     let spacer = "&nbsp;";
-    if (this.$link.text().trim().length < 1) {
+    if (this.$link[0].hasAttribute("data-external-link-spacer")) {
+      spacer = this.$link.data("external-link-spacer");
+    } else if ($target.text().trim().length < 1) {
       // Fixes image links extra space
       spacer = "";
     }
-    this.$link.append(`${spacer}${this.generateElement()}`);
+
+    $target.append(`${spacer}${this.generateElement()}`);
   }
 
   generateElement() {

--- a/decidim-core/app/packs/src/decidim/external_link.test.js
+++ b/decidim-core/app/packs/src/decidim/external_link.test.js
@@ -9,7 +9,6 @@ describe("ExternalLink", () => {
       <a href="https://decidim.org/" target="_blank"><img src="/path/to/image.png" alt=""></a>
       <a href="https://decidim.org/" target="_blank" data-external-link-spacer="%%%">Custom spacer link</a>
       <a href="https://decidim.org/" target="_blank" data-external-link-target=".external-wrapper"><span class="external-wrapper"></span>This is the link</a>
-      <a href="/">Link to home</a>
     </div>
   `;
 

--- a/decidim-core/app/packs/src/decidim/external_link.test.js
+++ b/decidim-core/app/packs/src/decidim/external_link.test.js
@@ -1,0 +1,65 @@
+import $ from "jquery"; // eslint-disable-line id-length
+
+import ExternalLink from "./external_link";
+
+describe("ExternalLink", () => {
+  const content = `
+    <div id="links">
+      <a href="https://decidim.org/" target="_blank">This is an external link</a>
+      <a href="https://decidim.org/" target="_blank"><img src="/path/to/image.png" alt=""></a>
+      <a href="https://decidim.org/" target="_blank" data-external-link-spacer="%%%">Custom spacer link</a>
+      <a href="https://decidim.org/" target="_blank" data-external-link-target=".external-wrapper"><span class="external-wrapper"></span>This is the link</a>
+      <a href="/">Link to home</a>
+    </div>
+  `;
+
+  const config = {
+    "icons_path": "/path/to/icons.svg"
+  };
+  window.Decidim = {
+    config: {
+      get: (key) => config[key]
+    }
+  }
+  const expectedIcon = '<svg class="icon icon--external-link" role="img" aria-hidden="true"><title>external-link</title><use href="/path/to/icons.svg#icon-external-link"></use></svg>';
+
+  beforeEach(() => {
+    $("body").html(content);
+    $('a[target="_blank"]').each((_i, elem) => {
+      const $link = $(elem);
+      $link.data("external-link", new ExternalLink($link));
+    });
+  });
+
+  it("adds the external link indicator to the normal external link", () => {
+    const $link = $("#links a")[0];
+
+    expect($link.outerHTML).toEqual(
+      `<a href="https://decidim.org/" target="_blank" class="external-link-container">This is an external link&nbsp;<span class="external-link-indicator">${expectedIcon}<span class="show-for-sr">(External link)</span></span></a>`
+    );
+  });
+
+  it("adds the external link indicator without a spacer to the image link", () => {
+    const $link = $("#links a")[1];
+
+    expect($link.outerHTML).toEqual(
+      `<a href="https://decidim.org/" target="_blank" class="external-link-container"><img src="/path/to/image.png" alt=""><span class="external-link-indicator">${expectedIcon}<span class="show-for-sr">(External link)</span></span></a>`
+    );
+  });
+
+  it("adds the external link indicator with a custom spacer to the link with the custom spacer configuration", () => {
+    const $link = $("#links a")[2];
+
+    expect($link.outerHTML).toEqual(
+      `<a href="https://decidim.org/" target="_blank" data-external-link-spacer="%%%" class="external-link-container">Custom spacer link%%%<span class="external-link-indicator">${expectedIcon}<span class="show-for-sr">(External link)</span></span></a>`
+    );
+  });
+
+  it("adds the external link indicator with a custom container to the link with the custom container configuration", () => {
+    const $link = $("#links a")[3];
+
+    expect($link.outerHTML).toEqual(
+      `<a href="https://decidim.org/" target="_blank" data-external-link-target=".external-wrapper"><span class="external-wrapper external-link-container"><span class="external-link-indicator">${expectedIcon}<span class="show-for-sr">(External link)</span></span></span>This is the link</a>`
+    );
+  });
+});


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds two new features to the external links feature:
- Ability to define a custom spacer element that is printed before the external link indicator (`&nbsp;` by default)
- Ability to define a custom container for the external link element within the link (by default it is appended at the end of the link)

The first feature can be useful if we want to fix some styling issues in special cases caused by the `&nbsp;` character.

The second feature is useful when the link is e.g. a complicated card link where we want to show the external link indicator in a specific place.

I needed these features in a project, so I thought I'd send these back to the core.

#### Testing
See the added Jest test for few examples.

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.