### PR TITLE
Fix editor content saving when the content has only one video

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -348,6 +348,29 @@ describe "Admin manages organization", type: :system do
           )["innerHTML"]).to eq(terms_content.to_s.gsub("\n", ""))
         end
       end
+
+      context "when the admin terms of use content has only a video" do
+        let(:organization) { create(:organization, admin_terms_of_use_body: {}) }
+
+        it "saves the content correctly with the video" do
+          within ".editor" do
+            within ".editor .ql-toolbar" do
+              find("button.ql-video").click
+            end
+            within "div[data-mode='video'].ql-tooltip.ql-editing" do
+              find("input[data-video='Embed URL']").fill_in with: "https://www.youtube.com/watch?v=f6JMgJAQ2tc"
+              find("a.ql-action").click
+            end
+          end
+
+          click_button "Update"
+
+          organization.reload
+          expect(translated(organization.admin_terms_of_use_body)).to eq(
+            %(<iframe class="ql-video" frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/f6JMgJAQ2tc?showinfo=0"></iframe>)
+          )
+        end
+      end
     end
   end
 

--- a/decidim-core/app/packs/src/decidim/editor.js
+++ b/decidim-core/app/packs/src/decidim/editor.js
@@ -10,6 +10,7 @@ export default function createQuillEditor(container) {
   const toolbar = $(container).data("toolbar");
   const disabled = $(container).data("disabled");
 
+  const allowedEmptyContentSelector = "iframe";
   let quillToolbar = [
     ["bold", "italic", "underline", "linebreak"],
     [{ list: "ordered" }, { list: "bullet" }],
@@ -93,10 +94,15 @@ export default function createQuillEditor(container) {
     });
     container.dispatchEvent(event);
 
-    if (text === "\n" || text === "\n\n") {
+    if ((text === "\n" || text === "\n\n") && quill.root.querySelectorAll(allowedEmptyContentSelector).length === 0) {
       $input.val("");
     } else {
-      $input.val(quill.root.innerHTML);
+      const emptyParagraph = "<p><br></p>";
+      const cleanHTML = quill.root.innerHTML.replace(
+        new RegExp(`^${emptyParagraph}|${emptyParagraph}$`, "g"),
+        ""
+      );
+      $input.val(cleanHTML);
     }
   });
   // After editor is ready, linebreak_module deletes two extraneous new lines


### PR DESCRIPTION
#### :tophat: What? Why?
When the editor content has nothing but one video (i.e. no text content), the content is not saved properly currently. It only saves when the editor also contains some text with the video.

#### :pushpin: Related Issues
- Fixes #8331

#### Testing
- Find a rich text editor from admin
- Add a video through the editor's video button (e.g. a YouTube video)
- Save the form
- Go back to the form
- See that the video is now there after reload