### PR TITLE
Add a link to the data consent section at the customize index

### DIFF
--- a/docs/modules/customize/pages/index.adoc
+++ b/docs/modules/customize/pages/index.adoc
@@ -20,6 +20,7 @@ Inside of your application you can customize it in different ways:
 * xref:customize:gemfile.adoc[Gemfile]
 * xref:customize:images.adoc[Images]
 * xref:customize:javascript.adoc[Javascript]
+* xref:customize:logic.adoc[Logic]
 * xref:customize:menu.adoc[Menu]
 * xref:customize:oauth.adoc[OAuth]
 * xref:customize:styles.adoc[Styles]

--- a/docs/modules/customize/pages/index.adoc
+++ b/docs/modules/customize/pages/index.adoc
@@ -16,6 +16,7 @@ Inside of your application you can customize it in different ways:
 
 * xref:customize:authorizations.adoc[Authorizations]
 * xref:customize:code.adoc[Code]
+* xref:customize:data_consent.adoc[Data consent]
 * xref:customize:gemfile.adoc[Gemfile]
 * xref:customize:images.adoc[Images]
 * xref:customize:javascript.adoc[Javascript]


### PR DESCRIPTION
#### :tophat: What? Why?
Adds the missing link to the customize index.

#### :pushpin: Related Issues
- Related to decidim/documentation#94
- Related to decidim/documentation#109