### PR TITLE
Fix importing a page component without a body

### DIFF
--- a/decidim-dev/lib/decidim/dev/assets/assemblies.json
+++ b/decidim-dev/lib/decidim/dev/assets/assemblies.json
@@ -512,7 +512,17 @@
         },
         "weight": 0,
         "permissions": null,
-        "published_at": "2020-01-22 07:55:04 UTC"
+        "published_at": "2020-01-22 07:55:04 UTC",
+        "specific_data": {
+          "body": {
+            "en": "English content",
+            "ca": "Catalan content",
+            "es": "Spanish content",
+            "machine_translations": {
+              "es": "Machine translation spanish content"
+            }
+          }
+        }
       },
       {
         "manifest_name": "proposals",

--- a/decidim-pages/app/serializers/decidim/pages/data_importer.rb
+++ b/decidim-pages/app/serializers/decidim/pages/data_importer.rb
@@ -15,6 +15,8 @@ module Decidim
       # @param _user [Decidim::User] The user performing the import.
       # @return [Decidim::Pages::Page] The imported page
       def import(serialized, _user)
+        return unless serialized
+
         Page.create!(
           component: @component,
           body: serialized["body"]

--- a/decidim-pages/spec/serializers/decidim/pages/data_importer_spec.rb
+++ b/decidim-pages/spec/serializers/decidim/pages/data_importer_spec.rb
@@ -14,30 +14,40 @@ module Decidim::Pages
     describe "#import" do
       subject { importer.import(as_json, user) }
 
-      let(:as_json) do
-        JSON.parse(
-          <<~JSON
-            {
-              "body": {
-                "en": "English content",
-                "ca": "Catalan content",
-                "es": "Spanish content"
+      context "with body" do
+        let(:as_json) do
+          JSON.parse(
+            <<~JSON
+              {
+                "body": {
+                  "en": "English content",
+                  "ca": "Catalan content",
+                  "es": "Spanish content"
+                }
               }
+            JSON
+          )
+        end
+
+        it "imports the page" do
+          expect(subject).to be_a(Decidim::Pages::Page)
+          expect(subject.id).to eq(Page.find_by(component:).id)
+          expect(subject.body).to eq(
+            {
+              "en" => "English content",
+              "ca" => "Catalan content",
+              "es" => "Spanish content"
             }
-          JSON
-        )
+          )
+        end
       end
 
-      it "imports the page" do
-        expect(subject).to be_a(Decidim::Pages::Page)
-        expect(subject.id).to eq(Page.find_by(component:).id)
-        expect(subject.body).to eq(
-          {
-            "en" => "English content",
-            "ca" => "Catalan content",
-            "es" => "Spanish content"
-          }
-        )
+      context "without body" do
+        let(:as_json) { nil }
+
+        it "doesn't import the page" do
+          expect(subject).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

After merging #9638 we have the CI broken. This is because we have a broken example that was generated with a bad export, and now it's failing. This PR fixes the imported file. 


#### :pushpin: Related Issues
 
- Related to #9638


#### Testing
Wait for the CI to be all green 


:hearts: Thank you!
