### PR TITLE
Backport 'Fix date/time formats at component forms' to v0.27

### DIFF
--- a/decidim-conferences/spec/controllers/admin/conferences_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/admin/conferences_controller_spec.rb
@@ -42,7 +42,8 @@ module Decidim
           expect(Decidim::Conferences::Admin::ConferenceForm).to receive(:from_params).with(hash_including(id: conference.id.to_s)).and_call_original
           patch :update, params: { slug: conference.id, conference: conference_params }
 
-          expect(response).to be_successful
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to edit_conference_path(conference)
         end
       end
     end

--- a/decidim-core/lib/decidim/attributes/localized_date.rb
+++ b/decidim-core/lib/decidim/attributes/localized_date.rb
@@ -16,7 +16,7 @@ module Decidim
 
         Date.strptime(value, I18n.t("date.formats.decidim_short"))
       rescue ArgumentError
-        nil
+        super
       end
     end
   end

--- a/decidim-core/lib/decidim/attributes/time_with_zone.rb
+++ b/decidim-core/lib/decidim/attributes/time_with_zone.rb
@@ -4,7 +4,7 @@ module Decidim
   module Attributes
     # Custom attributes value to parse a String representing a Time using
     # the app TimeZone.
-    class TimeWithZone < ActiveModel::Type::Time
+    class TimeWithZone < ActiveModel::Type::DateTime
       def type
         :"decidim/attributes/time_with_zone"
       end
@@ -16,7 +16,10 @@ module Decidim
 
         Time.zone.strptime(value, I18n.t("time.formats.decidim_short"))
       rescue ArgumentError
-        nil
+        fallback = super
+        return fallback unless fallback.is_a?(Time)
+
+        ActiveSupport::TimeWithZone.new(fallback, Time.zone)
       end
     end
   end

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -387,7 +387,14 @@ module Decidim
     def datetime_field(attribute, options = {})
       value = object.send(attribute)
       data = { datepicker: "", timepicker: "" }
-      data[:startdate] = I18n.l(value, format: :decidim_short) if value.present? && value.is_a?(ActiveSupport::TimeWithZone)
+      if value.present?
+        case value
+        when ActiveSupport::TimeWithZone
+          data[:startdate] = I18n.l(value, format: :decidim_short)
+        when Time, DateTime
+          data[:startdate] = I18n.l(value.in_time_zone(Time.zone), format: :decidim_short)
+        end
+      end
       datepicker_format = ruby_format_to_datepicker(I18n.t("time.formats.decidim_short"))
       data[:"date-format"] = datepicker_format
 

--- a/decidim-core/lib/decidim/settings_manifest.rb
+++ b/decidim-core/lib/decidim/settings_manifest.rb
@@ -97,7 +97,7 @@ module Decidim
         enum: { klass: String, default: nil },
         select: { klass: String, default: nil },
         scope: { klass: Integer, default: nil },
-        time: { klass: DateTime, default: nil }
+        time: { klass: Decidim::Attributes::TimeWithZone, default: nil }
       }.freeze
 
       attribute :type, Symbol, default: :boolean

--- a/decidim-core/spec/lib/attributes/localized_date_spec.rb
+++ b/decidim-core/spec/lib/attributes/localized_date_spec.rb
@@ -49,6 +49,14 @@ module Decidim
             expect(subject).to be_nil
           end
         end
+
+        context "with serialized ISO 8601 datetime format" do
+          let(:value) { "2017-02-01" }
+
+          it "parses the String in the correct format" do
+            expect(subject).to eq(Date.new(2017, 2, 1))
+          end
+        end
       end
     end
   end

--- a/decidim-core/spec/lib/attributes/time_with_timezone_spec.rb
+++ b/decidim-core/spec/lib/attributes/time_with_timezone_spec.rb
@@ -24,7 +24,7 @@ module Decidim
       context "when given a String" do
         let(:value) { "01/02/2017 15:00" }
 
-        context "and in a different timezone" do
+        context "with a different timezone" do
           it "parses the String in the correct timezone" do
             Time.use_zone("CET") do
               expect(subject.utc.to_s).to eq("2017-02-01 14:00:00 UTC")
@@ -52,11 +52,19 @@ module Decidim
           end
         end
 
-        context "and an incorrect format" do
+        context "with incorrect format" do
           let(:value) { "foo" }
 
           it "returns nil" do
             expect(subject).to be_nil
+          end
+        end
+
+        context "with serialized ISO 8601 datetime format" do
+          let(:value) { "2017-02-01T15:00:00.000Z" }
+
+          it "parses the String in the correct format" do
+            expect(subject.utc.to_s).to eq("2017-02-01 15:00:00 UTC")
           end
         end
       end

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -380,13 +380,68 @@ module Decidim
     end
 
     describe "datetime_field" do
+      let(:output) do
+        builder.datetime_field :start_time
+      end
+
+      context "when the start_time is set as ActiveSupport::TimeWithZone" do
+        before do
+          resource.start_time = Time.parse("2017-02-01T15:00:00.000Z").in_time_zone("UTC")
+        end
+
+        it { expect(resource.start_time).to be_a(ActiveSupport::TimeWithZone) }
+
+        it "formats the start date correctly" do
+          expect(parsed.css("input").first.attr("data-startdate")).to eq("01/02/2017 15:00")
+        end
+
+        context "with another timezone", tz: "Helsinki" do
+          it "formats the start date in the original time zone" do
+            # Note: this case is correct because it should preserve the zone stored within the value itself.
+            expect(parsed.css("input").first.attr("data-startdate")).to eq("01/02/2017 15:00")
+          end
+        end
+      end
+
+      context "when the start_time is set as Time" do
+        before do
+          resource.start_time = Time.parse("2017-02-01T15:00:00.000Z")
+        end
+
+        it { expect(resource.start_time).to be_a(Time) }
+
+        it "formats the start date correctly" do
+          expect(parsed.css("input").first.attr("data-startdate")).to eq("01/02/2017 15:00")
+        end
+
+        context "with another timezone", tz: "Helsinki" do
+          it "formats the start date in the correct time zone" do
+            expect(parsed.css("input").first.attr("data-startdate")).to eq("01/02/2017 17:00")
+          end
+        end
+      end
+
+      context "when the start_time is set as DateTime" do
+        before do
+          resource.start_time = DateTime.parse("2017-02-01T15:00:00.000Z") # rubocop:disable Style/DateTime
+        end
+
+        it { expect(resource.start_time).to be_a(DateTime) }
+
+        it "formats the start date correctly" do
+          expect(parsed.css("input").first.attr("data-startdate")).to eq("01/02/2017 15:00")
+        end
+
+        context "with another timezone", tz: "Helsinki" do
+          it "formats the start date in the correct time zone" do
+            expect(parsed.css("input").first.attr("data-startdate")).to eq("01/02/2017 17:00")
+          end
+        end
+      end
+
       context "when the resource has errors" do
         before do
           resource.valid?
-        end
-
-        let(:output) do
-          builder.datetime_field :start_time
         end
 
         it "renders the input with the proper class" do


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9632 to v0.27

:hearts: Thank you!