### PR TITLE
Add Javascript workflow for Github Actions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -20,7 +20,7 @@ Individual workflows with changes:
   working-directory: ${{ env.DECIDIM_MODULE }}
 ```
 
-- `ci_comments.yml`: Runs tests for the JS files. Tests must run from the project root folder. You'll need to install NodeJS and the JS dependencies:
+- `ci_javascript.yml`: Runs tests for the JS files. Tests must run from the project root folder. You'll need to install NodeJS and the JS dependencies:
 
 ```yml
 - uses: actions/setup-node@master

--- a/.github/workflows/ci_javascript.yml
+++ b/.github/workflows/ci_javascript.yml
@@ -1,0 +1,54 @@
+name: "[CI] Javascript"
+on:
+  push:
+    branches:
+      - develop
+      - release/*
+      - "*-stable"
+  pull_request:
+    branches-ignore:
+      - "chore/l10n*"
+    paths:
+      - "*"
+      - ".github/**"
+      - "decidim-admin/**"
+      - "decidim-comments/**"
+      - "decidim-core/**"
+      - "decidim-dev/**"
+
+env:
+  CI: "true"
+  NODE_VERSION: 16.9.1
+
+jobs:
+  main:
+    name: Tests
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'chore/l10n')"
+    timeout-minutes: 60
+    steps:
+      - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
+        if: "github.ref != 'refs/heads/develop'"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/checkout@v2.0.0
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Get npm cache directory path
+        id: npm-cache-dir-path
+        run: echo "::set-output name=dir::$(npm get cache)-javascript"
+      - uses: actions/cache@v2
+        id: npm-cache
+        with:
+          path: ${{ steps.npm-cache-dir-path.outputs.dir }}
+          key: npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            npm-
+      - name: Install JS dependencies
+        run: npm ci
+      - run: npm run test
+        name: Test JS files
+

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -12,6 +12,8 @@
 // This is necessary for testing purposes
 const $ = window.$;
 
+import Rails from "@rails/ujs";
+
 import { createCharacterCounter } from "src/decidim/input_character_counter"
 import ExternalLink from "src/decidim/external_link"
 import updateExternalDomainLinks from "src/decidim/external_domain_warning"

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
@@ -13,6 +13,10 @@ window.$.ajax = jest.fn().mockImplementation((...args) => $.ajax(...args));
 import Quill from "quill"
 window.Quill = Quill
 
+// Rails.ajax is used by the fetching/polling of the comments
+import Rails from "@rails/ujs";
+jest.mock("@rails/ujs");
+
 // Fake timers for testing polling
 jest.useFakeTimers();
 
@@ -383,16 +387,16 @@ describe("CommentsComponent", () => {
 
     jest.advanceTimersByTime(1000);
 
-    expect(window.$.ajax).toHaveBeenCalledWith({
+    expect(Rails.ajax).toHaveBeenCalledWith({
       url: "/comments",
-      method: "GET",
-      contentType: "application/javascript",
-      data: {
+      type: "GET",
+      data: new URLSearchParams({
         "commentable_gid": "commentable-gid",
         "root_depth": 0,
         order: "older",
         after: 456
-      }
+      }),
+      success: window.undefined
     });
   });
 


### PR DESCRIPTION
#### :tophat: What? Why?

While working on #9439, I saw that we were running `jest` through the ci_comments workflow: 

>  ci_comments.yml: Runs tests for the JS files. Tests must run from the project root folder. You'll need to install NodeJS and the JS dependencies:
> 
>``` 
> - uses: actions/setup-node@master
>   with:
>     node-version: ${{ env.NODE_VERSION }}
> - run: npm ci
>   name: Install JS deps
> - run: npm run test
>   name: Test JS files
> ```

The problem is that with a workflow configuration refactoring (on #8677) we dropped those instructions. This PR reintroduces it, but in a new workflow, so it's harder to miss. 

#### :pushpin: Related Issues

- Related to #8677
 
#### Testing

There should be a new action for "[CI] Javascript"
It should (hopefully) be green/passing 


:hearts: Thank you!
