### PR TITLE
Fix "disappearing" underscores with comments

### DIFF
--- a/decidim-comments/lib/decidim/comments/markdown.rb
+++ b/decidim-comments/lib/decidim/comments/markdown.rb
@@ -50,6 +50,18 @@ module Decidim
 
         "<p>#{text}</p>"
       end
+
+      # Prevents underscores to be replaced with <em> tags in comments, such as
+      # https://github.com/org/module_with_underscores or within words such as
+      # "Look for comment_maximum_length in the code". The `no_intra_emphasis`
+      # option for Redcarpet does not apparently work for this renderer.
+      #
+      # Related issues:
+      # https://github.com/vmg/redcarpet/issues/402
+      # https://github.com/vmg/redcarpet/issues/427
+      def emphasis(text)
+        "_#{text}_"
+      end
     end
   end
 end

--- a/decidim-comments/spec/lib/decidim/comments/markdown_spec.rb
+++ b/decidim-comments/spec/lib/decidim/comments/markdown_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Comments
+    describe Markdown do
+      subject { markdown }
+
+      let(:markdown) { Decidim::Comments::Markdown.new }
+
+      describe "#render" do
+        subject { markdown.render(text) }
+
+        context "with underscores" do
+          let(:text) { "Look for comment_maximum_length in the code." }
+
+          it "does not replace the underscores" do
+            expect(subject).to eq("<p>#{text}</p>")
+          end
+        end
+
+        context "with underscore links" do
+          let(:text) { "Check out https://decidim.org/democracy_for_everyone for more information." }
+
+          it "does not replace the underscores" do
+            expect(subject).to eq(%(<p>#{text}</p>))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Some underscores are "disappearing" with Decidim comments as described at #9394. Well it turns out they are not actually disappearing but replaced with `<em>`s during the Redcarpet markdown parsing which is probably not desired functionality for Decidim as can be seen e.g. from this bug.

I also tried the `:no_intra_emphasis` option provided by Redcarpet but it's not working properly, so I just decided to disable the functionality altogether.

#### :pushpin: Related Issues
- Related to vmg/redcarpet#402, vmg/redcarpet#427
- Fixes #9394

#### Testing
Try posting the example comment from #9394 and see whether it is rendered correctly.