### PR TITLE
Backport 'Fix order when filtering Meetings' to v0.26

### DIFF
--- a/decidim-core/app/helpers/decidim/filters_helper.rb
+++ b/decidim-core/app/helpers/decidim/filters_helper.rb
@@ -24,7 +24,11 @@ module Decidim
           remote: true,
           html: { id: nil }.merge(html_options)
         ) do |form|
-          yield form
+          # Cannot use `concat()` here because it's not available in cells
+          inner = []
+          inner << hidden_field_tag("per_page", params[:per_page], id: nil) if params[:per_page]
+          inner << capture { yield form }
+          inner.join.html_safe
         end
       end
     end

--- a/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
@@ -26,7 +26,7 @@ module Decidim
 
         def meetings
           is_past_meetings = params.dig("filter", "date")&.include?("past")
-          @meetings ||= paginate(search.result.order(start_time: is_past_meetings ? :desc : :asc))
+          @meetings ||= paginate(search.results.order(start_time: is_past_meetings ? :desc : :asc))
         end
 
         def search_klass

--- a/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
@@ -25,7 +25,8 @@ module Decidim
         private
 
         def meetings
-          @meetings ||= paginate(search.results)
+          is_past_meetings = params.dig("filter", "date")&.include?("past")
+          @meetings ||= paginate(search.result.order(start_time: is_past_meetings ? :desc : :asc))
         end
 
         def search_klass

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -108,7 +108,8 @@ module Decidim
       end
 
       def meetings
-        @meetings ||= paginate(search.results.order(start_time: :desc))
+        is_past_meetings = params.dig("filter", "date")&.include?("past")
+        @meetings ||= paginate(search.result.order(start_time: is_past_meetings ? :desc : :asc))
       end
 
       def registration
@@ -126,7 +127,7 @@ module Decidim
       def default_filter_params
         {
           search_text: "",
-          date: %w(upcoming),
+          date: "upcoming",
           activity: "all",
           scope_id: default_filter_scope_params,
           category_id: default_filter_category_params,

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -109,7 +109,7 @@ module Decidim
 
       def meetings
         is_past_meetings = params.dig("filter", "date")&.include?("past")
-        @meetings ||= paginate(search.result.order(start_time: is_past_meetings ? :desc : :asc))
+        @meetings ||= paginate(search.results.order(start_time: is_past_meetings ? :desc : :asc))
       end
 
       def registration

--- a/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
@@ -41,13 +41,11 @@ module Decidim
       end
 
       def filter_date_values
-        TreeNode.new(
-          TreePoint.new("", t("decidim.meetings.meetings.filters.date_values.all")),
-          [
-            TreePoint.new("upcoming", t("decidim.meetings.meetings.filters.date_values.upcoming")),
-            TreePoint.new("past", t("decidim.meetings.meetings.filters.date_values.past"))
-          ]
-        )
+        [
+          ["all", t("decidim.meetings.meetings.filters.date_values.all")],
+          ["upcoming", t("decidim.meetings.meetings.filters.date_values.upcoming")],
+          ["past", t("decidim.meetings.meetings.filters.date_values.past")]
+        ]
       end
 
       # Options to filter meetings by activity.

--- a/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/directory/application_helper.rb
@@ -27,13 +27,11 @@ module Decidim
         end
 
         def filter_date_values
-          TreeNode.new(
-            TreePoint.new("", t("decidim.meetings.meetings.filters.date_values.all")),
-            [
-              TreePoint.new("upcoming", t("decidim.meetings.meetings.filters.date_values.upcoming")),
-              TreePoint.new("past", t("decidim.meetings.meetings.filters.date_values.past"))
-            ]
-          )
+          [
+            ["all", t("decidim.meetings.meetings.filters.date_values.all")],
+            ["upcoming", t("decidim.meetings.meetings.filters.date_values.upcoming")],
+            ["past", t("decidim.meetings.meetings.filters.date_values.past")]
+          ]
         end
 
         def directory_filter_scopes_values

--- a/decidim-meetings/app/views/decidim/meetings/directory/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/directory/meetings/_filters.html.erb
@@ -15,7 +15,7 @@
   </div>
 
   <% unless @forced_past_meetings %>
-    <%= form.check_boxes_tree :date, filter_date_values, legend_title: t("decidim.meetings.meetings.filters.date") %>
+    <%= form.collection_radio_buttons :date, filter_date_values, :first, :last, legend_title: t("decidim.meetings.meetings.filters.date") %>
   <% end %>
 
   <%= form.check_boxes_tree :type, filter_type_values, legend_title: t("decidim.meetings.meetings.filters.type") %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -17,7 +17,7 @@
   <%= form.hidden_field "state", value: params.dig("filter", "state") %>
 
   <% unless @forced_past_meetings %>
-    <%= form.check_boxes_tree :date, filter_date_values, legend_title: t(".date") %>
+    <%= form.collection_radio_buttons :date, filter_date_values, :first, :last, legend_title: t(".date") %>
   <% end %>
 
   <%= form.check_boxes_tree :type, filter_type_values, legend_title: t(".type") %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
@@ -1,11 +1,17 @@
 var $meetings = $('#meetings');
 var $meetingsCount = $('#meetings-count');
 
+// make sure that calendar modal will use the updated filter values
+var $calendarShare = $('#calendarShare');
+$calendarShare.remove();
+
 $meetings.html('<%= j(render partial: "meetings").strip.html_safe %>');
 $meetingsCount.html('<%= j(render partial: "count").strip.html_safe %>');
 
 var $dropdownMenu = $('.dropdown.menu', $meetings);
 $dropdownMenu.foundation();
+
+$("#calendarShare").foundation(); // initialize export calendar on the page
 
 var markerData = JSON.parse('<%= escape_javascript meetings_data_for_map(search.results.select(&:geocoded_and_valid?)).to_json.html_safe %>');
 

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -127,7 +127,7 @@ Decidim.register_component(:meetings) do |component|
     end
 
     2.times do
-      start_time = [rand(1..20).weeks.from_now, rand(1..20).weeks.ago].sample
+      start_time = Faker::Date.between(from: 20.weeks.ago, to: 20.weeks.from_now)
       end_time = start_time + [rand(1..4).hours, rand(1..20).days].sample
       params = {
         component: component,
@@ -282,7 +282,7 @@ Decidim.register_component(:meetings) do |component|
         author = user_group.users.sample
       end
 
-      start_time = [rand(1..20).weeks.from_now, rand(1..20).weeks.ago].sample
+      start_time = Faker::Date.between(from: 20.weeks.ago, to: 20.weeks.from_now)
       params = {
         component: component,
         scope: Faker::Boolean.boolean(true_ratio: 0.5) ? global : scopes.sample,

--- a/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
+++ b/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
@@ -212,7 +212,7 @@ describe "Explore meeting directory", type: :system do
 
     context "with all meetings" do
       it "orders them by start date" do
-        visit "#{directory}?per_page=20"
+        visit directory
 
         within ".date_check_boxes_tree_filter" do
           choose "All"

--- a/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
+++ b/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
@@ -3,9 +3,7 @@
 require "spec_helper"
 
 describe "Explore meeting directory", type: :system do
-  let(:directory) do
-    Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path
-  end
+  let(:directory) { Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path }
   let(:organization) { create(:organization) }
   let(:participatory_process) { create :participatory_process, organization: organization }
   let(:components) do
@@ -22,12 +20,30 @@ describe "Explore meeting directory", type: :system do
     visit directory
   end
 
-  it "shows all the upcoming meetings" do
-    within "#meetings" do
-      expect(page).to have_css(".card--meeting", count: 6)
+  describe "with default filter" do
+    let!(:past_meeting) { create(:meeting, :published, start_time: 2.weeks.ago, component: components.first) }
+    let!(:upcoming_meeting) { create(:meeting, :published, :not_official, component: components.first) }
+
+    it "shows all the upcoming meetings" do
+      visit directory
+
+      within ".date_check_boxes_tree_filter" do
+        expect(find("input[value='upcoming']").checked?).to be(true)
+      end
+
+      within "#meetings" do
+        expect(page).to have_css(".card--meeting", count: 7)
+      end
+
+      expect(page).to have_css("#meetings-count", text: "7 MEETINGS")
+      expect(page).to have_content(translated(upcoming_meeting.title))
     end
 
-    expect(page).to have_css("#meetings-count", text: "6 MEETINGS")
+    it "doesn't show past meetings" do
+      within "#meetings" do
+        expect(page).not_to have_content(translated(past_meeting.title))
+      end
+    end
   end
 
   describe "category filter" do
@@ -143,12 +159,8 @@ describe "Explore meeting directory", type: :system do
 
   describe "type filter" do
     context "when there are only online meetings" do
-      let!(:online_meeting1) do
-        create(:meeting, :published, :online, component: components.last)
-      end
-      let!(:online_meeting2) do
-        create(:meeting, :published, :online, component: components.last)
-      end
+      let!(:online_meeting1) { create(:meeting, :published, :online, component: components.last) }
+      let!(:online_meeting2) { create(:meeting, :published, :online, component: components.last) }
 
       it "allows filtering by type 'online'" do
         within ".type_check_boxes_tree_filter" do
@@ -163,9 +175,7 @@ describe "Explore meeting directory", type: :system do
     end
 
     context "when there are only in-person meetings" do
-      let!(:in_person_meeting) do
-        create(:meeting, :published, :in_person, component: components.last)
-      end
+      let!(:in_person_meeting) { create(:meeting, :published, :in_person, component: components.last) }
 
       it "allows filtering by type 'in-person'" do
         within ".type_check_boxes_tree_filter" do
@@ -179,9 +189,7 @@ describe "Explore meeting directory", type: :system do
     end
 
     context "when there are hybrid meetings" do
-      let!(:online_meeting) do
-        create(:meeting, :published, :hybrid, component: components.last)
-      end
+      let!(:online_meeting) { create(:meeting, :published, :hybrid, component: components.last) }
 
       it "allows filtering by type 'both'" do
         within ".type_check_boxes_tree_filter" do
@@ -194,19 +202,59 @@ describe "Explore meeting directory", type: :system do
     end
   end
 
-  context "when there's a past meeting" do
-    let!(:past_meeting) do
-      create(:meeting, :published, component: components.last, start_time: 1.week.ago)
+  describe "date filter" do
+    let!(:past_meeting1) { create(:meeting, :published, component: components.last, start_time: 1.week.ago) }
+    let!(:past_meeting2) { create(:meeting, :published, component: components.last, start_time: 3.months.ago) }
+    let!(:past_meeting3) { create(:meeting, :published, component: components.last, start_time: 2.days.ago) }
+    let!(:upcoming_meeting1) { create(:meeting, :published, component: components.last, start_time: 1.week.from_now) }
+    let!(:upcoming_meeting2) { create(:meeting, :published, component: components.last, start_time: 3.months.from_now) }
+    let!(:upcoming_meeting3) { create(:meeting, :published, component: components.last, start_time: 2.days.from_now) }
+
+    context "with all meetings" do
+      it "orders them by start date" do
+        visit "#{directory}?per_page=20"
+
+        within ".date_check_boxes_tree_filter" do
+          choose "All"
+        end
+
+        expect(page).to have_css("#meetings-count", text: "12 MEETINGS")
+
+        result = page.find("#meetings .card-grid").text
+        expect(result.index(translated(past_meeting2.title))).to be < result.index(translated(past_meeting1.title))
+        expect(result.index(translated(past_meeting1.title))).to be < result.index(translated(past_meeting3.title))
+        expect(result.index(translated(past_meeting2.title))).to be < result.index(translated(upcoming_meeting1.title))
+        expect(result.index(translated(upcoming_meeting3.title))).to be < result.index(translated(upcoming_meeting1.title))
+        expect(result.index(translated(upcoming_meeting1.title))).to be < result.index(translated(upcoming_meeting2.title))
+      end
     end
 
-    it "allows filtering by past events" do
-      within ".date_check_boxes_tree_filter" do
-        uncheck "All"
-        check "Past"
-      end
+    context "with past meetings" do
+      it "orders them by start date" do
+        visit directory
 
-      expect(page).to have_content(past_meeting.title["en"])
-      expect(page).to have_css("#meetings-count", text: "1 MEETING")
+        within ".date_check_boxes_tree_filter" do
+          choose "Past"
+        end
+
+        expect(page).to have_css("#meetings-count", text: "3 MEETINGS")
+
+        result = page.find("#meetings .card-grid").text
+        expect(result.index(translated(past_meeting3.title))).to be < result.index(translated(past_meeting1.title))
+        expect(result.index(translated(past_meeting1.title))).to be < result.index(translated(past_meeting2.title))
+      end
+    end
+
+    context "with upcoming meetings" do
+      it "orders them by start date" do
+        visit directory
+
+        expect(page).to have_css("#meetings-count", text: "9 MEETINGS")
+
+        result = page.find("#meetings .card-grid").text
+        expect(result.index(translated(upcoming_meeting3.title))).to be < result.index(translated(upcoming_meeting1.title))
+        expect(result.index(translated(upcoming_meeting1.title))).to be < result.index(translated(upcoming_meeting2.title))
+      end
     end
   end
 
@@ -233,8 +281,7 @@ describe "Explore meeting directory", type: :system do
       # reset the contents to no meetings at all, and then showing only the upcoming
       # assembly meetings.
       within ".date_check_boxes_tree_filter" do
-        uncheck "All"
-        check "Past"
+        choose "Past"
       end
 
       expect(page).to have_no_css(".card--meeting")

--- a/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
+++ b/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
@@ -27,7 +27,7 @@ describe "Explore meeting directory", type: :system do
     it "shows all the upcoming meetings" do
       visit directory
 
-      within ".date_check_boxes_tree_filter" do
+      within ".date_collection_radio_buttons_filter" do
         expect(find("input[value='upcoming']").checked?).to be(true)
       end
 
@@ -214,7 +214,7 @@ describe "Explore meeting directory", type: :system do
       it "orders them by start date" do
         visit directory
 
-        within ".date_check_boxes_tree_filter" do
+        within ".date_collection_radio_buttons_filter" do
           choose "All"
         end
 
@@ -233,7 +233,7 @@ describe "Explore meeting directory", type: :system do
       it "orders them by start date" do
         visit directory
 
-        within ".date_check_boxes_tree_filter" do
+        within ".date_collection_radio_buttons_filter" do
           choose "Past"
         end
 
@@ -280,7 +280,7 @@ describe "Explore meeting directory", type: :system do
       # have_content to wait for the card list to change. This is a hack to
       # reset the contents to no meetings at all, and then showing only the upcoming
       # assembly meetings.
-      within ".date_check_boxes_tree_filter" do
+      within ".date_collection_radio_buttons_filter" do
         choose "Past"
       end
 
@@ -290,8 +290,8 @@ describe "Explore meeting directory", type: :system do
         check "Assemblies"
       end
 
-      within ".date_check_boxes_tree_filter" do
-        check "Upcoming"
+      within ".date_collection_radio_buttons_filter" do
+        choose "Upcoming"
       end
 
       expect(page).to have_content(assembly_meeting.title["en"])

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -33,7 +33,7 @@ describe "Explore meetings", :slow, type: :system do
 
       it "shows all the upcoming meetings" do
         visit_component
-        within ".date_check_boxes_tree_filter" do
+        within ".date_collection_radio_buttons_filter" do
           expect(find("input[value='upcoming']").checked?).to be(true)
         end
 
@@ -214,7 +214,7 @@ describe "Explore meetings", :slow, type: :system do
         it "lists filtered meetings" do
           visit_component
 
-          within ".date_check_boxes_tree_filter" do
+          within ".date_collection_radio_buttons_filter" do
             choose "Past"
           end
 
@@ -222,7 +222,7 @@ describe "Explore meetings", :slow, type: :system do
           expect(page).to have_content(translated(past_meeting1.title))
           expect(page).not_to have_content(translated(upcoming_meeting1.title))
 
-          within ".date_check_boxes_tree_filter" do
+          within ".date_collection_radio_buttons_filter" do
             choose "Upcoming"
           end
 
@@ -231,7 +231,7 @@ describe "Explore meetings", :slow, type: :system do
 
           expect(page).to have_css(".card--meeting", count: 8)
 
-          within ".date_check_boxes_tree_filter" do
+          within ".date_collection_radio_buttons_filter" do
             choose "All"
           end
 
@@ -243,7 +243,7 @@ describe "Explore meetings", :slow, type: :system do
         context "when there are multiple past meetings" do
           it "orders them by start date" do
             visit_component
-            within ".date_check_boxes_tree_filter" do
+            within ".date_collection_radio_buttons_filter" do
               choose "Past"
             end
 
@@ -258,7 +258,7 @@ describe "Explore meetings", :slow, type: :system do
         context "when there are multiple upcoming meetings" do
           it "orders them by start date" do
             visit_component
-            within ".date_check_boxes_tree_filter" do
+            within ".date_collection_radio_buttons_filter" do
               choose "Upcoming"
             end
 
@@ -273,7 +273,7 @@ describe "Explore meetings", :slow, type: :system do
         context "when there are multiple meetings" do
           it "orders them by start date" do
             visit_component
-            within ".date_check_boxes_tree_filter" do
+            within ".date_collection_radio_buttons_filter" do
               choose "All"
             end
 
@@ -293,7 +293,7 @@ describe "Explore meetings", :slow, type: :system do
         past_meeting = create(:meeting, :published, component: component, start_time: 1.day.ago)
         visit_component
 
-        within ".date_check_boxes_tree_filter" do
+        within ".date_collection_radio_buttons_filter" do
           choose "Past"
         end
 

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -27,6 +27,66 @@ describe "Explore meetings", :slow, type: :system do
       end
     end
 
+    context "with default filter" do
+      let!(:past_meeting) { create(:meeting, :published, start_time: 2.weeks.ago, component: component) }
+      let!(:upcoming_meeting) { create(:meeting, :published, :not_official, component: component) }
+
+      it "shows all the upcoming meetings" do
+        visit_component
+        within ".date_check_boxes_tree_filter" do
+          expect(find("input[value='upcoming']").checked?).to be(true)
+        end
+
+        within "#meetings" do
+          expect(page).to have_css(".card--meeting", count: 6)
+        end
+
+        expect(page).to have_css("#meetings-count", text: "6 MEETINGS")
+        expect(page).to have_content(translated(upcoming_meeting.title))
+      end
+
+      it "doesn't show past meetings" do
+        visit_component
+        within "#meetings" do
+          expect(page).not_to have_content(translated(past_meeting.title))
+        end
+      end
+    end
+
+    context "when checking withdrawn meetings" do
+      context "when there are no withrawn meetings" do
+        let!(:meeting) { create_list(:meeting, 3, :published, component: component) }
+
+        before do
+          visit_component
+          click_link "See all withdrawn meetings"
+        end
+
+        it "shows an empty page with a message" do
+          expect(page).to have_content("No meetings match your search criteria or there isn't any meeting scheduled.")
+          within ".callout.warning", match: :first do
+            expect(page).to have_content("You are viewing the list of meetings withdrawn by their authors.")
+          end
+        end
+      end
+
+      context "when there are withrawn meetings" do
+        let!(:withdrawn_meetings) { create_list(:meeting, 3, :withdrawn, :published, component: component) }
+
+        before do
+          visit_component
+          click_link "See all withdrawn meetings"
+        end
+
+        it "shows all the withdrawn meetings" do
+          expect(page).to have_css(".card--meeting.alert", count: 3)
+          within ".callout.warning", match: :first do
+            expect(page).to have_content("You are viewing the list of meetings withdrawn by their authors.")
+          end
+        end
+      end
+    end
+
     context "with hidden meetings" do
       let(:meeting) { meetings.last }
 
@@ -143,24 +203,123 @@ describe "Explore meetings", :slow, type: :system do
         expect(page).to have_content(translated(meetings.first.title))
       end
 
-      it "allows filtering by date" do
+      context "when filtering by date" do
+        let!(:past_meeting1) { create(:meeting, :published, component: component, start_time: 1.week.ago) }
+        let!(:past_meeting2) { create(:meeting, :published, component: component, start_time: 3.months.ago) }
+        let!(:past_meeting3) { create(:meeting, :published, component: component, start_time: 2.days.ago) }
+        let!(:upcoming_meeting1) { create(:meeting, :published, component: component, start_time: 1.week.from_now) }
+        let!(:upcoming_meeting2) { create(:meeting, :published, component: component, start_time: 3.months.from_now) }
+        let!(:upcoming_meeting3) { create(:meeting, :published, component: component, start_time: 2.days.from_now) }
+
+        it "lists filtered meetings" do
+          visit_component
+
+          within ".date_check_boxes_tree_filter" do
+            choose "Past"
+          end
+
+          expect(page).to have_css(".card--meeting", count: 3)
+          expect(page).to have_content(translated(past_meeting1.title))
+          expect(page).not_to have_content(translated(upcoming_meeting1.title))
+
+          within ".date_check_boxes_tree_filter" do
+            choose "Upcoming"
+          end
+
+          expect(page).to have_content(translated(upcoming_meeting1.title))
+          expect(page).not_to have_content(translated(past_meeting1.title))
+
+          expect(page).to have_css(".card--meeting", count: 8)
+
+          within ".date_check_boxes_tree_filter" do
+            choose "All"
+          end
+
+          expect(page).to have_css(".card--meeting", count: 8)
+          expect(page).to have_content(translated(past_meeting1.title))
+          expect(page).to have_content(translated(upcoming_meeting1.title))
+        end
+
+        context "when there are multiple past meetings" do
+          it "orders them by start date" do
+            visit_component
+            within ".date_check_boxes_tree_filter" do
+              choose "Past"
+            end
+
+            expect(page).to have_css("#meetings-count", text: "3 MEETINGS")
+
+            result = page.find("#meetings .card-grid").text
+            expect(result.index(translated(past_meeting3.title))).to be < result.index(translated(past_meeting1.title))
+            expect(result.index(translated(past_meeting1.title))).to be < result.index(translated(past_meeting2.title))
+          end
+        end
+
+        context "when there are multiple upcoming meetings" do
+          it "orders them by start date" do
+            visit_component
+            within ".date_check_boxes_tree_filter" do
+              choose "Upcoming"
+            end
+
+            expect(page).to have_css("#meetings-count", text: "8 MEETINGS")
+
+            result = page.find("#meetings .card-grid").text
+            expect(result.index(translated(upcoming_meeting3.title))).to be < result.index(translated(upcoming_meeting1.title))
+            expect(result.index(translated(upcoming_meeting1.title))).to be < result.index(translated(upcoming_meeting2.title))
+          end
+        end
+
+        context "when there are multiple meetings" do
+          it "orders them by start date" do
+            visit_component
+            within ".date_check_boxes_tree_filter" do
+              choose "All"
+            end
+
+            expect(page).to have_css("#meetings-count", text: "11 MEETINGS")
+
+            result = page.find("#meetings .card-grid").text
+            expect(result.index(translated(past_meeting2.title))).to be < result.index(translated(past_meeting1.title))
+            expect(result.index(translated(past_meeting1.title))).to be < result.index(translated(past_meeting3.title))
+            expect(result.index(translated(past_meeting2.title))).to be < result.index(translated(upcoming_meeting1.title))
+            expect(result.index(translated(upcoming_meeting3.title))).to be < result.index(translated(upcoming_meeting1.title))
+            expect(result.index(translated(upcoming_meeting1.title))).to be < result.index(translated(upcoming_meeting2.title))
+          end
+        end
+      end
+
+      it "allows linking to the filtered view using a short link" do
         past_meeting = create(:meeting, :published, component: component, start_time: 1.day.ago)
         visit_component
 
         within ".date_check_boxes_tree_filter" do
-          uncheck "All"
-          check "Past"
+          choose "Past"
         end
 
         expect(page).to have_css(".card--meeting", count: 1)
         expect(page).to have_content(translated(past_meeting.title))
 
-        within ".date_check_boxes_tree_filter" do
-          uncheck "All"
-          check "Upcoming"
+        filter_params = CGI.parse(URI.parse(page.current_url).query)
+        base_url = "http://#{organization.host}:#{Capybara.server_port}"
+
+        click_button "Export calendar"
+        expect(page).to have_content("Calendar URL:")
+        expect(page).to have_css("#calendarShare", visible: :visible)
+        short_url = nil
+        within "#calendarShare" do
+          input = find("input#urlCalendarUrl[readonly]")
+          short_url = input.value
+          expect(short_url).to match(%r{^#{base_url}/s/[a-zA-Z0-9]{10}$})
         end
 
-        expect(page).to have_css(".card--meeting", count: 5)
+        visit short_url
+        expect(page).to have_css(".card--meeting", count: 1)
+        expect(page).to have_content(translated(past_meeting.title))
+        expect(page).to have_current_path(/^#{main_component_path(component)}/)
+
+        current_params = CGI.parse(URI.parse(page.current_url).query)
+        expect(current_params).to eq(filter_params)
       end
 
       it "allows filtering by scope" do

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -301,19 +301,19 @@ describe "Explore meetings", :slow, type: :system do
         expect(page).to have_content(translated(past_meeting.title))
 
         filter_params = CGI.parse(URI.parse(page.current_url).query)
-        base_url = "http://#{organization.host}:#{Capybara.server_port}"
+        base_url = "http://#{organization.host}"
 
         click_button "Export calendar"
         expect(page).to have_content("Calendar URL:")
         expect(page).to have_css("#calendarShare", visible: :visible)
-        short_url = nil
+        share_url = nil
         within "#calendarShare" do
-          input = find("input#urlCalendarUrl[readonly]")
-          short_url = input.value
-          expect(short_url).to match(%r{^#{base_url}/s/[a-zA-Z0-9]{10}$})
+          input = find("input[readonly]")
+          share_url = input.value
+          expect(share_url).to match(%r{^#{base_url}:[0-9]+/processes/#{participatory_process.slug}/f/#{component.id}/calendar$})
         end
 
-        visit short_url
+        visit share_url
         expect(page).to have_css(".card--meeting", count: 1)
         expect(page).to have_content(translated(past_meeting.title))
         expect(page).to have_current_path(/^#{main_component_path(component)}/)

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -37,6 +37,9 @@ describe "Meeting registrations", type: :system do
       available_slots: available_slots,
       registration_terms: registration_terms
     )
+
+    # Make static map requests not to fail with HTTP 500 (causes JS error)
+    stub_request(:get, Regexp.new(Decidim.maps.fetch(:static).fetch(:url))).to_return(body: "")
   end
 
   context "when meeting registrations are not enabled" do


### PR DESCRIPTION
#### :tophat: What? Why?
Backport #9683 to v0.26

:hearts: Thank you!