### PR TITLE
Fix broken link in the data consent documentation

### DIFF
--- a/docs/modules/customize/pages/data_consent.adoc
+++ b/docs/modules/customize/pages/data_consent.adoc
@@ -72,7 +72,7 @@ Decidim.configure do |config|
 end
 ----
 
-When adding categories and items also remember to add the following xref:admin:texts.adoc[translations]:
+When adding categories and items also remember to add the following xref:customize:texts.adoc[translations]:
 
 For category:
 


### PR DESCRIPTION
#### :tophat: What? Why?
After #9570 was merged, there is now a broken link in the data consent documentation which is causing the documentation site not to build.

This fixes the issue.

#### :pushpin: Related Issues
- Related to #9570
- Related to decidim/documentation#104

#### Testing
Try to build the documentation site. Note that there are also few other issues right now that I am going to fix shortly.