### PR TITLE
Fix for initiative mailer when promoting committee is disabled

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
@@ -3,7 +3,7 @@
 <%= link_to t("decidim.initiatives.initiatives_mailer.more_information"), decidim.page_url("initiatives", host: @organization.host) %>
 </p>
 
-<% if @initiative.created_by_individual? %>
+<% if @initiative.promoting_committee_enabled? %>
     <p>
       <%= t "decidim.initiatives.initiatives_mailer.promotal_committee_help",
            member_count: Decidim::Initiatives.minimum_committee_members %>

--- a/decidim-initiatives/spec/mailers/decidim/initiatives/initiatives_mailer_spec.rb
+++ b/decidim-initiatives/spec/mailers/decidim/initiatives/initiatives_mailer_spec.rb
@@ -10,13 +10,39 @@ module Decidim
       context "when notifies creation" do
         let(:mail) { InitiativesMailer.notify_creation(initiative) }
 
-        it "renders the headers" do
-          expect(mail.subject).to eq("Your initiative '#{initiative.title["en"]}' has been created")
-          expect(mail.to).to eq([initiative.author.email])
+        context "when the promoting committee is enabled" do
+          it "renders the headers" do
+            expect(mail.subject).to eq("Your initiative '#{initiative.title["en"]}' has been created")
+            expect(mail.to).to eq([initiative.author.email])
+          end
+
+          it "renders the body" do
+            expect(mail.body.encoded).to match(initiative.title["en"])
+          end
+
+          it "renders the promoter committee help" do
+            expect(mail.body).to match("Forward the following link to invite people to the promoter committee")
+          end
         end
 
-        it "renders the body" do
-          expect(mail.body.encoded).to match(initiative.title["en"])
+        context "when the promoting committee is disabled" do
+          let(:organization) { create(:organization) }
+          let(:initiatives_type) { create(:initiatives_type, organization: organization, promoting_committee_enabled: false) }
+          let(:scoped_type) { create(:initiatives_type_scope, type: initiatives_type) }
+          let(:initiative) { create(:initiative, organization: organization, scoped_type: scoped_type) }
+
+          it "renders the headers" do
+            expect(mail.subject).to eq("Your initiative '#{initiative.title["en"]}' has been created")
+            expect(mail.to).to eq([initiative.author.email])
+          end
+
+          it "renders the body" do
+            expect(mail.body.encoded).to match(initiative.title["en"])
+          end
+
+          it "doesn't render the promoter committee help" do
+            expect(mail.body).not_to match("Forward the following link to invite people to the promoter committee")
+          end
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
When the promoting committee setting in the initiatives type is disabled, we're still  showing the promoting committee help in the creation mailer.

This PR fixes that. 

#### :pushpin: Related Issues
 
- Fixes #9517

#### Testing

1. Create an initiative type with promotor committee disabled
2. Create an initiative 
3. See the email

:hearts: Thank you!
