### PR TITLE
Add slash in PR linter configuration

### DIFF
--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -16,7 +16,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: deepakputhraya/action-pr-title@master
         with:
-          disallowed_prefixes: "feat,chore,build,ci,refactor,docs,wip"
+          disallowed_prefixes: "feat/,chore/,build/,ci/,refactor/,docs/,wip/"
           prefix_case_sensitive: false
           min_length: 5
           max_length: 100


### PR DESCRIPTION
#### :tophat: What? Why?

The past week we had a couple PR that started with "Refactor". The current PR title linter configuration gives a false positive. 

More details in my comment https://github.com/decidim/decidim/pull/10032#pullrequestreview-1170206749: 

>  I will ignore the "Lint PR format" wrong check, as we need to fix the configuration. The original idea was to check when the PR was created with things like gh, where the title is the branch name, so in this case the title would be "refactor/cell-titles" and we didn't want that merged as it'd be the commit message. We can fix this configuration later.

The idea is to only catch when someones leave the default title when working with `hub` or `gh`, that's the default branch, and not when someone uses "Refactor XXX" as title.
 
#### :pushpin: Related Issues
 
- Related to #10032

#### Testing

1. Change this PR title to "Refactor XX", see that it passes
2. Change this PR title to "Refactor/XX", see that it fails

:hearts: Thank you!
