### PR TITLE
Split parallel test coverage reports into their own folders

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 if ENV["SIMPLECOV"]
+  test_env = ENV.fetch("TEST_ENV_NUMBER", "")
+  test_env = "1" if test_env.empty?
+
   SimpleCov.start do
     # `ENGINE_ROOT` holds the name of the engine we're testing.
     # This brings us to the main Decidim folder.
@@ -24,6 +27,7 @@ if ENV["SIMPLECOV"]
   end
 
   SimpleCov.merge_timeout 1800
+  SimpleCov.coverage_dir "coverage/#{test_env}/"
 
   if ENV["CI"]
     require "simplecov-cobertura"


### PR DESCRIPTION
#### :tophat: What? Why?
I started to first improve the unit test coverage on the core but then I bumped into one report where the `Decidim::GroupsController` coverage was at 0% although all specs had been run correctly during that run.

I started to investigate this and I found this issue with the `simplecov` when used with the `parallel_tests`:
https://github.com/simplecov-ruby/simplecov/issues/1019

This issue seems really close to what we are experiencing with Decidim and the suggested solution is to split the coverage reports for each parallel test run into their separate folders. This way merging should happen at Codecov's side which means that if the `simplecov` merging is buggy, it shouldn't affect our CI coverage reports.

Regardless of this, I will still continue on #9684 to add a bit more unit tests.

#### :pushpin: Related Issues
- Related to #9684
- Related to #8678
- Related to simplecov-ruby/simplecov#1019

#### Testing
We'll just have to see if the coverage reports consistency improves.