### PR TITLE
Fix bug regarding user group moderation action logs

### DIFF
--- a/decidim-core/app/presenters/decidim/admin_log/user_moderation_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/user_moderation_presenter.rb
@@ -52,7 +52,7 @@ module Decidim
       end
 
       def unreported_user
-        @unreported_user ||= Decidim::User.find_by(id: action_log.extra.dig("extra", "user_id"))
+        @unreported_user ||= Decidim::UserBaseEntity.find_by(id: action_log.extra.dig("extra", "user_id"))
       end
 
       def has_diff?

--- a/decidim-core/spec/presenters/decidim/admin_log/user_moderation_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/admin_log/user_moderation_presenter_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::AdminLog::UserModerationPresenter, type: :helper do
+  context "with user" do
+    include_examples "present admin log entry" do
+      let(:reportable) { create(:user, :blocked, organization:) }
+      let(:moderation) { create(:user_moderation, user: reportable) }
+      let(:admin_log_resource) { reportable }
+      let(:admin_log_extra_data) { { extra: { user_id: reportable.id } } }
+      let(:action) { "report" }
+    end
+  end
+
+  context "with user group" do
+    include_examples "present admin log entry" do
+      let(:reportable) { create(:user_group, :blocked, organization:) }
+      let(:moderation) { create(:user_moderation, user: reportable) }
+      let(:admin_log_resource) { reportable }
+      let(:admin_log_extra_data) { { extra: { user_id: reportable.id } } }
+      let(:action) { "report" }
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
After merging #10021, I noticed that the action log entries were broken for the user group moderation actions.

#### :pushpin: Related Issues
- Related to #10021

#### Testing
- Moderate a user group (block it)
- Go to action logs