### PR TITLE
Respect "rich text editor" setting in Initiatives

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -34,7 +34,7 @@
             </div>
 
             <div class="field">
-              <%= f.editor :description, lines: 8, toolbar: :full %>
+              <%= text_editor_for(form, :description, lines: 8, toolbar: :full ) %>
             </div>
 
             <% signature_type_options = signature_type_options(f.object) %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -34,7 +34,7 @@
             </div>
 
             <div class="field">
-              <%= text_editor_for(f, :description, lines: 8, toolbar: :basic ) %>
+              <%= text_editor_for(f, :description, lines: 8, toolbar: :full ) %>
             </div>
 
             <% signature_type_options = signature_type_options(f.object) %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -34,7 +34,7 @@
             </div>
 
             <div class="field">
-              <%= text_editor_for(f, :description, lines: 8, toolbar: :full ) %>
+              <%= text_editor_for(f, :description, lines: 8, toolbar: :full) %>
             </div>
 
             <% signature_type_options = signature_type_options(f.object) %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -34,7 +34,7 @@
             </div>
 
             <div class="field">
-              <%= text_editor_for(form, :description, lines: 8, toolbar: :full ) %>
+              <%= text_editor_for(f, :description, lines: 8, toolbar: :basic ) %>
             </div>
 
             <% signature_type_options = signature_type_options(f.object) %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/previous_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/previous_form.html.erb
@@ -27,7 +27,7 @@
           </div>
 
           <div class="field">
-            <%= f.editor :description, lines: 8, toolbar: :full %>
+            <%= text_editor_for(f, :description, lines: 8, toolbar: :full) %>
           </div>
 
           <div class="actions">

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/previous_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/previous_form.html.erb
@@ -27,7 +27,7 @@
           </div>
 
           <div class="field">
-            <%= text_editor_for(f, :description, lines: 8, toolbar: :basic) %>
+            <%= text_editor_for(f, :description, lines: 8, toolbar: :full) %>
           </div>
 
           <div class="actions">

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/previous_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/previous_form.html.erb
@@ -27,7 +27,7 @@
           </div>
 
           <div class="field">
-            <%= text_editor_for(f, :description, lines: 8, toolbar: :full) %>
+            <%= text_editor_for(f, :description, lines: 8, toolbar: :basic) %>
           </div>
 
           <div class="actions">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <div class="field">
-  <%= form.editor :description, toolbar: :full, lines: 8, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.description) %>
+  <%= text_editor_for(form, :description, toolbar: :full, lines: 8, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.description)) %>
 </div>
 
 <div class="field">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <div class="field">
-  <%= text_editor_for(form, :description, toolbar: :basic, lines: 8, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.description)) %>
+  <%= text_editor_for(form, :description, toolbar: :full, lines: 8, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.description)) %>
 </div>
 
 <div class="field">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <div class="field">
-  <%= text_editor_for(form, :description, toolbar: :full, lines: 8, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.description)) %>
+  <%= text_editor_for(form, :description, toolbar: :basic, lines: 8, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.description)) %>
 </div>
 
 <div class="field">

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -350,6 +350,16 @@ describe "Initiative", type: :system do
     end
   end
 
+  context "when rich text editor is enabled for participants" do
+    before do
+      organization.update(rich_text_editor_in_public_views: true)
+      click_link "New initiative"
+      find_button("I want to promote this initiative").click
+    end
+
+    it_behaves_like "having a rich text editor", "new_initiative_previous_form", "basic"
+  end
+
   describe "creating an initiative" do
     context "without validation" do
       before do
@@ -390,7 +400,7 @@ describe "Initiative", type: :system do
 
         it "have fields for title and description" do
           expect(page).to have_xpath("//input[@id='initiative_title']")
-          expect(page).to have_xpath("//input[@id='initiative_description']", visible: :all)
+          expect(page).to have_xpath("//textarea[@id='initiative_description']", visible: :all)
         end
 
         it "offers contextual help" do
@@ -421,7 +431,7 @@ describe "Initiative", type: :system do
 
         it "have fields for title and description" do
           expect(page).to have_xpath("//input[@id='initiative_title']")
-          expect(page).to have_xpath("//input[@id='initiative_description']", visible: :all)
+          expect(page).to have_xpath("//textarea[@id='initiative_description']", visible: :all)
         end
 
         it "offers contextual help" do
@@ -437,7 +447,7 @@ describe "Initiative", type: :system do
         before do
           find_button("I want to promote this initiative").click
           fill_in "Title", with: translated(initiative.title, locale: :en)
-          fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
+          fill_in "initiative_description", with: translated(initiative.description, locale: :en)
           find_button("Continue").click
         end
 
@@ -469,7 +479,7 @@ describe "Initiative", type: :system do
 
           before do
             fill_in "Title", with: translated(initiative.title, locale: :en)
-            fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
+            fill_in "initiative_description", with: translated(initiative.description, locale: :en)
             find_button("Continue").click
           end
 
@@ -483,7 +493,7 @@ describe "Initiative", type: :system do
           before do
             find_button("I want to promote this initiative").click
             fill_in "Title", with: translated(initiative.title, locale: :en)
-            fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
+            fill_in "initiative_description", with: translated(initiative.description, locale: :en)
             find_button("Continue").click
           end
 
@@ -502,7 +512,7 @@ describe "Initiative", type: :system do
           it "shows information collected in previous steps already filled" do
             expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
             expect(find(:xpath, "//input[@id='initiative_title']").value).to eq(translated(initiative.title, locale: :en))
-            expect(find(:xpath, "//input[@id='initiative_description']", visible: :all).value).to eq(translated(initiative.description, locale: :en))
+            expect(find(:xpath, "//textarea[@id='initiative_description']", visible: :all).value).to eq(translated(initiative.description, locale: :en))
           end
 
           context "when only one signature collection and scope are available" do
@@ -563,7 +573,7 @@ describe "Initiative", type: :system do
           find_button("I want to promote this initiative").click
 
           fill_in "Title", with: translated(initiative.title, locale: :en)
-          fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
+          fill_in "initiative_description", with: translated(initiative.description, locale: :en)
           find_button("Continue").click
 
           select("Online", from: "Signature collection type")
@@ -617,7 +627,7 @@ describe "Initiative", type: :system do
           find_button("I want to promote this initiative").click
 
           fill_in "Title", with: translated(initiative.title, locale: :en)
-          fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
+          fill_in "initiative_description", with: translated(initiative.description, locale: :en)
           find_button("Continue").click
 
           select(translated(initiative_type_scope.scope.name, locale: :en), from: "Scope")

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -357,7 +357,7 @@ describe "Initiative", type: :system do
       find_button("I want to promote this initiative").click
     end
 
-    it_behaves_like "having a rich text editor", "new_initiative_previous_form", "basic"
+    it_behaves_like "having a rich text editor", "new_initiative_previous_form", "full"
   end
 
   describe "creating an initiative" do


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
In the organization admin settings, the "Enable rich text editor for participants" is unchecked, yet, when trying to create an initiative, the WYSIWYG is still being created.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10063

#### Testing

1. Go to public website,
2. Go to Initiatives an click on "New Initiative"
3. See the WYSIWYG ( on description)
4. Go to Admin / Organization settings
5. Toggle "Enable rich text editor for participants"
6. Repeat steps 1, 2, 3 and see the description field has changed its appearance

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
Before the fix
![image](https://user-images.githubusercontent.com/105683/201292142-b2f2a922-243e-4b32-931f-09c5791878a7.png)

:hearts: Thank you!
