### PR TITLE
Backport 'Prevent missing ActionLog entries to break the application' to v0.26

### DIFF
--- a/decidim-core/app/models/decidim/action_log.rb
+++ b/decidim-core/app/models/decidim/action_log.rb
@@ -130,16 +130,16 @@ module Decidim
     end
 
     # Whether this activity or log is visible for a given user (can also be nil)
-    #
-    # Returns a True/False.
     def visible_for?(user)
-      return false if resource_lazy.blank?
-      return false if participatory_space_lazy.blank?
-      return false if resource_lazy.respond_to?(:deleted?) && resource_lazy.deleted?
-      return false if resource_lazy.respond_to?(:hidden?) && resource_lazy.hidden?
-      return false if resource_lazy.respond_to?(:can_participate?) && !resource_lazy.can_participate?(user)
+      resource_lazy.present? &&
+        participatory_space_lazy.present? &&
+        !resource_lazy.try(:deleted?) &&
+        !resource_lazy.try(:hidden?) &&
+        (!resource_lazy.respond_to?(:can_participate?) || resource_lazy.try(:can_participate?, user))
+    rescue NameError => e
+      Rails.logger.warn "Failed resource for #{self.class.name}(id=#{id}): #{e.message}"
 
-      true
+      false
     end
   end
 end

--- a/decidim-core/spec/models/decidim/action_log_spec.rb
+++ b/decidim-core/spec/models/decidim/action_log_spec.rb
@@ -118,6 +118,19 @@ describe Decidim::ActionLog do
       it { is_expected.to be_falsey }
     end
 
+    context "when resource does not exist" do
+      before do
+        allow(Rails.logger).to receive(:warn).at_least(:once)
+        action_log.resource_type = "ANonExistingClass"
+        action_log.participatory_space.save!
+      end
+
+      it "creates a log entry" do
+        expect(subject).to be_falsey
+        expect(Rails.logger).to have_received(:warn).with(/Failed resource/).once
+      end
+    end
+
     it { is_expected.to be_truthy }
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9502 to v0.26

:hearts: Thank you!