### PR TITLE
Refactor the meeting list item title display

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/meeting_list_item_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_list_item_cell.rb
@@ -28,7 +28,7 @@ module Decidim
       end
 
       def title
-        present(model).title
+        present(model).title(html_escape: true)
       end
 
       def resource_date_time

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_s_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_s_cell.rb
@@ -5,8 +5,6 @@ module Decidim
     # This cell renders the Small (:s) meeting card
     # for an given instance of a Meeting
     class MeetingSCell < MeetingMCell
-      delegate :title, to: :presenter
-
       def meeting_path
         resource_locator(model).path
       end

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_s_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_s_cell.rb
@@ -21,10 +21,6 @@ module Decidim
         resource_locator(model.component.participatory_space).path
       end
 
-      def presenter
-        @presenter ||= Decidim::Meetings::MeetingPresenter.new(model)
-      end
-
       private
 
       def cache_hash

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_highlighted_list_item_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_highlighted_list_item_cell_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Meetings
+  describe MeetingHighlightedListItemCell, type: :cell do
+    controller Decidim::Meetings::MeetingsController
+
+    subject { my_cell.call }
+
+    let!(:meeting) { create(:meeting, :published) }
+    let(:my_cell) { cell("decidim/meetings/meeting_highlighted_list_item", meeting) }
+
+    context "when rendering" do
+      it "renders the card" do
+        expect(subject).to have_css(".card")
+      end
+    end
+
+    context "when title contains special html entities" do
+      let!(:original_title) { meeting.title["en"] }
+
+      before do
+        meeting.update!(title: { en: "<strong>#{original_title}</strong> &'<" })
+        meeting.reload
+      end
+
+      it "escapes them correctly" do
+        expect(subject.to_s).to include("&lt;strong&gt;#{original_title}&lt;/strong&gt; &amp;'&lt;")
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_list_item_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_list_item_cell_spec.rb
@@ -19,13 +19,12 @@ module Decidim::Meetings
       let!(:original_title) { meeting.title["en"] }
 
       before do
-        meeting.update!(title: { en: "#{original_title} &'<" })
+        meeting.update!(title: { en: "<strong>#{original_title}</strong> &'<" })
         meeting.reload
       end
 
       it "escapes them correctly" do
-        expect(subject).to have_content("#{original_title} &'<")
-        expect(subject.to_s).to include("#{original_title} &amp;'&lt;")
+        expect(subject.to_s).to include("&lt;strong&gt;#{original_title}&lt;/strong&gt; &amp;'&lt;")
       end
     end
   end

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_list_item_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_list_item_cell_spec.rb
@@ -4,12 +4,28 @@ require "spec_helper"
 
 module Decidim::Meetings
   describe MeetingListItemCell, type: :cell do
+    subject { my_cell.call }
+
     let!(:meeting) { create(:meeting, :published) }
+    let(:my_cell) { cell("decidim/meetings/meeting_list_item", meeting) }
 
     context "when rendering" do
       it "renders the card" do
-        html = cell("decidim/meetings/meeting_list_item", meeting).call
-        expect(html).to have_css(".card--list__item")
+        expect(subject).to have_css(".card--list__item")
+      end
+    end
+
+    context "when title contains special html entities" do
+      let!(:original_title) { meeting.title["en"] }
+
+      before do
+        meeting.update!(title: { en: "#{original_title} &'<" })
+        meeting.reload
+      end
+
+      it "escapes them correctly" do
+        expect(subject).to have_content("#{original_title} &'<")
+        expect(subject.to_s).to include("#{original_title} &amp;'&lt;")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This is a continuation for #10032. There was one more place where we are displaying the title in an inconsistent manner.

#### :pushpin: Related Issues
- Related to #10032

#### Testing
Check that the related cell title is displayed correctly.