### PR TITLE
Backport 'Capture unhandled errors from JS promises and inform the user' to v0.26

### DIFF
--- a/decidim-elections/app/packs/src/decidim/elections/voter/setup-vote.js
+++ b/decidim-elections/app/packs/src/decidim/elections/voter/setup-vote.js
@@ -46,5 +46,12 @@ export default function setupVoteComponent($voteWrapper) {
   });
 }
 
+/* Fallback for non-handled failed promises */
+window.addEventListener("unhandledrejection", (event) => {
+  $("#server-failure .tech-info").html(event.reason);
+  $("#server-failure").foundation("open");
+});
+
 window.Decidim = window.Decidim || {};
 window.Decidim.setupVoteComponent = setupVoteComponent;
+

--- a/decidim-elections/app/views/decidim/elections/votes/_server_error_modal.html.erb
+++ b/decidim-elections/app/views/decidim/elections/votes/_server_error_modal.html.erb
@@ -1,0 +1,28 @@
+<div class="reveal" id="server-failure" data-reveal>
+  <div class="reveal__header">
+    <h3 class="reveal__title">
+      <%= t("modal.title", scope: "decidim.elections.votes.failed") %>
+    </h3>
+
+    <button class="close-button" data-close aria-label="<%= t("modal.close", scope: "decidim.elections.votes.failed") %>"
+      type="button">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+
+  <div class="row">
+    <p>
+      <%= t("modal.communication_lost", scope: "decidim.elections.votes.failed").html_safe %>
+    </p>
+
+    <p class="help-text tech-info"></p>
+  </div>
+
+  <div class="row">
+    <div class="column flex-center">
+      <button class="button primary expanded" data-close type="button">
+        <%= t("modal.close", scope: "decidim.elections.votes.failed") %>
+      </button>
+    </div>
+  </div>
+</div>

--- a/decidim-elections/app/views/decidim/elections/votes/new.html.erb
+++ b/decidim-elections/app/views/decidim/elections/votes/new.html.erb
@@ -59,6 +59,8 @@
   </div>
 </div>
 
+<%= render "server_error_modal" %>
+
 <% if preview_mode? %>
   <%= javascript_pack_tag "decidim_elections_voter_setup_preview" %>
 <% else %>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -640,6 +640,10 @@ en:
         failed:
           header: Vote failed
           lead: Your vote has not been casted!
+          modal:
+            close: Close
+            communication_lost: Unfortunately, it looks like the communication with the voting server (Bulletin Board) is lost.<br>It might be that the Internet connection is broken or that the destination server is too busy.<br>You can try again later or contact support if this problem persist.
+            title: Something went wrong
           text: Something went wrong, please try it again.
           try_again: Try again
         header:

--- a/decidim-elections/spec/system/vote_online_spec.rb
+++ b/decidim-elections/spec/system/vote_online_spec.rb
@@ -164,4 +164,23 @@ describe "Vote online in an election", type: :system do
       expect(page).to have_content("Next")
     end
   end
+
+  context "when the comunication with bulletin board fails" do
+    before do
+      election.questions.last.destroy!
+      election.questions.last.destroy!
+      election.questions.last.destroy!
+      allow(Decidim::Elections.bulletin_board).to receive(:bulletin_board_server).and_return("http://idontexist.tld/api")
+    end
+
+    it "alerts the user about the error" do
+      visit_component
+      click_link translated(election.title)
+      click_link "Start voting"
+
+      within "#server-failure" do
+        expect(page).to have_content("Something went wrong")
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9430 to v0.26

:hearts: Thank you!