### PR TITLE
Make Metadecidim naming consistent

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -28,7 +28,7 @@ If applicable, add the error stacktrace to help explain your problem.
  - Device OS: [e.g. iOS8.1, Windows 10]
  - Browser: [e.g. Chrome, Firefox, Safari]
  - Decidim Version: [e.g. 0.10]
- - Decidim installation: [e.g. MetaDecidim]
+ - Decidim installation: [e.g. Metadecidim]
 
 **Additional context**
 Add any other context about the problem here. For instance, add Metadecidim link. 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,14 +1,14 @@
 ---
 name: Feature request creation disabled
-about: Go to MetaDecidim :)
+about: Go to Metadecidim :)
 
 ---
 
-We've disabled the feature request's issue creation on this repository. If you want to discuss about a new feature, you can do this through MetaDecidim:
+We've disabled the feature request's issue creation on this repository. If you want to discuss about a new feature, you can do this through Metadecidim:
 
 * [Feature Request](https://meta.decidim.org/processes/roadmap)
 
-We're doing this because we're trying to eat our own dog food. Once your proposal is collaboratively reviewed and accepted by the Product Comitee, we'll create the new issue on GitHub and notify you through MetaDecidim.
+We're doing this because we're trying to eat our own dog food. Once your proposal is collaboratively reviewed and accepted by the Product Comitee, we'll create the new issue on GitHub and notify you through Metadecidim.
 
 Thanks for contributing to Decidim!
 

--- a/docs/modules/install/pages/checklist.adoc
+++ b/docs/modules/install/pages/checklist.adoc
@@ -35,5 +35,5 @@ As a technopolitical project, Decidim needs several things to work. This is a no
 . Comply with your current *legal requirements*, like to registrate your privacy policy with the autorities (eg LOPD on Spain).
 . Fill the *Participatory Processes Configuration Form* to prepare your Participatory Process for Decidim.
 . Read the *xref:admin:index.adoc[Administration manual]*.
-. Participate on *http://meta.decidim.org[MetaDecidim]*.
+. Participate on *http://meta.decidim.org[Metadecidim]*.
 . Read the Decidim *https://decidim.org/contract/[Social Contract]*.


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While working on Metadecidim we've seen that we weren't consistent in the `Metadecidim` naming, as sometimes we're using `MetaDecidim`. 

This PR fixes that. 

:hearts: Thank you!
