### PR TITLE
Fix hardcoded hour in election dashboard

### DIFF
--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -250,7 +250,7 @@ en:
               minimum_answers: Questions must have <strong>at least two answers</strong>.
               minimum_questions: The election <strong>must have at least one question</strong>.
               published: The election is <strong>not published</strong>.
-              time_before: The start time is in <strong>less than 3 hours</strong> before the election starts.
+              time_before: The start time is in <strong>less than %{hours} hours</strong> before the election starts.
               trustees_number: The participatory space <strong>must have at least %{number} trustees with public key</strong>.
             invalid: There was a problem setting up this election
             no_trustees: There are no Trustees configured for this participatory space


### PR DESCRIPTION
#### :tophat: What? Why?

While trying out `decidim-elections`, I found that we had a hard-coded number in an error. This PR fixes it.

Mind that, when this rule pass, the hour is shown correctly: 

https://github.com/decidim/decidim/blob/3c3b74ce1ff5560c13e82125162c2a166f3e9edf/decidim-elections/config/locales/en.yml#L267


#### Testing
*Describe the best way to test or validate your PR.*

1. Change the `elections.setup_minimum_hours_before_start` key in `development_app/config/secrets.yml` to any number that isn't `3`. 
2. Go to the dashboard of a new election in a participatory process
3. See that the you have the number 3 
 
:hearts: Thank you!
