### PR TITLE
Make ToS agreement translatable

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
         password_confirmation: Confirm your password
         personal_url: Personal URL
         remove_avatar: Remove avatar
-        tos_agreement: Tos agreement
+        tos_agreement: Terms and conditions of use agreement
     models:
       decidim/attachment_created_event: Attachment
       decidim/component_published_event: Active component

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
         password_confirmation: Confirm your password
         personal_url: Personal URL
         remove_avatar: Remove avatar
+        tos_agreement: Tos agreement
     models:
       decidim/attachment_created_event: Attachment
       decidim/component_published_event: Active component

--- a/decidim-core/spec/controllers/registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/registrations_controller_spec.rb
@@ -89,7 +89,7 @@ module Decidim
                 "Confirm your password doesn't match Password",
                 "Password is too short",
                 "Password does not have enough unique characters",
-                "Tos agreement must be accepted"
+                "Terms and conditions of use agreement must be accepted"
               ].join(", ")
             )
           end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR aims to translate the TOS agreement attribute so error messages can be translated if tos are not accepted during the sign up. 

#### :pushpin: Related Issues

- Fixes https://github.com/decidim/decidim/issues/9908?

#### Testing
1. Go to the sign up page in another locale than en
2. Try to sign up without accepting TOS
3. See that the message is translated

### :camera: Screenshots
<img width="1512" alt="Capture d’écran 2022-10-17 à 17 16 08" src="https://user-images.githubusercontent.com/52420208/196216104-6a9ace53-0369-4b70-a2c2-29781c0ad792.png">

:hearts: Thank you!
