### PR TITLE
Fix form error overlap with character counter in the admin panel

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/modules/_forms.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/modules/_forms.scss
@@ -116,12 +116,10 @@ label,
   margin-bottom: $input-margin;
 }
 
-.hashtags__container{
-  &:not(.field){
-    .form-input-extra-before + span.form-error{
-      margin-top: -2.5rem !important;
-    }
-  }
+.form-input-extra-before{
+  margin-bottom: $form-spacing * 1.5;
+  display: block;
+  margin-top: $form-spacing * -1;
 }
 
 .custom-error{

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/modules/_forms.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/modules/_forms.scss
@@ -116,6 +116,14 @@ label,
   margin-bottom: $input-margin;
 }
 
+.hashtags__container{
+  &:not(.field){
+    .form-input-extra-before + span.form-error{
+      margin-top: -2.5rem !important;
+    }
+  }
+}
+
 .custom-error{
   @extend .form-error;
 }


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
The validation rules of the proposals form are stepped between them in the administration panel.

#### :pushpin: Related Issues

- Fixes #6527

#### Testing
No testing is needed for such changes. Visually, it can be testified.

### :camera: Screenshots
After this fix, the error looks like this: 
![image](https://user-images.githubusercontent.com/104360479/184342316-b29beda8-b48d-452c-a275-49e6d39a562e.png)

:hearts: Thank you!
