### PR TITLE
Do not import resources multiple times

### DIFF
--- a/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
@@ -84,7 +84,10 @@ module Decidim
         end
 
         def proposal_already_copied?(original_proposal)
-          original_proposal.linked_resources(:projects, "included_proposals").any? do |project|
+          # Note: we are including also projects from unpublished components
+          # because otherwise duplicates could be created until the component is
+          # published.
+          original_proposal.linked_resources(:projects, "included_proposals", component_published: false).any? do |project|
             project.budget == form.budget
           end
         end

--- a/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
+++ b/decidim-budgets/spec/commands/decidim/budgets/admin/import_proposals_to_budgets_spec.rb
@@ -96,6 +96,22 @@ module Decidim
                 expect(first_project.title).to eq(proposal.title)
                 expect(last_project.title).to eq(second_proposal.title)
               end
+
+              context "and the current component was not published" do
+                before { current_component.unpublish! }
+
+                it "doesn't import it again" do
+                  expect do
+                    command.call
+                  end.to change { Project.where(budget:).count }.by(1)
+
+                  projects = Project.where(budget:)
+                  first_project = projects.first
+                  last_project = projects.last
+                  expect(first_project.title).to eq(proposal.title)
+                  expect(last_project.title).to eq(second_proposal.title)
+                end
+              end
             end
 
             it "links the proposals" do

--- a/decidim-elections/app/commands/decidim/elections/admin/import_proposals_to_elections.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/import_proposals_to_elections.rb
@@ -77,7 +77,10 @@ module Decidim
         end
 
         def proposal_already_copied?(original_proposal)
-          original_proposal.linked_resources(:answers, "related_proposals").any? do |answer|
+          # Note: we are including also answers from unpublished components
+          # because otherwise duplicates could be created until the component is
+          # published.
+          original_proposal.linked_resources(:answers, "related_proposals", component_published: false).any? do |answer|
             answer.question == target_question
           end
         end

--- a/decidim-elections/spec/commands/decidim/elections/admin/import_proposals_to_elections_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/import_proposals_to_elections_spec.rb
@@ -81,6 +81,22 @@ module Decidim
                 expect(first_answer.title).to eq(proposal.title)
                 expect(last_answer.title).to eq(proposal.title)
               end
+
+              context "and the current component was not published" do
+                before { component.unpublish! }
+
+                it "doesn't import it again" do
+                  expect do
+                    command.call
+                  end.not_to(change { Decidim::Elections::Answer.where(question:).count })
+
+                  answers = Decidim::Elections::Answer.where(question:)
+                  first_answer = answers.first
+                  last_answer = answers.last
+                  expect(first_answer.title).to eq(proposal.title)
+                  expect(last_answer.title).to eq(proposal.title)
+                end
+              end
             end
 
             it "links the proposals" do

--- a/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
@@ -76,7 +76,10 @@ module Decidim
         end
 
         def proposal_already_copied?(original_proposal, target_component)
-          original_proposal.linked_resources(:proposals, "copied_from_component").any? do |proposal|
+          # Note: we are including also proposals from unpublished components
+          # because otherwise duplicates could be created until the component is
+          # published.
+          original_proposal.linked_resources(:proposals, "copied_from_component", component_published: false).any? do |proposal|
             proposal.component == target_component
           end
         end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/import_proposals_spec.rb
@@ -88,6 +88,19 @@ module Decidim
                 titles = Proposal.where(component: current_component).map(&:title)
                 expect(titles).to match_array([proposal.title, second_proposal.title])
               end
+
+              context "and the current component was not published" do
+                before { current_component.unpublish! }
+
+                it "doesn't import it again" do
+                  expect do
+                    command.call
+                  end.to change { Proposal.where(component: current_component).count }.by(1)
+
+                  titles = Proposal.where(component: current_component).map(&:title)
+                  expect(titles).to match_array([proposal.title, second_proposal.title])
+                end
+              end
             end
 
             it "links the proposals" do


### PR DESCRIPTION
#### :tophat: What? Why?
When importing resources to unpublished components, they can be imported currently multiple times. This PR fixes the issue.

#### :pushpin: Related Issues
- Fixes #9303

#### Testing
- Go to processes and unpublish the "budgets" component
- Go to the unpublished budgets component
- Make sure you have accepted proposals in the same space
- Go into a budget
- Import projects from proposals
- See successfully imported projects
- Redo the same import
- The same projects should not be imported twice