### PR TITLE
Fix initiative sign if the authorization metadata is set to `nil`

### DIFF
--- a/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
@@ -83,6 +83,7 @@ module Decidim
       def user_authorized_scope
         return scope if handler_name.blank?
         return unless authorized?
+        return if authorization.metadata.blank?
 
         @user_authorized_scope ||= authorized_scope_candidates.find do |scope|
           scope&.id == authorization.metadata.symbolize_keys[:scope_id]

--- a/decidim-initiatives/spec/forms/vote_form_spec.rb
+++ b/decidim-initiatives/spec/forms/vote_form_spec.rb
@@ -156,6 +156,21 @@ module Decidim
 
           it { is_expected.to eq(initiative.scope) }
         end
+
+        context "when the authorization does not have metadata" do
+          let!(:authorization) do
+            create(
+              :authorization,
+              :granted,
+              name: "dummy_authorization_handler",
+              user: current_user,
+              unique_id: document_number,
+              metadata: nil
+            )
+          end
+
+          it { is_expected.to be_nil }
+        end
       end
 
       describe "authorized_scope_candidates" do


### PR DESCRIPTION
#### :tophat: What? Why?
Apparently in some older Decidim versions it was possible that the authorization's metadata column was set to `nil`.

This means that there can still be database records that have it set to `nil` which can cause the initiative signing process to fail as explained at #6960 (see the stacktrace).

I could not replicate the particular issue locally (I guess due to some fixes/updates with authorizations) but this should fix it even in that non-typical case.

#### :pushpin: Related Issues
- Fixes #6960

#### Testing
See #6960 but manually set the user's `authorization` data to `nil` in the database.