### PR TITLE
Don't show the 'unreport' action when user is blocked

### DIFF
--- a/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
@@ -60,7 +60,7 @@
             </td>
 
             <td class="actions">
-              <% if allowed_to?(:unreport, :moderate_users) %>
+              <% if !moderation.user.blocked? && allowed_to?(:unreport, :moderate_users) %>
                 <%= icon_link_to "action-undo", ignore_moderated_user_path(id: moderation), t(".actions.unreport"), class: "action-icon--unreport", method: :put %>
               <% end %>
               <% if allowed_to?(:block, :moderate_users) %>

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -173,11 +173,17 @@ shared_examples "manage moderations" do
   end
 
   context "when listing hidden resources" do
-    it "user can review them" do
+    before do
       within ".card-title" do
         click_link "Hidden"
       end
+    end
 
+    it "user can't unreport them" do
+      expect(page).not_to have_css(".action-icon--unreport")
+    end
+
+    it "user can review them" do
       hidden_moderations.each do |moderation|
         within "tr[data-id=\"#{moderation.id}\"]" do
           expect(page).to have_css("a[href='#{moderation.reportable.reported_content_url}']")

--- a/decidim-admin/spec/system/admin_manage_moderated_users_spec.rb
+++ b/decidim-admin/spec/system/admin_manage_moderated_users_spec.rb
@@ -110,6 +110,10 @@ describe "Admin manages moderated users", type: :system do
       visit decidim_admin.moderated_users_path(blocked: true)
     end
 
+    it "user can't unreport them" do
+      expect(page).not_to have_css(".action-icon--unreport")
+    end
+
     context "when filtering by report reason" do
       it_behaves_like "a filtered collection", options: "Report reason", filter: "Spam" do
         let(:in_filter) { first_user.nickname }


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While working with users moderations, I found out a bug with blocked users: you can unreport a blocked user. This doesn't make much sense, and in fact with moderated hidden contents we don't show the action in this page: 


https://github.com/decidim/decidim/blob/7d84bd2c5c84e3e2c8e67d6ea42265afa00ecc43/decidim-admin/app/views/decidim/admin/moderations/index.html.erb#L76

This PR applies the same fix for blocked users, and also add specs (for this case and also for moderated contents). 


#### Testing

1. Report and block a user
2. Go to http://localhost:3000/admin/moderated_users?blocked=true
3. See that you don't have the unreport action anymore

### :camera: Screenshots

#### Before 

![Selection_420](https://user-images.githubusercontent.com/717367/203021838-696f5ee5-2325-4ec0-976e-cd0d38e4948b.png)

#### After

![Selection_421](https://user-images.githubusercontent.com/717367/203021817-8fa8b5f5-03e6-464c-a5f9-f2c323aa4495.png)

:hearts: Thank you!
