### PR TITLE
Fix incorrect expecations after change of allowed file extensions

### DIFF
--- a/decidim-core/spec/validators/uploader_content_type_validator_spec.rb
+++ b/decidim-core/spec/validators/uploader_content_type_validator_spec.rb
@@ -74,7 +74,7 @@ describe UploaderContentTypeValidator do
       it "adds the correct content type error with the allowed extensions" do
         expect(subject.count).to eq(1)
         expect(subject[:file]).to eq(
-          ["only files with the following extensions are allowed: bmp, gif, jpeg, jpg, png"]
+          ["only files with the following extensions are allowed: jpeg, jpg, png"]
         )
       end
     end
@@ -108,7 +108,7 @@ describe UploaderContentTypeValidator do
       it "adds the recognized extensions and content type to the error in correct order" do
         expect(subject.count).to eq(1)
         expect(subject[:file]).to eq(
-          ["only files with the following extensions are allowed: bmp, gif, jpeg, jpg, png, foobar/*"]
+          ["only files with the following extensions are allowed: jpeg, jpg, png, foobar/*"]
         )
       end
     end

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -55,7 +55,7 @@ describe "Edit proposals", type: :system do
         dynamically_attach_file(:proposal_photos, Decidim::Dev.asset("participatory_text.md"), keep_modal_open: true) do
           expect(page).to have_content("Accepted formats: #{Decidim::OrganizationSettings.for(organization).upload_allowed_file_extensions_image.join(", ")}")
         end
-        expect(page).to have_content("only files with the following extensions are allowed: bmp, gif, jpeg, jpg, pdf, png, rtf, txt")
+        expect(page).to have_content("only files with the following extensions are allowed: jpeg, jpg, pdf, png, rtf, txt")
       end
 
       context "with a file and photo" do


### PR DESCRIPTION
#### :tophat: What? Why?
The build is broken after merging #9663 because #9641 before that changed the allowed file types.

This fixes the broken specs.

#### :pushpin: Related Issues
- Related to #9663
- Related to #9641

#### Testing
See the CI is green.