### PR TITLE
Fix parallel tests port in use

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -38,7 +38,16 @@ Capybara.register_driver :headless_chrome do |app|
   )
 end
 
-Capybara.server_port = rand(5000..6999)
+1.step do
+  port = rand(5000..6999)
+  begin
+    Socket.tcp("127.0.0.1", port, connect_timeout: 5).close
+  rescue Errno::ECONNREFUSED
+    # When connection is refused, the port is available for use.
+    Capybara.server_port = port
+    break
+  end
+end
 
 # In order to work with PWA apps, Chrome can't be run in headless mode, and requires
 # setting up special prefs and flags


### PR DESCRIPTION
#### :tophat: What? Why?
When the tests are run in parallel, they can occasionally fail because multiple servers are started and the port might be already in use that is assigned to Capybara.

This conflict can happen randomly when two consecutive calls to `rand(5000..6999)` return exactly the same number which I understand can happen once every 1999 runs.

This PR provides a fix for this edge case which should allow the parallel tests to always be assigned a port that is available.

When this happens, the following kind of errors appear in the CI logs:
```
2nd Try error in /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/manage_attachment_collections_examples.rb:16:
Address already in use - bind(2) for "127.0.0.1" port 6807
Address already in use - bind(2) for "127.0.0.1" port 6807
Address already in use - bind(2) for "127.0.0.1" port 6807
```

#### Testing
It's a tough one to test as it happens randomly but if you **really** want to test it out, run some system specs in parallel for about 10 000 times and you should hit this edge case with a high probability. As stated, on average it should happen about once every 2000 runs when the tests are run in parallel.

Another way to test it would be to reserve ports 5000-6995 with some other script and then start the tests in parallel with a processor count of 4 (`PARALLEL_TEST_PROCESSORS=4 bundle exec rake parallel:create parallel:migrate parallel:spec[^spec/system]`). This way you should expect to see the failure with the original code just after few runs.

Note that if you try the same with the new code, it can still fail due to timing out when there are not enough ports available. But in the CI this should never happen as these ports are expected to be available.

When the tests are not run in parallel, this never happens (unless you happen to have some other service that has reserved the ports on the machine).