### PR TITLE
Fix commenting field disabled when polling new comments

### DIFF
--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -43,7 +43,10 @@ export default class CommentsComponent {
       this.mounted = true;
       this._initializeComments(this.$element);
       if (!this.singleComment) {
-        this._fetchComments();
+        $(".add-comment textarea", this.$element).prop("disabled", true);
+        this._fetchComments(() => {
+          $(".add-comment textarea", this.$element).prop("disabled", false);
+        });
       }
 
       $(".order-by__dropdown .is-submenu-item a", this.$element).on("click.decidim-comments", () => this._onInitOrder());
@@ -212,10 +215,11 @@ export default class CommentsComponent {
    * Sends an ajax request based on current
    * params to get comments for the component
    * @private
+   * @param {Function} successCallback A callback that is called after a
+   *   successful fetch
    * @returns {Void} - Returns nothing
    */
-  _fetchComments() {
-    $(".add-comment textarea", this.$element).prop("disabled", true);
+  _fetchComments(successCallback = null) {
     Rails.ajax({
       url: this.commentsUrl,
       type: "GET",
@@ -228,7 +232,9 @@ export default class CommentsComponent {
         ...(this.lastCommentId && { "after": this.lastCommentId })
       }),
       success: () => {
-        $(".add-comment textarea", this.$element).prop("disabled", false);
+        if (successCallback) {
+          successCallback();
+        }
         this._pollComments();
       }
     });

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
@@ -418,6 +418,21 @@ describe("CommentsComponent", () => {
     expect(window.setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
   });
 
+  it("does not disable the textarea when polling comments normally", () => {
+    Rails.ajax.mockImplementationOnce((options) => options.success());
+
+    subject.mountComponent();
+
+    // Delay the success call 2s after the polling has happened to test that
+    // the textarea is still enabled when the polling is happening.
+    Rails.ajax.mockImplementationOnce((options) => {
+      setTimeout(options.success(), 2000);
+    });
+    jest.advanceTimersByTime(1500);
+
+    expect($(`${selector} .add-comment textarea`).prop("disabled")).toBeFalsy();
+  });
+
   describe("when mounted", () => {
     beforeEach(() => {
       spyOnAddComment("on");


### PR DESCRIPTION
#### :tophat: What? Why?
The comments field gets disabled when polling for new comments.

This makes the commenting experience extremely cumbersome as every 15s the focus goes out of the textarea field and the user has to make the textarea focused manually after that.

This is a side-effect of fixing the flaky comments specs at #9614.

#### :pushpin: Related Issues
- Related to #9614

#### Testing
- Login to the platform
- Go to a page with comments enabled, e.g. a proposal page
- Open the developer console's "Network" tab to see any polling requests happening in the background
- While looking at the network tab, type in something slowly to the comment field and looking the focus does not go away from it when a polling event happens
- Open another window in private browsing mode (to get a separate session)
- Go to the same page as the other user
- In the first window, wait for one polling to happen
- In the second private browsing window, post a comment quickly
- Repeat the same process as before, i.e. start typing a comment slowly
- Check that the focus stays in the textarea while the polling happens
- Check that the new comment posted from the other window appears correctly