### PR TITLE
Fix nested attributes model mapping

### DIFF
--- a/decidim-core/lib/decidim/attributes/model.rb
+++ b/decidim-core/lib/decidim/attributes/model.rb
@@ -15,7 +15,15 @@ module Decidim
         return value if value.is_a?(Decidim::AttributeObject::Model)
         return primitive.new(value) if value.is_a?(::Hash)
         return primitive.new(value.to_h) if value.respond_to?(:to_h)
-        return primitive.new(value.attributes) if value.respond_to?(:attributes)
+
+        if value.respond_to?(:attributes)
+          # In case the primitive is a form object, we also need to call the
+          # `map_model` method in case the target form object defines it for
+          # nested forms to work properly.
+          converted = primitive.new(value.attributes)
+          converted.map_model(value) if converted.respond_to?(:map_model)
+          return converted
+        end
 
         value
       end

--- a/decidim-core/spec/lib/attribute_object/form_spec.rb
+++ b/decidim-core/spec/lib/attribute_object/form_spec.rb
@@ -33,6 +33,12 @@ module Decidim
         attribute :name, String
 
         validates :name, presence: true
+
+        attr_reader :secret_sauce
+
+        def map_model(model)
+          @secret_sauce = model.custom_sauce
+        end
       end
     end
     let(:foodform) do
@@ -179,6 +185,27 @@ module Decidim
         expect(subject.foods[:voner].name).to eq("Vöner")
         expect(subject.foods[:voner].vegan).to be(true)
         expect(subject.gadgets.empty?).to be(true)
+      end
+
+      context "when Active Record objects are provided as nested attribute values" do
+        let(:drink_class) do
+          Class.new(ApplicationRecord) do
+            self.table_name = :decidim_dummy_resources_dummy_resources
+
+            def custom_sauce
+              "foobar"
+            end
+          end
+        end
+        let(:drink) { drink_class.new }
+
+        let(:model) do
+          OpenStruct.new(id: 1, drinks: [drink])
+        end
+
+        it "calls the map_model method on the created nested form object" do
+          expect(subject.drinks.first.secret_sauce).to eq("foobar")
+        end
       end
     end
 

--- a/decidim-core/spec/lib/attributes/model_spec.rb
+++ b/decidim-core/spec/lib/attributes/model_spec.rb
@@ -93,6 +93,24 @@ module Decidim
         end
       end
 
+      context "when the value is an Active Record object and the primitive is a form" do
+        let(:primitive) do
+          Class.new(Decidim::Form) do
+            attr_reader :provided_model
+
+            def map_model(model)
+              @provided_model = model
+            end
+          end
+        end
+        let(:value) { create(:organization) }
+
+        it "calls the map_model method on the created primitive record" do
+          expect(subject).to be_a(primitive)
+          expect(subject.provided_model).to be(value)
+        end
+      end
+
       context "when the value does not match any of the expected value conditions" do
         let(:value) { double }
 


### PR DESCRIPTION
#### :tophat: What? Why?
When doing the term customizer 0.27 upgrade, I noticed that the `map_model` method is not properly called when the form defines nested models and the value arguments provided to that are models. This causes an issue e.g. with the term customizer which does something like this:
https://github.com/mainio/decidim-module-term_customizer/blob/9540a2ab20b872896e51ea5f97c5ebae3388ca60/app/forms/decidim/term_customizer/admin/translation_set_constraint_form.rb#L19-L29

This PR fixes that issue.

#### :pushpin: Related Issues
- Related to #8669

#### Testing
- Create a form structure similar to term customizer
- Create the nested records for the form by providing an array (or collection) of active record objects
- Call the nested argument and see if the `map_model` method was called for the nested arguments

#### :clipboard: Checklist

- [x] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [x] :x:**AVOID** making significant changes to the overall architecture.