### PR TITLE
Fix budgets seeds on non development apps

### DIFF
--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -124,7 +124,7 @@ Decidim.register_component(:budgets) do |component|
       settings: {
         landing_page_content: landing_page_content,
         more_information_modal: Decidim::Faker::Localized.paragraph(sentence_count: 4),
-        workflow: %w(one random all).sample
+        workflow: Decidim::Budgets.workflows.keys.sample
       }
     )
 


### PR DESCRIPTION
#### :tophat: What? Why?

There's a problem on the budgets seeds, where if you have an instance without the random workflow enabled, it'll create a component that uses it, and you'll have an exception when visiting the component public page. 

I caught this one in our exception tracking system from Try/Nightly. 

It's important to note that this doesn't happen on the `development_app` as the random workflow is enabled there.

The relevant stacktrace: 
  
```ruby
NoMethodError (undefined method `new' for nil:NilClass):
  
decidim-budgets (0.27.0.rc1) app/controllers/decidim/budgets/application_controller.rb:14:in `current_workflow'
decidim-budgets (0.27.0.rc1) app/controllers/decidim/budgets/budgets_controller.rb:8:in `index'
```

#### Testing

1. Using an external app, for instance I used https://github.com/decidim/metadecidim 
2. Change the Gemfile to point to the repository: 
```diff
diff --git a/Gemfile b/Gemfile
index 5961b4a..e02da63 100644
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ source "https://rubygems.org"
 ruby RUBY_VERSION
 
 #DECIDIM_VERSION = { github: "decidim/decidim", branch: "release/0.26-stable" }
-DECIDIM_VERSION = "0.27.0.rc1"
+#DECIDIM_VERSION = "0.27.0.rc1"
+DECIDIM_VERSION = {path: "/home/user/path/to/your/decidim/decidim"}
 
 gem "decidim", DECIDIM_VERSION
 gem "decidim-initiatives", DECIDIM_VERSION

```
3. Run `bundle install && bin/rails decidim:upgrade`
4. Run the seeds in a clean database: `bin/rails db:drop db:create db:migrate && bin/rails db:seed`
5. Visit multiple budgets component public pages inside different participatory spaces 
6. See that you don't have 500 errors anymore 
 

:hearts: Thank you!
