### PR TITLE
Fix issues with a11y specs

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/modules/_callout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_callout.scss
@@ -26,6 +26,10 @@
     border-color: $medium-gray;
     border-left: 8px solid var(--alert);
   }
+
+  a{
+    text-decoration: underline;
+  }
 }
 
 .callout.flash{

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
 module AxeMatchers
+  def self.axe_version
+    @axe_version ||= begin
+      package = JSON.load_file(Rails.root.join("node_modules/axe-core/package.json"))
+      package["version"]
+    end
+  end
+
+  def self.axe_mainline_version
+    @axe_mainline_version ||= axe_version.split(".")[0..1].join(".")
+  end
+
   class ResultFormatter
     def initialize(result)
       @result = result

--- a/decidim-dev/spec/system/axe_matchers_spec.rb
+++ b/decidim-dev/spec/system/axe_matchers_spec.rb
@@ -54,6 +54,7 @@ describe AxeMatchers, type: :system do
       end
 
       let(:simplified_html) { html_document.sub(/<!DOCTYPE html>/, "").gsub(/\n\s*/, "") }
+      let(:axe_version) { AxeMatchers.axe_mainline_version }
 
       it "formats the message correctly" do
         message = <<~MSG
@@ -61,7 +62,7 @@ describe AxeMatchers, type: :system do
           Found 3 accessibility violations:
 
           1) landmark-one-main: Document should have one main landmark (moderate)
-              https://dequeuniversity.com/rules/axe/4.4/landmark-one-main?application=axeAPI
+              https://dequeuniversity.com/rules/axe/#{axe_version}/landmark-one-main?application=axeAPI
               The following 1 node violate this rule:
 
                   Selector: html
@@ -71,7 +72,7 @@ describe AxeMatchers, type: :system do
 
 
           2) page-has-heading-one: Page should contain a level-one heading (moderate)
-              https://dequeuniversity.com/rules/axe/4.4/page-has-heading-one?application=axeAPI
+              https://dequeuniversity.com/rules/axe/#{axe_version}/page-has-heading-one?application=axeAPI
               The following 1 node violate this rule:
 
                   Selector: html
@@ -81,7 +82,7 @@ describe AxeMatchers, type: :system do
 
 
           3) region: All page content should be contained by landmarks (moderate)
-              https://dequeuniversity.com/rules/axe/4.4/region?application=axeAPI
+              https://dequeuniversity.com/rules/axe/#{axe_version}/region?application=axeAPI
               The following 1 node violate this rule:
 
                   Selector: div


### PR DESCRIPTION
#### :tophat: What? Why?
Recently we have few accessibility tests broken because `axe-core` was updated:

1. The axe matchers specs are bound to the previous axe mainline version, after this it will be read dynamically from the package
2. The new version added stricter checks for [link color contrasts](https://dequeuniversity.com/rules/axe/4.5/link-in-text-block?application=axeAPI) which causes actual a11y violations

#### Testing
See that CI is green.