### PR TITLE
Fix default seeds on first login (password_updated_at and accepted_tos_version)

### DIFF
--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -125,7 +125,7 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
     tos_agreement: true,
     personal_url: Faker::Internet.url,
     about: Faker::Lorem.paragraph(sentence_count: 2),
-    accepted_tos_version: organization.tos_version,
+    accepted_tos_version: organization.tos_version + 1.hour,
     password_updated_at: Time.current,
     admin_terms_accepted_at: Time.current
   }
@@ -144,7 +144,7 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
       tos_agreement: true,
       personal_url: Faker::Internet.url,
       about: Faker::Lorem.paragraph(sentence_count: 2),
-      accepted_tos_version: organization.tos_version
+      accepted_tos_version: organization.tos_version + 1.hour
     )
   end
 
@@ -163,7 +163,7 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
     tos_agreement: true,
     personal_url: Faker::Internet.url,
     about: Faker::Lorem.paragraph(sentence_count: 2),
-    accepted_tos_version: organization.tos_version
+    accepted_tos_version: organization.tos_version + 1.hour
   )
 
   locked_user.lock_access!

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -126,6 +126,7 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
     personal_url: Faker::Internet.url,
     about: Faker::Lorem.paragraph(sentence_count: 2),
     accepted_tos_version: organization.tos_version,
+    password_updated_at: Time.current,
     admin_terms_accepted_at: Time.current
   }
   admin_hash.merge!(password: "decidim123456789", password_confirmation: "decidim123456789") if admin.encrypted_password.blank?


### PR DESCRIPTION
#### :tophat: What? Why?

After introducing the strong passwords for admins, an admin one a seeded database gets this screen always. This is specially problematic on staging servers like https://nightly.decidim.org, and although we could fix it there, I think we should just fix it in the seeds. This PR fixes that.

It also fixes other tiny pain point, where admin/users get to accept the TOS. 

#### :pushpin: Related Issues

- Related to #9347 

#### Testing

1. Regenerate database by running `bin/rails db:drop db:create db:migrate && bin/rails db:seed `
2. Sign in as admin

And then:
* (Before this): you'll get the "change your password" page and after that the "accept our TOS" page"
* (After this): you'll sign in directly


:hearts: Thank you!
