### PR TITLE
Fix duplicate stats on home page and participatory space main page

### DIFF
--- a/decidim-core/app/presenters/decidim/home_stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/home_stats_presenter.rb
@@ -42,12 +42,19 @@ module Decidim
     end
 
     def component_stats(conditions)
+      stats = {}
       Decidim.component_manifests.flat_map do |component|
-        component.stats.except([:supports_count])
-                 .filter(conditions)
-                 .with_context(published_components)
-                 .map { |name, data| [name, data] }
+        component
+          .stats.except([:supports_count])
+          .filter(conditions)
+          .with_context(published_components)
+          .each do |name, data|
+            stats[name] ||= 0
+            stats[name] += data
+          end
       end
+
+      stats.to_a
     end
 
     def published_components

--- a/decidim-core/app/presenters/decidim/stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/stats_presenter.rb
@@ -15,18 +15,17 @@ module Decidim
     end
 
     def statistics(grouped_stats)
-      statistics = []
-      grouped_stats.each do |_manifest_name, stats|
-        stats.each_with_index.each do |stat, _index|
-          stat.each_with_index.map do |_item, subindex|
-            next unless (subindex % 3).zero?
-            next if stat[subindex + 2].zero?
+      statistics = {}
 
-            statistics << { stat_title: stat[subindex + 1], stat_number: stat[subindex + 2] }
-          end
+      grouped_stats.each do |_manifest_name, stats|
+        stats.each do |_space_manifest, component_manifest, count|
+          next if count.zero?
+
+          statistics[component_manifest] ||= 0
+          statistics[component_manifest] += count
         end
       end
-      statistics
+      statistics.map { |key, number| { stat_title: key, stat_number: number } }
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
The endorsement stats can be duplicated in the home page and the participatory space main page because multiple components register the same stat with the same name. This fixes the issue.

#### :pushpin: Related Issues
- Fixes #8258

#### Testing
- Go into a participatory space
- Go into proposals and create endorsement there
- Go into meetings and create endorsement there
- Go to the participatory main page and see that the statistic is not duplicated
- Go to the home page (with the stats content block enabled) and see that the statistic is not duplicated