### PR TITLE
Improve the default gitignore files created by the generators

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -221,7 +221,7 @@ module Decidim
         prepend_to_file "config/spring.rb", "require \"decidim/spring\"\n\n"
       end
 
-      def add_ignore_uploads
+      def modify_gitignore
         return if options[:skip_git]
 
         append_file ".gitignore", <<~GITIGNORE

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -222,7 +222,24 @@ module Decidim
       end
 
       def add_ignore_uploads
-        append_file ".gitignore", "\n# Ignore public uploads\npublic/uploads" unless options["skip_git"]
+        return if options[:skip_git]
+
+        append_file ".gitignore", <<~GITIGNORE
+
+          # Ignore env configuration files
+          .env
+          .envrc
+          .rbenv-vars
+
+          # Ignore the files and folders generated through Webpack
+          /public/decidim-packs
+          /public/packs-test
+          /public/sw.js
+          /public/sw.js.map
+
+          # Ignore node modules
+          /node_modules
+        GITIGNORE
       end
 
       def remove_default_error_pages

--- a/decidim-generators/lib/decidim/generators/component_templates/gitignore
+++ b/decidim-generators/lib/decidim/generators/component_templates/gitignore
@@ -10,6 +10,11 @@
 # rspec failure tracking
 .rspec-failures
 
+# env configuration files
+.env
+.envrc
+.rbenv-vars
+
 # default test application
 spec/decidim_dummy_app
 


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing decidim/metadecidim#103, I noticed a bunch of lines added to the `.gitignore` of the instance.

Maybe we should add these automatically also to any new applications created with the generator?

I also added the env configuration files to the `.gitignore` of generated components.

#### Testing
Applications:
1. Run `bundle exec rake test_app`
2. Run `cat spec/decidim_dummy_app/.gitignore`
3. See the result

For components
1. Run `bundle exec ./decidim-generators/exe/decidim --component foobar` (note that `bundle exec` here is important for the executable not to load the installed version of the requirements)
2. Give description for the component
3. Run `cat decidim-module-foobar/.gitignore`
4. See the result

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.