### PR TITLE
Fix hashtag presentation for meetings and debates activities

### DIFF
--- a/decidim-debates/app/cells/decidim/debates/debate_activity_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/debate_activity_cell.rb
@@ -20,7 +20,15 @@ module Decidim
       end
 
       def resource_link_text
-        Decidim::Debates::DebatePresenter.new(resource).title
+        presenter.title
+      end
+
+      def description
+        strip_tags(presenter.description(links: true))
+      end
+
+      def presenter
+        @presenter ||= Decidim::Debates::DebatePresenter.new(resource)
       end
     end
   end

--- a/decidim-debates/spec/cells/decidim/debates/debate_activity_cell_spec.rb
+++ b/decidim-debates/spec/cells/decidim/debates/debate_activity_cell_spec.rb
@@ -26,6 +26,19 @@ module Decidim
           expect(html).to have_css("#action-#{action_log.id} .card__content")
         end
 
+        context "when the description contains hashtags" do
+          let(:component) { create(:debates_component) }
+          let(:description) do
+            Decidim::ContentProcessor.parse_with_processor(:hashtag, "Description #description", current_organization: component.organization).rewrite
+          end
+          let!(:debate) { create(:debate, component:, description: { en: description }) }
+
+          it "renders the hashtags correctly" do
+            html = cell("decidim/debates/debate_activity", action_log).call
+            expect(html).to have_content("Description #description")
+          end
+        end
+
         context "when action is update" do
           let(:action) { :update }
 

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_activity_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_activity_cell.rb
@@ -20,7 +20,15 @@ module Decidim
       end
 
       def resource_link_text
-        Decidim::Meetings::MeetingPresenter.new(resource).title
+        presenter.title
+      end
+
+      def description
+        strip_tags(presenter.description(links: true))
+      end
+
+      def presenter
+        @presenter ||= Decidim::Meetings::MeetingPresenter.new(resource)
       end
     end
   end

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_activity_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_activity_cell_spec.rb
@@ -26,6 +26,19 @@ module Decidim
           expect(html).to have_css("#action-#{action_log.id} .card__content")
         end
 
+        context "when the description contains hashtags" do
+          let(:component) { create(:meeting_component) }
+          let(:description) do
+            Decidim::ContentProcessor.parse_with_processor(:hashtag, "Description #description", current_organization: component.organization).rewrite
+          end
+          let!(:meeting) { create(:meeting, :published, component:, description: { en: description }) }
+
+          it "renders the hashtags correctly" do
+            html = cell("decidim/meetings/meeting_activity", action_log).call
+            expect(html).to have_content("Description #description")
+          end
+        end
+
         context "when action is update" do
           let(:action) { :update }
 


### PR DESCRIPTION
#### :tophat: What? Why?
When meetings or debates are shown in the "last activities" section, their hashtags are not presented correctly. They are currently presented as the global IDs as described at #7089.

#### :pushpin: Related Issues
- Fixes #7089

#### Testing
- Create a meeting or a debate with a hashtag in its description
- See the front page "last activities" view
- See that there is no longer the global IDs after this fix