### PR TITLE
Ignore participatory spaces without models in meetings visible_for scope

### DIFF
--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -82,7 +82,8 @@ module Decidim
       scope :visible_for, lambda { |user|
         (all.distinct if user&.admin?) ||
           if user.present?
-            spaces = Decidim.participatory_space_registry.manifests.map do |manifest|
+            spaces = Decidim.participatory_space_registry.manifests.filter_map do |manifest|
+              next unless manifest.model_class_name.constantize.respond_to?(:table_name)
               {
                 name: manifest.model_class_name.constantize.table_name.singularize,
                 class_name: manifest.model_class_name

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -83,9 +83,11 @@ module Decidim
         (all.distinct if user&.admin?) ||
           if user.present?
             spaces = Decidim.participatory_space_registry.manifests.filter_map do |manifest|
-              next unless manifest.model_class_name.constantize.respond_to?(:table_name)
+              table_name = manifest.model_class_name.constantize.try(:table_name)
+              next if table_name.blank?
+
               {
-                name: manifest.model_class_name.constantize.table_name.singularize,
+                name: table_name.singularize,
                 class_name: manifest.model_class_name
               }
             end

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -66,6 +66,34 @@ module Decidim::Meetings
       end
     end
 
+    describe "#visible_for" do
+      subject { Decidim::Meetings::Meeting.visible_for(user) }
+      let(:meeting) { create :meeting, :published }
+      let(:user) { create :user, organization: meeting.component.organization }
+
+      it "returns published meetings" do
+        expect(subject).to include(meeting)
+      end
+
+      context "when the meeting is not published" do
+        let(:meeting) { create :meeting }
+
+        it "does not returns the meeting" do
+          expect(subject).not_to include(meeting)
+        end
+      end
+
+      context "when some participatory space does not have a model" do
+        before do
+          allow(Decidim::Assembly).to receive(:table_name).and_return(nil)
+        end
+
+        it "does not return an exception" do
+          expect(subject).to include(meeting)
+        end
+      end
+    end
+
     describe "#can_be_joined_by?" do
       subject { meeting.can_be_joined_by?(user) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

We've found out that it is possible to define a participatory space not associated with a model (for instance see the (decidim-calendar)[https://github.com/alabs/decidim-module-calendar] module).

But some methods are not prepared for that, in particular the scope `visible_for?` for the meetings model.

This should fix this by ignoring any participatory space without models in that scope.

*Please describe your pull request.*

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing

To test the bug, install the decidim calendar module, and try to edit a meeting as a user (not admin), it should give you a 500 error.

### :camera: Screenshots
N/A

:hearts: Thank you!
