### PR TITLE
Remove the description field from the elections component seeds

### DIFF
--- a/decidim-elections/lib/decidim/elections/component.rb
+++ b/decidim-elections/lib/decidim/elections/component.rb
@@ -113,9 +113,6 @@ Decidim.register_component(:elections) do |component|
           {
             election: upcoming_election,
             title: Decidim::Faker::Localized.sentence(word_count: 2),
-            description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
             max_selections: Faker::Number.between(from: 1, to: 3),
             weight: Faker::Number.number(digits: 1),
             random_answers_order: Faker::Boolean.boolean(true_ratio: 0.5),

--- a/decidim-elections/lib/decidim/elections/component.rb
+++ b/decidim-elections/lib/decidim/elections/component.rb
@@ -210,9 +210,6 @@ Decidim.register_component(:elections) do |component|
           {
             election: finished_election,
             title: Decidim::Faker::Localized.sentence(word_count: 2),
-            description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
             max_selections: 2,
             weight: Faker::Number.number(digits: 1),
             random_answers_order: Faker::Boolean.boolean(true_ratio: 0.5),
@@ -333,9 +330,6 @@ Decidim.register_component(:elections) do |component|
           {
             election: election_with_results,
             title: Decidim::Faker::Localized.sentence(word_count: 2),
-            description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
             max_selections: 2,
             weight: Faker::Number.number(digits: 1),
             random_answers_order: Faker::Boolean.boolean(true_ratio: 0.5),
@@ -453,9 +447,6 @@ Decidim.register_component(:elections) do |component|
         {
           election: ongoing_election,
           title: Decidim::Faker::Localized.sentence(word_count: 2),
-          description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-            Decidim::Faker::Localized.paragraph(sentence_count: 3)
-          end,
           max_selections: 2,
           weight: Faker::Number.number(digits: 1),
           random_answers_order: Faker::Boolean.boolean(true_ratio: 0.5),


### PR DESCRIPTION
#### :tophat: What? Why?
After #9401 was merged, some specs started failing because the description field was still in the elections component's seeds.

This wasn't spotted at #9401 because it only ran the elections specs.

#### :pushpin: Related Issues
- Related to #9401

#### Testing
See that CI is green.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.