### PR TITLE
Fix unpublished processes shown in the group process count

### DIFF
--- a/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/title_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/title_cell.rb
@@ -43,10 +43,17 @@ module Decidim
         end
 
         def participatory_processes_count
-          @participatory_processes_count ||= participatory_process_group.participatory_processes.count
+          @participatory_processes_count ||= processes.count
         end
 
         private
+
+        def processes
+          @processes ||= Decidim::ParticipatoryProcesses::GroupPublishedParticipatoryProcesses.new(
+            participatory_process_group,
+            current_user
+          ).query
+        end
 
         def group_uri
           @group_uri = URI.parse(group_url)

--- a/decidim-participatory_processes/spec/cells/decidim/participatory_process_groups/content_blocks/title_cell_spec.rb
+++ b/decidim-participatory_processes/spec/cells/decidim/participatory_process_groups/content_blocks/title_cell_spec.rb
@@ -69,5 +69,14 @@ describe Decidim::ParticipatoryProcessGroups::ContentBlocks::TitleCell, type: :c
         expect(subject).to have_no_selector("svg.icon--globe")
       end
     end
+
+    context "when there are unpublished processes in the group" do
+      let!(:published_processes) { create_list(:participatory_process, 2, :published, organization:, participatory_process_group:) }
+      let!(:unpublished_processes) { create_list(:participatory_process, 2, :unpublished, organization:, participatory_process_group:) }
+
+      it "shows correct participatory processes count" do
+        expect(subject).to have_content("2 processes")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
The participatory process group landing page shows also unpublished processes in the process count. This fixes the issue.

#### :pushpin: Related Issues
- Fixes #9681

#### Testing
See #9681.