### PR TITLE
Backport 'Fix order when filtering Meetings' to v0.27

### DIFF
--- a/decidim-core/app/helpers/decidim/filters_helper.rb
+++ b/decidim-core/app/helpers/decidim/filters_helper.rb
@@ -24,7 +24,11 @@ module Decidim
           remote: true,
           html: { id: nil }.merge(html_options)
         ) do |form|
-          yield form
+          # Cannot use `concat()` here because it's not available in cells
+          inner = []
+          inner << hidden_field_tag("per_page", params[:per_page], id: nil) if params[:per_page]
+          inner << capture { yield form }
+          inner.join.html_safe
         end
       end
     end

--- a/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
@@ -26,7 +26,8 @@ module Decidim
         private
 
         def meetings
-          @meetings ||= paginate(search.result)
+          is_past_meetings = params.dig("filter", "with_any_date")&.include?("past")
+          @meetings ||= paginate(search.result.order(start_time: is_past_meetings ? :desc : :asc))
         end
 
         def search_collection

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -109,7 +109,8 @@ module Decidim
       end
 
       def meetings
-        @meetings ||= paginate(search.result.order(start_time: :desc))
+        is_past_meetings = params.dig("filter", "with_any_date")&.include?("past")
+        @meetings ||= paginate(search.result.order(start_time: is_past_meetings ? :desc : :asc))
       end
 
       def registration
@@ -132,7 +133,7 @@ module Decidim
       def default_filter_params
         {
           search_text_cont: "",
-          with_any_date: %w(upcoming),
+          with_any_date: "upcoming",
           activity: "all",
           with_availability: "",
           with_any_scope: default_filter_scope_params,

--- a/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
@@ -41,13 +41,11 @@ module Decidim
       end
 
       def filter_date_values
-        TreeNode.new(
-          TreePoint.new("", t("decidim.meetings.meetings.filters.date_values.all")),
-          [
-            TreePoint.new("upcoming", t("decidim.meetings.meetings.filters.date_values.upcoming")),
-            TreePoint.new("past", t("decidim.meetings.meetings.filters.date_values.past"))
-          ]
-        )
+        [
+          ["all", t("decidim.meetings.meetings.filters.date_values.all")],
+          ["upcoming", t("decidim.meetings.meetings.filters.date_values.upcoming")],
+          ["past", t("decidim.meetings.meetings.filters.date_values.past")]
+        ]
       end
 
       # Options to filter meetings by activity.

--- a/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
@@ -27,13 +27,11 @@ module Decidim
         end
 
         def filter_date_values
-          TreeNode.new(
-            TreePoint.new("", t("decidim.meetings.meetings.filters.date_values.all")),
-            [
-              TreePoint.new("upcoming", t("decidim.meetings.meetings.filters.date_values.upcoming")),
-              TreePoint.new("past", t("decidim.meetings.meetings.filters.date_values.past"))
-            ]
-          )
+          [
+            ["all", t("decidim.meetings.meetings.filters.date_values.all")],
+            ["upcoming", t("decidim.meetings.meetings.filters.date_values.upcoming")],
+            ["past", t("decidim.meetings.meetings.filters.date_values.past")]
+          ]
         end
 
         def directory_filter_scopes_values

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/_filters.html.erb
@@ -15,7 +15,7 @@
   </div>
 
   <% unless @forced_past_meetings %>
-    <%= form.check_boxes_tree :with_any_date, filter_date_values, legend_title: t("decidim.meetings.meetings.filters.date") %>
+    <%= form.collection_radio_buttons :with_any_date, filter_date_values, :first, :last, legend_title: t("decidim.meetings.meetings.filters.date") %>
   <% end %>
 
   <%= form.check_boxes_tree :with_any_type, filter_type_values, legend_title: t("decidim.meetings.meetings.filters.type") %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -17,7 +17,7 @@
   <%= form.hidden_field "with_availability", value: params.dig("filter", "with_availability") %>
 
   <% unless @forced_past_meetings %>
-    <%= form.check_boxes_tree :with_any_date, filter_date_values, legend_title: t(".date") %>
+    <%= form.collection_radio_buttons :with_any_date, filter_date_values, :first, :last, legend_title: t(".date") %>
   <% end %>
 
   <%= form.check_boxes_tree :with_any_type, filter_type_values, legend_title: t(".type") %>

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -127,7 +127,7 @@ Decidim.register_component(:meetings) do |component|
     end
 
     2.times do
-      start_time = [rand(1..20).weeks.from_now, rand(1..20).weeks.ago].sample
+      start_time = Faker::Date.between(from: 20.weeks.ago, to: 20.weeks.from_now)
       end_time = start_time + [rand(1..4).hours, rand(1..20).days].sample
       params = {
         component: component,
@@ -282,7 +282,7 @@ Decidim.register_component(:meetings) do |component|
         author = user_group.users.sample
       end
 
-      start_time = [rand(1..20).weeks.from_now, rand(1..20).weeks.ago].sample
+      start_time = Faker::Date.between(from: 20.weeks.ago, to: 20.weeks.from_now)
       params = {
         component: component,
         scope: Faker::Boolean.boolean(true_ratio: 0.5) ? global : scopes.sample,

--- a/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
+++ b/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
@@ -3,9 +3,7 @@
 require "spec_helper"
 
 describe "Explore meeting directory", type: :system do
-  let(:directory) do
-    Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path
-  end
+  let(:directory) { Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path }
   let(:organization) { create(:organization) }
   let(:participatory_process) { create :participatory_process, organization: organization }
   let(:components) do
@@ -25,19 +23,35 @@ describe "Explore meeting directory", type: :system do
     visit directory
   end
 
-  it "shows all the upcoming meetings" do
-    within "#meetings" do
-      expect(page).to have_css(".card--meeting", count: 6)
+  describe "with default filter" do
+    let!(:past_meeting) { create(:meeting, :published, start_time: 2.weeks.ago, component: components.first) }
+    let!(:upcoming_meeting) { create(:meeting, :published, :not_official, component: components.first) }
+
+    it "shows all the upcoming meetings" do
+      visit directory
+
+      within ".with_any_date_collection_radio_buttons_filter" do
+        expect(find("input[value='upcoming']").checked?).to be(true)
+      end
+
+      within "#meetings" do
+        expect(page).to have_css(".card--meeting", count: 7)
+      end
+
+      expect(page).to have_css("#meetings-count", text: "7 MEETINGS")
+      expect(page).to have_content(translated(upcoming_meeting.title))
     end
 
-    expect(page).to have_css("#meetings-count", text: "6 MEETINGS")
+    it "doesn't show past meetings" do
+      within "#meetings" do
+        expect(page).not_to have_content(translated(past_meeting.title))
+      end
+    end
   end
 
   describe "category filter" do
     context "with a category" do
-      let!(:category1) do
-        create(:category, participatory_space: participatory_process, name: { en: "Category1" })
-      end
+      let!(:category1) { create(:category, participatory_space: participatory_process, name: { en: "Category1" }) }
       let!(:meeting) do
         meeting = meetings.first
         meeting.category = category1
@@ -146,12 +160,8 @@ describe "Explore meeting directory", type: :system do
 
   describe "type filter" do
     context "when there are only online meetings" do
-      let!(:online_meeting1) do
-        create(:meeting, :published, :online, component: components.last)
-      end
-      let!(:online_meeting2) do
-        create(:meeting, :published, :online, component: components.last)
-      end
+      let!(:online_meeting1) { create(:meeting, :published, :online, component: components.last) }
+      let!(:online_meeting2) { create(:meeting, :published, :online, component: components.last) }
 
       it "allows filtering by type 'online'" do
         within ".with_any_type_check_boxes_tree_filter" do
@@ -199,9 +209,7 @@ describe "Explore meeting directory", type: :system do
     end
 
     context "when there are only in-person meetings" do
-      let!(:in_person_meeting) do
-        create(:meeting, :published, :in_person, component: components.last)
-      end
+      let!(:in_person_meeting) { create(:meeting, :published, :in_person, component: components.last) }
 
       it "allows filtering by type 'in-person'" do
         within ".with_any_type_check_boxes_tree_filter" do
@@ -215,9 +223,7 @@ describe "Explore meeting directory", type: :system do
     end
 
     context "when there are hybrid meetings" do
-      let!(:online_meeting) do
-        create(:meeting, :published, :hybrid, component: components.last)
-      end
+      let!(:online_meeting) { create(:meeting, :published, :hybrid, component: components.last) }
 
       it "allows filtering by type 'both'" do
         within ".with_any_type_check_boxes_tree_filter" do
@@ -230,19 +236,59 @@ describe "Explore meeting directory", type: :system do
     end
   end
 
-  context "when there's a past meeting" do
-    let!(:past_meeting) do
-      create(:meeting, :published, component: components.last, start_time: 1.week.ago)
+  describe "date filter" do
+    let!(:past_meeting1) { create(:meeting, :published, component: components.last, start_time: 1.week.ago) }
+    let!(:past_meeting2) { create(:meeting, :published, component: components.last, start_time: 3.months.ago) }
+    let!(:past_meeting3) { create(:meeting, :published, component: components.last, start_time: 2.days.ago) }
+    let!(:upcoming_meeting1) { create(:meeting, :published, component: components.last, start_time: 1.week.from_now) }
+    let!(:upcoming_meeting2) { create(:meeting, :published, component: components.last, start_time: 3.months.from_now) }
+    let!(:upcoming_meeting3) { create(:meeting, :published, component: components.last, start_time: 2.days.from_now) }
+
+    context "with all meetings" do
+      it "orders them by start date" do
+        visit "#{directory}?per_page=20"
+
+        within ".with_any_date_collection_radio_buttons_filter" do
+          choose "All"
+        end
+
+        expect(page).to have_css("#meetings-count", text: "12 MEETINGS")
+
+        result = page.find("#meetings .card-grid").text
+        expect(result.index(translated(past_meeting2.title))).to be < result.index(translated(past_meeting1.title))
+        expect(result.index(translated(past_meeting1.title))).to be < result.index(translated(past_meeting3.title))
+        expect(result.index(translated(past_meeting2.title))).to be < result.index(translated(upcoming_meeting1.title))
+        expect(result.index(translated(upcoming_meeting3.title))).to be < result.index(translated(upcoming_meeting1.title))
+        expect(result.index(translated(upcoming_meeting1.title))).to be < result.index(translated(upcoming_meeting2.title))
+      end
     end
 
-    it "allows filtering by past events" do
-      within ".with_any_date_check_boxes_tree_filter" do
-        uncheck "All"
-        check "Past"
-      end
+    context "with past meetings" do
+      it "orders them by start date" do
+        visit directory
 
-      expect(page).to have_content(past_meeting.title["en"])
-      expect(page).to have_css("#meetings-count", text: "1 MEETING")
+        within ".with_any_date_collection_radio_buttons_filter" do
+          choose "Past"
+        end
+
+        expect(page).to have_css("#meetings-count", text: "3 MEETINGS")
+
+        result = page.find("#meetings .card-grid").text
+        expect(result.index(translated(past_meeting3.title))).to be < result.index(translated(past_meeting1.title))
+        expect(result.index(translated(past_meeting1.title))).to be < result.index(translated(past_meeting2.title))
+      end
+    end
+
+    context "with upcoming meetings" do
+      it "orders them by start date" do
+        visit directory
+
+        expect(page).to have_css("#meetings-count", text: "9 MEETINGS")
+
+        result = page.find("#meetings .card-grid").text
+        expect(result.index(translated(upcoming_meeting3.title))).to be < result.index(translated(upcoming_meeting1.title))
+        expect(result.index(translated(upcoming_meeting1.title))).to be < result.index(translated(upcoming_meeting2.title))
+      end
     end
   end
 
@@ -268,9 +314,8 @@ describe "Explore meeting directory", type: :system do
       # have_content to wait for the card list to change. This is a hack to
       # reset the contents to no meetings at all, and then showing only the upcoming
       # assembly meetings.
-      within ".with_any_date_check_boxes_tree_filter" do
-        uncheck "All"
-        check "Past"
+      within ".with_any_date_collection_radio_buttons_filter" do
+        choose "Past"
       end
 
       expect(page).to have_no_css(".card--meeting")
@@ -279,8 +324,8 @@ describe "Explore meeting directory", type: :system do
         check "Assemblies"
       end
 
-      within ".with_any_date_check_boxes_tree_filter" do
-        check "Upcoming"
+      within ".with_any_date_collection_radio_buttons_filter" do
+        choose "Upcoming"
       end
 
       expect(page).to have_content(assembly_meeting.title["en"])

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -30,6 +30,32 @@ describe "Explore meetings", :slow, type: :system do
       end
     end
 
+    context "with default filter" do
+      let!(:past_meeting) { create(:meeting, :published, start_time: 2.weeks.ago, component: component) }
+      let!(:upcoming_meeting) { create(:meeting, :published, :not_official, component: component) }
+
+      it "shows all the upcoming meetings" do
+        visit_component
+        within ".with_any_date_collection_radio_buttons_filter" do
+          expect(find("input[value='upcoming']").checked?).to be(true)
+        end
+
+        within "#meetings" do
+          expect(page).to have_css(".card--meeting", count: 6)
+        end
+
+        expect(page).to have_css("#meetings-count", text: "6 MEETINGS")
+        expect(page).to have_content(translated(upcoming_meeting.title))
+      end
+
+      it "doesn't show past meetings" do
+        visit_component
+        within "#meetings" do
+          expect(page).not_to have_content(translated(past_meeting.title))
+        end
+      end
+    end
+
     context "when checking withdrawn meetings" do
       context "when there are no withrawn meetings" do
         let!(:meeting) { create_list(:meeting, 3, :published, component: component) }
@@ -180,33 +206,98 @@ describe "Explore meetings", :slow, type: :system do
         expect(page).to have_content(translated(meetings.first.title))
       end
 
-      it "allows filtering by date" do
-        past_meeting = create(:meeting, :published, component: component, start_time: 1.day.ago)
-        visit_component
+      context "when filtering by date" do
+        let!(:past_meeting1) { create(:meeting, :published, component: component, start_time: 1.week.ago) }
+        let!(:past_meeting2) { create(:meeting, :published, component: component, start_time: 3.months.ago) }
+        let!(:past_meeting3) { create(:meeting, :published, component: component, start_time: 2.days.ago) }
+        let!(:upcoming_meeting1) { create(:meeting, :published, component: component, start_time: 1.week.from_now) }
+        let!(:upcoming_meeting2) { create(:meeting, :published, component: component, start_time: 3.months.from_now) }
+        let!(:upcoming_meeting3) { create(:meeting, :published, component: component, start_time: 2.days.from_now) }
 
-        within ".with_any_date_check_boxes_tree_filter" do
-          uncheck "All"
-          check "Past"
+        it "lists filtered meetings" do
+          visit_component
+
+          within ".with_any_date_collection_radio_buttons_filter" do
+            choose "Past"
+          end
+
+          expect(page).to have_css(".card--meeting", count: 3)
+          expect(page).to have_content(translated(past_meeting1.title))
+          expect(page).not_to have_content(translated(upcoming_meeting1.title))
+
+          within ".with_any_date_collection_radio_buttons_filter" do
+            choose "Upcoming"
+          end
+
+          expect(page).to have_content(translated(upcoming_meeting1.title))
+          expect(page).not_to have_content(translated(past_meeting1.title))
+
+          expect(page).to have_css(".card--meeting", count: 8)
+
+          within ".with_any_date_collection_radio_buttons_filter" do
+            choose "All"
+          end
+
+          expect(page).to have_css(".card--meeting", count: 8)
+          expect(page).to have_content(translated(past_meeting1.title))
+          expect(page).to have_content(translated(upcoming_meeting1.title))
         end
 
-        expect(page).to have_css(".card--meeting", count: 1)
-        expect(page).to have_content(translated(past_meeting.title))
+        context "when there are multiple past meetings" do
+          it "orders them by start date" do
+            visit_component
+            within ".with_any_date_collection_radio_buttons_filter" do
+              choose "Past"
+            end
 
-        within ".with_any_date_check_boxes_tree_filter" do
-          uncheck "All"
-          check "Upcoming"
+            expect(page).to have_css("#meetings-count", text: "3 MEETINGS")
+
+            result = page.find("#meetings .card-grid").text
+            expect(result.index(translated(past_meeting3.title))).to be < result.index(translated(past_meeting1.title))
+            expect(result.index(translated(past_meeting1.title))).to be < result.index(translated(past_meeting2.title))
+          end
         end
 
-        expect(page).to have_css(".card--meeting", count: 5)
+        context "when there are multiple upcoming meetings" do
+          it "orders them by start date" do
+            visit_component
+            within ".with_any_date_collection_radio_buttons_filter" do
+              choose "Upcoming"
+            end
+
+            expect(page).to have_css("#meetings-count", text: "8 MEETINGS")
+
+            result = page.find("#meetings .card-grid").text
+            expect(result.index(translated(upcoming_meeting3.title))).to be < result.index(translated(upcoming_meeting1.title))
+            expect(result.index(translated(upcoming_meeting1.title))).to be < result.index(translated(upcoming_meeting2.title))
+          end
+        end
+
+        context "when there are multiple meetings" do
+          it "orders them by start date" do
+            page.visit "#{main_component_path(component)}?per_page=20"
+            within ".with_any_date_collection_radio_buttons_filter" do
+              choose "All"
+            end
+
+            expect(page).to have_css("#meetings-count", text: "11 MEETINGS")
+
+            result = page.find("#meetings .card-grid").text
+            expect(result.index(translated(past_meeting2.title))).to be < result.index(translated(past_meeting1.title))
+            expect(result.index(translated(past_meeting1.title))).to be < result.index(translated(past_meeting3.title))
+            expect(result.index(translated(past_meeting2.title))).to be < result.index(translated(upcoming_meeting1.title))
+            expect(result.index(translated(upcoming_meeting3.title))).to be < result.index(translated(upcoming_meeting1.title))
+            expect(result.index(translated(upcoming_meeting1.title))).to be < result.index(translated(upcoming_meeting2.title))
+          end
+        end
       end
 
       it "allows linking to the filtered view using a short link" do
         past_meeting = create(:meeting, :published, component: component, start_time: 1.day.ago)
         visit_component
 
-        within ".with_any_date_check_boxes_tree_filter" do
-          uncheck "All"
-          check "Past"
+        within ".with_any_date_collection_radio_buttons_filter" do
+          choose "Past"
         end
 
         expect(page).to have_css(".card--meeting", count: 1)

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -37,6 +37,9 @@ describe "Meeting registrations", type: :system do
       available_slots: available_slots,
       registration_terms: registration_terms
     )
+
+    # Make static map requests not to fail with HTTP 500 (causes JS error)
+    stub_request(:get, Regexp.new(Decidim.maps.fetch(:static).fetch(:url))).to_return(body: "")
   end
 
   context "when meeting registrations are not enabled" do


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9505 to v0.27

:hearts: Thank you!