### PR TITLE
Fix hashtags not recognized at the beginning of the string

### DIFF
--- a/decidim-core/lib/decidim/content_parsers/hashtag_parser.rb
+++ b/decidim-core/lib/decidim/content_parsers/hashtag_parser.rb
@@ -18,7 +18,7 @@ module Decidim
 
       # Matches a hashtag if it starts with a letter or number
       # and only contains letters, numbers or underscores.
-      HASHTAG_REGEX = /\s\K\B#([[:alnum:]](?:[[:alnum:]]|_)*)\b/i
+      HASHTAG_REGEX = /(?:\A|\s\K)\B#([[:alnum:]](?:[[:alnum:]]|_)*)\b/i
 
       # Replaces hashtags name with new or existing hashtags models global ids.
       #

--- a/decidim-core/spec/content_parsers/decidim/hashtag_parser_spec.rb
+++ b/decidim-core/spec/content_parsers/decidim/hashtag_parser_spec.rb
@@ -90,6 +90,13 @@ module Decidim
       it_behaves_like "find and stores the hashtags references"
     end
 
+    context "when the hashtag is at the beginning of the string" do
+      let(:content) { "##{hashtag.name} is at the beginning of the string" }
+      let(:parsed_content) { "#{hashtag.to_global_id}/#{hashtag.name} is at the beginning of the string" }
+
+      it_behaves_like "find and stores the hashtags references"
+    end
+
     context "when content contains an URL with a fragment (aka anchor link)" do
       let(:content) { "You can add an URL and this shouldn't be parsed http://www.example.org/path##{hashtag.name}" }
       let(:parsed_content) { "You can add an URL and this shouldn't be parsed http://www.example.org/path#fragment" }


### PR DESCRIPTION
#### :tophat: What? Why?
When adding e.g. a debate without the rich text editors and the hashtag is at the very beginning of the string it is not recognized currently after #9221.

This PR fixes the issue.

#### :pushpin: Related Issues
- Related to #9221

#### Testing
- Make sure you don't have rich text editors enabled
- Allow debate creation for participants
- Create a debate with a hashtag at the beginning of the description and submit it
- See the content for that debate from the DB where the hashtag is not correctly parsed