### PR TITLE
Fix hidden error messages on the registration form

### DIFF
--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -39,7 +39,7 @@ module Decidim
           end
 
           on(:invalid) do
-            flash.now[:alert] = @form.errors[:base].join(", ") if @form.errors[:base].any?
+            flash.now[:alert] = @form.errors.full_messages.join(", ") if @form.errors.full_messages.any?
             render :new
           end
         end

--- a/decidim-core/spec/controllers/registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/registrations_controller_spec.rb
@@ -56,6 +56,44 @@ module Decidim
         it "renders the new template" do
           send_form_and_expect_rendering_the_new_template_again
         end
+
+        it "adds the flash message" do
+          post :create, params: params
+          expect(controller.flash.now[:alert]).to have_content("Your email can't be blank")
+        end
+
+        context "when all params are invalid" do
+          let(:params) do
+            {
+              user: {
+                sign_up_as: "",
+                name: "",
+                nickname: "",
+                email:,
+                password: "123",
+                password_confirmation: "456",
+                tos_agreement: "0",
+                newsletter: "0"
+              }
+            }
+          end
+
+          it "adds the flash message" do
+            post :create, params: params
+            expect(controller.flash.now[:alert]).to have_content(
+              [
+                "Your name can't be blank",
+                "Nickname can't be blank",
+                "Nickname is invalid",
+                "Your email can't be blank",
+                "Confirm your password doesn't match Password",
+                "Password is too short",
+                "Password does not have enough unique characters",
+                "Tos agreement must be accepted"
+              ].join(", ")
+            )
+          end
+        end
       end
 
       context "when the registering user has pending invitations" do


### PR DESCRIPTION
#### :tophat: What? Why?
The registration page does not show the flash alert in case there are errors on the form which can be a confusing experience for the participant. This fixes the issue.

#### :pushpin: Related Issues
- Fixes #8266

#### Testing
- Go to the registration form
- Fill in all other details but set the password confirmation differently than the password
- Submit the form
- Expect to see a flash error at the top of the page