### PR TITLE
Fix publish event on official proposals

### DIFF
--- a/decidim-proposals/app/events/decidim/proposals/publish_proposal_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/publish_proposal_event.rb
@@ -13,7 +13,7 @@ module Decidim
       end
 
       def i18n_options
-        return super unless author.present?
+        return super if author.blank?
 
         author_path = link_to("@#{author.nickname}", profile_path(author.nickname))
         author_string = "#{author.name} #{author_path}"

--- a/decidim-proposals/app/events/decidim/proposals/publish_proposal_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/publish_proposal_event.rb
@@ -13,6 +13,8 @@ module Decidim
       end
 
       def i18n_options
+        return super unless author.present?
+
         author_path = link_to("@#{author.nickname}", profile_path(author.nickname))
         author_string = "#{author.name} #{author_path}"
         super.merge({ author: author_string })
@@ -33,6 +35,12 @@ module Decidim
 
       def safe_resource_translated_text
         I18n.with_locale(I18n.locale) { translated_attribute(resource_text, nil, true).to_s.html_safe }
+      end
+
+      def notification_title
+        i18n_key = author.present? ? "notification_title" : "notification_title_official"
+
+        I18n.t(i18n_key, **i18n_options).html_safe
       end
 
       private

--- a/decidim-proposals/app/events/decidim/proposals/publish_proposal_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/publish_proposal_event.rb
@@ -38,7 +38,7 @@ module Decidim
       end
 
       def notification_title
-        i18n_key = author.present? ? "notification_title" : "notification_title_official"
+        i18n_key = resource.official? ? "notification_title_official" : "notification_title"
 
         I18n.t(i18n_key, **i18n_options).html_safe
       end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -298,7 +298,6 @@ en:
           email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
           email_subject: New proposal "%{resource_title}" by %{author_nickname}
           notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal was published by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
-          notification_title_official: The official proposal <a href="%{resource_path}">%{resource_title}</a> was published.
         proposal_published_for_space:
           email_intro: The proposal "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
           email_outro: You have received this notification because you are following "%{participatory_space_title}". You can stop receiving notifications following the previous link.

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -304,7 +304,7 @@ en:
           email_outro: You have received this notification because you are following "%{participatory_space_title}". You can stop receiving notifications following the previous link.
           email_subject: New proposal "%{resource_title}" added to %{participatory_space_title}
           notification_title: The proposal <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title} by %{author}
-          notification_title_official: The official proposal <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}.
+          notification_title_official: The official proposal <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}
         proposal_rejected:
           affected_user:
             email_intro: 'Your proposal "%{resource_title}" has been rejected. You can read the answer in this page:'

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -298,12 +298,13 @@ en:
           email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
           email_subject: New proposal "%{resource_title}" by %{author_nickname}
           notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal was published by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
-          notification_title_official: The <a href="%{resource_path}">%{resource_title}</a> official proposal was published.
+          notification_title_official: The official proposal <a href="%{resource_path}">%{resource_title}</a> was published.
         proposal_published_for_space:
           email_intro: The proposal "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
           email_outro: You have received this notification because you are following "%{participatory_space_title}". You can stop receiving notifications following the previous link.
           email_subject: New proposal "%{resource_title}" added to %{participatory_space_title}
           notification_title: The proposal <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title} by %{author}
+          notification_title_official: The official proposal <a href="%{resource_path}">%{resource_title}</a> has been added to %{participatory_space_title}.
         proposal_rejected:
           affected_user:
             email_intro: 'Your proposal "%{resource_title}" has been rejected. You can read the answer in this page:'

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -298,6 +298,7 @@ en:
           email_outro: You have received this notification because you are following %{author_nickname}. You can stop receiving notifications following the previous link.
           email_subject: New proposal "%{resource_title}" by %{author_nickname}
           notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal was published by <a href="%{author_path}">%{author_name} %{author_nickname}</a>.
+          notification_title_official: The <a href="%{resource_path}">%{resource_title}</a> official proposal was published.
         proposal_published_for_space:
           email_intro: The proposal "%{resource_title}" has been added to "%{participatory_space_title}" that you are following.
           email_outro: You have received this notification because you are following "%{participatory_space_title}". You can stop receiving notifications following the previous link.

--- a/decidim-proposals/spec/events/decidim/proposals/publish_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/publish_proposal_event_spec.rb
@@ -61,11 +61,12 @@ module Decidim
 
       context "when the proposal is official" do
         let(:resource) { create :proposal, :official, title: "A nice proposal" }
+        let(:extra) { { participatory_space: resource.participatory_space } }
 
         describe "notification_title" do
           it "is generated correctly" do
             expect(subject.notification_title)
-              .to include("The official proposal <a href=\"#{resource_path}\">#{resource_title}</a> was published.")
+              .to include("The official proposal <a href=\"#{resource_path}\">#{resource_title}</a> has been added to #{participatory_space_title}")
           end
         end
       end

--- a/decidim-proposals/spec/events/decidim/proposals/publish_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/publish_proposal_event_spec.rb
@@ -59,6 +59,17 @@ module Decidim
         end
       end
 
+      context "when the proposal is official" do
+        let(:resource) { create :proposal, :official, title: "A nice proposal" }
+
+        describe "notification_title" do
+          it "is generated correctly" do
+            expect(subject.notification_title)
+              .to include("The <a href=\"#{resource_path}\">#{resource_title}</a> official proposal was published.")
+          end
+        end
+      end
+
       context "when the target are the participatory space followers" do
         let(:event_name) { "decidim.events.proposals.proposal_published_for_space" }
         let(:extra) { { participatory_space: true } }

--- a/decidim-proposals/spec/events/decidim/proposals/publish_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/publish_proposal_event_spec.rb
@@ -65,7 +65,7 @@ module Decidim
         describe "notification_title" do
           it "is generated correctly" do
             expect(subject.notification_title)
-              .to include("The <a href=\"#{resource_path}\">#{resource_title}</a> official proposal was published.")
+              .to include("The official proposal <a href=\"#{resource_path}\">#{resource_title}</a> was published.")
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes the publish event associated to a proposal when it's official and has been created by an admin.

#### :pushpin: Related Issues

- Fixes #9279

#### Testing

Steps to reproduce the behaviour:

- As a user, follow a participatory space with a proposals component
- As an admin, create a proposal via the admin backend
- As the user, click on the yellow notification bell icon
- You shouldn't see the error

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
