### PR TITLE
Remove duplication of LastActivity queries

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/last_activity_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/last_activity_cell.rb
@@ -56,10 +56,7 @@ module Decidim
       end
 
       def activities
-        @activities ||= ActionLog.where(
-          organization: current_organization,
-          visibility: %w(public-only all)
-        ).with_new_resource_type("all").order(created_at: :desc).limit(activities_to_show * 6)
+        @activities ||= LastActivity.new(current_organization).query.limit(activities_to_show * 6)
       end
 
       def activities_to_show

--- a/decidim-core/app/controllers/decidim/last_activities_controller.rb
+++ b/decidim-core/app/controllers/decidim/last_activities_controller.rb
@@ -32,13 +32,7 @@ module Decidim
     end
 
     def search_collection
-      ActionLog
-        .where(
-          organization: current_organization,
-          visibility: %w(public-only all)
-        )
-        .with_new_resource_type("all")
-        .order(created_at: :desc)
+      LastActivity.new(current_organization).query
     end
 
     def default_filter_params

--- a/decidim-core/app/queries/decidim/last_activity.rb
+++ b/decidim-core/app/queries/decidim/last_activity.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This query finds the public ActionLog entries that can be shown in the
+  # activities views of the application within a Decidim Organization. It is
+  # intended to be used in the "Last activities" content block in the homepage,
+  # and also in the "Last activities" page, to retrieve public activity of this
+  # organization.
+  class LastActivity < Decidim::Query
+    def initialize(organization)
+      @organization = organization
+    end
+
+    def query
+      ActionLog
+        .where(
+          organization: @organization,
+          visibility: %w(public-only all)
+        )
+        .with_new_resource_type("all")
+        .order(created_at: :desc)
+    end
+  end
+end

--- a/decidim-core/spec/queries/decidim/last_activity_spec.rb
+++ b/decidim-core/spec/queries/decidim/last_activity_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::LastActivity do
+  subject { query.query }
+
+  let(:query) { described_class.new(organization) }
+  let(:organization) { create(:organization) }
+
+  let(:commentable) { create(:dummy_resource, component:) }
+  let(:comment) { create(:comment, commentable:) }
+  let!(:action_log) do
+    create(:action_log, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: comment, organization:)
+  end
+
+  let(:component) do
+    create(:component, :published, organization:)
+  end
+  let(:resource) do
+    create(:dummy_resource, component:, published_at: Time.current)
+  end
+  let!(:other_action_log) do
+    create(:action_log, action: "publish", visibility: "all", resource:, organization:, participatory_space: component.participatory_space)
+  end
+
+  let(:another_comment) { create(:comment) }
+  let!(:another_action_log) do
+    create(:action_log, created_at: 2.days.ago, action: "create", visibility: "public-only", resource: another_comment, organization:)
+  end
+
+  before do
+    allow(Decidim::ActionLog).to receive(:public_resource_types).and_return(
+      %w(
+        Decidim::Comments::Comment
+        Decidim::DummyResources::DummyResource
+      )
+    )
+    allow(Decidim::ActionLog).to receive(:publicable_public_resource_types).and_return(
+      %w(Decidim::DummyResources::DummyResource)
+    )
+  end
+
+  describe "#query" do
+    it "returns the activities" do
+      expect(subject.count).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION


#### :tophat: What? Why?

In the past we've had bugs where the "Last activities" queries didn't match. For instance you'd see the last 8 actions in the "Last activities" homepage content block that when you clicked to the "Last activities" controller (/last_activities), you'd see others actions. 

This was mitigated by manually maintaining both queries in synchronization but this is error-prone.

This PR unifies these both queries. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #9844
- Fixes #9879

#### Testing
As it's a refactor, there shouldn't be any difference before and after. All the specs should pass of course. 

:hearts: Thank you!
