### PR TITLE
Add title and description to the attachment API type

### DIFF
--- a/decidim-core/lib/decidim/api/types/attachment_type.rb
+++ b/decidim-core/lib/decidim/api/types/attachment_type.rb
@@ -5,6 +5,8 @@ module Decidim
     class AttachmentType < Decidim::Api::Types::BaseObject
       description "A file attachment"
 
+      field :title, Decidim::Core::TranslatedFieldType, "The title of this attachment.", null: false
+      field :description, Decidim::Core::TranslatedFieldType, "The description of this attachment.", null: false
       field :url, GraphQL::Types::String, "The url of this attachment", null: false
       field :type, GraphQL::Types::String, "The type of this attachment", method: :file_type, null: false
       field :thumbnail, GraphQL::Types::String, "A thumbnail of this attachment, if it's an image.", method: :thumbnail_url, null: true

--- a/decidim-core/spec/types/attachment_type_spec.rb
+++ b/decidim-core/spec/types/attachment_type_spec.rb
@@ -8,12 +8,30 @@ module Decidim
     describe AttachmentType do
       include_context "with a graphql class type"
 
+      let(:title) { { en: "Participation guidelines", es: "Pautas de participación", ca: "Pautes de participació" } }
+      let(:description) { { en: "Read through these guidelines carefully.", es: "Lea atentamente estas pautas.", ca: "Llegiu atentament aquestes directrius." } }
       let(:url) { "https://foo.bar/baz" }
       let(:file_type) { "image" }
       let(:thumbnail) { "https://foo.bar/baz.thumb" }
 
       let(:model) do
-        double(url:, file_type:, thumbnail_url: thumbnail)
+        double(title:, description:, url:, file_type:, thumbnail_url: thumbnail)
+      end
+
+      describe "title" do
+        let(:query) { "{ title { translations { locale text } } }" }
+
+        it "returns the attachment's url" do
+          expect(response).to eq("title" => { "translations" => title.map { |locale, text| { "locale" => locale.to_s, "text" => text } } })
+        end
+      end
+
+      describe "description" do
+        let(:query) { "{ description { translations { locale text } } }" }
+
+        it "returns the attachment's url" do
+          expect(response).to eq("description" => { "translations" => description.map { |locale, text| { "locale" => locale.to_s, "text" => text } } })
+        end
       end
 
       describe "url" do


### PR DESCRIPTION
#### :tophat: What? Why?
We recently needed to expose the title and description of an attachment to the API, so let's add them to the core as well?

#### Testing
- Create attachments e.g. in a process
- Query the attachments of that process through the API
- See that the title and description are now in the API response