### PR TITLE
Fix a typo in the logic customization manual

### DIFF
--- a/docs/modules/customize/pages/logic.adoc
+++ b/docs/modules/customize/pages/logic.adoc
@@ -71,7 +71,7 @@ end
 [source,ruby]
 ----
   config.to_prepare do
-    Decidim::Budgets::Admin::ProjectForm.include(Decidim::Budgets::Admin::ProjectForm.include(AdminProjectFormExtensions)
+    Decidim::Budgets::Admin::ProjectForm.include(AdminProjectFormExtensions)
   end
 ----
 This applies to almost all classes you want to change in Decidim but controllers and helpers are special cases due to order of how things are loaded in the Decidim boot process. If you want to add any changes to controllers or helpers, you need to wrap the `config.to_prepare` block within an initializer that is run at the correct phase of the boot process as follows:


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Fix a typo in the documentation.

#### :pushpin: Related Issues

#### Testing
No testing prerequisit
### :camera: Screenshots
There is a typo in this section:
![image](https://user-images.githubusercontent.com/104360479/190419445-b422a0ca-5aed-422b-a6e8-e8d7d85f05e3.png)
![Description](URL)

:hearts: Thank you!
