### PR TITLE
Fix published conferences order

### DIFF
--- a/decidim-conferences/app/queries/decidim/conferences/organization_published_conferences.rb
+++ b/decidim-conferences/app/queries/decidim/conferences/organization_published_conferences.rb
@@ -14,7 +14,7 @@ module Decidim
           OrganizationConferences.new(@organization),
           VisibleConferences.new(@user),
           PublishedConferences.new
-        ).query
+        ).query.order(start_date: :desc)
       end
     end
   end

--- a/decidim-conferences/spec/queries/organization_published_conferences_spec.rb
+++ b/decidim-conferences/spec/queries/organization_published_conferences_spec.rb
@@ -9,7 +9,9 @@ module Decidim::Conferences
     let!(:organization) { create(:organization) }
 
     let!(:published_conferences) do
-      create_list(:conference, 3, :published, organization: organization)
+      create(:conference, :published, organization: organization, start_date: 1.year.ago, end_date: 1.year.ago + 3.days)
+      create(:conference, :published, organization: organization, start_date: 30.days.ago, end_date: 30.days.ago + 7.days)
+      create(:conference, :published, organization: organization, start_date: 7.days.from_now, end_date: 7.days.from_now + 4.days)
     end
 
     let!(:unpublished_conferences) do
@@ -31,6 +33,10 @@ module Decidim::Conferences
 
       it "excludes other organization's published conferences" do
         expect(subject).not_to include(*foreign_conferences)
+      end
+
+      it "order conferences by start date" do
+        expect(subject.to_a.first.start_date).to eq 7.days.from_now.to_date
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

While working on the last #DecidimFest, it was detected that the conferences didn't have a logic order: 

![image](https://user-images.githubusercontent.com/717367/177131467-40b77401-d281-4286-8fde-3221fbc7c8e1.png)

This PR fixes that, showing the newer conferences first, as that's the most common use case. 

#### Testing

1. Sign in as admin
2. Edit conferences' start dates
3. See that its always ordered by the start date, showing the newer first 

### :camera: Screenshots

In this example, the OLD conference has a start date of October 2021, and NEW is on September 2022 

#### Before
![Selection_259](https://user-images.githubusercontent.com/717367/177132108-142f8296-0a73-4828-89d1-9424cd328773.png)

#### After
![Selection_258](https://user-images.githubusercontent.com/717367/177132121-33cff81e-a6ae-48b2-b370-a7975418fba9.png)

:hearts: Thank you!
