### PR TITLE
Resolve open-ended dependency warning in turbo-rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ PATH
       rubyXL (~> 3.4)
       rubyzip (~> 2.0)
       seven_zip_ruby (~> 1.3)
-      turbo-rails (>= 1.3.0)
+      turbo-rails (~> 1.3.0)
       valid_email2 (~> 4.0)
       webpacker (= 6.0.0.rc.5)
       webpush (~> 1.1)

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -73,7 +73,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rubyXL", "~> 3.4"
   s.add_dependency "rubyzip", "~> 2.0"
   s.add_dependency "seven_zip_ruby", "~> 1.3"
-  s.add_dependency "turbo-rails", ">= 1.3.0"
+  s.add_dependency "turbo-rails", "~> 1.3.0"
   s.add_dependency "valid_email2", "~> 4.0"
   s.add_dependency "webpacker", "= 6.0.0.rc.5"
   s.add_dependency "webpush", "~> 1.1"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -104,7 +104,7 @@ PATH
       rubyXL (~> 3.4)
       rubyzip (~> 2.0)
       seven_zip_ruby (~> 1.3)
-      turbo-rails (>= 1.3.0)
+      turbo-rails (~> 1.3.0)
       valid_email2 (~> 4.0)
       webpacker (= 6.0.0.rc.5)
       webpush (~> 1.1)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -104,7 +104,7 @@ PATH
       rubyXL (~> 3.4)
       rubyzip (~> 2.0)
       seven_zip_ruby (~> 1.3)
-      turbo-rails (>= 1.3.0)
+      turbo-rails (~> 1.3.0)
       valid_email2 (~> 4.0)
       webpacker (= 6.0.0.rc.5)
       webpush (~> 1.1)


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

With the introduction of `turbo-rails` on #9881, there's an open-ended dependency warning in `decidim-generators`. 

This PR fixes that. 

#### :pushpin: Related Issues
 
- Related to #9881 

#### Testing

1. Run `bin/rspec decidim-generators/spec/runtime/generators_spec.rb`

2. See that you don't have this warning anymore:

```
(...)
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spel
l_checker)' instead.
WARNING:  open-ended dependency on turbo-rails (>= 1.3.0) is not recommended
  if turbo-rails is semantically versioned, use:
    add_runtime_dependency 'turbo-rails', '~> 1.3', '>= 1.3.0'
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spel
l_checker)' instead.
(...)
```

:hearts: Thank you!
