### PR TITLE
Fix service worker cache in development environment

### DIFF
--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -21,6 +21,7 @@ env:
   NODE_VERSION: 16.9.1
   DECIDIM_MODULE: decidim-core
   PARALLEL_TEST_PROCESSORS: 2
+  DECIDIM_SERVICE_WORKER_ENABLED: true
 
 jobs:
   main:

--- a/decidim-core/app/packs/entrypoints/decidim_core.js
+++ b/decidim-core/app/packs/entrypoints/decidim_core.js
@@ -57,7 +57,6 @@ import "src/decidim/notifications"
 import "src/decidim/identity_selector_dialog"
 import "src/decidim/gallery"
 import "src/decidim/direct_uploads/upload_field"
-import "src/decidim/sw"
 import "src/decidim/back_to_list"
 import "src/decidim/cookie_consent/cookie_consent"
 

--- a/decidim-core/app/packs/entrypoints/decidim_sw.js
+++ b/decidim-core/app/packs/entrypoints/decidim_sw.js
@@ -1,0 +1,1 @@
+import "src/decidim/sw"

--- a/decidim-core/app/views/layouts/decidim/_decidim_javascript.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_decidim_javascript.html.erb
@@ -1,4 +1,5 @@
 <%= javascript_pack_tag "decidim_core", defer: false %>
+<%= javascript_pack_tag "decidim_sw", defer: false %>
 <%= render partial: "layouts/decidim/js_configuration" %>
 
 <%= yield :js_content %>

--- a/decidim-core/app/views/layouts/decidim/_decidim_javascript.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_decidim_javascript.html.erb
@@ -1,5 +1,7 @@
 <%= javascript_pack_tag "decidim_core", defer: false %>
-<%= javascript_pack_tag "decidim_sw", defer: false %>
+<% if Decidim.service_worker_enabled %>
+  <%= javascript_pack_tag "decidim_sw", defer: false %>
+<% end %>
 <%= render partial: "layouts/decidim/js_configuration" %>
 
 <%= yield :js_content %>

--- a/decidim-core/config/assets.rb
+++ b/decidim-core/config/assets.rb
@@ -5,6 +5,7 @@ base_path = File.expand_path("..", __dir__)
 Decidim::Webpacker.register_path("#{base_path}/app/packs")
 Decidim::Webpacker.register_entrypoints(
   decidim_core: "#{base_path}/app/packs/entrypoints/decidim_core.js",
+  decidim_sw: "#{base_path}/app/packs/entrypoints/decidim_sw.js",
   decidim_conference_diploma: "#{base_path}/app/packs/entrypoints/decidim_conference_diploma.js",
   decidim_email: "#{base_path}/app/packs/entrypoints/decidim_email.js",
   decidim_map: "#{base_path}/app/packs/entrypoints/decidim_map.js",

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -447,6 +447,11 @@ module Decidim
     "/"
   end
 
+  # Having this on true will change the way the svg assets are being served.
+  config_accessor :service_worker_enabled do
+    true
+  end
+
   # Public: Registers a global engine. This method is intended to be used
   # by component engines that also offer unscoped functionality
   #

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -449,7 +449,7 @@ module Decidim
 
   # Enable/Disable the service worker
   config_accessor :service_worker_enabled do
-    true
+    Rails.env.exclude?("development")
   end
 
   # Public: Registers a global engine. This method is intended to be used

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -447,7 +447,7 @@ module Decidim
     "/"
   end
 
-  # Having this on true will change the way the svg assets are being served.
+  # Enable/Disable the service worker
   config_accessor :service_worker_enabled do
     true
   end

--- a/decidim-core/spec/lib/webpacker/configuration_spec.rb
+++ b/decidim-core/spec/lib/webpacker/configuration_spec.rb
@@ -36,6 +36,7 @@ module Decidim
         it "adds the core entrypoints to the webpacker runtime configuration" do
           expect(runtime_config["default"]["entrypoints"]).to include(
             "decidim_core" => "#{core_path}/app/packs/entrypoints/decidim_core.js",
+            "decidim_sw" => "#{core_path}/app/packs/entrypoints/decidim_sw.js",
             "decidim_conference_diploma" => "#{core_path}/app/packs/entrypoints/decidim_conference_diploma.js",
             "decidim_email" => "#{core_path}/app/packs/entrypoints/decidim_email.js",
             "decidim_map" => "#{core_path}/app/packs/entrypoints/decidim_map.js",

--- a/decidim-core/spec/lib/webpacker/runner_spec.rb
+++ b/decidim-core/spec/lib/webpacker/runner_spec.rb
@@ -33,6 +33,7 @@ module Webpacker
         expect(runtime_config["default"]["additional_paths"]).to include("#{core_path}/app/packs")
         expect(runtime_config["default"]["entrypoints"]).to include(
           "decidim_core" => "#{core_path}/app/packs/entrypoints/decidim_core.js",
+          "decidim_sw" => "#{core_path}/app/packs/entrypoints/decidim_sw.js",
           "decidim_conference_diploma" => "#{core_path}/app/packs/entrypoints/decidim_conference_diploma.js",
           "decidim_email" => "#{core_path}/app/packs/entrypoints/decidim_email.js",
           "decidim_map" => "#{core_path}/app/packs/entrypoints/decidim_map.js",

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -37,8 +37,8 @@ Decidim.configure do |config|
   # or set it up manually and prevent any ENV manipulation:
   # config.force_ssl = true
 
-  # Enable the service worker
-  config.service_worker_enabled = Rails.env.development? ? false : true
+  # Enable the service worker. By default is disabled in development and enabled in the rest of environments.
+  config.service_worker_enabled = Rails.env.exclude?("development")
 
   # Map and Geocoder configuration
   #

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -37,8 +37,8 @@ Decidim.configure do |config|
   # or set it up manually and prevent any ENV manipulation:
   # config.force_ssl = true
 
-  # Enable the service worker. By default is disabled in development and enabled in the rest of environments.
-  config.service_worker_enabled = Rails.env.exclude?("development")
+  # Enable the service worker. By default is disabled in development and enabled in the rest of environments
+  config.service_worker_enabled = Rails.application.secrets.decidim[:service_worker_enabled].present?
 
   # Map and Geocoder configuration
   #

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -37,6 +37,9 @@ Decidim.configure do |config|
   # or set it up manually and prevent any ENV manipulation:
   # config.force_ssl = true
 
+  # Enable the service worker
+  config.service_worker_enabled = Rails.env.development? ? false : true
+
   # Map and Geocoder configuration
   #
   # == HERE Maps ==

--- a/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
@@ -40,6 +40,7 @@ decidim_default: &decidim_default
   maximum_conversation_message_length: <%%= Decidim::Env.new("DECIDIM_MAXIMUM_CONVERSATION_MESSAGE_LENGTH", "1000").to_i %>
   password_blacklist: <%%= Decidim::Env.new("DECIDIM_PASSWORD_BLACKLIST").to_array(separator: ", ").to_json %>
   allow_open_redirects: <%%= Decidim::Env.new("DECIDIM_ALLOW_OPEN_REDIRECTS").to_boolean_string %>
+  service_worker_enabled: <%%= Decidim::Env.new("DECIDIM_SERVICE_WORKER_ENABLED").to_boolean_string %>
   api:
     schema_max_per_page: <%%= Decidim::Env.new("API_SCHEMA_MAX_PER_PAGE", 50).to_i %>
     schema_max_complexity: <%%= Decidim::Env.new("API_SCHEMA_MAX_COMPLEXITY", 5000).to_i %>

--- a/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
@@ -40,7 +40,7 @@ decidim_default: &decidim_default
   maximum_conversation_message_length: <%%= Decidim::Env.new("DECIDIM_MAXIMUM_CONVERSATION_MESSAGE_LENGTH", "1000").to_i %>
   password_blacklist: <%%= Decidim::Env.new("DECIDIM_PASSWORD_BLACKLIST").to_array(separator: ", ").to_json %>
   allow_open_redirects: <%%= Decidim::Env.new("DECIDIM_ALLOW_OPEN_REDIRECTS").to_boolean_string %>
-  service_worker_enabled: <%%= Decidim::Env.new("DECIDIM_SERVICE_WORKER_ENABLED").to_boolean_string %>
+  service_worker_enabled: <%%= Decidim::Env.new("DECIDIM_SERVICE_WORKER_ENABLED", Rails.env.exclude?("development")).to_boolean_string %>
   api:
     schema_max_per_page: <%%= Decidim::Env.new("API_SCHEMA_MAX_PER_PAGE", 50).to_i %>
     schema_max_complexity: <%%= Decidim::Env.new("API_SCHEMA_MAX_COMPLEXITY", 5000).to_i %>

--- a/decidim-generators/lib/decidim/generators/test/generator_examples.rb
+++ b/decidim-generators/lib/decidim/generators/test/generator_examples.rb
@@ -272,7 +272,7 @@ shared_examples_for "an application with configurable env vars" do
       %w(decidim base_uploads_path) => nil,
       %w(decidim default_csv_col_sep) => ";",
       %w(decidim cors_enabled) => false,
-      %w(decidim service_worker_enabled) => false,
+      %w(decidim service_worker_enabled) => true,
       %w(decidim consent_cookie_name) => "decidim-consent",
       %w(decidim cache_key_separator) => "/",
       %w(decidim expire_session_after) => 30,

--- a/decidim-generators/lib/decidim/generators/test/generator_examples.rb
+++ b/decidim-generators/lib/decidim/generators/test/generator_examples.rb
@@ -82,6 +82,7 @@ shared_context "with application env vars" do
       "DECIDIM_BASE_UPLOADS_PATH" => "",
       "DECIDIM_DEFAULT_CSV_COL_SEP" => "",
       "DECIDIM_CORS_ENABLED" => "",
+      "DECIDIM_SERVICE_WORKER_ENABLED" => "",
       "RAILS_LOG_LEVEL" => "nonsense",
       "STORAGE_PROVIDER" => ""
     }
@@ -111,7 +112,8 @@ shared_context "with application env vars" do
       "DECIDIM_THROTTLING_PERIOD" => "false",
       "DECIDIM_UNCONFIRMED_ACCESS_FOR" => "false",
       "DECIDIM_SYSTEM_ACCESSLIST_IPS" => "false",
-      "DECIDIM_CORS_ENABLED" => "falsE"
+      "DECIDIM_CORS_ENABLED" => "false",
+      "DECIDIM_SERVICE_WORKER_ENABLED" => "false"
     }
   end
 
@@ -152,6 +154,7 @@ shared_context "with application env vars" do
       "DECIDIM_BASE_UPLOADS_PATH" => "some-path/",
       "DECIDIM_DEFAULT_CSV_COL_SEP" => ",",
       "DECIDIM_CORS_ENABLED" => "true",
+      "DECIDIM_SERVICE_WORKER_ENABLED" => "true",
       "DECIDIM_CONSENT_COOKIE_NAME" => ":weird-consent-cookie-name:",
       "DECIDIM_CACHE_KEY_SEPARATOR" => ":",
       "DECIDIM_EXPIRE_SESSION_AFTER" => "45",
@@ -269,6 +272,7 @@ shared_examples_for "an application with configurable env vars" do
       %w(decidim base_uploads_path) => nil,
       %w(decidim default_csv_col_sep) => ";",
       %w(decidim cors_enabled) => false,
+      %w(decidim service_worker_enabled) => false,
       %w(decidim consent_cookie_name) => "decidim-consent",
       %w(decidim cache_key_separator) => "/",
       %w(decidim expire_session_after) => 30,
@@ -368,6 +372,7 @@ shared_examples_for "an application with configurable env vars" do
       %w(decidim base_uploads_path) => "some-path/",
       %w(decidim default_csv_col_sep) => ",",
       %w(decidim cors_enabled) => true,
+      %w(decidim service_worker_enabled) => true,
       %w(decidim consent_cookie_name) => ":weird-consent-cookie-name:",
       %w(decidim cache_key_separator) => ":",
       %w(decidim expire_session_after) => 45,

--- a/docs/modules/configure/pages/environment_variables.adoc
+++ b/docs/modules/configure/pages/environment_variables.adoc
@@ -651,6 +651,12 @@ Additional context: This has been revealed as an issue during a security audit o
 |false
 |No
 
+|*DECIDIM_SERVICE_WORKER_ENABLED*
+|Enable/Disable the service worker. This is used to enable offline support and to deliver push notifications. In development it's recommended to be disabled because its aggresive cache configuration might cause some issues when submitting forms.
+|false
+|No
+
+
 |===
 
 .Optional Env Vars fine tuning some Decidim modules (such the API or Proposal behaviors)


### PR DESCRIPTION
#### :tophat: What? Why?

This PR let's enable/disable the service worker via Decidim configuration, while disables it by default in development, to prevent some form submitting issues.

By default it's enabled in production, because it's the expected behaviour.

To the reviewers: this is a quick PR that I think might be a good solution, if you agree with this approach I'll update the PR with a new entry in the Changelog.

#### :pushpin: Related Issues

- Fixes #9187

#### Testing

- You should create a development app, and a new entry in `config/initializers/decidim.rb` should be available
- If the setting is enabled, the service worker should be installed and running
- If the setting is disabled and you unregister the service worker, it shouldn't get installed again

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
