### PR TITLE
Backport 'Fix usages of `reorder` and `paginate`' to v0.27

### DIFF
--- a/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
@@ -28,8 +28,8 @@ module Decidim
       def projects
         return @projects if @projects
 
-        @projects = search.result.page(params[:page]).per(current_component.settings.projects_per_page)
-        @projects = reorder(@projects)
+        @projects = reorder(search.result)
+        @projects = @projects.page(params[:page]).per(current_component.settings.projects_per_page)
       end
 
       def all_geocoded_projects

--- a/decidim-budgets/spec/system/sorting_projects_spec.rb
+++ b/decidim-budgets/spec/system/sorting_projects_spec.rb
@@ -93,6 +93,29 @@ describe "Sorting projects", type: :system do
         expect(page).to have_selector("#projects .budget-list .budget-list__item:first-child", text: translated(project2.title))
         expect(page).to have_selector("#projects .budget-list .budget-list__item:last-child", text: translated(project1.title))
       end
+
+      it "automatically sorts by votes and respect the pagination" do
+        component.update!(settings: { projects_per_page: 1 })
+
+        visit_budget
+
+        within "#projects li.is-dropdown-submenu-parent a" do
+          expect(page).to have_content("Most voted")
+        end
+
+        # project2 on first page
+        expect(page).to have_content(translated(project2.title))
+        expect(page).not_to have_content(translated(project1.title))
+
+        within "#projects [data-pagination]" do
+          expect(page).to have_content("2")
+          page.find("a", text: "2").click
+        end
+
+        # project1 on second page
+        expect(page).not_to have_content(translated(project2.title))
+        expect(page).to have_content(translated(project1.title))
+      end
     end
   end
 

--- a/decidim-elections/app/controllers/decidim/elections/elections_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/elections_controller.rb
@@ -59,8 +59,8 @@ module Decidim
       end
 
       def paginated_elections
-        @paginated_elections ||= paginate(search.result.published)
-        @paginated_elections = reorder(@paginated_elections)
+        @paginated_elections ||= reorder(search.result.published)
+        @paginated_elections = paginate(@paginated_elections)
       end
 
       def scheduled_elections

--- a/decidim-elections/app/controllers/decidim/votings/votings_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/votings_controller.rb
@@ -133,8 +133,8 @@ module Decidim
       end
 
       def paginated_votings
-        @paginated_votings ||= paginate(search.result.published)
-        @paginated_votings = reorder(@paginated_votings)
+        @paginated_votings ||= reorder(search.result.published)
+        @paginated_votings = paginate(@paginated_votings)
       end
 
       def promoted_votings

--- a/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
@@ -30,8 +30,8 @@ module Decidim
                                 .includes(:category)
                                 .includes(:scope)
 
-        @collaborative_drafts = paginate(@collaborative_drafts)
         @collaborative_drafts = reorder(@collaborative_drafts)
+        @collaborative_drafts = paginate(@collaborative_drafts)
       end
 
       def show

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -59,8 +59,8 @@ module Decidim
                              else
                                []
                              end
-          @proposals = paginate(@proposals)
           @proposals = reorder(@proposals)
+          @proposals = paginate(@proposals)
         end
       end
 

--- a/decidim-sortitions/app/controllers/decidim/sortitions/sortitions_controller.rb
+++ b/decidim-sortitions/app/controllers/decidim/sortitions/sortitions_controller.rb
@@ -18,8 +18,8 @@ module Decidim
                       .result
                       .includes(:category)
 
-        @sortitions = paginate(@sortitions)
         @sortitions = reorder(@sortitions)
+        @sortitions = paginate(@sortitions)
       end
 
       def show


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #9926 to v0.27

:hearts: Thank you!