### PR TITLE
Fix admin autocomplete when a locale is defined in the URL

### DIFF
--- a/decidim-admin/app/packs/src/decidim/admin/admin_autocomplete.js
+++ b/decidim-admin/app/packs/src/decidim/admin/admin_autocomplete.js
@@ -18,6 +18,7 @@ import AutoComplete from "src/decidim/autocomplete";
  */
 const autoConfigure = (el) => {
   const config = JSON.parse(el.dataset.autocomplete);
+  const searchUrl = new URL(config.searchURL);
   const textInput = document.createElement("input");
   textInput.type = "text";
   textInput.className = "autocomplete-input";
@@ -46,8 +47,11 @@ const autoConfigure = (el) => {
   }
 
   const dataSource = (query, callback) => {
-    const params = new URLSearchParams({ term: query });
-    fetch(`${config.searchURL}?${params.toString()}`, {
+    const params = new URLSearchParams({
+      ...Object.fromEntries(searchUrl.searchParams),
+      term: query
+    });
+    fetch(`${searchUrl.origin}${searchUrl.pathname}?${params.toString()}`, {
       method: "GET",
       headers: { "Content-Type": "application/json" }
     }).then((response) => response.json()).then((data) => {

--- a/decidim-admin/spec/system/autocomplete/multiselect_spec.rb
+++ b/decidim-admin/spec/system/autocomplete/multiselect_spec.rb
@@ -103,6 +103,16 @@ describe "Autocomplete multiselect", type: :system do
           text_input = find("input[type='text']")
           expect(text_input.value).to eq("")
         end
+
+        context "when the URL has extra parameters in it" do
+          let(:url) { "http://#{organization.host}:#{Capybara.current_session.server.port}#{path}?locale=ca" }
+
+          it "shows selected participant" do
+            find("input[type='text']").fill_in with: participant.name.slice(0..2)
+            find(".autoComplete_wrapper ul#autoComplete_list_1 li", match: :first, wait: 2).click
+            expect(page).to have_content(participant.name)
+          end
+        end
       end
 
       describe "remove selected item" do


### PR DESCRIPTION
#### :tophat: What? Why?
The admin autocomplete is broken after #8524 when the user switches to some other locale than the main locale and the locale is preserved in the search URL as reported at #9462.

This PR fixes the issue.

#### :pushpin: Related Issues
- Fixes #9462
- Related to #8524

#### Testing
- Go to any view with autocomplete at the admin panel, e.g. add conference speaker (select "participant" from the dropdown in that view)
- Switch to some other locale and make sure the current URL has `?locale=nn` in it
- Try to do a search using the autocomplete