### PR TITLE
Disable parallel specs for elections' system admin CI

### DIFF
--- a/.github/workflows/ci_elections_system_admin.yml
+++ b/.github/workflows/ci_elections_system_admin.yml
@@ -75,7 +75,7 @@ jobs:
           processor_count: ${{ env.PARALLEL_TEST_PROCESSORS }}
           ruby_version: ${{ env.RUBY_VERSION }}
           node_version: ${{ env.NODE_VERSION }}
-      - run: bundle exec rake parallel:spec[^spec/system/admin]
+      - run: bundle exec rspec spec/system/admin
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
         env:


### PR DESCRIPTION
#### :tophat: What? Why?

We have at least a flaky spec with the elections' system specs for admin panel. This is because the parallel specs don't play nice with the same instance of the Bulletin Board server and the resetting of the database.

On the last week or so, I had to rerun manually this workflow multiple times a day, most of the time on branches that weren't touching anything related to elections. 

I've solved this in the past for public system specs by disabling parallel specs only for this workflow, so this PR changes the CI config so admin specs doesn't run on parallel. 

#### Traceback

```ruby

Failures:
  1) Admin manages election steps view key ceremony step shows the step information
     Failure/Error: expect(page).to have_content("Upload your identification keys")
       expected to find text "Upload your identification keys" in "Tillman-Lebsack\nSearch\nSearch\nEnglish\nChoose language\nNotifications Conversations\nMafalda Stiedemann\nHome\nProcesses\nInitiatives\nHelp\nParticipant settings\nAccount\nNotifications settings\nAuthorizations\nMy interests\nMy data\nTrustee zone\nDelete my account\nYou have been assigned to act as a Trustee in some of the elections celebrated in this platform.\nElections\nElection Voting period Status Action required?\nVoluptas quis ipsum. 5194 28/06/2022 07:11 - 30/06/2022 07:11 key_ceremony Perform action\nDownload Open Data files Cookie settings\nTillman-Lebsack at Twitter\nTwitter\nTillman-Lebsack at Facebook\nFacebook\nTillman-Lebsack at Instagram\nInstagram\nTillman-Lebsack at YouTube\nYouTube\nTillman-Lebsack at GitHub\nGitHub\nWebsite made with free software \n(External link)\n.". (However, it was found 1 time including non-visible text.)
     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_election_steps_view_key_ceremony_step_shows_the_step_information_788.png
     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_election_steps_view_key_ceremony_step_shows_the_step_information_788.html
     # ./spec/shared/full_election_process_shared_context.rb:67:in `access_trustee_zone'
     # ./spec/shared/full_election_process_shared_context.rb:49:in `download_election_keys'
     # ./spec/system/admin/admin_manages_election_steps_spec.rb:74:in `block (3 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:116:in `block (3 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:115:in `block (2 levels) in <top (required)>'
Finished in 10 minutes 3 seconds (files took 7.1 seconds to load)
83 examples, 1 failure
Failed examples:
rspec ./spec/system/admin/admin_manages_election_steps_spec.rb:65 # Admin manages election steps view key ceremony step shows the step information

```


#### :pushpin: Related Issues

- Related to https://github.com/decidim/decidim/pull/9448#issuecomment-1158704848


#### Testing

This should be green. I'll rerun this workflow 10 times just to be sure. 


:hearts: Thank you!
