### PR TITLE
Remove unused permissions on Blogs

### DIFF
--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -66,8 +66,10 @@ en:
     components:
       blogs:
         actions:
+          comment: Comment
           create: Create
           destroy: Delete
+          endorse: Endorse
           update: Update
         name: Blog
         settings:

--- a/decidim-blogs/lib/decidim/blogs/component.rb
+++ b/decidim-blogs/lib/decidim/blogs/component.rb
@@ -36,7 +36,7 @@ Decidim.register_component(:blogs) do |component|
   component.register_resource(:blogpost) do |resource|
     resource.model_class_name = "Decidim::Blogs::Post"
     resource.card = "decidim/blogs/post"
-    resource.actions = %w(endorse vote amend comment)
+    resource.actions = %w(endorse comment)
     resource.searchable = true
   end
 


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing some things on the redesign, we find out that we had some permissions on Blogs that weren't used: amend and vote. This PR removes them.  

I think this comes from a copypaste on the initial introduction of Endorsements in Blogs in  #5542

There were also some translations missing on these actions. 

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/pull/9852#discussion_r1028114403 
- Endorsements were implemented on #5542
- Comments permissions were implemented on #8035

#### Testing

1. Sign in as admin
2. Go to a blog manage table in a process in admin panele
3. Click on permissions on a single post 
4. See that you don't have the translation missing error and that you have permissions to things that you can actually do in a Post 

:hearts: Thank you!
