### PR TITLE
Rename IgnoredMethods to AllowedMethods in Rubocop configuration

### DIFF
--- a/.rubocop_ruby.yml
+++ b/.rubocop_ruby.yml
@@ -220,7 +220,7 @@ Style/BlockDelimiters:
     # This looks at the usage of a block's method to determine its type (e.g. is
     # the result of a `map` assigned to a variable or passed to another
     # method) but exceptions are permitted in the `ProceduralMethods`,
-    # `FunctionalMethods` and `IgnoredMethods` sections below.
+    # `FunctionalMethods` and `AllowedMethods` sections below.
     - semantic
     # The `braces_for_chaining` style enforces braces around single line blocks
     # and do..end around multi-line blocks, except for multi-line blocks whose
@@ -259,7 +259,7 @@ Style/BlockDelimiters:
     - let!
     - subject
     - watch
-  IgnoredMethods:
+  AllowedMethods:
     # Methods that can be either procedural or functional and cannot be
     # categorised from their usage alone, e.g.
     #


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

Rubocop is giving a warning about a renamed deprecated method. This PR renames it. 
 
```bash
$ rubocop -F
Warning: obsolete parameter `IgnoredMethods` (for `Style/BlockDelimiters`) found in .rubocop_ruby.yml
`IgnoredMethods` has been renamed to `AllowedMethods` and/or `AllowedPatterns`.
Warning: obsolete parameter `IgnoredMethods` (for `Style/BlockDelimiters`) found in .rubocop.yml
`IgnoredMethods` has been renamed to `AllowedMethods` and/or `AllowedPatterns`.
Inspecting 6497 files
(...)
```

You can see the new default at https://github.com/rubocop/rubocop/blob/e1624ee6fd856f243f2555ed51eacdbfc1e2f22e/config/default.yml#L3137 

#### Testing

Run `rubocop`, you shouldn't see the warning anymore. 
 
:hearts: Thank you!
