### PR TITLE
Move i18n attribute key of Post's body

### DIFF
--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/_form.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/_form.html.erb
@@ -12,7 +12,7 @@
       <%= form.translated :text_field, :title, autofocus: true %>
     </div>
     <div class="row column">
-      <%= form.translated :editor, :body, toolbar: :full, lines: 30, label: t("models.components.body", scope: "decidim.blogs.admin") %>
+      <%= form.translated :editor, :body, toolbar: :full, lines: 30 %>
     </div>
     <div class="row">
       <div class="columns xlarge-6">

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
   activemodel:
     attributes:
       post:
+        body: Body
         decidim_author_id: Author
         published_at: Publish time
         title: Title
@@ -24,8 +25,6 @@ en:
         title: Actions
       admin:
         models:
-          components:
-            body: Body
           post:
             name: Post
         posts:


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While working on some missing i18n keys on forms, @ahukkanen found some inconsistency en decidim-blogs Posts body attribute. 

This PR fixes that 

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/pull/10072#discussion_r1025345814

#### Testing

1. Change the key in the i18n file
2. Check it in a console with  `Decidim::Blogs::Admin::PostForm.human_attribute_name(:body)`


:hearts: Thank you!
