### PR TITLE
Disallow creating grandchildren results

### DIFF
--- a/decidim-accountability/app/permissions/decidim/accountability/admin/permissions.rb
+++ b/decidim-accountability/app/permissions/decidim/accountability/admin/permissions.rb
@@ -30,15 +30,21 @@ module Decidim
 
         def can_perform_actions_on?(subject, resource)
           return unless permission_action.subject == subject
+          return false if can_create_grandchildren_results?
 
           case permission_action.action
-          when :create
+          when :create, :create_children
             true
           when :update, :destroy
             resource.present?
           else
             false
           end
+        end
+
+        def can_create_grandchildren_results?
+          result&.parent&.present? &&
+            permission_action.action == :create_children
         end
       end
     end

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
@@ -74,7 +74,7 @@
               <td class="table-list__actions">
                 <%= icon_link_to "eye", resource_locator(result).path, t("actions.preview", scope: "decidim.accountability"), class: "action-icon--preview", target: :blank %>
 
-                <% if allowed_to? :update, :result, result: result %>
+                <% if allowed_to? :create_children, :result, result: result %>
                   <%= icon_link_to "plus", results_path(parent_id: result.id), t("actions.new", scope: "decidim.accountability", name: t("models.result.name", scope: "decidim.accountability.admin")), class: "action-icon--plus" %>
                 <% end %>
 

--- a/decidim-accountability/spec/permissions/decidim/accountability/admin/permissions_spec.rb
+++ b/decidim-accountability/spec/permissions/decidim/accountability/admin/permissions_spec.rb
@@ -71,6 +71,27 @@ describe Decidim::Accountability::Admin::Permissions do
     let(:extra_context) { { result: resource } }
 
     it_behaves_like "crud permissions"
+
+    describe "creating a children" do
+      let(:resource) { create :result, component: accountability_component }
+      let(:action_subject) { :result }
+      let(:extra_context) { { result: resource } }
+      let(:action) do
+        { scope: :admin, action: :create_children, subject: action_subject }
+      end
+
+      it { is_expected.to be true }
+    end
+
+    describe "creating a grandchildren" do
+      let(:parent_result) { create :result, component: accountability_component }
+      let(:resource) { create :result, parent: parent_result }
+      let(:action) do
+        { scope: :admin, action: :create_children, subject: action_subject }
+      end
+
+      it_behaves_like "permission is not set"
+    end
   end
 
   describe "status" do

--- a/decidim-accountability/spec/shared/manage_child_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_child_results_examples.rb
@@ -67,6 +67,7 @@ RSpec.shared_examples "manage child results" do
 
     within "table" do
       expect(page).to have_content("My result")
+      expect(page).not_to have_selector(".action-icon--plus"), "results grandchildren creation is disallowed"
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

While working on accountability docs, I found a bug on the creation of children results. 

Basically: 

1. Sign in as admin
2. Go to a manage results index page in accountability in a space in the admin panel
3. Click on the "New result" button (plus sign icon) in a result
3. Click again on the "New result" button (plus sign icon) in a result
4. Click on the "New Result" blue button to create a grandchildren result 
5. See that this grandchild doesn't have a parent associated

This is actually by design, as you only can have one level of nesting in results.

This PR fixes that, by not showing the button on step 3


#### Testing

1. Sign in as admin
2. Go to a manage results index page in accountability in a space in the admin panel
3. Click on the "New result" button (plus sign icon) in a result
3. See that you don't have the "New result" button (plus sign icon) in this page

### :camera: Screenshots

#### Before 

https://user-images.githubusercontent.com/717367/177941325-d6b3ce24-1357-4789-9e6d-5a49ca0189cf.mp4

#### After 


https://user-images.githubusercontent.com/717367/177941396-c630dc30-7ddd-44a9-9b79-f0381bdef333.mp4



:hearts: Thank you!
