### PR TITLE
Return 404 when there isn't a valid component in program

### DIFF
--- a/decidim-conferences/app/controllers/decidim/conferences/conference_program_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conference_program_controller.rb
@@ -26,7 +26,7 @@ module Decidim
       end
 
       def meetings
-        return unless meeting_component.published? || !meeting_component.presence
+        return unless meeting_component&.published? || !meeting_component.presence
 
         @meetings ||= Decidim::Meetings::Meeting.where(component: meeting_component).visible_for(current_user).order(:start_time)
       end

--- a/decidim-conferences/spec/controllers/conference_program_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/conference_program_controller_spec.rb
@@ -27,8 +27,15 @@ module Decidim
 
       describe "GET show" do
         context "when conference has no meetings" do
-          it "redirects to 404" do
+          it "returns 404" do
             expect { get :show, params: { conference_slug: conference.slug, id: component.id } }
+              .to raise_error(ActionController::RoutingError)
+          end
+        end
+
+        context "when conference has an invalid component id" do
+          it "returns 404" do
+            expect { get :show, params: { conference_slug: conference.slug, id: 999 } }
               .to raise_error(ActionController::RoutingError)
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?

In some controllers, we're doing some incorrect checks when finding resources. This makes that some URLs return 500 when they should be returning 404. 

This PR fixes this for conference_program#show, https://meta.decidim.org/conferences/decidimfest19/program/99999

#### Testing

. Go to a conference, copy the slug and change it on conference-slug
. Change the slug on this URL http://localhost:3000/conferences/conference-slug/program/99999 and visit it
. See that it returns 404 (`Routing Error` in development)

:hearts: Thank you!
