### PR TITLE
Backport 'Fix initiative sign if the authorization metadata is set to `nil`' to v0.27

### DIFF
--- a/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
@@ -83,6 +83,7 @@ module Decidim
       def user_authorized_scope
         return scope if handler_name.blank?
         return unless authorized?
+        return if authorization.metadata.blank?
 
         @user_authorized_scope ||= authorized_scope_candidates.find do |scope|
           scope&.id == authorization.metadata.symbolize_keys[:scope_id]

--- a/decidim-initiatives/spec/forms/vote_form_spec.rb
+++ b/decidim-initiatives/spec/forms/vote_form_spec.rb
@@ -156,6 +156,21 @@ module Decidim
 
           it { is_expected.to eq(initiative.scope) }
         end
+
+        context "when the authorization does not have metadata" do
+          let!(:authorization) do
+            create(
+              :authorization,
+              :granted,
+              name: "dummy_authorization_handler",
+              user: current_user,
+              unique_id: document_number,
+              metadata: nil
+            )
+          end
+
+          it { is_expected.to be_nil }
+        end
       end
 
       describe "authorized_scope_candidates" do


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9647 to v0.27

:hearts: Thank you!