### PR TITLE
Fix machine translations at the API

### DIFF
--- a/decidim-core/lib/decidim/api/types/localized_string_type.rb
+++ b/decidim-core/lib/decidim/api/types/localized_string_type.rb
@@ -8,6 +8,15 @@ module Decidim
 
       field :locale, GraphQL::Types::String, "The standard locale of this translation.", null: false
       field :text, GraphQL::Types::String, "The content of this translation.", null: true
+      field :machine_translated, GraphQL::Types::Boolean, "Whether this string is machine translated or not.", null: false
+
+      def machine_translated
+        if object.respond_to?(:machine_translated)
+          object.machine_translated.present?
+        else
+          false
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/types/localized_string_type_spec.rb
+++ b/decidim-core/spec/types/localized_string_type_spec.rb
@@ -27,6 +27,54 @@ module Decidim
           expect(response).to include("text" => "A test locale.")
         end
       end
+
+      describe "machineTranslated" do
+        let(:query) { "{ machineTranslated }" }
+
+        it "returns false by default" do
+          expect(response).to include("machineTranslated" => false)
+        end
+
+        context "when the model responds to machine_translated" do
+          let(:model) { OpenStruct.new(machine_translated: true) }
+
+          it "returns the correct value" do
+            expect(response).to include("machineTranslated" => true)
+          end
+
+          context "and the model returns false" do
+            let(:model) { OpenStruct.new(machine_translated: false) }
+
+            it "returns the correct value" do
+              expect(response).to include("machineTranslated" => false)
+            end
+          end
+
+          context "and the model returns a nil" do
+            let(:model) { OpenStruct.new(machine_translated: nil) }
+
+            it "returns false" do
+              expect(response).to include("machineTranslated" => false)
+            end
+          end
+
+          context "and the model returns a non-boolean evaluating as present" do
+            let(:model) { OpenStruct.new(machine_translated: "true") }
+
+            it "returns true" do
+              expect(response).to include("machineTranslated" => true)
+            end
+          end
+
+          context "and the model returns a non-boolean evaluating as blank" do
+            let(:model) { OpenStruct.new(machine_translated: "") }
+
+            it "returns false" do
+              expect(response).to include("machineTranslated" => false)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-participatory_processes/spec/types/integration_schema_spec.rb
+++ b/decidim-participatory_processes/spec/types/integration_schema_spec.rb
@@ -152,7 +152,10 @@ describe "Decidim::Api::QueryType" do
   let!(:participatory_process_response) do
     {
       "announcement" => {
-        "locales" => participatory_process.announcement.keys.sort,
+        "locales" => (
+          participatory_process.announcement.keys.excluding("machine_translations") +
+          participatory_process.announcement["machine_translations"].keys
+        ).sort,
         "translation" => participatory_process.announcement[locale]
       },
       "attachments" => [],

--- a/decidim-participatory_processes/spec/types/participatory_process_step_type_spec.rb
+++ b/decidim-participatory_processes/spec/types/participatory_process_step_type_spec.rb
@@ -36,7 +36,8 @@ module Decidim
         let(:query) { '{ title { locales translation(locale:"en") } }' }
 
         it "returns its title" do
-          expect(response["title"]["locales"]).to include(*model.title.keys)
+          expected_keys = (model.description.keys.excluding("machine_translations") + model.description["machine_translations"].keys).sort
+          expect(response["title"]["locales"]).to include(*expected_keys)
           expect(response["title"]["translation"]).to eq(model.title["en"])
         end
       end
@@ -45,7 +46,8 @@ module Decidim
         let(:query) { '{ description { locales translation(locale:"en") } }' }
 
         it "returns its description" do
-          expect(response["description"]["locales"]).to include(*model.description.keys)
+          expected_keys = (model.description.keys.excluding("machine_translations") + model.description["machine_translations"].keys).sort
+          expect(response["description"]["locales"]).to include(*expected_keys)
           expect(response["description"]["translation"]).to eq(model.description["en"])
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently the machine translations are represented incorrectly at the API as described by #9592.

This fixes the issue and also introduces a new `machineTranslated` field at the `LocalizedStringType` indicating whether the string is machine translated or not.

#### :pushpin: Related Issues
- Fixes #9592

#### Testing
- Create a development app
- Run the example query from #9592 at the GraphiQL interface
- Expect to see valid results without broken "machine_translation" fields