### PR TITLE
Add help text for proposals' 'publish answers immediately' setting 

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -90,6 +90,9 @@ module Decidim
 
       # Returns a translation or nil. If nil, ZURB Foundation won't add the help_text.
       def text_for_setting(name, suffix, i18n_scope)
+        html_key = "#{i18n_scope}.#{name}_#{suffix}_html"
+        return t(html_key) if I18n.exists?(html_key)
+
         key = "#{i18n_scope}.#{name}_#{suffix}"
         return t(key) if I18n.exists?(key)
       end

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -18,16 +18,19 @@ module Decidim
         time: :datetime_field
       }.freeze
 
-      # Public: Renders a form field that matches a settings attribute's
-      # type.
+      # Renders a form field that matches a settings attribute's type.
+      # Besides the field itself, it also renders all the metadata (like the labels and help texts)
       #
-      # form      - The form in which to render the field.
-      # attribute - The Settings::Attribute instance with the
-      #             description of the attribute.
-      # name      - The name of the field.
-      # options   - Extra options to be passed to the field helper.
-      #
-      # Returns a rendered form field.
+      # @param form [Decidim::Admin::FormBuilder] The form in which to render the field
+      # @param attribute [Decidim::SettingsManifest::Attribute] The Settings::Attribute instance with the
+      #   description of the attribute.
+      # @param name [Symbol] The name of the field.
+      # @param i18n_scope [String] The scope where it'll find all the texts for the internationalization (locales)
+      # @param options [Hash] Extra options to be passed to the field helper.
+      # @option options [String] :tabs_prefix The type of the setting.
+      #   It can be "global-settings" or "step-N-settings", where N is the number of the step.
+      # @option options [nil, Boolean] :readonly True if the input is readonly.
+      # @return [ActiveSupport::SafeBuffer] Rendered form field.
       def settings_attribute_input(form, attribute, name, i18n_scope, options = {})
         form_method = form_method_for_attribute(attribute)
 
@@ -62,6 +65,18 @@ module Decidim
 
       private
 
+      # Renders a select field collection input for the given attribute
+      #
+      # @param form (see #settings_attribute_input)
+      # @param attribute (see #settings_attribute_input)
+      # @param name (see #settings_attribute_input)
+      # @param i18n_scope (see #settings_attribute_input)
+      # @param options (see #settings_attribute_input)
+      # @option :tabs_prefix (see #settings_attribute_input)
+      # @option :readonly (see #settings_attribute_input)
+      # @option options [String] :label The label that this field has
+      # @option options [String] :help_text The help text shown after the input field
+      # @return (see #settings_attribute_input)
       def render_select_form_field(form, attribute, name, i18n_scope, options)
         html = form.select(
           name,
@@ -73,6 +88,17 @@ module Decidim
       end
 
       # Returns a radio buttons collection input for the given attribute
+      #
+      # @param form (see #settings_attribute_input)
+      # @param attribute (see #settings_attribute_input)
+      # @param name (see #settings_attribute_input)
+      # @param i18n_scope (see #settings_attribute_input)
+      # @param options (see #settings_attribute_input)
+      # @option :tabs_prefix (see #settings_attribute_input)
+      # @option :readonly (see #settings_attribute_input)
+      # @option :label (see #render_select_form_field)
+      # @option :help_text (see #render_select_form_field)
+      # @return (see #settings_attribute_input)
       def render_enum_form_field(form, attribute, name, i18n_scope, options)
         html = label_tag(name) do
           concat options[:label]
@@ -88,7 +114,13 @@ module Decidim
         html
       end
 
+      # Get the translation for a given attribute
       # Returns a translation or nil. If nil, ZURB Foundation won't add the help_text.
+      #
+      # @param name (see #settings_attribute_input)
+      # @param suffix [String] What suffix the i18n key has
+      # @param i18n_scope (see #settings_attribute_input)
+      # @return [String, nil]
       def text_for_setting(name, suffix, i18n_scope)
         html_key = "#{i18n_scope}.#{name}_#{suffix}_html"
         return t(html_key) if I18n.exists?(html_key)
@@ -97,7 +129,10 @@ module Decidim
         return t(key) if I18n.exists?(key)
       end
 
-      # Returns the FormBuilder's method used to render
+      # Which form method is being used for this attribute
+      #
+      # @param attribute [Decidim::SettingsManifest::Attribute]
+      # @return [Symbol] The FormBuilder's method used to render
       def form_method_for_attribute(attribute)
         return :editor if attribute.type.to_sym == :text && attribute.editor?
 
@@ -105,7 +140,9 @@ module Decidim
       end
 
       # Handles special cases.
-      # Returns an empty Hash or a Hash with extra HTML options.
+      #
+      # @param input_type [Symbol]
+      # @return [Hash] Empty Hash or a Hash with extra HTML options.
       def extra_options_for_type(input_type)
         case input_type
         when :text_area
@@ -116,6 +153,12 @@ module Decidim
       end
 
       # Build options for enum attributes
+      # Get the translation for a given attribute of type choice
+      #
+      # @param name (see #settings_attribute_input)
+      # @param i18n_scope (see #settings_attribute_input)
+      # @param choices [Array<Symbol>]
+      # @return [Array<Array<String>>]
       def build_enum_choices(name, i18n_scope, choices)
         choices.map do |choice|
           [t("#{name}_choices.#{choice}", scope: i18n_scope), choice]

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -161,6 +161,25 @@ module Decidim
           render_input
         end
       end
+
+      describe "help texts" do
+        let(:form) { Decidim::Admin::FormBuilder.new(:foo, double(name => value), template, {}) }
+        let(:template) { Class.new(ActionView::Base).new(ActionView::LookupContext.new(ActionController::Base.view_paths), {}, []) }
+        let(:type) { :boolean }
+        let(:name) { :guided }
+
+        it "renders the help text" do
+          expect(render_input).to include(%(<span class="help-text">Help text</span>))
+        end
+
+        context "with HTML enriched help text" do
+          let(:name) { :guided_rich }
+
+          it "renders the HTML formatted help text" do
+            expect(render_input).to include(%(<span class="help-text">HTML <strong>help</strong> text</span>))
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -180,6 +180,50 @@ module Decidim
           end
         end
       end
+
+      describe "#text_for_setting" do
+        let(:name) { :guided }
+
+        context "with inexistent suffix" do
+          let(:suffix) { :inexistent }
+
+          it "doesn't render anything" do
+            expect(helper.send(:text_for_setting, name, suffix, i18n_scope)).to be_nil
+          end
+        end
+
+        context "with readonly" do
+          let(:suffix) { "readonly" }
+
+          it "renders the text" do
+            expect(helper.send(:text_for_setting, name, suffix, i18n_scope)).to eq("Disabled input")
+          end
+
+          context "with HTML enriched text" do
+            let(:name) { :guided_rich }
+
+            it "renders the HTML formatted text" do
+              expect(helper.send(:text_for_setting, name, suffix, i18n_scope)).to eq("HTML <strong>help</strong> text for disabled input")
+            end
+          end
+        end
+
+        context "with help" do
+          let(:suffix) { "help" }
+
+          it "renders the text" do
+            expect(helper.send(:text_for_setting, name, suffix, i18n_scope)).to eq("Help text")
+          end
+
+          context "with HTML enriched text" do
+            let(:name) { :guided_rich }
+
+            it "renders the HTML formatted text" do
+              expect(helper.send(:text_for_setting, name, suffix, i18n_scope)).to eq("HTML <strong>help</strong> text")
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-dev/config/locales/en.yml
+++ b/decidim-dev/config/locales/en.yml
@@ -17,8 +17,10 @@ en:
           global:
             guided: Guided input
             guided_help: Help text
+            guided_readonly: Disabled input
             guided_rich: Guided rich input
             guided_rich_help_html: HTML <strong>help</strong> text
+            guided_rich_readonly_html: HTML <strong>help</strong> text for disabled input
             readonly_attribute: Readonly attribute
             test: A test
             test_choices:

--- a/decidim-dev/config/locales/en.yml
+++ b/decidim-dev/config/locales/en.yml
@@ -15,6 +15,10 @@ en:
       dummy:
         settings:
           global:
+            guided: Guided input
+            guided_help: Help text
+            guided_rich: Guided rich input
+            guided_rich_help_html: HTML <strong>help</strong> text
             readonly_attribute: Readonly attribute
             test: A test
             test_choices:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -214,6 +214,7 @@ en:
             endorsements_enabled: Endorsements enabled
             proposal_answering_enabled: Proposal answering enabled
             publish_answers_immediately: Publish proposal answers immediately
+            publish_answers_immediately_help_html: Mind that if you answer any proposal without this enabled, you'll need to publish them manually by selecting them and using the action for publication. For more info on how this works, see <a href="https://docs.decidim.org/en/admin/components/proposals/answers#_publication" target="_blank">proposals' answers documentation page</a>.
             suggested_hashtags: Hashtags suggested to participants for new proposals
             votes_blocked: Supports blocked
             votes_enabled: Supports enabled


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing the 'publish answers immediately' setting, I had to double-check the history definition to see how it should work. As that's not optimal, I've made a change in the documentation to clarify it https://github.com/decidim/documentation/pull/91. This PR  adds the link in the admin to [this page](https://docs.decidim.org/en/admin/components/proposals/answers#_publication). 

For this, I needed to add HTML support to the help text feature in the SettingsHelper. Mind that I've only done that in the text types, as that's where I had the need. Should we add it to the other attribute types, or should we apply YAGNI? 

As a bonus track, I've also converted the docs of this file to yardoc and also added more detail. I can extract this commit to another PR as it's not relevant, but it shouldn't break anything of course as its comments. 

I couldn't find an elegant way to test this. I've seen that we have this spec https://github.com/decidim/decidim/blob/develop/decidim-admin/spec/helpers/settings_helper_spec.rb, but the helper has lots more logic than this spec has. Should we add that there? Or there's another spec(s) that indirectly cover these features?

#### :pushpin: Related Issues

- Fixes https://meta.decidim.org/processes/bug-report/f/210/proposals/16980

#### Testing

1. Sign in as admin
2. Go to admin dashboard
3. Go to a participatory space
4. Add a new proposal component
5. See the new help text 

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/717367/177788077-96a6ed46-27f2-4f51-9149-5a2f58598d72.png)


:hearts: Thank you!
