### PR TITLE
Make initiatives order translatable

### DIFF
--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -20,6 +20,8 @@ en:
         title: Title
       initiatives_committee_member:
         user: Committee member
+      initiatives_settings:
+        initiatives_order: Order
       initiatives_type:
         area_enabled: Enable authors to choose the area for their initiative
         attachments_enabled: Enable attachments


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While working on the admin panel, I found out yet another attribute that we didn't translate. This PR adds it. 
 

#### Testing

You can check it out at http://localhost:3000/admin/initiatives_settings/1/edit or:
1. Sign in as admin
2. Go to admin dashboard
3. Go to Initiatives
4. Click on Settings in the submenu
 

:hearts: Thank you!
