### PR TITLE
Add ability to hide content from front page

### DIFF
--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -17,6 +17,7 @@ import Rails from "@rails/ujs";
 import { createCharacterCounter } from "src/decidim/input_character_counter"
 import ExternalLink from "src/decidim/redesigned_external_link"
 import updateExternalDomainLinks from "src/decidim/external_domain_warning"
+import changeReportFormBehavior from "src/decidim/change_report_form_behavior"
 
 export default class CommentsComponent {
   constructor($element, config) {
@@ -139,6 +140,8 @@ export default class CommentsComponent {
         $submit.attr("disabled", "disabled");
         this._stopPolling();
       });
+
+      document.querySelectorAll(".new_report").forEach((container) => changeReportFormBehavior(container))
 
       if ($text.length && $text.get(0) !== null) {
         // Attach event to the DOM node, instead of the jQuery object

--- a/decidim-core/app/cells/decidim/flag_modal/show.erb
+++ b/decidim-core/app/cells/decidim/flag_modal/show.erb
@@ -20,7 +20,27 @@
           <label><%= builder.radio_button(id: nil) + builder.text %></label>
         <% end %>
       </fieldset>
+
+      <% if frontend_administrable? %>
+        <div class="callout secondary"><%= t("decidim.shared.flag_modal.visit_profile", user_link: link_to(author&.nickname, link_to_profile)) %></div>
+      <% end %>
       <%= f.text_area :details, rows: 4, id: "#{modal_id}_details", label_options: { for: "#{modal_id}_details" } %>
+
+      <% if frontend_administrable? %>
+        <fieldset>
+          <div class="modal__report-container__radio">
+            <%= f.check_box :hide, label: false , data: {
+              label_hide: t("decidim.shared.flag_modal.hide"),
+              label_report: t("decidim.shared.flag_modal.report"),
+              hide: "true"
+            }, id: hide_checkbox_id %>
+            <label for="<%= hide_checkbox_id %>">
+              <%= t("decidim.shared.flag_modal.hide_content") %>
+            </label>
+          </div>
+        </fieldset>
+      <% end %>
+
       <%= f.submit t("decidim.shared.flag_modal.report") %>
     <% end %>
   <% end %>

--- a/decidim-core/app/cells/decidim/flag_modal_cell.rb
+++ b/decidim-core/app/cells/decidim/flag_modal_cell.rb
@@ -45,8 +45,10 @@ module Decidim
     end
 
     def report_form
-      context = { can_hide: model.try(:can_be_administred_by?, current_user) }
-      @report_form ||= Decidim::ReportForm.new(reason: "spam").with_context(context)
+      @report_form ||= begin
+        context = { can_hide: model.try(:can_be_administred_by?, current_user) }
+        Decidim::ReportForm.new(reason: "spam").with_context(context)
+      end
     end
   end
 end

--- a/decidim-core/app/cells/decidim/flag_modal_cell.rb
+++ b/decidim-core/app/cells/decidim/flag_modal_cell.rb
@@ -20,6 +20,18 @@ module Decidim
 
     private
 
+    def frontend_administrable?
+      model.can_be_administred_by?(current_user) && (model.respond_to?(:official?) && !model.official?)
+    end
+
+    def link_to_profile
+      author.presenter.profile_url
+    end
+
+    def author
+      model.try(:creator_identity) || model.try(:normalized_author)
+    end
+
     def user_report_form
       Decidim::ReportForm.from_params(reason: "spam")
     end
@@ -28,8 +40,13 @@ module Decidim
       options[:modal_id] || "flagModal"
     end
 
+    def hide_checkbox_id
+      @hide_checkbox_id ||= Digest::MD5.hexdigest("report_form_hide_#{model.class.name}_#{model.id}")
+    end
+
     def report_form
-      @report_form ||= Decidim::ReportForm.new(reason: "spam")
+      context = { can_hide: model.try(:can_be_administred_by?, current_user) }
+      @report_form ||= Decidim::ReportForm.new(reason: "spam").with_context(context)
     end
   end
 end

--- a/decidim-core/app/commands/decidim/create_report.rb
+++ b/decidim-core/app/commands/decidim/create_report.rb
@@ -78,8 +78,12 @@ module Decidim
       end
     end
 
+    def hidden_by_admin?
+      form.hide == true && form.context[:can_hide] == true
+    end
+
     def hideable?
-      !@reportable.hidden? && @moderation.report_count >= Decidim.max_reports_before_hiding
+      hidden_by_admin? || (!@reportable.hidden? && @moderation.report_count >= Decidim.max_reports_before_hiding)
     end
 
     def hide!

--- a/decidim-core/app/controllers/decidim/reports_controller.rb
+++ b/decidim-core/app/controllers/decidim/reports_controller.rb
@@ -11,7 +11,7 @@ module Decidim
     def create
       enforce_permission_to :create, :moderation
 
-      @form = form(Decidim::ReportForm).from_params(params)
+      @form = form(Decidim::ReportForm).from_params(params, can_hide: reportable.try(:can_be_administred_by?, current_user))
 
       CreateReport.call(@form, reportable, current_user) do
         on(:ok) do

--- a/decidim-core/app/forms/decidim/report_form.rb
+++ b/decidim-core/app/forms/decidim/report_form.rb
@@ -7,6 +7,7 @@ module Decidim
 
     attribute :reason, String
     attribute :details, String
+    attribute :hide, Boolean, default: false
 
     validates :reason, inclusion: { in: Report::REASONS }
   end

--- a/decidim-core/app/packs/src/decidim/change_report_form_behavior.js
+++ b/decidim-core/app/packs/src/decidim/change_report_form_behavior.js
@@ -1,0 +1,28 @@
+/**
+ * These set of functions aims to change the behavior of the report modal forms
+ * so that when checking various checkboxes, to change the label of the button
+ * to either report or hide.
+ */
+
+/**
+ * @param {Object} container The form handling the report.
+ * @return {Void} Nothing
+ */
+export default function changeReportFormBehavior(container) {
+  container.querySelectorAll("[data-hide=true]").forEach((checkbox) => {
+    checkbox.addEventListener("change", (event) => {
+      let input = event.target;
+      let submit = input.closest("form").querySelector("button[type=submit]");
+
+      if (submit.querySelector("span") !== null) {
+        submit = submit.querySelector("span");
+      }
+
+      if (input.checked === true) {
+        submit.innerHTML = input.dataset.labelHide;
+      } else {
+        submit.innerHTML = input.dataset.labelReport;
+      }
+    });
+  });
+}

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -17,6 +17,7 @@ import dialogMode from "src/decidim/dialog_mode"
 import FocusGuard from "src/decidim/focus_guard"
 import backToListLink from "src/decidim/back_to_list"
 import markAsReadNotifications from "src/decidim/notifications"
+import changeReportFormBehavior from "src/decidim/change_report_form_behavior"
 
 // NOTE: new libraries required to give functionality to redesigned views
 import Accordions from "a11y-accordion-component";
@@ -98,6 +99,7 @@ $(() => {
 
     formFilter.mountComponent();
   })
+  document.querySelectorAll(".new_report").forEach((container) => changeReportFormBehavior(container))
 
   updateExternalDomainLinks($("body"))
 

--- a/decidim-core/app/presenters/decidim/official_author_presenter.rb
+++ b/decidim-core/app/presenters/decidim/official_author_presenter.rb
@@ -21,6 +21,10 @@ module Decidim
       ""
     end
 
+    def profile_url
+      ""
+    end
+
     def avatar_url(_variant = nil)
       ActionController::Base.helpers.asset_pack_path("media/images/default-avatar.svg")
     end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1419,11 +1419,14 @@ en:
         close: Close
         description: Is this content inappropriate?
         does_not_belong: Contains illegal activity, suicide threats, personal information, or something else you think doesn't belong on %{organization_name}.
+        hide: Hide
+        hide_content: Hide this content
         offensive: Contains racism, sexism, slurs, personal attacks, death threats, suicide requests or any form of hate speech.
         reason: Reason
         report: Report
         spam: Contains clickbait, advertising, scams or script bots.
         title: Report inappropriate content
+        visit_profile: If you want to also block the participant and the rest of its contents, go to %{user_link} profile page.
       flag_user_modal:
         already_reported: This content is already reported and it will be reviewed by an admin.
         close: Close

--- a/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
@@ -13,6 +13,62 @@ shared_examples "reports" do
     end
   end
 
+  context "when the admin is logged in" do
+    let!(:admin) { create(:user, :admin, :confirmed, organization: user.organization) }
+    before do
+      login_as admin, scope: :user
+    end
+
+    context "and the admin reports the resource" do
+      it "reports the resource" do
+        visit reportable_path
+
+        expect(page).to have_selector(".author-data__extra")
+
+        within ".author-data__extra", match: :first do
+          page.find("button").click
+        end
+
+        expect(page).to have_css(".flag-modal", visible: :visible)
+
+        within ".flag-modal" do
+          click_button "Report"
+        end
+
+        expect(page).to have_content "report has been created"
+      end
+    end
+
+    context "and the admin hides the resource" do
+      around do |example|
+        previous = Capybara.raise_server_errors
+
+        Capybara.raise_server_errors = false
+        example.run
+        Capybara.raise_server_errors = previous
+      end
+
+      it "reports the resource" do
+        visit reportable_path
+
+        expect(page).to have_selector(".author-data__extra")
+
+        within ".author-data__extra", match: :first do
+          page.find("button").click
+        end
+
+        expect(page).to have_css(".flag-modal", visible: :visible)
+
+        within ".flag-modal" do
+          find(:css, "input[name='report[hide]']").set(true)
+          click_button "Hide"
+        end
+
+        expect(reportable.reload).to be_hidden
+      end
+    end
+  end
+
   context "when the user is logged in" do
     before do
       login_as user, scope: :user

--- a/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
@@ -1,74 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples "reports" do
-  context "when the user is not logged in" do
-    it "gives the option to sign in" do
-      visit reportable_path
-
-      expect(page).to have_no_css("html.is-reveal-open")
-
-      click_button "Report"
-
-      expect(page).to have_css("html.is-reveal-open")
-    end
-  end
-
-  context "when the admin is logged in" do
-    let!(:admin) { create(:user, :admin, :confirmed, organization: user.organization) }
-    before do
-      login_as admin, scope: :user
-    end
-
-    context "and the admin reports the resource" do
-      it "reports the resource" do
-        visit reportable_path
-
-        expect(page).to have_selector(".author-data__extra")
-
-        within ".author-data__extra", match: :first do
-          page.find("button").click
-        end
-
-        expect(page).to have_css(".flag-modal", visible: :visible)
-
-        within ".flag-modal" do
-          click_button "Report"
-        end
-
-        expect(page).to have_content "report has been created"
-      end
-    end
-
-    context "and the admin hides the resource" do
-      around do |example|
-        previous = Capybara.raise_server_errors
-
-        Capybara.raise_server_errors = false
-        example.run
-        Capybara.raise_server_errors = previous
-      end
-
-      it "reports the resource" do
-        visit reportable_path
-
-        expect(page).to have_selector(".author-data__extra")
-
-        within ".author-data__extra", match: :first do
-          page.find("button").click
-        end
-
-        expect(page).to have_css(".flag-modal", visible: :visible)
-
-        within ".flag-modal" do
-          find(:css, "input[name='report[hide]']").set(true)
-          click_button "Hide"
-        end
-
-        expect(reportable.reload).to be_hidden
-      end
-    end
-  end
-
+shared_examples "logged in user reports content" do
   context "when the user is logged in" do
     before do
       login_as user, scope: :user
@@ -93,26 +25,137 @@ shared_examples "reports" do
         expect(page).to have_content "report has been created"
       end
     end
+  end
+end
 
-    context "and the user has reported the resource previously" do
-      before do
-        moderation = create(:moderation, reportable:, participatory_space: participatory_process)
-        create(:report, moderation:, user:, reason: "spam")
+shared_examples "higher user role reports" do
+  include_examples "logged in user reports content"
+end
+
+shared_examples "higher user role hides" do
+  context "and the admin hides the resource" do
+    before do
+      login_as user, scope: :user
+    end
+    around do |example|
+      previous = Capybara.raise_server_errors
+
+      Capybara.raise_server_errors = false
+      example.run
+      Capybara.raise_server_errors = previous
+    end
+
+    it "reports the resource" do
+      visit reportable_path
+
+      expect(page).to have_selector(".author-data__extra")
+
+      within ".author-data__extra", match: :first do
+        page.find("button").click
       end
 
-      it "cannot report it twice" do
-        visit reportable_path
+      expect(page).to have_css(".flag-modal", visible: :visible)
 
-        expect(page).to have_selector(".author-data__extra")
+      within ".flag-modal" do
+        find(:css, "input[name='report[hide]']").set(true)
+        click_button "Hide"
+      end
 
-        within ".author-data__extra", match: :first do
-          page.find("button").click
-        end
+      expect(reportable.reload).to be_hidden
+    end
+  end
+end
 
-        expect(page).to have_css(".flag-modal", visible: :visible)
+shared_examples "higher user role does not have hide" do
+  context "and the admin reports" do
+    before do
+      login_as user, scope: :user
+    end
 
-        expect(page).to have_content "already reported"
+    it "reports the resource" do
+      visit reportable_path
+
+      expect(page).to have_selector(".author-data__extra")
+
+      within ".author-data__extra", match: :first do
+        page.find("button").click
+      end
+
+      expect(page).to have_css(".flag-modal", visible: :visible)
+
+      within ".flag-modal" do
+        expect(page).not_to have_selector "input[name='report[hide]']"
       end
     end
+  end
+end
+
+shared_examples "reports" do
+  context "when the user is not logged in" do
+    it "gives the option to sign in" do
+      visit reportable_path
+
+      expect(page).to have_no_css("html.is-reveal-open")
+
+      click_button "Report"
+
+      expect(page).to have_css("html.is-reveal-open")
+    end
+  end
+
+  include_examples "logged in user reports content"
+
+  context "and the user has reported the resource previously" do
+    before do
+      moderation = create(:moderation, reportable:, participatory_space: participatory_process)
+      create(:report, moderation:, user:, reason: "spam")
+      login_as user, scope: :user
+    end
+
+    it "cannot report it twice" do
+      visit reportable_path
+
+      expect(page).to have_selector(".author-data__extra")
+
+      within ".author-data__extra", match: :first do
+        page.find("button").click
+      end
+
+      expect(page).to have_css(".flag-modal", visible: :visible)
+
+      expect(page).to have_content "already reported"
+    end
+  end
+end
+shared_examples "reports by user type" do
+  context "when reporting user is regular visitor" do
+    include_examples "reports"
+  end
+
+  context "When reporting user is platform admin" do
+    let!(:user) { create(:user, :admin, :confirmed, organization:) }
+    include_examples "higher user role reports"
+    include_examples "higher user role hides"
+  end
+  context "When reporting user is process admin" do
+    let!(:user) { create :process_admin, :confirmed, participatory_process: }
+
+    include_examples "higher user role reports"
+    include_examples "higher user role hides"
+  end
+  context "When reporting user is process collaborator" do
+    let!(:user) { create :process_collaborator, :confirmed, participatory_process: }
+    include_examples "higher user role reports"
+    include_examples "higher user role does not have hide"
+  end
+  context "When reporting user is process moderator" do
+    let!(:user) { create :process_moderator, :confirmed, participatory_process: }
+    include_examples "higher user role reports"
+    include_examples "higher user role hides"
+  end
+  context "When reporting user is process valuator" do
+    let!(:user) { create :process_valuator, :confirmed, participatory_process: }
+    include_examples "higher user role reports"
+    include_examples "higher user role hides"
   end
 end

--- a/decidim-core/lib/decidim/reportable.rb
+++ b/decidim-core/lib/decidim/reportable.rb
@@ -15,6 +15,19 @@ module Decidim
       scope :hidden, -> { left_outer_joins(:moderation).where.not(Decidim::Moderation.arel_table[:hidden_at].eq nil) }
       scope :not_hidden, -> { left_outer_joins(:moderation).where(Decidim::Moderation.arel_table[:hidden_at].eq nil) }
 
+      # Public: Check if the supplied user can administrate the resource
+      #
+      # Returns Boolean
+      def can_be_administred_by?(user)
+        return false if user.blank?
+
+        [
+          user.admin?,
+          participatory_space.moderators.exists?(id: user.id),
+          participatory_space.admins.exists?(id: user.id)
+        ].any?
+      end
+
       # Public: Check if the user has reported the reportable.
       #
       # Returns Boolean.

--- a/decidim-debates/spec/system/report_debate_spec.rb
+++ b/decidim-debates/spec/system/report_debate_spec.rb
@@ -6,7 +6,7 @@ describe "Report a debate", type: :system do
   include_context "with a component"
 
   let(:manifest_name) { "debates" }
-  let!(:debates) { create_list(:debate, 3, component:) }
+  let!(:debates) { create_list(:debate, 3, :participant_author, component:) }
   let(:reportable) { debates.first }
   let(:reportable_path) { resource_locator(reportable).path }
   let!(:user) { create :user, :confirmed, organization: }

--- a/decidim-debates/spec/system/report_debate_spec.rb
+++ b/decidim-debates/spec/system/report_debate_spec.rb
@@ -9,7 +9,6 @@ describe "Report a debate", type: :system do
   let!(:debates) { create_list(:debate, 3, :participant_author, component:) }
   let(:reportable) { debates.first }
   let(:reportable_path) { resource_locator(reportable).path }
-  let!(:user) { create :user, :confirmed, organization: }
 
   let!(:component) do
     create(:debates_component,
@@ -17,5 +16,5 @@ describe "Report a debate", type: :system do
            participatory_space: participatory_process)
   end
 
-  include_examples "reports"
+  include_examples "reports by user type"
 end

--- a/decidim-meetings/spec/system/report_meeting_spec.rb
+++ b/decidim-meetings/spec/system/report_meeting_spec.rb
@@ -9,13 +9,12 @@ describe "Report Meeting", type: :system do
   let!(:meetings) { create_list(:meeting, 3, :not_official, :published, component:) }
   let(:reportable) { meetings.first }
   let(:reportable_path) { resource_locator(reportable).path }
-  let!(:user) { create :user, :confirmed, organization: }
 
   let!(:component) do
-    create(:proposal_component,
+    create(:meeting_component,
            manifest:,
            participatory_space: participatory_process)
   end
 
-  include_examples "reports"
+  include_examples "reports by user type"
 end

--- a/decidim-meetings/spec/system/report_meeting_spec.rb
+++ b/decidim-meetings/spec/system/report_meeting_spec.rb
@@ -6,7 +6,7 @@ describe "Report Meeting", type: :system do
   include_context "with a component"
 
   let(:manifest_name) { "meetings" }
-  let!(:meetings) { create_list(:meeting, 3, :published, component:) }
+  let!(:meetings) { create_list(:meeting, 3, :not_official, :published, component:) }
   let(:reportable) { meetings.first }
   let(:reportable_path) { resource_locator(reportable).path }
   let!(:user) { create :user, :confirmed, organization: }

--- a/decidim-proposals/spec/system/report_proposal_spec.rb
+++ b/decidim-proposals/spec/system/report_proposal_spec.rb
@@ -9,7 +9,6 @@ describe "Report Proposal", type: :system do
   let!(:proposals) { create_list(:proposal, 3, component:) }
   let(:reportable) { proposals.first }
   let(:reportable_path) { resource_locator(reportable).path }
-  let!(:user) { create :user, :confirmed, organization: }
 
   let!(:component) do
     create(:proposal_component,
@@ -45,5 +44,5 @@ describe "Report Proposal", type: :system do
     end
   end
 
-  include_examples "reports"
+  include_examples "reports by user type"
 end


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR adds a checkbox in the report form that will allow the admin to directly hide the content of an user. 

This PR depends on : #9852 

Ref: SPAM04

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10036 
- Fixes #10036

#### Testing
1. Checkout the branch
2. Visit any content page
3. Click on report 
4. Use the checkbox to hide content 
5. Observe behavior

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![image](https://user-images.githubusercontent.com/105683/203644408-9893aaf6-7006-49dd-ada2-7ab294e6ba59.png)

:hearts: Thank you!
