### PR TITLE
Prevent showing announcement on meetings registrations

### DIFF
--- a/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
@@ -5,7 +5,7 @@
 
 <% columns = allow_answers? && visitor_can_answer? && @form.responses.map(&:question).any?(&:matrix?) ? 9 : 6 %>
 
-<%= render partial: "decidim/shared/component_announcement" %>
+<%= render partial: "decidim/shared/component_announcement" if current_component.manifest_name == "surveys" %>
 
 <div class="row columns">
   <h2 class="section-heading"><%= translated_attribute questionnaire.title %></h2>

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -339,6 +339,26 @@ describe "Meeting registrations", type: :system do
 
           expect(page).to have_content("Needs to be reattached")
         end
+
+        context "and the announcement for the meeting is configured" do
+          before do
+            component.update!(
+              settings: {
+                announcement: {
+                  en: "An important announcement",
+                  es: "Un aviso muy importante",
+                  ca: "Un avís molt important"
+                }
+              }
+            )
+          end
+
+          it "the user should not see it" do
+            visit questionnaire_public_path
+
+            expect(page).not_to have_content("An important announcement")
+          end
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

If you configure an announcement for a meeting component and also configure registrations for that meeting, you'll see the announcement during the registration. This doesn't make much sense, and it's confusing.

This PR fixes that. 

#### :pushpin: Related Issues

- Fixes https://meta.decidim.org/processes/bug-report/f/210/proposals/15307

#### Testing

1. Sign in as admin
2. In a meeting component, configure an announcement
3. Configure a meeting with registrations on this platform with a form 
4. Go to the registration form 
5. See that you don't have the announcement anymore 

### :camera: Screenshots

#### Before 

![Selection_269](https://user-images.githubusercontent.com/717367/178003011-de611545-6972-460c-90e3-e454fbe3c837.png)

#### After 
![Selection_272](https://user-images.githubusercontent.com/717367/178003146-6631a3bd-2ead-4c74-a6cb-b914a6fbddd4.png)

:hearts: Thank you!
