### PR TITLE
Backport 'Fix preserving bold text in the rich text editor when pasting content' to v0.27

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe "Admin manages organization", type: :system do
+  include ActionView::Helpers::SanitizeHelper
+
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, :confirmed, organization: organization) }
 
@@ -36,6 +38,9 @@ describe "Admin manages organization", type: :system do
     context "when using the rich text editor" do
       before do
         visit decidim_admin.edit_organization_path
+
+        # Makes sure in the error screenshots the editor is visible
+        page.scroll_to(find("#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor"))
       end
 
       context "when the admin terms of use content is empty" do
@@ -346,6 +351,107 @@ describe "Admin manages organization", type: :system do
           expect(find(
             "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq(terms_content.to_s.gsub("\n", ""))
+        end
+      end
+
+      context "when pasting content with bold text" do
+        let(:organization) do
+          create(
+            :organization,
+            admin_terms_of_use_body: Decidim::Faker::Localized.localized { "" }
+          )
+        end
+
+        let(:clipboard_content_html) do
+          # The pasted content contains always all styles for the elements, so
+          # this is just to test that the styles don't interfere with the pasted
+          # content handling.
+          styles = {
+            p: {
+              "box-sizing" => "border-box",
+              "font-family" => "Helvetica, Arial, sans-serif",
+              "font-style" => "normal"
+            },
+            strong: {
+              "box-sizing" => "border-box",
+              "font-weight" => "600",
+              "line-height" => "inherit"
+            },
+            a: {
+              "box-sizing" => "border-box",
+              "background-color" => "transparent",
+              "line-height" => "inherit",
+              "color" => "rgb(0, 102, 204)",
+              "text-decoration" => "underline",
+              "cursor" => "pointer",
+              "font-weight" => "normal"
+            },
+            br: {
+              "box-sizing" => "border-box"
+            }
+          }.transform_values { |css| css.map { |k, v| "#{k}: #{v}" }.join("; ").concat(";") }
+
+          cnt = <<~HTML
+            <p style="#{styles[:p]}">testing</p>
+            <p style="#{styles[:p]}"><strong style="#{styles[:strong]}">foo</strong><br style="styles[:br]"><a href="https://www.decidim.org/" rel="noopener noreferrer" target="_blank" style="#{styles[:a]}">link</a></p>
+          HTML
+
+          cnt.gsub("\n", "")
+        end
+
+        let(:clipboard_content_plain) { "testing\n\nfoo\nlink" }
+
+        let(:parsed_content) do
+          cnt = <<~HTML
+            <p>testing</p>
+            <p><strong>foo</strong><br><a href="https://www.decidim.org/" rel="noopener noreferrer" target="_blank">link</a></p>
+            <p><br></p>
+          HTML
+
+          cnt.gsub("\n", "")
+        end
+
+        it "parses the pasted content correctly with the strong element" do
+          # Focus the editor before sending the paste event
+          find('div[contenteditable="true"].ql-editor').native.send_keys "a", [:backspace]
+
+          page.execute_script(
+            <<~JS
+              var dt = new DataTransfer();
+              dt.setData("text/html", #{clipboard_content_html.to_json});
+              dt.setData("text/plain", #{clipboard_content_plain.to_json});
+
+              var element = document.querySelector("#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 div[contenteditable='true'].ql-editor");
+              element.dispatchEvent(new ClipboardEvent("paste", { clipboardData: dt }));
+            JS
+          )
+
+          expect(find(
+            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+          )["innerHTML"]).to eq(parsed_content)
+        end
+      end
+
+      context "when the admin terms of use content has only a video" do
+        let(:organization) { create(:organization, admin_terms_of_use_body: {}) }
+
+        it "saves the content correctly with the video" do
+          within ".editor" do
+            within ".editor .ql-toolbar" do
+              find("button.ql-video").click
+            end
+            within "div[data-mode='video'].ql-tooltip.ql-editing" do
+              find("input[data-video='Embed URL']").fill_in with: "https://www.youtube.com/watch?v=f6JMgJAQ2tc"
+              find("a.ql-action").click
+            end
+          end
+
+          click_button "Update"
+
+          organization.reload
+          expect(translated(organization.admin_terms_of_use_body)).to eq(
+            %(<iframe class="ql-video" frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/f6JMgJAQ2tc?showinfo=0"></iframe>)
+          )
         end
       end
     end

--- a/decidim-core/app/packs/src/decidim/editor.js
+++ b/decidim-core/app/packs/src/decidim/editor.js
@@ -1,6 +1,7 @@
 /* eslint-disable require-jsdoc */
 
 import lineBreakButtonHandler from "src/decidim/editor/linebreak_module"
+import "src/decidim/editor/clipboard_override"
 import "src/decidim/vendor/image-resize.min"
 import "src/decidim/vendor/image-upload.min"
 

--- a/decidim-core/app/packs/src/decidim/editor/clipboard_override.js
+++ b/decidim-core/app/packs/src/decidim/editor/clipboard_override.js
@@ -1,0 +1,136 @@
+/* eslint max-lines: ["error", 350] */
+
+/**
+ * Quill clipboard utilities
+ *
+ * Copyright (c) 2017, Slab
+ * Copyright (c) 2014, Jason Chen
+ * Copyright (c) 2013, salesforce.com
+ * BSD 3-Clause "New" or "Revised" License
+ *
+ * Extends the original version from https://github.com/quilljs/quill
+ * Relevant parts converted from TypeScript to JavaScript
+ */
+
+import CodeBlock from "quill/formats/code";
+import { matchNewline, matchBreak, deltaEndsWith, traverse } from "src/decidim/editor/clipboard_utilities";
+
+const Delta = Quill.import("delta");
+const Clipboard = Quill.import("modules/clipboard");
+
+/**
+ * Pasting bold text is broken in Quill as described at:
+ * https://github.com/quilljs/quill/issues/306
+ *
+ * The reason is that the `<strong>` nodes are not recognized as bold types.
+ * This override fixes the issue by introducing parts of the newer Quill code
+ * at GitHub and defining the `<strong>` tags as bold tags.
+ */
+export default class ClipboardOverride extends Clipboard {
+  constructor(quill, options) {
+    super(quill, options);
+    this.overrideMatcher("b", "b, strong");
+    this.overrideMatcher("br", "br", matchBreak);
+
+    // Change the matchNewLine matchers to the newer version
+    this.matchers[1][1] = matchNewline;
+    this.matchers[3][1] = matchNewline;
+
+    // Remove `matchSpacing` as that is also removed in the newer versions.
+    this.matchers.splice(5, 1);
+  }
+
+  overrideMatcher(originalSelector, newSelector, newMatcher = null) {
+    const idx = this.matchers.findIndex((item) => item[0] === originalSelector);
+    if (idx >= 0) {
+      this.matchers[idx][0] = newSelector;
+      if (newMatcher) {
+        this.matchers[idx][1] = newMatcher;
+      }
+    }
+  }
+
+  onPaste(ev) {
+    if (ev.defaultPrevented || !this.quill.isEnabled()) {
+      return;
+    }
+    ev.preventDefault();
+    const range = this.quill.getSelection(true);
+    if (range === null) {
+      return;
+    }
+    const html = ev.clipboardData.getData("text/html");
+    const text = ev.clipboardData.getData("text/plain");
+    const files = Array.from(ev.clipboardData.files || []);
+    if (!html && files.length > 0) {
+      this.quill.uploader.upload(range, files);
+      return;
+    }
+    if (html && files.length > 0) {
+      const doc = new DOMParser().parseFromString(html, "text/html");
+      if (
+        doc.body.childElementCount === 1 &&
+        doc.body.firstElementChild.tagName === "IMG"
+      ) {
+        this.quill.uploader.upload(range, files);
+        return;
+      }
+    }
+    this.onPasteRange(range, { html, text });
+  }
+
+  onPasteRange(range, { text, html }) {
+    const formats = this.quill.getFormat(range.index);
+    const pastedDelta = this.convertPaste({ text, html }, formats);
+    // debug.log('onPaste", pastedDelta, { text, html });
+    const delta = new Delta().retain(range.index).delete(range.length).concat(pastedDelta);
+    this.quill.updateContents(delta, Quill.sources.USER);
+    // range.length contributes to delta.length()
+    this.quill.setSelection(
+      delta.length() - range.length,
+      Quill.sources.SILENT,
+    );
+    this.quill.scrollIntoView();
+  }
+
+  convertPaste({ html, text }, formats = {}) {
+    if (formats[CodeBlock.blotName]) {
+      return new Delta().insert(text, {
+        [CodeBlock.blotName]: formats[CodeBlock.blotName]
+      });
+    }
+    if (!html) {
+      return new Delta().insert(text || "");
+    }
+    const delta = this.convertPasteHTML(html);
+    // Remove trailing newline
+    if (
+      deltaEndsWith(delta, "\n") &&
+      (delta.ops[delta.ops.length - 1].attributes === null || formats.table)
+    ) {
+      return delta.compose(new Delta().retain(delta.length() - 1).delete(1));
+    }
+    return delta;
+  }
+
+  convertPasteHTML(html) {
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const container = doc.body;
+    const nodeMatches = new WeakMap();
+    const [elementMatchers, textMatchers] = this.prepareMatching(
+      container,
+      nodeMatches
+    );
+    return traverse(
+      this.quill.scroll,
+      container,
+      elementMatchers,
+      textMatchers,
+      nodeMatches
+    );
+  }
+}
+
+// Disable warning messages from overwritting modules
+Quill.debug("error");
+Quill.register({"modules/clipboard": ClipboardOverride}, true);

--- a/decidim-core/app/packs/src/decidim/editor/clipboard_utilities.js
+++ b/decidim-core/app/packs/src/decidim/editor/clipboard_utilities.js
@@ -1,0 +1,119 @@
+import { BlockEmbed } from "quill/blots/block";
+
+const Delta = Quill.import("delta");
+const Parchment = Quill.import("parchment");
+
+// Newer version used only for the pasting, not compatible with the version of
+// Quill in use.
+const traverse = (scroll, node, elementMatchers, textMatchers, nodeMatches) => { // eslint-disable-line max-params
+  // Post-order
+  if (node.nodeType === node.TEXT_NODE) {
+    return textMatchers.reduce((delta, matcher) => {
+      return matcher(node, delta, scroll);
+    }, new Delta());
+  }
+  if (node.nodeType === node.ELEMENT_NODE) {
+    return Array.from(node.childNodes || []).reduce((delta, childNode) => {
+      let childrenDelta = traverse(
+        scroll,
+        childNode,
+        elementMatchers,
+        textMatchers,
+        nodeMatches,
+      );
+      if (childNode.nodeType === node.ELEMENT_NODE) {
+        childrenDelta = elementMatchers.reduce((reducedDelta, matcher) => {
+          return matcher(childNode, reducedDelta, scroll);
+        }, childrenDelta);
+        childrenDelta = (nodeMatches.get(childNode) || []).reduce(
+          (reducedDelta, matcher) => {
+            return matcher(childNode, reducedDelta, scroll);
+          },
+          childrenDelta,
+        );
+      }
+      return delta.concat(childrenDelta);
+    }, new Delta());
+  }
+  return new Delta();
+}
+
+const deltaEndsWith = (delta, text) => {
+  let endText = "";
+  for (let idx = delta.ops.length - 1; idx >= 0 && endText.length < text.length; idx -= 1) {
+    const op = delta.ops[idx];
+    if (typeof op.insert !== "string") {
+      break;
+    }
+    endText = op.insert + endText;
+  }
+  return endText.slice(-1 * text.length) === text;
+}
+
+const isLine = (node) => {
+  if (node.childNodes.length === 0) {
+    // Exclude embed blocks
+    return false;
+  }
+  return [
+    "address", "article", "blockquote", "canvas", "dd", "div", "dl", "dt",
+    "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2", "h3",
+    "h4", "h5", "h6", "header", "iframe", "li", "main", "nav", "ol", "output",
+    "p", "pre", "section", "table", "td", "tr", "ul", "video"
+  ].includes(node.tagName.toLowerCase());
+}
+
+const matchNewLineScroll = (nextSibling, delta, scroll) => {
+  if (!scroll) {
+    return null;
+  }
+
+  const match = Parchment.query(nextSibling)
+  if (match && match.prototype instanceof BlockEmbed) {
+    return delta.insert("\n");
+  }
+  return null;
+}
+
+const matchNewline = (node, delta, scroll) => {
+  if (!deltaEndsWith(delta, "\n")) {
+    // When scroll is defined, it was initiated from the paste event. Otherwise
+    // it is a normal Quill initiated traversal which handles adding the line
+    // breaks already.
+    if (scroll && node.nodeType === node.ELEMENT_NODE && node.tagName === "BR") {
+      return delta.insert({"break": ""});
+    }
+    if (isLine(node)) {
+      return delta.insert("\n");
+    }
+    if (delta.length() > 0 && node.nextSibling) {
+      let { nextSibling } = node;
+      while (nextSibling !== null) {
+        if (isLine(nextSibling)) {
+          return delta.insert("\n");
+        }
+        const scrollMatch = matchNewLineScroll(nextSibling, delta, scroll);
+        if (scrollMatch) {
+          return scrollMatch;
+        }
+        nextSibling = nextSibling.firstChild;
+      }
+    }
+  }
+  return delta;
+}
+
+const matchBreak = (node, delta) => {
+  if (!deltaEndsWith(delta, "\n")) {
+    delta.insert({"break": ""});
+  }
+  return delta;
+}
+
+export {
+  traverse,
+  deltaEndsWith,
+  isLine,
+  matchNewline,
+  matchBreak
+}

--- a/decidim-core/app/packs/src/decidim/editor/linebreak_module.js
+++ b/decidim-core/app/packs/src/decidim/editor/linebreak_module.js
@@ -129,7 +129,6 @@ class ScrollOvderride extends Scroll {
 Quill.register("blots/scroll", ScrollOvderride, true);
 Parchment.register(ScrollOvderride);
 
-
 export default function lineBreakButtonHandler(quill) {
   let range = quill.selection.getRange()[0];
   let currentLeaf = quill.getLeaf(range.index)[0];
@@ -165,13 +164,6 @@ Quill.register("modules/linebreak", (quill) => {
     if (text === "\n\n") {
       quill.deleteText(quill.getLength() - 2, 2);
     }
-  });
-
-  quill.clipboard.addMatcher("BR", (node) => {
-    if (node?.parentNode?.tagName === "A") {
-      return new Delta().insert("\n");
-    }
-    return new Delta().insert({"break": ""});
   });
 
   addEnterBindings(quill);


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9640 to v0.27

:hearts: Thank you!