### PR TITLE
Fix creating automatic nicknames when taken by user_groups

### DIFF
--- a/decidim-core/lib/decidim/nicknamizable.rb
+++ b/decidim-core/lib/decidim/nicknamizable.rb
@@ -52,7 +52,7 @@ module Decidim
         candidate = name
 
         2.step do |n|
-          return candidate if Decidim::User.where("nickname ILIKE ?", candidate.downcase).where(scope).empty?
+          return candidate if Decidim::UserBaseEntity.where("nickname ILIKE ?", candidate.downcase).where(scope).empty?
 
           candidate = numbered_variation_of(name, n)
         end

--- a/decidim-core/spec/lib/nicknamizable_spec.rb
+++ b/decidim-core/spec/lib/nicknamizable_spec.rb
@@ -41,24 +41,32 @@ module Decidim
         expect(nickname.length).to eq(20)
       end
 
-      it "resolves conflicts with current nicknames" do
-        create(:user, nickname: "ana_pastor")
+      shared_examples "resolves existing conflicts" do |factory|
+        it "resolves conflicts with current nicknames" do
+          create(factory, nickname: "ana_pastor")
 
-        expect(subject.nicknamize("ana_pastor")).to eq("ana_pastor_2")
+          expect(subject.nicknamize("ana_pastor")).to eq("ana_pastor_2")
+        end
+
+        it "resolves conflicts with long current nicknames" do
+          create(factory, nickname: "felipe_rocks_so_much")
+
+          expect(subject.nicknamize("Felipe Rocks So Much")).to eq("felipe_rocks_so_mu_2")
+        end
+
+        it "resolves conflicts with other existing nicknames" do
+          create(factory, nickname: "existing")
+          create(factory, nickname: "existing_1")
+          create(factory, nickname: "existing_2")
+
+          expect(subject.nicknamize("existing")).to eq("existing_3")
+        end
       end
 
-      it "resolves conflicts with long current nicknames" do
-        create(:user, nickname: "felipe_rocks_so_much")
+      it_behaves_like "resolves existing conflicts", :user
 
-        expect(subject.nicknamize("Felipe Rocks So Much")).to eq("felipe_rocks_so_mu_2")
-      end
-
-      it "resolves conflicts with other existing nicknames" do
-        create(:user, nickname: "existing")
-        create(:user, nickname: "existing_1")
-        create(:user, nickname: "existing_2")
-
-        expect(subject.nicknamize("existing")).to eq("existing_3")
+      context "when user groups have the same nickname" do
+        it_behaves_like "resolves existing conflicts", :user_group
       end
     end
   end


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

Similar as #9452  this prevents generating nicknames already taken by user_groups. This feature is currently used when the user is created by an OAuth login but i might become more relevant in the future if the nickname is removed in the new design.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #9452
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
