### PR TITLE
Add pending moderations dashboard

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/dashboard_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/dashboard_controller.rb
@@ -8,12 +8,17 @@ module Decidim
       helper_method :latest_action_logs
       helper_method :users_counter
       helper_method :metrics_presenter
+      helper_method :count_pending_moderations
 
       def show
         enforce_permission_to :read, :admin_dashboard
       end
 
       private
+
+      def count_pending_moderations
+        @count_pending_moderations ||= Decidim::Admin::ModerationStatsQuery.new(current_user).count_pending_moderations
+      end
 
       def latest_action_logs
         @latest_action_logs ||= Decidim::ActionLog

--- a/decidim-admin/app/controllers/decidim/admin/dashboard_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/dashboard_controller.rb
@@ -17,7 +17,7 @@ module Decidim
       private
 
       def count_pending_moderations
-        @count_pending_moderations ||= Decidim::Admin::ModerationStatsQuery.new(current_user).count_pending_moderations
+        @count_pending_moderations ||= Decidim::Admin::ModerationStats.new(current_user).count_pending_moderations
       end
 
       def latest_action_logs

--- a/decidim-admin/app/queries/decidim/admin/moderation_stats.rb
+++ b/decidim-admin/app/queries/decidim/admin/moderation_stats.rb
@@ -15,6 +15,18 @@ module Decidim
         @user_reports ||= UserModeration.joins(:user).where(decidim_users: { decidim_organization_id: user.decidim_organization_id })
       end
 
+      def count_content_moderations
+        content_moderations.not_hidden.count
+      end
+
+      def count_user_pending_reports
+        user_reports.unblocked.count
+      end
+
+      def count_pending_moderations
+        count_content_moderations + count_user_pending_reports
+      end
+
       private
 
       attr_reader :user

--- a/decidim-admin/app/views/decidim/admin/dashboard/_pending_moderations.html.erb
+++ b/decidim-admin/app/views/decidim/admin/dashboard/_pending_moderations.html.erb
@@ -1,0 +1,12 @@
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= t(".title") %>
+    </h2>
+  </div>
+
+  <div class="card-section">
+    <p><%= t(".anouncement", count: count_pending_moderations) %></p>
+    <p><%= link_to t(".goto_moderation"), moderations_path, class: "button tiny button--title"%></p>
+  </div>
+</div>

--- a/decidim-admin/app/views/decidim/admin/dashboard/_pending_moderations.html.erb
+++ b/decidim-admin/app/views/decidim/admin/dashboard/_pending_moderations.html.erb
@@ -7,6 +7,6 @@
 
   <div class="card-section">
     <p><%= t(".anouncement", count: count_pending_moderations) %></p>
-    <p><%= link_to t(".goto_moderation"), moderations_path, class: "button tiny button--title"%></p>
+    <p><%= link_to t(".goto_moderation"), moderations_path, class: "button tiny button--title" %></p>
   </div>
 </div>

--- a/decidim-admin/app/views/decidim/admin/dashboard/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/dashboard/show.html.erb
@@ -11,6 +11,14 @@
     <%= cell("decidim/announcement", announcement_body, callout_class: current_user.admin_terms_accepted? ? "success" : "warning" ) %>
   <% end %>
 
+  <% if count_pending_moderations.positive? %>
+    <div class="grid-x grid-margin-x">
+      <div class="cell small-12 medium-6 large-4">
+        <%= render "pending_moderations" %>
+      </div>
+    </div>
+  <% end %>
+
   <div class="grid-x grid-margin-x">
     <% if allowed_to? :read, :users_statistics %>
       <div class="cell small-12 medium-6 large-4">

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -362,6 +362,12 @@ en:
         'true': 'Yes'
         user_name: User
       dashboard:
+        pending_moderations:
+          anouncement:
+            one: There are %{count} pending moderation
+            other: There are %{count} pending moderations
+          goto_moderation: Go to global moderations
+          title: Pending Moderations
         show:
           view_more_logs: View more logs
           welcome: Welcome to the Admin Panel.

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -30,7 +30,7 @@ module Decidim
 
       initializer "decidim_admin.global_moderation_menu" do
         Decidim.menu :admin_global_moderation_menu do |menu|
-          moderations_count = Decidim::Admin::ModerationStatsQuery.new(current_user).count_content_moderations
+          moderations_count = Decidim::Admin::ModerationStats.new(current_user).count_content_moderations
 
           caption = I18n.t("menu.content", scope: "decidim.admin")
           caption += content_tag(:span, moderations_count, class: moderations_count.zero? ? "component-counter component-counter--off" : "component-counter")
@@ -42,7 +42,7 @@ module Decidim
                         active: is_active_link?(decidim_admin.moderations_path),
                         if: allowed_to?(:read, :global_moderation)
 
-          user_reports = Decidim::Admin::ModerationStatsQuery.new(current_user).count_user_pending_reports
+          user_reports = Decidim::Admin::ModerationStats.new(current_user).count_user_pending_reports
 
           caption = I18n.t("menu.reported_users", scope: "decidim.admin")
           caption += content_tag(:span, user_reports, class: user_reports.zero? ? "component-counter component-counter--off" : "component-counter")

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -30,7 +30,7 @@ module Decidim
 
       initializer "decidim_admin.global_moderation_menu" do
         Decidim.menu :admin_global_moderation_menu do |menu|
-          moderations_count = Decidim::Admin::ModerationStats.new(current_user).content_moderations.not_hidden.count
+          moderations_count = Decidim::Admin::ModerationStatsQuery.new(current_user).count_content_moderations
 
           caption = I18n.t("menu.content", scope: "decidim.admin")
           caption += content_tag(:span, moderations_count, class: moderations_count.zero? ? "component-counter component-counter--off" : "component-counter")
@@ -42,7 +42,7 @@ module Decidim
                         active: is_active_link?(decidim_admin.moderations_path),
                         if: allowed_to?(:read, :global_moderation)
 
-          user_reports = Decidim::Admin::ModerationStats.new(current_user).user_reports.unblocked.count
+          user_reports = Decidim::Admin::ModerationStatsQuery.new(current_user).count_user_pending_reports
 
           caption = I18n.t("menu.reported_users", scope: "decidim.admin")
           caption += content_tag(:span, user_reports, class: user_reports.zero? ? "component-counter component-counter--off" : "component-counter")

--- a/decidim-admin/spec/queries/moderation_stats_spec.rb
+++ b/decidim-admin/spec/queries/moderation_stats_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe ModerationStats do
+    let(:admin) { create(:user, :admin, :confirmed) }
+    let(:query) { described_class.new(admin) }
+    let(:organization) { admin.organization }
+
+    describe "#count_content_moderations" do
+      context "when there is no data" do
+        it "returns 0 matches" do
+          expect(query.count_content_moderations).to eq(0)
+        end
+      end
+
+      context "when executing query" do
+        let(:current_component) { create(:dummy_component, organization:) }
+        let(:reportables) { create_list(:dummy_resource, 4, component: current_component) }
+        let(:moderations) do
+          reportables.first(3).map do |reportable|
+            moderation = create(:moderation, reportable:, report_count: 1, reported_content: reportable.reported_searchable_content_text)
+            create(:report, moderation:)
+            moderation
+          end
+        end
+        let!(:moderation) { moderations.first }
+        let!(:hidden_moderations) do
+          moderation = create(:moderation, reportable: reportables.last, report_count: 3, reported_content: reportables.last.reported_searchable_content_text, hidden_at: Time.current)
+          create_list(:report, 3, moderation:, reason: :spam)
+          [moderation]
+        end
+
+        it "displays the right number" do
+          expect(query.count_content_moderations).to eq(3)
+        end
+      end
+    end
+
+    describe "#count_user_pending_reports" do
+      context "when there is no data" do
+        it "returns 0 matches" do
+          expect(query.count_user_pending_reports).to eq(0)
+        end
+      end
+
+      context "when executing query" do
+        let(:reported_user) { create(:user, :confirmed, organization:) }
+        let!(:moderation) { create(:user_moderation, user: reported_user, report_count: 1) }
+        let!(:report) { create(:user_report, moderation:, user: admin, reason: "spam") }
+
+        it "returns some matches" do
+          expect(query.count_user_pending_reports).to eq(1)
+        end
+      end
+    end
+    describe "#count_pending_moderations" do
+      context "when there is no data" do
+        it "returns 0 matches" do
+          expect(query.count_pending_moderations).to eq(0)
+        end
+      end
+
+      context "when executing query" do
+        context "when there are users reported" do
+          before do
+            expect_any_instance_of(described_class).to receive(:count_user_pending_reports).and_return(2)
+            expect_any_instance_of(described_class).to receive(:count_content_moderations).and_return(0)
+          end
+
+          it "returns some matches" do
+            expect(query.count_pending_moderations).to eq(2)
+          end
+        end
+
+        context "when there is some content reported" do
+          before do
+            expect_any_instance_of(described_class).to receive(:count_user_pending_reports).and_return(0)
+            expect_any_instance_of(described_class).to receive(:count_content_moderations).and_return(2)
+          end
+
+          it "displays the right number" do
+            expect(query.count_pending_moderations).to eq(2)
+          end
+        end
+
+        context "when we have users and content reported" do
+          before do
+            expect_any_instance_of(described_class).to receive(:count_user_pending_reports).and_return(2)
+            expect_any_instance_of(described_class).to receive(:count_content_moderations).and_return(2)
+          end
+          it "displays the right number" do
+            expect(query.count_pending_moderations).to eq(4)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/queries/moderation_stats_spec.rb
+++ b/decidim-admin/spec/queries/moderation_stats_spec.rb
@@ -55,6 +55,7 @@ module Decidim::Admin
         end
       end
     end
+
     describe "#count_pending_moderations" do
       context "when there is no data" do
         it "returns 0 matches" do
@@ -65,8 +66,8 @@ module Decidim::Admin
       context "when executing query" do
         context "when there are users reported" do
           before do
-            expect_any_instance_of(described_class).to receive(:count_user_pending_reports).and_return(2)
-            expect_any_instance_of(described_class).to receive(:count_content_moderations).and_return(0)
+            allow(query).to receive(:count_user_pending_reports).and_return(2)
+            allow(query).to receive(:count_content_moderations).and_return(0)
           end
 
           it "returns some matches" do
@@ -76,8 +77,8 @@ module Decidim::Admin
 
         context "when there is some content reported" do
           before do
-            expect_any_instance_of(described_class).to receive(:count_user_pending_reports).and_return(0)
-            expect_any_instance_of(described_class).to receive(:count_content_moderations).and_return(2)
+            allow(query).to receive(:count_user_pending_reports).and_return(0)
+            allow(query).to receive(:count_content_moderations).and_return(2)
           end
 
           it "displays the right number" do
@@ -87,9 +88,10 @@ module Decidim::Admin
 
         context "when we have users and content reported" do
           before do
-            expect_any_instance_of(described_class).to receive(:count_user_pending_reports).and_return(2)
-            expect_any_instance_of(described_class).to receive(:count_content_moderations).and_return(2)
+            allow(query).to receive(:count_user_pending_reports).and_return(2)
+            allow(query).to receive(:count_content_moderations).and_return(2)
           end
+
           it "displays the right number" do
             expect(query.count_pending_moderations).to eq(4)
           end

--- a/decidim-admin/spec/system/admin_active_users_counter_spec.rb
+++ b/decidim-admin/spec/system/admin_active_users_counter_spec.rb
@@ -12,9 +12,62 @@ describe "Admin checks active users panel statistics", type: :system do
     visit decidim_admin.root_path
   end
 
+  it "shows Welcome message" do
+    expect(page).to have_content(t("decidim.admin.dashboard.show.welcome"))
+  end
+
   it "show users Activity panel" do
     expect(page).to have_content(t("decidim.admin.titles.statistics"))
     expect(page).to have_content(t("decidim.admin.users_statistics.users_count.participants"))
     expect(page).to have_content(t("decidim.admin.users_statistics.users_count.admins"))
+  end
+
+  it "show metrics panel" do
+    # More in admin_checks_metrics_spec.rb
+    expect(page).to have_content(t("decidim.admin.titles.metrics"))
+  end
+
+  it "show Admin log panel" do
+    expect(page).to have_content(t("decidim.admin.titles.admin_log"))
+  end
+
+  context "when does not have Pending moderations" do
+    it "hides the panel" do
+      expect(page).not_to have_content(t("decidim.admin.dashboard.pending_moderations.title"))
+      expect(page).not_to have_content(t("decidim.admin.dashboard.pending_moderations.goto_moderation"))
+    end
+  end
+
+  context "when has Pending moderations" do
+    context "when having reported resources" do
+      let(:current_component) { create :component }
+      let!(:reportable) { create(:dummy_resource, component: current_component, title: { "en" => "<p>Dummy<br> Title</p>" }) }
+      let!(:moderation) { create(:moderation, reportable:) }
+      let(:organization) { current_component.organization }
+
+      before do
+        visit decidim_admin.root_path
+      end
+
+      it "displays the panel" do
+        expect(page).to have_content(t("decidim.admin.dashboard.pending_moderations.title"))
+        expect(page).to have_content(t("decidim.admin.dashboard.pending_moderations.goto_moderation"))
+      end
+    end
+
+    context "when having reported users" do
+      let!(:reported_user) { create(:user, :confirmed, organization:) }
+      let!(:moderation) { create(:user_moderation, user: reported_user, report_count: 1) }
+      let!(:report) { create(:user_report, moderation:, user:, reason: "spam") }
+
+      before do
+        visit decidim_admin.root_path
+      end
+
+      it "displays the panel" do
+        expect(page).to have_content(t("decidim.admin.dashboard.pending_moderations.title"))
+        expect(page).to have_content(t("decidim.admin.dashboard.pending_moderations.goto_moderation"))
+      end
+    end
   end
 end

--- a/decidim-admin/spec/system/admin_dashboard_count_checks_spec.rb
+++ b/decidim-admin/spec/system/admin_dashboard_count_checks_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Admin checks active users panel statistics", type: :system do
+describe "Admin checks dashboard panel statistics", type: :system do
   let(:organization) { create(:organization) }
   let!(:user) { create(:user, :admin, :confirmed, organization:) }
 


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
As an admin or moderator when I enter the admin dashboard I don’t have any information about the pending moderations.

Ref: SPAM03

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10018
- Fixes #10035

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![image](https://user-images.githubusercontent.com/105683/199430827-62377905-6871-4929-8d13-681937d0c3f9.png)

:hearts: Thank you!
