### PR TITLE
Publication date field for blog articles

### DIFF
--- a/decidim-blogs/app/commands/decidim/blogs/admin/create_post.rb
+++ b/decidim-blogs/app/commands/decidim/blogs/admin/create_post.rb
@@ -31,6 +31,7 @@ module Decidim
           attributes = {
             title: @form.title,
             body: @form.body,
+            published_at: @form.published_at,
             component: @form.current_component,
             author: @form.author
           }

--- a/decidim-blogs/app/commands/decidim/blogs/admin/update_post.rb
+++ b/decidim-blogs/app/commands/decidim/blogs/admin/update_post.rb
@@ -39,6 +39,7 @@ module Decidim
             @user,
             title: form.title,
             body: form.body,
+            published_at: @form.published_at,
             author: form.author
           )
         end

--- a/decidim-blogs/app/commands/decidim/blogs/admin/update_post.rb
+++ b/decidim-blogs/app/commands/decidim/blogs/admin/update_post.rb
@@ -37,11 +37,19 @@ module Decidim
           Decidim.traceability.update!(
             post,
             @user,
+            attributes
+          )
+        end
+
+        def attributes
+          {
             title: form.title,
             body: form.body,
             published_at: form.published_at,
             author: form.author
-          )
+          }.reject do |attribute, value|
+            value.blank? && attribute == :published_at
+          end
         end
       end
     end

--- a/decidim-blogs/app/commands/decidim/blogs/admin/update_post.rb
+++ b/decidim-blogs/app/commands/decidim/blogs/admin/update_post.rb
@@ -39,7 +39,7 @@ module Decidim
             @user,
             title: form.title,
             body: form.body,
-            published_at: @form.published_at,
+            published_at: form.published_at,
             author: form.author
           )
         end

--- a/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
@@ -13,7 +13,9 @@ module Decidim
 
       def index; end
 
-      def show; end
+      def show
+        raise ActionController::RoutingError, "Not Found" unless post
+      end
 
       private
 
@@ -26,7 +28,7 @@ module Decidim
       end
 
       def posts
-        @posts ||= Post.where(component: current_component)
+        @posts ||= Post.published.where(component: current_component)
       end
 
       # PROVISIONAL if we implement counter cache

--- a/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
@@ -20,7 +20,7 @@ module Decidim
       private
 
       def paginate_posts
-        @paginate_posts ||= paginate(posts.published.created_at_desc)
+        @paginate_posts ||= paginate(posts.created_at_desc)
       end
 
       def post
@@ -28,7 +28,11 @@ module Decidim
       end
 
       def posts
-        @posts ||= Post.published.where(component: current_component)
+        @posts ||= if current_user&.admin?
+                     Post.where(component: current_component)
+                   else
+                     Post.published.where(component: current_component)
+                   end
       end
 
       # PROVISIONAL if we implement counter cache

--- a/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
@@ -18,7 +18,7 @@ module Decidim
       private
 
       def paginate_posts
-        @paginate_posts ||= paginate(posts.created_at_desc)
+        @paginate_posts ||= paginate(posts.published.created_at_desc)
       end
 
       def post

--- a/decidim-blogs/app/forms/decidim/blogs/admin/post_form.rb
+++ b/decidim-blogs/app/forms/decidim/blogs/admin/post_form.rb
@@ -11,7 +11,7 @@ module Decidim
         translatable_attribute :body, String
 
         attribute :decidim_author_id, Integer
-        attribute :published_at
+        attribute :published_at, Decidim::Attributes::TimeWithZone
 
         validates :title, translatable_presence: true
         validates :body, translatable_presence: true

--- a/decidim-blogs/app/forms/decidim/blogs/admin/post_form.rb
+++ b/decidim-blogs/app/forms/decidim/blogs/admin/post_form.rb
@@ -11,6 +11,7 @@ module Decidim
         translatable_attribute :body, String
 
         attribute :decidim_author_id, Integer
+        attribute :published_at
 
         validates :title, translatable_presence: true
         validates :body, translatable_presence: true

--- a/decidim-blogs/app/helpers/decidim/blogs/admin/posts_helper.rb
+++ b/decidim-blogs/app/helpers/decidim/blogs/admin/posts_helper.rb
@@ -37,10 +37,8 @@ module Decidim
         def publish_data(published_at)
           data = {}
           if published_at > Time.current
-            data[:icon] = icon("clock", aria_label: "Not published yet", role: "img")
-            data[:popup] = "Not published yet"
-          else
-            data[:popup] = "Published"
+            data[:icon] = icon("clock", aria_label: t("decidim.blogs.admin.posts.index.not_published_yet"), role: "img")
+            data[:popup] = t("decidim.blogs.admin.posts.index.not_published_yet")
           end
           data
         end

--- a/decidim-blogs/app/helpers/decidim/blogs/admin/posts_helper.rb
+++ b/decidim-blogs/app/helpers/decidim/blogs/admin/posts_helper.rb
@@ -34,19 +34,15 @@ module Decidim
           form.select(name, select_options)
         end
 
-        def set_up_publicatin_time(published_at, created_at)
-          result = {}
-          result[:popup] = "Published"
-          if published_at.nil?
-            result[:status] = l created_at, format: "%d/%m/%Y - %H:%M"
+        def publish_data(published_at)
+          data = {}
+          if published_at > Time.current
+            data[:icon] = icon("clock", aria_label: "Not published yet", role: "img")
+            data[:popup] = "Not published yet"
           else
-            result[:status] = l published_at, format: "%d/%m/%Y - %H:%M"
-            if published_at >= Time.current
-              result[:icon] = icon("clock", aria_label: "Not published yet", role: "img")
-              result[:popup] = "Not published yet"
-            end
+            data[:popup] = "Published"
           end
-          result
+          data
         end
       end
     end

--- a/decidim-blogs/app/helpers/decidim/blogs/admin/posts_helper.rb
+++ b/decidim-blogs/app/helpers/decidim/blogs/admin/posts_helper.rb
@@ -33,6 +33,21 @@ module Decidim
 
           form.select(name, select_options)
         end
+
+        def set_up_publicatin_time(published_at, created_at)
+          result = {}
+          result[:popup] = "Published"
+          if published_at.nil?
+            result[:status] = l created_at, format: "%d/%m/%Y - %H:%M"
+          else
+            result[:status] = l published_at, format: "%d/%m/%Y - %H:%M"
+            if published_at >= Time.current
+              result[:icon] = icon("clock", aria_label: "Not published yet", role: "img")
+              result[:popup] = "Not published yet"
+            end
+          end
+          result
+        end
       end
     end
   end

--- a/decidim-blogs/app/models/decidim/blogs/post.rb
+++ b/decidim-blogs/app/models/decidim/blogs/post.rb
@@ -24,7 +24,10 @@ module Decidim
 
       validates :title, presence: true
 
+      after_save :set_published_at, if: -> { published_at.nil? }
+
       scope :created_at_desc, -> { order(arel_table[:created_at].desc) }
+      scope :published, -> { where("published_at <= ?", Time.current) }
 
       searchable_fields({
                           participatory_space: { component: :participatory_space },
@@ -72,6 +75,12 @@ module Decidim
 
       def attachment_context
         :admin
+      end
+
+      private
+
+      def set_published_at
+        update_attribute(:published_at, created_at) # rubocop:disable Rails/SkipsModelValidations
       end
     end
   end

--- a/decidim-blogs/app/models/decidim/blogs/post.rb
+++ b/decidim-blogs/app/models/decidim/blogs/post.rb
@@ -45,9 +45,8 @@ module Decidim
           Decidim::Blogs::AdminLog::PostPresenter
         end
       end
-
       def visible?
-        participatory_space.try(:visible?) && component.try(:published?)
+        participatory_space.try(:visible?) && component.try(:published?) && published_at <= Time.current
       end
 
       # Public: Overrides the `comments_have_alignment?` Commentable concern method.

--- a/decidim-blogs/app/models/decidim/blogs/post.rb
+++ b/decidim-blogs/app/models/decidim/blogs/post.rb
@@ -45,6 +45,7 @@ module Decidim
           Decidim::Blogs::AdminLog::PostPresenter
         end
       end
+
       def visible?
         participatory_space.try(:visible?) && component.try(:published?) && published_at <= Time.current
       end

--- a/decidim-blogs/app/models/decidim/blogs/post.rb
+++ b/decidim-blogs/app/models/decidim/blogs/post.rb
@@ -47,7 +47,11 @@ module Decidim
       end
 
       def visible?
-        participatory_space.try(:visible?) && component.try(:published?) && published_at <= Time.current
+        participatory_space.try(:visible?) && component.try(:published?) && published?
+      end
+
+      def published?
+        published_at <= Time.current
       end
 
       # Public: Overrides the `comments_have_alignment?` Commentable concern method.

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/_form.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/_form.html.erb
@@ -14,5 +14,10 @@
     <div class="row column">
       <%= form.translated :editor, :body, toolbar: :full, lines: 30, label: t("models.components.body", scope: "decidim.blogs.admin") %>
     </div>
+    <div class="row">
+      <div class="columns xlarge-6">
+        <%= form.datetime_field :published_at %>
+      </div>
+    </div>
   </div>
 </div>

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
@@ -33,14 +33,14 @@
                 <%= post.try(:author).try(:name) %>
               </td>
               <td>
-                <%= l post.created_at, format: "%d/%m/%Y - %H:%M" %>
+                <%= l post.created_at, format: :decidim_short %>
               </td>
-              <% publish_data = set_up_publicatin_time(post.published_at, post.created_at) %>
+              <% publish_data = publish_data(post.published_at) %>
               <td class="table-list__actions">
                 <%= content_tag :span, class: "padding-3", data: { tooltip: true, disable_hover: false, click_open: false }, title: publish_data[:popup] do
-                      publish_data[:icon]
-                    end %>
-                <%= publish_data[:status] %>
+                  publish_data[:icon]
+                end %>
+                <%= l post.published_at, format: :decidim_short %>
               </td>
               <td class="table-list__actions">
                 <% if allowed_to? :update, :blogpost, blog_post: post %>

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
@@ -35,12 +35,12 @@
               <td>
                 <%= l post.created_at, format: "%d/%m/%Y - %H:%M" %>
               </td>
-              <td>
-              <% if post.published_at %>
-                <%= l post.published_at, format: "%d/%m/%Y - %H:%M" %>
-              <% else %>
-                <%= "---" %>
-              <% end %>
+              <% publish_data = set_up_publicatin_time(post.published_at, post.created_at) %>
+              <td class="table-list__actions">
+                <%= content_tag :span, class: "padding-3", data: { tooltip: true, disable_hover: false, click_open: false }, title: publish_data[:popup] do
+                      publish_data[:icon]
+                    end %>
+                <%= publish_data[:status] %>
               </td>
               <td class="table-list__actions">
                 <% if allowed_to? :update, :blogpost, blog_post: post %>

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
@@ -15,6 +15,7 @@
             <th><%= t("models.post.fields.body", scope: "decidim.blogs") %></th>
             <th><%= t("models.post.fields.author", scope: "decidim.blogs") %></th>
             <th><%= t("models.post.fields.created_at", scope: "decidim.blogs") %></th>
+            <th><%= t("models.post.fields.published_at", scope: "decidim.blogs") %></th>
             <th class="actions"><%= t("actions.title", scope: "decidim.blogs") %></th>
           </tr>
         </thead>
@@ -33,6 +34,13 @@
               </td>
               <td>
                 <%= l post.created_at, format: "%d/%m/%Y - %H:%M" %>
+              </td>
+              <td>
+              <% if post.published_at %>
+                <%= l post.published_at, format: "%d/%m/%Y - %H:%M" %>
+              <% else %>
+                <%= "---" %>
+              <% end %>
               </td>
               <td class="table-list__actions">
                 <% if allowed_to? :update, :blogpost, blog_post: post %>

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
@@ -14,7 +14,6 @@
             <th><%= t("models.post.fields.title", scope: "decidim.blogs") %></th>
             <th><%= t("models.post.fields.body", scope: "decidim.blogs") %></th>
             <th><%= t("models.post.fields.author", scope: "decidim.blogs") %></th>
-            <th><%= t("models.post.fields.created_at", scope: "decidim.blogs") %></th>
             <th><%= t("models.post.fields.published_at", scope: "decidim.blogs") %></th>
             <th class="actions"><%= t("actions.title", scope: "decidim.blogs") %></th>
           </tr>
@@ -31,9 +30,6 @@
               </td>
               <td>
                 <%= post.try(:author).try(:name) %>
-              </td>
-              <td>
-                <%= l post.created_at, format: :decidim_short %>
               </td>
               <% publish_data = publish_data(post.published_at) %>
               <td class="table-list__actions">

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -56,7 +56,6 @@ en:
           fields:
             author: Author
             body: Body
-            created_at: Created at
             official_blog_post: Official post
             published_at: Publish time
             title: title

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
   activemodel:
     attributes:
       post:
-        published_at: "Publish time"
+        published_at: Publish time
     models:
       decidim/blogs/create_post_event: New blog post
   activerecord:

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
             body: Body
             created_at: Created at
             official_blog_post: Official post
+            published_at: Publish time
             title: title
       posts:
         show:

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -1,6 +1,9 @@
 ---
 en:
   activemodel:
+    attributes:
+      post:
+        published_at: "Publish time"
     models:
       decidim/blogs/create_post_event: New blog post
   activerecord:

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
             save: Update
             title: Edit post
           index:
+            not_published_yet: Not published yet
             title: Posts
           new:
             create: Create

--- a/decidim-blogs/db/migrate/20220812122940_add_published_at_to_decidim_blogs_posts.rb
+++ b/decidim-blogs/db/migrate/20220812122940_add_published_at_to_decidim_blogs_posts.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToDecidimBlogsPosts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :decidim_blogs_posts, :published_at, :datetime
+  end
+end

--- a/decidim-blogs/db/migrate/20220812122940_add_published_at_to_decidim_blogs_posts.rb
+++ b/decidim-blogs/db/migrate/20220812122940_add_published_at_to_decidim_blogs_posts.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 
 class AddPublishedAtToDecidimBlogsPosts < ActiveRecord::Migration[6.1]
+  class Post < ApplicationRecord
+    self.table_name = :decidim_blogs_posts
+  end
+
   def change
     add_column :decidim_blogs_posts, :published_at, :datetime
+
+    reversible do |direction|
+      direction.up do
+        Post.update_all("published_at = created_at") # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
   end
 end

--- a/decidim-blogs/db/migrate/20220812122940_add_published_at_to_decidim_blogs_posts.rb
+++ b/decidim-blogs/db/migrate/20220812122940_add_published_at_to_decidim_blogs_posts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPublishedAtToDecidimBlogsPosts < ActiveRecord::Migration[6.1]
   def change
     add_column :decidim_blogs_posts, :published_at, :datetime

--- a/decidim-blogs/lib/decidim/api/blogs_type.rb
+++ b/decidim-blogs/lib/decidim/api/blogs_type.rb
@@ -27,7 +27,15 @@ module Decidim
       end
 
       def post(id:)
-        posts.find_by(id:)
+        # posts.find_by(id:)
+        scope =
+          if context[:current_user]&.admin?
+            Post
+          else
+            Post.published
+          end
+
+        Decidim::Core::ComponentFinderBase.new(model_class: scope).call(object, { id: }, context)
       end
     end
   end

--- a/decidim-blogs/lib/decidim/api/blogs_type.rb
+++ b/decidim-blogs/lib/decidim/api/blogs_type.rb
@@ -18,7 +18,7 @@ module Decidim
       end
 
       def posts(filter: {}, order: {})
-        Decidim::Core::ComponentListBase.new(model_class: Post).call(object, { filter:, order: }, context)
+        Decidim::Core::ComponentListBase.new(model_class: Post).call(object, { filter:, order: }, context).published
       end
 
       def post(id:)

--- a/decidim-blogs/lib/decidim/api/blogs_type.rb
+++ b/decidim-blogs/lib/decidim/api/blogs_type.rb
@@ -27,7 +27,6 @@ module Decidim
       end
 
       def post(id:)
-        # posts.find_by(id:)
         scope =
           if context[:current_user]&.admin?
             Post

--- a/decidim-blogs/lib/decidim/api/blogs_type.rb
+++ b/decidim-blogs/lib/decidim/api/blogs_type.rb
@@ -18,11 +18,16 @@ module Decidim
       end
 
       def posts(filter: {}, order: {})
-        Decidim::Core::ComponentListBase.new(model_class: Post).call(object, { filter:, order: }, context).published
+        base_query = Decidim::Core::ComponentListBase.new(model_class: Post).call(object, { filter:, order: }, context)
+        if context[:current_user]&.admin?
+          base_query
+        else
+          base_query.published
+        end
       end
 
       def post(id:)
-        Decidim::Core::ComponentFinderBase.new(model_class: Post).call(object, { id: }, context)
+        posts.find_by(id:)
       end
     end
   end

--- a/decidim-blogs/lib/decidim/api/post_type.rb
+++ b/decidim-blogs/lib/decidim/api/post_type.rb
@@ -16,6 +16,7 @@ module Decidim
       field :id, GraphQL::Types::ID, "The internal ID of this post", null: false
       field :title, Decidim::Core::TranslatedFieldType, "The title for this post", null: true
       field :body, Decidim::Core::TranslatedFieldType, "The body of this post", null: true
+      field :published_at, Decidim::Core::DateTimeType, "The time this page was published", null: false
     end
   end
 end

--- a/decidim-blogs/spec/commands/decidim/blogs/admin/create_post_spec.rb
+++ b/decidim-blogs/spec/commands/decidim/blogs/admin/create_post_spec.rb
@@ -41,7 +41,7 @@ module Decidim
 
           it "creates the post" do
             expect { subject.call }.to change(Post, :count).by(1)
-            expect(post.published_at).to be_nil
+            expect(post.published_at).to eq(post.created_at)
           end
 
           it "creates a searchable resource" do

--- a/decidim-blogs/spec/commands/decidim/blogs/admin/create_post_spec.rb
+++ b/decidim-blogs/spec/commands/decidim/blogs/admin/create_post_spec.rb
@@ -14,6 +14,7 @@ module Decidim
         let(:current_user) { create :user, organization: }
         let(:title) { "Post title" }
         let(:body) { "Lorem Ipsum dolor sit amet" }
+        let(:publish_time) { nil }
 
         let(:invalid) { false }
         let(:form) do
@@ -21,6 +22,7 @@ module Decidim
             invalid?: invalid,
             title: { en: title },
             body: { en: body },
+            published_at: publish_time,
             current_component:,
             author: current_user
           )
@@ -39,6 +41,7 @@ module Decidim
 
           it "creates the post" do
             expect { subject.call }.to change(Post, :count).by(1)
+            expect(post.published_at).to be_nil
           end
 
           it "creates a searchable resource" do
@@ -67,6 +70,15 @@ module Decidim
 
           it "broadcasts ok" do
             expect { subject.call }.to broadcast(:ok)
+          end
+
+          context "when publish time is provided" do
+            let!(:publish_time) { Time.new(2022, 11, 12, 8, 37, 48, "-06:00") }
+
+            it "sets the publish time" do
+              subject.call
+              expect(post.published_at).to eq(publish_time)
+            end
           end
 
           it "sends a notification to the participatory space followers" do
@@ -104,6 +116,7 @@ module Decidim
               double(
                 invalid?: invalid,
                 title: { en: title },
+                published_at: publish_time,
                 body: { en: body },
                 current_component:,
                 author: group

--- a/decidim-blogs/spec/commands/decidim/blogs/admin/update_post_spec.rb
+++ b/decidim-blogs/spec/commands/decidim/blogs/admin/update_post_spec.rb
@@ -16,11 +16,13 @@ module Decidim
         let(:body) { "Lorem Ipsum dolor sit amet" }
         let(:post) { create(:post, component: current_component, author: current_user) }
         let(:invalid) { false }
+        let(:publish_time) { nil }
         let(:form) do
           double(
             invalid?: invalid,
             title: { en: title },
             body: { en: body },
+            published_at: publish_time,
             current_component:,
             author: current_user
           )
@@ -53,6 +55,15 @@ module Decidim
             expect(translated(post.body)).to eq body
           end
 
+          context "when updating publish time" do
+            let!(:publish_time) { Time.new(2022, 11, 19, 8, 37, 48, "-06:00") }
+
+            it "updates the published_at" do
+              subject.call
+              expect(post.published_at).to eq(publish_time)
+            end
+          end
+
           it "broadcasts ok" do
             expect { subject.call }.to broadcast(:ok)
           end
@@ -67,6 +78,7 @@ module Decidim
               .with(post, current_user, {
                       title: { en: title },
                       body: { en: body },
+                      published_at: publish_time,
                       author: current_user
                     })
               .and_call_original
@@ -85,6 +97,7 @@ module Decidim
                 invalid?: invalid,
                 title: { en: title },
                 body: { en: body },
+                published_at: publish_time,
                 current_component:,
                 author: group
               )

--- a/decidim-blogs/spec/commands/decidim/blogs/admin/update_post_spec.rb
+++ b/decidim-blogs/spec/commands/decidim/blogs/admin/update_post_spec.rb
@@ -16,7 +16,7 @@ module Decidim
         let(:body) { "Lorem Ipsum dolor sit amet" }
         let(:post) { create(:post, component: current_component, author: current_user) }
         let(:invalid) { false }
-        let(:publish_time) { nil }
+        let(:publish_time) { 2.days.ago }
         let(:form) do
           double(
             invalid?: invalid,

--- a/decidim-blogs/spec/controllers/decidim/blogs/posts_controller_spec.rb
+++ b/decidim-blogs/spec/controllers/decidim/blogs/posts_controller_spec.rb
@@ -13,6 +13,7 @@ module Decidim
           let!(:post_component) { create(:post_component, participatory_space: participatory_process) }
           let!(:unpublished) { create(:post, component: post_component, created_at: 2.days.ago, published_at: 2.days.from_now) }
           let!(:published) { create(:post, component: post_component, created_at: 2.days.ago, published_at: 2.days.ago) }
+          let!(:current_user) { create(:user, :admin, :confirmed, organization:) }
 
           before do
             request.env["decidim.current_organization"] = organization
@@ -20,14 +21,40 @@ module Decidim
             request.env["decidim.current_participatory_space"] = participatory_process
           end
 
-          it "throws exception on non published page" do
-            expect { get :show, params: { id: unpublished.id } }
-              .to raise_error(ActiveRecord::RecordNotFound)
-          end
-
-          it "does notthrow exception on published page" do
+          it "shows published posts" do
             get :show, params: { id: published.id }
             expect(response).to have_http_status(:ok)
+          end
+
+          context "when not logged in" do
+            it "throws exception on non published page" do
+              expect { get :show, params: { id: unpublished.id } }
+                .to raise_error(ActiveRecord::RecordNotFound)
+            end
+          end
+
+          context "when non-admin user" do
+            before do
+              current_user.admin = false
+              current_user.save!
+              sign_in current_user
+            end
+
+            it "throws exception on non published page" do
+              expect { get :show, params: { id: unpublished.id } }
+                .to raise_error(ActiveRecord::RecordNotFound)
+            end
+          end
+
+          context "when admin user" do
+            before do
+              sign_in current_user
+            end
+
+            it "does not throw exception on unpublished page" do
+              get :show, params: { id: unpublished.id }
+              expect(response).to have_http_status(:ok)
+            end
           end
         end
       end

--- a/decidim-blogs/spec/controllers/decidim/blogs/posts_controller_spec.rb
+++ b/decidim-blogs/spec/controllers/decidim/blogs/posts_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Blogs
+    describe PostsController, type: :controller do
+      routes { Decidim::Blogs::Engine.routes }
+      describe "show" do
+        context "when the post has not published yet" do
+          let(:organization) { create :organization }
+          let(:participatory_process) { create :participatory_process, organization: }
+          let!(:post_component) { create(:post_component, participatory_space: participatory_process) }
+          let!(:unpublished) { create(:post, component: post_component, created_at: 2.days.ago, published_at: 2.days.from_now) }
+          let!(:published) { create(:post, component: post_component, created_at: 2.days.ago, published_at: 2.days.ago) }
+
+          before do
+            request.env["decidim.current_organization"] = organization
+            request.env["decidim.current_component"] = post_component
+            request.env["decidim.current_participatory_space"] = participatory_process
+          end
+
+          it "throws exception on non published page" do
+            expect { get :show, params: { id: unpublished.id } }
+              .to raise_error(ActiveRecord::RecordNotFound)
+          end
+
+          it "does notthrow exception on published page" do
+            get :show, params: { id: published.id }
+            expect(response).to have_http_status(:ok)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-blogs/spec/forms/decidim/blogs/admin/post_form_spec.rb
+++ b/decidim-blogs/spec/forms/decidim/blogs/admin/post_form_spec.rb
@@ -19,7 +19,8 @@ module Decidim
         let(:user_group) { create(:user_group, :verified, organization: current_organization) }
         let(:decidim_author_id) { "" }
         let(:component) { create(:post_component, organization: current_organization) }
-        let(:post) { create(:post, component:, author:) }
+        let(:post) { create(:post, component:, author:, published_at:) }
+        let(:published_at) { nil }
         let(:user_from_another_org) { create(:user) }
         let(:post_id) { nil }
 
@@ -45,7 +46,8 @@ module Decidim
               "title" => title,
               "body" => body,
               "decidim_author_id" => decidim_author_id,
-              "id" => post_id
+              "id" => post_id,
+              "published_at" => published_at
             }
           }
         end

--- a/decidim-blogs/spec/helpers/decidim/blogs/admin/post_helper_spec.rb
+++ b/decidim-blogs/spec/helpers/decidim/blogs/admin/post_helper_spec.rb
@@ -4,6 +4,8 @@ require "spec_helper"
 
 module Decidim::Blogs::Admin
   describe PostsHelper, type: :helper do
+    include Decidim::DisabledRedesignLayout
+
     describe "#post_author_select_field" do
       let(:organization) { create :organization }
       let(:user) { create :user, :admin, :confirmed, organization: }
@@ -111,6 +113,32 @@ module Decidim::Blogs::Admin
 
         it "Returns all types of authors" do
           expect(helper.post_author_select_field(form, name)).to eq(extra_group_fields)
+        end
+      end
+    end
+
+    describe "#publish_data" do
+      let!(:created_at) { 3.days.ago }
+      let(:formatted_created_time) { l(created_at, format: :decidim_short) }
+
+      context "when published_at is reached" do
+        let(:published_at) { 2.days.ago }
+        let(:formatted_published_time) { l(published_at, format: :decidim_short) }
+
+        it "shows correct publishing info" do
+          action = helper.publish_data(published_at)
+          expect(action[:popup]).to eq("Published")
+        end
+      end
+
+      context "when publish in future" do
+        let(:published_at) { 2.days.from_now }
+        let(:formatted_published_time) { l(published_at, format: :decidim_short) }
+
+        it "shows correct publishing info" do
+          action = helper.publish_data(published_at)
+          expect(action[:popup]).to eq("Not published yet")
+          expect(action[:icon]).to include("svg")
         end
       end
     end

--- a/decidim-blogs/spec/helpers/decidim/blogs/admin/post_helper_spec.rb
+++ b/decidim-blogs/spec/helpers/decidim/blogs/admin/post_helper_spec.rb
@@ -127,7 +127,7 @@ module Decidim::Blogs::Admin
 
         it "shows correct publishing info" do
           action = helper.publish_data(published_at)
-          expect(action[:popup]).to eq("Published")
+          expect(action[:popup]).to be_nil
         end
       end
 

--- a/decidim-blogs/spec/helpers/decidim/blogs/admin/post_helper_spec.rb
+++ b/decidim-blogs/spec/helpers/decidim/blogs/admin/post_helper_spec.rb
@@ -119,11 +119,11 @@ module Decidim::Blogs::Admin
 
     describe "#publish_data" do
       let!(:created_at) { 3.days.ago }
-      let(:formatted_created_time) { l(created_at, format: :decidim_short) }
+      let(:formatted_created_time) { created_at.strftime("%d/%m/%Y %H:%M") }
 
       context "when published_at is reached" do
         let(:published_at) { 2.days.ago }
-        let(:formatted_published_time) { l(published_at, format: :decidim_short) }
+        let(:formatted_published_time) { published_at.strftime("%d/%m/%Y %H:%M") }
 
         it "shows correct publishing info" do
           action = helper.publish_data(published_at)
@@ -133,7 +133,7 @@ module Decidim::Blogs::Admin
 
       context "when publish in future" do
         let(:published_at) { 2.days.from_now }
-        let(:formatted_published_time) { l(published_at, format: :decidim_short) }
+        let(:formatted_published_time) { published_at.stftime("%d/%m/%Y %H:%M") }
 
         it "shows correct publishing info" do
           action = helper.publish_data(published_at)

--- a/decidim-blogs/spec/models/decidim/blogs/post_spec.rb
+++ b/decidim-blogs/spec/models/decidim/blogs/post_spec.rb
@@ -10,7 +10,8 @@ module Decidim::Blogs
     let(:current_user) { create(:user, :confirmed, organization: current_organization) }
     let(:participatory_process) { create :participatory_process, organization: current_organization }
     let(:current_component) { create :component, participatory_space: participatory_process, manifest_name: "blogs" }
-    let(:post) { create(:post, component: current_component, author: current_user) }
+    let(:post) { create(:post, component: current_component, author: current_user, published_at:) }
+    let(:published_at) { nil }
 
     include_examples "endorsable"
     include_examples "has component"

--- a/decidim-blogs/spec/shared/manage_posts_examples.rb
+++ b/decidim-blogs/spec/shared/manage_posts_examples.rb
@@ -254,5 +254,17 @@ shared_examples "manage posts" do
         expect(page).to have_content(author.name)
       end
     end
+
+    it "changes the publish time" do
+      within find("tr", text: translated(post1.title)) do
+        click_link "Edit"
+      end
+      within ".edit_post" do
+        fill_in "Publish time", with: "01/01/2022 00:00"
+        find("*[type=submit]").click
+      end
+      expect(page).to have_admin_callout("successfully")
+      expect(page).to have_content("01/01/2022 00:00")
+    end
   end
 end

--- a/decidim-blogs/spec/system/admin_manages_posts_spec.rb
+++ b/decidim-blogs/spec/system/admin_manages_posts_spec.rb
@@ -27,12 +27,11 @@ describe "Admin manages posts", type: :system do
   it "sets publish time correctly" do
     within "table" do
       within find("tr", text: translated(post1.title)) do
-        expect(find("td:nth-child(5)")).to have_content(two_days_ago)
-        expect(find("td:nth-child(4)")).to have_content(two_days_ago)
+        expect(page).to have_content(two_days_ago)
       end
       within find("tr", text: translated(post2.title)) do
-        expect(find("td:nth-child(5)")).to have_content(two_days_from_now)
-        expect(find("td:nth-child(5) svg")[:class]).to have_content("icon--clock icon")
+        expect(page).to have_content(two_days_from_now)
+        expect(find("td:nth-child(4) svg")[:class]).to have_content("icon--clock icon")
       end
     end
   end

--- a/decidim-blogs/spec/system/admin_manages_posts_spec.rb
+++ b/decidim-blogs/spec/system/admin_manages_posts_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 
 describe "Admin manages posts", type: :system do
   let(:manifest_name) { "blogs" }
-  let(:two_days_ago) { l(2.days.ago, format: :decidim_short) }
-  let(:two_days_from_now) { l(2.days.from_now, format: :decidim_short) }
+  let(:two_days_ago) { 2.days.ago.strftime("%d/%m/%Y %H:%M") }
+  let(:two_days_from_now) { 2.days.from_now.strftime("%d/%m/%Y %H:%M") }
   let!(:post1) { create :post, component: current_component, author:, title: { en: "Post title 1" }, created_at: two_days_ago }
   let!(:post2) { create :post, component: current_component, title: { en: "Post title 2" }, published_at: two_days_from_now }
   let(:author) { create :user, organization: }

--- a/decidim-blogs/spec/system/admin_manages_posts_spec.rb
+++ b/decidim-blogs/spec/system/admin_manages_posts_spec.rb
@@ -6,7 +6,7 @@ describe "Admin manages posts", type: :system do
   let(:manifest_name) { "blogs" }
   let(:two_days_ago) { 2.days.ago.strftime("%d/%m/%Y %H:%M") }
   let(:two_days_from_now) { 2.days.from_now.strftime("%d/%m/%Y %H:%M") }
-  let!(:post1) { create :post, component: current_component, author:, title: { en: "Post title 1" }, created_at: two_days_ago, published_at: two_days_ago}
+  let!(:post1) { create :post, component: current_component, author:, title: { en: "Post title 1" }, created_at: two_days_ago, published_at: two_days_ago }
   let!(:post2) { create :post, component: current_component, title: { en: "Post title 2" }, published_at: two_days_from_now }
   let(:author) { create :user, organization: }
 

--- a/decidim-blogs/spec/system/admin_manages_posts_spec.rb
+++ b/decidim-blogs/spec/system/admin_manages_posts_spec.rb
@@ -6,7 +6,7 @@ describe "Admin manages posts", type: :system do
   let(:manifest_name) { "blogs" }
   let(:two_days_ago) { 2.days.ago.strftime("%d/%m/%Y %H:%M") }
   let(:two_days_from_now) { 2.days.from_now.strftime("%d/%m/%Y %H:%M") }
-  let!(:post1) { create :post, component: current_component, author:, title: { en: "Post title 1" }, created_at: two_days_ago }
+  let!(:post1) { create :post, component: current_component, author:, title: { en: "Post title 1" }, created_at: two_days_ago, published_at: two_days_ago}
   let!(:post2) { create :post, component: current_component, title: { en: "Post title 2" }, published_at: two_days_from_now }
   let(:author) { create :user, organization: }
 

--- a/decidim-blogs/spec/system/admin_manages_posts_spec.rb
+++ b/decidim-blogs/spec/system/admin_manages_posts_spec.rb
@@ -4,8 +4,10 @@ require "spec_helper"
 
 describe "Admin manages posts", type: :system do
   let(:manifest_name) { "blogs" }
-  let!(:post1) { create :post, component: current_component, author:, title: { en: "Post title 1" } }
-  let!(:post2) { create :post, component: current_component, title: { en: "Post title 2" } }
+  let(:two_days_ago) { l(2.days.ago, format: :decidim_short) }
+  let(:two_days_from_now) { l(2.days.from_now, format: :decidim_short) }
+  let!(:post1) { create :post, component: current_component, author:, title: { en: "Post title 1" }, created_at: two_days_ago }
+  let!(:post2) { create :post, component: current_component, title: { en: "Post title 2" }, published_at: two_days_from_now }
   let(:author) { create :user, organization: }
 
   include_context "when managing a component as an admin"
@@ -20,5 +22,18 @@ describe "Admin manages posts", type: :system do
     let(:author) { create :user, organization: }
 
     it_behaves_like "manage posts"
+  end
+
+  it "sets publish time correctly" do
+    within "table" do
+      within find("tr", text: translated(post1.title)) do
+        expect(find("td:nth-child(5)")).to have_content(two_days_ago)
+        expect(find("td:nth-child(4)")).to have_content(two_days_ago)
+      end
+      within find("tr", text: translated(post2.title)) do
+        expect(find("td:nth-child(5)")).to have_content(two_days_from_now)
+        expect(find("td:nth-child(5) svg")[:class]).to have_content("icon--clock icon")
+      end
+    end
   end
 end

--- a/decidim-blogs/spec/system/explore_posts_spec.rb
+++ b/decidim-blogs/spec/system/explore_posts_spec.rb
@@ -50,6 +50,18 @@ describe "Explore posts", type: :system do
         expect(page).to have_css("[data-pages] [data-page]", count: 2)
       end
     end
+
+    context "with some unpublished posts" do
+      let!(:unpublishedpost) { create(:post, component:, published_at: 2.days.from_now) }
+      let!(:resource_selector) { "div[data-post]" }
+
+      before { visit_component }
+
+      it "shows only published blogs" do
+        expect(Decidim::Blogs::Post.count).to eq(3)
+        expect(page).to have_css(resource_selector, count: 2)
+      end
+    end
   end
 
   describe "show" do

--- a/decidim-blogs/spec/system/explore_posts_spec.rb
+++ b/decidim-blogs/spec/system/explore_posts_spec.rb
@@ -61,14 +61,6 @@ describe "Explore posts", type: :system do
         expect(Decidim::Blogs::Post.count).to eq(3)
         expect(page).to have_css(resource_selector, count: 2)
       end
-
-      # context "when trying to browse into unpublished post" do
-      #   it "renders 404 error" do
-      #     expect do
-      #       visit resource_locator(unpublished).path
-      #     end.to raise_error(ActiveRecord::RecordNotFound)
-      #   end
-      # end
     end
   end
 

--- a/decidim-blogs/spec/system/explore_posts_spec.rb
+++ b/decidim-blogs/spec/system/explore_posts_spec.rb
@@ -52,7 +52,7 @@ describe "Explore posts", type: :system do
     end
 
     context "with some unpublished posts" do
-      let!(:unpublishedpost) { create(:post, component:, published_at: 2.days.from_now) }
+      let!(:unpublished) { create(:post, component:, published_at: 2.days.from_now) }
       let!(:resource_selector) { "div[data-post]" }
 
       before { visit_component }
@@ -61,6 +61,14 @@ describe "Explore posts", type: :system do
         expect(Decidim::Blogs::Post.count).to eq(3)
         expect(page).to have_css(resource_selector, count: 2)
       end
+
+      # context "when trying to browse into unpublished post" do
+      #   it "renders 404 error" do
+      #     expect do
+      #       visit resource_locator(unpublished).path
+      #     end.to raise_error(ActiveRecord::RecordNotFound)
+      #   end
+      # end
     end
   end
 

--- a/decidim-blogs/spec/types/integration_schema_spec.rb
+++ b/decidim-blogs/spec/types/integration_schema_spec.rb
@@ -225,12 +225,27 @@ describe "Decidim::Api::QueryType" do
         let!(:third_post) { create(:post, created_at: 2.weeks.ago, updated_at: 1.week.ago, component: current_component, published_at: 2.weeks.from_now) }
         let(:criteria) { "order: { id: \"asc\" }" }
 
-        it {
-          expect(edges).to eq([
-                                { "node" => { "id" => post.id.to_s } },
-                                { "node" => { "id" => other_post.id.to_s } }
-                              ])
-        }
+        context "when not admin" do
+          it {
+            expect(edges).to eq([
+                                  { "node" => { "id" => post.id.to_s } },
+                                  { "node" => { "id" => other_post.id.to_s } }
+                                ])
+          }
+        end
+
+        context "with admin user" do
+          let!(:current_user) { create(:user, :admin, :confirmed, organization:) }
+          let(:organization) { create :organization }
+
+          it {
+            expect(edges).to eq([
+                                  { "node" => { "id" => post.id.to_s } },
+                                  { "node" => { "id" => other_post.id.to_s } },
+                                  { "node" => { "id" => third_post.id.to_s } }
+                                ])
+          }
+        end
       end
     end
   end

--- a/decidim-blogs/spec/types/integration_schema_spec.rb
+++ b/decidim-blogs/spec/types/integration_schema_spec.rb
@@ -8,7 +8,7 @@ describe "Decidim::Api::QueryType" do
   include_context "with a graphql decidim component"
   let(:component_type) { "Blogs" }
   let!(:current_component) { create(:post_component, participatory_space: participatory_process) }
-  let!(:post) { create(:post, :with_endorsements, component: current_component) }
+  let!(:post) { create(:post, :with_endorsements, component: current_component, published_at: 2.days.ago) }
 
   let(:post_single_result) do
     {
@@ -157,7 +157,7 @@ describe "Decidim::Api::QueryType" do
         )
       end
 
-      let!(:other_post) { create(:post, created_at: 2.weeks.ago, updated_at: 1.week.ago, component: current_component) }
+      let!(:other_post) { create(:post, created_at: 2.weeks.ago, updated_at: 1.week.ago, component: current_component, published_at: 2.weeks.from_now) }
       let(:edges) { response["participatoryProcess"]["components"].first["posts"]["edges"] }
 
       context "when ordered by" do

--- a/decidim-blogs/spec/types/integration_schema_spec.rb
+++ b/decidim-blogs/spec/types/integration_schema_spec.rb
@@ -157,7 +157,7 @@ describe "Decidim::Api::QueryType" do
         )
       end
 
-      let!(:other_post) { create(:post, created_at: 2.weeks.ago, updated_at: 1.week.ago, component: current_component, published_at: 2.weeks.from_now) }
+      let!(:other_post) { create(:post, created_at: 2.weeks.ago, updated_at: 1.week.ago, component: current_component, published_at: 2.weeks.ago) }
       let(:edges) { response["participatoryProcess"]["components"].first["posts"]["edges"] }
 
       context "when ordered by" do
@@ -219,6 +219,18 @@ describe "Decidim::Api::QueryType" do
 
           it { expect(edges).to eq([{ "node" => { "id" => other_post.id.to_s } }]) }
         end
+      end
+
+      context "with unpublished" do
+        let!(:third_post) { create(:post, created_at: 2.weeks.ago, updated_at: 1.week.ago, component: current_component, published_at: 2.weeks.from_now) }
+        let(:criteria) { "order: { id: \"asc\" }" }
+
+        it {
+          expect(edges).to eq([
+                                { "node" => { "id" => post.id.to_s } },
+                                { "node" => { "id" => other_post.id.to_s } }
+                              ])
+        }
       end
     end
   end

--- a/decidim-core/app/cells/decidim/redesigned_author_cell.rb
+++ b/decidim-core/app/cells/decidim/redesigned_author_cell.rb
@@ -119,6 +119,7 @@ module Decidim
 
     def creation_date
       date_at = from_context.try(:published_at) || from_context.try(:created_at)
+
       l date_at, format: :decidim_short
     end
 

--- a/decidim-core/app/cells/decidim/redesigned_author_cell.rb
+++ b/decidim-core/app/cells/decidim/redesigned_author_cell.rb
@@ -118,13 +118,7 @@ module Decidim
     end
 
     def creation_date
-      date_at = if from_context.respond_to?(:published_at) &&
-                   from_context.published_at &&
-                   Time.current >= from_context.published_at
-                  from_context.published_at
-                else
-                  from_context.try(:created_at)
-                end
+      date_at = from_context.try(:published_at) || from_context.try(:created_at)
       l date_at, format: :decidim_short
     end
 

--- a/decidim-core/app/cells/decidim/redesigned_author_cell.rb
+++ b/decidim-core/app/cells/decidim/redesigned_author_cell.rb
@@ -118,8 +118,11 @@ module Decidim
     end
 
     def creation_date
-      date_at = from_context.try(:published_at) || from_context.try(:created_at)
-
+      date_at = if from_context.respond_to(:published_at) && Time.current >= from_context.published_at
+                  from_context.published_at
+                else
+                  from_context.try(:created_at)
+                end
       l date_at, format: :decidim_short
     end
 

--- a/decidim-core/app/cells/decidim/redesigned_author_cell.rb
+++ b/decidim-core/app/cells/decidim/redesigned_author_cell.rb
@@ -118,7 +118,9 @@ module Decidim
     end
 
     def creation_date
-      date_at = if from_context.respond_to(:published_at) && Time.current >= from_context.published_at
+      date_at = if from_context.respond_to?(:published_at) &&
+                   from_context.published_at &&
+                   Time.current >= from_context.published_at
                   from_context.published_at
                 else
                   from_context.try(:created_at)


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
The blog articles currently do not allow setting a separate publication date for the articles. Many times in real life situations, the publication date can differ from the date when the article was posted on the website.

#### :pushpin: Related Issues
The issue was discussed in[ meta decidim](https://meta.decidim.org/processes/roadmap/f/122/proposals/16932)

#### Testing
No prerequisite needed to run the test. Just run the test as you would normally do.

### :camera: Screenshots
After adding this feature, a drop-down calendar will be added to new/update post, and user will be able to select a publication date, or leave it blank:
![image](https://user-images.githubusercontent.com/104360479/185409654-c650a961-4b21-4e02-929b-cfb3f882eafc.png)
If the user leaves this section blank, the blog will be displayed in the participant area as soon as the blog was created(in other words, creation and publication time will be the same), but if he/ she sets a date and time in the future, the blog will be shown only after the time has reached.
In admin section, a column was added (namely "publish time") to show the date and time of the publication of an article (highlighted with "1" in the following image);  if the article has not published yet, a clock will be shown at the beginning of the publication time, indicating that the blog component is not published yet ("highlighted with 2").
![image](https://user-images.githubusercontent.com/104360479/185412415-e9c98397-84aa-4b85-a29b-8493c12dd111.png)
