### PR TITLE
Remove autocomplete attribute from hidden inputs

### DIFF
--- a/decidim-core/app/helpers/concerns/decidim/tags/hidden_field_extensions.rb
+++ b/decidim-core/app/helpers/concerns/decidim/tags/hidden_field_extensions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Tags
+    module HiddenFieldExtensions
+      def render
+        @options.delete(:autocomplete)
+        super
+      end
+    end
+  end
+end

--- a/decidim-core/app/helpers/decidim/decidim_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/decidim_form_helper.rb
@@ -3,6 +3,8 @@
 module Decidim
   # A heper to expose an easy way to add authorization forms in a view.
   module DecidimFormHelper
+    include Decidim::TagHelper
+
     # A custom form for that injects client side validations with Abide.
     #
     # record - The object to build the form for.

--- a/decidim-core/app/helpers/decidim/tag_helper.rb
+++ b/decidim-core/app/helpers/decidim/tag_helper.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Decidim
+  module TagHelper
+    extend ActiveSupport::Concern
+
+    included do
+      # Customized to remove the `autocomplete` attribute from hidden inputs as
+      # an accessibility violation. Otherwise exactly the same as original.
+      #
+      # @see ActionView::Helpers::TagHelper#tag
+      # rubocop:disable Metrics/ParameterLists, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Style/OptionalBooleanParameter
+      def tag(name = nil, options = nil, open = false, escape = true)
+        if name&.to_sym == :input && options.is_a?(Hash)
+          type = options[:type] || options["type"]
+          if type&.to_sym == :hidden
+            options.delete(:autocomplete)
+            options.delete("autocomplete")
+          end
+        end
+
+        if name.nil?
+          tag_builder
+        else
+          name = ERB::Util.xml_name_escape(name) if escape
+          "<#{name}#{tag_builder.tag_options(options, escape) if options}#{open ? ">" : " />"}".html_safe
+        end
+      end
+      # rubocop:enable Metrics/ParameterLists, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Style/OptionalBooleanParameter
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -693,6 +693,8 @@ module Decidim
 
       config.to_prepare do
         FoundationRailsHelper::FlashHelper.include Decidim::FlashHelperExtensions
+        ActionView::Helpers.include Decidim::TagHelper
+        ActionView::Helpers::Tags::HiddenField.include Decidim::Tags::HiddenFieldExtensions
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Since the recent HTML validator update, some validation specs started failing because Rails helpers add the `autocomplete="off"` attribute automatically to hidden input elements. This is no longer allowed, so this PR fixes the issue by removing that attribute from hidden inputs by customizing the Rails helpers.

The errors you would see in the system specs look as follows:

```
  1) Participatory Processes when there are some published processes when requesting the processes path with highlighted processes behaves like accessible page passes HTML validation
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       ######
       line 375: An “input” element with a “type” attribute whose value is “hidden” must not have an “autocomplete” attribute whose value is “on” or “off”.
```

#### :pushpin: Related Issues
- Related to rails/rails#46405

#### Testing

```bash
$ cd decidim-core
$ bundle exec rpsec spec/system/messaging/conversations_spec.rb
$ cd ../decidim-proposals
$ bundle exec rspec spec/system/proposals_spec.rb
$ bundle exec rspec spec/system/amendable/amendment_diff_spec.rb
$ cd ../decidim-participatory_processes
$ bundle exec rspec spec/system/participatory_processes_spec.rb
```