### PR TITLE
Fix cache hash on Hightlighted spaces

### DIFF
--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
@@ -36,6 +36,7 @@ module Decidim
         def cache_hash
           hash = []
           hash.push(I18n.locale)
+          hash.push(highlighted_assemblies.map(&:cache_key_with_version))
           hash.join(Decidim.cache_key_separator)
         end
 

--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
@@ -39,10 +39,6 @@ module Decidim
           hash.push(highlighted_assemblies.map(&:cache_key_with_version))
           hash.join(Decidim.cache_key_separator)
         end
-
-        def cache_expiry_time
-          10.minutes
-        end
       end
     end
   end

--- a/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
@@ -27,6 +27,7 @@ module Decidim
         def cache_hash
           hash = []
           hash.push(I18n.locale)
+          hash.push(highlighted_conferences.map(&:cache_key_with_version))
           hash.join(Decidim.cache_key_separator)
         end
 

--- a/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
@@ -30,10 +30,6 @@ module Decidim
           hash.push(highlighted_conferences.map(&:cache_key_with_version))
           hash.join(Decidim.cache_key_separator)
         end
-
-        def cache_expiry_time
-          10.minutes
-        end
       end
     end
   end

--- a/decidim-elections/app/cells/decidim/votings/content_blocks/highlighted_votings_cell.rb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/highlighted_votings_cell.rb
@@ -33,6 +33,7 @@ module Decidim
         def cache_hash
           hash = []
           hash.push(I18n.locale)
+          hash.push(highlighted_votings.map(&:cache_key_with_version))
           hash.join(Decidim.cache_key_separator)
         end
 

--- a/decidim-elections/app/cells/decidim/votings/content_blocks/highlighted_votings_cell.rb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/highlighted_votings_cell.rb
@@ -36,10 +36,6 @@ module Decidim
           hash.push(highlighted_votings.map(&:cache_key_with_version))
           hash.join(Decidim.cache_key_separator)
         end
-
-        def cache_expiry_time
-          10.minutes
-        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

While working on the last set of bug fixes regarding caching, I found that we were too aggressive on these highlighted spaces on the homepage. This PR fixes that. 

I've also removed the cache expiration time, as it doesn't make sense anymore. 

Another related thing that I saw is that we aren't caching other highlighted spaces like Participatory Processes or Initiatives. This should be handled on another PR as it's an improvement/feature and this particular PR is a fix. 

#### Testing

1. Enable cache with  `bin/rails dev:cache`
5. Sign in as admin
6. Change the title or image of an assembly or conference that's on the homepage 
7. See that isn't changed

:hearts: Thank you!
