### PR TITLE
Fix mobile notifications switch component overlaps

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/modules/_forms.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_forms.scss
@@ -77,6 +77,11 @@ label > [type="radio"]{
     margin-right: 1rem;
     flex-shrink: 0;
   }
+
+  &,
+  &.tiny{
+    height: auto;
+  }
 }
 
 .switch{

--- a/decidim-core/app/views/decidim/download_your_data/show.html.erb
+++ b/decidim-core/app/views/decidim/download_your_data/show.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_page_title(t("my_data", scope: "layouts.decidim.user_profile")) %>
 <% content_for(:subtitle) { t("my_data", scope: "layouts.decidim.user_profile") } %>
 
-<div class="row download-your-data">
+<div class="download-your-data">
   <strong><%= t(".download_data") %></strong>
   <p><%= t(".download_data_description", user_email: current_user.email).html_safe %></p>
   <%= button_to t(".request_data"), export_download_your_data_path, class: "button", data: { disable: true } %>

--- a/decidim-core/app/views/decidim/notifications_settings/show.html.erb
+++ b/decidim-core/app/views/decidim/notifications_settings/show.html.erb
@@ -1,87 +1,85 @@
 <% add_decidim_page_title(t("notifications_settings", scope: "layouts.decidim.user_profile")) %>
 <% content_for(:subtitle) { t("notifications_settings", scope: "layouts.decidim.user_profile") } %>
 
-<div class="row mb-m">
-  <%= form_for(@notifications_settings, url: notifications_settings_path, method: :put, class: "user-form") do |f| %>
-    <p><strong><%= t(".receive_notifications_about") %></strong></p>
-    <div class="switch tiny switch-with-label notifications_from_own_activity">
-      <%= f.label :notifications_from_own_activity do %>
-        <%= f.check_box :notifications_from_own_activity, label: false, class: "switch-input" %>
-        <span class="switch-paddle"></span>
-        <span class="switch-label"><%= t(".own_activity") %></span>
-      <% end %>
-    </div>
-    <div class="switch tiny switch-with-label notifications_from_followed">
-      <%= f.label :notifications_from_followed do %>
-        <%= f.check_box :notifications_from_followed, label: false, class: "switch-input" %>
-        <span class="switch-paddle"></span>
-        <span class="switch-label"><%= t(".everything_followed") %></span>
-      <% end %>
-    </div>
+<%= form_for(@notifications_settings, url: notifications_settings_path, method: :put, class: "user-form") do |f| %>
+  <p><strong><%= t(".receive_notifications_about") %></strong></p>
+  <div class="switch tiny switch-with-label notifications_from_own_activity">
+    <%= f.label :notifications_from_own_activity do %>
+      <%= f.check_box :notifications_from_own_activity, label: false, class: "switch-input" %>
+      <span class="switch-paddle"></span>
+      <span class="switch-label"><%= t(".own_activity") %></span>
+    <% end %>
+  </div>
+  <div class="switch tiny switch-with-label notifications_from_followed">
+    <%= f.label :notifications_from_followed do %>
+      <%= f.check_box :notifications_from_followed, label: false, class: "switch-input" %>
+      <span class="switch-paddle"></span>
+      <span class="switch-label"><%= t(".everything_followed") %></span>
+    <% end %>
+  </div>
 
-    <p><strong><%= t(".notifications_sending_frequency") %></strong></p>
-    <%= f.collection_radio_buttons :notifications_sending_frequency, frequencies_collection, :first, :last, { checked: @notifications_settings.notifications_sending_frequency || "daily" } %>
+  <p><strong><%= t(".notifications_sending_frequency") %></strong></p>
+  <%= f.collection_radio_buttons :notifications_sending_frequency, frequencies_collection, :first, :last, { checked: @notifications_settings.notifications_sending_frequency || "daily" } %>
 
-    <p><strong><%= t(".newsletters") %></strong></p>
-    <div class="switch tiny switch-with-label newsletter_notifications">
+  <p><strong><%= t(".newsletters") %></strong></p>
+  <div class="switch tiny switch-with-label newsletter_notifications">
+    <label>
+      <%= f.check_box :newsletter_notifications, label: false, class: "switch-input" %>
+      <span class="switch-paddle"></span>
+      <span class="switch-label"><%= t(".newsletter_notifications") %></span>
+    </label>
+  </div>
+
+  <p><strong><%= t(".direct_messages") %></strong></p>
+  <div class="switch tiny switch-with-label allow_public_contact">
+    <label>
+      <%= f.check_box :allow_public_contact, label: false, class: "switch-input" %>
+      <span class="switch-paddle"></span>
+      <span class="switch-label"><%= t(".allow_public_contact") %></span>
+    </label>
+  </div>
+
+  <% if @notifications_settings.user_is_moderator?(current_user) %>
+    <p><strong><%= t(".administrators") %></strong></p>
+    <div class="switch tiny switch-with-label email_on_moderations">
       <label>
-        <%= f.check_box :newsletter_notifications, label: false, class: "switch-input" %>
+        <%= f.check_box :email_on_moderations, label: false, class: "switch-input" %>
         <span class="switch-paddle"></span>
-        <span class="switch-label"><%= t(".newsletter_notifications") %></span>
+        <span class="switch-label"><%= t(".email_on_moderations") %></span>
       </label>
     </div>
 
-    <p><strong><%= t(".direct_messages") %></strong></p>
-    <div class="switch tiny switch-with-label allow_public_contact">
-      <label>
-        <%= f.check_box :allow_public_contact, label: false, class: "switch-input" %>
-        <span class="switch-paddle"></span>
-        <span class="switch-label"><%= t(".allow_public_contact") %></span>
-      </label>
-    </div>
-
-    <% if @notifications_settings.user_is_moderator?(current_user) %>
-      <p><strong><%= t(".administrators") %></strong></p>
-      <div class="switch tiny switch-with-label email_on_moderations">
+    <% Decidim.notification_settings_registry.manifests.filter{ |a| a.settings_area == :administrators }.each do |manifest| %>
+      <div class="switch tiny switch-with-label notification_settings">
         <label>
-          <%= f.check_box :email_on_moderations, label: false, class: "switch-input" %>
+          <%= f.check_box "notification_settings[#{manifest.name}]",
+                          checked: ["1", true].include?(current_user.notification_settings.fetch(manifest.name.to_s, manifest.default_value)),
+                          label: false,
+                          class: "switch-input" %>
           <span class="switch-paddle"></span>
-          <span class="switch-label"><%= t(".email_on_moderations") %></span>
+          <span class="switch-label"><%= t(".notification_settings.#{manifest.name}") %></span>
         </label>
       </div>
-
-      <% Decidim.notification_settings_registry.manifests.filter{ |a| a.settings_area == :administrators }.each do |manifest| %>
-        <div class="switch tiny switch-with-label notification_settings">
-          <label>
-            <%= f.check_box "notification_settings[#{manifest.name}]",
-                            checked: ["1", true].include?(current_user.notification_settings.fetch(manifest.name.to_s, manifest.default_value)),
-                            label: false,
-                            class: "switch-input" %>
-            <span class="switch-paddle"></span>
-            <span class="switch-label"><%= t(".notification_settings.#{manifest.name}") %></span>
-          </label>
-        </div>
-      <% end %>
-
     <% end %>
 
-    <% if @notifications_settings.meet_push_notifications_requirements? %>
-      <div class="push-notifications js-sw-mandatory">
-        <p><strong><%= t(".push_notifications") %></strong></p>
-        <p id="push-notifications-reminder" class="push-notifications__reminder"><i><%= t(".push_notifications_reminder") %></i></p>
-        <div class="switch tiny switch-with-label allow_push_notifications">
-          <label>
-            <%= check_box_tag :allow_push_notifications, 0, false, class: "switch-input" %>
-            <span class="switch-paddle"></span>
-            <span class="switch-label"><%= t(".allow_push_notifications") %></span>
-          </label>
-        </div>
-      </div>
-
-      <input id="vapidPublicKey" name="vapid_public_key" type="hidden" value="<%= Base64.urlsafe_decode64(Rails.application.secrets.vapid[:public_key]).bytes %>">
-      <input id="subKeys" name="sub_key" type="hidden" value="<%= current_user.notifications_subscriptions.keys %>">
-    <% end %>
-
-    <%= f.submit t(".update_notifications_settings") %>
   <% end %>
-</div>
+
+  <% if @notifications_settings.meet_push_notifications_requirements? %>
+    <div class="push-notifications js-sw-mandatory">
+      <p><strong><%= t(".push_notifications") %></strong></p>
+      <p id="push-notifications-reminder" class="push-notifications__reminder"><i><%= t(".push_notifications_reminder") %></i></p>
+      <div class="switch tiny switch-with-label allow_push_notifications">
+        <label>
+          <%= check_box_tag :allow_push_notifications, 0, false, class: "switch-input" %>
+          <span class="switch-paddle"></span>
+          <span class="switch-label"><%= t(".allow_push_notifications") %></span>
+        </label>
+      </div>
+    </div>
+
+    <input id="vapidPublicKey" name="vapid_public_key" type="hidden" value="<%= Base64.urlsafe_decode64(Rails.application.secrets.vapid[:public_key]).bytes %>">
+    <input id="subKeys" name="sub_key" type="hidden" value="<%= current_user.notifications_subscriptions.keys %>">
+  <% end %>
+
+  <%= f.submit t(".update_notifications_settings") %>
+<% end %>

--- a/decidim-core/app/views/decidim/user_interests/show.html.erb
+++ b/decidim-core/app/views/decidim/user_interests/show.html.erb
@@ -1,17 +1,15 @@
 <% add_decidim_page_title(t("my_interests", scope: "layouts.decidim.user_profile")) %>
 <% content_for(:subtitle) { t("my_interests", scope: "layouts.decidim.user_profile") } %>
 
-<div class="row">
-  <p><%= t(".select_your_interests") %></p>
-  <%= form_for(@user_interests, url: user_interests_path, method: :put, class: "user-form") do |f| %>
-    <p><strong><%= t(".my_interests") %></strong></p>
-    <% if @user_interests.scopes.any? %>
-      <div class="clearfix m-bottom">
-        <%= render partial: "scopes", locals: { scopes: @user_interests.scopes, f: f } %>
-      </div>
-      <%= f.submit t(".update_my_interests") %>
-    <% else %>
-      <p><%= t(".no_scopes") %></p>
-    <% end %>
+<p><%= t(".select_your_interests") %></p>
+<%= form_for(@user_interests, url: user_interests_path, method: :put, class: "user-form") do |f| %>
+  <p><strong><%= t(".my_interests") %></strong></p>
+  <% if @user_interests.scopes.any? %>
+    <div class="clearfix m-bottom">
+      <%= render partial: "scopes", locals: { scopes: @user_interests.scopes, f: f } %>
+    </div>
+    <%= f.submit t(".update_my_interests") %>
+  <% else %>
+    <p><%= t(".no_scopes") %></p>
   <% end %>
-</div>
+<% end %>

--- a/decidim-core/spec/system/download_your_data_spec.rb
+++ b/decidim-core/spec/system/download_your_data_spec.rb
@@ -18,7 +18,7 @@ describe "DownloadYourData", type: :system do
 
     describe "show button export data" do
       it "export the user's data" do
-        within ".row.download-your-data" do
+        within ".download-your-data" do
           expect(page).to have_content("Download the data")
           expect(page).to have_content(user.email)
         end


### PR DESCRIPTION
#### :tophat: What? Why?
Remove the forced height for the switch component, in order to stretch it over the content, instead of chop it.

#### :pushpin: Related Issues
- Fixes #9561 

#### Testing
1. Go to 'https://nightly.decidim.org/notifications_settings' through a mobile device
2. See error

### :camera: Screenshots
![imagen](https://user-images.githubusercontent.com/817526/180394576-af276ffc-cd62-44e6-b2ff-915ac731144e.png)

:hearts: Thank you!
