### PR TITLE
Footer new design integration

### DIFF
--- a/decidim-core/app/cells/decidim/footer_pages/pages.erb
+++ b/decidim-core/app/cells/decidim/footer_pages/pages.erb
@@ -1,0 +1,3 @@
+<% pages.each do |page| %>
+  <%= page_item(page) %>
+<% end %>

--- a/decidim-core/app/cells/decidim/footer_pages/topics.erb
+++ b/decidim-core/app/cells/decidim/footer_pages/topics.erb
@@ -1,0 +1,12 @@
+<div class="lg:w-2/3 grid grid-cols-2 gap-x-4 gap-y-10 lg:grid-cols-4 text-md text-white">
+  <% pages.each do |topic| %>
+    <nav role="navigation" aria-label="<%= topic[:title] %>">
+      <h5 class="h5 mb-4"><%= topic[:title] %></h5>
+      <ul class="space-y-4 break-inside-avoid">
+        <% topic[:pages].each do |page| %>
+          <%= page_item(page, class: "font-semibold") %>
+        <% end %>
+      </ul>
+    </nav>
+  <% end %>
+</div>

--- a/decidim-core/app/cells/decidim/footer_pages_cell.rb
+++ b/decidim-core/app/cells/decidim/footer_pages_cell.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "cell/partial"
+
+module Decidim
+  # This cell renders the pages in the footer. It has 2 types of pages with
+  # different layouts:
+  # * Pages of topics: To appear in the footer both the topic and the page must
+  #   be marked to appear in footer. The topic will be shown as the title and
+  #   all the pages marked will appear below
+  # * Pages without topic. The pages marked to appear in footer which don't
+  #   belong to a topic will be shown as a list
+  #
+  # Example:
+  #
+  #    cell("decidim/footer_pages", :topics)
+  class FooterPagesCell < Decidim::ViewModel
+    include ApplicationHelper
+
+    OPTIONS = [:topics, :pages].freeze
+
+    def show
+      return unless model.present? && OPTIONS.include?(model.to_sym)
+      return if pages.blank?
+
+      render model
+    end
+
+    private
+
+    def pages
+      @pages = case model.to_sym
+               when :topics
+                 organization_topics
+               when :pages
+                 organization_pages
+               end
+    end
+
+    def organization_pages
+      current_organization
+        .static_pages_accessible_for(current_user)
+        .where(show_in_footer: true, topic_id: nil)
+        .where.not(slug: "terms-and-conditions").map do |page|
+        { title: translated_attribute(page.title), path: decidim.page_path(page) }
+      end
+    end
+
+    def organization_topics
+      current_organization.static_page_topics.where(show_in_footer: true).map do |topic|
+        next if (topic_pages = topic.accessible_pages_for(current_user).where(show_in_footer: true)).blank?
+
+        {
+          title: translated_attribute(topic.title),
+          pages: topic_pages.map do |page|
+            { title: translated_attribute(page.title), path: decidim.page_path(page) }
+          end
+        }
+      end.compact
+    end
+
+    def page_item(page_data, opts = {})
+      content_tag(:li, **opts.slice(:class)) do
+        link_to page_data[:title], page_data[:path]
+      end
+    end
+  end
+end

--- a/decidim-core/app/helpers/decidim/menu_helper.rb
+++ b/decidim-core/app/helpers/decidim/menu_helper.rb
@@ -24,5 +24,16 @@ module Decidim
         label: t("layouts.decidim.user_menu.title")
       )
     end
+
+    def footer_menu
+      @footer_menu ||= ::Decidim::FooterMenuPresenter.new(
+        :menu,
+        self,
+        element_class: "font-semibold",
+        active_class: "is-active",
+        container_options: { class: "space-y-4 break-inside-avoid" },
+        label: t("layouts.decidim.footer.decidim_title")
+      )
+    end
   end
 end

--- a/decidim-core/app/presenters/decidim/footer_menu_presenter.rb
+++ b/decidim-core/app/presenters/decidim/footer_menu_presenter.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A presenter to render footer menu
+  class FooterMenuPresenter < MenuPresenter
+    def render
+      content_tag(:nav, role: "navigation", "aria-label" => @options[:label]) do
+        safe_join([content_tag(:h5, @options[:label], class: "h5 mb-4"), render_menu])
+      end
+    end
+  end
+end

--- a/decidim-core/app/views/layouts/decidim/footer/_redesigned_main.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_redesigned_main.html.erb
@@ -6,6 +6,7 @@
     <div class="lg:w-2/3 grid grid-cols-2 gap-x-4 gap-y-10 lg:grid-cols-4 text-md text-white">
       <%= render partial: "layouts/decidim/footer/redesigned_main_links" %>
     </div>
+    <%= cell("decidim/footer_pages", :topics) %>
   </div>
   <div class="border-t border-black flex flex-wrap items-center gap-6 container py-6 text-white">
     <nav class="md:w-1/2 lg:w-auto" role="navigation" aria-label="Legal">

--- a/decidim-core/app/views/layouts/decidim/footer/_redesigned_main_legal.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_redesigned_main_legal.html.erb
@@ -1,7 +1,7 @@
 <ul class="flex flex-col md:flex-row gap-10 text-sm text-white">
   <%= cell("decidim/footer_pages", :pages) %>
   <li>
-    <%= link_to t("layouts.decidim.footer.terms_and_conditions"), page_path("terms-and-conditions") %>
+    <%= link_to t("layouts.decidim.footer.terms_and_conditions"), decidim.page_path("terms-and-conditions") %>
   </li>
   <li>
     <a href="#" data-open="cc-modal"><%= t("layouts.decidim.footer.cookie_settings") %></a>

--- a/decidim-core/app/views/layouts/decidim/footer/_redesigned_main_legal.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_redesigned_main_legal.html.erb
@@ -4,6 +4,6 @@
     <%= link_to t("layouts.decidim.footer.terms_and_conditions"), decidim.page_path("terms-and-conditions") %>
   </li>
   <li>
-    <a href="#" data-open="cc-modal"><%= t("layouts.decidim.footer.cookie_settings") %></a>
+    <a href="#" data-open="cc-modal"><%= t("layouts.decidim.footer.data_consent_settings") %></a>
   </li>
 </ul>

--- a/decidim-core/app/views/layouts/decidim/footer/_redesigned_main_legal.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_redesigned_main_legal.html.erb
@@ -1,4 +1,5 @@
 <ul class="flex flex-col md:flex-row gap-10 text-sm text-white">
+  <%= cell("decidim/footer_pages", :pages) %>
   <li>
     <%= link_to t("layouts.decidim.footer.terms_and_conditions"), page_path("terms-and-conditions") %>
   </li>

--- a/decidim-core/app/views/layouts/decidim/footer/_redesigned_main_legal.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_redesigned_main_legal.html.erb
@@ -1,11 +1,8 @@
 <ul class="flex flex-col md:flex-row gap-10 text-sm text-white">
   <li>
-    <%= link_to "Avís Legal" %>
+    <%= link_to t("layouts.decidim.footer.terms_and_conditions"), page_path("terms-and-conditions") %>
   </li>
   <li>
-    <%= link_to "Termes i condicions d'ús" %>
-  </li>
-  <li>
-    <%= link_to "Cookies" %>
+    <a href="#" data-open="cc-modal"><%= t("layouts.decidim.footer.cookie_settings") %></a>
   </li>
 </ul>

--- a/decidim-core/app/views/layouts/decidim/footer/_redesigned_main_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_redesigned_main_links.html.erb
@@ -1,37 +1,27 @@
-<nav role="navigation" aria-label="Decidim">
-  <h5 class="h5 mb-4">Decidim</h5>
+<%= footer_menu.render %>
+
+<nav role="navigation" aria-label="<%= t("layouts.decidim.footer.resources") %>">
+  <h5 class="h5 mb-4"><%= t("layouts.decidim.footer.resources") %></h5>
   <ul class="space-y-4 break-inside-avoid">
-     <li class="font-semibold"><%= link_to "Processos" %></li>
-     <li class="font-semibold"><%= link_to "Assemblees" %></li>
-     <li class="font-semibold"><%= link_to "Iniciativas" %></li>
-     <li class="font-semibold"><%= link_to "Votacions" %></li>
-     <li class="font-semibold"><%= link_to "Consultes" %></li>
-     <li class="font-semibold"><%= link_to "Jornades" %></li>
+    <li class="font-semibold"><%= link_to t("decidim.profiles.show.activity"), decidim.last_activities_path %></li>
+    <li class="font-semibold"><%= link_to t("decidim.pages.home.extended.meetings"), Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path %></li>
+    <li class="font-semibold"><%= link_to t("layouts.decidim.footer.download_open_data"), decidim.open_data_download_path %></li>
   </ul>
 </nav>
-<nav role="navigation" aria-label="Recursos">
-  <h5 class="h5 mb-4">Recursos</h5>
+
+<nav role="navigation" aria-label="<%= t("layouts.decidim.user_menu.profile") %>">
+  <h5 class="h5 mb-4"><%= t("layouts.decidim.user_menu.profile") %></h5>
   <ul class="space-y-4 break-inside-avoid">
-     <li class="font-semibold"><%= link_to "Activitat" %></li>
-     <li class="font-semibold"><%= link_to "Trobades" %></li>
-  </ul>
-</nav>
-<nav role="navigation" aria-label="Interaccions">
-  <h5 class="h5 mb-4">Interaccions</h5>
-  <ul class="space-y-4 break-inside-avoid">
-     <li class="font-semibold"><%= link_to "Ajuda general" %></li>
-     <li class="font-semibold"><%= link_to "Preguntes freqüents" %></li>
-     <li class="font-semibold"><%= link_to "Tutorials de participació" %></li>
-     <li class="font-semibold"><%= link_to "Accesibilitat" %></li>
-     <li class="font-semibold"><%= link_to "Dades obertes" %></li>
-  </ul>
-</nav>
-<nav role="navigation" aria-label="El meu compte">
-  <h5 class="h5 mb-4">El meu compte</h5>
-  <ul class="space-y-4 break-inside-avoid">
-     <li class="font-semibold"><%= link_to "Configuració" %></li>
-     <li class="font-semibold"><%= link_to "Perfil públic" %></li>
-     <li class="font-semibold"><%= link_to "Notificacions" %></li>
-     <li class="font-semibold"><%= link_to "Converses" %></li>
+    <% if current_user %>
+      <li class="font-semibold"><%= link_to t("layouts.decidim.user_menu.configuration"), decidim.account_path %></li>
+      <li class="font-semibold"><%= link_to t("layouts.decidim.user_menu.public_profile"), decidim.profile_path(current_user.nickname) %></li>
+      <li class="font-semibold"><%= link_to t("layouts.decidim.user_menu.notifications"), decidim.notifications_path %></li>
+      <li class="font-semibold"><%= link_to t("layouts.decidim.user_menu.conversations"), decidim.conversations_path %></li>
+    <% else %>
+      <% if current_organization.sign_up_enabled? %>
+        <li class="font-semibold"><%= link_to t("layouts.decidim.footer.sign_up"), decidim.new_user_registration_path %></li>
+      <% end %>
+      <li class="font-semibold"><%= link_to t("layouts.decidim.footer.sign_in"), decidim.new_user_session_path %></li>
+    <% end %>
   </ul>
 </nav>

--- a/decidim-core/app/views/layouts/decidim/footer/_redesigned_mini.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_redesigned_mini.html.erb
@@ -9,7 +9,7 @@
       </div>
     </div>
     <a class="flex gap-1" rel="license noopener noreferrer" href="http://creativecommons.org/licenses/by-sa/4.0/" target="_blank" no-external-link>
-      <span class="sr-only">t("layouts.decidim.footer.cc_by_license")</span>
+      <span class="sr-only"><%= t("layouts.decidim.footer.cc_by_license") %></span>
       <%= icon "creative-commons-line", class: "w-6 h-6 fill-current" %>
       <%= icon "creative-commons-by-line", class: "w-6 h-6 fill-current" %>
       <%= icon "creative-commons-sa-line", class: "w-6 h-6 fill-current" %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1821,6 +1821,9 @@ en:
         decidim_title: Decidim
         download_open_data: Download Open Data files
         made_with_open_source: Website made with <a target="_blank" href="https://github.com/decidim/decidim">free software</a>.
+        resources: Resources
+        sign_in: Sign In
+        sign_up: Sign Up
         terms_and_conditions: Terms and Conditions
       header:
         close_menu: Close menu
@@ -1856,6 +1859,7 @@ en:
       user_menu:
         account: 'User account: %{name}'
         admin_dashboard: Admin dashboard
+        configuration: Configuration
         conversations: Conversations
         notifications: Notifications
         profile: My account

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1818,6 +1818,7 @@ en:
         cc_by_license: Creative Commons License
         data_consent_settings: Cookie settings
         decidim_logo: Decidim Logo
+        decidim_title: Decidim
         download_open_data: Download Open Data files
         made_with_open_source: Website made with <a target="_blank" href="https://github.com/decidim/decidim">free software</a>.
       header:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1821,6 +1821,7 @@ en:
         decidim_title: Decidim
         download_open_data: Download Open Data files
         made_with_open_source: Website made with <a target="_blank" href="https://github.com/decidim/decidim">free software</a>.
+        terms_and_conditions: Terms and Conditions
       header:
         close_menu: Close menu
         main_menu: Main menu


### PR DESCRIPTION
#### :tophat: What? Why?

This PR integrates the footer links:
* Uses the same elements defined by `MenuPresenter` for the `:menu` view (the same items appearing in the current header) and defines a specific `FooterMenuPresenter` 
* Defines a `FooterPages` cell which changes the current behavior of the static pages presence in footer:
  * Adds in a grid all the pages configured to appear in footer which belong to a topic configured also to appear in footer, grouped by topic (one column for each topic)
  * The pages not belonging to a topic configured to appear in footer are displayed in the bottom left with terms-and-conditions and cookies settings
  
![Screenshot from 2022-07-15 20-08-12](https://user-images.githubusercontent.com/446459/179285049-ae92b2c5-413a-4248-9537-7daf5dbce867.png)

Pending:

* The grid of links has been divided in 2 and the second one should appear below the first. Changes in styles are pending
* Tests for the cell

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
