### PR TITLE
Fix access or manage initiative components

### DIFF
--- a/decidim-admin/app/controllers/concerns/decidim/admin/participatory_space_admin_context.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/participatory_space_admin_context.rb
@@ -54,7 +54,13 @@ module Decidim
       end
 
       def layout
-        current_participatory_space_manifest.context(current_participatory_space_context).layout
+        space_manifest = if current_participatory_space_manifest.is_a? Decidim::ResourceManifest
+                           Decidim.participatory_space_manifests.find { |manifest| manifest.model_class_name == current_participatory_space.class.name }
+                         else
+                           current_participatory_space_manifest
+                         end
+
+        space_manifest.context(current_participatory_space_context).layout
       end
     end
   end

--- a/decidim-core/app/controllers/concerns/decidim/participatory_space_context.rb
+++ b/decidim-core/app/controllers/concerns/decidim/participatory_space_context.rb
@@ -59,7 +59,13 @@ module Decidim
     end
 
     def layout
-      current_participatory_space_manifest.context(current_participatory_space_context).layout
+      space_manifest = if current_participatory_space_manifest.is_a? Decidim::ResourceManifest
+                         Decidim.participatory_space_manifests.find { |manifest| manifest.model_class_name == current_participatory_space.class.name }
+                       else
+                         current_participatory_space_manifest
+                       end
+
+      space_manifest.context(current_participatory_space_context).layout
     end
 
     # Method for current user can visit the space (assembly or proces)

--- a/decidim-core/app/helpers/decidim/participatory_space_helpers.rb
+++ b/decidim-core/app/helpers/decidim/participatory_space_helpers.rb
@@ -18,7 +18,7 @@ module Decidim
     def participatory_space_helpers
       return @participatory_space_helpers if defined?(@participatory_space_helpers)
 
-      helper = current_participatory_space_manifest.context(current_participatory_space_context).helper
+      helper = participatory_space_manifest.context(current_participatory_space_context).helper
 
       klass = Class.new(SimpleDelegator) do
         include helper.constantize if helper
@@ -40,6 +40,14 @@ module Decidim
         concat(participatory_space_floating_help)
         concat(capture(&block))
       end
+    end
+
+    def participatory_space_manifest
+      @participatory_space_manifest ||= if current_participatory_space_manifest.is_a? Decidim::ResourceManifest
+                                          Decidim.participatory_space_manifests.find { |manifest| manifest.model_class_name == current_participatory_space.class.name }
+                                        else
+                                          current_participatory_space_manifest
+                                        end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes a bug where admins can't manage components that are in the initiative space, also participants can´t access the initiative components public views.
This is the error: 

```
Could not render layout: undefined method `context' for #<Decidim::ResourceManifest:0x000055b6dfdb6b40  ...
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
- Log in as an admin
- go to manage an Intitative
- go to manage the initiative's component
- It's possible to manage the component!

### :camera: Screenshots

**Before**:
> TBD


#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.



:hearts: Thank you!
