### PR TITLE
Backport 'Fix cache when changing background image on homepage's Hero's cell' to v0.27

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/hero_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/hero_cell.rb
@@ -29,6 +29,7 @@ module Decidim
         hash << Digest::MD5.hexdigest(model.attributes.to_s)
         hash << current_organization.cache_key_with_version
         hash << I18n.locale.to_s
+        hash << background_image
 
         hash.join(Decidim.cache_key_separator)
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9471 to v0.27

:hearts: Thank you!