### PR TITLE
Update the gitignore statement for development app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ pkg/
 .DS_Store
 node_modules/
 .vscode
-development_app/
+development_app*/
 .projectile
 npm-debug.log
 karma-*


### PR DESCRIPTION
#### :tophat: What? Why?
Since recently we have made so many changes between the Decidim versions, it is becoming hard to jump quickly between these versions.

I am suggesting here that we are adding any folder starting with the `development_app` prefix to the `.gitignore` of the project. This would support maintaining the following kind of development apps:
- development_app (for `develop`)
- development_app_027 (for `release/0.27-stable`)
- development_app_026 (for `release/0.26-stable`)
- etc.

#### Testing
```bash
$ cp -R development_app development_app_test
$ git status
```

You should see no changes to commit after running these commands.