### PR TITLE
Enable newsletters for admin on seeds

### DIFF
--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -145,7 +145,8 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
       tos_agreement: true,
       personal_url: Faker::Internet.url,
       about: Faker::Lorem.paragraph(sentence_count: 2),
-      accepted_tos_version: organization.tos_version + 1.hour
+      accepted_tos_version: organization.tos_version + 1.hour,
+      newsletter_notifications_at: Time.current
     )
   end
 

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -126,6 +126,7 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
     personal_url: Faker::Internet.url,
     about: Faker::Lorem.paragraph(sentence_count: 2),
     accepted_tos_version: organization.tos_version + 1.hour,
+    newsletter_notifications_at: Time.current,
     password_updated_at: Time.current,
     admin_terms_accepted_at: Time.current
   }


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why? 

While reviewing  #9635 and other PRs related to newsletters, you always have to check that there's at least a participant with newsletters notifications enabled. This enables them by default on seeds with admin user. 

It makes a bit more comfortable working with newsletters locally (as you can skip making 5 clicks 😄)

#### Testing

1. Run seeds
2. See that the admin has enabled the newsletters notification

:hearts: Thank you!
