### PR TITLE
Backport 'Ignore participatory spaces without models in meetings visible_for scope' to v0.27

### DIFF
--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -82,9 +82,12 @@ module Decidim
       scope :visible_for, lambda { |user|
         (all.distinct if user&.admin?) ||
           if user.present?
-            spaces = Decidim.participatory_space_registry.manifests.map do |manifest|
+            spaces = Decidim.participatory_space_registry.manifests.filter_map do |manifest|
+              table_name = manifest.model_class_name.constantize.try(:table_name)
+              next if table_name.blank?
+
               {
-                name: manifest.model_class_name.constantize.table_name.singularize,
+                name: table_name.singularize,
                 class_name: manifest.model_class_name
               }
             end

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -66,6 +66,34 @@ module Decidim::Meetings
       end
     end
 
+    describe "#visible_for" do
+      subject { Decidim::Meetings::Meeting.visible_for(user) }
+      let(:meeting) { create :meeting, :published }
+      let(:user) { create :user, organization: meeting.component.organization }
+
+      it "returns published meetings" do
+        expect(subject).to include(meeting)
+      end
+
+      context "when the meeting is not published" do
+        let(:meeting) { create :meeting }
+
+        it "does not returns the meeting" do
+          expect(subject).not_to include(meeting)
+        end
+      end
+
+      context "when some participatory space does not have a model" do
+        before do
+          allow(Decidim::Assembly).to receive(:table_name).and_return(nil)
+        end
+
+        it "does not return an exception" do
+          expect(subject).to include(meeting)
+        end
+      end
+    end
+
     describe "#can_be_joined_by?" do
       subject { meeting.can_be_joined_by?(user) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9790 to v0.27

:hearts: Thank you!