### PR TITLE
Fix API GraphiQL system spec for 0.26 with newer ChromeDriver

### DIFF
--- a/decidim-api/spec/system/graphiql_spec.rb
+++ b/decidim-api/spec/system/graphiql_spec.rb
@@ -29,6 +29,10 @@ describe "GraphiQL", type: :system do
   end
 
   it "is able to execute the default query" do
+    # Wait for the page to finish loading and the GraphiQL interface to start
+    # before clicking the button for it to actually work.
+    expect(page).to have_content("participatoryProcesses {")
+    expect(page).not_to have_content("Loading...")
     find(".execute-button").click
     within ".result-window" do
       expect(page).to have_content("\"id\": \"#{participatory_process.id}\"")

--- a/decidim-api/spec/system/graphiql_spec.rb
+++ b/decidim-api/spec/system/graphiql_spec.rb
@@ -32,7 +32,6 @@ describe "GraphiQL", type: :system do
     # Wait for the page to finish loading and the GraphiQL interface to start
     # before clicking the button for it to actually work.
     expect(page).to have_content("participatoryProcesses {")
-    expect(page).not_to have_content("Loading...")
     find(".execute-button").click
     within ".result-window" do
       expect(page).to have_content("\"id\": \"#{participatory_process.id}\"")


### PR DESCRIPTION
#### :tophat: What? Why?
This spec seems to be flaky at the `release/0.26-stable` branch with newer ChromeDriver versions.

The reason for the spec not working always is that the execute button is being clicked before the interface is listening to that click causing the query not to be executed.

This fixes the issue by waiting that the default query appears on the screen before clicking the execute button.

This is only fixed for 0.26 as this problem does not seem to exist at `develop` with the newer version of the GraphiQL interface.

#### Testing
Run the spec 20 times in a row and see that all runs should pass.