### PR TITLE
Redirect correctly at the user timeline controller

### DIFF
--- a/decidim-core/app/controllers/decidim/user_timeline_controller.rb
+++ b/decidim-core/app/controllers/decidim/user_timeline_controller.rb
@@ -12,7 +12,9 @@ module Decidim
     helper_method :activities, :resource_types, :user
 
     def index
-      raise ActionController::RoutingError, "Not Found" if current_user != user
+      raise Decidim::ActionForbidden unless user_signed_in?
+
+      redirect_to profile_activity_path(nickname: params[:nickname]) unless current_user == user
     end
 
     private


### PR DESCRIPTION
#### :tophat: What? Why?
Changes how the timeline view is handled when another user than the current user is trying to access that view:
1. When the user is signed out, it will now redirect to sign in
2. When the user is signed in, it will now redirect to the public activity view which should be accessible

#### :pushpin: Related Issues
- Fixes #8853

#### Testing
- Try to go to a user's timeline view when logged out, see that you are now redirected to login
- Try to go to another user's timeline when logged in, see that you are now redirected to their public activity