### PR TITLE
Export proposal body without HTML tags

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -33,7 +33,7 @@ module Decidim
           },
           component: { id: component.id },
           title: proposal.title,
-          body: strip_tags_from(proposal.body),
+          body: convert_to_plain_text(proposal.body),
           address: proposal.address,
           latitude: proposal.latitude,
           longitude: proposal.longitude,
@@ -96,13 +96,10 @@ module Decidim
       end
 
       # Recursively strips HTML tags from given Hash strings using convert_to_text from Premailer
-      def strip_tags_from(hash)
-        return hash unless hash.is_a?(Hash)
-        return hash if hash.blank?
+      def convert_to_plain_text(value)
+        return value.transform_values { |v| convert_to_plain_text(v) } if value.is_a?(Hash)
 
-        hash.transform_values do |v|
-          v.is_a?(Hash) ? strip_tags_from(v) : convert_to_text(v)
-        end
+        convert_to_text(value)
       end
     end
   end

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -5,8 +5,6 @@ module Decidim
     # This class serializes a Proposal so can be exported to CSV, JSON or other
     # formats.
     class ProposalSerializer < Decidim::Exporters::Serializer
-      include ActionView::Helpers::SanitizeHelper
-      include Decidim::SanitizeHelper
       include Decidim::ApplicationHelper
       include Decidim::ResourceHelper
       include Decidim::TranslationsHelper

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -33,7 +33,7 @@ module Decidim
           },
           component: { id: component.id },
           title: proposal.title,
-          body: plain_text_body,
+          body: strip_tags_from(proposal.body),
           address: proposal.address,
           latitude: proposal.latitude,
           longitude: proposal.longitude,
@@ -95,9 +95,13 @@ module Decidim
         Decidim::ResourceLocatorPresenter.new(proposal.amendable).url
       end
 
-      def plain_text_body
-        proposal.body.transform_values do |v|
-          v.is_a?(Hash) ? v : convert_to_text(v)
+      # Recursively strips HTML tags from given Hash strings using convert_to_text from Premailer
+      def strip_tags_from(hash)
+        return hash unless hash.is_a?(Hash)
+        return hash if hash.blank?
+
+        hash.transform_values do |v|
+          v.is_a?(Hash) ? strip_tags_from(v) : convert_to_text(v)
         end
       end
     end

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -5,6 +5,8 @@ module Decidim
     # This class serializes a Proposal so can be exported to CSV, JSON or other
     # formats.
     class ProposalSerializer < Decidim::Exporters::Serializer
+      include ActionView::Helpers::SanitizeHelper
+      include Decidim::SanitizeHelper
       include Decidim::ApplicationHelper
       include Decidim::ResourceHelper
       include Decidim::TranslationsHelper
@@ -99,7 +101,7 @@ module Decidim
           if v.is_a? Hash
             v
           else
-            Nokogiri::HTML(v).text
+            decidim_sanitize(v, strip_tags: true)
           end
         end
       end

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -10,6 +10,7 @@ module Decidim
       include Decidim::ApplicationHelper
       include Decidim::ResourceHelper
       include Decidim::TranslationsHelper
+      include HtmlToPlainText
 
       # Public: Initializes the serializer with a proposal.
       def initialize(proposal)
@@ -98,11 +99,7 @@ module Decidim
 
       def plain_text_body
         proposal.body.transform_values do |v|
-          if v.is_a? Hash
-            v
-          else
-            decidim_sanitize(v, strip_tags: true)
-          end
+          v.is_a?(Hash) ? v : convert_to_text(v)
         end
       end
     end

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -32,7 +32,7 @@ module Decidim
           },
           component: { id: component.id },
           title: proposal.title,
-          body: proposal.body,
+          body: plain_text_body,
           address: proposal.address,
           latitude: proposal.latitude,
           longitude: proposal.longitude,
@@ -92,6 +92,16 @@ module Decidim
         return unless proposal.emendation? && proposal.amendable.present?
 
         Decidim::ResourceLocatorPresenter.new(proposal.amendable).url
+      end
+
+      def plain_text_body
+        proposal.body.transform_values do |v|
+          if v.is_a? Hash
+            v
+          else
+            Nokogiri::HTML(v).text
+          end
+        end
       end
     end
   end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -172,7 +172,15 @@ module Decidim
               <p><code>Here is code block</code></p>
             TEXT
           end
-          let(:body) { { "en" => body_content } }
+          let(:body) do
+            {
+              "en" => body_content,
+              "machine_translation" => {
+                "es" => body_content,
+                "ca" => body_content
+              }
+            }
+          end
 
           it "serializes the body without HTML tags" do
             expected_body = <<~TEXT
@@ -198,6 +206,10 @@ module Decidim
 
             expect(serialized[:body]["en"]).to eq(expected_body.chomp)
             expect(serialized[:body]["en"]).to include("Logo alt attribute")
+            expect(serialized[:body]["machine_translation"]["es"]).to eq(expected_body.chomp)
+            expect(serialized[:body]["machine_translation"]["es"]).to include("Logo alt attribute")
+            expect(serialized[:body]["machine_translation"]["ca"]).to eq(expected_body.chomp)
+            expect(serialized[:body]["machine_translation"]["ca"]).to include("Logo alt attribute")
           end
 
           context "and image is uploaded without 'alt' attribute" do
@@ -205,6 +217,8 @@ module Decidim
 
             it "serializes the body without image" do
               expect(serialized[:body]["en"]).not_to include("Logo alt attribute")
+              expect(serialized[:body]["machine_translation"]["es"]).not_to include("Logo alt attribute")
+              expect(serialized[:body]["machine_translation"]["ca"]).not_to include("Logo alt attribute")
             end
           end
         end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -153,10 +153,50 @@ module Decidim
         context "with rich text proposal body" do
           let(:image) { "<img src=\"logo.png\" #{alt_attribute} width=\"407\">" }
           let(:alt_attribute) { "alt=\"Logo alt attribute\"" }
-          let(:body) { { "en" => "<h2>This is my \"heading 2\" title</h2><h2><br></h2><p>A \"normal\" description below Heading 2</p><h3>Now this is my \"heading 3\"</h3><h3><br></h3><ul><li>This is my first option</li><li>This is my second option</li><li>This is my third option</li></ul><p><br></p><p>And below an uploaded image</p><p>#{image}</p><p><br></p><p><code>Here is code block</code></p>" } }
+          let(:body_content) do
+            <<~TEXT
+              <h2>This is my "heading 2" title</h2>
+              <p>A "normal" description below Heading 2</p>
+              <p><br></p>
+              <h3>Now this is my "heading 3"</h3>
+              <p><br></p>
+              <ul>
+              <li>This is my first option</li>
+              <li>This is my second option</li>
+              <li>This is my third option</li>
+              </ul>
+              <p><br></p>
+              <p>And below an uploaded image</p>
+              <p>#{image}</p>
+              <p><br></p>
+              <p><code>Here is code block</code></p>
+            TEXT
+          end
+          let(:body) { { "en" => body_content } }
 
           it "serializes the body without HTML tags" do
-            expect(serialized).to include(body: { "en" => "----------------------------\nThis is my \"heading 2\" title\n----------------------------\n\nA \"normal\" description below Heading 2\n\nNow this is my \"heading 3\"\n--------------------------\n\n* This is my first option\n* This is my second option\n* This is my third option\n\nAnd below an uploaded image\n\nLogo alt attribute\n\nHere is code block" })
+            expected_body = <<~TEXT
+              ----------------------------
+              This is my "heading 2" title
+              ----------------------------
+
+              A "normal" description below Heading 2
+
+              Now this is my "heading 3"
+              --------------------------
+
+              * This is my first option
+              * This is my second option
+              * This is my third option
+
+              And below an uploaded image
+
+              Logo alt attribute
+
+              Here is code block
+            TEXT
+
+            expect(serialized[:body]["en"]).to eq(expected_body.chomp)
             expect(serialized[:body]["en"]).to include("Logo alt attribute")
           end
 

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -151,10 +151,21 @@ module Decidim
         end
 
         context "with rich text proposal body" do
-          let(:body) { { "en" => "<h3>Proposal body</h3><p><strong>This is the body</strong> of the proposal</p>" } }
+          let(:image) { "<img src=\"logo.png\" #{alt_attribute} width=\"407\">" }
+          let(:alt_attribute) { "alt=\"Logo alt attribute\"" }
+          let(:body) { { "en" => "<h2>This is my \"heading 2\" title</h2><h2><br></h2><p>A \"normal\" description below Heading 2</p><h3>Now this is my \"heading 3\"</h3><h3><br></h3><ul><li>This is my first option</li><li>This is my second option</li><li>This is my third option</li></ul><p><br></p><p>And below an uploaded image</p><p>#{image}</p><p><br></p><p><code>Here is code block</code></p>" } }
 
           it "serializes the body without HTML tags" do
-            expect(serialized).to include(body: { "en" => "Proposal bodyThis is the body of the proposal" })
+            expect(serialized).to include(body: { "en" => "----------------------------\nThis is my \"heading 2\" title\n----------------------------\n\nA \"normal\" description below Heading 2\n\nNow this is my \"heading 3\"\n--------------------------\n\n* This is my first option\n* This is my second option\n* This is my third option\n\nAnd below an uploaded image\n\nLogo alt attribute\n\nHere is code block" })
+            expect(serialized[:body]["en"]).to include("Logo alt attribute")
+          end
+
+          context "and image is uploaded without 'alt' attribute" do
+            let(:alt_attribute) { "" }
+
+            it "serializes the body without image" do
+              expect(serialized[:body]["en"]).not_to include("Logo alt attribute")
+            end
           end
         end
       end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -183,7 +183,7 @@ module Decidim
           end
 
           it "serializes the body without HTML tags" do
-            expected_body = <<~TEXT
+            expected_body = <<~TEXT.chomp
               ----------------------------
               This is my "heading 2" title
               ----------------------------
@@ -204,11 +204,11 @@ module Decidim
               Here is code block
             TEXT
 
-            expect(serialized[:body]["en"]).to eq(expected_body.chomp)
+            expect(serialized[:body]["en"]).to eq(expected_body)
             expect(serialized[:body]["en"]).to include("Logo alt attribute")
-            expect(serialized[:body]["machine_translation"]["es"]).to eq(expected_body.chomp)
+            expect(serialized[:body]["machine_translation"]["es"]).to eq(expected_body)
             expect(serialized[:body]["machine_translation"]["es"]).to include("Logo alt attribute")
-            expect(serialized[:body]["machine_translation"]["ca"]).to eq(expected_body.chomp)
+            expect(serialized[:body]["machine_translation"]["ca"]).to eq(expected_body)
             expect(serialized[:body]["machine_translation"]["ca"]).to include("Logo alt attribute")
           end
 

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -9,7 +9,7 @@ module Decidim
         described_class.new(proposal)
       end
 
-      let!(:proposal) { create(:proposal, :accepted) }
+      let!(:proposal) { create(:proposal, :accepted, body:) }
       let!(:category) { create(:category, participatory_space: component.participatory_space) }
       let!(:scope) { create(:scope, organization: component.participatory_space.organization) }
       let(:participatory_process) { component.participatory_space }
@@ -20,6 +20,7 @@ module Decidim
 
       let!(:proposals_component) { create(:component, manifest_name: "proposals", participatory_space: participatory_process) }
       let(:other_proposals) { create_list(:proposal, 2, component: proposals_component) }
+      let(:body) { Decidim::Faker::Localized.localized { ::Faker::Lorem.sentences(number: 3).join("\n") } }
 
       let(:expected_answer) do
         answer = proposal.answer
@@ -61,7 +62,7 @@ module Decidim
         end
 
         it "serializes the body" do
-          expect(serialized).to include(body: proposal.body)
+          expect(serialized[:body]).to eq(proposal.body)
         end
 
         it "serializes the address" do
@@ -146,6 +147,14 @@ module Decidim
 
           it "serializes the answer" do
             expect(serialized).to include(answer: expected_answer)
+          end
+        end
+
+        context "with rich text proposal body" do
+          let(:body) { { "en" => "<h3>Proposal body</h3><p><strong>This is the body</strong> of the proposal</p>" } }
+
+          it "serializes the body without HTML tags" do
+            expect(serialized[:body]).to eq({ "en" => "Proposal bodyThis is the body of the proposal" })
           end
         end
       end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -62,7 +62,7 @@ module Decidim
         end
 
         it "serializes the body" do
-          expect(serialized[:body]).to eq(proposal.body)
+          expect(serialized).to include(body: proposal.body)
         end
 
         it "serializes the address" do
@@ -154,7 +154,7 @@ module Decidim
           let(:body) { { "en" => "<h3>Proposal body</h3><p><strong>This is the body</strong> of the proposal</p>" } }
 
           it "serializes the body without HTML tags" do
-            expect(serialized[:body]).to eq({ "en" => "Proposal bodyThis is the body of the proposal" })
+            expect(serialized).to include(body: { "en" => "Proposal bodyThis is the body of the proposal" })
           end
         end
       end


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

When rich text editor is enabled, proposals body are exported with HTML tags and can complexify the reading in export. 
This PR remove all HTML tags from proposal body in the serializer using `premailer` . 

#### :pushpin: Related Issues

- Fixes #9197

#### Testing

- Enable rich text editor
- Create a new proposal
- Add Heading, bold and whatever using the WYSIWYG editor
- Save and export proposal
You should not have HTML tags in the body column

#### Additional information

This solution just remove HTML tags from body, but text won't be formatted. To me, the proposal body won't always be easier to read for an admin. 

:hearts: Thank you!
