### PR TITLE
Fix importing participatory process from legacy format

### DIFF
--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -54,7 +54,7 @@ module Decidim
       def import_process_group(attributes)
         Decidim.traceability.perform_action!("create", ParticipatoryProcessGroup, @user) do
           group = ParticipatoryProcessGroup.find_or_initialize_by(
-            title: attributes["title"],
+            title: attributes["title"] || attributes["name"],
             description: attributes["description"],
             organization: @organization
           )

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::ParticipatoryProcesses
+  describe ParticipatoryProcessImporter do
+    subject { importer }
+
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user, :confirmed, :admin, organization:) }
+    let(:importer) { described_class.new(organization, user) }
+
+    describe "#import" do
+      subject { importer.import(import_data, user, options) }
+
+      let(:options) do
+        {
+          title: generate_localized_title,
+          slug: "imported"
+        }
+      end
+      let(:import_data) do
+        {
+          "subtitle" => Decidim::Faker::Localized.sentence(word_count: 3),
+          "hashtag" => "hashtag",
+          "description" => Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title },
+          "short_description" => Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title },
+          "promoted" => false,
+          "developer_group" => Decidim::Faker::Localized.sentence(word_count: 3),
+          "local_area" => Decidim::Faker::Localized.sentence(word_count: 3),
+          "target" => Decidim::Faker::Localized.sentence(word_count: 3),
+          "participatory_scope" => Decidim::Faker::Localized.sentence(word_count: 3),
+          "participatory_structure" => Decidim::Faker::Localized.sentence(word_count: 3),
+          "meta_scope" => Decidim::Faker::Localized.sentence(word_count: 3),
+          "start_date" => "2022-08-01",
+          "end_date" => "2023-08-01",
+          "announcement" => Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title },
+          "private_space" => false,
+          "scopes_enabled" => false,
+          "participatory_process_group" => group_data
+        }
+      end
+      let(:group_data) do
+        {
+          "title" => generate_localized_title,
+          "description" => Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title }
+        }
+      end
+
+      it "imports the process correctly" do
+        expect { subject }.to change(Decidim::ParticipatoryProcess, :count).by(1)
+
+        expect(subject.title).to eq(options[:title])
+        expect(subject.slug).to eq(options[:slug])
+        expect(subject.subtitle).to eq(import_data["subtitle"])
+        expect(subject.hashtag).to eq(import_data["hashtag"])
+        expect(subject.description).to eq(import_data["description"])
+        expect(subject.short_description).to eq(import_data["short_description"])
+        expect(subject.promoted).to eq(import_data["promoted"])
+        expect(subject.developer_group).to eq(import_data["developer_group"])
+        expect(subject.local_area).to eq(import_data["local_area"])
+        expect(subject.target).to eq(import_data["target"])
+        expect(subject.participatory_scope).to eq(import_data["participatory_scope"])
+        expect(subject.participatory_structure).to eq(import_data["participatory_structure"])
+        expect(subject.meta_scope).to eq(import_data["meta_scope"])
+        expect(subject.start_date).to eq(Date.parse(import_data["start_date"]))
+        expect(subject.end_date).to eq(Date.parse(import_data["end_date"]))
+        expect(subject.announcement).to eq(import_data["announcement"])
+        expect(subject.private_space).to eq(import_data["private_space"])
+        expect(subject.participatory_process_group).to be_a(Decidim::ParticipatoryProcessGroup)
+      end
+
+      it "imports the process group correctly" do
+        expect { subject }.to change(Decidim::ParticipatoryProcessGroup, :count).by(1)
+
+        group = subject.participatory_process_group
+        expect(group.organization).to eq(subject.organization)
+        expect(group.title).to eq(group_data["title"])
+        expect(group.description).to eq(group_data["description"])
+      end
+
+      context "when the process group title is defined with the name key" do
+        let(:group_data) do
+          {
+            "name" => generate_localized_title,
+            "description" => Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title }
+          }
+        end
+
+        it "imports the process group correctly" do
+          expect { subject }.to change(Decidim::ParticipatoryProcessGroup, :count).by(1)
+
+          group = subject.participatory_process_group
+          expect(group.title).to eq(group_data["name"])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
v0.24.0 renamed the participatory process group's `name` column to `title` after PR #6823.

This also caused a change in the export/import formats that caused the formats between different Decidim versions to be incompatible with each other as seen at #7060 (see the example import file linked in that PR).

This PR fixes the incompatibiltiy and adds some specs for the import.

#### :pushpin: Related Issues
- Fixes #7060

#### Testing
- Download the example export file from #7060
- Try to import a process using that file