### PR TITLE
Backport 'Return 404 when there isn't a valid component in program' to v0.27

### DIFF
--- a/decidim-conferences/app/controllers/decidim/conferences/conference_program_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conference_program_controller.rb
@@ -26,7 +26,7 @@ module Decidim
       end
 
       def meetings
-        return unless meeting_component.published? || !meeting_component.presence
+        return unless meeting_component&.published? || !meeting_component.presence
 
         @meetings ||= Decidim::Meetings::Meeting.where(component: meeting_component).visible_for(current_user).order(:start_time)
       end

--- a/decidim-conferences/spec/controllers/conference_program_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/conference_program_controller_spec.rb
@@ -27,8 +27,15 @@ module Decidim
 
       describe "GET show" do
         context "when conference has no meetings" do
-          it "redirects to 404" do
+          it "returns 404" do
             expect { get :show, params: { conference_slug: conference.slug, id: component.id } }
+              .to raise_error(ActionController::RoutingError)
+          end
+        end
+
+        context "when conference has an invalid component id" do
+          it "returns 404" do
+            expect { get :show, params: { conference_slug: conference.slug, id: 999 } }
               .to raise_error(ActionController::RoutingError)
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9576 to v0.27

:hearts: Thank you!