### PR TITLE
Backport 'Fix invalid translation in spec' to v0.26

### DIFF
--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -134,7 +134,7 @@ describe "Meeting registrations", type: :system do
             end
 
             within ".card.extra" do
-              click_button "Inscriu-te a la trobada"
+              click_button "Unir-se a la trobada"
             end
 
             within "#loginModal" do


### PR DESCRIPTION
#### :tophat: What? Why?
Backport #9434 to v0.26

:hearts: Thank you!