### PR TITLE
Strip tags keeping entity characters

### DIFF
--- a/decidim-core/app/presenters/decidim/push_notification_presenter.rb
+++ b/decidim-core/app/presenters/decidim/push_notification_presenter.rb
@@ -10,7 +10,8 @@ module Decidim
     end
 
     def body
-      ActionView::Base.full_sanitizer.sanitize(event_class_instance.notification_title)
+      # Not using Rails sanitizers here because they escape HTML entities (i.e &amp;) and we want to keep them
+      event_class_instance.notification_title.gsub(%r{</?[^>]*>}, "") if event_class_instance.notification_title.present?
     end
 
     def icon

--- a/decidim-core/app/presenters/decidim/push_notification_presenter.rb
+++ b/decidim-core/app/presenters/decidim/push_notification_presenter.rb
@@ -11,7 +11,7 @@ module Decidim
 
     def body
       # Not using Rails sanitizers here because they escape HTML entities (i.e &amp;) and we want to keep them
-      event_class_instance.notification_title.gsub(%r{</?[^>]*>}, "") if event_class_instance.notification_title.present?
+      Nokogiri::HTML(event_class_instance.notification_title).text if event_class_instance.notification_title.present?
     end
 
     def icon

--- a/decidim-core/spec/presenters/decidim/push_notification_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/push_notification_presenter_spec.rb
@@ -20,10 +20,10 @@ module Decidim
         it "returns text without links and with HTML entities unescaped" do
           # rubocop:disable RSpec/AnyInstance
           allow_any_instance_of(event_class).to receive(:notification_title).and_return(
-            "There is a new comment from <a href='/path/to/profile'>Foo & Bar</a>"
+            "There is a new comment from <a href='/path/to/profile'>Foo & Bar 1 < 2 & 2 > 3</a>"
           )
 
-          expect(subject.body).to eq("There is a new comment from Foo & Bar")
+          expect(subject.body).to eq("There is a new comment from Foo & Bar 1 < 2 & 2 > 3")
           # rubocop:enable RSpec/AnyInstance
         end
       end

--- a/decidim-core/spec/presenters/decidim/push_notification_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/push_notification_presenter_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe PushNotificationPresenter, type: :presenter do
+    let(:notification) { create(:notification) }
+    let(:np) { described_class.new(notification) }
+
+    subject { described_class.new(notification) }
+
+    context "with a valid notification" do
+      let(:event_class) { Decidim::Comments::CommentCreatedEvent }
+      let(:event_name) { "decidim.events.comments.comment_created" }
+      let(:extra) { { comment_id: create(:comment).id } }
+
+      let(:notification) { create(:notification, event_class: event_class, event_name: event_name, extra: extra) }
+
+      describe "#body" do
+        it "returns text without links and with HTML entities unescaped" do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(event_class).to receive(:notification_title).and_return(
+            "There is a new comment from <a href='/path/to/profile'>Foo & Bar</a>"
+          )
+
+          expect(subject.body).to eq("There is a new comment from Foo & Bar")
+          # rubocop:enable RSpec/AnyInstance
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR replaces the HTML sanitizer for push notifications: the previous Rails sanitizer always escapers HTML entities. Now, tags are strip but entities are maintained.

#### :pushpin: Related Issues

- Fixes #9560 

#### Testing

- Activate push notifications in your settings
- Create/Update a resource and add a & in the title
- Follow it
- Generate some activity with other user and wait for the push notification


### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
