### PR TITLE
Fix PWA install prompt keeps appearing more than once

### DIFF
--- a/decidim-core/app/packs/entrypoints/decidim_core.js
+++ b/decidim-core/app/packs/entrypoints/decidim_core.js
@@ -59,6 +59,7 @@ import "src/decidim/gallery"
 import "src/decidim/direct_uploads/upload_field"
 import "src/decidim/back_to_list"
 import "src/decidim/cookie_consent/cookie_consent"
+import "src/decidim/pwa"
 
 // CSS
 import "entrypoints/decidim_core.scss"

--- a/decidim-core/app/packs/src/decidim/pwa.js
+++ b/decidim-core/app/packs/src/decidim/pwa.js
@@ -1,0 +1,9 @@
+window.addEventListener("beforeinstallprompt", (ev) => {
+  // Disable the application install prompt showing constantly. This event is
+  // not a standard event but it fixes the issue where it exists, i.e. Chrome.
+  if (localStorage.getItem("pwaInstallPromptSeen")) {
+    ev.preventDefault();
+  } else {
+    localStorage.setItem("pwaInstallPromptSeen", true);
+  }
+});

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1751,8 +1751,12 @@ en:
             decidim-consent:
               description: Stores information about the cookies allowed by the user on this website.
               service: This website
+            pwaInstallPromptSeen:
+              description: Stores status if the progressive web application (PWA) install notification has been already seen by the user.
+              service: This website
           types:
             cookie: Cookie
+            local_storage: Local storage
         dialog:
           accept_all: Accept all
           accept_only_essential: Accept only essential

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -428,6 +428,10 @@ module Decidim
           {
             type: "cookie",
             name: Decidim.consent_cookie_name
+          },
+          {
+            type: "local_storage",
+            name: "pwaInstallPromptSeen"
           }
         ]
       },


### PR DESCRIPTION
#### :tophat: What? Why?
After the PWA introduction, the PWA install prompt keeps appearing over and over again in Chrome which is not desired functionality as described at #9602.

This fixes the issue by preventing the dialog after it has been seen once.

Note that the fix is using a non-standard event only available at webkit based browsers as described at:
https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent

This should be fine as this issue only appears in those browsers, reported for Chrome.

#### :pushpin: Related Issues
- Fixes #9602

#### Testing
This can be a bit hard to test locally because in order for the browser to identify the PWA as valid, the following conditions have to be met:
- The application has to be served over HTTPS using a valid certificate
- The application has to have an icon (which you can configure from the admin panel)
- A service worker has to be registered (which you can enable using `DECIDIM_SERVICE_WORKER_ENABLED=true` environment variable)

The first one can be hard to test locally as making Chrome trust self-signed certificates is becoming harder and harder. You need to loosen the security configurations for your browser and also add a special flag to trust insecure certificates from localhost.

Or just wait until we deploy RC2 with this fix to MetaDecidim and we can test it there.