### PR TITLE
Don't allow access to admin panel without ToS acceptance

### DIFF
--- a/decidim-admin/app/controllers/concerns/decidim/admin/needs_admin_tos_accepted.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/needs_admin_tos_accepted.rb
@@ -18,6 +18,7 @@ module Decidim
         return if current_user.admin_terms_accepted?
         return if permitted_paths?
 
+        session[:user_return_to] = request.url
         redirect_to admin_tos_path
       end
 

--- a/decidim-admin/app/controllers/concerns/decidim/admin/needs_admin_tos_accepted.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/needs_admin_tos_accepted.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # Shared behaviour for signed_in admins that require the latest TOS accepted
+    module NeedsAdminTosAccepted
+      extend ActiveSupport::Concern
+
+      included do
+        before_action :tos_accepted_by_admin
+      end
+
+      private
+
+      def tos_accepted_by_admin
+        return true unless request.format.html?
+        return true unless current_user
+        return if current_user.admin_terms_accepted?
+        return if permitted_paths?
+
+        redirect_to admin_tos_path
+      end
+
+      def permitted_paths?
+        # ensure that path with or without query string pass
+        permitted_paths.find { |el| el.split("?").first == request.path }
+      end
+
+      def permitted_paths
+        [admin_tos_path, decidim_admin.admin_terms_accept_path]
+      end
+
+      def admin_tos_path
+        decidim_admin.admin_terms_show_path
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/admin_terms_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/admin_terms_controller.rb
@@ -9,7 +9,7 @@ module Decidim
         current_user.admin_terms_accepted_at = Time.current
         if current_user.save!
           flash[:notice] = t("accept.success", scope: "decidim.admin.admin_terms_of_use")
-          redirect_to decidim_admin.root_path
+          redirect_to session[:user_return_to] || decidim_admin.root_path
         else
           flash[:alert] = t("accept.error", scope: "decidim.admin.admin_terms_of_use")
           redirect_to decidim_admin.admin_terms_show_path

--- a/decidim-admin/app/controllers/decidim/admin/application_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/application_controller.rb
@@ -14,6 +14,7 @@ module Decidim
       include PayloadInfo
       include HttpCachingDisabler
       include DisableRedirectionToExternalHost
+      include Decidim::Admin::NeedsAdminTosAccepted
 
       include DisabledRedesignLayout
 

--- a/decidim-admin/spec/controllers/concerns/needs_admin_tos_accepted_spec.rb
+++ b/decidim-admin/spec/controllers/concerns/needs_admin_tos_accepted_spec.rb
@@ -64,6 +64,7 @@ module Decidim
 
           expect(response).to redirect_to("/admin_tos")
           expect(response.body).to have_text("You are being redirected")
+          expect(session[:user_return_to]).to eq("http://test.host/another")
         end
       end
 

--- a/decidim-admin/spec/controllers/concerns/needs_admin_tos_accepted_spec.rb
+++ b/decidim-admin/spec/controllers/concerns/needs_admin_tos_accepted_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe "NeedsAdminTosAccepted", type: :controller do
+      let!(:organization) { create :organization }
+
+      controller do
+        include Decidim::Admin::NeedsAdminTosAccepted
+
+        def root
+          render plain: "Root page"
+        end
+
+        def admin_tos
+          render plain: "Admin ToS page"
+        end
+
+        def another
+          render plain: "Another page"
+        end
+
+        private
+
+        def permitted_paths
+          ["/root", "/admin_tos"]
+        end
+
+        def admin_tos_path
+          "/admin_tos"
+        end
+      end
+
+      before do
+        routes.draw do
+          get "root" => "anonymous#root"
+          get "another" => "anonymous#another"
+          get "admin_tos" => "anonymous#admin_tos"
+        end
+
+        request.env["decidim.current_organization"] = organization
+        sign_in user, scope: :user
+      end
+
+      context "when the user hasn't accepted the ToS" do
+        let(:user) { create(:user, :admin, :confirmed, admin_terms_accepted_at: nil, organization:) }
+
+        it "allows entering the root page" do
+          get :root
+
+          expect(response.body).to have_text("Root page")
+        end
+
+        it "allows entering the ToS page" do
+          get :admin_tos
+
+          expect(response.body).to have_text("Admin ToS page")
+        end
+
+        it "doesn't allow entering another page" do
+          get :another
+
+          expect(response).to redirect_to("/admin_tos")
+          expect(response.body).to have_text("You are being redirected")
+        end
+      end
+
+      context "when the user has accepted the ToS" do
+        let(:user) { create(:user, :admin, :confirmed, admin_terms_accepted_at: Time.zone.now, organization:) }
+
+        it "allows entering the root page" do
+          get :root
+
+          expect(response.body).to have_text("Root page")
+        end
+
+        it "allows entering the ToS page" do
+          get :admin_tos
+
+          expect(response.body).to have_text("Admin ToS page")
+        end
+
+        it "allows entering another page" do
+          get :another
+
+          expect(response.body).to have_text("Another page")
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/system/admin_tos_acceptance_spec.rb
+++ b/decidim-admin/spec/system/admin_tos_acceptance_spec.rb
@@ -27,7 +27,7 @@ describe "AdminTosAcceptance", type: :system do
 
       it "has only the Dashboard menu item in the main navigation" do
         within ".main-nav" do
-          expect(page).to have_text("Dashboard")
+          expect(page).to have_content("Dashboard")
           expect(page).to have_selector("li a", count: 1)
         end
       end
@@ -54,9 +54,9 @@ describe "AdminTosAcceptance", type: :system do
 
       it "allows accepting and redirects to the previous page" do
         click_button "I agree with the terms"
-        expect(page).to have_text("New process")
-        expect(page).to have_text("Process types")
-        expect(page).to have_text("Process groups")
+        expect(page).to have_content("New process")
+        expect(page).to have_content("Process types")
+        expect(page).to have_content("Process groups")
       end
     end
 
@@ -66,20 +66,20 @@ describe "AdminTosAcceptance", type: :system do
       end
 
       it "renders the TOS page" do
-        expect(page).to have_text("Agree to the terms and conditions of use")
+        expect(page).to have_content("Agree to the terms and conditions of use")
       end
 
       it "allows accepting the terms" do
         click_button "I agree with the terms"
-        expect(page).to have_text("Activity")
-        expect(page).to have_text("Metrics")
+        expect(page).to have_content("Activity")
+        expect(page).to have_content("Metrics")
 
         within ".main-nav" do
-          expect(page).to have_text("Dashboard")
-          expect(page).to have_text("Newsletters")
-          expect(page).to have_text("Participants")
-          expect(page).to have_text("Settings")
-          expect(page).to have_text("Admin activity log")
+          expect(page).to have_content("Dashboard")
+          expect(page).to have_content("Newsletters")
+          expect(page).to have_content("Participants")
+          expect(page).to have_content("Settings")
+          expect(page).to have_content("Admin activity log")
         end
       end
     end

--- a/decidim-admin/spec/system/admin_tos_acceptance_spec.rb
+++ b/decidim-admin/spec/system/admin_tos_acceptance_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 describe "AdminTosAcceptance", type: :system do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, :confirmed, admin_terms_accepted_at: nil, organization:) }
+  let(:review_message) { "Please take a moment to review Admin Terms of Use. Otherwise you won't be able to manage the platform" }
 
   before do
     switch_to_host(organization.host)
@@ -21,7 +22,7 @@ describe "AdminTosAcceptance", type: :system do
       end
 
       it "has a message that they need to accept the admin TOS" do
-        expect(page).to have_content("Please take a moment to review Admin Terms of Use. Otherwise you won't be able to manage the platform")
+        expect(page).to have_content(review_message)
       end
 
       it "has only the Dashboard menu item in the main navigation" do
@@ -37,10 +38,18 @@ describe "AdminTosAcceptance", type: :system do
         visit decidim_admin.newsletters_path
       end
 
-      it "says that you're not authorized" do
-        within ".callout.alert" do
-          expect(page).to have_text("You are not authorized to perform this action")
-        end
+      it "has a message that they need to accept the admin TOS" do
+        expect(page).to have_content(review_message)
+      end
+    end
+
+    context "when they visit other admin pages from other engines" do
+      before do
+        visit decidim_admin_participatory_processes.participatory_processes_path
+      end
+
+      it "has a message that they need to accept the admin TOS" do
+        expect(page).to have_content(review_message)
       end
     end
 

--- a/decidim-admin/spec/system/admin_tos_acceptance_spec.rb
+++ b/decidim-admin/spec/system/admin_tos_acceptance_spec.rb
@@ -51,6 +51,13 @@ describe "AdminTosAcceptance", type: :system do
       it "has a message that they need to accept the admin TOS" do
         expect(page).to have_content(review_message)
       end
+
+      it "allows accepting and redirects to the previous page" do
+        click_button "I agree with the terms"
+        expect(page).to have_text("New process")
+        expect(page).to have_text("Process types")
+        expect(page).to have_text("Process groups")
+      end
     end
 
     context "when they visit the TOS page" do


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

When working on  #9907 I found a bug: 

Even though an admin didn't accept the ToS, they still can access the admin panel through some admin spaces. Steps to reproduce this: 

1. Reject the admin terms, for instance by running this in a console: `Decidim::User.first.update(admin_terms_accepted_at: nil)   `
3. Sign in as this account (admin@example.org with the defaults seed) 
4. Go to /processes 
5. Click on the Edit button on the main navbar 
6. See that you have access to the admin panel even though you haven't accepted the ToS:

![image](https://user-images.githubusercontent.com/717367/196942028-6cc96a8d-f41d-4215-b228-46fbc5d60e71.png)

This PR fixes it by introducing a concern that check if the admin has accepted the terms, based on what we already have for the frontend users (https://github.com/decidim/decidim/blob/develop/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb) 

#### :pushpin: Related Issues
 
- Related to #9907

#### Testing

1. Reject the admin terms, for instance by running this in a console: `Decidim::User.first.update(admin_terms_accepted_at: nil)   `
3. Sign in as this account (admin@example.org with the defaults seed) 
4. Go to /processes 
5. Click on the Edit button on the main navbar 
6. See that you have are redirected to the ToS acceptance page
7. And when you accept it, see that you're redirected to where you wanted to initially go

:hearts: Thank you!
