### PR TITLE
Update PR template with redesign guideline and drop "Checklist" section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,22 +9,6 @@
 #### Testing
 *Describe the best way to test or validate your PR.*
 
-#### :clipboard: Checklist
-:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.
-
-- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
-- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
-- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
-- [ ] :heavy_check_mark: **DO** build locally before pushing.
-- [ ] :heavy_check_mark: **DO** make sure tests pass.
-- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
-- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
-- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
-- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
-- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
-- [ ] :x:**AVOID** breaking the continuous integration build.
-- [ ] :x:**AVOID** making significant changes to the overall architecture.
-
 ### :camera: Screenshots
 *Please add screenshots of the changes you're proposing*
 ![Description](URL)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+<!--
+NOTE: We're in the middle of a big redesign of the frontend.
+That could mean that your PR will not get through on the next few months.
+Please see https://github.com/decidim/decidim/discussions/9512
+-->
+
 #### :tophat: What? Why?
 *Please describe your pull request.*
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR updates the PR template with:

1. A commented section to new PRs, to let contributors know about the new redesign guidelines
2. Drop the Checklist section, as most of the time it wasn't followed. It's probably something that should be enforced by reviewers. 

:hearts: Thank you!
