### PR TITLE
Backport 'Add the rexml gem as a requirement for Ruby 3.0.0+ compatibility' to v0.27

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,7 @@ PATH
       decidim-core (= 0.27.0.rc1)
       decidim-verifications (= 0.27.0.rc1)
       origami (~> 2.1)
+      rexml (~> 3.2.5)
       wicked (~> 1.3)
       wicked_pdf (~> 2.1)
       wkhtmltopdf-binary (~> 0.12)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -158,6 +158,7 @@ PATH
       decidim-core (= 0.27.0.rc1)
       decidim-verifications (= 0.27.0.rc1)
       origami (~> 2.1)
+      rexml (~> 3.2.5)
       wicked (~> 1.3)
       wicked_pdf (~> 2.1)
       wkhtmltopdf-binary (~> 0.12)

--- a/decidim-initiatives/decidim-initiatives.gemspec
+++ b/decidim-initiatives/decidim-initiatives.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-core", Decidim::Initiatives.version
   s.add_dependency "decidim-verifications", Decidim::Initiatives.version
   s.add_dependency "origami", "~> 2.1"
+  s.add_dependency "rexml", "~> 3.2.5" # Required for Origami gem to work with Ruby 3.0.0+
   s.add_dependency "wicked", "~> 1.3"
   s.add_dependency "wicked_pdf", "~> 2.1"
   s.add_dependency "wkhtmltopdf-binary", "~> 0.12"

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -158,6 +158,7 @@ PATH
       decidim-core (= 0.27.0.rc1)
       decidim-verifications (= 0.27.0.rc1)
       origami (~> 2.1)
+      rexml (~> 3.2.5)
       wicked (~> 1.3)
       wicked_pdf (~> 2.1)
       wkhtmltopdf-binary (~> 0.12)


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9511 to v0.27

:hearts: Thank you!