### PR TITLE
Add missing logs for UserGroup block and unblock actions

### DIFF
--- a/decidim-core/app/presenters/decidim/admin_log/user_group_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/user_group_presenter.rb
@@ -20,7 +20,7 @@ module Decidim
 
       def action_string
         case action
-        when "verify", "verify_via_csv", "reject"
+        when "verify", "verify_via_csv", "reject", "block", "unblock"
           "decidim.admin_log.user_group.#{action}"
         else
           super

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -247,7 +247,9 @@ en:
         unblock: "%{user_name} unblocked user %{resource_name}"
         unofficialize: "%{user_name} unofficialized the participant %{resource_name}"
       user_group:
+        block: "%{user_name} blocked user group %{resource_name}"
         reject: "%{user_name} rejected the %{resource_name} group verification"
+        unblock: "%{user_name} unblocked user group %{resource_name}"
         verify: "%{user_name} verified the group %{resource_name}"
         verify_via_csv: "%{user_name} verified the group %{resource_name} via a CSV file"
       user_moderation:


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing #10085 I found out that we had some unknwon actions when blocking and unblocking user groups. This PR fixes that. 

#### :pushpin: Related Issues
 
- Related to #10021
 
#### Testing

To check the bug: 

1. Sign in as admin
2. Report a UserGroup
3. Block it
4. Go to admin log, see that you have "performed some action"
5. Unblock it
4. Go to admin log, see that you have another "performed some action"

This PR changes 4 and 6 

### :camera: Screenshots

#### Before 

![Selection_414](https://user-images.githubusercontent.com/717367/202667418-b487dc95-dd27-4346-b12b-8ccac0f5d924.png)

#### After

![Selection_413](https://user-images.githubusercontent.com/717367/202667435-1d5d1641-8add-427a-bddd-ac3bc747ae68.png)


:hearts: Thank you!
