### PR TITLE
Prevent `aria-describedby` attribute being added to hidden inputs

### DIFF
--- a/decidim-core/app/packs/src/decidim/input_character_counter.js
+++ b/decidim-core/app/packs/src/decidim/input_character_counter.js
@@ -33,7 +33,7 @@ export default class InputCharacterCounter {
     this.$target = $(this.$input.data("remaining-characters"));
     this.minCharacters = parseInt(this.$input.attr("minlength"), 10);
     this.maxCharacters = parseInt(this.$input.attr("maxlength"), 10);
-    this.describeByCounter = typeof this.$input.attr("aria-describedby") === "undefined";
+    this.describeByCounter = this.$input.attr("type") !== "hidden" && typeof this.$input.attr("aria-describedby") === "undefined";
 
     // Define the closest length for the input "gaps" defined by the threshold.
     if (this.maxCharacters > 10) {

--- a/decidim-core/app/packs/src/decidim/redesigned_input_character_counter.js
+++ b/decidim-core/app/packs/src/decidim/redesigned_input_character_counter.js
@@ -33,7 +33,7 @@ export default class InputCharacterCounter {
     this.$target = $(this.$input.data("remaining-characters"));
     this.minCharacters = parseInt(this.$input.attr("minlength"), 10);
     this.maxCharacters = parseInt(this.$input.attr("maxlength"), 10);
-    this.describeByCounter = typeof this.$input.attr("aria-describedby") === "undefined";
+    this.describeByCounter = this.$input.attr("type") !== "hidden" && typeof this.$input.attr("aria-describedby") === "undefined";
 
     // Define the closest length for the input "gaps" defined by the threshold.
     if (this.maxCharacters > 10) {


### PR DESCRIPTION
#### :tophat: What? Why?
While fixing another bug (#10020) we discovered that the `aria-*` attributes are no longer valid HTML on hidden inputs.

This requires us to add some extra exclusions to the HTML validation process until foundation/foundation-sites#12496 is resolved.

But meanwhile investigating this issue, I also found one potential similar issue in the core character counter which I am fixing in this PR. The problem appears only if you initiate the character counter for hidden inputs, which is essentially what we are doing e.g. here for the WYSIWYG editors:

https://github.com/decidim/decidim/blob/2fa06d4bf3c08c1431c3f3a6441ebe7f05fb9ba0/decidim-core/app/packs/src/decidim/index.js#L78

https://github.com/decidim/decidim/blob/2fa06d4bf3c08c1431c3f3a6441ebe7f05fb9ba0/decidim-core/app/packs/src/decidim/redesigned_index.js#L142

#### :pushpin: Related Issues
- Related to #10020

#### Testing
See that CI is green or run these manually (using the older HTML validator version that we use at CI):

```bash
$ cd decidim-core
$ bundle exec rpsec spec/system/messaging/conversations_spec.rb
```