### PR TITLE
Fix collaborative drafts page when there are errors on the form

### DIFF
--- a/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
@@ -63,7 +63,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("proposals.collaborative_drafts.create.error", scope: "decidim")
-            render :complete
+            render :new
           end
         end
       end

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_wizard_aside.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_wizard_aside.html.erb
@@ -1,6 +1,6 @@
 <div class="columns large-3">
   <div class="m-bottom">
-    <%= link_to :back do %>
+    <%= link_to collaborative_drafts_path do %>
       <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
       <%= t("back_from_collaborative_draft", scope: "decidim.proposals.collaborative_drafts.wizard_aside").html_safe %>
     <% end %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -637,7 +637,7 @@ en:
             one: "%{count} collaborative draft"
             other: "%{count} collaborative drafts"
         create:
-          error: There was a problem creating this collaborative drafts
+          error: There was a problem creating this collaborative draft.
           success: Collaborative draft successfully created.
         edit:
           attachment_legend: "(Optional) Add an attachment"

--- a/decidim-proposals/spec/system/collaborative_drafts_fields_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_fields_spec.rb
@@ -90,6 +90,31 @@ describe "Collaborative drafts", type: :system do
           expect(page).to have_author(user.name)
         end
 
+        context "when there are errors on the form", :slow do
+          before do
+            visit new_collaborative_draft_path
+
+            within ".new_collaborative_draft" do
+              fill_in :collaborative_draft_title, with: "More sidewalks and less roads"
+              fill_in :collaborative_draft_body, with: "Cities"
+
+              find("*[type=submit]").click
+            end
+          end
+
+          it "shows the form with the error message" do
+            expect(page).to have_content("There was a problem creating this collaborative draft.")
+            expect(page).to have_field(:collaborative_draft_title, with: "More sidewalks and less roads")
+            expect(page).to have_field(:collaborative_draft_body, with: "Cities")
+          end
+
+          it "allows returning to the index" do
+            click_link "Back to collaborative drafts"
+
+            expect(page).to have_content("0 COLLABORATIVE DRAFTS")
+          end
+        end
+
         context "when geocoding is enabled", :serves_map, :serves_geocoding_autocomplete do
           let!(:component) do
             create(:proposal_component,


### PR DESCRIPTION
#### :tophat: What? Why?
When the collaborative draft form has some errors on it, it breaks the whole system.

Other issues I noticed while at it:
1. The return to index link was not working in this case as it was a `:back` link
2. The flash error message had "collaborative draft**s**" in plural which sounded weird to me

#### :pushpin: Related Issues
- Fixes #9500

#### Testing
- Go to proposals with creation enabled and collaborative drafts enabled
- Go create new collaborative draft
- Fill in the title correctly as it has a min characters limit at the front-end
- Put some text in the body that doesn't pass one of the validators, e.g. make it FULL CAPS or too short