### PR TITLE
Refactor admin listing titles

### DIFF
--- a/decidim-debates/spec/shared/manage_debates_examples.rb
+++ b/decidim-debates/spec/shared/manage_debates_examples.rb
@@ -5,6 +5,19 @@ RSpec.shared_examples "manage debates" do
 
   before { visit_component_admin }
 
+  describe "listing" do
+    context "with enriched content" do
+      before do
+        debate.update!(title: { en: "Debate <strong>title</strong>" })
+        visit current_path
+      end
+
+      it "displays the correct title" do
+        expect(page.html).to include("Debate &lt;strong&gt;title&lt;/strong&gt;")
+      end
+    end
+  end
+
   describe "admin form" do
     before { click_on "New Debate" }
 

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -49,10 +49,10 @@
               </td>
               <td>
                 <% if allowed_to? :update, :meeting, meeting: meeting %>
-                  <%= link_to present(meeting).title, edit_meeting_path(meeting) %>
+                  <%= link_to present(meeting).title(html_escape: true), edit_meeting_path(meeting) %>
                   <br>
                 <% else %>
-                  <%= present(meeting).title %><br>
+                  <%= present(meeting).title(html_escape: true) %><br>
                 <% end %>
               </td>
               <td>

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -51,6 +51,17 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
         expect(page).to have_css(".action-icon--unpublish")
       end
     end
+
+    context "with enriched content" do
+      before do
+        meeting.update!(title: { en: "Meeting <strong>title</strong>" })
+        visit current_path
+      end
+
+      it "displays the correct title" do
+        expect(page.html).to include("Meeting &lt;strong&gt;title&lt;/strong&gt;")
+      end
+    end
   end
 
   describe "admin form" do

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
@@ -7,9 +7,9 @@
   </td>
   <td>
     <% if allowed_to? :edit, :proposal, proposal: proposal %>
-      <%= link_to decidim_html_escape(present(proposal).title).html_safe, edit_proposal_path(proposal) %><br>
+      <%= link_to present(proposal).title(html_escape: true), edit_proposal_path(proposal) %><br>
     <% else %>
-      <%= decidim_html_escape(present(proposal).title).html_safe %><br>
+      <%= present(proposal).title(html_escape: true) %><br>
     <% end %>
   </td>
   <td>

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -27,6 +27,19 @@ shared_examples "manage proposals" do
     end
   end
 
+  describe "listing" do
+    context "with enriched content" do
+      before do
+        proposal.update!(title: { en: "Proposal <strong>title</strong>" })
+        visit current_path
+      end
+
+      it "displays the correct title" do
+        expect(page.html).to include("Proposal &lt;strong&gt;title&lt;/strong&gt;")
+      end
+    end
+  end
+
   describe "creation" do
     context "when official_proposals setting is enabled" do
       before do


### PR DESCRIPTION
#### :tophat: What? Why?
This is a continuation for #10032, we should also apply the same refactor to the admin listings.

#### :pushpin: Related Issues
- Related to #10032

#### Testing
Check that the cell titles are displayed correctly.