### PR TITLE
Backport 'Fix absolute urls on 'managed user error' event' to v0.26

### DIFF
--- a/decidim-blogs/spec/events/decidim/blogs/create_post_event_spec.rb
+++ b/decidim-blogs/spec/events/decidim/blogs/create_post_event_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "decidim/core/test/shared_examples/simple_event"
 
 describe Decidim::Blogs::CreatePostEvent do
   let(:resource) { create :post }

--- a/decidim-sortitions/spec/events/decidim/sortitions/create_sortition_event_spec.rb
+++ b/decidim-sortitions/spec/events/decidim/sortitions/create_sortition_event_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "decidim/core/test/shared_examples/simple_event"
 
 describe Decidim::Sortitions::CreateSortitionEvent do
   let(:resource) { create :sortition }

--- a/decidim-verifications/app/events/decidim/verifications/managed_user_error_event.rb
+++ b/decidim-verifications/app/events/decidim/verifications/managed_user_error_event.rb
@@ -6,12 +6,11 @@ module Decidim
       include Rails.application.routes.mounted_helpers
 
       delegate :profile_path, :profile_url, :name, to: :updated_user
+      delegate :conflicts_path, :conflicts_url, to: :decidim_admin
 
       def i18n_scope
         "decidim.events.verifications.verify_with_managed_user"
       end
-
-      delegate :conflicts_path, to: :decidim_admin
 
       def resource_path
         profile_path
@@ -26,7 +25,13 @@ module Decidim
       end
 
       def default_i18n_options
-        super.merge({ conflicts_path: conflicts_path, managed_user_path: managed_user.profile_path, managed_user_name: managed_user.name })
+        super.merge({
+                      conflicts_path: conflicts_path,
+                      conflicts_url: conflicts_url,
+                      managed_user_path: managed_user.profile_path,
+                      managed_user_url: managed_user.profile_url,
+                      managed_user_name: managed_user.name
+                    })
       end
 
       private
@@ -37,6 +42,10 @@ module Decidim
 
       def managed_user
         @managed_user ||= Decidim::UserPresenter.new(resource.managed_user)
+      end
+
+      def decidim_admin
+        @decidim_admin ||= Decidim::EngineRouter.new("decidim_admin", { host: managed_user.organization.host })
       end
     end
   end

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -79,10 +79,10 @@ en:
     events:
       verifications:
         verify_with_managed_user:
-          email_intro: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify themself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>.
-          email_outro: Check the <a href="%{conflicts_path}">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue.
-          email_subject: Failed verification attempt against a managed participant
-          notification_title: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify themself with the data of the managed participant <a href="%{managed_user_path}">%{managed_user_name}</a>.
+          email_intro: The participant <a href="%{resource_url}">%{resource_title}</a> has tried to verify themself with the data of another participant (<a href="%{managed_user_url}">%{managed_user_name}</a>).
+          email_outro: Check the <a href="%{conflicts_url}">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue.
+          email_subject: Failed verification attempt against another participant
+          notification_title: The participant <a href="%{resource_path}">%{resource_title}</a> has tried to verify themself with the data of another participant (<a href="%{managed_user_path}">%{managed_user_name}</a>).
     verifications:
       authorizations:
         authorization_metadata:

--- a/decidim-verifications/lib/decidim/verifications/test/factories.rb
+++ b/decidim-verifications/lib/decidim/verifications/test/factories.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
 
   factory :conflict, class: "Decidim::Verifications::Conflict" do
     current_user { create(:user) }
-    managed_user { create(:user, managed: true) }
+    managed_user { create(:user, managed: true, organization: current_user.organization) }
     unique_id { "12345678X" }
     times { 1 }
   end

--- a/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
+++ b/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
@@ -7,6 +7,7 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
 
   let(:event_name) { "decidim.events.verifications.managed_user_error_event" }
   let(:resource) { create :conflict }
+  let(:organization_host) { resource.current_user.organization.host }
 
   describe "resource_title" do
     it "is generated correctly" do
@@ -22,7 +23,7 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
 
   describe "resource_url" do
     it "is generated correctly" do
-      expect(subject.resource_url).to eq("http://#{resource.current_user.organization.host}/profiles/#{resource.current_user.nickname}")
+      expect(subject.resource_url).to eq("http://#{organization_host}/profiles/#{resource.current_user.nickname}")
     end
   end
 
@@ -38,25 +39,25 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
 
   describe "notification_title" do
     it "is generated correctly" do
-      expect(subject.notification_title).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify themself with the data of the managed participant <a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>.")
+      expect(subject.notification_title).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify themself with the data of another participant (<a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>).")
     end
   end
 
   describe "email_subject" do
     it "is generated correctly" do
-      expect(subject.email_subject).to eq("Failed verification attempt against a managed participant")
+      expect(subject.email_subject).to eq("Failed verification attempt against another participant")
     end
   end
 
   describe "email_intro" do
     it "is generated correctly" do
-      expect(subject.email_intro).to eq("The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify themself with the data of the managed participant <a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>.")
+      expect(subject.email_intro).to eq("The participant <a href=\"http://#{organization_host}/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify themself with the data of another participant (<a href=\"http://#{organization_host}/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>).")
     end
   end
 
   describe "email_outro" do
     it "is generated correctly" do
-      expect(subject.email_outro).to eq("Check the <a href=\"/admin/conflicts\">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue.")
+      expect(subject.email_outro).to eq("Check the <a href=\"http://#{organization_host}:#{Capybara.server_port}/admin/conflicts\">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue.")
     end
   end
 end

--- a/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
+++ b/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
@@ -57,7 +57,7 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
 
   describe "email_outro" do
     it "is generated correctly" do
-      expect(subject.email_outro).to eq("Check the <a href=\"http://#{organization_host}:#{Capybara.server_port}/admin/conflicts\">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue.")
+      expect(subject.email_outro).to eq("Check the <a href=\"http://#{organization_host}/admin/conflicts\">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue.")
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9550 to v0.26

:hearts: Thank you!