### PR TITLE
Use public link on initiatives mailer

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
@@ -18,5 +18,5 @@
 <p>
   <%= t("check_initiative_details", scope: "decidim.initiatives.initiatives_mailer.initiative_link") %>
   <%= link_to t("here",  scope: "decidim.initiatives.initiatives_mailer.initiative_link"),
-              decidim_admin_initiatives.initiative_url(@initiative, host: @organization.host) %>
+              decidim_initiatives.initiative_url(@initiative, host: @organization.host) %>
 </p>

--- a/decidim-initiatives/spec/mailers/decidim/initiatives/initiatives_mailer_spec.rb
+++ b/decidim-initiatives/spec/mailers/decidim/initiatives/initiatives_mailer_spec.rb
@@ -5,7 +5,10 @@ require "spec_helper"
 module Decidim
   module Initiatives
     describe InitiativesMailer, type: :mailer do
-      let(:initiative) { create(:initiative) }
+      let(:organization) { create(:organization, host: "1.lvh.me") }
+      let(:initiative) { create(:initiative, organization: organization) }
+      let(:router) { Decidim::Initiatives::Engine.routes.url_helpers }
+      let(:admin_router) { Decidim::Initiatives::AdminEngine.routes.url_helpers }
 
       context "when notifies creation" do
         let(:mail) { described_class.notify_creation(initiative) }
@@ -17,6 +20,11 @@ module Decidim
 
         it "renders the body" do
           expect(mail.body.encoded).to match(initiative.title["en"])
+        end
+
+        it "renders the correct link" do
+          expect(mail).to have_link(router.initiative_url(initiative, host: initiative.organization.host))
+          expect(mail).not_to have_link(admin_router.initiative_url(initiative, host: initiative.organization.host))
         end
       end
 

--- a/decidim-initiatives/spec/mailers/decidim/initiatives/initiatives_mailer_spec.rb
+++ b/decidim-initiatives/spec/mailers/decidim/initiatives/initiatives_mailer_spec.rb
@@ -8,7 +8,7 @@ module Decidim
       let(:initiative) { create(:initiative) }
 
       context "when notifies creation" do
-        let(:mail) { InitiativesMailer.notify_creation(initiative) }
+        let(:mail) { described_class.notify_creation(initiative) }
 
         it "renders the headers" do
           expect(mail.subject).to eq("Your initiative '#{initiative.title["en"]}' has been created")
@@ -21,7 +21,7 @@ module Decidim
       end
 
       context "when notifies state change" do
-        let(:mail) { InitiativesMailer.notify_state_change(initiative, initiative.author) }
+        let(:mail) { described_class.notify_state_change(initiative, initiative.author) }
 
         it "renders the headers" do
           expect(mail.subject).to eq("The initiative #{initiative.title["en"]} has changed its status")
@@ -34,7 +34,7 @@ module Decidim
       end
 
       context "when notifies progress" do
-        let(:mail) { InitiativesMailer.notify_progress(initiative, initiative.author) }
+        let(:mail) { described_class.notify_progress(initiative, initiative.author) }
 
         it "renders the headers" do
           expect(mail.subject).to eq("Summary about the initiative: #{initiative.title["en"]}")


### PR DESCRIPTION
#### :tophat: What? Why?

Sometime ago, we've migrated the initiatives edit for users from the admin to the public views. It seems we've left a link on one mail. 

This PR fixes that. 

#### :pushpin: Related Issues
- Fixes #9518

#### Testing

1. Create an initiative
2. See the link in the email that's sent

:hearts: Thank you!
