### PR TITLE
Fix the HERE geocoding specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ PATH
       file_validators (~> 3.0)
       fog-local (~> 0.6)
       foundation_rails_helper (~> 4.0)
-      geocoder (~> 1.5)
+      geocoder (~> 1.8)
       hashdiff (>= 0.4.0, < 2.0.0)
       invisible_captcha (~> 0.12)
       kaminari (~> 1.2, >= 1.2.1)

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "file_validators", "~> 3.0"
   s.add_dependency "fog-local", "~> 0.6"
   s.add_dependency "foundation_rails_helper", "~> 4.0"
-  s.add_dependency "geocoder", "~> 1.5"
+  s.add_dependency "geocoder", "~> 1.8"
   s.add_dependency "hashdiff", ">= 0.4.0", "< 2.0.0"
   s.add_dependency "invisible_captcha", "~> 0.12"
   s.add_dependency "kaminari", "~> 1.2", ">= 1.2.1"

--- a/decidim-core/lib/decidim/map/provider/geocoding/here.rb
+++ b/decidim-core/lib/decidim/map/provider/geocoding/here.rb
@@ -22,15 +22,15 @@ module Decidim
             # Always prioritize house number results, even if they are not as
             # close as street level matches.
             hn_result = results.find do |r|
-              r.data["MatchLevel"] == "houseNumber"
+              r.data["resultType"] == "houseNumber"
             end
             return hn_result.address if hn_result
 
-            # Some of the matches that have "MatchLevel" == "street" do not even
-            # contain the street name unless they also have the "Street" key in
-            # the "MatchQuality" attribute defined.
+            # Some of the matches that have "resultType" == "street" do not even
+            # contain the street name unless they also have the "streets" key in
+            # the "scoring" -> "fieldScore" attribute defined.
             street_result = results.find do |r|
-              r.data["MatchQuality"].has_key?("Street")
+              r.data["scoring"]["fieldScore"].has_key?("streets")
             end
             return street_result.address if street_result
 

--- a/decidim-core/spec/lib/map/provider/geocoding/here_spec.rb
+++ b/decidim-core/spec/lib/map/provider/geocoding/here_spec.rb
@@ -29,24 +29,24 @@ module Decidim
             end
 
             describe "#coordinates" do
-              let(:request_url) { "https://geocoder.ls.hereapi.com/6.2/geocode.json?apikey=key1234&gen=9&language=en&searchtext=#{CGI.escape(query)}" }
-              let(:query) { "Madison Square Garden, 4 Penn Plaza, New York, NY" }
+              let(:request_url) { "https://geocode.search.hereapi.com/v1/geocode?apiKey=key1234&lang=en&q=5%20Rue%20Daunou,%2075000%20Paris,%20France" }
+              let(:query) { "5 Rue Daunou, 75000 Paris, France" }
 
               it "requests the nominatim API with correct parameters" do
                 expect(
                   subject.coordinates(query)
-                ).to eq([40.7504692, -73.9933777])
+                ).to eq([48.86926, 2.3321])
               end
             end
 
             describe "#address" do
-              let(:request_url) { "https://reverse.geocoder.ls.hereapi.com/6.2/reversegeocode.json?apikey=key1234&gen=9&language=en&maxresults=5&mode=retrieveAddresses&prox=#{query[0]},#{query[1]},50&sortby=distance" }
-              let(:query) { [40.7504692, -73.9933777] }
+              let(:request_url) { "https://revgeocode.search.hereapi.com/v1/revgeocode?apiKey=key1234&at=48.86926,2.3321,50&lang=en&maxresults=5&sortby=distance" }
+              let(:query) { [48.86926, 2.3321] }
 
               it "requests the nominatim API with correct parameters" do
                 expect(
                   subject.address(query)
-                ).to eq("4 Penn Plz, New York, NY 10001, United States")
+                ).to eq("5 Rue Daunou, 75002 Paris, France")
               end
             end
           end

--- a/decidim-dev/lib/decidim/dev/assets/geocoder_result_here.json
+++ b/decidim-dev/lib/decidim/dev/assets/geocoder_result_here.json
@@ -1,72 +1,51 @@
 {
-    "Response": {
-      "MetaInfo": {
-        "Timestamp": "2013-02-08T16:26:39.382+0000"
+  "items": [
+    {
+      "title": "5 Rue Daunou, 75002 Paris, France",
+      "id": "here:af:streetsection:bI4Le6cyA.1mlQyLunYpjC:CggIBCCi-9SPARABGgE1KGQ",
+      "resultType": "houseNumber",
+      "houseNumberType": "PA",
+      "address": {
+        "label": "5 Rue Daunou, 75002 Paris, France",
+        "countryCode": "FRA",
+        "countryName": "France",
+        "stateCode": "IDF",
+        "state": "Île-de-France",
+        "county": "Paris",
+        "city": "Paris",
+        "district": "2e Arrondissement",
+        "street": "Rue Daunou",
+        "postalCode": "75002",
+        "houseNumber": "5"
       },
-      "View": [
+      "position": {
+        "lat": 48.86926,
+        "lng": 2.3321
+      },
+      "access": [
         {
-          "_type": "SearchResultsViewType",
-          "ViewId": 0,
-          "Result": [
-            {
-              "Relevance": 1.0,
-              "MatchLevel": "houseNumber",
-              "MatchQuality": {
-                "State": 1.0,
-                "City": 1.0,
-                "Street": [
-                  1.0
-                ],
-                "HouseNumber": 1.0
-              },
-              "MatchType": "pointAddress",
-              "Location": {
-                "LocationId": "NT_ArsGdYbpo6dqjPQel9gTID_4",
-                "LocationType": "point",
-                "DisplayPosition": {
-                  "Latitude": 40.7504692,
-                  "Longitude": -73.9933777
-                },
-                "NavigationPosition": [
-                  {
-                    "Latitude": 40.7500305,
-                    "Longitude": -73.9942398
-                  }
-                ],
-                "MapView": {
-                  "TopLeft": {
-                    "Latitude": 40.7515934,
-                    "Longitude": -73.9948616
-                  },
-                  "BottomRight": {
-                    "Latitude": 40.7493451,
-                    "Longitude": -73.9918938
-                  }
-                },
-                "Address": {
-                  "Label": "4 Penn Plz, New York, NY 10001, United States",
-                  "Country": "USA",
-                  "State": "NY",
-                  "County": "New York",
-                  "City": "New York",
-                  "Street": "Penn Plz",
-                  "HouseNumber": "4",
-                  "PostalCode": "10001",
-                  "AdditionalData": [
-                    {
-                      "value": "United States",
-                      "key": "CountryName"
-                    },
-                    {
-                      "value": "New York",
-                      "key": "StateName"
-                    }
-                  ]
-                }
-              }
-            }
-          ]
+          "lat": 48.86931,
+          "lng": 2.33215
         }
-      ]
+      ],
+      "mapView": {
+        "west": 2.33073,
+        "south": 48.86836,
+        "east": 2.33347,
+        "north": 48.87016
+      },
+      "scoring": {
+        "queryScore": 0.97,
+        "fieldScore": {
+          "country": 1,
+          "city": 1,
+          "streets": [
+            1
+          ],
+          "houseNumber": 1,
+          "postalCode": 0.82
+        }
+      }
     }
-  }
+  ]
+}

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -75,7 +75,7 @@ PATH
       file_validators (~> 3.0)
       fog-local (~> 0.6)
       foundation_rails_helper (~> 4.0)
-      geocoder (~> 1.5)
+      geocoder (~> 1.8)
       hashdiff (>= 0.4.0, < 2.0.0)
       invisible_captcha (~> 0.12)
       kaminari (~> 1.2, >= 1.2.1)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -75,7 +75,7 @@ PATH
       file_validators (~> 3.0)
       fog-local (~> 0.6)
       foundation_rails_helper (~> 4.0)
-      geocoder (~> 1.5)
+      geocoder (~> 1.8)
       hashdiff (>= 0.4.0, < 2.0.0)
       invisible_captcha (~> 0.12)
       kaminari (~> 1.2, >= 1.2.1)


### PR DESCRIPTION
#### :tophat: What? Why?
After the version number bump, apparently also the `geocoder` gem was updated which meant that it now uses the v7 of the HERE API instead of version 6.2 that it used before.

This was apparently changed in version 1.8.0 of the `geocoder` gem as described here:
https://github.com/alexreisner/geocoder/blob/master/CHANGELOG.md

#### Testing
See that CI is green.

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.