### PR TITLE
Remove the threads limit from the Capybara Puma server

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -81,7 +81,7 @@ Capybara.register_driver :iphone do |app|
   )
 end
 
-Capybara.server = :puma, { Silent: true, Threads: "1:1" }
+Capybara.server = :puma, { Silent: true }
 
 Capybara.asset_host = "http://localhost:3000"
 


### PR DESCRIPTION
#### :tophat: What? Why?
In the past we added the min-max threads limit as 1:1 to the puma server running during the "system" / E2E tests at #7366.

The reason was that there were specific tests that were constantly timing out and we figured we could fix this issue by limiting the threads to 1:1 allowing the tests to finish properly.

The particular test that was freezing was related to the admin newsletters view. Later during Ruby 3 upgrade, we figured out that there was actually a thread safety issue with Webpacker which caused the newsletters view to fail when using more than a single thread. This was fixed at #9203.

So I believe after #9203 the original issue described at #7366 no longer exists which means we can remove the threads limit.

I'm not expecting any major benefits from this but I feel it might be a good idea to also run the tests in multi-threaded mode so that we can identify possible further thread safety issues when they arise.

#### :pushpin: Related Issues
- Related to #7366, #9203

#### Testing
- Run the test described at #7366 multiple times in a row
- Expect all test runs to complete without timing out or errors

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.