### PR TITLE
Update the CHANGELOG template and fix detailed changes heading levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,30 +31,22 @@ bin/rails db:migrate
 
 These are one time actions that need to be done after the code is updated in the production database.
 
-#### 3.1. [[TITLE OF THE ACTION]]
+#### 3.1. Tailwind CSS introduction
 
-You can read more about this change on PR [\#XXXX](https://github.com/decidim/decidim/pull/XXXX).
+Decidim redesign has introduced Tailwind CSS framework to compile CSS. It integrates with Webpacker, which generates Tailwind configuration dynamically when Webpacker is invoked.
+
+You'll need to add `tailwind.config.js` to your app `.gitignore`. If you generate a new Decidim app from scratch, that entry will already be included in the `.gitignore`.
+
+You can read more about this change on PR [\#9480](https://github.com/decidim/decidim/pull/9480).
 
 ### 4. Scheduled tasks
 
 Implementers need to configure these changes it in your scheduler task system in the production server. We give the examples
  with `crontab`, although alternatively you could use `whenever` gem or the scheduled jobs of your hosting provider.
 
-#### 4.1. [[TITLE OF THE TASK]]
+#### 4.1. Automatically change active step in participatory processes
 
-```bash
-4 0 * * * cd /home/user/decidim_application && RAILS_ENV=production bundle exec rails decidim:TASK
-```
-
-You can read more about this change on PR [\#XXXX](https://github.com/decidim/decidim/pull/XXXX).
-
-### 5. Changes in APIs
-
-### Added
-
-#### Automatically change active step in participatory processes
-
-PR [\#9026](https://github.com/decidim/decidim/pull/9026) adds the ability to automatically change the active step of participatory processess. This is an optional behavior that system admins can enable by configuring a cron job. The frequency of the cron task should be decided by the system admin and depends on each platform's use cases. A precision of 15min is enough for most cases. An example of a crontab job may be:
+We have added the ability to automatically change the active step of participatory processess. This is an optional behavior that system admins can enable by configuring a cron job. The frequency of the cron task should be decided by the system admin and depends on each platform's use cases. A precision of 15min is enough for most cases. An example of a crontab job may be:
 
 ```bash
 */15 * * * * cd /home/user/decidim_application && RAILS_ENV=production bundle exec rake decidim_participatory_processes:change_active_step
@@ -64,21 +56,21 @@ Each time the job executes it checks all currently active and published particip
 
 Platform administrators will always have the possibility to manually change phases, although if a cron job is configured the change may be undone.
 
-This PR also changes the Step `start_date` and `end_date`  fields to timestamps.
+These feature also changes the step `start_date` and `end_date`  fields to timestamps.
 
-### Changed
+You can read more about this change on PR [\#9026](https://github.com/decidim/decidim/pull/9026).
 
-#### Tailwind CSS introduction
+### 5. Changes in APIs
 
-Decidim redesign has introduced Tailwind CSS framework to compile CSS. It integrates with Webpacker,
-which generates Tailwind configuration dynamically when Webpacker is invoked. More details in the PR [#9480](https://github.com/decidim/decidim/pull/9480/).
+### Detailed changes
 
-You'll need to add `tailwind.config.js` to your app `.gitignore`. If you generate a new Decidim app
-from scratch, that entry will already be included in the `.gitignore`.
+#### Added
 
-### Fixed
+#### Changed
 
-### Removed
+#### Fixed
+
+#### Removed
 
 ## Previous versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Each time the job executes it checks all currently active and published particip
 
 Platform administrators will always have the possibility to manually change phases, although if a cron job is configured the change may be undone.
 
-These feature also changes the step `start_date` and `end_date`  fields to timestamps.
+This feature also changes the step `start_date` and `end_date`  fields to timestamps.
 
 You can read more about this change on PR [\#9026](https://github.com/decidim/decidim/pull/9026).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,18 @@ You can read more about this change on PR [\#9026](https://github.com/decidim/de
 
 ### 5. Changes in APIs
 
+#### 5.1. Tailwind CSS instead of Foundation
+
+In this version we are introducing Tailwind CSS as the underlying layer to build the user interface on. In the previous versions, we used Foundation but its development stagnated which led to changing the whole layer that we are using to build user interfaces on.
+
+This means that in case you have done any changes in the Decidim user interface or developed any modules with participant facing user interfaces, you need to do changes in all your views, partials and view components (aka cells).
+
+Tailwind is quite different from Foundation and it cannot
+
+You can read more about this change on PR [\#9480](https://github.com/decidim/decidim/pull/9480).
+
+You can read more about Tailwind from the [Tailwind documentation](https://tailwindcss.com/docs/utility-first).
+
 ### Detailed changes
 
 #### Added

--- a/bin/changelog_generator
+++ b/bin/changelog_generator
@@ -81,7 +81,7 @@ class ChangeLogGenerator
         data[:type].include?(type_data[:label])
       end
 
-      output "### #{type_title}"
+      output "#### #{type_title}"
       output ""
 
       if type_prs.any?

--- a/docs/modules/develop/pages/releases.adoc
+++ b/docs/modules/develop/pages/releases.adoc
@@ -76,13 +76,33 @@ You can read more about this change on PR [\#XXXX](https://github.com/decidim/de
 
 ### 5. Changes in APIs
 
-### Added
+### 5.1. [[TITLE OF THE CHANGE]]
 
-### Changed
+In order to [[REASONING (e.g. improve the maintenance of the code base)]] we have changed...
 
-### Fixed
+If you have used code as such:
 
-### Removed
+```ruby
+# Explain the usage of the API as it was in the previous version
+result = 1 + 1 if before
+```
+
+You need to change it to:
+
+```ruby
+# Explain the usage of the API as it is in the new version
+result = 1 + 1 if after
+```
+
+### Detailed changes
+
+#### Added
+
+#### Changed
+
+#### Fixed
+
+#### Removed
 
 ...
 

--- a/docs/modules/develop/pages/releases.adoc
+++ b/docs/modules/develop/pages/releases.adoc
@@ -76,7 +76,7 @@ You can read more about this change on PR [\#XXXX](https://github.com/decidim/de
 
 ### 5. Changes in APIs
 
-### 5.1. [[TITLE OF THE CHANGE]]
+#### 5.1. [[TITLE OF THE CHANGE]]
 
 In order to [[REASONING (e.g. improve the maintenance of the code base)]] we have changed...
 


### PR DESCRIPTION
#### :tophat: What? Why?
At #9836 we did a small change in the CHANGELOG template which I am documenting here to the related documentation page.

Also fixing the "detailed changes" heading levels as they are generated by the CHANGELOG generator script.

Both changes based on the 0.27 CHANGELOG.

#### :pushpin: Related Issues
- Related to #9836