### PR TITLE
Fix translated attributes field type change

### DIFF
--- a/decidim-core/lib/decidim/translatable_attributes.rb
+++ b/decidim-core/lib/decidim/translatable_attributes.rb
@@ -43,7 +43,14 @@ module Decidim
 
           define_method attribute_name do
             field = public_send(name) || {}
-            value = field[locale.to_s] || field[locale.to_sym]
+            value =
+              if field.is_a?(Hash)
+                field[locale.to_s] || field[locale.to_sym]
+              else
+                # The value may not be a hash in case the attribute type was
+                # changed and the old value is still stored against the record.
+                field
+              end
             value_type = self.class.attribute_types[attribute_name.to_s]
             value_type ? value_type.cast(value) : value
           end

--- a/decidim-core/spec/lib/translatable_attributes_spec.rb
+++ b/decidim-core/spec/lib/translatable_attributes_spec.rb
@@ -24,7 +24,7 @@ module Decidim
       allow(Decidim).to receive(:available_locales).and_return available_locales
     end
 
-    describe "#translatable_attribute do" do
+    describe "#translatable_attribute" do
       before do
         klass.class_eval do
           translatable_attribute :name, String
@@ -52,6 +52,18 @@ module Decidim
       it "coerces values" do
         model.name_en = 1
         expect(model.name_en).to eq("1")
+      end
+
+      context "when the stored value is a string" do
+        before do
+          allow(model).to receive(:name).and_return("Hello")
+        end
+
+        it "returns the stored value for the locale specific getters" do
+          expect(model.name_en).to eq("Hello")
+          expect(model.name_ca).to eq("Hello")
+          expect(model.name_pt__BR).to eq("Hello")
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
The translated attributes getter does not properly work in case the original stored value for the record is not in the expected hash format. This is annoying when changing the field type from string to translated e.g. in content blocks as this breaks the editing view.

This fixes the problem by checking if the stored value is a hash and returning the original value for all locale specific getters in case this happens.

#### Testing
- Create a content block with a non-translated string attribute
- Edit that content block and save it from the admin panel
- Change the string attribute as translated and restart the server
- Try to go back to the content block editing view
