### PR TITLE
Fix doorkeeper initialization after 5.6.0 release

### DIFF
--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -274,7 +274,7 @@ module Decidim
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Core::Engine.root}/app/views") # for partials
       end
 
-      initializer "doorkeeper" do
+      initializer "doorkeeper", before: "doorkeeper.params.filter" do
         Doorkeeper.configure do
           orm :active_record
 


### PR DESCRIPTION
#### :tophat: What? Why?
Yesterday Doorkeeper released version 5.6.0 and Decidim generators will automatically start using that due to the loose version lock to Doorkeeper `5.x`.

It included this change:
https://github.com/doorkeeper-gem/doorkeeper/commit/e19466f42fcdd5cea1b598358ec1f22b56714a9d

This causes Doorkeeper to check if it has been configured already during the initialization hook. Which then causes the exception because Doorkeeper configuration in Decidim runs **after** the Doorkeeper initialization has run.

This causes the generators tests to fail constantly in the CI to the following exception:

```
/.../.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/doorkeeper-5.6.0/lib/doorkeeper/config.rb:33:in `configuration': Configuration for doorkeeper missing. Do you have doorkeeper initializer? (Doorkeeper::MissingConfiguration)
	from /.../.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/doorkeeper-5.6.0/lib/doorkeeper/engine.rb:7:in `block in <class:Engine>'
	from /.../.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-6.1.6/lib/rails/initializable.rb:32:in `instance_exec'
	from /.../.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-6.1.6/lib/rails/initializable.rb:32:in `run'
	from /.../.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/railties-6.1.6/lib/rails/initializable.rb:61:in `block in run_initializers'
```

#### Testing
See that the generators tests are green.