### PR TITLE
Fix creation notification when editing a comment 

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/edit_comment_modal_form_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/edit_comment_modal_form_cell.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Comments
-    # A cell to display a form for edditing a comment.
+    # A cell to display a form for editing a comment.
     class EditCommentModalFormCell < Decidim::ViewModel
       delegate :current_user, :user_signed_in?, to: :controller
       alias comment model

--- a/decidim-comments/app/commands/decidim/comments/update_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/update_comment.rb
@@ -48,14 +48,7 @@ module Decidim
           edit: true
         )
 
-        mentioned_users = parsed.metadata[:user].users
-        mentioned_groups = parsed.metadata[:user_group].groups
         CommentCreation.publish(@comment, parsed.metadata)
-        send_notifications(mentioned_users, mentioned_groups)
-      end
-
-      def send_notifications(mentioned_users, mentioned_groups)
-        NewCommentNotificationCreator.new(comment, mentioned_users, mentioned_groups).create
       end
     end
   end

--- a/decidim-comments/spec/commands/update_comment_spec.rb
+++ b/decidim-comments/spec/commands/update_comment_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Comments
+    describe UpdateComment do
+      let(:organization) { create(:organization) }
+      let(:participatory_process) { create(:participatory_process, organization: organization) }
+      let(:component) { create(:component, participatory_space: participatory_process) }
+      let(:author) { create(:user, organization: organization) }
+      let(:dummy_resource) { create :dummy_resource, component: component }
+      let(:commentable) { dummy_resource }
+      let(:comment) { create :comment, author: author, commentable: commentable }
+      let(:body) { "This is a reasonable comment" }
+      let(:form_params) do
+        {
+          "comment" => {
+            "body" => body,
+            "commentable" => commentable
+          }
+        }
+      end
+      let(:form) do
+        Decidim::Comments::CommentForm.from_params(
+          form_params
+        ).with_context(
+          current_organization: organization
+        )
+      end
+      let(:current_user) { author }
+      let(:command) { described_class.new(comment, current_user, form) }
+
+      describe "call" do
+        describe "when the form is not valid" do
+          before do
+            allow(form).to receive(:invalid?).and_return(true)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't update the comment" do
+            expect { command.call }.not_to change(comment, :body)
+          end
+        end
+
+        describe "when the comment is not authored by the user" do
+          before do
+            allow(comment).to receive(:authored_by?).and_return(false)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't update the comment" do
+            expect { command.call }.not_to change(comment, :body)
+          end
+        end
+
+        describe "when the form is valid" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "updates the comment" do
+            command.call
+            comment.reload
+            expect(comment.body).to be_kind_of(Hash)
+            expect(comment.body["en"]).to eq body
+          end
+
+          it "sends the notifications" do
+            creator_double = instance_double(NewCommentNotificationCreator, create: true)
+
+            allow(NewCommentNotificationCreator)
+              .to receive(:new)
+              .with(kind_of(Comment), [], [])
+              .and_return(creator_double)
+
+            expect(creator_double)
+              .to receive(:create)
+
+            command.call
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:update!)
+              .with(
+                Decidim::Comments::Comment,
+                author,
+                { body: { en: "This is a reasonable comment" } },
+                { edit: true, visibility: "public-only" }
+              )
+              .and_call_original
+
+            expect { command.call }.to change(Decidim::ActionLog, :count)
+            action_log = Decidim::ActionLog.last
+            expect(action_log.version).to be_present
+            expect(action_log.version.event).to eq "update"
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-comments/spec/commands/update_comment_spec.rb
+++ b/decidim-comments/spec/commands/update_comment_spec.rb
@@ -72,16 +72,8 @@ module Decidim
             expect(comment.body["en"]).to eq body
           end
 
-          it "sends the notifications" do
-            creator_double = instance_double(NewCommentNotificationCreator, create: true)
-
-            allow(NewCommentNotificationCreator)
-              .to receive(:new)
-              .with(kind_of(Comment), [], [])
-              .and_return(creator_double)
-
-            expect(creator_double)
-              .to receive(:create)
+          it "does not notify the followers" do
+            expect(Decidim::EventsManager).not_to receive(:publish)
 
             command.call
           end

--- a/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/update_proposal_spec.rb
@@ -94,7 +94,7 @@ module Decidim
           end
         end
 
-        context "when the author changinng the author to one that has reached the proposal limit" do
+        context "when the author changing the author to one that has reached the proposal limit" do
           let!(:other_proposal) { create :proposal, component: component, users: [author], user_groups: [user_group] }
           let(:component) { create(:proposal_component, :with_proposal_limit) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

#### :tophat: What? Why?

While reviewing the v0.27.0.dev at nightly, @carolromero found that there were "A comment has been created" notifications for the same comment. We found out that this was because it was notifying when the comment was edited, and it was sending the same notification. 

We thought about using a new notification ("A comment has been edited") but at the moment this can be overkill and bring too much noise, so we'll just drop this notification. 

As this class didn't have specs directly [*], I've also added it. 

[*] As far as I could find, we only have system/capybara specs at https://github.com/decidim/decidim/blob/00c6b2a63c29c5f0e1eeabf2ff2102bce910173f/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb#L251 

But testing against the class is cleaner IMHO. 

I've also found a couple random typos, this PR fixes them too. 

#### :pushpin: Related Issues

- Related to #8072

#### Testing

1. Sign in as a user, follow a process, enable notifications
2. In another browser, sign in as another user, create a comment, edit this comment two times
3. Go to the first user, see the notifications
  a. Before this PR: you'll see three notifications
  a. After this PR: you'll see one notification for this event

:hearts: Thank you!
