### PR TITLE
Backport 'Add missing queue close_meeting_reminder to sidekiq configuration' to v0.27

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_templates/sidekiq.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/sidekiq.yml.erb
@@ -13,3 +13,4 @@
   - [block_user, 2]
   - [metrics, 1]
   - [exports, 1]
+  - [close_meeting_reminder, 1]

--- a/decidim-generators/lib/decidim/generators/test/generator_examples.rb
+++ b/decidim-generators/lib/decidim/generators/test/generator_examples.rb
@@ -1067,7 +1067,8 @@ shared_examples_for "an application with storage and queue gems" do
     current = rails_value("YAML.load(ERB.new(IO.read(\"config/sidekiq.yml\")).result)", test_app, queue_envs_on)
     expect(current["concurrency"]).to eq(11), "sidekiq concurrency (#{current["concurrency"]}) expected to eq 11"
 
-    queues = %w(mailers vote_reminder reminders default newsletter newsletters_opt_in conference_diplomas events translations user_report block_user metrics exports)
+    queues = %w(mailers vote_reminder reminders default newsletter newsletters_opt_in conference_diplomas events translations user_report block_user metrics exports
+                close_meeting_reminder)
     expect(current["queues"].flatten).to include(*queues), "sidekiq queues (#{current["queues"].flatten}) expected to eq containt (#{queues})"
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9568 to v0.27

:hearts: Thank you!