### PR TITLE
Fix user sign up with invalid name

### DIFF
--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -19,7 +19,7 @@ module Decidim
     attribute :personal_url
     attribute :about
 
-    validates :name, presence: true
+    validates :name, presence: true, format: { with: Decidim::User::REGEXP_NAME }
     validates :email, presence: true, "valid_email_2/email": { disposable: true }
     validates :nickname, presence: true, format: Decidim::User::REGEXP_NICKNAME
 

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -21,7 +21,7 @@ module Decidim
 
     validates :name, presence: true, format: { with: Decidim::User::REGEXP_NAME }
     validates :email, presence: true, "valid_email_2/email": { disposable: true }
-    validates :nickname, presence: true, format: Decidim::User::REGEXP_NICKNAME
+    validates :nickname, presence: true, format: { with: Decidim::User::REGEXP_NICKNAME }
 
     validates :nickname, length: { maximum: Decidim::User.nickname_max_length, allow_blank: true }
     validates :password, confirmation: true

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -14,7 +14,7 @@ module Decidim
     attribute :tos_agreement, Boolean
     attribute :current_locale, String
 
-    validates :name, presence: true
+    validates :name, presence: true, format: { with: Decidim::User::REGEXP_NAME }
     validates :nickname, presence: true, format: Decidim::User::REGEXP_NICKNAME, length: { maximum: Decidim::User.nickname_max_length }
     validates :email, presence: true, "valid_email_2/email": { disposable: true }
     validates :password, confirmation: true

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -15,7 +15,7 @@ module Decidim
     attribute :current_locale, String
 
     validates :name, presence: true, format: { with: Decidim::User::REGEXP_NAME }
-    validates :nickname, presence: true, format: Decidim::User::REGEXP_NICKNAME, length: { maximum: Decidim::User.nickname_max_length }
+    validates :nickname, presence: true, format: { with: Decidim::User::REGEXP_NICKNAME }, length: { maximum: Decidim::User.nickname_max_length }
     validates :email, presence: true, "valid_email_2/email": { disposable: true }
     validates :password, confirmation: true
     validates :password, password: { name: :name, email: :email, username: :nickname }

--- a/decidim-core/spec/forms/account_form_spec.rb
+++ b/decidim-core/spec/forms/account_form_spec.rb
@@ -49,6 +49,24 @@ module Decidim
       end
     end
 
+    describe "name" do
+      context "with an empty name" do
+        let(:name) { "" }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+        end
+      end
+
+      context "with invalid characters" do
+        let(:name) { "foo@bar" }
+
+        it "is invalid" do
+          expect(subject).not_to be_valid
+        end
+      end
+    end
+
     describe "email" do
       context "with an empty email" do
         let(:email) { "" }

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -111,6 +111,18 @@ module Decidim
       it { is_expected.to be_invalid }
     end
 
+    context "when the name is an email" do
+      let(:name) { "test@example.org" }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "when the nickname has spaces" do
+      let(:nickname) { "test example" }
+
+      it { is_expected.to be_invalid }
+    end
+
     context "when the password is not present" do
       let(:password) { nil }
 


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

If you register (aka sign up) with an invalid name, the form gives an error but it doesn't tell it explicitly. 

This also happens in the account form, where if you add an invalid character in your name, you'll see that there was an error but not the explicit field where this error has been. 

I've also found out that in the nickname field we have this validation: 

https://github.com/decidim/decidim/blob/62478dace26b421cc6d8775bd9df3a019d6e9cd1/decidim-core/app/forms/decidim/account_form.rb#L24

Mind that it says `format: Decidim::User::REGEXP_NICKNAME`, and according to [Rails documentation](https://guides.rubyonrails.org/active_record_validations.html#format) it should be `format: { with: Decidim::User::REGEXP_NICKNAME }`. It works either way, but for consistency and not doing weird things I prefer to make it consistent. 

This PR fixes those two bugs.  

#### :pushpin: Related Issues
 
- Fixes #9876

#### Testing

1. Go to Sign Up
2. Fill in the required fields. With Your Name, try '[test@example.org](mailto:test@example.org)'
3. Submit
4. See the error 

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/717367/195112265-9680fcce-43c1-430c-8467-81b04ed8c4f0.png)


:hearts: Thank you!
