### PR TITLE
Integrate reported users in Global moderation

### DIFF
--- a/decidim-admin/app/controllers/concerns/decidim/admin/global_moderation_context.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/global_moderation_context.rb
@@ -20,7 +20,7 @@ module Decidim
         #
         # Returns an `ActiveRecord::Relation`
         def moderations_for_user
-          @moderations_for_user ||= Decidim::Admin::ModerationStatsQuery.new(current_user).content_moderations
+          @moderations_for_user ||= Decidim::Admin::ModerationStats.new(current_user).content_moderations
         end
       end
     end

--- a/decidim-admin/app/controllers/concerns/decidim/admin/global_moderation_context.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/global_moderation_context.rb
@@ -14,32 +14,13 @@ module Decidim
           :global_moderation
         end
 
-        # Private: Finds the participatory spaces the current user is admin to.
-        # This method will later be used to find out what moderations the
-        # current user can manage.
-        #
-        # Returns an Array.
-        def spaces_user_is_admin_to
-          @spaces_user_is_admin_to ||=
-            Decidim.participatory_space_manifests.flat_map do |manifest|
-              Decidim
-                .find_participatory_space_manifest(manifest.name)
-                .participatory_spaces
-                .call(current_organization)&.select do |space|
-                  space.moderators.exists?(id: current_user.id) ||
-                    space.admins.exists?(id: current_user.id)
-                end
-            end
-        end
-
         # Private: finds the moderations the current user can manage, taking into
         # account whether the user is an organization-wide admin or a
         # "participatory space admin".
         #
         # Returns an `ActiveRecord::Relation`
         def moderations_for_user
-          @moderations_for_user ||=
-            Decidim::Moderation.where(participatory_space: spaces_user_is_admin_to)
+          @moderations_for_user ||= Decidim::Admin::ModerationStatsQuery.new(current_user).content_moderations
         end
       end
     end

--- a/decidim-admin/app/controllers/decidim/admin/block_user_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/block_user_controller.rb
@@ -44,7 +44,7 @@ module Decidim
           end
         end
 
-        redirect_to moderated_users_path(blocked: false), notice:
+        redirect_to moderated_users_path, notice:
       end
 
       private

--- a/decidim-admin/app/controllers/decidim/admin/block_user_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/block_user_controller.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Admin
     class BlockUserController < Decidim::Admin::ApplicationController
-      layout "decidim/admin/users"
+      layout "decidim/admin/global_moderations"
 
       helper_method :user
 

--- a/decidim-admin/app/controllers/decidim/admin/moderated_users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderated_users_controller.rb
@@ -5,7 +5,7 @@ module Decidim
     class ModeratedUsersController < Decidim::Admin::ApplicationController
       include Decidim::ModeratedUsers::Admin::Filterable
 
-      layout "decidim/admin/users"
+      layout "decidim/admin/global_moderations"
 
       def index
         enforce_permission_to :read, :moderate_users
@@ -36,12 +36,15 @@ module Decidim
       end
 
       def base_query_finder
-        UserModeration.joins(:user).where(decidim_users: { decidim_organization_id: current_organization.id })
+        Decidim::Admin::ModerationStatsQuery.new(current_user).user_reports
       end
 
       def collection
-        target_scope = params[:blocked] && params[:blocked] == "true" ? :blocked : :unblocked
-        base_query_finder.send(target_scope)
+        @collection ||= if params[:blocked]
+                          base_query_finder.blocked
+                        else
+                          base_query_finder.unblocked
+                        end
       end
     end
   end

--- a/decidim-admin/app/controllers/decidim/admin/moderated_users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderated_users_controller.rb
@@ -36,7 +36,7 @@ module Decidim
       end
 
       def base_query_finder
-        Decidim::Admin::ModerationStatsQuery.new(current_user).user_reports
+        Decidim::Admin::ModerationStats.new(current_user).user_reports
       end
 
       def collection

--- a/decidim-admin/app/queries/decidim/admin/moderation_stats.rb
+++ b/decidim-admin/app/queries/decidim/admin/moderation_stats.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Admin
-    class ModerationStatsQuery
+    class ModerationStats
       def initialize(user)
         @user = user
       end

--- a/decidim-admin/app/queries/decidim/admin/moderation_stats_query.rb
+++ b/decidim-admin/app/queries/decidim/admin/moderation_stats_query.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    class ModerationStatsQuery
+      def initialize(user)
+        @user = user
+      end
+
+      def content_moderations
+        @content_moderations ||= Decidim::Moderation.where(participatory_space: spaces_user_is_admin_to)
+      end
+
+      def user_reports
+        @user_reports ||= UserModeration.joins(:user).where(decidim_users: { decidim_organization_id: user.decidim_organization_id })
+      end
+
+      private
+
+      attr_reader :user
+
+      # Private: Finds the participatory spaces the current user is admin to.
+      # This method will later be used to find out what moderations the
+      # current user can manage.
+      #
+      # Returns an Array.
+      def spaces_user_is_admin_to
+        @spaces_user_is_admin_to ||=
+          Decidim.participatory_space_manifests.flat_map do |manifest|
+            Decidim
+              .find_participatory_space_manifest(manifest.name)
+              .participatory_spaces
+              .call(user.organization)&.select do |space|
+              space.moderators.exists?(id: user.id) ||
+                space.admins.exists?(id: user.id)
+            end
+          end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
@@ -1,28 +1,13 @@
 <div class="card with-overflow">
   <div class="card-divider">
     <h2 class="card-title">
-      <%= t(".title") %>
-    </h2>
 
-    <h2 class="card-title">
-      <div class="inline-block" style="float: right; text-align: right">
-        <table>
-          <tbody>
-          <tr>
-            <td>
-              <%= link_to moderated_users_path(blocked: false), class: "btn btn-small" do %>
-                <%= t("decidim.admin.moderated_users.tabs.unblocked") %>
-              <% end %>
-            </td>
-            <td>|</td>
-            <td>
-              <%= link_to moderated_users_path(blocked: true), class: "btn btn-small" do %>
-                <%= t("decidim.admin.moderated_users.tabs.blocked") %>
-              <% end %>
-            </td>
-          </tr>
-          </tbody>
-        </table>
+      <%= t(".title") %>
+
+      <div class="card__filter">
+        <%= link_to t("decidim.admin.moderated_users.tabs.unblocked"), moderated_users_path %>
+        |
+        <%= link_to  t("decidim.admin.moderated_users.tabs.blocked"), moderated_users_path(blocked: true) %>
       </div>
     </h2>
   </div>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -561,7 +561,7 @@ en:
         moderation: Global moderations
         newsletters: Newsletters
         participants: Participants
-        reported_users: Reported Participants
+        reported_users: Reported participants
         scope_types: Scope types
         scopes: Scopes
         settings: Settings

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -561,7 +561,7 @@ en:
         moderation: Global moderations
         newsletters: Newsletters
         participants: Participants
-        reported_users: Reported Users
+        reported_users: Reported Participants
         scope_types: Scope types
         scopes: Scopes
         settings: Settings
@@ -660,7 +660,7 @@ en:
           nickname: Nickname
           reason: Reason
           reports: Reports count
-          title: Listing reported users
+          title: Listing participants
         report:
           reasons:
             does_not_belong: Does not belong
@@ -1118,7 +1118,7 @@ en:
     decidim:
       admin:
         global_moderations:
-          title: Global moderations
+          title: Content moderations
         newsletters:
           title: Newsletters
         settings:

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -552,6 +552,7 @@ en:
         area_types: Area types
         areas: Areas
         configuration: Configuration
+        content: Content
         dashboard: Dashboard
         external_domain_whitelist: Allowed external domains
         help_sections: Help sections

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -43,7 +43,6 @@ Decidim::Admin::Engine.routes.draw do
       member do
         post :resend_invitation, to: "users#resend_invitation"
       end
-      resource :block, only: [:new, :create, :destroy], controller: :block_user
     end
 
     resources :officializations, only: [:new, :create, :index, :destroy], param: :user_id do
@@ -55,6 +54,11 @@ Decidim::Admin::Engine.routes.draw do
     resources :moderated_users, only: [:index] do
       member do
         put :ignore
+      end
+      collection do
+        scope "/:user_id" do
+          resource :user_block, only: [:new, :create, :destroy], controller: :block_user
+        end
       end
     end
 

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -30,7 +30,7 @@ module Decidim
 
       initializer "decidim_admin.global_moderation_menu" do
         Decidim.menu :admin_global_moderation_menu do |menu|
-          moderations_count = Decidim::Admin::ModerationStatsQuery.new(current_user).content_moderations.count
+          moderations_count = Decidim::Admin::ModerationStats.new(current_user).content_moderations.not_hidden.count
 
           caption = I18n.t("menu.content", scope: "decidim.admin")
           caption += content_tag(:span, moderations_count, class: moderations_count.zero? ? "component-counter component-counter--off" : "component-counter")
@@ -42,7 +42,7 @@ module Decidim
                         active: is_active_link?(decidim_admin.moderations_path),
                         if: allowed_to?(:read, :global_moderation)
 
-          user_reports = Decidim::Admin::ModerationStatsQuery.new(current_user).user_reports.unblocked.count
+          user_reports = Decidim::Admin::ModerationStats.new(current_user).user_reports.unblocked.count
 
           caption = I18n.t("menu.reported_users", scope: "decidim.admin")
           caption += content_tag(:span, user_reports, class: user_reports.zero? ? "component-counter component-counter--off" : "component-counter")

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -30,17 +30,28 @@ module Decidim
 
       initializer "decidim_admin.global_moderation_menu" do
         Decidim.menu :admin_global_moderation_menu do |menu|
+          moderations_count = Decidim::Admin::ModerationStatsQuery.new(current_user).content_moderations.count
+
+          caption = I18n.t("menu.content", scope: "decidim.admin")
+          caption += content_tag(:span, moderations_count, class: moderations_count.zero? ? "component-counter component-counter--off" : "component-counter")
+
           menu.add_item :moderations,
-                        I18n.t("actions.not_hidden", scope: "decidim.moderations"),
+                        caption.html_safe,
                         decidim_admin.moderations_path,
                         position: 1,
-                        active: params[:hidden].blank?
+                        active: is_active_link?(decidim_admin.moderations_path),
+                        if: allowed_to?(:read, :global_moderation)
 
-          menu.add_item :hidden_moderations,
-                        I18n.t("actions.hidden", scope: "decidim.moderations"),
-                        decidim_admin.moderations_path(hidden: true),
-                        position: 2,
-                        active: params[:hidden].present?
+          user_reports = Decidim::Admin::ModerationStatsQuery.new(current_user).user_reports.unblocked.count
+
+          caption = I18n.t("menu.reported_users", scope: "decidim.admin")
+          caption += content_tag(:span, user_reports, class: user_reports.zero? ? "component-counter component-counter--off" : "component-counter")
+
+          menu.add_item :moderated_users,
+                        caption.html_safe,
+                        decidim_admin.moderated_users_path,
+                        active: is_active_link?(decidim_admin.moderated_users_path),
+                        if: allowed_to?(:index, :moderate_users)
         end
       end
 
@@ -89,10 +100,6 @@ module Decidim
                         if: allowed_to?(:index, :impersonatable_user),
                         submenu: { target_menu: :impersonate_menu }
 
-          menu.add_item :moderated_users,
-                        I18n.t("menu.reported_users", scope: "decidim.admin"), decidim_admin.moderated_users_path,
-                        active: is_active_link?(decidim_admin.moderated_users_path),
-                        if: allowed_to?(:index, :moderate_users)
           menu.add_item :authorization_workflows,
                         I18n.t("menu.authorization_workflows", scope: "decidim.admin"), decidim_admin.authorization_workflows_path,
                         active: is_active_link?(decidim_admin.authorization_workflows_path),
@@ -186,8 +193,9 @@ module Decidim
                         active: [%w(
                           decidim/admin/global_moderations
                           decidim/admin/global_moderations/reports
+                          decidim/admin/moderated_users
                         ), []],
-                        if: allowed_to?(:read, :global_moderation)
+                        if: allowed_to?(:read, :global_moderation) || allowed_to?(:index, :moderate_users)
 
           menu.add_item :static_pages,
                         I18n.t("menu.static_pages", scope: "decidim.admin"),
@@ -210,7 +218,6 @@ module Decidim
                           decidim/admin/officializations
                           decidim/admin/impersonatable_users
                           decidim/admin/conflicts
-                          decidim/admin/moderated_users
                           decidim/admin/managed_users/impersonation_logs
                           decidim/admin/managed_users/promotions
                           decidim/admin/authorization_workflows

--- a/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
@@ -24,6 +24,34 @@ describe "Admin manages global moderations", type: :system do
   end
 
   context "when displaying the counter" do
+    let!(:reportables) { create_list(:dummy_resource, 4, component: current_component) }
+    let!(:moderations) do
+      reportables.first(3).map do |reportable|
+        moderation = create(:moderation, reportable:, report_count: 1, reported_content: reportable.reported_searchable_content_text)
+        create(:report, moderation:)
+        moderation
+      end
+    end
+    let!(:moderation) { moderations.first }
+    let!(:hidden_moderations) do
+      moderation = create(:moderation, reportable: reportables.last, report_count: 3, reported_content: reportables.last.reported_searchable_content_text, hidden_at: Time.current)
+      create_list(:report, 3, moderation:, reason: :spam)
+      [moderation]
+    end
+
+    it "displays the right count" do
+      visit decidim_admin.moderations_path
+
+      within ".secondary-nav" do
+        within ".is-active" do
+          expect(page).to have_css("span.component-counter", visible: :visible)
+          expect(page).to have_css("span", text: (reportables.size - hidden_moderations.size))
+        end
+      end
+    end
+  end
+
+  context "when displaying the user counter" do
     let!(:reported_user) { create(:user, :confirmed, organization:) }
     let!(:moderation) { create(:user_moderation, user: reported_user, report_count: 1) }
     let!(:reportables) { create(:user_report, moderation:, user:, reason: "spam") }

--- a/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
@@ -23,6 +23,44 @@ describe "Admin manages global moderations", type: :system do
     login_as user, scope: :user
   end
 
+  context "when displaying the counter" do
+    let!(:reported_user) { create(:user, :confirmed, organization:) }
+    let!(:moderation) { create(:user_moderation, user: reported_user, report_count: 1) }
+    let!(:reportables) { create(:user_report, moderation:, user:, reason: "spam") }
+
+    context "when displaying the user counter" do
+      it "can not see user menu counter for resources" do
+        visit decidim_admin.moderations_path
+
+        within ".secondary-nav" do
+          within ".is-active" do
+            expect(page).to have_css("span.component-counter--off", visible: :visible)
+            expect(page).to have_css("span", text: "0")
+          end
+        end
+      end
+
+      it "can see user menu counter" do
+        visit decidim_admin.moderations_path
+
+        within ".secondary-nav" do
+          expect(page).to have_css("span.component-counter", visible: :visible, count: 2)
+          expect(page).to have_css("span", text: "1")
+        end
+      end
+    end
+  end
+
+  it "can see menu counter" do
+    visit decidim_admin.moderations_path
+
+    within ".secondary-nav" do
+      within ".is-active" do
+        expect(page).to have_css("span.component-counter", visible: :visible)
+      end
+    end
+  end
+
   it_behaves_like "manage moderations" do
     let(:moderations_link_text) { "Global moderations" }
   end


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
As an administrator, when a participant is reported I can’t see them in the “Global moderation” panel. This PR is moving the moderated users panel from user's to Global moderation. 

Please refer to #10034 for additional details.

Ref: SPAM02

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to  #10016
- Fixes #10034

#### Testing
1. Enter the application 
2. Report some content and some users 
3. Go to admin dashboard. In the participants section you should not see reported users
4. Go to Global moderation. You should see reported users section, and menu counter

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Participants section](https://user-images.githubusercontent.com/105683/199418065-61da5024-2e04-488f-9d63-f3ed107a1f39.png)
![Global moderation](https://user-images.githubusercontent.com/105683/199418355-46076cd3-5f7e-4030-b788-2beec5db6acd.png)


:hearts: Thank you!
