### PR TITLE
Fix exporting and importing a page component

### DIFF
--- a/decidim-pages/app/serializers/decidim/pages/data_importer.rb
+++ b/decidim-pages/app/serializers/decidim/pages/data_importer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Pages
+    # Importer for Pages specific data (i.e. its page content).
+    class DataImporter < Decidim::Importers::Importer
+      def initialize(component)
+        @component = component
+      end
+
+      # Creates a new Decidim::Pages::Page associated to the given **component**
+      # for the serialized page object.
+      #
+      # @param serialized [Hash] The serialized data read from the import file.
+      # @param _user [Decidim::User] The user performing the import.
+      # @return [Decidim::Pages::Page] The imported page
+      def import(serialized, _user)
+        Page.create!(
+          component: @component,
+          body: serialized["body"]
+        )
+      end
+    end
+  end
+end

--- a/decidim-pages/app/serializers/decidim/pages/data_serializer.rb
+++ b/decidim-pages/app/serializers/decidim/pages/data_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Pages
+    # This class serializes the specific data in each Page. This is the page
+    # data outside of the component settings.
+    class DataSerializer < Decidim::Exporters::Serializer
+      include Decidim::TranslationsHelper
+
+      # Serializes the page data for this component.
+      #
+      # @return [Hash] The serialized data
+      def serialize
+        page = Page.find_by(component: resource)
+
+        {
+          body: page&.body || empty_translatable
+        }
+      end
+    end
+  end
+end

--- a/decidim-pages/lib/decidim/pages/component.rb
+++ b/decidim-pages/lib/decidim/pages/component.rb
@@ -6,6 +6,9 @@ Decidim.register_component(:pages) do |component|
   component.engine = Decidim::Pages::Engine
   component.admin_engine = Decidim::Pages::AdminEngine
   component.icon = "media/images/decidim_pages.svg"
+  component.serializes_specific_data = true
+  component.specific_data_serializer_class_name = "Decidim::Pages::DataSerializer"
+  component.specific_data_importer_class_name = "Decidim::Pages::DataImporter"
   component.permissions_class_name = "Decidim::Pages::Permissions"
 
   component.query_type = "Decidim::Pages::PagesType"

--- a/decidim-pages/spec/serializers/decidim/pages/data_importer_spec.rb
+++ b/decidim-pages/spec/serializers/decidim/pages/data_importer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Pages
+  describe DataImporter do
+    let(:importer) { described_class.new(component) }
+
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user, :admin, :confirmed, organization:) }
+    let(:participatory_process) { create(:participatory_process, organization:) }
+    let(:component) { create(:component, manifest_name: "pages", participatory_space: participatory_process) }
+
+    describe "#import" do
+      subject { importer.import(as_json, user) }
+
+      let(:as_json) do
+        JSON.parse(
+          <<~JSON
+            {
+              "body": {
+                "en": "English content",
+                "ca": "Catalan content",
+                "es": "Spanish content"
+              }
+            }
+          JSON
+        )
+      end
+
+      it "imports the page" do
+        expect(subject).to be_a(Decidim::Pages::Page)
+        expect(subject.id).to eq(Page.find_by(component:).id)
+        expect(subject.body).to eq(
+          {
+            "en" => "English content",
+            "ca" => "Catalan content",
+            "es" => "Spanish content"
+          }
+        )
+      end
+    end
+  end
+end

--- a/decidim-pages/spec/serializers/decidim/pages/data_serializer_spec.rb
+++ b/decidim-pages/spec/serializers/decidim/pages/data_serializer_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Pages
+  describe DataSerializer do
+    let!(:page) { create(:page) }
+    let(:serializer) { described_class.new(page.component) }
+
+    describe "#serialize" do
+      subject { serializer.serialize }
+
+      it "serializes the page data" do
+        expect(subject).to eq({ body: page.body })
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When exporting a participatory process that has a page component and then importing that, the page is not correctly created causing a HTTP 500 when trying to access the page component as a participant.

The reason is that the "specific data" is not correctly exported/imported for the component.

#### :pushpin: Related Issues
- Fixes #8895

#### Testing
- Export a participatory process that has a page component
- Import the process from the downloaded export file
- Try to go to the page component as a participant in the newly imported process