### PR TITLE
Improve the release_all rake task with multiple remotes

### DIFF
--- a/lib/decidim/release_manager.rb
+++ b/lib/decidim/release_manager.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/module/delegation"
+require "open3"
+
+module Decidim
+  # Provides utilities for performing the releases.
+  class ReleaseManager
+    # Resolves the remote where the tags will be pushed during the release.
+    def self.git_remote
+      @git_remote ||= `git remote -v | grep -e 'decidim/decidim\\([^ ]*\\) (push)' | sed 's/\\s.*//'`.strip
+    end
+
+    def self.git_remote_set?
+      git_remote.present?
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Because of the multi-remote setup that I have, I've had the release fail a couple of times because of the following error:

```
decidim-admin 0.26.4 built to pkg/decidim-admin-0.26.4.gem.
Tagged v0.26.4.
Untagging v0.26.4 due to error.
rake aborted!
Couldn't git push. `git push  --tags' failed with the following output:

To github.com:decidim/decidim.git
 * [new tag]               v0.26.4 -> v0.26.4
 ! [rejected]              v0.22.0.rc1 -> v0.22.0.rc1 (already exists)
 ! [rejected]              v0.26.3 -> v0.26.3 (already exists)
error: failed to push some refs to 'github.com:decidim/decidim.git'
hint: Updates were rejected because the tag already exists in the remote.
```

In order to fix this I would like to add the following to the release process:

- Add check that we have `decidim/decidim` as one of the remotes
- Fetch the existing tags before doing the release
- Define the release remote to the correct remote (decidim/decidim)

I found out that we can pass the correct remote using `rake release[remote]` from here:
https://github.com/rubygems/rubygems/blob/116a6ee3ee6c84665dbc03faa73449ae7f95232a/bundler/lib/bundler/gem_helper.rb#L67

I am also introducing a new class `Decidim::ReleaseManager` where I moved the git remote resolving because of the rather obfuscated nature of that command, so that I don't have to repeat it in multiple times. In the future I could imagine this class emerging in case we want to move some logic from the `Rakefile` to this class.

#### Testing
As we know these are hard to test as we don't want to do new releases during testing these but you can try the added rake tasks individually to see how they work.

In order to test the aborting of the release, add the following rake task in the root `Rakefile`:

```ruby
task test_things: [:ensure_git_remote] do
  puts "remote is: #{Decidim::ReleaseManager.git_remote}"
end
```

After this, in the new class `Decidim::ReleaseManager` change `grep -e 'decidim/decidim...` to e.g. `grep -e 'dictar/dictar...` and run that rake task `bundle exec rake test_things`.

After you made such change, you should get the abort message and should not see the message the task is supposed to print out normally.

The `fetch_git_tags` command can be tested as-is.