### PR TITLE
Remove unecessary line in push notifications spec

### DIFF
--- a/decidim-core/spec/presenters/decidim/push_notification_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/push_notification_presenter_spec.rb
@@ -5,7 +5,6 @@ require "spec_helper"
 module Decidim
   describe PushNotificationPresenter, type: :presenter do
     let(:notification) { create(:notification) }
-    let(:np) { described_class.new(notification) }
 
     subject { described_class.new(notification) }
 


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
While reviewing backports this week, I found a line that isn't used in a spec. This PR removes it. 

#### :pushpin: Related Issues
 
- Related to  https://github.com/decidim/decidim/pull/9584#discussion_r968140581

#### Testing

As it's a change in a spec, it should be all green 
 
:hearts: Thank you!
