### PR TITLE
Always allow image upload in WYSWYG editor

### DIFF
--- a/decidim-admin/lib/decidim/admin/form_builder.rb
+++ b/decidim-admin/lib/decidim/admin/form_builder.rb
@@ -67,8 +67,7 @@ module Decidim
           name,
           {
             toolbar: :full,
-            lines: 25,
-            editor_images: true
+            lines: 25
           }.merge(options)
         )
       end

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -181,7 +181,6 @@ module Decidim
     #                      or 'full' (optional) (default: 'basic')
     #           :lines - The Integer to indicate how many lines should editor have (optional) (default: 10)
     #           :disabled - Whether the editor should be disabled
-    #           :editor_images - Allow attached images (optional) (default: false)
     #
     # Renders a container with both hidden field and editor container
     def editor(name, options = {})
@@ -200,8 +199,11 @@ module Decidim
         template += hidden_field(name, hidden_options)
         template += content_tag(:div, nil, class: "editor-container #{"js-hashtags" if hashtaggable}", data: {
           toolbar:,
-          disabled: options[:disabled]
-        }.merge(editor_images_options(options)), style: "height: #{lines}rem")
+          disabled: options[:disabled],
+          editor_images: true,
+          upload_images_path: Decidim::Core::Engine.routes.url_helpers.editor_images_path,
+          drag_and_drop_help_text: I18n.t("drag_and_drop_help", scope: "decidim.editor_images")
+        }, style: "height: #{lines}rem")
         template += error_for(name, options) if error?(name)
         template.html_safe
       end
@@ -922,16 +924,6 @@ module Decidim
           end
         end
       end
-    end
-
-    def editor_images_options(options)
-      return {} unless options[:editor_images]
-
-      {
-        editor_images: true,
-        upload_images_path: Decidim::Core::Engine.routes.url_helpers.editor_images_path,
-        drag_and_drop_help_text: I18n.t("drag_and_drop_help", scope: "decidim.editor_images")
-      }
     end
 
     # Private: Determines the correct resource class for validators from the

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -198,12 +198,12 @@ module Decidim
         template += label(name, label_text + required_for_attribute(name)) if options.fetch(:label, true)
         template += hidden_field(name, hidden_options)
         template += content_tag(:div, nil, class: "editor-container #{"js-hashtags" if hashtaggable}", data: {
-          toolbar:,
-          disabled: options[:disabled],
-          editor_images: true,
-          upload_images_path: Decidim::Core::Engine.routes.url_helpers.editor_images_path,
-          drag_and_drop_help_text: I18n.t("drag_and_drop_help", scope: "decidim.editor_images")
-        }, style: "height: #{lines}rem")
+                                  toolbar:,
+                                  disabled: options[:disabled],
+                                  editor_images: true,
+                                  upload_images_path: Decidim::Core::Engine.routes.url_helpers.editor_images_path,
+                                  drag_and_drop_help_text: I18n.t("drag_and_drop_help", scope: "decidim.editor_images")
+                                }, style: "height: #{lines}rem")
         template += error_for(name, options) if error?(name)
         template.html_safe
       end


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing #9639, I [found out that we still were allowing base64 image upload](https://github.com/decidim/decidim/pull/9639#issuecomment-1269431318) in WYSWYG editor. This PR enables it by default always when there's an editor, so the images are upload with ActiveStorage.

I can't come up with any reason for allowing base64 images. If there ̇'s any please let me know. 

#### :pushpin: Related Issues
 
- Related to #9639

#### Testing

1. Sign in as admin
2. Enable "Enable rich text editor for participants" on http://localhost:3000/admin/organization/edit?locale=en
3. Go to a proposals component settings, enable "Participants can create proposals"
4. Create a new proposal in the admin panel. Drag and drop an image, see with the inspector that the image is uploaded to the server
5. Create a new proposal in the frontend. Drag and drop an image, see with the inspector that the image is uploaded to the server (until now was base64)

:hearts: Thank you!
