### PR TITLE
Light optimization on last activities loading

### DIFF
--- a/decidim-core/app/cells/decidim/activities_cell.rb
+++ b/decidim-core/app/cells/decidim/activities_cell.rb
@@ -39,7 +39,7 @@ module Decidim
         activity.participatory_space_lazy
         activity.component_lazy
         activity
-      end
+      end.compact
     end
   end
 end

--- a/decidim-core/app/cells/decidim/activities_cell.rb
+++ b/decidim-core/app/cells/decidim/activities_cell.rb
@@ -27,13 +27,13 @@ module Decidim
     end
 
     def activities
-      @activities ||= last_activities.select do |activity|
-        activity.visible_for?(current_user)
-      end
+      @activities ||= last_activities
     end
 
     def last_activities
       @last_activities ||= model.map do |activity|
+        next unless activity.visible_for?(current_user)
+
         activity.organization_lazy
         activity.resource_lazy
         activity.participatory_space_lazy


### PR DESCRIPTION
#### :tophat: What? Why?
Just a little optimization on last activities loading. 

I noticed an extra loop that we can refactor 

**Benchmarks**

Loading on development mode : 

Before: 
```
  Rendered cell decidim/comments/comment_activity (144.3ms)
  Rendered cell decidim/comments/comment_activity (101.8ms)
  Rendered cell decidim/comments/comment_activity (84.5ms)
  Rendered cell decidim/comments/comment_activity (83.9ms)
  Rendered cell decidim/comments/comment_activity (77.1ms)
  Rendered cell decidim/comments/comment_activity (76.5ms)
  Rendered cell decidim/comments/comment_activity (87.3ms)
  Rendered cell decidim/comments/comment_activity (73.1ms)
```

After:
```
  Rendered cell decidim/comments/comment_activity (107.2ms)
  Rendered cell decidim/comments/comment_activity (92.2ms)
  Rendered cell decidim/comments/comment_activity (70.2ms)
  Rendered cell decidim/comments/comment_activity (72.5ms)
  Rendered cell decidim/comments/comment_activity (72.2ms)
  Rendered cell decidim/comments/comment_activity (63.1ms)
  Rendered cell decidim/comments/comment_activity (76.6ms)
  Rendered cell decidim/comments/comment_activity (65.8ms)
```
#### :pushpin: Related Issues
- No related issue, just a light refactor

:hearts: Thank you!
