### PR TITLE
Fix API GraphiQL system spec with newer ChromeDriver

### DIFF
--- a/decidim-api/spec/system/graphiql_spec.rb
+++ b/decidim-api/spec/system/graphiql_spec.rb
@@ -29,6 +29,9 @@ describe "GraphiQL", type: :system do
   end
 
   it "is able to execute the default query" do
+    # Wait for the page to finish loading and the GraphiQL interface to start
+    # before clicking the button for it to actually work.
+    expect(page).to have_content("participatoryProcesses {")
     find(".execute-button").click
     within ".result-window" do
       expect(page).to have_content("\"id\": \"#{participatory_process.id}\"")


### PR DESCRIPTION
#### :tophat: What? Why?
Frontports the fix at #9556 to `develop`. I initially thought it wouldn't be needed but apparently it is.

I had this spec failing at #9639
![Failure image](https://user-images.githubusercontent.com/864340/182043648-9b972357-072d-48d5-8651-e9c58a407593.png)

#### :pushpin: Related Issues
- Related to #9556