### PR TITLE
Backport: Error duplicating hybrid meetings (0.26)

### DIFF
--- a/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
@@ -62,7 +62,9 @@ module Decidim
             questionnaire: form.questionnaire,
             registrations_enabled: meeting.registrations_enabled,
             available_slots: meeting.available_slots,
-            registration_terms: meeting.registration_terms
+            registration_terms: meeting.registration_terms,
+            online_meeting_url: meeting.online_meeting_url,
+            type_of_meeting: meeting.type_of_meeting
           )
         end
 


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Fix the copy meeting functionality in 0.26.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #9899
- Fixes #9848

#### Testing
Test the issue reported in #9848

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
