### PR TITLE
Remove margin-bottom on votings navigation

### DIFF
--- a/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/description/show.erb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/description/show.erb
@@ -1,4 +1,4 @@
-<div class="row section voting-description-cell">
+<div class="row section voting-description-cell mt-m">
   <div class="columns">
     <% if introductory_image.attached? %>
       <div id="introductory-image" class="columns medium-4 mediumlarge-5">

--- a/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/header/show.erb
+++ b/decidim-elections/app/cells/decidim/votings/content_blocks/landing_page/header/show.erb
@@ -24,6 +24,6 @@
   </div>
 </section>
 
-<section class="section">
+<section>
   <%= extended_navigation_bar(navigation_items) %>
 </section>


### PR DESCRIPTION
#### :tophat: What? Why?

Reviewing nightly with @carolromero last week, we've found that there's too much margin in the voting module navigation. This PR fixes that. 

It was probably introduced for the landing page, but it went to other pages too. 
 
#### Testing

1. Go to a votings' component index page
2. See the margin between the navigation and the content 

### :camera: Screenshots

#### Before

![image](https://user-images.githubusercontent.com/717367/177266798-e96d3389-a20d-4c19-b483-09d33c97eafc.png)

#### After

![image](https://user-images.githubusercontent.com/717367/177266925-ad2e95ee-25f8-4b4d-9983-3ec7ee0ae2ee.png)


:hearts: Thank you!
