### PR TITLE
Fix redundant notification on comments with linked proposals

### DIFF
--- a/decidim-proposals/app/jobs/decidim/proposals/notify_proposals_mentioned_job.rb
+++ b/decidim-proposals/app/jobs/decidim/proposals/notify_proposals_mentioned_job.rb
@@ -8,7 +8,7 @@ module Decidim
 
         linked_proposals.each do |proposal_id|
           proposal = Proposal.find(proposal_id)
-          affected_users = proposal.notifiable_identities
+          affected_users = proposal.notifiable_identities - [comment.author]
 
           Decidim::EventsManager.publish(
             event: "decidim.events.proposals.proposal_mentioned",


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
When a link to a proposal in attached to a comment, a notification will be sent to the author of that proposal. However, this is redundant, if the author of the proposal is the same as the comment author.

#### :pushpin: Related Issues

- Fixes #9027

#### Testing
No prerequisite is needed to run the test. Just run the test as you would do normally.

:hearts: Thank you!

