### PR TITLE
Backport 'Fix doorkeeper initialization after 5.6.0 release' to v0.27

### DIFF
--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -265,7 +265,7 @@ module Decidim
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Core::Engine.root}/app/views") # for partials
       end
 
-      initializer "doorkeeper" do
+      initializer "doorkeeper", before: "doorkeeper.params.filter" do
         Doorkeeper.configure do
           orm :active_record
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9785 to v0.27

:hearts: Thank you!