### PR TITLE
Allow blocking a UserGroup

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/unblock_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/unblock_user.rb
@@ -39,7 +39,7 @@ module Decidim
           @blocked_user.blocked = false
           @blocked_user.blocked_at = nil
           @blocked_user.block_id = nil
-          @blocked_user.name = @blocked_user.user_name
+          @blocked_user.name = @blocked_user.extended_data["user_name"]
           @blocked_user.save!
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/block_user_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/block_user_controller.rb
@@ -50,7 +50,7 @@ module Decidim
       private
 
       def user
-        @user ||= Decidim::User.find_by(
+        @user ||= Decidim::UserBaseEntity.find_by(
           id: params[:user_id],
           organization: current_organization
         )

--- a/decidim-admin/app/controllers/decidim/admin/block_user_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/block_user_controller.rb
@@ -21,7 +21,7 @@ module Decidim
         BlockUser.call(@form) do
           on(:ok) do
             flash[:notice] = I18n.t("officializations.block.success", scope: "decidim.admin")
-            redirect_to officializations_path(q: { name_or_nickname_or_email_cont: user.name }), notice:
+            redirect_to moderated_users_path(blocked: true), notice:
           end
 
           on(:invalid) do
@@ -44,7 +44,7 @@ module Decidim
           end
         end
 
-        redirect_to officializations_path(q: { name_or_nickname_or_email_cont: user.name }), notice:
+        redirect_to moderated_users_path(blocked: false), notice:
       end
 
       private

--- a/decidim-admin/app/forms/decidim/admin/block_user_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/block_user_form.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Admin
-    # A form object used to officialize users from the admin dashboard.
+    # A form object used to block users or user groups on the admin dashboard.
     class BlockUserForm < Form
       attribute :user_id, Integer
       attribute :justification, String

--- a/decidim-admin/app/forms/decidim/admin/block_user_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/block_user_form.rb
@@ -15,7 +15,7 @@ module Decidim
       end
 
       def user
-        @user ||= Decidim::User.find_by(
+        @user ||= Decidim::UserBaseEntity.find_by(
           id: user_id,
           organization: current_organization
         )

--- a/decidim-admin/spec/commands/decidim/admin/block_user_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/block_user_spec.rb
@@ -8,68 +8,83 @@ module Decidim::Admin
 
     let(:organization) { create :organization }
     let(:current_user) { create :user, :admin, organization: }
-    let(:user_to_block) { create :user, :managed, name: "Testingname", organization: }
     let(:justification) { "justification for blocking the user" }
     let(:user_block) { create :justification, :user, :current_user }
 
-    context "when the form is valid" do
-      let(:form) do
-        double(
-          user: user_to_block,
-          current_user:,
-          justification: :justification,
-          valid?: true
-        )
+    shared_examples "blocking user or group form" do
+      context "when the form is valid" do
+        let(:form) do
+          double(
+            user: user_to_block,
+            current_user:,
+            justification: :justification,
+            valid?: true
+          )
+        end
+
+        it "broadcasts ok" do
+          expect { subject.call }.to broadcast(:ok, user_to_block)
+        end
+
+        it "user is notified" do
+          subject.call
+          expect(Decidim::BlockUserJob).to have_been_enqueued.on_queue("block_user")
+        end
+
+        it "user is updated" do
+          subject.call
+          expect(form.user.blocked).to be(true)
+          expect(form.user.extended_data["user_name"]).to eq(user_name)
+          expect(form.user.name).to eq("Blocked user")
+        end
+
+        it "original username is stored in the action log entry's resource title" do
+          subject.call
+          log = Decidim::ActionLog.last
+          expect(log.resource).to eq(form.user)
+          expect(log.extra["resource"]["title"]).to eq(user_name)
+        end
+
+        it "tracks the changes" do
+          expect(Decidim.traceability).to receive(:perform_action!).with("block",
+                                                                         user_to_block,
+                                                                         current_user,
+                                                                         extra: {
+                                                                           reportable_type: form.user.class.name,
+                                                                           current_justification: form.justification
+                                                                         },
+                                                                         resource: {
+                                                                           title: form.user.name
+                                                                         })
+          subject.call
+        end
       end
 
-      it "broadcasts ok" do
-        expect { subject.call }.to broadcast(:ok, user_to_block)
-      end
+      context "when the form is not ok" do
+        let(:form) do
+          double(
+            valid?: false
+          )
+        end
 
-      it "user is notified" do
-        subject.call
-        expect(Decidim::BlockUserJob).to have_been_enqueued.on_queue("block_user")
-      end
-
-      it "user is updated" do
-        subject.call
-        expect(form.user.blocked).to be(true)
-        expect(form.user.extended_data["user_name"]).to eq("Testingname")
-        expect(form.user.name).to eq("Blocked user")
-      end
-
-      it "original username is stored in the action log entry's resource title" do
-        subject.call
-        log = Decidim::ActionLog.last
-        expect(log.resource).to eq(form.user)
-        expect(log.extra["resource"]["title"]).to eq("Testingname")
-      end
-
-      it "tracks the changes" do
-        expect(Decidim.traceability).to receive(:perform_action!).with("block",
-                                                                       user_to_block,
-                                                                       current_user,
-                                                                       extra: {
-                                                                         reportable_type: form.user.class.name,
-                                                                         current_justification: form.justification
-                                                                       },
-                                                                       resource: {
-                                                                         title: form.user.name
-                                                                       })
-        subject.call
+        it "broadcasts invalid" do
+          expect { subject.call }.to broadcast(:invalid)
+        end
       end
     end
 
-    context "when the form is not ok" do
-      let(:form) do
-        double(
-          valid?: false
-        )
-      end
+    context "with a user" do
+      let(:user_to_block) { create :user, name: user_name, organization: }
+      let(:user_name) { "Testing user" }
 
-      it "broadcasts invalid" do
-        expect { subject.call }.to broadcast(:invalid)
-      end
+      it_behaves_like "blocking user or group form"
+    end
+
+    context "with a user group" do
+      let(:user_to_block) { create :user_group, name: user_name, organization: }
+      let(:user_name) { "Testing user group" }
+
+      it_behaves_like "blocking user or group form"
     end
   end
 end

--- a/decidim-admin/spec/commands/decidim/admin/unblock_user_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/unblock_user_spec.rb
@@ -6,6 +6,7 @@ module Decidim::Admin
   describe UnblockUser do
     subject { described_class.new(user_to_unblock, current_user) }
 
+    let(:extended_data) { { user_name: } }
     let(:current_user) { create :user, :admin }
 
     shared_examples "unblocking a user or group" do
@@ -45,14 +46,14 @@ module Decidim::Admin
     end
 
     context "with a user" do
-      let(:user_to_unblock) { create :user, blocked: true, name: user_name }
+      let(:user_to_unblock) { create :user, :blocked, extended_data: }
       let(:user_name) { "Testing user" }
 
       it_behaves_like "unblocking a user or group"
     end
 
     context "with a user group" do
-      let(:user_to_unblock) { create :user_group, blocked: true, name: user_name }
+      let(:user_to_unblock) { create :user_group, :blocked, extended_data: }
       let(:user_name) { "Testing user group" }
 
       it_behaves_like "unblocking a user or group"

--- a/decidim-admin/spec/controllers/block_user_controller_spec.rb
+++ b/decidim-admin/spec/controllers/block_user_controller_spec.rb
@@ -16,77 +16,101 @@ module Decidim
       end
 
       describe "unblock" do
-        let!(:user) { create(:user, :blocked, :confirmed, organization:, nickname: "some_nickname") }
+        shared_examples "unblocking a user or group" do
+          context "when having a user" do
+            it "flashes a notice message" do
+              delete :destroy, params: { user_id: user.id }
 
-        context "when having a user" do
-          it "flashes a notice message" do
-            delete :destroy, params: { user_id: user.id }
+              expect(flash[:notice]).to be_present
+              expect(user.reload.blocked?).to be(false)
+            end
+          end
 
-            expect(flash[:notice]).to be_present
-            expect(user.reload.blocked?).to be(false)
+          context "when the user is not blocked" do
+            before do
+              user.blocked = false
+              user.save!
+            end
+
+            it "flashes an alert message" do
+              delete :destroy, params: { user_id: user.id }
+
+              expect(flash[:alert]).to be_present
+              expect(user.reload.blocked?).to be(false)
+            end
+          end
+
+          context "when current user is not an admin" do
+            before do
+              current_user.admin = false
+              current_user.save!
+            end
+
+            it "the user remains blocked" do
+              delete :destroy, params: { user_id: user.id }
+
+              expect(user.reload.blocked?).to be(true)
+            end
           end
         end
 
-        context "when the user is not blocked" do
-          before do
-            user.blocked = false
-            user.save!
-          end
+        context "when its a user" do
+          let!(:user) { create(:user, :blocked, :confirmed, organization:, nickname: "some_nickname") }
 
-          it "flashes an alert message" do
-            delete :destroy, params: { user_id: user.id }
-
-            expect(flash[:alert]).to be_present
-            expect(user.reload.blocked?).to be(false)
-          end
+          it_behaves_like "unblocking a user or group"
         end
 
-        context "when current user is not an admin" do
-          before do
-            current_user.admin = false
-            current_user.save!
-          end
+        context "when its a user group" do
+          let!(:user) { create(:user_group, :blocked, :confirmed, organization:, nickname: "another_nickname") }
 
-          it "the user remains blocked" do
-            delete :destroy, params: { user_id: user.id }
-
-            expect(user.reload.blocked?).to be(true)
-          end
+          it_behaves_like "unblocking a user or group"
         end
       end
 
       describe "block" do
-        let!(:user) { create(:user, :confirmed, organization:, nickname: "some_nickname") }
+        shared_examples "blocking a user or group" do
+          context "when having a user" do
+            it "flashes a notice message" do
+              put :create, params: { user_id: user.id, justification: ::Faker::Lorem.sentence(word_count: 12) }
 
-        context "when having a user" do
-          it "flashes a notice message" do
-            put :create, params: { user_id: user.id, justification: ::Faker::Lorem.sentence(word_count: 12) }
+              expect(flash[:notice]).to be_present
+              expect(user.reload.blocked?).to be(true)
+            end
+          end
 
-            expect(flash[:notice]).to be_present
-            expect(user.reload.blocked?).to be(true)
+          context "when form is invalid" do
+            it "flashes an alert message" do
+              put :create, params: { user_id: user.id, justification: nil }
+
+              expect(flash[:alert]).to be_present
+              expect(user.reload.blocked?).to be(false)
+            end
+          end
+
+          context "when current user is not an admin" do
+            before do
+              current_user.admin = false
+              current_user.save!
+            end
+
+            it "the user remains unblocked" do
+              put :create, params: { user_id: user.id, justification: ::Faker::Lorem.sentence(word_count: 12) }
+
+              expect(user.reload.blocked?).to be(false)
+            end
           end
         end
 
-        context "when form is invalid" do
-          it "flashes an alert message" do
-            put :create, params: { user_id: user.id, justification: nil }
+        context "when its a user" do
+          let!(:user) { create(:user, :confirmed, organization:, nickname: "some_nickname") }
 
-            expect(flash[:alert]).to be_present
-            expect(user.reload.blocked?).to be(false)
-          end
+          it_behaves_like "blocking a user or group"
         end
 
-        context "when current user is not an admin" do
-          before do
-            current_user.admin = false
-            current_user.save!
-          end
+        context "when its a user group" do
+          let!(:user) { create(:user_group, :confirmed, organization:, nickname: "another_nickname") }
 
-          it "the user remains unblocked" do
-            put :create, params: { user_id: user.id, justification: ::Faker::Lorem.sentence(word_count: 12) }
-
-            expect(user.reload.blocked?).to be(false)
-          end
+          it_behaves_like "blocking a user or group"
         end
       end
     end

--- a/decidim-admin/spec/forms/block_user_form_spec.rb
+++ b/decidim-admin/spec/forms/block_user_form_spec.rb
@@ -6,51 +6,62 @@ module Decidim
   module Admin
     describe BlockUserForm do
       let(:organization) { create(:organization) }
-
-      let(:user) { create(:user, organization:) }
-
       let(:justification) { "" }
 
-      describe "from a model" do
-        subject do
-          described_class.from_model(
-            user
-          ).with_context(
-            current_organization: organization
-          )
+      shared_examples "blocking a user or group" do
+        describe "from a model" do
+          subject do
+            described_class.from_model(
+              user
+            ).with_context(
+              current_organization: organization
+            )
+          end
+
+          context "when justification form is empty" do
+            it { is_expected.not_to be_valid }
+          end
         end
 
-        context "when justification form is empty" do
-          it { is_expected.not_to be_valid }
+        describe "from params" do
+          subject do
+            described_class.from_params(
+              justification:, user_id: user.id
+            ).with_context(
+              current_organization: organization
+            )
+          end
+
+          context "when justification has the correct length" do
+            let(:justification) { "Not TOS compliant." }
+
+            it { is_expected.to be_valid }
+          end
+
+          context "when justification is too short" do
+            let(:justification) { "Not TOS." }
+
+            it { is_expected.not_to be_valid }
+          end
+
+          context "when the user does not exist" do
+            let(:user_id) { 9999 }
+
+            it { is_expected.not_to be_valid }
+          end
         end
       end
 
-      describe "from params" do
-        subject do
-          described_class.from_params(
-            justification:, user_id: user.id
-          ).with_context(
-            current_organization: organization
-          )
-        end
+      context "with a user" do
+        let(:user) { create(:user, organization:) }
 
-        context "when justification has the correct length" do
-          let(:justification) { "Not TOS compliant." }
+        it_behaves_like "blocking a user or group"
+      end
 
-          it { is_expected.to be_valid }
-        end
+      context "with a user group" do
+        let(:user) { create(:user_group, organization:) }
 
-        context "when justification is too short" do
-          let(:justification) { "Not TOS." }
-
-          it { is_expected.not_to be_valid }
-        end
-
-        context "when the user does not exist" do
-          let(:user_id) { 9999 }
-
-          it { is_expected.not_to be_valid }
-        end
+        it_behaves_like "blocking a user or group"
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/groups_controller.rb
+++ b/decidim-core/app/controllers/decidim/groups_controller.rb
@@ -7,6 +7,7 @@ module Decidim
     include UserGroups
 
     before_action :enforce_user_groups_enabled
+    before_action :ensure_user_group_not_blocked
 
     def new
       enforce_permission_to :create, :user_group, current_user: current_user
@@ -77,6 +78,10 @@ module Decidim
     end
 
     private
+
+    def ensure_user_group_not_blocked
+      raise ActionController::RoutingError, "Blocked User Group" if user_group&.blocked?
+    end
 
     def accepted_user_group
       @accepted_user_group ||= Decidim::UserGroups::AcceptedUserGroups.for(current_user).find_by(nickname: params[:id])

--- a/decidim-core/app/controllers/decidim/profiles_controller.rb
+++ b/decidim-core/app/controllers/decidim/profiles_controller.rb
@@ -13,7 +13,7 @@ module Decidim
     before_action :ensure_profile_holder
     before_action :ensure_profile_holder_is_a_group, only: [:members]
     before_action :ensure_profile_holder_is_a_user, only: [:groups, :following]
-    before_action :ensure_user_not_blocked, only: [:following, :followers, :badges]
+    before_action :ensure_user_not_blocked
 
     redesign active: true
 

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -36,8 +36,6 @@ module Decidim
     has_many :access_tokens, class_name: "Doorkeeper::AccessToken", foreign_key: :resource_owner_id, dependent: :destroy
     has_many :reminders, foreign_key: "decidim_user_id", class_name: "Decidim::Reminder", dependent: :destroy
 
-    has_one :blocking, class_name: "Decidim::UserBlock", foreign_key: :id, primary_key: :block_id, dependent: :destroy
-
     validates :name, presence: true, unless: -> { deleted? }
     validates :nickname,
               presence: true,

--- a/decidim-core/app/models/decidim/user_base_entity.rb
+++ b/decidim-core/app/models/decidim/user_base_entity.rb
@@ -17,6 +17,8 @@ module Decidim
     has_many :notifications, foreign_key: "decidim_user_id", class_name: "Decidim::Notification", dependent: :destroy
     has_many :following_follows, foreign_key: "decidim_user_id", class_name: "Decidim::Follow", dependent: :destroy
 
+    has_one :blocking, class_name: "Decidim::UserBlock", foreign_key: :id, primary_key: :block_id, dependent: :destroy
+
     # Regex for name & nickname format validations
     REGEXP_NAME = /\A(?!.*[<>?%&\^*#@()\[\]=+:;"{}\\|])/
 

--- a/decidim-core/app/models/decidim/user_block.rb
+++ b/decidim-core/app/models/decidim/user_block.rb
@@ -4,7 +4,7 @@ module Decidim
   class UserBlock < ApplicationRecord
     MINIMUM_JUSTIFICATION_LENGTH = 15
 
-    belongs_to :user, class_name: "Decidim::User", foreign_key: :decidim_user_id
-    belongs_to :blocking_user, class_name: "Decidim::User"
+    belongs_to :user, class_name: "Decidim::UserBaseEntity", foreign_key: :decidim_user_id
+    belongs_to :blocking_user, class_name: "Decidim::UserBaseEntity"
   end
 end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -234,6 +234,13 @@ FactoryBot.define do
       confirmed_at { Time.current }
     end
 
+    trait :blocked do
+      blocked { true }
+      blocked_at { Time.current }
+      extended_data { { user_name: generate(:name) } }
+      name { "Blocked user group" }
+    end
+
     after(:build) do |user_group, evaluator|
       user_group.extended_data = {
         document_number: evaluator.document_number,

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -242,12 +242,12 @@ FactoryBot.define do
     end
 
     after(:build) do |user_group, evaluator|
-      user_group.extended_data = {
-        document_number: evaluator.document_number,
-        phone: evaluator.phone,
-        rejected_at: evaluator.rejected_at,
-        verified_at: evaluator.verified_at
-      }
+      user_group.extended_data = user_group.extended_data.merge({
+                                                                  document_number: evaluator.document_number,
+                                                                  phone: evaluator.phone,
+                                                                  rejected_at: evaluator.rejected_at,
+                                                                  verified_at: evaluator.verified_at
+                                                                })
     end
 
     after(:create) do |user_group, evaluator|

--- a/decidim-core/spec/controllers/decidim/profiles_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/profiles_controller_spec.rb
@@ -21,5 +21,40 @@ module Decidim
         end
       end
     end
+
+    describe "#show" do
+      context "with a normal user" do
+        it "redirects to the correct page" do
+          get :show, params: { nickname: "Nick" }
+          expect(response).to redirect_to("/profiles/Nick/activity")
+        end
+      end
+
+      context "with a blocked user" do
+        let!(:user) { create(:user, :confirmed, :blocked, nickname: "Nick", organization:) }
+
+        it "doesn't return the page" do
+          expect { get :show, params: { nickname: "Nick" } }.to raise_error(ActionController::RoutingError)
+        end
+      end
+
+      context "with a normal user group" do
+        let!(:user) { create(:user_group, nickname: "acme", organization:) }
+
+        it "redirects to the correct page" do
+          get :show, params: { nickname: "acme" }
+
+          expect(response).to redirect_to("/profiles/acme/members")
+        end
+      end
+
+      context "with a blocked user group" do
+        let!(:user) { create(:user_group, nickname: "acme", organization:) }
+
+        it "doesn't return the page" do
+          expect { get :show, params: { nickname: "blocked" } }.to raise_error(ActionController::RoutingError)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

When you try to block a reported UserGroup, there's an exception. 

This is because the users moderation feature was developed for users only, although you can report a user group. This PR fixes that, by changing the behavior from using the "Users" model to "UserBaseEntity"

#### :pushpin: Related Issues
 
- Fixes #9780

#### Testing

1. Log in as administrator
2. Search for a group and report it
3. Click on block from the admin panel http://localhost:3000/admin/moderated_users
4. See that it works all the flow: 
4.1 Adding a justification
4.2 Blocking the user group
4.3 Going to the user group profile page and see that it's blocked indeed (with an incognito session) 
4.4 Unblocking the user group 

:hearts: Thank you!
