### PR TITLE
Fix source format in the data consent docs for the example

### DIFF
--- a/docs/modules/customize/pages/data_consent.adoc
+++ b/docs/modules/customize/pages/data_consent.adoc
@@ -15,7 +15,7 @@ By default there are four (4) data consent categories: **essential**, **preferen
 The recommended place for scripts is ```app/views/layouts/decidim/_head_extra.html.erb```.
 For example, if you want to add a script that requires marketing consent, you can add the following code:
 
-[source,javascript]
+[source,html]
 ----
 <script type="text/plain" data-consent="marketing">
   console.log("marketing data consent given");


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed when reading through the data consent docs that this source format was not correct as it is not highlighting this section correctly.

#### :pushpin: Related Issues
- Related to #9271

### :camera: Screenshots
Currently looks like this:
![Code highlighting](https://user-images.githubusercontent.com/864340/191013254-dc37fe3e-a2ed-4eb1-ac84-43e0f1da9e4a.png)