### PR TITLE
Add a "show password" button in forms

### DIFF
--- a/decidim-admin/spec/shared/manage_impersonations_examples.rb
+++ b/decidim-admin/spec/shared/manage_impersonations_examples.rb
@@ -256,7 +256,6 @@ shared_examples "manage impersonations examples" do
 
       within "form.new_user" do
         fill_in :invitation_user_password, with: "decidim123456789"
-        fill_in :invitation_user_password_confirmation, with: "decidim123456789"
         check :invitation_user_tos_agreement
         find("*[type=submit]").click
       end

--- a/decidim-admin/spec/system/admin_invite_spec.rb
+++ b/decidim-admin/spec/system/admin_invite_spec.rb
@@ -43,7 +43,6 @@ describe "Admin invite", type: :system do
       within "form.new_user" do
         fill_in :invitation_user_nickname, with: "caballo_loco"
         fill_in :invitation_user_password, with: "decidim123456789"
-        fill_in :invitation_user_password_confirmation, with: "decidim123456789"
         check :invitation_user_tos_agreement
         find("*[type=submit]").click
       end

--- a/decidim-admin/spec/system/admin_passwords_spec.rb
+++ b/decidim-admin/spec/system/admin_passwords_spec.rb
@@ -22,7 +22,6 @@ describe "Admin passwords", type: :system do
       expect(page).to have_content("Admin users need to change their password every 90 days")
       expect(page).to have_content("Password change")
       fill_in :password_user_password, with: new_password
-      fill_in :password_user_password_confirmation, with: new_password
       click_button "Change my password"
       expect(page).to have_css(".callout.success")
       expect(page).to have_content("Password successfully updated")
@@ -48,7 +47,6 @@ describe "Admin passwords", type: :system do
         manual_login(user.email, password)
         expect(page).to have_content("Password change")
         fill_in :password_user_password, with: new_password
-        fill_in :password_user_password_confirmation, with: new_password
         click_button "Change my password"
         expect(page).to have_css(".callout.success")
         expect(page).to have_current_path(decidim_admin.root_path)

--- a/decidim-core/app/packs/entrypoints/decidim_registrations.js
+++ b/decidim-core/app/packs/entrypoints/decidim_registrations.js
@@ -1,0 +1,1 @@
+import "src/decidim/password_helper"

--- a/decidim-core/app/packs/src/decidim/password_helper.js
+++ b/decidim-core/app/packs/src/decidim/password_helper.js
@@ -1,0 +1,7 @@
+import PasswordToggler from "src/decidim/registrations/password_toggler";
+
+$(() => {
+  const pass = new PasswordToggler($('.user-password input[type="password"]:first'));
+  pass.init();
+  $(".user-password-confirmation").hide();
+});

--- a/decidim-core/app/packs/src/decidim/password_helper.js
+++ b/decidim-core/app/packs/src/decidim/password_helper.js
@@ -1,6 +1,7 @@
 import PasswordToggler from "src/decidim/registrations/password_toggler";
 
 $(() => {
-  const pass = new PasswordToggler($(".user-password"), $(".user-password-confirmation"));
-  pass.init();
+  window.Decidim = window.Decidim || {};
+  window.Decidim.passwordToggler = new PasswordToggler($(".user-password"), $(".user-password-confirmation"));
+  window.Decidim.passwordToggler.init();
 });

--- a/decidim-core/app/packs/src/decidim/password_helper.js
+++ b/decidim-core/app/packs/src/decidim/password_helper.js
@@ -1,7 +1,6 @@
 import PasswordToggler from "src/decidim/registrations/password_toggler";
 
 $(() => {
-  const pass = new PasswordToggler($('.user-password input[type="password"]:first'));
+  const pass = new PasswordToggler($(".user-password"), $(".user-password-confirmation"));
   pass.init();
-  $(".user-password-confirmation").hide();
 });

--- a/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
+++ b/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
@@ -14,8 +14,7 @@ export default class PasswordToggler {
       shownPassword: this.$password.data("shownPassword") || "Your password is shown"
     }
     this.icons = {
-      show: icon("eye", {title: this.texts.showPassword}),
-      hide: icon("ban", {title: this.texts.hidePassword})
+      show: icon("eye", {title: this.texts.showPassword})
     }
   }
 
@@ -70,13 +69,13 @@ export default class PasswordToggler {
 
   showPassword() {
     this.$statusText.text(this.texts.shownPassword);
-    this.$button.attr("aria-label", this.texts.hidePassword).html(this.icons.hide);
+    this.$button.attr("aria-label", this.texts.hidePassword).addClass("crossed");
     this.$input.attr("type", "text");
   }
 
   hidePassword() {
     this.$statusText.text(this.texts.hiddenPassword);
-    this.$button.attr("aria-label", this.texts.showPassword).html(this.icons.show)
+    this.$button.attr("aria-label", this.texts.showPassword).removeClass("crossed")
     this.$input.attr("type", "password");
   }
 

--- a/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
+++ b/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
@@ -48,12 +48,12 @@ export default class PasswordToggler {
     this.$button = $(`<button type="button" 
                             aria-controls="${this.$input.attr("id")}" 
                             aria-label="${this.texts.showPassword}">${this.icons.show}</button>`);
-    this.$buttonGroup = $('<div class="input-group"/>');
+    this.$buttonGroup = $('<span class="input-group"/>');
     this.$statusText = $(`<span class="show-for-sr" aria-live="polite">${this.texts.hiddenPassword}</span>`);
     // ensure error message is handled by foundation abide
     this.$input.next(".form-error").attr("data-form-error-for", this.$input.attr("id"));
     this.$buttonGroup.html(this.$button);
-    this.$input.wrap('<div class="input-inline-group"/>').
+    this.$input.wrap('<span class="input-inline-group"/>').
       after(this.$statusText).
       after(this.$buttonGroup);
     this.$inputGroup = this.$input.parent();

--- a/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
+++ b/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
@@ -45,8 +45,8 @@ export default class PasswordToggler {
   }
 
   createControls() {
-    this.$button = $(`<button type="button" 
-                            aria-controls="${this.$input.attr("id")}" 
+    this.$button = $(`<button type="button"
+                            aria-controls="${this.$input.attr("id")}"
                             aria-label="${this.texts.showPassword}">${this.icons.show}</button>`);
     this.$buttonGroup = $('<span class="input-group"/>');
     this.$statusText = $(`<span class="show-for-sr" aria-live="polite">${this.texts.hiddenPassword}</span>`);
@@ -73,7 +73,7 @@ export default class PasswordToggler {
     this.$button.attr("aria-label", this.texts.hidePassword).html(this.icons.hide);
     this.$input.attr("type", "text");
   }
-  
+
   hidePassword() {
     this.$statusText.text(this.texts.hiddenPassword);
     this.$button.attr("aria-label", this.texts.showPassword).html(this.icons.show)

--- a/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
+++ b/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
@@ -23,11 +23,22 @@ export default class PasswordToggler {
     this.createControls();
     this.$confirmation.hide();
     this.$button.on("click", (evt) => this.toggleVisibiliy(evt));
+    this.$input.on("change", () => {
+      this.$inputConfirmation.val(this.$input.val());
+    });
     // to prevent browsers trying to use autocomplete, turn the type back to password before submitting
     this.$form.on("submit", () => {
       this.$inputConfirmation.val(this.$input.val());
       this.hidePassword();
     });
+  }
+
+  destroy() {
+    const $input = this.$input.detach();
+    console.log("destroy", $input)
+    $input.off("change");
+    this.$inputGroup.replaceWith($input);
+    this.$confirmation.show();
   }
 
   createControls() {
@@ -36,11 +47,13 @@ export default class PasswordToggler {
                             aria-label="${this.texts.showPassword}">${this.icons.show}</button>`);
     this.$buttonGroup = $('<div class="input-group"/>');
     this.$statusText = $(`<span class="show-for-sr" aria-live="polite">${this.texts.hiddenPassword}</span>`);
-    this.$inputGroup = $('<div class="input-inline-group"/>');
+    // ensure error message is handled by foundation abide
+    this.$input.next(".form-error").attr("data-form-error-for", this.$input.attr("id"));
     this.$buttonGroup.html(this.$button);
-    this.$input.wrap(this.$inputGroup).
+    this.$input.wrap('<div class="input-inline-group"/>').
       after(this.$statusText).
       after(this.$buttonGroup);
+    this.$inputGroup = this.$input.parent();
   }
 
   toggleVisibiliy(evt) {

--- a/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
+++ b/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
@@ -1,15 +1,17 @@
 import icon from "src/decidim/icon"
 
 export default class PasswordToggler {
-  constructor($input) {
-    console.log($input)
-    this.$input = $input.first();
+  constructor($password, $confirmation) {
+    this.$password = $password.first();
+    this.$confirmation = $confirmation.first();
+    this.$input = this.$password.find('input[type="password"]');
+    this.$inputConfirmation = this.$confirmation.find('input[type="password"]');
     this.$form = this.$input.closest("form");
     this.texts = {
-      showPassword: "Show password",
-      hidePassword: "Hide password",
-      hiddenPassword: "Your password is hidden",
-      visiblePassword: "Your password is shown"
+      showPassword: this.$password.data("showPassword") || "Show password",
+      hidePassword: this.$password.data("hidePassword") || "Hide password",
+      hiddenPassword: this.$password.data("hiddenPassword") || "Your password is hidden",
+      shownPassword: this.$password.data("shownPassword") || "Your password is shown"
     }
     this.icons = {
       show: icon("eye", {title: this.texts.showPassword}),
@@ -19,9 +21,13 @@ export default class PasswordToggler {
   
   init() {
     this.createControls();
+    this.$confirmation.hide();
     this.$button.on("click", (evt) => this.toggleVisibiliy(evt));
     // to prevent browsers trying to use autocomplete, turn the type back to password before submitting
-    this.$form.on("submit", () => this.hidePassword());
+    this.$form.on("submit", () => {
+      this.$inputConfirmation.val(this.$input.val());
+      this.hidePassword();
+    });
   }
 
   createControls() {
@@ -47,7 +53,7 @@ export default class PasswordToggler {
   }
 
   showPassword() {
-    this.$statusText.text(this.texts.visiblePassword);
+    this.$statusText.text(this.texts.shownPassword);
     this.$button.attr("aria-label", this.texts.hidePassword).html(this.icons.hide);
     this.$input.attr("type", "text");
   }

--- a/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
+++ b/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
@@ -18,25 +18,28 @@ export default class PasswordToggler {
       hide: icon("ban", {title: this.texts.hidePassword})
     }
   }
-  
+
+  // Call init() to hide the password confirmation and add a "view password" inline button
   init() {
     this.createControls();
     this.$confirmation.hide();
-    this.$button.on("click", (evt) => this.toggleVisibiliy(evt));
-    this.$input.on("change", () => {
+    this.$button.on("click.password_toggler", (evt) => this.toggleVisibiliy(evt));
+    this.$input.on("change.password_toggler", () => {
       this.$inputConfirmation.val(this.$input.val());
     });
     // to prevent browsers trying to use autocomplete, turn the type back to password before submitting
-    this.$form.on("submit", () => {
+    this.$form.on("submit.password_toggler", () => {
       this.$inputConfirmation.val(this.$input.val());
       this.hidePassword();
     });
   }
 
+  // Call destroy() to switch back to the original password/password confirmation boxes
   destroy() {
+    this.$button.off("click.password_toggler");
+    this.$input.off("change.password_toggler");
+    this.$form.off("submit.password_toggler");
     const $input = this.$input.detach();
-    console.log("destroy", $input)
-    $input.off("change");
     this.$inputGroup.replaceWith($input);
     this.$confirmation.show();
   }

--- a/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
+++ b/decidim-core/app/packs/src/decidim/registrations/password_toggler.js
@@ -1,0 +1,64 @@
+import icon from "src/decidim/icon"
+
+export default class PasswordToggler {
+  constructor($input) {
+    console.log($input)
+    this.$input = $input.first();
+    this.$form = this.$input.closest("form");
+    this.texts = {
+      showPassword: "Show password",
+      hidePassword: "Hide password",
+      hiddenPassword: "Your password is hidden",
+      visiblePassword: "Your password is shown"
+    }
+    this.icons = {
+      show: icon("eye", {title: this.texts.showPassword}),
+      hide: icon("ban", {title: this.texts.hidePassword})
+    }
+  }
+  
+  init() {
+    this.createControls();
+    this.$button.on("click", (evt) => this.toggleVisibiliy(evt));
+    // to prevent browsers trying to use autocomplete, turn the type back to password before submitting
+    this.$form.on("submit", () => this.hidePassword());
+  }
+
+  createControls() {
+    this.$button = $(`<button type="button" 
+                            aria-controls="${this.$input.attr("id")}" 
+                            aria-label="${this.texts.showPassword}">${this.icons.show}</button>`);
+    this.$buttonGroup = $('<div class="input-group"/>');
+    this.$statusText = $(`<span class="show-for-sr" aria-live="polite">${this.texts.hiddenPassword}</span>`);
+    this.$inputGroup = $('<div class="input-inline-group"/>');
+    this.$buttonGroup.html(this.$button);
+    this.$input.wrap(this.$inputGroup).
+      after(this.$statusText).
+      after(this.$buttonGroup);
+  }
+
+  toggleVisibiliy(evt) {
+    evt.preventDefault();
+    if (this.isText()) {
+      this.hidePassword();
+    } else {
+      this.showPassword();
+    }
+  }
+
+  showPassword() {
+    this.$statusText.text(this.texts.visiblePassword);
+    this.$button.attr("aria-label", this.texts.hidePassword).html(this.icons.hide);
+    this.$input.attr("type", "text");
+  }
+  
+  hidePassword() {
+    this.$statusText.text(this.texts.hiddenPassword);
+    this.$button.attr("aria-label", this.texts.showPassword).html(this.icons.show)
+    this.$input.attr("type", "password");
+  }
+
+  isText() {
+    return this.$input.attr("type") === "text"
+  }
+}

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_input-groups.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_input-groups.scss
@@ -5,8 +5,21 @@
     position: absolute;
     top: 0;
     right: 0;
-    margin-right: 1.5em;
-    margin-top: .9em;
+    margin-right: 1em;
+    margin-top: .5em;
     width: 1%;
+
+    .icon{
+      width: 1.125em;
+      height: 1.125em;
+      margin: 5px;
+      color: $black;
+    }
+  }
+}
+
+.register-form{
+  .input-group{
+    margin-top: .75em;
   }
 }

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_input-groups.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_input-groups.scss
@@ -1,11 +1,12 @@
-.input-inline-group {
+.input-inline-group{
   position: relative;
-  .input-group {
+
+  .input-group{
     position: absolute;
     top: 0;
     right: 0;
     margin-right: 1.5em;
-    margin-top: 0.9em;
+    margin-top: .9em;
     width: 1%;
   }
 }

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_input-groups.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_input-groups.scss
@@ -1,5 +1,6 @@
 .input-inline-group{
   position: relative;
+  display: block;
 
   .input-group{
     position: absolute;

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_input-groups.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_input-groups.scss
@@ -10,11 +10,34 @@
     margin-top: .5em;
     width: 1%;
 
-    .icon{
-      width: 1.125em;
-      height: 1.125em;
-      margin: 5px;
-      color: $black;
+    button{
+      .icon{
+        width: 1.125em;
+        height: 1.125em;
+        margin: 5px;
+        color: $black;
+      }
+
+      &.crossed{
+        position: relative;
+
+        &::before{
+          content: "";
+          position: absolute;
+          top: 5px;
+          left: 5px;
+          background:
+            linear-gradient(
+              to right bottom,
+              transparent calc(50% - 1px),
+              black calc(50% - 1px),
+              black calc(50% + 1px),
+              transparent calc(50% + 1px)
+            ) no-repeat 0 0 / 100% 100%;
+          width: calc(100% - 10px);
+          height: calc(100% - 10px);
+        }
+      }
     }
   }
 }

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_input-groups.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_input-groups.scss
@@ -1,0 +1,11 @@
+.input-inline-group {
+  position: relative;
+  .input-group {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-right: 1.5em;
+    margin-top: 0.9em;
+    width: 1%;
+  }
+}

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_modules.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_modules.scss
@@ -34,6 +34,7 @@
 @import "stylesheets/decidim/modules/address";
 @import "stylesheets/decidim/modules/order-by";
 @import "stylesheets/decidim/modules/tags";
+@import "stylesheets/decidim/modules/input-groups";
 @import "stylesheets/decidim/modules/input-tags";
 @import "stylesheets/decidim/modules/input-mentions";
 @import "stylesheets/decidim/modules/input-multiple-mentions";

--- a/decidim-core/app/views/decidim/account/_password_fields.html.erb
+++ b/decidim-core/app/views/decidim/account/_password_fields.html.erb
@@ -1,2 +1,15 @@
-<%= form.password_field :password, password_field_options_for(current_user).merge(value: form.object.password) %>
-<%= form.password_field :password_confirmation, password_field_options_for(current_user).except(:help_text).merge(value: form.object.password_confirmation) %>
+<div class="user-password"
+  data-show-password="<%= t "show_password", scope: "decidim.devise.shared.password_fields" %>"
+  data-hide-password="<%= t "hide_password", scope: "decidim.devise.shared.password_fields" %>"
+  data-hidden-password="<%= t "hidden_password", scope: "decidim.devise.shared.password_fields" %>"
+  data-shown-password="<%= t "shown_password", scope: "decidim.devise.shared.password_fields" %>">
+  <%= form.password_field :password, password_field_options_for(current_user).merge(value: form.object.password) %>
+</div>
+
+<div class="user-password-confirmation">
+  <%= form.password_field :password_confirmation, password_field_options_for(current_user).except(:help_text).merge(value: form.object.password_confirmation) %>
+</div>
+
+<% content_for :js_content do %>
+  <%= javascript_pack_tag "decidim_registrations" %>
+<% end %>

--- a/decidim-core/app/views/decidim/account/_password_fields.html.erb
+++ b/decidim-core/app/views/decidim/account/_password_fields.html.erb
@@ -1,14 +1,14 @@
-<div class="user-password"
+<span class="user-password"
   data-show-password="<%= t "show_password", scope: "decidim.devise.shared.password_fields" %>"
   data-hide-password="<%= t "hide_password", scope: "decidim.devise.shared.password_fields" %>"
   data-hidden-password="<%= t "hidden_password", scope: "decidim.devise.shared.password_fields" %>"
   data-shown-password="<%= t "shown_password", scope: "decidim.devise.shared.password_fields" %>">
   <%= form.password_field :password, password_field_options_for(current_user).merge(value: form.object.password) %>
-</div>
+</span>
 
-<div class="user-password-confirmation">
+<span class="user-password-confirmation">
   <%= form.password_field :password_confirmation, password_field_options_for(current_user).except(:help_text).merge(value: form.object.password_confirmation) %>
-</div>
+</span>
 
 <% content_for :js_content do %>
   <%= javascript_pack_tag "decidim_registrations" %>

--- a/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
@@ -26,12 +26,7 @@
             </div>
 
             <% if f.object.class.require_password_on_accepting %>
-              <div class="field">
-                <p><%= f.password_field :password, password_field_options_for(:user).except(:help_text) %></p>
-              </div>
-              <div class="field">
-                <p><%= f.password_field :password_confirmation, password_field_options_for(:user).except(:help_text) %></p>
-              </div>
+              <%= render("decidim/devise/shared/password_fields", form: f, options: password_field_options_for(:user).except(:help_text)) %>
             <% end %>
           </div>
         </div>

--- a/decidim-core/app/views/decidim/devise/passwords/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/passwords/edit.html.erb
@@ -15,13 +15,7 @@
 
             <%= f.hidden_field :reset_password_token %>
 
-            <div class="field">
-              <%= f.password_field :password, password_field_options_for(current_user || params["reset_password_token"]) %>
-            </div>
-
-            <div class="field">
-              <%= f.password_field :password_confirmation, password_field_options_for(current_user || params["reset_password_token"]).except(:help_text) %>
-            </div>
+            <%= render("decidim/devise/shared/password_fields", form: f, options: password_field_options_for(current_user || params["reset_password_token"])) %>
 
             <div class="actions">
               <%= f.submit t("devise.passwords.edit.change_my_password"), class: "button expanded" %>

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -34,13 +34,13 @@
 
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :name, help_text: t(".username_help"), autocomplete: "name" %>
+                <%= f.text_field :name, help_text: t(".username_help"), autocomplete: "off" %>
               </div>
             </div>
 
             <div class="user-nickname">
               <div class="field">
-                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), prefix: { value: "@", small: 1, large: 1 }, autocomplete: "nickname" %>
+                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), prefix: { value: "@", small: 1, large: 1 }, autocomplete: "off" %>
               </div>
             </div>
 
@@ -48,12 +48,16 @@
               <%= f.email_field :email, autocomplete: "email" %>
             </div>
 
-            <div class="field">
-              <%= f.password_field :password, password_field_options_for(:user) %>
+            <div class="user-password">
+              <div class="field">
+                <%= f.password_field :password, password_field_options_for(:user) %>
+              </div>
             </div>
 
-            <div class="field">
-              <%= f.password_field :password_confirmation, password_field_options_for(:user).except(:help_text) %>
+            <div class="user-password-confirmation">
+              <div class="field">
+                <%= f.password_field :password_confirmation, password_field_options_for(:user).except(:help_text) %>
+              </div>
             </div>
           </div>
         </div>
@@ -95,3 +99,7 @@
 </div>
 </div>
 <%= render "decidim/devise/shared/newsletter_modal" %>
+
+<% content_for :js_content do %>
+  <%= javascript_pack_tag "decidim_registrations" %>
+<% end %>

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -48,17 +48,7 @@
               <%= f.email_field :email, autocomplete: "email" %>
             </div>
 
-            <div class="user-password">
-              <div class="field">
-                <%= f.password_field :password, password_field_options_for(:user) %>
-              </div>
-            </div>
-
-            <div class="user-password-confirmation">
-              <div class="field">
-                <%= f.password_field :password_confirmation, password_field_options_for(:user).except(:help_text) %>
-              </div>
-            </div>
+            <%= render("decidim/devise/shared/password_fields", form: f, options: password_field_options_for(:user)) %>
           </div>
         </div>
 
@@ -99,7 +89,3 @@
 </div>
 </div>
 <%= render "decidim/devise/shared/newsletter_modal" %>
-
-<% content_for :js_content do %>
-  <%= javascript_pack_tag "decidim_registrations" %>
-<% end %>

--- a/decidim-core/app/views/decidim/devise/shared/_password_fields.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_password_fields.html.erb
@@ -1,0 +1,19 @@
+<div class="user-password"
+    data-show-password="<%= t ".show_password" %>"
+    data-hide-password="<%= t ".hide_password" %>"
+    data-hidden-password="<%= t ".hidden_password" %>"
+    data-shown-password="<%= t ".shown_password" %>">
+    <div class="field">
+    <%= form.password_field :password, options %>
+    </div>
+</div>
+
+<div class="user-password-confirmation">
+    <div class="field">
+    <%= form.password_field :password_confirmation, options.except(:help_text, :autocomplete) %>
+    </div>
+</div>
+
+<% content_for :js_content do %>
+  <%= javascript_pack_tag "decidim_registrations" %>
+<% end %>

--- a/decidim-core/app/views/decidim/devise/shared/_password_fields.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_password_fields.html.erb
@@ -1,17 +1,17 @@
 <div class="user-password"
-    data-show-password="<%= t ".show_password" %>"
-    data-hide-password="<%= t ".hide_password" %>"
-    data-hidden-password="<%= t ".hidden_password" %>"
-    data-shown-password="<%= t ".shown_password" %>">
-    <div class="field">
+  data-show-password="<%= t ".show_password" %>"
+  data-hide-password="<%= t ".hide_password" %>"
+  data-hidden-password="<%= t ".hidden_password" %>"
+  data-shown-password="<%= t ".shown_password" %>">
+  <div class="field">
     <%= form.password_field :password, options %>
-    </div>
+  </div>
 </div>
 
 <div class="user-password-confirmation">
-    <div class="field">
+  <div class="field">
     <%= form.password_field :password_confirmation, options.except(:help_text, :autocomplete) %>
-    </div>
+  </div>
 </div>
 
 <% content_for :js_content do %>

--- a/decidim-core/config/assets.rb
+++ b/decidim-core/config/assets.rb
@@ -13,5 +13,6 @@ Decidim::Webpacker.register_entrypoints(
   decidim_geocoding_provider_here: "#{base_path}/app/packs/entrypoints/decidim_geocoding_provider_here.js",
   decidim_map_provider_default: "#{base_path}/app/packs/entrypoints/decidim_map_provider_default.js",
   decidim_map_provider_here: "#{base_path}/app/packs/entrypoints/decidim_map_provider_here.js",
+  decidim_registrations: "#{base_path}/app/packs/entrypoints/decidim_registrations.js",
   decidim_widget: "#{base_path}/app/packs/entrypoints/decidim_widget.js"
 )

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -570,6 +570,11 @@ en:
           title: Newsletter notifications
         omniauth_buttons:
           or: Or
+        password_fields:
+          hidden_password: Your password is hidden
+          hide_password: Hide password
+          show_password: Show password
+          shown_password: Your password is shown
     doorkeeper:
       authorizations:
         new:

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -92,7 +92,6 @@ describe "Account", type: :system do
             page.find(".change-password").click
 
             fill_in :user_password, with: "sekritpass123"
-            fill_in :user_password_confirmation, with: "sekritpass123"
 
             find("*[type=submit]").click
           end
@@ -109,7 +108,8 @@ describe "Account", type: :system do
         it "doesn't update the password" do
           within "form.edit_user" do
             page.find(".change-password").click
-
+            # disable passwordTogler and restore the old behavior
+            page.execute_script("window.Decidim.passwordToggler.destroy()")
             fill_in :user_password, with: "sekritpass123"
             fill_in :user_password_confirmation, with: "oopseytypo"
 

--- a/decidim-core/spec/system/admin_passwords_spec.rb
+++ b/decidim-core/spec/system/admin_passwords_spec.rb
@@ -37,6 +37,7 @@ describe "Admin passwords", type: :system do
       expect(page).to have_current_path(decidim.change_password_path)
     end
 
+    # we keep this test to ensure the old way is still available (password/password confirmation)
     it "shows error when passwords doesnt match" do
       manual_login(user.email, password)
       # disable passwordTogler and restore the old behavior
@@ -46,6 +47,7 @@ describe "Admin passwords", type: :system do
       click_button "Change my password"
       expect(page).to have_css(".callout.alert")
       expect(page).to have_content("There was a problem updating the password")
+      page.execute_script("window.Decidim.passwordToggler.destroy()")
       expect(page).to have_content("doesn't match Password")
     end
 

--- a/decidim-core/spec/system/admin_passwords_spec.rb
+++ b/decidim-core/spec/system/admin_passwords_spec.rb
@@ -22,7 +22,6 @@ describe "Admin passwords", type: :system do
       expect(page).to have_content("Admin users need to change their password every 90 days")
       expect(page).to have_content("Password change")
       fill_in :password_user_password, with: new_password
-      fill_in :password_user_password_confirmation, with: new_password
       click_button "Change my password"
       expect(page).to have_css(".callout.success")
       expect(page).to have_content("Password successfully updated")
@@ -40,6 +39,8 @@ describe "Admin passwords", type: :system do
 
     it "shows error when passwords doesnt match" do
       manual_login(user.email, password)
+      # disable passwordTogler and restore the old behavior
+      page.execute_script("window.Decidim.passwordToggler.destroy()")
       fill_in :password_user_password, with: new_password
       fill_in :password_user_password_confirmation, with: "decidim12345678"
       click_button "Change my password"
@@ -55,7 +56,6 @@ describe "Admin passwords", type: :system do
         manual_login(user.email, password)
         expect(page).to have_content("Password change")
         fill_in :password_user_password, with: new_password
-        fill_in :password_user_password_confirmation, with: new_password
         click_button "Change my password"
         expect(page).to have_css(".callout.alert")
         expect(page).to have_content("There was a problem updating the password")
@@ -74,7 +74,6 @@ describe "Admin passwords", type: :system do
         manual_login(user.email, password)
         expect(page).to have_content("Password change")
         fill_in :password_user_password, with: new_password
-        fill_in :password_user_password_confirmation, with: new_password
         click_button "Change my password"
         expect(page).to have_css(".callout.success")
         expect(page).to have_current_path(decidim.page_path(static_page))

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -21,7 +21,6 @@ describe "Authentication", type: :system do
           fill_in :registration_user_name, with: "Responsible Citizen"
           fill_in :registration_user_nickname, with: "responsible"
           fill_in :registration_user_password, with: "DfyvHn425mYAy2HL"
-          fill_in :registration_user_password_confirmation, with: "DfyvHn425mYAy2HL"
           check :registration_user_tos_agreement
           check :registration_user_newsletter
           find("*[type=submit]").click
@@ -46,7 +45,6 @@ describe "Authentication", type: :system do
           fill_in :registration_user_name, with: "Responsible Citizen"
           fill_in :registration_user_nickname, with: "responsible"
           fill_in :registration_user_password, with: "DfyvHn425mYAy2HL"
-          fill_in :registration_user_password_confirmation, with: "DfyvHn425mYAy2HL"
           check :registration_user_tos_agreement
           check :registration_user_newsletter
           find("*[type=submit]").click
@@ -67,7 +65,6 @@ describe "Authentication", type: :system do
           fill_in :registration_user_name, with: "Responsible Citizen"
           fill_in :registration_user_nickname, with: "responsible"
           fill_in :registration_user_password, with: "DfyvHn425mYAy2HL"
-          fill_in :registration_user_password_confirmation, with: "DfyvHn425mYAy2HL"
           check :registration_user_tos_agreement
           check :registration_user_newsletter
           find("*[type=submit]").click
@@ -237,7 +234,6 @@ describe "Authentication", type: :system do
           fill_in :registration_user_name, with: "Responsible Citizen"
           fill_in :registration_user_nickname, with: "NiCk"
           fill_in :registration_user_password, with: "DfyvHn425mYAy2HL"
-          fill_in :registration_user_password_confirmation, with: "DfyvHn425mYAy2HL"
           check :registration_user_tos_agreement
           check :registration_user_newsletter
           find("*[type=submit]").click
@@ -377,7 +373,6 @@ describe "Authentication", type: :system do
 
         within ".new_user" do
           fill_in :password_user_password, with: "DfyvHn425mYAy2HL"
-          fill_in :password_user_password_confirmation, with: "DfyvHn425mYAy2HL"
           find("*[type=submit]").click
         end
 
@@ -390,7 +385,6 @@ describe "Authentication", type: :system do
 
         within ".new_user" do
           fill_in :password_user_password, with: "whatislove"
-          fill_in :password_user_password_confirmation, with: "whatislove"
           find("*[type=submit]").click
         end
 
@@ -405,12 +399,10 @@ describe "Authentication", type: :system do
 
         within ".new_user" do
           fill_in :password_user_password, with: "example"
-          fill_in :password_user_password_confirmation, with: "example"
           find("*[type=submit]").click
         end
 
         expect(page).to have_content("The password is too short.")
-        expect(page).to have_content("Password confirmation must match the password.")
       end
     end
 
@@ -616,7 +608,6 @@ describe "Authentication", type: :system do
             fill_in :registration_user_name, with: "Responsible Citizen"
             fill_in :registration_user_nickname, with: "responsible"
             fill_in :registration_user_password, with: "DfyvHn425mYAy2HL"
-            fill_in :registration_user_password_confirmation, with: "DfyvHn425mYAy2HL"
             check :registration_user_tos_agreement
             check :registration_user_newsletter
             find("*[type=submit]").click

--- a/decidim-core/spec/system/registration_spec.rb
+++ b/decidim-core/spec/system/registration_spec.rb
@@ -7,7 +7,6 @@ def fill_registration_form
   fill_in :registration_user_nickname, with: "the-greatest-genius-in-history"
   fill_in :registration_user_email, with: "nikola.tesla@example.org"
   fill_in :registration_user_password, with: "sekritpass123"
-  fill_in :registration_user_password_confirmation, with: "sekritpass123"
 end
 
 describe "Registration", type: :system do
@@ -27,7 +26,6 @@ describe "Registration", type: :system do
         expect(page).to have_field("registration_user_nickname", with: "")
         expect(page).to have_field("registration_user_email", with: "")
         expect(page).to have_field("registration_user_password", with: "")
-        expect(page).to have_field("registration_user_password_confirmation", with: "")
         expect(page).to have_field("registration_user_newsletter", checked: false)
       end
     end

--- a/decidim-meetings/spec/shared/manage_invites_examples.rb
+++ b/decidim-meetings/spec/shared/manage_invites_examples.rb
@@ -77,7 +77,6 @@ shared_examples "manage invites" do
           within "form.new_user" do
             fill_in :invitation_user_nickname, with: "caballo_loco"
             fill_in :invitation_user_password, with: "decidim123456789"
-            fill_in :invitation_user_password_confirmation, with: "decidim123456789"
             check :invitation_user_tos_agreement
             find("*[type=submit]").click
           end
@@ -96,7 +95,6 @@ shared_examples "manage invites" do
           within "form.new_user" do
             fill_in :invitation_user_nickname, with: "caballo_loco"
             fill_in :invitation_user_password, with: "decidim123456789"
-            fill_in :invitation_user_password_confirmation, with: "decidim123456789"
             check :invitation_user_tos_agreement
             find("*[type=submit]").click
           end

--- a/decidim-participatory_processes/spec/system/admin/invite_process_admin_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/invite_process_admin_spec.rb
@@ -22,7 +22,6 @@ describe "Invite process administrator", type: :system do
       within "form.new_user" do
         fill_in :invitation_user_nickname, with: "caballo_loco"
         fill_in :invitation_user_password, with: "decidim123456789"
-        fill_in :invitation_user_password_confirmation, with: "decidim123456789"
         check :invitation_user_tos_agreement
         find("*[type=submit]").click
       end

--- a/decidim-participatory_processes/spec/system/admin/invite_process_collaborator_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/invite_process_collaborator_spec.rb
@@ -21,7 +21,6 @@ describe "Invite process collaborator", type: :system do
       within "form.new_user" do
         fill_in :invitation_user_nickname, with: "caballo_loco"
         fill_in :invitation_user_password, with: "decidim123456789"
-        fill_in :invitation_user_password_confirmation, with: "decidim123456789"
         check :invitation_user_tos_agreement
         find("*[type=submit]").click
       end

--- a/decidim-participatory_processes/spec/system/admin/invite_process_moderator_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/invite_process_moderator_spec.rb
@@ -20,7 +20,6 @@ describe "Invite process moderator", type: :system do
       within "form.new_user" do
         fill_in :invitation_user_nickname, with: "caballo_loco"
         fill_in :invitation_user_password, with: "decidim123456789"
-        fill_in :invitation_user_password_confirmation, with: "decidim123456789"
         check :invitation_user_tos_agreement
         find("*[type=submit]").click
       end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds a password toggle button via unobstructive javascript (defaults to the traditional password/confirm password if javascript is disabled). This means it also hides the "confirm password" field.

To ensure full accessibility, it is based on GOV.UK article: https://technology.blog.gov.uk/2021/04/19/simple-things-are-complicated-making-a-show-password-option/
(see their implementation here: https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/components/show-password.js)

Applies to:
- [x] User sign-up
- [x] Forgot password
- [x] Admin/forced password change
- [x] Account/password change
- [x] Set password on invitation
- [ ] ~System registration~
- [ ] ~System edit admin~

NOTE: While doing this I noticed this bug https://github.com/decidim/decidim/issues/9498 (I skipped modifying that obsolete view)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://meta.decidim.org/processes/roadmap/f/122/proposals/17026
- Fixes https://github.com/openpoke/decidim/issues/2

#### Testing
*Describe the best way to test or validate your PR.*

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

![Screenshot from 2022-06-30 12-55-51](https://user-images.githubusercontent.com/1401520/176660693-345c8df3-fac8-4a11-b127-38d9ad9aec03.png)

![Screenshot from 2022-06-30 12-55-45](https://user-images.githubusercontent.com/1401520/176660697-0955214d-6c38-4665-bb41-40ca6469405f.png)


![image](https://user-images.githubusercontent.com/1401520/176161137-94fb503b-16c3-4bdc-87ee-387e7a7b1190.png)

![image](https://user-images.githubusercontent.com/1401520/176165552-afd37870-918e-4797-9b27-889751838ac8.png)

:hearts: Thank you!
