### PR TITLE
Limit invitation redirects only to paths within the application

### DIFF
--- a/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
@@ -21,7 +21,7 @@ module Decidim
       # invitation. Using the param `invite_redirect` we can redirect the user
       # to a custom path after it has accepted the invitation.
       def after_accept_path_for(resource)
-        params[:invite_redirect] || after_sign_in_path_for(resource)
+        invite_redirect_path || after_sign_in_path_for(resource)
       end
 
       # When a managed user accepts the invitation is promoted to non-managed user.
@@ -39,6 +39,14 @@ module Decidim
       end
 
       protected
+
+      def invite_redirect_path
+        path = params[:invite_redirect]
+        return unless path
+        return unless path.starts_with?(%r{^/[a-z0-9]+})
+
+        path
+      end
 
       def configure_permitted_parameters
         devise_parameter_sanitizer.permit(:accept_invitation, keys: [:nickname, :tos_agreement, :newsletter_notifications])

--- a/decidim-core/spec/controllers/decidim/devise/invitations_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/devise/invitations_controller_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Devise
+  describe InvitationsController, type: :controller do
+    routes { Decidim::Core::Engine.routes }
+
+    let(:organization) { create(:organization) }
+    let(:inviter) { create(:user, :admin, organization:) }
+    let(:invitation_params) do
+      {
+        organization:,
+        name: "Invited User",
+        email: "inviteduser@example.org"
+      }
+    end
+    let!(:user) { Decidim::User.invite!(invitation_params, inviter) }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      request.env["devise.mapping"] = ::Devise.mappings[:user]
+    end
+
+    describe "accepting invitation" do
+      let(:password) { "decidim123456789" }
+      let(:registration_params) do
+        {
+          invitation_token: user.raw_invitation_token,
+          nickname: "invited_user",
+          password:,
+          password_confirmation: password
+        }
+      end
+
+      it "responds to the edit path" do
+        get :edit, params: { invitation_token: user.raw_invitation_token }
+        expect(response.status).to eq(200)
+      end
+
+      it "redirects to the provided path" do
+        post :update, params: { user: registration_params }
+        expect(response).to redirect_to("/")
+      end
+
+      context "when an invite redirect is provided" do
+        it "redirects to the redirect path" do
+          post :update, params: { invite_redirect: "/admin/", user: registration_params }
+          expect(response).to redirect_to("/admin/")
+        end
+
+        context "with a full HTTP URL" do
+          it "redirects to the default path" do
+            post :update, params: { invite_redirect: "http://example.org", user: registration_params }
+            expect(response).to redirect_to("/")
+          end
+        end
+
+        context "with a full HTTPS URL" do
+          it "redirects to the default path" do
+            post :update, params: { invite_redirect: "https://example.org", user: registration_params }
+            expect(response).to redirect_to("/")
+          end
+        end
+
+        context "with a URL without protocol" do
+          it "redirects to the default path" do
+            post :update, params: { invite_redirect: "//example.org", user: registration_params }
+            expect(response).to redirect_to("/")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This limits the invitation redirects to only paths within the application.

Generally these URLs should be only created by admin users, so this should be considered a security improvement and not a serious threat. 

#### Testing
- Send an invitation, e.g. invite an admin to the platform
- From the invitation email, copy the link but do not click it yet
- Modify the invitation redirection parameter to point to some other URL
- See that the user is now kept within the application