### PR TITLE
Add missing i18n key in Initiatives

### DIFF
--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
   activemodel:
     attributes:
       initiative:
+        area_id: Area
         decidim_user_group_id: Author
         description: Description
         offline_votes: In-person signatures
@@ -34,6 +35,7 @@ en:
         online_signature_enabled: Online signature enabled
         only_global_scope_enabled: Only allow global scope initiatives creation
         promoting_committee_enabled: Enable promoting committee
+        signature_type: Signature type
         title: Title
         undo_online_signatures_enabled: Enable participants to undo their online signatures
         validate_sms_code_on_votes: Add SMS code validation step to signature process


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

There are a couple missing translations in initiatives. This PR adds them. 

#### :pushpin: Related Issues

- Fixes #9880

#### Testing

1. Sign in as admin
2. Go to [edit an Initiative type](http://localhost:3000/admin/initiatives_types/1/edit?locale=ca). See missing translation for  "Signature type" key.
3. Enable areas for this type. 
4. Create a new initiative of this type. See missing translation for  "Area" key

NOTE: as the English missing key is the same that the translation, you should change it to something else locally for testing. 

### :camera: Screenshots
![Selection_354](https://user-images.githubusercontent.com/717367/194879725-e64f8ba6-6a5a-4980-a821-ccbb8ed68d13.png)

![Selection_355](https://user-images.githubusercontent.com/717367/194880227-e54a5068-d31a-4ff0-a56f-399bc32106fe.png)


:hearts: Thank you!
