### PR TITLE
Add the rexml gem as a requirement for Ruby 3.0.0+ compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,7 @@ PATH
       decidim-core (= 0.28.0.dev)
       decidim-verifications (= 0.28.0.dev)
       origami (~> 2.1)
+      rexml (~> 3.2.5)
       wicked (~> 1.3)
       wicked_pdf (~> 2.1)
       wkhtmltopdf-binary (~> 0.12)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -158,6 +158,7 @@ PATH
       decidim-core (= 0.28.0.dev)
       decidim-verifications (= 0.28.0.dev)
       origami (~> 2.1)
+      rexml (~> 3.2.5)
       wicked (~> 1.3)
       wicked_pdf (~> 2.1)
       wkhtmltopdf-binary (~> 0.12)

--- a/decidim-initiatives/decidim-initiatives.gemspec
+++ b/decidim-initiatives/decidim-initiatives.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-core", Decidim::Initiatives.version
   s.add_dependency "decidim-verifications", Decidim::Initiatives.version
   s.add_dependency "origami", "~> 2.1"
+  s.add_dependency "rexml", "~> 3.2.5" # Required for Origami gem to work with Ruby 3.0.0+
   s.add_dependency "wicked", "~> 1.3"
   s.add_dependency "wicked_pdf", "~> 2.1"
   s.add_dependency "wkhtmltopdf-binary", "~> 0.12"

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -158,6 +158,7 @@ PATH
       decidim-core (= 0.28.0.dev)
       decidim-verifications (= 0.28.0.dev)
       origami (~> 2.1)
+      rexml (~> 3.2.5)
       wicked (~> 1.3)
       wicked_pdf (~> 2.1)
       wkhtmltopdf-binary (~> 0.12)


### PR DESCRIPTION
#### :tophat: What? Why?
During MetaDecidim upgrade, I ran into this issue that the server did not start because it did not find the `rexml` gem which used to be included in older Ruby versions but from now on has to be installed from a separate gem as explained at the Ruby 3.0.0 release notes:
https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

> The following default gems are now bundled gems.
> - rexml
> - rss

The following lines of the `origami` gem are assuming that the `rexml` gem is available:
https://github.com/gdelugre/origami/blob/ac1df803517601d486556fd40af5d422a6f4378e/lib/origami/metadata.rb#L21
https://github.com/gdelugre/origami/blob/ac1df803517601d486556fd40af5d422a6f4378e/lib/origami/xfa/package.rb#L21

These cause a load error when the gem is not installed at the target system because the `origami` gem does not specify the `rexml` gem as its dependency.

#### Testing
- Create a new Decidim app using 0.27.0.rc1
- Deploy the app to Heroku (or similar environments where this gem does not exist)
- After deployment and server start, check the logs for the load error

#### :clipboard: Checklist

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [x] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.