### PR TITLE
Improve i18n-tasks error messages

### DIFF
--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -24,12 +24,12 @@ describe "I18n sanity" do
 
   it "does not have missing keys" do
     expect(missing_keys).to be_empty,
-                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+                            "Missing #{missing_keys.leaves.count} i18n keys, please run `bundle exec i18n-tasks missing --locales #{locales}' to show them"
   end
 
   it "does not have unused keys" do
     expect(unused_keys).to be_empty,
-                           "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+                           "#{unused_keys.leaves.count} unused i18n keys, please run `bundle exec i18n-tasks unused --locales #{locales}' to show them"
   end
 
   unless ENV["SKIP_NORMALIZATION"]
@@ -44,7 +44,7 @@ describe "I18n sanity" do
 
   it "does not have inconsistent interpolations" do
     error_message = "#{inconsistent_interpolations.leaves.count} i18n keys have inconsistent interpolations.\n" \
-                    "Run `i18n-tasks check-consistent-interpolations' to show them"
+                    "Please run `bundle exec i18n-tasks check-consistent-interpolations --locales #{locales}` to show them"
     expect(inconsistent_interpolations).to be_empty, error_message
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Improves a bit the i18n-tasks maintainers tasks output, by clarifying that you should use the --locales/-l flag to check these.

I've been bitten by this on my first release, and it's something that's easy to miss. 

I also added the "please" and the `bundle exec`. 

All of this we also had it in one of the examples: https://github.com/decidim/decidim/blob/2c880398a09469df11d96ba2a981deebdd8c83a2/spec/i18n_spec.rb#L39

So this also brings my much beloved consistency 😄 

:hearts: Thank you!
