### PR TITLE
Fix long word breaking on comments and cards

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_cards.scss
@@ -30,6 +30,8 @@ $datetime-bg: var(--primary);
   border-radius: $card-border-radius;
   // Keep visible for accessibility (active/focused card as a link)
   overflow: visible;
+  overflow-wrap: break-word;
+  hyphens: auto;
 
   @include modifiers(
     border-top-color,

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_comments.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_comments.scss
@@ -80,6 +80,8 @@ $comment-form-bg: $light-gray;
 
 .comment__content{
   padding: 0 $comment-padding;
+  overflow-wrap: break-word;
+  hyphens: auto;
 
   > :last-child{
     margin-bottom: 0;


### PR DESCRIPTION
#### :tophat: What? Why?
When using long words in the comments the display appears broken.
This PR fixes this.

#### :pushpin: Related Issues
- Fix #9060 

#### Testing
Enter a long word in the comments section

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
<img width="1381" alt="Capture d’écran 2022-06-23 à 15 46 56" src="https://user-images.githubusercontent.com/20232956/175319152-91cdf383-eeb1-4cf4-ba87-c18e07a33c3a.png">
<img width="897" alt="Capture d’écran 2022-06-23 à 15 59 07" src="https://user-images.githubusercontent.com/20232956/175319136-043dd5d4-cc12-47c4-a494-b836ab22aebc.png">

:hearts: Thank you!
