### PR TITLE
Backport 'Prevent showing announcement on meetings registrations' to v0.27

### DIFF
--- a/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
@@ -5,7 +5,7 @@
 
 <% columns = allow_answers? && visitor_can_answer? && @form.responses.map(&:question).any?(&:matrix?) ? 9 : 6 %>
 
-<%= render partial: "decidim/shared/component_announcement" %>
+<%= render partial: "decidim/shared/component_announcement" if current_component.manifest_name == "surveys" %>
 
 <div class="row columns">
   <h2 class="section-heading"><%= translated_attribute questionnaire.title %></h2>

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -339,6 +339,26 @@ describe "Meeting registrations", type: :system do
 
           expect(page).to have_content("Needs to be reattached")
         end
+
+        context "and the announcement for the meeting is configured" do
+          before do
+            component.update!(
+              settings: {
+                announcement: {
+                  en: "An important announcement",
+                  es: "Un aviso muy importante",
+                  ca: "Un avís molt important"
+                }
+              }
+            )
+          end
+
+          it "the user should not see it" do
+            visit questionnaire_public_path
+
+            expect(page).not_to have_content("An important announcement")
+          end
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9557 to v0.27

:hearts: Thank you!