### PR TITLE
Update manual.adoc

### DIFF
--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -18,7 +18,7 @@ In this guide, we'll see how to install rbenv, PostgreSQL, Node.js and, Decidim,
 
 == 1. Installing rbenv
 
-First, we're going to install https://github.com/rbenv/rbenv[rbenv], for managing various ruby versions. You could also use https://rvm.io/[rvm] or https://github.com/asdf-vm/asdf[asdf] as alternatives on this step. Mind that at the moment, Decidim isn't compatible with Ruby 3.0.
+First, we're going to install https://github.com/rbenv/rbenv[rbenv], for managing various ruby versions. You could also use https://rvm.io/[rvm] or https://github.com/asdf-vm/asdf[asdf] as alternatives on this step. Decidim is compatible with Ruby >= 3.0.
 
 [source,bash]
 ----
@@ -29,8 +29,8 @@ echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 source ~/.bashrc
 git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
-rbenv install 2.7.5
-rbenv global 2.7.5
+rbenv install 3.1.1
+rbenv global 3.1.1
 ----
 
 == 2. Installing PostgreSQL


### PR DESCRIPTION
decidim seems to work with Ruby 3.0 and later now (didn't succeed to install decidim gem with ruby 2.7.5, I've received the advice to use ruby >= 3.0)


#### :tophat: What? Why?
Update of Ruby installation guide

#### :pushpin: Related Issues
No linked issue

#### Testing
Install decidim with Ruby 3.1.1

### :camera: Screenshots
![Error message while installing decidim gem](https://user-images.githubusercontent.com/7131900/198897895-9c0476bf-3003-4012-97c3-f873d7ddc4d5.jpg)

:hearts: Thank you!
