### PR TITLE
Return 404 when there isn't an initiative

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -111,7 +111,7 @@ module Decidim
       alias current_initiative current_participatory_space
 
       def current_participatory_space
-        @current_participatory_space ||= Initiative.find_by!(id: id_from_slug(params[:slug]))
+        @current_participatory_space ||= Initiative.find(id_from_slug(params[:slug]))
       end
 
       def current_participatory_space_manifest

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -111,7 +111,7 @@ module Decidim
       alias current_initiative current_participatory_space
 
       def current_participatory_space
-        @current_participatory_space ||= Initiative.find_by(id: id_from_slug(params[:slug]))
+        @current_participatory_space ||= Initiative.find_by!(id: id_from_slug(params[:slug]))
       end
 
       def current_participatory_space_manifest

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
@@ -67,6 +67,11 @@ describe Decidim::Initiatives::InitiativesController, type: :controller do
         expect(subject.helpers.current_initiative).to eq(initiative)
       end
 
+      it "Returns 404 when there isn't an initiative" do
+        expect { get :show, params: { slug: "invalid-initiative" } }
+          .to raise_error(ActiveRecord::RecordNotFound)
+      end
+
       it "Throws exception on non published initiatives" do
         get :show, params: { slug: created_initiative.slug }
         expect(flash[:alert]).not_to be_empty


### PR DESCRIPTION
#### :tophat: What? Why?

In some controllers, we're doing some incorrect checks when finding resources. This makes that some URLs return 500 when they should be returning 404. 

This PR fixes this for initiatives#show, https://try.decidim.org/initiatives/DOESNTEXIST 

#### Testing

. Go to http://localhost:3000/initiatives/DOESNTEXIST
. See that it returns 404 (`ActiveRecord::RecordNotFound` in development)

:hearts: Thank you!
