### PR TITLE
Fix email subject when participatory space title is present

### DIFF
--- a/decidim-blogs/spec/events/decidim/blogs/create_post_event_spec.rb
+++ b/decidim-blogs/spec/events/decidim/blogs/create_post_event_spec.rb
@@ -11,6 +11,14 @@ describe Decidim::Blogs::CreatePostEvent do
   it_behaves_like "a simple event"
 
   describe "email_subject" do
+    let(:assembly) { create(:assembly, organization: organization, title: { en: "It's a test" }) }
+    let(:blogs_component) { create :component, :published, name: { en: "Blogs" }, participatory_space: assembly, manifest_name: :blogs }
+
+    before do
+      resource.component = blogs_component
+      resource.save!
+    end
+
     it "is generated correctly" do
       expect(subject.email_subject).to eq("New post published in #{participatory_space_title}")
     end

--- a/decidim-core/lib/decidim/events/simple_event.rb
+++ b/decidim-core/lib/decidim/events/simple_event.rb
@@ -40,6 +40,7 @@ module Decidim
       def email_subject_i18n_options
         sanitized_values = { resource_title: decidim_sanitize(resource_title) }
         sanitized_values[:mentioned_proposal_title] = decidim_sanitize(mentioned_proposal_title) if i18n_options.has_key?(:mentioned_proposal_title)
+        sanitized_values[:participatory_space_title] = decidim_sanitize(participatory_space_title) if i18n_options.has_key?(:participatory_space_title)
         i18n_options.merge(sanitized_values)
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Email subject is wrongly displayed when contains participatory space title with special characters

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #9477 

#### Testing
- Create a "Post" under "Blog" component
- Check the received notification
- Email subject is wrongly displayed

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Scree
BEFORE
![Screenshot from 2022-06-27 18-51-50](https://user-images.githubusercontent.com/66411127/175983324-19750419-86c9-4e3c-ad6a-33eb3412076c.png)

AFTER
![Screenshot from 2022-06-27 18-49-36](https://user-images.githubusercontent.com/66411127/175983370-a1f74685-900b-49e2-87b3-0ae2cbcb7a4c.png)


:hearts: Thank you!
