### PR TITLE
Fix order of last activities

### DIFF
--- a/decidim-core/app/controllers/decidim/last_activities_controller.rb
+++ b/decidim-core/app/controllers/decidim/last_activities_controller.rb
@@ -35,6 +35,7 @@ module Decidim
       ActionLog
         .where(visibility: %w(public-only all))
         .where(organization: current_organization)
+        .order(created_at: :desc)
     end
 
     def default_filter_params

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -6,7 +6,7 @@ describe "Last activity", type: :system do
   let(:organization) { create(:organization) }
   let(:comment) { create(:comment) }
   let!(:action_log) do
-    create(:action_log, action: "create", visibility: "public-only", resource: comment, organization:)
+    create(:action_log, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: comment, organization:)
   end
   let!(:other_action_log) do
     create(:action_log, action: "publish", visibility: "all", resource:, organization:, participatory_space: component.participatory_space)
@@ -14,7 +14,7 @@ describe "Last activity", type: :system do
   let(:long_body_comment) { "This is my very long comment for Last Activity card that must be shorten up because is more than 100 chars" }
   let(:another_comment) { create(:comment, body: long_body_comment) }
   let!(:another_action_log) do
-    create(:action_log, action: "create", visibility: "public-only", resource: another_comment, organization:)
+    create(:action_log, created_at: 2.days.ago, action: "create", visibility: "public-only", resource: another_comment, organization:)
   end
   let(:component) do
     create(:component, :published, organization:)
@@ -76,6 +76,12 @@ describe "Last activity", type: :system do
         expect(page).to have_content(translated(resource.title))
         expect(page).to have_content(translated(comment.commentable.title))
         expect(page).to have_content(translated(another_comment.commentable.title))
+      end
+
+      it "shows the activities in correct order" do
+        result = page.find("#activities .row").text
+        expect(result.index(translated(resource.title))).to be < result.index(translated(comment.commentable.title))
+        expect(result.index(translated(comment.commentable.title))).to be < result.index(translated(another_comment.commentable.title))
       end
 
       it "allows filtering by type" do


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed that the last activities page is not ordering the activities correctly as it used to in 0.26 because it is missing the default order from the search query. This was broken at #8748.

#### :pushpin: Related Issues
- Related to #8748

#### Testing
- Go to `/last_activities`
- See that items are ordered correctly (newest first)