### PR TITLE
Fix sub assemblies order

### DIFF
--- a/decidim-assemblies/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -30,10 +30,10 @@ module Decidim
             render json: published_assemblies.query.includes(:children).where(parent: nil).collect { |assembly|
               {
                 name: assembly.title[I18n.locale.to_s],
-                children: assembly.children.collect do |child|
+                children: assembly.children.order(weight: :asc).collect do |child|
                   {
                     name: child.title[I18n.locale.to_s],
-                    children: child.children.collect { |child_of_child| { name: child_of_child.title[I18n.locale.to_s] } }
+                    children: child.children.order(weight: :asc).collect { |child_of_child| { name: child_of_child.title[I18n.locale.to_s] } }
                   }
                 end
               }

--- a/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
@@ -53,9 +53,9 @@ module Decidim
 
       describe "GET assemblies in json format" do
         let!(:first_level) { create(:assembly, :published, :with_parent, parent: published, organization: organization) }
-        let!(:second_level_2) { create(:assembly, :published, :with_parent, parent: first_level, weight: 2, organization: organization) }
-        let!(:second_level_1) { create(:assembly, :published, :with_parent, parent: first_level, weight: 1, organization: organization) }
-        let!(:third_level) { create(:assembly, :published, :with_parent, parent: second_level_1, organization: organization) }
+        let!(:second_level2) { create(:assembly, :published, :with_parent, parent: first_level, weight: 2, organization: organization) }
+        let!(:second_level1) { create(:assembly, :published, :with_parent, parent: first_level, weight: 1, organization: organization) }
+        let!(:third_level) { create(:assembly, :published, :with_parent, parent: second_level1, organization: organization) }
 
         let(:parsed_response) { JSON.parse(response.body, symbolize_names: true) }
 
@@ -74,10 +74,10 @@ module Decidim
                     name: translated(first_level.title),
                     children: [
                       {
-                        name: translated(second_level_1.title)
+                        name: translated(second_level1.title)
                       },
                       {
-                        name: translated(second_level_2.title)
+                        name: translated(second_level2.title)
                       }
                     ]
                   }

--- a/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
@@ -53,8 +53,9 @@ module Decidim
 
       describe "GET assemblies in json format" do
         let!(:first_level) { create(:assembly, :published, :with_parent, parent: published, organization: organization) }
-        let!(:second_level) { create(:assembly, :published, :with_parent, parent: first_level, organization: organization) }
-        let!(:third_level) { create(:assembly, :published, :with_parent, parent: second_level, organization: organization) }
+        let!(:second_level_2) { create(:assembly, :published, :with_parent, parent: first_level, weight: 2, organization: organization) }
+        let!(:second_level_1) { create(:assembly, :published, :with_parent, parent: first_level, weight: 1, organization: organization) }
+        let!(:third_level) { create(:assembly, :published, :with_parent, parent: second_level_1, organization: organization) }
 
         let(:parsed_response) { JSON.parse(response.body, symbolize_names: true) }
 
@@ -71,7 +72,14 @@ module Decidim
                 children: [
                   {
                     name: translated(first_level.title),
-                    children: [{ name: translated(second_level.title) }]
+                    children: [
+                      {
+                        name: translated(second_level_1.title)
+                      },
+                      {
+                        name: translated(second_level_2.title)
+                      }
+                    ]
                   }
                 ]
               }


### PR DESCRIPTION
#### :tophat: What? Why?
As an admin, even though I entered a weight for my assemblies, they are displayed in the wrong order in the sub-assemblies section in the parent assembly presentation page. 
Sub assemblies should be ordered by the weight admins gave them. 

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### Testing
* Add sub-assemblies with a weight of one and 2 respectively.
* See error

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [x] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [x] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [x] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [x] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [x] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.

:hearts: Thank you!
