### PR TITLE
Fix rubocop offences

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/deliver_newsletter.rb
+++ b/decidim-admin/app/commands/decidim/admin/deliver_newsletter.rb
@@ -16,12 +16,12 @@ module Decidim
       end
 
       def call
-        @newsletter.with_lock do
-          return broadcast(:invalid) if @form.send_to_all_users && !@user.admin?
-          return broadcast(:invalid) unless @form.valid?
-          return broadcast(:invalid) if @newsletter.sent?
-          return broadcast(:no_recipients) if recipients.blank?
+        return broadcast(:invalid) if @form.send_to_all_users && !@user.admin?
+        return broadcast(:invalid) unless @form.valid?
+        return broadcast(:invalid) if @newsletter.sent?
+        return broadcast(:no_recipients) if recipients.blank?
 
+        @newsletter.with_lock do
           send_newsletter!
         end
 

--- a/decidim-admin/spec/commands/decidim/admin/impersonate_user_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/impersonate_user_spec.rb
@@ -46,13 +46,13 @@ module Decidim::Admin
         it "creates a impersonation log" do
           expect do
             subject.call
-          end.to change { Decidim::ImpersonationLog.count }.by(1)
+          end.to change(Decidim::ImpersonationLog, :count).by(1)
         end
 
         it "creates a action log" do
           expect do
             subject.call
-          end.to change { Decidim::ActionLog.count }.by(1)
+          end.to change(Decidim::ActionLog, :count).by(1)
         end
 
         it "expires the impersonation session automatically" do
@@ -77,7 +77,7 @@ module Decidim::Admin
       it "creates a action log with reason" do
         expect do
           subject.call
-        end.to change { Decidim::ActionLog.count }.by(1)
+        end.to change(Decidim::ActionLog, :count).by(1)
 
         expect(Decidim::ActionLog.last.action).to eq("manage")
       end

--- a/decidim-assemblies/spec/commands/copy_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/copy_assembly_spec.rb
@@ -43,7 +43,7 @@ module Decidim::Assemblies
 
     context "when everything is ok" do
       it "duplicates an assembly" do
-        expect { subject.call }.to change { Decidim::Assembly.count }.by(1)
+        expect { subject.call }.to change(Decidim::Assembly, :count).by(1)
 
         old_assembly = Decidim::Assembly.first
         new_assembly = Decidim::Assembly.last
@@ -86,7 +86,7 @@ module Decidim::Assemblies
       let(:copy_categories) { true }
 
       it "duplicates a assembly and the categories" do
-        expect { subject.call }.to change { Decidim::Category.count }.by(1)
+        expect { subject.call }.to change(Decidim::Category, :count).by(1)
         expect(Decidim::Category.unscoped.distinct.pluck(:decidim_participatory_space_id).count).to eq 2
 
         old_assembly_category = Decidim::Category.unscoped.first
@@ -106,7 +106,7 @@ module Decidim::Assemblies
         component.manifest.on :copy, &dummy_hook
         expect(dummy_hook).to receive(:call).with({ new_component: an_instance_of(Decidim::Component), old_component: component })
 
-        expect { subject.call }.to change { Decidim::Component.count }.by(1)
+        expect { subject.call }.to change(Decidim::Component, :count).by(1)
 
         last_assembly = Decidim::Assembly.last
         last_component = Decidim::Component.all.reorder(:id).last
@@ -134,7 +134,7 @@ module Decidim::Assemblies
         let!(:assembly) { create :assembly, parent: assembly_parent, organization: organization }
 
         it "duplicates an assembly" do
-          expect { subject.call }.to change { Decidim::Assembly.count }.by(1)
+          expect { subject.call }.to change(Decidim::Assembly, :count).by(1)
 
           old_assembly = Decidim::Assembly.find_by(id: assembly.id)
           new_assembly = Decidim::Assembly.last

--- a/decidim-assemblies/spec/commands/create_assemblies_type_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assemblies_type_spec.rb
@@ -34,7 +34,7 @@ module Decidim::Assemblies
       end
 
       it "creates a new assembly type for the organization" do
-        expect { subject.call }.to change { Decidim::AssembliesType.count }.by(1)
+        expect { subject.call }.to change(Decidim::AssembliesType, :count).by(1)
       end
 
       it "traces the action", versioning: true do

--- a/decidim-assemblies/spec/commands/create_assembly_member_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_member_spec.rb
@@ -73,7 +73,7 @@ module Decidim::Assemblies
       let(:assembly_member) { Decidim::AssemblyMember.last }
 
       it "creates an assembly" do
-        expect { subject.call }.to change { Decidim::AssemblyMember.count }.by(1)
+        expect { subject.call }.to change(Decidim::AssemblyMember, :count).by(1)
       end
 
       it "broadcasts ok" do

--- a/decidim-assemblies/spec/commands/create_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_spec.rb
@@ -145,7 +145,7 @@ module Decidim::Assemblies
       let(:assembly) { Decidim::Assembly.last }
 
       it "creates an assembly" do
-        expect { subject.call }.to change { Decidim::Assembly.count }.by(1)
+        expect { subject.call }.to change(Decidim::Assembly, :count).by(1)
       end
 
       it "broadcasts ok" do

--- a/decidim-assemblies/spec/commands/decidim/assemblies/admin/import_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/decidim/assemblies/admin/import_assembly_spec.rb
@@ -76,7 +76,7 @@ module Decidim::Assemblies::Admin
       it "doesn't create any assembly" do
         expect do
           subject.call
-        end.to change(::Decidim::Assembly, :count).by(0)
+        end.not_to change(::Decidim::Assembly, :count)
       end
     end
 
@@ -92,7 +92,7 @@ module Decidim::Assemblies::Admin
       let(:import_categories) { true }
 
       it "imports an assembly and the categories" do
-        expect { subject.call }.to change { Decidim::Category.count }.by(8)
+        expect { subject.call }.to change(Decidim::Category, :count).by(8)
         expect(Decidim::Category.distinct.select(:decidim_participatory_space_id).count).to eq 1
 
         imported_assembly_category = Decidim::Category.first
@@ -110,7 +110,7 @@ module Decidim::Assemblies::Admin
 
       context "when attachment collections exists" do
         it "imports a assembly and the collections" do
-          expect { subject.call }.to change { Decidim::AttachmentCollection.count }.by(1)
+          expect { subject.call }.to change(Decidim::AttachmentCollection, :count).by(1)
           imported_assembly_collection = Decidim::AttachmentCollection.first
           expect(imported_assembly_collection.name).to eq("ca" => "deleniti", "en" => "laboriosam", "es" => "quia")
           expect(imported_assembly_collection.collection_for).to eq(Decidim::Assembly.last)

--- a/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
@@ -27,9 +27,9 @@ module Decidim
 
           add_line_item
           broadcast(:ok, order)
-        rescue ActiveRecord::RecordInvalid
-          return broadcast(:invalid)
         end
+      rescue ActiveRecord::RecordInvalid
+        broadcast(:invalid)
       end
 
       private

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/create_budget_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/create_budget_spec.rb
@@ -30,7 +30,7 @@ describe Decidim::Budgets::Admin::CreateBudget do
   let(:budget) { Decidim::Budgets::Budget.last }
 
   it "creates the budget" do
-    expect { subject.call }.to change { Decidim::Budgets::Budget.count }.by(1)
+    expect { subject.call }.to change(Decidim::Budgets::Budget, :count).by(1)
   end
 
   it "stores the given data" do

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/destroy_budget_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/destroy_budget_spec.rb
@@ -10,7 +10,7 @@ describe Decidim::Budgets::Admin::DestroyBudget do
   let(:user) { create :user, :admin, :confirmed, organization: organization }
 
   it "destroys the budget" do
-    expect { subject.call }.to change { Decidim::Budgets::Budget.count }.by(-1)
+    expect { subject.call }.to change(Decidim::Budgets::Budget, :count).by(-1)
   end
 
   it "traces the action", versioning: true do

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
@@ -50,7 +50,7 @@ module Decidim
             it "doesn't create the project" do
               expect do
                 command.call
-              end.to change(Project, :count).by(0)
+              end.not_to change(Project, :count)
             end
           end
 

--- a/decidim-budgets/spec/services/decidim/budgets/order_reminder_generator_spec.rb
+++ b/decidim-budgets/spec/services/decidim/budgets/order_reminder_generator_spec.rb
@@ -77,9 +77,8 @@ module Decidim::Budgets
             it "sends existing reminder but does not re-add record to the reminder" do
               expect(Decidim::Budgets::SendVoteReminderJob).to receive(:perform_later)
 
-              expect { subject.generate }.to change(reminder.records, :count)
-                .by(0)
-                .and change(Decidim::Reminder, :count).by(0)
+              expect { subject.generate }.not_to change(reminder.records, :count)
+              expect { subject.generate }.not_to change(Decidim::Reminder, :count)
             end
 
             context "with confirmed order" do

--- a/decidim-budgets/spec/services/decidim/budgets/order_reminder_generator_spec.rb
+++ b/decidim-budgets/spec/services/decidim/budgets/order_reminder_generator_spec.rb
@@ -75,7 +75,7 @@ module Decidim::Budgets
             before { reminder.records << reminder_record }
 
             it "sends existing reminder but does not re-add record to the reminder" do
-              expect(Decidim::Budgets::SendVoteReminderJob).to receive(:perform_later)
+              expect(Decidim::Budgets::SendVoteReminderJob).to receive(:perform_later).twice
 
               expect { subject.generate }.not_to change(reminder.records, :count)
               expect { subject.generate }.not_to change(Decidim::Reminder, :count)

--- a/decidim-comments/spec/controllers/decidim/comments/comments_controller_spec.rb
+++ b/decidim-comments/spec/controllers/decidim/comments/comments_controller_spec.rb
@@ -81,7 +81,7 @@ module Decidim
           it "creates the comment" do
             expect do
               post :create, xhr: true, params: { comment: comment_params }
-            end.to change { Decidim::Comments::Comment.count }.by(1)
+            end.to change(Decidim::Comments::Comment, :count).by(1)
 
             expect(comment.body.values.first).to eq("This is a new comment")
             expect(comment.alignment).to eq(comment_alignment)
@@ -122,7 +122,7 @@ module Decidim
             it "creates the comment with the alignment defined as 1" do
               expect do
                 post :create, xhr: true, params: { comment: comment_params }
-              end.to change { Decidim::Comments::Comment.count }.by(1)
+              end.to change(Decidim::Comments::Comment, :count).by(1)
 
               expect(comment.alignment).to eq(comment_alignment)
               expect(subject).to render_template(:create)
@@ -135,7 +135,7 @@ module Decidim
             it "creates the comment with the alignment defined as -1" do
               expect do
                 post :create, xhr: true, params: { comment: comment_params }
-              end.to change { Decidim::Comments::Comment.count }.by(1)
+              end.to change(Decidim::Comments::Comment, :count).by(1)
 
               expect(comment.alignment).to eq(comment_alignment)
               expect(subject).to render_template(:create)

--- a/decidim-conferences/app/commands/decidim/conferences/admin/confirm_conference_registration.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/confirm_conference_registration.rb
@@ -18,9 +18,9 @@ module Decidim
         #
         # Broadcasts :ok if successful, :invalid otherwise.
         def call
-          @conference_registration.with_lock do
-            return broadcast(:invalid) unless can_join_conference?
+          return broadcast(:invalid) unless can_join_conference?
 
+          @conference_registration.with_lock do
             confirm_registration
             send_email_confirmation
             send_notification_confirmation

--- a/decidim-conferences/app/commands/decidim/conferences/admin/update_diploma.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/update_diploma.rb
@@ -18,9 +18,9 @@ module Decidim
         #
         # Broadcasts :ok if successful, :invalid otherwise.
         def call
-          @conference.with_lock do
-            return broadcast(:invalid) if form.invalid?
+          return broadcast(:invalid) if form.invalid?
 
+          @conference.with_lock do
             update_conference_diploma
             Decidim.traceability.perform_action!(:update_diploma, @conference, form.current_user) do
               @conference

--- a/decidim-conferences/app/commands/decidim/conferences/join_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/join_conference.rb
@@ -20,9 +20,9 @@ module Decidim
       #
       # Broadcasts :ok if successful, :invalid otherwise.
       def call
-        conference.with_lock do
-          return broadcast(:invalid) unless can_join_conference?
+        return broadcast(:invalid) unless can_join_conference?
 
+        conference.with_lock do
           create_registration
           create_meetings_registrations
           accept_invitation

--- a/decidim-conferences/app/commands/decidim/conferences/leave_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/leave_conference.rb
@@ -20,10 +20,10 @@ module Decidim
       #
       # Broadcasts :ok if successful, :invalid otherwise.
       def call
-        @conference.with_lock do
-          return broadcast(:invalid) unless registration
-          return broadcast(:invalid) unless meetings_registrations
+        return broadcast(:invalid) unless registration
+        return broadcast(:invalid) unless meetings_registrations
 
+        @conference.with_lock do
           destroy_registration
           destroy_meeting_registration
         end

--- a/decidim-conferences/spec/commands/copy_conference_spec.rb
+++ b/decidim-conferences/spec/commands/copy_conference_spec.rb
@@ -42,7 +42,7 @@ module Decidim::Conferences
 
     context "when everything is ok" do
       it "duplicates an conference" do
-        expect { subject.call }.to change { Decidim::Conference.count }.by(1)
+        expect { subject.call }.to change(Decidim::Conference, :count).by(1)
 
         old_conference = Decidim::Conference.first
         new_conference = Decidim::Conference.last
@@ -71,7 +71,7 @@ module Decidim::Conferences
       let(:copy_categories) { true }
 
       it "duplicates a conference and the categories" do
-        expect { subject.call }.to change { Decidim::Category.count }.by(1)
+        expect { subject.call }.to change(Decidim::Category, :count).by(1)
         expect(Decidim::Category.unscoped.distinct.pluck(:decidim_participatory_space_id).count).to eq 2
 
         old_conference_category = Decidim::Category.unscoped.first
@@ -91,7 +91,7 @@ module Decidim::Conferences
         component.manifest.on :copy, &dummy_hook
         expect(dummy_hook).to receive(:call).with({ new_component: an_instance_of(Decidim::Component), old_component: component })
 
-        expect { subject.call }.to change { Decidim::Component.count }.by(1)
+        expect { subject.call }.to change(Decidim::Component, :count).by(1)
 
         last_conference = Decidim::Conference.last
         last_component = Decidim::Component.all.reorder(:id).last

--- a/decidim-conferences/spec/commands/create_conference_speaker_spec.rb
+++ b/decidim-conferences/spec/commands/create_conference_speaker_spec.rb
@@ -91,7 +91,7 @@ module Decidim::Conferences
       let(:conference_speaker) { Decidim::ConferenceSpeaker.last }
 
       it "creates an conference" do
-        expect { subject.call }.to change { Decidim::ConferenceSpeaker.count }.by(1)
+        expect { subject.call }.to change(Decidim::ConferenceSpeaker, :count).by(1)
       end
 
       it "broadcasts ok" do

--- a/decidim-conferences/spec/commands/create_conference_spec.rb
+++ b/decidim-conferences/spec/commands/create_conference_spec.rb
@@ -106,7 +106,7 @@ module Decidim::Conferences
       let(:conference) { Decidim::Conference.last }
 
       it "creates an conference" do
-        expect { subject.call }.to change { Decidim::Conference.count }.by(1)
+        expect { subject.call }.to change(Decidim::Conference, :count).by(1)
       end
 
       it "broadcasts ok" do

--- a/decidim-conferences/spec/commands/create_media_link_spec.rb
+++ b/decidim-conferences/spec/commands/create_media_link_spec.rb
@@ -36,7 +36,7 @@ module Decidim::Conferences
       let(:media_link) { Decidim::Conferences::MediaLink.last }
 
       it "creates a media link" do
-        expect { subject.call }.to change { Decidim::Conferences::MediaLink.count }.by(1)
+        expect { subject.call }.to change(Decidim::Conferences::MediaLink, :count).by(1)
       end
 
       it "broadcasts ok" do

--- a/decidim-conferences/spec/commands/create_partner_spec.rb
+++ b/decidim-conferences/spec/commands/create_partner_spec.rb
@@ -67,7 +67,7 @@ module Decidim::Conferences
       let(:partner) { Decidim::Conferences::Partner.last }
 
       it "creates a partner" do
-        expect { subject.call }.to change { Decidim::Conferences::Partner.count }.by(1)
+        expect { subject.call }.to change(Decidim::Conferences::Partner, :count).by(1)
       end
 
       it "broadcasts ok" do

--- a/decidim-conferences/spec/commands/create_registration_type_spec.rb
+++ b/decidim-conferences/spec/commands/create_registration_type_spec.rb
@@ -51,7 +51,7 @@ module Decidim::Conferences
       let(:registration_type) { Decidim::Conferences::RegistrationType.last }
 
       it "creates a registration type" do
-        expect { subject.call }.to change { Decidim::Conferences::RegistrationType.count }.by(1)
+        expect { subject.call }.to change(Decidim::Conferences::RegistrationType, :count).by(1)
       end
 
       it "broadcasts ok" do

--- a/decidim-consultations/spec/commands/decidim/consultations/admin/create_consultation_spec.rb
+++ b/decidim-consultations/spec/commands/decidim/consultations/admin/create_consultation_spec.rb
@@ -70,7 +70,7 @@ module Decidim
 
         context "when everything is ok" do
           it "creates a consultation" do
-            expect { subject.call }.to change { Decidim::Consultation.count }.by(1)
+            expect { subject.call }.to change(Decidim::Consultation, :count).by(1)
           end
 
           it "broadcasts ok" do

--- a/decidim-consultations/spec/commands/decidim/consultations/admin/create_question_spec.rb
+++ b/decidim-consultations/spec/commands/decidim/consultations/admin/create_question_spec.rb
@@ -84,7 +84,7 @@ module Decidim
 
         context "when everything is ok" do
           it "creates a question" do
-            expect { subject.call }.to change { Decidim::Consultations::Question.count }.by(1)
+            expect { subject.call }.to change(Decidim::Consultations::Question, :count).by(1)
           end
 
           it "broadcasts ok" do

--- a/decidim-consultations/spec/commands/decidim/consultations/admin/create_response_group_spec.rb
+++ b/decidim-consultations/spec/commands/decidim/consultations/admin/create_response_group_spec.rb
@@ -36,7 +36,7 @@ module Decidim
 
         context "when everything is ok" do
           it "creates a response group" do
-            expect { subject.call }.to change { Decidim::Consultations::ResponseGroup.count }.by(1)
+            expect { subject.call }.to change(Decidim::Consultations::ResponseGroup, :count).by(1)
           end
 
           it "broadcasts ok" do

--- a/decidim-consultations/spec/commands/decidim/consultations/admin/create_response_spec.rb
+++ b/decidim-consultations/spec/commands/decidim/consultations/admin/create_response_spec.rb
@@ -37,7 +37,7 @@ module Decidim
 
         context "when everything is ok" do
           it "creates a response" do
-            expect { subject.call }.to change { Decidim::Consultations::Response.count }.by(1)
+            expect { subject.call }.to change(Decidim::Consultations::Response, :count).by(1)
           end
 
           it "broadcasts ok" do

--- a/decidim-core/spec/commands/decidim/create_editor_image_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_editor_image_spec.rb
@@ -37,7 +37,7 @@ module Decidim
       end
 
       it "doesn't create an editor image" do
-        expect { subject.call }.not_to(change { Decidim::EditorImage.count })
+        expect { subject.call }.not_to(change(Decidim::EditorImage, :count))
       end
     end
 
@@ -47,7 +47,7 @@ module Decidim
       end
 
       it "creates an editor image" do
-        expect { subject.call }.to change { Decidim::EditorImage.count }.by(1)
+        expect { subject.call }.to change(Decidim::EditorImage, :count).by(1)
       end
     end
   end

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -113,14 +113,14 @@ module Decidim
 
               it "links a previously existing user" do
                 user = create(:user, email: email, organization: organization)
-                expect { command.call }.to change(User, :count).by(0)
+                expect { command.call }.not_to change(User, :count)
 
                 expect(user.identities.length).to eq(1)
               end
 
               it "confirms a previously existing user" do
                 create(:user, email: email, organization: organization)
-                expect { command.call }.to change(User, :count).by(0)
+                expect { command.call }.not_to change(User, :count)
 
                 user = User.find_by(email: email)
                 expect(user).to be_confirmed

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -64,11 +64,11 @@ module Decidim
             end
 
             it "receives the invitation email again" do
+              expect { command.call }.not_to change(User, :count)
               expect do
                 command.call
                 user.reload
-              end.to change(User, :count).by(0)
-                                         .and broadcast(:invalid)
+              end.to broadcast(:invalid)
                 .and change(user.reload, :invitation_token)
               expect(ActionMailer::MailDeliveryJob).to have_been_enqueued.on_queue("mailers")
             end

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -70,7 +70,7 @@ module Decidim
                 user.reload
               end.to broadcast(:invalid)
                 .and change(user.reload, :invitation_token)
-              expect(ActionMailer::MailDeliveryJob).to have_been_enqueued.on_queue("mailers")
+              expect(ActionMailer::MailDeliveryJob).to have_been_enqueued.on_queue("mailers").twice
             end
           end
         end

--- a/decidim-core/spec/controllers/editor_images_controller_spec.rb
+++ b/decidim-core/spec/controllers/editor_images_controller_spec.rb
@@ -24,7 +24,7 @@ module Decidim
         it "doesn't create an editor image" do
           expect do
             post :create, params: valid_params
-          end.not_to(change { Decidim::EditorImage.count })
+          end.not_to(change(Decidim::EditorImage, :count))
 
           expect(response).to have_http_status(:redirect)
         end
@@ -38,7 +38,7 @@ module Decidim
         it "doesn't create an editor image" do
           expect do
             post :create, params: valid_params
-          end.not_to(change { Decidim::EditorImage.count })
+          end.not_to(change(Decidim::EditorImage, :count))
 
           expect(response).to have_http_status(:redirect)
         end
@@ -52,7 +52,7 @@ module Decidim
         it "creates an editor image" do
           expect do
             post :create, params: valid_params
-          end.to change { Decidim::EditorImage.count }.by(1)
+          end.to change(Decidim::EditorImage, :count).by(1)
 
           expect(response).to have_http_status(:ok)
         end
@@ -61,7 +61,7 @@ module Decidim
           it "doesn't create an editor image and returns an error message" do
             expect do
               post :create, params: invalid_params
-            end.not_to(change { Decidim::EditorImage.count })
+            end.not_to(change(Decidim::EditorImage, :count))
 
             expect(response).to have_http_status(:unprocessable_entity)
             expect(response.body).to include("Error uploading image")

--- a/decidim-debates/spec/commands/decidim/debates/admin/create_debate_spec.rb
+++ b/decidim-debates/spec/commands/decidim/debates/admin/create_debate_spec.rb
@@ -44,7 +44,7 @@ describe Decidim::Debates::Admin::CreateDebate do
     let(:debate) { Decidim::Debates::Debate.last }
 
     it "creates the debate" do
-      expect { subject.call }.to change { Decidim::Debates::Debate.count }.by(1)
+      expect { subject.call }.to change(Decidim::Debates::Debate, :count).by(1)
     end
 
     context "when debate is open" do

--- a/decidim-debates/spec/commands/decidim/debates/create_debate_spec.rb
+++ b/decidim-debates/spec/commands/decidim/debates/create_debate_spec.rb
@@ -38,7 +38,7 @@ describe Decidim::Debates::CreateDebate do
     let(:debate) { Decidim::Debates::Debate.last }
 
     it "creates the debate" do
-      expect { subject.call }.to change { Decidim::Debates::Debate.count }.by(1)
+      expect { subject.call }.to change(Decidim::Debates::Debate, :count).by(1)
     end
 
     it "sets the scope" do

--- a/decidim-elections/spec/commands/decidim/elections/admin/add_user_as_trustee_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/add_user_as_trustee_spec.rb
@@ -26,7 +26,7 @@ describe Decidim::Elections::Admin::AddUserAsTrustee do
     let(:trustee) { nil }
 
     it "adds the user to trustees" do
-      expect { subject.call }.to change { Decidim::Elections::Trustee.count }.by(1)
+      expect { subject.call }.to change(Decidim::Elections::Trustee, :count).by(1)
     end
 
     it "adds the user organization to trustee" do

--- a/decidim-elections/spec/commands/decidim/elections/admin/create_answer_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/create_answer_spec.rb
@@ -38,7 +38,7 @@ describe Decidim::Elections::Admin::CreateAnswer do
   let(:answer) { Decidim::Elections::Answer.last }
 
   it "creates the answer" do
-    expect { subject.call }.to change { Decidim::Elections::Answer.count }.by(1)
+    expect { subject.call }.to change(Decidim::Elections::Answer, :count).by(1)
   end
 
   it "stores the given data" do
@@ -86,7 +86,7 @@ describe Decidim::Elections::Admin::CreateAnswer do
     let(:proposals) { create_list :proposal, 2, component: proposals_component }
 
     it "creates the answer" do
-      expect { subject.call }.to change { Decidim::Elections::Answer.count }.by(1)
+      expect { subject.call }.to change(Decidim::Elections::Answer, :count).by(1)
     end
 
     it "stores the relations with proposals" do

--- a/decidim-elections/spec/commands/decidim/elections/admin/create_election_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/create_election_spec.rb
@@ -34,7 +34,7 @@ describe Decidim::Elections::Admin::CreateElection do
   let(:election) { Decidim::Elections::Election.last }
 
   it "creates the election" do
-    expect { subject.call }.to change { Decidim::Elections::Election.count }.by(1)
+    expect { subject.call }.to change(Decidim::Elections::Election, :count).by(1)
   end
 
   it "stores the given data" do

--- a/decidim-elections/spec/commands/decidim/elections/admin/create_question_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/create_question_spec.rb
@@ -29,7 +29,7 @@ describe Decidim::Elections::Admin::CreateQuestion do
   let(:question) { Decidim::Elections::Question.last }
 
   it "creates the question" do
-    expect { subject.call }.to change { Decidim::Elections::Question.count }.by(1)
+    expect { subject.call }.to change(Decidim::Elections::Question, :count).by(1)
   end
 
   it "stores the given data" do

--- a/decidim-elections/spec/commands/decidim/elections/admin/destroy_answer_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/destroy_answer_spec.rb
@@ -13,7 +13,7 @@ describe Decidim::Elections::Admin::DestroyAnswer do
   let(:user) { create :user, :admin, :confirmed, organization: organization }
 
   it "destroys the answer" do
-    expect { subject.call }.to change { Decidim::Elections::Answer.count }.by(-1)
+    expect { subject.call }.to change(Decidim::Elections::Answer, :count).by(-1)
   end
 
   it "traces the action", versioning: true do

--- a/decidim-elections/spec/commands/decidim/elections/admin/destroy_election_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/destroy_election_spec.rb
@@ -10,7 +10,7 @@ describe Decidim::Elections::Admin::DestroyElection do
   let(:user) { create :user, :admin, :confirmed, organization: organization }
 
   it "destroys the election" do
-    expect { subject.call }.to change { Decidim::Elections::Election.count }.by(-1)
+    expect { subject.call }.to change(Decidim::Elections::Election, :count).by(-1)
   end
 
   it "traces the action", versioning: true do

--- a/decidim-elections/spec/commands/decidim/elections/admin/destroy_question_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/destroy_question_spec.rb
@@ -11,7 +11,7 @@ describe Decidim::Elections::Admin::DestroyQuestion do
   let(:user) { create :user, :admin, :confirmed, organization: organization }
 
   it "destroys the question" do
-    expect { subject.call }.to change { Decidim::Elections::Question.count }.by(-1)
+    expect { subject.call }.to change(Decidim::Elections::Question, :count).by(-1)
   end
 
   it "traces the action", versioning: true do

--- a/decidim-elections/spec/commands/decidim/elections/admin/end_vote_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/end_vote_spec.rb
@@ -56,7 +56,7 @@ describe Decidim::Elections::Admin::EndVote do
     end
 
     it "creates an action" do
-      expect { subject.call }.to change { Decidim::Elections::Action.count }.by(1)
+      expect { subject.call }.to change(Decidim::Elections::Action, :count).by(1)
 
       expect(action.election).to eq(election)
       expect(action.message_id).to eq "a.message+id"

--- a/decidim-elections/spec/commands/decidim/elections/admin/import_proposals_to_elections_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/import_proposals_to_elections_spec.rb
@@ -47,7 +47,7 @@ module Decidim
             it "doesn't create the answer" do
               expect do
                 command.call
-              end.to change(Decidim::Elections::Answer, :count).by(0)
+              end.not_to change(Decidim::Elections::Answer, :count)
             end
           end
 
@@ -73,7 +73,7 @@ module Decidim
               it "doesn't import it again" do
                 expect do
                   command.call
-                end.to change { Decidim::Elections::Answer.where(question: question).count }.by(0)
+                end.not_to(change { Decidim::Elections::Answer.where(question: question).count })
 
                 answers = Decidim::Elections::Answer.where(question: question)
                 first_answer = answers.first

--- a/decidim-elections/spec/commands/decidim/elections/admin/publish_results_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/publish_results_spec.rb
@@ -66,7 +66,7 @@ describe Decidim::Elections::Admin::PublishResults do
     end
 
     it "creates an action" do
-      expect { subject.call }.to change { Decidim::Elections::Action.count }.by(1)
+      expect { subject.call }.to change(Decidim::Elections::Action, :count).by(1)
 
       expect(action.election).to eq(election)
       expect(action.message_id).to eq "a.message+id"

--- a/decidim-elections/spec/commands/decidim/elections/admin/report_missing_trustee_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/report_missing_trustee_spec.rb
@@ -63,7 +63,7 @@ describe Decidim::Elections::Admin::ReportMissingTrustee do
     end
 
     it "creates an action" do
-      expect { subject.call }.to change { Decidim::Elections::Action.count }.by(1)
+      expect { subject.call }.to change(Decidim::Elections::Action, :count).by(1)
 
       expect(action.election).to eq(election)
       expect(action.message_id).to eq "a.message+id"

--- a/decidim-elections/spec/commands/decidim/elections/admin/start_key_ceremony_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/start_key_ceremony_spec.rb
@@ -56,7 +56,7 @@ describe Decidim::Elections::Admin::StartKeyCeremony do
     end
 
     it "creates an action" do
-      expect { subject.call }.to change { Decidim::Elections::Action.count }.by(1)
+      expect { subject.call }.to change(Decidim::Elections::Action, :count).by(1)
 
       expect(action.election).to eq(election)
       expect(action.message_id).to eq "a.message+id"

--- a/decidim-elections/spec/commands/decidim/elections/admin/start_tally_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/start_tally_spec.rb
@@ -56,7 +56,7 @@ describe Decidim::Elections::Admin::StartTally do
     end
 
     it "creates an action" do
-      expect { subject.call }.to change { Decidim::Elections::Action.count }.by(1)
+      expect { subject.call }.to change(Decidim::Elections::Action, :count).by(1)
 
       expect(action.election).to eq(election)
       expect(action.message_id).to eq "a.message+id"

--- a/decidim-elections/spec/commands/decidim/elections/admin/start_vote_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/start_vote_spec.rb
@@ -56,7 +56,7 @@ describe Decidim::Elections::Admin::StartVote do
     end
 
     it "creates an action" do
-      expect { subject.call }.to change { Decidim::Elections::Action.count }.by(1)
+      expect { subject.call }.to change(Decidim::Elections::Action, :count).by(1)
 
       expect(action.election).to eq(election)
       expect(action.message_id).to eq "a.message+id"

--- a/decidim-elections/spec/commands/decidim/elections/admin/update_answer_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/update_answer_spec.rb
@@ -57,7 +57,7 @@ describe Decidim::Elections::Admin::UpdateAnswer do
     let(:proposals) { create_list :proposal, 2, component: proposals_component }
 
     it "creates the answer" do
-      expect { subject.call }.to change { Decidim::Elections::Answer.count }.by(1)
+      expect { subject.call }.to change(Decidim::Elections::Answer, :count).by(1)
     end
 
     it "stores the relations with proposals" do

--- a/decidim-elections/spec/commands/decidim/votings/admin/create_ballot_style_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/admin/create_ballot_style_spec.rb
@@ -32,11 +32,11 @@ module Decidim
         let(:ballot_style) { Decidim::Votings::BallotStyle.last }
 
         it "creates the ballot style" do
-          expect { subject.call }.to change { Decidim::Votings::BallotStyle.count }.by(1)
+          expect { subject.call }.to change(Decidim::Votings::BallotStyle, :count).by(1)
         end
 
         it "creates the association between ballot style and questions" do
-          expect { subject.call }.to change { Decidim::Votings::BallotStyleQuestion.count }.by(2)
+          expect { subject.call }.to change(Decidim::Votings::BallotStyleQuestion, :count).by(2)
         end
 
         it "broadcasts ok" do

--- a/decidim-elections/spec/commands/decidim/votings/admin/create_polling_station_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/admin/create_polling_station_spec.rb
@@ -44,7 +44,7 @@ module Decidim
         let(:polling_station) { Decidim::Votings::PollingStation.last }
 
         it "creates the voting" do
-          expect { subject.call }.to change { Decidim::Votings::PollingStation.count }.by(1)
+          expect { subject.call }.to change(Decidim::Votings::PollingStation, :count).by(1)
         end
 
         it "broadcasts ok" do

--- a/decidim-elections/spec/commands/decidim/votings/admin/create_voting_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/admin/create_voting_spec.rb
@@ -46,7 +46,7 @@ module Decidim
         let(:voting) { Decidim::Votings::Voting.last }
 
         it "creates the voting" do
-          expect { subject.call }.to change { Decidim::Votings::Voting.count }.by(1)
+          expect { subject.call }.to change(Decidim::Votings::Voting, :count).by(1)
         end
 
         it "broadcasts ok" do

--- a/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
+++ b/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
@@ -173,7 +173,7 @@ module Decidim
             end
 
             it "does not create atachments for the proposal" do
-              expect { command.call }.to change(Decidim::Attachment, :count).by(0)
+              expect { command.call }.not_to change(Decidim::Attachment, :count)
             end
 
             it "broadcasts invalid" do

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -110,7 +110,7 @@ module Decidim
               redirect_to EngineRouter.main_proxy(current_initiative).initiatives_path(initiative_slug: nil), flash: {
                 notice: I18n.t(
                   "success",
-                  scope: %w(decidim initiatives admin initiatives edit)
+                  scope: "decidim.initiatives.admin.initiatives.edit"
                 )
               }
             end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/committee_requests_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/committee_requests_controller.rb
@@ -28,7 +28,7 @@ module Decidim
             redirect_to initiatives_path, flash: {
               notice: I18n.t(
                 "success",
-                scope: %w(decidim initiatives committee_requests spawn)
+                scope: "decidim.initiatives.committee_requests.spawn"
               )
             }
           end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -60,7 +60,7 @@ module Decidim
             redirect_to EngineRouter.main_proxy(current_initiative).initiatives_path(initiative_slug: nil), flash: {
               notice: I18n.t(
                 "success",
-                scope: %w(decidim initiatives admin initiatives edit)
+                scope: "decidim.initiatives.admin.initiatives.edit"
               )
             }
           end

--- a/decidim-initiatives/app/helpers/decidim/initiatives/create_initiative_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/create_initiative_helper.rb
@@ -27,7 +27,7 @@ module Decidim
           [
             I18n.t(
               "online",
-              scope: %w(activemodel attributes initiative signature_type_values)
+              scope: "activemodel.attributes.initiative.signature_type_values"
             ), "online"
           ]
         ]
@@ -38,7 +38,7 @@ module Decidim
           [
             I18n.t(
               "offline",
-              scope: %w(activemodel attributes initiative signature_type_values)
+              scope: "activemodel.attributes.initiative.signature_type_values"
             ), "offline"
           ]
         ]
@@ -49,7 +49,7 @@ module Decidim
           [
             I18n.t(
               type,
-              scope: %w(activemodel attributes initiative signature_type_values)
+              scope: "activemodel.attributes.initiative.signature_type_values"
             ), type
           ]
         end

--- a/decidim-initiatives/spec/commands/decidim/initiatives/update_initiative_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/update_initiative_spec.rb
@@ -119,7 +119,7 @@ module Decidim
             end
 
             it "does not create atachments for the initiative" do
-              expect { command.call }.to change(Decidim::Attachment, :count).by(0)
+              expect { command.call }.not_to change(Decidim::Attachment, :count)
             end
 
             it "broadcasts invalid" do

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_type_scopes_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_type_scopes_controller_spec.rb
@@ -87,7 +87,7 @@ module Decidim
                        initiatives_type_id: initiative_type.id,
                        initiatives_type_scope: invalid_attributes
                      }
-              end.to change(InitiativesTypeScope, :count).by(0)
+              end.not_to change(InitiativesTypeScope, :count)
             end
           end
 
@@ -216,7 +216,7 @@ module Decidim
                          initiatives_type_id: initiative_type.id,
                          id: initiative_type_scope.to_param
                        }
-              end.to change(InitiativesTypeScope, :count).by(0)
+              end.not_to change(InitiativesTypeScope, :count)
             end
           end
 

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_types_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_types_controller_spec.rb
@@ -94,7 +94,7 @@ module Decidim
             it "fails creation" do
               expect do
                 post :create, params: { initiatives_type: invalid_attributes }
-              end.to change(InitiativesType, :count).by(0)
+              end.not_to change(InitiativesType, :count)
             end
           end
 
@@ -201,7 +201,7 @@ module Decidim
 
               expect do
                 delete :destroy, params: { id: initiative_type.id }
-              end.to change(InitiativesType, :count).by(0)
+              end.not_to change(InitiativesType, :count)
             end
 
             it "traces the action", versioning: true do

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/committee_requests_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/committee_requests_controller_spec.rb
@@ -38,7 +38,7 @@ module Decidim
 
             expect do
               get :spawn, params: { initiative_slug: initiative.slug }
-            end.to change(InitiativesCommitteeMember, :count).by(0)
+            end.not_to change(InitiativesCommitteeMember, :count)
           end
         end
 
@@ -48,7 +48,7 @@ module Decidim
           it "Membership request is not created" do
             expect do
               get :spawn, params: { initiative_slug: published_initiative.slug }
-            end.to change(InitiativesCommitteeMember, :count).by(0)
+            end.not_to change(InitiativesCommitteeMember, :count)
           end
         end
       end

--- a/decidim-initiatives/spec/shared/create_initiative_example.rb
+++ b/decidim-initiatives/spec/shared/create_initiative_example.rb
@@ -55,7 +55,7 @@ shared_examples "create an initiative" do
       it "creates a new initiative" do
         expect do
           command.call
-        end.to change { Decidim::Initiative.count }.by(1)
+        end.to change(Decidim::Initiative, :count).by(1)
       end
 
       context "when attachment is present" do

--- a/decidim-initiatives/spec/shared/create_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/create_initiative_type_example.rb
@@ -60,7 +60,7 @@ shared_examples "create an initiative type" do
       it "creates a new initiative type" do
         expect do
           command.call
-        end.to change { Decidim::InitiativesType.count }.by(1)
+        end.to change(Decidim::InitiativesType, :count).by(1)
       end
 
       it "traces the action", versioning: true do

--- a/decidim-initiatives/spec/shared/create_initiative_type_scope_example.rb
+++ b/decidim-initiatives/spec/shared/create_initiative_type_scope_example.rb
@@ -47,7 +47,7 @@ shared_examples "create an initiative type scope" do
       it "creates a new initiative type scope" do
         expect do
           command.call
-        end.to change { Decidim::InitiativesTypeScope.count }.by(1)
+        end.to change(Decidim::InitiativesTypeScope, :count).by(1)
       end
     end
   end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_registrations.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_registrations.rb
@@ -18,9 +18,9 @@ module Decidim
         #
         # Broadcasts :ok if successful, :invalid otherwise.
         def call
-          meeting.with_lock do
-            return broadcast(:invalid) if form.invalid?
+          return broadcast(:invalid) if form.invalid?
 
+          meeting.with_lock do
             update_meeting_registrations
             send_notification if should_notify_followers?
           end

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -21,12 +21,11 @@ module Decidim
       #
       # Broadcasts :ok if successful, :invalid otherwise.
       def call
+        return broadcast(:invalid) unless can_join_meeting?
+        return broadcast(:invalid_form) unless registration_form.valid?
+        return broadcast(:invalid) if answer_questionnaire == :invalid
+
         meeting.with_lock do
-          return broadcast(:invalid) unless can_join_meeting?
-          return broadcast(:invalid_form) unless registration_form.valid?
-
-          return broadcast(:invalid) if answer_questionnaire == :invalid
-
           create_registration
           accept_invitation
           send_email_confirmation

--- a/decidim-meetings/app/commands/decidim/meetings/leave_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/leave_meeting.rb
@@ -18,9 +18,9 @@ module Decidim
       #
       # Broadcasts :ok if successful, :invalid otherwise.
       def call
-        @meeting.with_lock do
-          return broadcast(:invalid) unless registration
+        return broadcast(:invalid) unless registration
 
+        @meeting.with_lock do
           destroy_registration
           destroy_questionnaire_answers
           decrement_score

--- a/decidim-meetings/spec/lib/decidim/meetings/component_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/component_spec.rb
@@ -12,7 +12,7 @@ describe "Meetings component" do # rubocop:disable RSpec/DescribeClass
       it "destroys the component" do
         expect do
           Decidim::Admin::DestroyComponent.call(component, current_user)
-        end.to change { Decidim::Component.count }.by(-1)
+        end.to change(Decidim::Component, :count).by(-1)
 
         expect(component).to be_destroyed
       end

--- a/decidim-meetings/spec/services/decidim/meetings/close_meeting_reminder_generator_spec.rb
+++ b/decidim-meetings/spec/services/decidim/meetings/close_meeting_reminder_generator_spec.rb
@@ -38,7 +38,7 @@ module Decidim::Meetings
           it "does not send the reminder" do
             expect(Decidim::Meetings::SendCloseMeetingReminderJob).not_to receive(:perform_later)
 
-            expect { subject.generate }.to change(Decidim::Reminder, :count).by(0)
+            expect { subject.generate }.not_to change(Decidim::Reminder, :count)
           end
         end
 
@@ -61,7 +61,7 @@ module Decidim::Meetings
           it "does not send the reminder" do
             expect(Decidim::Meetings::SendCloseMeetingReminderJob).not_to receive(:perform_later)
 
-            expect { subject.generate }.to change(Decidim::Reminder, :count).by(0)
+            expect { subject.generate }.not_to change(Decidim::Reminder, :count)
             expect(Decidim::Reminder.first).to be_nil
           end
         end
@@ -83,7 +83,7 @@ module Decidim::Meetings
         it "does not send the reminder" do
           expect(Decidim::Meetings::SendCloseMeetingReminderJob).not_to receive(:perform_later)
 
-          expect { subject.generate }.to change(Decidim::Reminder, :count).by(0)
+          expect { subject.generate }.not_to change(Decidim::Reminder, :count)
           expect(Decidim::Reminder.first).to be_nil
         end
       end

--- a/decidim-participatory_processes/spec/commands/copy_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/copy_participatory_process_spec.rb
@@ -46,7 +46,7 @@ module Decidim::ParticipatoryProcesses
 
     context "when everything is ok" do
       it "duplicates a participatory process" do
-        expect { subject.call }.to change { Decidim::ParticipatoryProcess.count }.by(1)
+        expect { subject.call }.to change(Decidim::ParticipatoryProcess, :count).by(1)
 
         old_participatory_process = Decidim::ParticipatoryProcess.first
         new_participatory_process = Decidim::ParticipatoryProcess.last
@@ -91,7 +91,7 @@ module Decidim::ParticipatoryProcesses
       let(:copy_steps) { true }
 
       it "duplicates a participatory process and the steps" do
-        expect { subject.call }.to change { Decidim::ParticipatoryProcessStep.count }.by(1)
+        expect { subject.call }.to change(Decidim::ParticipatoryProcessStep, :count).by(1)
         expect(Decidim::ParticipatoryProcessStep.distinct.pluck(:decidim_participatory_process_id).count).to eq 2
 
         old_participatory_process_step = Decidim::ParticipatoryProcessStep.first
@@ -108,7 +108,7 @@ module Decidim::ParticipatoryProcesses
       let(:copy_categories) { true }
 
       it "duplicates a participatory process and the categories" do
-        expect { subject.call }.to change { Decidim::Category.count }.by(1)
+        expect { subject.call }.to change(Decidim::Category, :count).by(1)
         expect(Decidim::Category.unscoped.distinct.pluck(:decidim_participatory_space_id).count).to eq 2
 
         old_participatory_process_category = Decidim::Category.unscoped.first
@@ -123,7 +123,7 @@ module Decidim::ParticipatoryProcesses
         let!(:subcategory) { create(:category, parent: category, participatory_space: participatory_process) }
 
         it "duplicates the parent and its children" do
-          expect { subject.call }.to change { Decidim::Category.count }.by(2)
+          expect { subject.call }.to change(Decidim::Category, :count).by(2)
           new_participatory_process = Decidim::ParticipatoryProcess.last
 
           expect(participatory_process.categories.count).to eq(2)
@@ -140,7 +140,7 @@ module Decidim::ParticipatoryProcesses
         component.manifest.on :copy, &dummy_hook
         expect(dummy_hook).to receive(:call).with({ new_component: an_instance_of(Decidim::Component), old_component: component })
 
-        expect { subject.call }.to change { Decidim::Component.count }.by(1)
+        expect { subject.call }.to change(Decidim::Component, :count).by(1)
 
         last_participatory_process = Decidim::ParticipatoryProcess.last
         last_component = Decidim::Component.all.reorder(:id).last

--- a/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
@@ -95,7 +95,7 @@ module Decidim::ParticipatoryProcesses
       let(:process) { Decidim::ParticipatoryProcess.last }
 
       it "creates a participatory process" do
-        expect { subject.call }.to change { Decidim::ParticipatoryProcess.count }.by(1)
+        expect { subject.call }.to change(Decidim::ParticipatoryProcess, :count).by(1)
       end
 
       it "traces the creation", versioning: true do

--- a/decidim-participatory_processes/spec/commands/create_participatory_process_step_spec.rb
+++ b/decidim-participatory_processes/spec/commands/create_participatory_process_step_spec.rb
@@ -31,7 +31,7 @@ module Decidim::ParticipatoryProcesses
 
     context "when everything is ok" do
       it "creates a participatory process step" do
-        expect { subject.call }.to change { Decidim::ParticipatoryProcessStep.count }.by(1)
+        expect { subject.call }.to change(Decidim::ParticipatoryProcessStep, :count).by(1)
       end
 
       it "broadcasts ok" do

--- a/decidim-participatory_processes/spec/commands/create_participatory_process_type_spec.rb
+++ b/decidim-participatory_processes/spec/commands/create_participatory_process_type_spec.rb
@@ -29,7 +29,7 @@ module Decidim::ParticipatoryProcesses
 
     context "when everything is ok" do
       it "creates a participatory process type" do
-        expect { subject.call }.to change { Decidim::ParticipatoryProcessType.count }.by(1)
+        expect { subject.call }.to change(Decidim::ParticipatoryProcessType, :count).by(1)
       end
 
       it "broadcasts ok" do

--- a/decidim-participatory_processes/spec/commands/decidim/participatory_processes/admin/create_participatory_process_group_spec.rb
+++ b/decidim-participatory_processes/spec/commands/decidim/participatory_processes/admin/create_participatory_process_group_spec.rb
@@ -46,7 +46,7 @@ module Decidim::ParticipatoryProcesses
       end
 
       it "creates a participatory process group" do
-        expect { subject.call }.to change { Decidim::ParticipatoryProcessGroup.count }.by(1)
+        expect { subject.call }.to change(Decidim::ParticipatoryProcessGroup, :count).by(1)
       end
 
       it "traces the creation", versioning: true do

--- a/decidim-participatory_processes/spec/commands/decidim/participatory_processes/admin/import_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/decidim/participatory_processes/admin/import_participatory_process_spec.rb
@@ -75,7 +75,7 @@ module Decidim::ParticipatoryProcesses
       it "doesn't create any proces" do
         expect do
           subject.call
-        end.to change(::Decidim::ParticipatoryProcess, :count).by(0)
+        end.not_to change(::Decidim::ParticipatoryProcess, :count)
       end
     end
 
@@ -91,7 +91,7 @@ module Decidim::ParticipatoryProcesses
       let(:import_components) { true }
 
       it "imports a participatory process and the steps" do
-        expect { subject.call }.to change { Decidim::Component.count }.by(3)
+        expect { subject.call }.to change(Decidim::Component, :count).by(3)
         expect(Decidim::Component.where(participatory_space_id: Decidim::ParticipatoryProcess.last).count).to eq 3
       end
 
@@ -106,7 +106,7 @@ module Decidim::ParticipatoryProcesses
       let(:import_steps) { true }
 
       it "imports a participatory process and the steps" do
-        expect { subject.call }.to change { Decidim::ParticipatoryProcessStep.count }.by(1)
+        expect { subject.call }.to change(Decidim::ParticipatoryProcessStep, :count).by(1)
         expect(Decidim::ParticipatoryProcessStep.distinct.pluck(:decidim_participatory_process_id).count).to eq 1
 
         imported_participatory_process_step = Decidim::ParticipatoryProcessStep.last
@@ -126,7 +126,7 @@ module Decidim::ParticipatoryProcesses
       let(:import_categories) { true }
 
       it "imports a participatory process and the categories" do
-        expect { subject.call }.to change { Decidim::Category.count }.by(8)
+        expect { subject.call }.to change(Decidim::Category, :count).by(8)
         expect(Decidim::Category.unscoped.distinct.pluck(:decidim_participatory_space_id).count).to eq 1
 
         imported_participatory_process_category = Decidim::Category.unscoped.first
@@ -150,7 +150,7 @@ module Decidim::ParticipatoryProcesses
 
       context "when attachment collections exists" do
         it "imports a participatory process and the collections" do
-          expect { subject.call }.to change { Decidim::AttachmentCollection.count }.by(1)
+          expect { subject.call }.to change(Decidim::AttachmentCollection, :count).by(1)
           imported_participatory_process_collection = Decidim::AttachmentCollection.first
           expect(imported_participatory_process_collection.name).to eq("ca" => "assumenda", "en" => "cumque", "es" => "rem")
           expect(imported_participatory_process_collection.collection_for).to eq(Decidim::ParticipatoryProcess.last)

--- a/decidim-participatory_processes/spec/types/integration_schema_spec.rb
+++ b/decidim-participatory_processes/spec/types/integration_schema_spec.rb
@@ -156,7 +156,7 @@ describe "Decidim::Api::QueryType" do
         "translation" => participatory_process.announcement[locale]
       },
       "attachments" => [],
-      "bannerImage" => participatory_process.attached_uploader(:banner_image).path.sub(Rails.root.join("public").to_s, ""),
+      "bannerImage" => participatory_process.attached_uploader(:banner_image).path.sub(Rails.public_path.to_s, ""),
       "categories" => [],
       "components" => components,
       "createdAt" => participatory_process.created_at.iso8601.to_s.gsub("Z", "+00:00"),
@@ -164,7 +164,7 @@ describe "Decidim::Api::QueryType" do
       "developerGroup" => { "translation" => participatory_process.developer_group[locale] },
       "endDate" => participatory_process.end_date.to_s,
       "hashtag" => "",
-      "heroImage" => participatory_process.attached_uploader(:hero_image).path.sub(Rails.root.join("public").to_s, ""),
+      "heroImage" => participatory_process.attached_uploader(:hero_image).path.sub(Rails.public_path.to_s, ""),
       "id" => participatory_process.id.to_s,
       "linkedParticipatorySpaces" => [],
       "localArea" => { "translation" => participatory_process.local_area[locale] },

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/import_participatory_text_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/import_participatory_text_spec.rb
@@ -70,7 +70,7 @@ module Decidim
             it "doesn't create any proposal" do
               expect do
                 command.call
-              end.to change(Proposal, :count).by(0)
+              end.not_to change(Proposal, :count)
             end
           end
 

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
@@ -55,7 +55,7 @@ module Decidim
             it "doesn't create the proposal" do
               expect do
                 command.call
-              end.to change(Proposal, :count).by(0)
+              end.not_to change(Proposal, :count)
             end
           end
 

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/merge_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/merge_proposals_spec.rb
@@ -35,7 +35,7 @@ module Decidim
             it "doesn't create the proposal" do
               expect do
                 command.call
-              end.to change(Proposal, :count).by(0)
+              end.not_to change(Proposal, :count)
             end
           end
 

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/split_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/split_proposals_spec.rb
@@ -35,7 +35,7 @@ module Decidim
             it "doesn't create the proposal" do
               expect do
                 command.call
-              end.to change(Proposal, :count).by(0)
+              end.not_to change(Proposal, :count)
             end
           end
 

--- a/decidim-proposals/spec/commands/decidim/proposals/admin_create_proposal_note_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin_create_proposal_note_spec.rb
@@ -35,7 +35,7 @@ module Decidim
             it "doesn't create the proposal note" do
               expect do
                 command.call
-              end.to change(ProposalVote, :count).by(0)
+              end.not_to change(ProposalVote, :count)
             end
           end
 

--- a/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
@@ -217,7 +217,7 @@ module Decidim
             end
 
             it "does not create atachments for the proposal" do
-              expect { command.call }.to change(Decidim::Attachment, :count).by(0)
+              expect { command.call }.not_to change(Decidim::Attachment, :count)
             end
 
             it "broadcasts invalid" do

--- a/decidim-proposals/spec/commands/decidim/proposals/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/vote_proposal_spec.rb
@@ -36,7 +36,7 @@ module Decidim
           it "doesn't create a new vote for the proposal" do
             expect do
               command.call
-            end.to change(ProposalVote, :count).by(0)
+            end.not_to change(ProposalVote, :count)
           end
         end
 

--- a/decidim-proposals/spec/commands/decidim/proposals/withdraw_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/withdraw_proposal_spec.rb
@@ -19,7 +19,7 @@ module Decidim
           it "withdraws the proposal" do
             expect do
               expect { command.call }.to broadcast(:ok)
-            end.to change { Decidim::Proposals::Proposal.count }.by(0)
+            end.not_to change(Decidim::Proposals::Proposal, :count)
             expect(proposal.state).to eq("withdrawn")
           end
         end
@@ -32,7 +32,7 @@ module Decidim
           it "is not able to withdraw the proposal" do
             expect do
               expect { command.call }.to broadcast(:has_supports)
-            end.to change { Decidim::Proposals::Proposal.count }.by(0)
+            end.not_to change(Decidim::Proposals::Proposal, :count)
             expect(proposal.state).not_to eq("withdrawn")
           end
         end

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -12,7 +12,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
       it "destroys the component" do
         expect do
           Decidim::Admin::DestroyComponent.call(component, current_user)
-        end.to change { Decidim::Component.count }.by(-1)
+        end.to change(Decidim::Component, :count).by(-1)
 
         expect(component).to be_destroyed
       end

--- a/decidim-sortitions/spec/commands/decidim/sortitions/admin/create_sortition_spec.rb
+++ b/decidim-sortitions/spec/commands/decidim/sortitions/admin/create_sortition_spec.rb
@@ -53,7 +53,7 @@ module Decidim
           it "doesn't create the sortition" do
             expect do
               command.call
-            end.to change { Sortition.where(component: sortition_component).count }.by(0)
+            end.not_to(change { Sortition.where(component: sortition_component).count })
           end
         end
 

--- a/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
+++ b/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
@@ -40,7 +40,7 @@ describe "Surveys component" do # rubocop:disable RSpec/DescribeClass
     end
 
     it "create a survey component" do
-      expect { subject.manifest.run_hooks(:copy, old_component: component, new_component: new_component) }.to change { Decidim::Surveys::Survey.count }.by(1)
+      expect { subject.manifest.run_hooks(:copy, old_component: component, new_component: new_component) }.to change(Decidim::Surveys::Survey, :count).by(1)
     end
   end
 end

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -24,6 +24,7 @@ module Decidim
 
         @organization = nil
         invite_form = nil
+        invitation_failed = false
 
         transaction do
           @organization = create_organization
@@ -31,8 +32,10 @@ module Decidim
           PopulateHelp.call(@organization)
           CreateDefaultContentBlocks.call(@organization)
           invite_form = invite_user_form(@organization)
-          return broadcast(:invalid) if invite_form.invalid?
+          invitation_failed = invite_form.invalid?
         end
+        return broadcast(:invalid) if invitation_failed
+
         Decidim::InviteUser.call(invite_form) if @organization && invite_form
 
         broadcast(:ok)

--- a/decidim-system/spec/lib/tasks/decidim_system_create_admin_spec.rb
+++ b/decidim-system/spec/lib/tasks/decidim_system_create_admin_spec.rb
@@ -32,7 +32,7 @@ describe "decidim_system:create_admin", type: :task do
 
     context "when provided data is valid" do
       it "creates an admin" do
-        expect { task.execute }.to change { Decidim::System::Admin.count }.by(1)
+        expect { task.execute }.to change(Decidim::System::Admin, :count).by(1)
         expect($stdout.string).to include("System admin created successfully")
       end
     end
@@ -43,7 +43,7 @@ describe "decidim_system:create_admin", type: :task do
         let(:password_confirmation) { "invalid" }
 
         it "prevents creation of admin and displays validation errors" do
-          expect { task.execute }.not_to(change { Decidim::System::Admin.count })
+          expect { task.execute }.not_to(change(Decidim::System::Admin, :count))
 
           expect($stdout.string).to include("Some errors prevented creation of admin")
           expect($stdout.string).to include("Email is invalid")
@@ -56,7 +56,7 @@ describe "decidim_system:create_admin", type: :task do
         let(:password_confirmation) { "password1234" }
 
         it "prevents creation of admin and displays validation errors" do
-          expect { task.execute }.not_to(change { Decidim::System::Admin.count })
+          expect { task.execute }.not_to(change(Decidim::System::Admin, :count))
 
           expect($stdout.string).to include("Some errors prevented creation of admin")
           expect($stdout.string).to include("Password is too common")

--- a/decidim-verifications/spec/commands/decidim/verifications/authorize_user_spec.rb
+++ b/decidim-verifications/spec/commands/decidim/verifications/authorize_user_spec.rb
@@ -66,7 +66,7 @@ module Decidim::Verifications
         end
 
         it "is invalid if there's another authorization with the same id" do
-          expect { subject.call }.to change(authorizations, :count).by(0)
+          expect { subject.call }.not_to change(authorizations, :count)
         end
       end
     end

--- a/lib/tasks/decidim_tasks.rake
+++ b/lib/tasks/decidim_tasks.rake
@@ -25,7 +25,7 @@ namespace :decidim do
             # Successful compilation!
             puts "SUCCESS"
             Dir.chdir(File.join(__dir__, "../..")) do
-              system "cp -r public/* #{Rails.root.join("public")}"
+              system "cp -r public/* #{Rails.public_path}"
             end
           else
             # Failed compilation


### PR DESCRIPTION
#### :tophat: What? Why?
Apparently rubocop was updated at the version bump (3a9f44a040b5ea7858900d183b57c3f750ee76b7) so this fixes some Rubocop offences it introduced.

#### Testing
Run rubocop.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.