### PR TITLE
Fix the finite value on the debate form when editing an existing debate

### DIFF
--- a/decidim-debates/app/forms/decidim/debates/admin/debate_form.rb
+++ b/decidim-debates/app/forms/decidim/debates/admin/debate_form.rb
@@ -29,6 +29,7 @@ module Decidim
         validates :scope_id, scope_belongs_to_component: true, if: ->(form) { form.scope_id.present? }
 
         def map_model(model)
+          self.finite = model.start_time.present? && model.end_time.present?
           self.decidim_category_id = model.categorization.decidim_category_id if model.categorization
           presenter = DebatePresenter.new(model)
 

--- a/decidim-debates/spec/forms/decidim/debates/admin/debate_form_spec.rb
+++ b/decidim-debates/spec/forms/decidim/debates/admin/debate_form_spec.rb
@@ -118,5 +118,17 @@ describe Decidim::Debates::Admin::DebateForm do
     it "sets the form category id correctly" do
       expect(subject.decidim_category_id).to eq category.id
     end
+
+    it "sets the finite value correctly" do
+      expect(subject.finite).to be(false)
+    end
+
+    context "when the debate has start and end dates" do
+      let(:debate) { create :debate, :open_ama }
+
+      it "sets the finite value correctly" do
+        expect(subject.finite).to be(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently the "finite" value is not set correctly for infinite debates when editing them. This fixes the issue.

#### :pushpin: Related Issues
- Fixes #8067

#### Testing
- Go to debates
- Create an infinite debate (i.e. "Open (No start or end times)")
- Edit that debate
- Check the value for "Debate type"