### PR TITLE
Add info about the tests to the release docs

### DIFF
--- a/docs/modules/develop/pages/releases.adoc
+++ b/docs/modules/develop/pages/releases.adoc
@@ -202,6 +202,8 @@ If this is a *Release Candidate version* release, the steps to follow are:
 . Run `bin/rake webpack`, this will update the JavaScript bundle.
 . Run `bin/rspec`, this will check things like if all the officially supported languages translations are OK.
 . Commit all the changes: `git add . && git commit -m "Bump to rcXX version" && git push origin release/x.y-stable`.
+. Wait for the tests to finish and check that everything is passing before releasing the version.
+NOTE: When you bump the version, the generator tests will fail because the gems and NPM pacakges have not yet been actually released that we are now depending on. You may see errors such as `No matching version found for @decidim/browserslist-config@~0.xx.y` in the CI logs. This should be fine as long as you have ensured that the generators tests passed in the previous commit.
 . Run `git pull && bin/rake release_all`, this will create all the tags, push the commits and tags and release the gems to RubyGems.
 
 Usually, at this point, the release branch is deployed to Metadecidim during, at least, one week to validate the stability of the version.
@@ -224,6 +226,8 @@ Release Candidates will be tested in a production server (usually Metadecidim) d
 At the top you should have an `Unreleased` header with the `Added`, `Changed`, `Fixed` and `Removed` empty sections.
 After that, the header with the current version and link like `+## [0.20.0](https://github.com/decidim/decidim/tree/v0.20.0)+` and again the headers for the `Added`, `Changed`, `Fixed` and `Removed` sections.
 . Commit all the changes: `git add . && git commit -m "Bump to v0.XX.0 final version" && git push origin release/x.y-stable`.
+. Wait for the tests to finish and check that everything is passing before releasing the version.
+NOTE: When you bump the version, the generator tests will fail because the gems and NPM pacakges have not yet been actually released that we are now depending on. You may see errors such as `No matching version found for @decidim/browserslist-config@~0.xx.y` in the CI logs. This should be fine as long as you have ensured that the generators tests passed in the previous commit.
 . Run `git pull && bin/rake release_all`, this will create all the tags, push the commits and tags and release the gems to RubyGems.
 . Once all the gems are published you should create a new release at this repository, just go to the https://github.com/decidim/decidim/releases[releases page] and create a new one.
 . Once you have create the release with the release notes, update the `RELEASE_NOTES.md` at `release/x.y-stable`.
@@ -288,7 +292,9 @@ The process is very similar from releasing a new Decidim version:
 At the top you should have an `Unreleased` header with the `Added`, `Changed`, `Fixed` and `Removed` empty sections.
 After that, the header with the current version and link like `+## [0.20.0](https://github.com/decidim/decidim/tree/v0.20.0)+` and again the headers for the `Added`, `Changed`, `Fixed` and `Removed` sections.
 . Commit all the changes: `git add . && git commit -m "Prepare VERSION release"`
-. Run `bin/rake release_all`, this will create all the tags, push the commits and tags and release the gems to RubyGems.
+. Wait for the tests to finish and check that everything is passing before releasing the version.
+NOTE: When you bump the version, the generator tests will fail because the gems and NPM pacakges have not yet been actually released that we are now depending on. You may see errors such as `No matching version found for @decidim/browserslist-config@~0.xx.y` in the CI logs. This should be fine as long as you have ensured that the generators tests passed in the previous commit.
+. Run `git pull && bin/rake release_all`, this will create all the tags, push the commits and tags and release the gems to RubyGems.
 . Once all the gems are published you should create a new release at this repository, just go to the https://github.com/decidim/decidim/releases[releases page] and create a new one.
 . Once you have create the release with the release notes, update the `RELEASE_NOTES.md` at `release/x.y-stable`.
 Clear out the old notes and replace them with the `RELEASE_NOTES.md` template shown shown above in this document.

--- a/docs/modules/develop/pages/releases.adoc
+++ b/docs/modules/develop/pages/releases.adoc
@@ -227,7 +227,7 @@ At the top you should have an `Unreleased` header with the `Added`, `Changed`, `
 After that, the header with the current version and link like `+## [0.20.0](https://github.com/decidim/decidim/tree/v0.20.0)+` and again the headers for the `Added`, `Changed`, `Fixed` and `Removed` sections.
 . Commit all the changes: `git add . && git commit -m "Bump to v0.XX.0 final version" && git push origin release/x.y-stable`.
 . Wait for the tests to finish and check that everything is passing before releasing the version.
-NOTE: When you bump the version, the generator tests will fail because the gems and NPM pacakges have not yet been actually released that we are now depending on. You may see errors such as `No matching version found for @decidim/browserslist-config@~0.xx.y` in the CI logs. This should be fine as long as you have ensured that the generators tests passed in the previous commit.
+NOTE: When you bump the version, the generator tests will fail because the gems and NPM packages have not been actually published yet (as in sent to rubygems/npm). You may see errors such as `No matching version found for @decidim/browserslist-config@~0.xx.y` in the CI logs. This should be fine as long as you have ensured that the generators tests passed in the previous commit.
 . Run `git pull && bin/rake release_all`, this will create all the tags, push the commits and tags and release the gems to RubyGems.
 . Once all the gems are published:
  .. Re-run the failed generators tests at the release branch.
@@ -293,7 +293,7 @@ At the top you should have an `Unreleased` header with the `Added`, `Changed`, `
 After that, the header with the current version and link like `+## [0.20.0](https://github.com/decidim/decidim/tree/v0.20.0)+` and again the headers for the `Added`, `Changed`, `Fixed` and `Removed` sections.
 . Commit all the changes: `git add . && git commit -m "Prepare VERSION release"`
 . Wait for the tests to finish and check that everything is passing before releasing the version.
-NOTE: When you bump the version, the generator tests will fail because the gems and NPM pacakges have not yet been actually released that we are now depending on. You may see errors such as `No matching version found for @decidim/browserslist-config@~0.xx.y` in the CI logs. This should be fine as long as you have ensured that the generators tests passed in the previous commit.
+NOTE: When you bump the version, the generator tests will fail because the gems and NPM packages have not been actually published yet (as in sent to rubygems/npm). You may see errors such as `No matching version found for @decidim/browserslist-config@~0.xx.y` in the CI logs. This should be fine as long as you have ensured that the generators tests passed in the previous commit.
 . Run `git pull && bin/rake release_all`, this will create all the tags, push the commits and tags and release the gems to RubyGems.
 . Once all the gems are published:
  .. Re-run the failed generators tests at the release branch.

--- a/docs/modules/develop/pages/releases.adoc
+++ b/docs/modules/develop/pages/releases.adoc
@@ -229,9 +229,9 @@ After that, the header with the current version and link like `+## [0.20.0](http
 . Wait for the tests to finish and check that everything is passing before releasing the version.
 NOTE: When you bump the version, the generator tests will fail because the gems and NPM pacakges have not yet been actually released that we are now depending on. You may see errors such as `No matching version found for @decidim/browserslist-config@~0.xx.y` in the CI logs. This should be fine as long as you have ensured that the generators tests passed in the previous commit.
 . Run `git pull && bin/rake release_all`, this will create all the tags, push the commits and tags and release the gems to RubyGems.
-. Once all the gems are published you should create a new release at this repository, just go to the https://github.com/decidim/decidim/releases[releases page] and create a new one.
-. Once you have create the release with the release notes, update the `RELEASE_NOTES.md` at `release/x.y-stable`.
-Clear out the old notes and replace them with the `RELEASE_NOTES.md` template shown shown above in this document.
+. Once all the gems are published:
+ .. Re-run the failed generators tests at the release branch.
+ .. Create a new release at this repository, just go to the https://github.com/decidim/decidim/releases[releases page] and create a new one.
 . Update Decidim's Docker repository as explained in the Docker images section below.
 . Update Crowdin synchronization configuration with Github:
  .. Add the new `release/x.y-stable` branch.
@@ -295,9 +295,9 @@ After that, the header with the current version and link like `+## [0.20.0](http
 . Wait for the tests to finish and check that everything is passing before releasing the version.
 NOTE: When you bump the version, the generator tests will fail because the gems and NPM pacakges have not yet been actually released that we are now depending on. You may see errors such as `No matching version found for @decidim/browserslist-config@~0.xx.y` in the CI logs. This should be fine as long as you have ensured that the generators tests passed in the previous commit.
 . Run `git pull && bin/rake release_all`, this will create all the tags, push the commits and tags and release the gems to RubyGems.
-. Once all the gems are published you should create a new release at this repository, just go to the https://github.com/decidim/decidim/releases[releases page] and create a new one.
-. Once you have create the release with the release notes, update the `RELEASE_NOTES.md` at `release/x.y-stable`.
-Clear out the old notes and replace them with the `RELEASE_NOTES.md` template shown shown above in this document.
+. Once all the gems are published:
+ .. Re-run the failed generators tests at the release branch.
+ .. Create a new release at this repository, just go to the https://github.com/decidim/decidim/releases[releases page] and create a new one.
 . Update Decidim's Docker repository as explained in the Docker images section.
 
 == Docker images for each release

--- a/docs/modules/develop/pages/releases.adoc
+++ b/docs/modules/develop/pages/releases.adoc
@@ -203,7 +203,7 @@ If this is a *Release Candidate version* release, the steps to follow are:
 . Run `bin/rspec`, this will check things like if all the officially supported languages translations are OK.
 . Commit all the changes: `git add . && git commit -m "Bump to rcXX version" && git push origin release/x.y-stable`.
 . Wait for the tests to finish and check that everything is passing before releasing the version.
-NOTE: When you bump the version, the generator tests will fail because the gems and NPM pacakges have not yet been actually released that we are now depending on. You may see errors such as `No matching version found for @decidim/browserslist-config@~0.xx.y` in the CI logs. This should be fine as long as you have ensured that the generators tests passed in the previous commit.
+NOTE: When you bump the version, the generator tests will fail because the gems and NPM packages have not been actually published yet (as in sent to rubygems/npm). You may see errors such as `No matching version found for @decidim/browserslist-config@~0.xx.y` in the CI logs. This should be fine as long as you have ensured that the generators tests passed in the previous commit.
 . Run `git pull && bin/rake release_all`, this will create all the tags, push the commits and tags and release the gems to RubyGems.
 
 Usually, at this point, the release branch is deployed to Metadecidim during, at least, one week to validate the stability of the version.


### PR DESCRIPTION
#### :tophat: What? Why?
I suggest adding the section to double check that the tests are passing after making the preparation for the new release.

I also added a note about the generators specs failing after pushing the new commit because before the gems and packages **actually** exist in the repositories, we will see this kind of failures for those specs in the CI:

```
             create  bin/yarn
       /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/2.7.0/net/protocol.rb:66: warning: already initialized constant Net::ProtocRetryError
       /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/gems/2.7.0/gems/net-protocol-0.1.3/lib/net/protocol.rb:68: warning: previous definition of ProtocRetryError was here
       /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/2.7.0/net/protocol.rb:206: warning: already initialized constant Net::BufferedIO::BUFSIZE
       /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/gems/2.7.0/gems/net-protocol-0.1.3/lib/net/protocol.rb:208: warning: previous definition of BUFSIZE was here
       /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/2.7.0/net/protocol.rb:503: warning: already initialized constant Net::NetPrivate::Socket
       /opt/hostedtoolcache/Ruby/2.7.5/x64/lib/ruby/gems/2.7.0/gems/net-protocol-0.1.3/lib/net/protocol.rb:504: warning: previous definition of Socket was here
       npm ERR! code ETARGET
       npm ERR! notarget No matching version found for @decidim/browserslist-config@~0.26.4.
       npm ERR! notarget In most cases you or one of your dependencies are requesting
       npm ERR! notarget a package version that doesn't exist.

       npm ERR! A complete log of this run can be found in:
       npm ERR!     /home/runner/.npm/_logs/2022-11-14T12_36_46_739Z-debug.log

       == Command npm i --save-prod @decidim/browserslist-config@~0.26.4 @decidim/core@~0.26.4 @decidim/elections@~0.26.4 @decidim/webpacker@~0.26.4 failed ==
       Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
       Coverage report generated for RSpec to /home/runner/work/decidim/decidim/coverage/1/coverage.xml
     Shared Example Group: "a new development application" called from ./spec/runtime/generators_spec.rb:129
     # ./spec/runtime/generators_spec.rb:69:in `block (4 levels) in <module:Decidim>'
```
