### PR TITLE
Fix blocked user nickname and avatar in user presenter

### DIFF
--- a/decidim-core/app/presenters/decidim/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/user_presenter.rb
@@ -13,7 +13,7 @@ module Decidim
     # nickname presented in a twitter-like style
     #
     def nickname
-      return "@blocked_user" if __getobj__.blocked?
+      return "" if __getobj__.blocked?
 
       "@#{__getobj__.nickname}"
     end

--- a/decidim-core/app/presenters/decidim/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/user_presenter.rb
@@ -13,6 +13,8 @@ module Decidim
     # nickname presented in a twitter-like style
     #
     def nickname
+      return "@blocked_user" if __getobj__.blocked?
+
       "@#{__getobj__.nickname}"
     end
 
@@ -33,13 +35,14 @@ module Decidim
     end
 
     def avatar_url(variant = nil)
+      return default_avatar_url if __getobj__.blocked?
       return avatar.default_url unless avatar.attached?
 
       avatar.path(variant:)
     end
 
     def default_avatar_url
-      attached_uploader.default_url
+      attached_uploader(:avatar).default_url
     end
 
     def profile_path

--- a/decidim-core/spec/presenters/decidim/user_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/user_presenter_spec.rb
@@ -18,7 +18,7 @@ module Decidim
           user.blocked = true
         end
 
-        it { is_expected.to eq("@blocked_user") }
+        it { is_expected.to eq("") }
       end
     end
 

--- a/decidim-core/spec/presenters/decidim/user_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/user_presenter_spec.rb
@@ -9,7 +9,17 @@ module Decidim
     describe "#nickname" do
       subject { described_class.new(user).nickname }
 
-      it { is_expected.to eq("@#{user.nickname}") }
+      context "when not blocked" do
+        it { is_expected.to eq("@#{user.nickname}") }
+      end
+
+      context "when blocked" do
+        before do
+          user.blocked = true
+        end
+
+        it { is_expected.to eq("@blocked_user") }
+      end
     end
 
     context "when user is not officialized" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR modify the way blocked user are presented.
Their avatar is now the default one and their nickname is "blocked_user", just like their username
#### :pushpin: Related Issues
- Fixes #9011 

#### Testing
*Describe the best way to test or validate your PR.*
- add an avatar to a user
- comment a ressource with this user
- block it
- go to this resource and see the changes without and with hover
- click on the user and see the changes

### :camera: 
![Screenshot from 2022-08-04 10-50-08](https://user-images.githubusercontent.com/93646702/182806592-860b0695-b542-4e74-90b5-52f1f73ad14b.png)

![Screenshot from 2022-08-04 10-49-37](https://user-images.githubusercontent.com/93646702/182806621-2d3d206e-0894-466a-b92c-18a38bb02c76.png)

:hearts: Thank you!
