### PR TITLE
Hide all public informations of blocked user

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/block_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/block_user.rb
@@ -67,7 +67,12 @@ module Decidim
           form.user.blocked_at = Time.current
           form.user.blocking = @current_blocking
           form.user.extended_data["user_name"] = form.user.name
+          form.user.extended_data["about"] = form.user.about
+          form.user.extended_data["personal_url"] = form.user.personal_url
           form.user.name = "Blocked user"
+          form.user.about = ""
+          form.user.personal_url = ""
+          form.user.avatar.purge if form.user.avatar.present?
           form.user.save!
         end
       end


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR aims to anonymize the personal data of blocked users.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10039
- Meta proposal: https://meta.decidim.org/processes/roadmap/f/122/proposals/16966

#### Testing
1. Login as administrator 
2. Block an user 
3. See user's public profile page
4. See there is no Avatar, personal url, about field information

### :camera: Screenshots
Not applicable.

:hearts: Thank you!
