### PR TITLE
Fix moderations for comments that are mapped to deleted resources

### DIFF
--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -48,9 +48,13 @@
                 <%= moderation.report_count %>
               </td>
               <td>
-                <%=
-                  link_to t("models.moderation.fields.visit_url", scope: "decidim.moderations"), moderation.reportable.reported_content_url, data: { tooltip: true }, title: strip_tags(reported_content_excerpt_for(moderation.reportable, limit: 250))
-                %>
+                <% if (reportable_url = moderation.reportable.reported_content_url) %>
+                  <%=
+                    link_to t("models.moderation.fields.visit_url", scope: "decidim.moderations"), reportable_url, data: { tooltip: true }, title: strip_tags(reported_content_excerpt_for(moderation.reportable, limit: 250))
+                  %>
+                <% else %>
+                  <%= t("models.moderation.fields.deleted_resource", scope: "decidim.moderations") %>
+                <% end %>
               </td>
               <td>
                 <% reports = moderation.reports.map { |report| render "report", report: report } %>

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
@@ -12,7 +12,11 @@
     </div>
     <dl>
       <dt><%= t("models.moderation.fields.reported_content_url", scope: "decidim.moderations") %></dt>
-      <dd><%= link_to moderation.reportable.reported_content_url, moderation.reportable.reported_content_url, target: "_blank" %></dd>
+      <% if (reportable_url = moderation.reportable.reported_content_url) %>
+        <dd><%= link_to moderation.reportable.reported_content_url, reportable_url, target: "_blank" %></dd>
+      <% else %>
+        <dd><%= t("models.moderation.fields.deleted_resource", scope: "decidim.moderations") %></dd>
+      <% end %>
 
       <dt><%= t("models.moderation.fields.reportable_id", scope: "decidim.moderations") %></dt>
       <dd><%= moderation.reportable.id %></dd>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -1062,6 +1062,7 @@ en:
         moderation:
           fields:
             created_at: Creation date
+            deleted_resource: Deleted resource
             hidden_at: Hidden at
             participatory_space: Participatory space
             report_count: Count

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -131,6 +131,8 @@ module Decidim
 
       # Public: Overrides the `reported_content_url` Reportable concern method.
       def reported_content_url
+        return unless root_commentable
+
         url_params = { anchor: "comment_#{id}" }
 
         if root_commentable.respond_to?(:polymorphic_resource_url)

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -132,6 +132,35 @@ module Decidim
         end
       end
 
+      describe "#reported_content_url" do
+        subject { comment.reported_content_url }
+
+        let(:url_format) { "http://%{host}:%{port}/processes/%{slug}/f/%{component_id}/dummy_resources/%{resource_id}#comment_%{comment_id}" }
+
+        it "returns the resource URL" do
+          expect(subject).to eq(
+            format(
+              url_format,
+              host: commentable.organization.host,
+              port: Capybara.server_port,
+              slug: commentable.participatory_space.slug,
+              component_id: commentable.component.id,
+              resource_id: commentable.id,
+              comment_id: comment.id
+            )
+          )
+        end
+
+        context "when the root commentable has been deleted" do
+          before do
+            comment.root_commentable.destroy!
+            comment.reload
+          end
+
+          it { is_expected.to be_nil }
+        end
+      end
+
       describe "#users_to_notify_on_comment_created" do
         let(:user) { create :user, organization: comment.organization }
 


### PR DESCRIPTION
#### :tophat: What? Why?
When comments are moderated and then the commentable resource is deleted, the moderation view is broken.

This fixes the issue.

#### :pushpin: Related Issues
- Fixes #7888

#### Testing
- Create a debate that you can delete later
- Create a comment within that debate
- Report the comment
- Delete the debate
- Go into the global moderations section at the admin panel

### :camera: Screenshots
![Comment report where commentable is deleted](https://user-images.githubusercontent.com/864340/181500126-41856d67-b72c-4d87-83c0-1967ef802826.png)