### PR TITLE
Add missing character on ActiveStorage documentations' code block

### DIFF
--- a/docs/modules/services/pages/activestorage.adoc
+++ b/docs/modules/services/pages/activestorage.adoc
@@ -48,7 +48,7 @@ Google Cloud Storage requires you to use the `gsutil` command line tool to set t
 [source,bash]
 ----
 gsutil cors set cors.json gs://your-bucket-name
----
+----
 
 Before running that command you need to have a `cors.json` file in the same directory where you are runnign the command from with the following content (replace `https://www.example.com` with the actual domain of your service):
 


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
After merging #9777, there's a broken code block that's messing up this page: https://docs.decidim.org/en/services/activestorage.html 

This PR fixes that. It's literally one character 😄 

#### :pushpin: Related Issues

- Related to #9777

#### Testing

To [compile the antora playbook locally](https://github.com/decidim/decidim/tree/develop/docs#local-development) - or alternatively, just merge this and wait a couple of minutes for the deployment.

### :camera: Screenshots 

![Selection_288](https://user-images.githubusercontent.com/717367/189945118-91c4a6e4-c224-4afa-8fd4-01701635d96a.png)


:hearts: Thank you!
