### PR TITLE
Backport 'Ignore the problematics HTML validation checks with hidden inputs' to v0.27

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/w3c_rspec_validators_overrides.rb
+++ b/decidim-dev/lib/decidim/dev/test/w3c_rspec_validators_overrides.rb
@@ -3,8 +3,13 @@
 # This is a temporary fix to ignore some HTML/CSS validation issues with the
 # Decidim HTML validation process.
 #
-# See: https://github.com/decidim/decidim/issues/8596
-# Related: https://github.com/w3c/css-validator/issues/355
+# See:
+# - https://github.com/decidim/decidim/issues/8596
+# - https://github.com/decidim/decidim/pull/10014
+# Related:
+# - https://github.com/w3c/css-validator/issues/355
+# - https://github.com/rails/rails/issues/46405
+# - https://github.com/foundation/foundation-sites/pull/12496
 module W3CValidators
   class NuValidator
     protected
@@ -17,7 +22,9 @@ module W3CValidators
 
     def ignore_errors
       @ignore_errors ||= [
-        "CSS: “--content-height”: One operand must be a number."
+        "CSS: “--content-height”: One operand must be a number.",
+        "An “input” element with a “type” attribute whose value is “hidden” must not have an “autocomplete” attribute whose value is “on” or “off”.",
+        "An “input” element with a “type” attribute whose value is “hidden” must not have any “aria-*” attributes."
       ]
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #10020 to v0.27

:hearts: Thank you!