### PR TITLE
Fix initiatives components

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/resource_permissions_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/resource_permissions_controller.rb
@@ -83,7 +83,7 @@ module Decidim
       end
 
       def manifest_name
-        @manifest_name ||= resource.manifest.name
+        @manifest_name ||= resource.resource_manifest.name
       end
 
       def permissions

--- a/decidim-admin/app/views/decidim/admin/resource_permissions/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/resource_permissions/edit.html.erb
@@ -21,7 +21,7 @@
           <% if @component %>
             <div class="card-divider"><%= t("#{@component.manifest.name}.actions.#{action}", scope: "decidim.components") %></div>
           <% else %>
-            <div class="card-divider"><%= t("#{resource.manifest.name}.actions.#{action}", scope: "decidim.resources") %></div>
+            <div class="card-divider"><%= t("#{resource.resource_manifest.name}.actions.#{action}", scope: "decidim.resources") %></div>
           <% end %>
 
           <div class="card-section">

--- a/decidim-core/lib/decidim/has_resource_permission.rb
+++ b/decidim-core/lib/decidim/has_resource_permission.rb
@@ -14,8 +14,6 @@ module Decidim
 
       delegate :resource_manifest, :resource_key, to: :class
 
-      alias_method :manifest, :resource_manifest
-
       # Public: Whether the permissions for this object actions can be set at resource level.
       def allow_resource_permissions?
         false

--- a/decidim-initiatives/decidim-initiatives.gemspec
+++ b/decidim-initiatives/decidim-initiatives.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |s|
   s.add_dependency "wkhtmltopdf-binary", "~> 0.12"
 
   s.add_development_dependency "decidim-dev", Decidim::Initiatives.version
+  s.add_development_dependency "decidim-meetings", Decidim::Initiatives.version
 end

--- a/decidim-initiatives/spec/factories.rb
+++ b/decidim-initiatives/spec/factories.rb
@@ -2,4 +2,5 @@
 
 require "decidim/core/test/factories"
 require "decidim/comments/test/factories"
+require "decidim/meetings/test/factories"
 require "decidim/initiatives/test/factories"

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -141,4 +141,33 @@ describe "Initiative", type: :system do
       end
     end
   end
+
+  describe "initiative components" do
+    let!(:initiative) { base_initiative }
+    let!(:meetings_component) { create(:component, :published, participatory_space: initiative, manifest_name: :meetings) }
+    let!(:proposals_component) { create(:component, :unpublished, participatory_space: initiative, manifest_name: :proposals) }
+
+    before do
+      create_list(:meeting, 3, :published, component: meetings_component)
+      allow(Decidim).to receive(:component_manifests).and_return([meetings_component.manifest, proposals_component.manifest])
+    end
+
+    context "when requesting the initiative path" do
+      before { visit decidim_initiatives.initiative_path(initiative) }
+
+      it "shows the components" do
+        within ".process-nav" do
+          expect(page).to have_content(translated(meetings_component.name, locale: :en).upcase)
+          expect(page).to have_no_content(translated(proposals_component.name, locale: :en).upcase)
+        end
+      end
+
+      it "allows visiting the components" do
+        within ".process-nav" do
+          click_link translated(meetings_component.name, locale: :en)
+        end
+        expect(page).to have_content("3 MEETINGS")
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently trying to enter any components under initiatives is broken.

The reason is the conflicting method name `manifest` for resources that are both participatory spaces and have resource permissions.

#### :pushpin: Related Issues
- Fixes #8462
- Supersedes #9458

#### Testing
- Add any component under any initiative
- Go to see if you can enter the component page