### PR TITLE
Fix form answer attachments breaking the answer view

### DIFF
--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_answer_presenter.rb
@@ -7,7 +7,7 @@ module Decidim
       # Presenter for questionnaire answer
       #
       class QuestionnaireAnswerPresenter < SimpleDelegator
-        delegate :content_tag, :safe_join, to: :view_context
+        delegate :content_tag, :safe_join, :link_to, :number_to_human_size, to: :view_context
 
         include Decidim::TranslatableAttributes
 
@@ -54,11 +54,14 @@ module Decidim
           # rubocop:disable Style/StringConcatenation
           # Interpolating strings that are `html_safe` is problematic with Rails.
           content_tag :li do
-            link_to(translated_attribute(attachment.title), attachment.url) +
-              " " +
-              content_tag(:small) do
+            link_to(attachment.url, target: "_blank", rel: "noopener noreferrer") do
+              content_tag(:span) do
+                translated_attribute(attachment.title).presence ||
+                  I18n.t("download_attachment", scope: "decidim.forms.questionnaire_answer_presenter")
+              end + " " + content_tag(:small) do
                 "#{attachment.file_type} #{number_to_human_size(attachment.file_size)}"
               end
+            end
           end
           # rubocop:enable Style/StringConcatenation
         end

--- a/decidim-forms/config/locales/en.yml
+++ b/decidim-forms/config/locales/en.yml
@@ -147,6 +147,8 @@ en:
         single_option: Single option
         sorting: Sorting
         title_and_description: Title and description
+      questionnaire_answer_presenter:
+        download_attachment: Download attachment
       questionnaires:
         answer:
           invalid: There was a problem answering the form.

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_answers.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_answers.rb
@@ -10,8 +10,11 @@ shared_examples_for "manage questionnaire answers" do
   let!(:second) do
     create :questionnaire_question, questionnaire:, position: 2, question_type: "single_option"
   end
+  let!(:third) do
+    create :questionnaire_question, questionnaire:, position: 3, question_type: "files"
+  end
   let(:questions) do
-    [first, second]
+    [first, second, third]
   end
 
   context "when there are no answers" do
@@ -25,6 +28,7 @@ shared_examples_for "manage questionnaire answers" do
     let!(:answer1) { create :answer, questionnaire:, question: first }
     let!(:answer2) { create :answer, body: "second answer", questionnaire:, question: first }
     let!(:answer3) { create :answer, questionnaire:, question: second }
+    let!(:file_answer) { create :answer, :with_attachments, questionnaire:, question: third, body: nil, user: answer3.user, session_token: answer3.session_token }
 
     it "shows the answer admin link" do
       visit questionnaire_edit_path
@@ -45,7 +49,7 @@ shared_examples_for "manage questionnaire answers" do
       end
 
       it "shows the percentage" do
-        expect(page).to have_content("50%")
+        expect(page).to have_content("33%")
       end
 
       it "has a detail link" do
@@ -120,6 +124,25 @@ shared_examples_for "manage questionnaire answers" do
         click_link answer3.session_token, match: :first
         expect(page).not_to have_link("Next ›")
         expect(page).to have_link("‹ Prev")
+      end
+
+      it "third answer has download link for the attachments" do
+        click_link answer3.session_token, match: :first
+        expect(page).to have_content(translated(file_answer.attachments.first.title))
+        expect(page).to have_content(translated(file_answer.attachments.second.title))
+      end
+
+      context "when the file answer does not have a title for the attachment" do
+        let!(:file_answer) { create :answer, questionnaire:, question: third, body: nil, user: answer3.user, session_token: answer3.session_token }
+
+        before do
+          create :attachment, :with_image, attached_to: file_answer, title: {}, description: {}
+        end
+
+        it "third answer has download link for the attachments" do
+          click_link answer3.session_token, match: :first
+          expect(page).to have_content("Download attachment")
+        end
       end
     end
   end

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
@@ -73,6 +73,23 @@ module Decidim
           end
         end
       end
+
+      context "when the answer has an attachment" do
+        let!(:answer) { create(:answer, body: nil) }
+        let!(:attachment) { create(:attachment, :with_image, attached_to: answer) }
+
+        it "returns the download attachment link" do
+          expect(subject.body).to eq(%(<ul><li><a target="_blank" rel="noopener noreferrer" href="#{attachment.url}"><span>#{translated(attachment.title)}</span> <small>jpeg 105 KB</small></a></li></ul>))
+        end
+
+        context "when the attachment does not have a title" do
+          let!(:attachment) { create(:attachment, :with_image, attached_to: answer, title: {}, description: {}) }
+
+          it "returns the download attachment link" do
+            expect(subject.body).to eq(%(<ul><li><a target="_blank" rel="noopener noreferrer" href="#{attachment.url}"><span>Download attachment</span> <small>jpeg 105 KB</small></a></li></ul>))
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
If the form answer has attachments (through the file question), the single answer view is currently broken. This fixes that issue.

#### :pushpin: Related Issues
- Fixes #9438

#### Testing
- Add a file question to the default survey component generated with the seeds
- Make sure answers are enabled for the component
- Submit an answer to the survey with an attachment
- Go to the single answer view at the admin panel