### PR TITLE
Add "no-reply" notification at the email footers

### DIFF
--- a/decidim-core/app/views/layouts/decidim/mailer.html.erb
+++ b/decidim-core/app/views/layouts/decidim/mailer.html.erb
@@ -75,7 +75,6 @@
                     <tr>
                       <th class="small-12 first columns">
                         <%= yield %>
-                        <%= t("decidim.newsletter_mailer.newsletter.no_reply_notice") %>
                       </th>
                       <th class="expander"></th>
                     </tr>
@@ -124,6 +123,19 @@
                 </tr>
               </table>
             <% end %>
+            <table class="main container">
+              <tr>
+                <td>
+                  <table class="row content">
+                    <tr>
+                      <th class="small-12 first columns footnote">
+                        <%= t("decidim.newsletter_mailer.newsletter.no_reply_notice") %>
+                      </th>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
           </center>
         </td>
       </tr>

--- a/decidim-core/app/views/layouts/decidim/mailer.html.erb
+++ b/decidim-core/app/views/layouts/decidim/mailer.html.erb
@@ -75,6 +75,7 @@
                     <tr>
                       <th class="small-12 first columns">
                         <%= yield %>
+                        <%= t("decidim.newsletter_mailer.newsletter.no_reply_notice") %>
                       </th>
                       <th class="expander"></th>
                     </tr>

--- a/decidim-core/app/views/layouts/decidim/mailer.html.erb
+++ b/decidim-core/app/views/layouts/decidim/mailer.html.erb
@@ -105,7 +105,6 @@
                 </td>
               </tr>
             </table>
-
             <% if content_for?(:note) or content_for?(:unsubscribe) %>
               <table class="container">
                 <tr>
@@ -123,17 +122,20 @@
                 </tr>
               </table>
             <% end %>
-            <table class="main container">
+          </center>
+        </td>
+      </tr>
+      <tr>
+        <td class="float-center" align="center" valign="top">
+          <center>
+            <table class="container">
+            <tr>
+              <td height="10px" style="font-size:10px;line-height:10px;"> </td>
+            </tr>
               <tr>
-                <td>
-                  <table class="row content">
-                    <tr>
-                      <th class="small-12 first columns footnote">
-                        <%= t("decidim.newsletter_mailer.newsletter.no_reply_notice") %>
-                      </th>
-                    </tr>
-                  </table>
-                </td>
+                <th class="small-12 first columns footnote">
+                  <%= t("decidim.newsletter_mailer.newsletter.no_reply_notice") %>
+                </th>
               </tr>
             </table>
           </center>

--- a/decidim-core/app/views/layouts/decidim/mailer.html.erb
+++ b/decidim-core/app/views/layouts/decidim/mailer.html.erb
@@ -129,9 +129,9 @@
         <td class="float-center" align="center" valign="top">
           <center>
             <table class="container">
-            <tr>
-              <td height="10px" style="font-size:10px;line-height:10px;"> </td>
-            </tr>
+              <tr>
+                <td height="10px" style="font-size:10px;line-height:10px;"> </td>
+              </tr>
               <tr>
                 <th class="small-12 first columns footnote">
                   <%= t("decidim.newsletter_mailer.newsletter.no_reply_notice") %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1122,6 +1122,7 @@ en:
     newsletter_mailer:
       newsletter:
         note: You received this email because you're subscribed to newsletters on %{organization_name}. You can change your settings on your <a href="%{link}">notifications page</a>.
+        no_reply_notice: Please do not answer to this email. This email is sent from a notification-only-email and is not intended to receive emails
         see_on_website: Can’t see this email correctly? View it on the <a href="%{link}" target="_blank">website</a>.
         unsubscribe: To opt out of receiving this type of email, <a href="%{link}" target="_blank" class="unsubscribe">Unsubscribe</a>.
     newsletter_templates:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1121,8 +1121,8 @@ en:
         title: Participants
     newsletter_mailer:
       newsletter:
-        note: You received this email because you're subscribed to newsletters on %{organization_name}. You can change your settings on your <a href="%{link}">notifications page</a>.
         no_reply_notice: Please do not answer to this email. This email is sent from a notification-only-email and is not intended to receive emails
+        note: You received this email because you're subscribed to newsletters on %{organization_name}. You can change your settings on your <a href="%{link}">notifications page</a>.
         see_on_website: Can’t see this email correctly? View it on the <a href="%{link}" target="_blank">website</a>.
         unsubscribe: To opt out of receiving this type of email, <a href="%{link}" target="_blank" class="unsubscribe">Unsubscribe</a>.
     newsletter_templates:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1121,7 +1121,7 @@ en:
         title: Participants
     newsletter_mailer:
       newsletter:
-        no_reply_notice: Please do not answer to this email. This email is sent from a notification-only-email and is not intended to receive emails
+        no_reply_notice: This email was sent from a notification email address that cannot accept incoming email. Please do not reply to this message.
         note: You received this email because you're subscribed to newsletters on %{organization_name}. You can change your settings on your <a href="%{link}">notifications page</a>.
         see_on_website: Can’t see this email correctly? View it on the <a href="%{link}" target="_blank">website</a>.
         unsubscribe: To opt out of receiving this type of email, <a href="%{link}" target="_blank" class="unsubscribe">Unsubscribe</a>.

--- a/decidim-core/spec/mailers/block_user_mailer_spec.rb
+++ b/decidim-core/spec/mailers/block_user_mailer_spec.rb
@@ -21,6 +21,10 @@ module Decidim
         expect(email_body(mail)).to include("Your account was blocked.")
         expect(email_body(mail)).to include("Reason: ")
       end
+
+      it "includes no-reply message" do
+        expect(email_body(mail)).to include("Please do not answer to this email. This email is sent from a notification-only-email and is not intended to receive emails")
+      end
     end
   end
 end

--- a/decidim-core/spec/mailers/block_user_mailer_spec.rb
+++ b/decidim-core/spec/mailers/block_user_mailer_spec.rb
@@ -23,7 +23,7 @@ module Decidim
       end
 
       it "includes no-reply message" do
-        expect(email_body(mail)).to include("Please do not answer to this email. This email is sent from a notification-only-email and is not intended to receive emails")
+        expect(email_body(mail)).to include("This email was sent from a notification email address that cannot accept incoming email. Please do not reply to this message.")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
No-reply-emails are lacking a notification indicating that these emails are not intended to receive a response. 
This might cause inconvenience for the users.
The current pull request adds a note to the end of emails being generated, indicating that these emails are only informative emails and should not be responded.

#### :pushpin: Related Issues
- Fixes #6541 

#### Testing
A spec has been added to the end of one of the generic email generators to test the feature

### :camera: Screenshots
After adding, generic emails with no-reply, will generate a no-reply message like this:
![image](https://user-images.githubusercontent.com/104360479/184106992-7e7f1b5c-0bf2-4468-9b30-ed49da4c562e.png)

:hearts: Thank you!
