### PR TITLE
Backport 'Fix commenting field disabled when polling new comments' to v0.27

### DIFF
--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -43,7 +43,10 @@ export default class CommentsComponent {
       this.mounted = true;
       this._initializeComments(this.$element);
       if (!this.singleComment) {
-        this._fetchComments();
+        $(".add-comment textarea", this.$element).prop("disabled", true);
+        this._fetchComments(() => {
+          $(".add-comment textarea", this.$element).prop("disabled", false);
+        });
       }
 
       $(".order-by__dropdown .is-submenu-item a", this.$element).on("click.decidim-comments", () => this._onInitOrder());
@@ -215,10 +218,11 @@ export default class CommentsComponent {
    * Sends an ajax request based on current
    * params to get comments for the component
    * @private
+   * @param {Function} successCallback A callback that is called after a
+   *   successful fetch
    * @returns {Void} - Returns nothing
    */
-  _fetchComments() {
-    $(".add-comment textarea", this.$element).prop("disabled", true);
+  _fetchComments(successCallback = null) {
     Rails.ajax({
       url: this.commentsUrl,
       type: "GET",
@@ -231,7 +235,9 @@ export default class CommentsComponent {
         ...(this.lastCommentId && { "after": this.lastCommentId })
       }),
       success: () => {
-        $(".add-comment textarea", this.$element).prop("disabled", false);
+        if (successCallback) {
+          successCallback();
+        }
         this._pollComments();
       }
     });

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
@@ -418,6 +418,21 @@ describe("CommentsComponent", () => {
     expect(window.setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
   });
 
+  it("does not disable the textarea when polling comments normally", () => {
+    Rails.ajax.mockImplementationOnce((options) => options.success());
+
+    subject.mountComponent();
+
+    // Delay the success call 2s after the polling has happened to test that
+    // the textarea is still enabled when the polling is happening.
+    Rails.ajax.mockImplementationOnce((options) => {
+      setTimeout(options.success(), 2000);
+    });
+    jest.advanceTimersByTime(1500);
+
+    expect($(`${selector} .add-comment textarea`).prop("disabled")).toBeFalsy();
+  });
+
   describe("when mounted", () => {
     beforeEach(() => {
       spyOnAddComment("on");


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9885 to v0.27

:hearts: Thank you!