### PR TITLE
Fix bug when blocking two UserGroups

### DIFF
--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -21,7 +21,7 @@ module Decidim
              foreign_key: :decidim_user_id,
              source: :user
 
-    validates :name, presence: true, uniqueness: { scope: :decidim_organization_id }
+    validates :name, presence: true, uniqueness: { scope: :decidim_organization_id }, unless: -> { blocked? }
 
     validate :correct_state
     validate :unique_document_number, if: :has_document_number?

--- a/decidim-core/spec/models/decidim/user_group_spec.rb
+++ b/decidim-core/spec/models/decidim/user_group_spec.rb
@@ -64,6 +64,28 @@ module Decidim
         it { is_expected.not_to be_valid }
       end
 
+      context "when the name is taken" do
+        subject { another_user_group }
+
+        let(:another_user_group) { build :user_group, name: user_group.name, organization: user_group.organization }
+
+        it { is_expected.not_to be_valid }
+
+        context "when the user group is blocked" do
+          before do
+            user_group.name = "Blocked user"
+            user_group.blocked_at = Time.zone.now
+            user_group.save!
+          end
+
+          it "can use the same name" do
+            expect do
+              create(:user_group, :blocked, name: "Blocked user", organization: user_group.organization)
+            end.not_to raise_error
+          end
+        end
+      end
+
       context "when the file is too big" do
         before do
           expect(subject.avatar.blob).to receive(:byte_size).at_least(:once).and_return(11.megabytes)


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

After #10021 was merged I noticed that there was a bug related when blocking a UserGroup after there was another already blocked. This is due to the name uniqueness validation, that we don't have on Users. This PR fixes this by disabling this validation when the UserGroup is blocked.  

#### :pushpin: Related Issues
 
- Related to #10021 
 

#### Testing

1. Sign in as admin
2. Report and block a UserGroup
2. Report and block another UserGroup

Until now when blocking the second UserGroup you'll see a validation error. 

:hearts: Thank you!
