### PR TITLE
Add missing active actions on admin navigation menu

### DIFF
--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -173,7 +173,10 @@ module Decidim
                         decidim_admin.root_path,
                         icon_name: "dashboard",
                         position: 1,
-                        active: ["decidim/admin/dashboard" => :show]
+                        active: [%w(
+                          decidim/admin/dashboard
+                          decidim/admin/metrics
+                        ), []]
 
           menu.add_item :moderations,
                         I18n.t("menu.moderation", scope: "decidim.admin"),

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -243,6 +243,8 @@ module Decidim
                             decidim/admin/scopes
                             decidim/admin/scope_types
                             decidim/admin/areas decidim/admin/area_types
+                            decidim/admin/help_sections
+                            decidim/admin/organization_external_domain_whitelist
                           ),
                           []
                         ],

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -208,10 +208,15 @@ module Decidim
                           decidim/admin/user_groups_csv_verifications
                           decidim/admin/officializations
                           decidim/admin/impersonatable_users
+                          decidim/admin/conflicts
                           decidim/admin/moderated_users
                           decidim/admin/managed_users/impersonation_logs
                           decidim/admin/managed_users/promotions
                           decidim/admin/authorization_workflows
+                          decidim/verifications/id_documents/admin/pending_authorizations
+                          decidim/verifications/id_documents/admin/config
+                          decidim/verifications/postal_letter/admin/pending_authorizations
+                          decidim/verifications/csv_census/admin/census
                         ), []],
                         if: allowed_to?(:read, :admin_user) || allowed_to?(:read, :managed_user)
 

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -103,7 +103,9 @@ module Decidim
                         decidim_admin_assemblies.assemblies_path,
                         icon_name: "dial",
                         position: 2.2,
-                        active: :inclusive,
+                        active: is_active_link?(decidim_admin_assemblies.assemblies_path) ||
+                                is_active_link?(decidim_admin_assemblies.assemblies_types_path) ||
+                                is_active_link?(decidim_admin_assemblies.edit_assemblies_settings_path),
                         if: allowed_to?(:enter, :space_area, space_name: :assemblies)
         end
       end

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -90,7 +90,13 @@ module Decidim
                         decidim_admin_initiatives.initiatives_path,
                         icon_name: "chat",
                         position: 2.4,
-                        active: :inclusive,
+                        active: is_active_link?(decidim_admin_initiatives.initiatives_path) ||
+                                is_active_link?(decidim_admin_initiatives.initiatives_types_path) ||
+                                is_active_link?(
+                                  decidim_admin_initiatives.edit_initiatives_setting_path(
+                                    Decidim::InitiativesSettings.find_or_create_by!(organization: current_organization)
+                                  )
+                                ),
                         if: allowed_to?(:enter, :space_area, space_name: :initiatives)
         end
       end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -103,7 +103,8 @@ module Decidim
                         icon_name: "target",
                         position: 2,
                         active: is_active_link?(decidim_admin_participatory_processes.participatory_processes_path, :inclusive) ||
-                                is_active_link?(decidim_admin_participatory_processes.participatory_process_groups_path, :inclusive),
+                                is_active_link?(decidim_admin_participatory_processes.participatory_process_groups_path, :inclusive) ||
+                                is_active_link?(decidim_admin_participatory_processes.participatory_process_types_path),
                         if: allowed_to?(:enter, :space_area, space_name: :processes) || allowed_to?(:enter, :space_area, space_name: :process_groups)
         end
       end


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
There are some actions in the admin's navigation menu that doesn't have the `is-active` class even though you're on that section. This PR fixes them.

#### Testing

1. Sign in as admin
2. Go to one of the fixed pages
3. See that the main navigation menu is selected (aka has the  `is-active` class, see screenshot)

Fixed pages:

- http://localhost:3000/admin/metrics
- http://localhost:3000/admin/conflicts
- http://localhost:3000/admin/id_documents/
- http://localhost:3000/admin/id_documents/config/edit
- http://localhost:3000/admin/postal_letter/
- http://localhost:3000/admin/csv_census/
- http://localhost:3000/admin/help_sections
- http://localhost:3000/admin/organization/external_domain_whitelist/edit
- http://localhost:3000/admin/participatory_process_groups
- http://localhost:3000/admin/participatory_process_types
- http://localhost:3000/admin/assemblies_types
- http://localhost:3000/admin/assemblies_settings/edit
- http://localhost:3000/admin/initiatives_types
- http://localhost:3000/admin/initiatives_settings/1/edit

### :camera: Screenshots

#### Before 

![Selection_360](https://user-images.githubusercontent.com/717367/196182577-764f049c-a71a-4c17-8eaf-6d495349cdbb.png)

#### After 

![Selection_359](https://user-images.githubusercontent.com/717367/196182370-19505fa1-b94e-46fc-89fa-1f6df9eddfa6.png)

:hearts: Thank you!
