### PR TITLE
Fix correct resource linking for amendments

### DIFF
--- a/decidim-core/app/cells/decidim/amendable/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/amendable/announcement_cell.rb
@@ -22,7 +22,7 @@ module Decidim::Amendable
     def promoted_message
       return "" unless model.amendment.promoted?
 
-      proposal = model.linked_promoted_resourcer
+      proposal = model.linked_promoted_resource
       text = message(:promoted, amendable_type)
       %(<br><strong>#{proposal_link(proposal, text)}</strong>)
     end

--- a/decidim-core/app/cells/decidim/amendable/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/amendable/announcement_cell.rb
@@ -22,7 +22,7 @@ module Decidim::Amendable
     def promoted_message
       return "" unless model.amendment.promoted?
 
-      proposal = model.linked_promoted_resource
+      proposal = model.linked_promoted_resourcer
       text = message(:promoted, amendable_type)
       %(<br><strong>#{proposal_link(proposal, text)}</strong>)
     end
@@ -36,7 +36,7 @@ module Decidim::Amendable
     end
 
     def proposal_link(resource = model.amendable, text = nil)
-      text ||= %(<strong>#{present(model.amendable).title}</strong>)
+      text ||= %(<strong>#{decidim_sanitize(present(model.amendable).title, strip_tags: true)}</strong>)
       link_to resource_locator(resource).path do
         text
       end

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -5,6 +5,7 @@ module Decidim
   # a events are received.
   class NotificationMailer < Decidim::ApplicationMailer
     helper Decidim::ResourceHelper
+    helper Decidim::SanitizeHelper
 
     def event_received(event, event_class_name, resource, user, user_role, extra) # rubocop:disable Metrics/ParameterLists
       with_user(user) do

--- a/decidim-core/app/mailers/decidim/notifications_digest_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notifications_digest_mailer.rb
@@ -5,6 +5,7 @@ module Decidim
   # a events are received.
   class NotificationsDigestMailer < Decidim::ApplicationMailer
     helper Decidim::ResourceHelper
+    helper Decidim::SanitizeHelper
     SIZE_LIMIT = 10
 
     def digest_mail(user, notification_ids)

--- a/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
+++ b/decidim-core/app/views/decidim/notification_mailer/event_received.html.erb
@@ -4,7 +4,7 @@
 
 <% if @event_instance.resource_path.present? && @event_instance.resource_title.present? %>
   <p class="email-button email-button__cta">
-    <%= link_to @event_instance.resource_title, @event_instance.resource_url %>
+    <%= link_to decidim_sanitize(@event_instance.resource_title, strip_tags: true), @event_instance.resource_url %>
   </p>
 <% end %>
 

--- a/decidim-core/app/views/decidim/notifications_digest_mailer/_email_content.html.erb
+++ b/decidim-core/app/views/decidim/notifications_digest_mailer/_email_content.html.erb
@@ -5,7 +5,7 @@
   </p>
   <% if notification.resource_path.present? && notification.resource_title.present? %>
     <p class="email-button email-button__cta">
-      <%= link_to notification.resource_title, notification.resource_url %>
+      <%= link_to decidim_sanitize(notification.resource_title, strip_tags: true), notification.resource_url %>
     </p>
   <% end %>
 </div>

--- a/decidim-core/spec/cells/decidim/amendable/announcement_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/amendable/announcement_cell_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Amendable::AnnouncementCell, type: :cell do
+  subject { my_cell.call }
+
+  controller Decidim::PagesController
+
+  let(:my_cell) { cell("decidim/amendable/announcement", emendation) }
+  let!(:amendment) { create(:amendment, amendable:, emendation:) }
+  let(:component) { create(:proposal_component) }
+  let(:amendable) { create(:proposal, component:, title: %(Testing <a href="https://example.org">proposal</a>)) }
+  let(:emendation) { create(:proposal, component:) }
+  let!(:linked_proposal) do
+    pr = create(:proposal, component:)
+    emendation.link_resources(pr, "created_from_rejected_emendation")
+    pr
+  end
+  let(:link_to_amendable) { ::Decidim::ResourceLocatorPresenter.new(amendable).path }
+
+  it "renders the link to the amendable resource" do
+    expect(subject.to_s).to include(
+      %(<a href="#{link_to_amendable}"><strong>Testing proposal</strong></a>)
+    )
+  end
+end

--- a/decidim-core/spec/mailers/notification_digest_mailer_spec.rb
+++ b/decidim-core/spec/mailers/notification_digest_mailer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe NotificationsDigestMailer, type: :mailer do
+    let(:organization) { create(:organization, name: "O'Connor") }
+    let(:user) { create(:user, name: "Sarah Connor", organization:) }
+    let(:notification_ids) { [notification.id] }
+    let(:notification) { create :notification, user:, resource: }
+    let(:component) { create(:component, manifest_name: "dummy", organization:) }
+    let(:resource) { create(:dummy_resource, title: { en: %(Testing <a href="/resource">resource</a>) }, component:) }
+
+    describe "digest_mail" do
+      subject { described_class.digest_mail(user, notification_ids) }
+
+      it "includes the link to the resource" do
+        expect(subject.body).to include(
+          %(<a href="#{::Decidim::ResourceLocatorPresenter.new(resource).url}">Testing resource</a>)
+        )
+      end
+    end
+  end
+end

--- a/decidim-core/spec/mailers/notification_mailer_spec.rb
+++ b/decidim-core/spec/mailers/notification_mailer_spec.rb
@@ -74,6 +74,51 @@ module Decidim
           expect(mail.body).to include(event_instance.button_url)
         end
       end
+
+      context "when the event has a linked resource" do
+        shared_examples "amendment notification mails" do
+          let!(:amendment) { create(:amendment, amendable:, emendation:) }
+          let(:component) { create(:proposal_component) }
+          let(:amendable) { create(:proposal, component:) }
+          let(:emendation) { create(:proposal, component:, title: %(Testing <a href="https://example.org">proposal</a>)) }
+          let(:link_to_emendation) { ::Decidim::ResourceLocatorPresenter.new(emendation).url }
+          let(:resource) { emendation }
+
+          it "includes the link to the resource" do
+            expect(mail.body).to include(
+              %(<a href="#{link_to_emendation}">Testing proposal</a>)
+            )
+          end
+        end
+
+        context "when the amendment is created" do
+          let(:event_class_name) { "Decidim::Amendable::AmendmentCreatedEvent" }
+          let(:event) { "decidim.events.amendments.amendment_created" }
+
+          it_behaves_like "amendment notification mails"
+        end
+
+        context "when the amendment is accepted" do
+          let(:event_class_name) { "Decidim::Amendable::AmendmentAcceptedEvent" }
+          let(:event) { "decidim.events.amendments.amendment_accepted" }
+
+          it_behaves_like "amendment notification mails"
+        end
+
+        context "when the amendment is rejected" do
+          let(:event_class_name) { "Decidim::Amendable::AmendmentRejectedEvent" }
+          let(:event) { "decidim.events.amendments.amendment_rejected" }
+
+          it_behaves_like "amendment notification mails"
+        end
+
+        context "when the emendation is promoted" do
+          let(:event_class_name) { "Decidim::Amendable::EmendationPromotedEvent" }
+          let(:event) { "decidim.events.amendments.emendation_promoted" }
+
+          it_behaves_like "amendment notification mails"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
The resource links are not correctly generated for the notification emails. This fixes that.

There was also an issue with the announcement cell linking when looking at an amendment (e.g. proposal amendment accept/reject view).

#### Testing
- Create something that triggers a notification
- See the notification email and that the links are correctly created
- Configure your account to receive notifications digest
- Trigger multiple similar notifications
- Run the digest
- See the notification email and that the links are correctly created