### PR TITLE
Exclude malformed file from codeclimate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -102,6 +102,7 @@ plugins:
       - "**/*/locales/*.yml"
       - "**/*/*.svg"
       - "decidim-dev/lib/decidim/dev/assets/iso-8859-15.md"
+      - "decidim-dev/lib/decidim/dev/assets/import_participatory_space_private_users_iso8859-1.csv"
 
   stylelint:
     # FIXME: after the webpacker packages changes, this is broken with this error:


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
On the last few weeks we're seeing a flaky spec on Codeclimate. The full error message says:

> An engine encountered an error
> View the build
> E10 Error
>
> We had trouble running the grep engine.
>
> The engine's output shown below may indicate the cause of the error.
>
> If not, please contact us so we can investigate further.
>
> undefined method `gsub' for nil:NilClass

This is visible on some PRs, for instance https://codeclimate.com/github/decidim/decidim/pull/9909 

This PR fixes it.
 
#### :pushpin: Related Issues
 
- Related to #9613
 

#### Testing

1. Install the [codeclimate CLI](https://github.com/codeclimate/codeclimate/) locally 

```bash
curl -L https://github.com/codeclimate/codeclimate/archive/master.tar.gz | tar xvz
cd codeclimate-* && sudo make install
```

2. For checking the failure, run the grep engine on develop.

```bash
codeclimate analyze -e grep
```

See the error:

3.  For checking the fix, run the grep engine on this branch:

```bash
gh pr checkout 9910
codeclimate analyze -e grep
```

See that it runs without the exception
 
:hearts: Thank you!
