### PR TITLE
Fix title and description too long in initiatives spec sometimes

### DIFF
--- a/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
@@ -104,12 +104,16 @@ describe Decidim::Initiatives::InitiativesController, type: :controller do
   end
 
   describe "Edit initiative as promoter" do
+    include ActionView::Helpers::TextHelper
+
     before do
       sign_in created_initiative.author, scope: :user
     end
 
     let(:valid_attributes) do
       attrs = attributes_for(:initiative, organization:)
+      attrs[:title] = truncate(translated(attrs[:title]), length: 150, omission: "")
+      attrs[:description] = Decidim::HtmlTruncation.new(translated(attrs[:description]), max_length: 150, tail: "").perform
       attrs[:signature_end_date] = I18n.l(attrs[:signature_end_date], format: :decidim_short)
       attrs[:signature_start_date] = I18n.l(attrs[:signature_start_date], format: :decidim_short)
       attrs[:type_id] = created_initiative.type.id


### PR DESCRIPTION
#### :tophat: What? Why?
As described at #9017, the initiatives controller spec was sometimes failing and the reason turned out to be that sometimes its title or description were too long depending on what faker created for them.

This fixes the issue.

#### :pushpin: Related Issues
- Fixes #9017

#### Testing
See #9017 or try hard-coding too long title or description for the initiative at the factory.