### PR TITLE
Fix conference speaker avatars

### DIFF
--- a/decidim-conferences/app/commands/decidim/conferences/admin/create_conference_speaker.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/create_conference_speaker.rb
@@ -52,8 +52,8 @@ module Decidim
 
         attr_reader :form, :conference, :current_user
 
-        def conference_speaker_with_attributes
-          attrs = form.attributes.slice(
+        def conference_speaker_attributes
+          @conference_speaker_attributes ||= form.attributes.slice(
             "full_name",
             "twitter_handle",
             "personal_url",
@@ -67,9 +67,12 @@ module Decidim
           ).merge(
             attachment_attributes(:avatar)
           )
+        end
+
+        def conference_speaker_with_attributes
           conference_speaker = conference.speakers.build
           conference_speaker.conference = conference
-          conference_speaker.assign_attributes(attrs)
+          conference_speaker.assign_attributes(conference_speaker_attributes)
           conference_speaker
         end
 
@@ -86,7 +89,7 @@ module Decidim
           @conference_speaker = Decidim.traceability.create!(
             Decidim::ConferenceSpeaker,
             current_user,
-            conference_speaker_with_attributes.attributes,
+            conference_speaker_attributes,
             log_info
           )
         end

--- a/decidim-conferences/app/forms/decidim/conferences/admin/conference_speaker_form.rb
+++ b/decidim-conferences/app/forms/decidim/conferences/admin/conference_speaker_form.rb
@@ -17,7 +17,7 @@ module Decidim
         attribute :full_name, String
         attribute :twitter_handle, String
         attribute :personal_url, String
-        attribute :avatar
+        attribute :avatar, Decidim::Attributes::Blob
         attribute :remove_avatar, Boolean, default: false
         attribute :user_id, Integer
         attribute :existing_user, Boolean, default: false

--- a/decidim-conferences/spec/commands/create_conference_speaker_spec.rb
+++ b/decidim-conferences/spec/commands/create_conference_speaker_spec.rb
@@ -114,6 +114,11 @@ module Decidim::Conferences
         expect(action_log.version).to be_present
       end
 
+      it "sets the avatar" do
+        subject.call
+        expect(conference_speaker.avatar.blob).to be_a(ActiveStorage::Blob)
+      end
+
       context "with an existing user in the platform" do
         let!(:user) { create(:user, organization: conference.organization) }
         let!(:user_id) { user.id }

--- a/decidim-conferences/spec/commands/update_conference_speaker_spec.rb
+++ b/decidim-conferences/spec/commands/update_conference_speaker_spec.rb
@@ -109,6 +109,11 @@ module Decidim::Conferences
         expect(action_log.version).to be_present
       end
 
+      it "sets the avatar" do
+        subject.call
+        expect(conference_speaker.avatar.blob).to be_a(ActiveStorage::Blob)
+      end
+
       it "links meetings" do
         subject.call
 

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -14,7 +14,7 @@ module Decidim
     attribute :email
     attribute :password
     attribute :password_confirmation
-    attribute :avatar
+    attribute :avatar, Decidim::Attributes::Blob
     attribute :remove_avatar, Boolean, default: false
     attribute :personal_url
     attribute :about

--- a/decidim-core/app/forms/decidim/user_group_form.rb
+++ b/decidim-core/app/forms/decidim/user_group_form.rb
@@ -10,7 +10,7 @@ module Decidim
     attribute :name
     attribute :nickname
     attribute :email
-    attribute :avatar
+    attribute :avatar, Decidim::Attributes::Blob
     attribute :about
     attribute :document_number
     attribute :phone


### PR DESCRIPTION
#### :tophat: What? Why?
When trying to add a new conference speaker with avatar or updating an avatar of an existing speaker, it won't work currently.

This fixes the issue.

Just for good measure, I also marked the correct attribute types for the user and group avatars (these shouldn't have any effect but just to make it consistent).

#### :pushpin: Related Issues
- Fixes #9365

#### Testing
- Go to conference speakers
- Create a new speaker and add an avatar image for them
- Submit the form
- Edit that speaker and see that there is now an avatar
- Pick some other speaker who does not have an avatar
- Try to add an avatar for them
- Submit the form
- Edit that speaker and see that there is now an avatar