### PR TITLE
Fix organization SMTP password not saved (became blank) in system panel

### DIFF
--- a/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -29,6 +29,7 @@ module Decidim
         [:authentication, String],
         [:enable_starttls_auto, Boolean]
       ]
+      attribute :password, String
       attribute :file_upload_settings, FileUploadSettingsForm
 
       OMNIATH_PROVIDERS_ATTRIBUTES = Decidim::OmniauthProvider.available.keys.map do |provider|

--- a/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -44,8 +44,6 @@ module Decidim
 
       jsonb_attribute :omniauth_settings, OMNIATH_PROVIDERS_ATTRIBUTES
 
-      attr_writer :password
-
       validates :name, :host, :users_registration_mode, presence: true
       validate :validate_organization_uniqueness
       validates :users_registration_mode, inclusion: { in: Decidim::Organization.users_registration_modes }
@@ -71,13 +69,13 @@ module Decidim
       end
 
       def password
-        Decidim::AttributeEncryptor.decrypt(encrypted_password) unless encrypted_password.nil?
+        encrypted_password.nil? ? super : Decidim::AttributeEncryptor.decrypt(encrypted_password)
       end
 
       def encrypted_smtp_settings
         smtp_settings["from"] = set_from
 
-        smtp_settings.merge(encrypted_password: Decidim::AttributeEncryptor.encrypt(@password))
+        smtp_settings.merge(encrypted_password: Decidim::AttributeEncryptor.encrypt(password))
       end
 
       def set_from

--- a/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
@@ -16,14 +16,7 @@ module Decidim::System
         default_locale: "en",
         users_registration_mode: "enabled",
         force_users_to_authenticate_before_access_organization: "false",
-        smtp_settings: {
-          "address" => "mail.gotham.gov",
-          "port" => "25",
-          "user_name" => "f.laguardia",
-          "password" => Decidim::AttributeEncryptor.encrypt("password"),
-          "from_email" => "decide@gotham.gov",
-          "from_label" => from_label
-        },
+        **smtp_settings,
         omniauth_settings: {
           "omniauth_settings_facebook_enabled" => true,
           "omniauth_settings_facebook_app_id" => facebook_app_id,
@@ -32,6 +25,17 @@ module Decidim::System
       )
     end
 
+    let(:smtp_settings) do
+      {
+        "address" => "mail.gotham.gov",
+        "port" => 25,
+        "user_name" => "f.laguardia",
+        "password" => password,
+        "from_email" => "decide@gotham.gov",
+        "from_label" => from_label
+      }
+    end
+    let(:password) { "secret_password" }
     let(:from_label) { "Decide Gotham" }
     let(:facebook_app_id) { "plain-text-facebook-app-id" }
     let(:facebook_app_secret) { "plain-text-facebook-app-secret" }
@@ -76,6 +80,13 @@ module Decidim::System
 
             expect(from).to eq("decide@gotham.gov")
           end
+        end
+      end
+
+      describe "smtp_settings" do
+        it "handles SMTP password properly" do
+          expect(subject.smtp_settings).to eq(smtp_settings.except("password"))
+          expect(Decidim::AttributeEncryptor.decrypt(subject.encrypted_smtp_settings[:encrypted_password])).to eq(password)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Issue started appearing after moving from `Virtus` to `ActiveModel::Attributes`, [PR#8669](https://github.com/decidim/decidim/pull/8669).
In system panel, when you edit the SMTP password and save - it clears the password and always save `encrypted_password` as `nil`.

I didn't go too deep into Virtus/Rectify logic to compare and to find out how exactly it handled the `password` attribute before. I assume the form just assigned all the passed attributes to the model, which is not the case for newer forms.

In newer [Decidim::AttributeObject::Form](https://github.com/decidim/decidim/blob/v0.27.0/decidim-core/lib/decidim/attribute_object/form.rb#L68) when the model is built, [during initialization it filters only attributes that are defined in the form](https://github.com/decidim/decidim/blob/v0.27.0/decidim-core/lib/decidim/attribute_object/model.rb#L96), so in turn the ActiveModel doesn't set the `password` attribute for a model as it's not in the list of attributes.

That behavior produces an issue that password is never saved/updated and [by that logic in the form](https://github.com/decidim/decidim/blob/v0.27.0/decidim-system/app/forms/decidim/system/update_organization_form.rb#L79) it is always cleared to `nil`.

Hope the explanation is well enough to understand the root of the issue :D

#### Side note
In the spec test I also changed a bit how `smtp_settings` comes to the `UpdateOrganizationForm`, [as in params from the page/controller](https://github.com/decidim/decidim/blob/v0.27.0/decidim-system/app/controllers/decidim/system/organizations_controller.rb#L46), just for sake that the test will be closer to real usage of the form.
SMTP attributes comes as attributes of organization and not grouped under the `smtp_settings` key
(don't know if it's simply a wrong usage of `fields_for` in [_smtp_settings.html.erb](https://github.com/decidim/decidim/blob/v0.27.0/decidim-system/app/views/decidim/system/organizations/_smtp_settings.html.erb#L3) or was done that way on purpose, that's a separate thing and not related to current changes).

#### Testing

- Go to system panel and edit organization
- Update SMTP password and save
- Get back to edit organization and check the SMTP password field - it is empty
