### PR TITLE
Remove unecessary requires for simple_event examples

### DIFF
--- a/decidim-blogs/spec/events/decidim/blogs/create_post_event_spec.rb
+++ b/decidim-blogs/spec/events/decidim/blogs/create_post_event_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "decidim/core/test/shared_examples/simple_event"
 
 describe Decidim::Blogs::CreatePostEvent do
   let(:resource) { create :post }

--- a/decidim-sortitions/spec/events/decidim/sortitions/create_sortition_event_spec.rb
+++ b/decidim-sortitions/spec/events/decidim/sortitions/create_sortition_event_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "decidim/core/test/shared_examples/simple_event"
 
 describe Decidim::Sortitions::CreateSortitionEvent do
   let(:resource) { create :sortition }

--- a/decidim-verifications/app/events/decidim/verifications/managed_user_error_event.rb
+++ b/decidim-verifications/app/events/decidim/verifications/managed_user_error_event.rb
@@ -6,12 +6,11 @@ module Decidim
       include Rails.application.routes.mounted_helpers
 
       delegate :profile_path, :profile_url, :name, to: :updated_user
+      delegate :conflicts_path, :conflicts_url, to: :decidim_admin
 
       def i18n_scope
         "decidim.events.verifications.verify_with_managed_user"
       end
-
-      delegate :conflicts_path, to: :decidim_admin
 
       def resource_path
         profile_path
@@ -26,7 +25,13 @@ module Decidim
       end
 
       def default_i18n_options
-        super.merge({ conflicts_path: conflicts_path, managed_user_path: managed_user.profile_path, managed_user_name: managed_user.name })
+        super.merge({
+                      conflicts_path: conflicts_path,
+                      conflicts_url: conflicts_url(host: managed_user.organization.host),
+                      managed_user_path: managed_user.profile_path,
+                      managed_user_url: managed_user.profile_url,
+                      managed_user_name: managed_user.name
+                    })
       end
 
       private

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -79,8 +79,8 @@ en:
     events:
       verifications:
         verify_with_managed_user:
-          email_intro: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify themself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>.
-          email_outro: Check the <a href="%{conflicts_path}">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue.
+          email_intro: The participant <a href="%{resource_url}">%{resource_title}</a> has tried to verify themself with the data of the managed participant <a href="%{managed_user_url}">%{managed_user_name}</a>.
+          email_outro: Check the <a href="%{conflicts_url}">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue.
           email_subject: Failed verification attempt against a managed participant
           notification_title: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify themself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>.
     verifications:

--- a/decidim-verifications/lib/decidim/verifications/test/factories.rb
+++ b/decidim-verifications/lib/decidim/verifications/test/factories.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
 
   factory :conflict, class: "Decidim::Verifications::Conflict" do
     current_user { create(:user) }
-    managed_user { create(:user, managed: true) }
+    managed_user { create(:user, managed: true, organization: current_user.organization) }
     unique_id { "12345678X" }
     times { 1 }
   end

--- a/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
+++ b/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
@@ -7,6 +7,7 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
 
   let(:event_name) { "decidim.events.verifications.managed_user_error_event" }
   let(:resource) { create :conflict }
+  let(:organization_host) { resource.current_user.organization.host }
 
   describe "resource_title" do
     it "is generated correctly" do
@@ -22,7 +23,7 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
 
   describe "resource_url" do
     it "is generated correctly" do
-      expect(subject.resource_url).to eq("http://#{resource.current_user.organization.host}/profiles/#{resource.current_user.nickname}")
+      expect(subject.resource_url).to eq("http://#{organization_host}/profiles/#{resource.current_user.nickname}")
     end
   end
 
@@ -50,13 +51,13 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
 
   describe "email_intro" do
     it "is generated correctly" do
-      expect(subject.email_intro).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify themself with the data of the managed participant <a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>.")
+      expect(subject.email_intro).to eq("The participant <a href=\"http://#{organization_host}/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify themself with the data of the managed participant <a href=\"http://#{organization_host}/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>.")
     end
   end
 
   describe "email_outro" do
     it "is generated correctly" do
-      expect(subject.email_outro).to eq("Check the <a href=\"/admin/conflicts\">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue.")
+      expect(subject.email_outro).to eq("Check the <a href=\"http://#{organization_host}/admin/conflicts\">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue.")
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Sometime ago, we detected that we were using relative URLs (aka paths) on some mailers (see #9146). I had one pending: 

> 
> I've also detected another one at `decidim-verifications`' [managed_user_error_event.rb](https://github.com/decidim/decidim/blob/develop/decidim-verifications/app/events/decidim/verifications/managed_user_error_event.rb) - it's easier to see in [managed_user_error_event_spec.rb](https://github.com/decidim/decidim/blob/develop/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb), but I think there's some missing piece in the rspec configuration regarding the absolute URLs in tests, as I have the classic 
> 
> >       Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true
> 
> I'll try to work with that, and I'll send the PR when I have the fix for that, but I don't want to block these others for that. 
> 

I found what was the missing piece, basically I had to explicitly pass the host on the URL method: 

https://github.com/decidim/decidim/blob/a07c7131be28320c0a01fa17c9459263086b4e26/decidim-verifications/app/events/decidim/verifications/managed_user_error_event.rb#L30

I thought this was handled automatically 😄 

In the process, I've removed some unnecessary requires that I found. That's already done here:

 https://github.com/decidim/decidim/blob/5288afe31ee4c4a24790de51399b3ad264d70774/decidim-core/lib/decidim/core/test.rb#L28

I've also fixed a bug on the factory where, on a verification conflict, a managed_user and a user could be from two different organizations. This doesn't make much sense. 

#### :pushpin: Related Issues

- Related to #9146

#### Testing

1. Generate a verification conflict that generates this email 
2. See the generated email.


:hearts: Thank you!
