### PR TITLE
Backport 'Fix API GraphiQL system spec with newer ChromeDriver' to v0.27

### DIFF
--- a/decidim-api/spec/system/graphiql_spec.rb
+++ b/decidim-api/spec/system/graphiql_spec.rb
@@ -29,6 +29,9 @@ describe "GraphiQL", type: :system do
   end
 
   it "is able to execute the default query" do
+    # Wait for the page to finish loading and the GraphiQL interface to start
+    # before clicking the button for it to actually work.
+    expect(page).to have_content("participatoryProcesses {")
     find(".execute-button").click
     within ".result-window" do
       expect(page).to have_content("\"id\": \"#{participatory_process.id}\"")


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9642 to v0.27

:hearts: Thank you!