### PR TITLE
Switch to GitHub concurrency in CI

### DIFF
--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -23,10 +23,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: rokroskar/workflow-run-cleanup-action@v0.3.3
-      if: "github.ref != 'refs/heads/develop'"
-      env:
-        GITHUB_TOKEN: " ${{ inputs.github_token }}"
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby_version }}

--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -28,6 +28,10 @@ env:
   DECIDIM_MODULE: decidim-accountability
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -23,6 +23,10 @@ env:
   DECIDIM_MODULE: decidim-admin
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_admin_system.yml
+++ b/.github/workflows/ci_admin_system.yml
@@ -23,6 +23,10 @@ env:
   DECIDIM_MODULE: decidim-admin
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -1,4 +1,4 @@
-name: "[CI] Api"
+name: "[CI] API"
 on:
   push:
     branches:

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -1,4 +1,4 @@
-name: "[CI] API"
+name: "[CI] Api"
 on:
   push:
     branches:

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -24,6 +24,10 @@ env:
   DECIDIM_MODULE: decidim-api
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -23,6 +23,10 @@ env:
   DECIDIM_MODULE: decidim-assemblies
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -26,6 +26,10 @@ env:
   DECIDIM_MODULE: decidim-blogs
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -25,6 +25,10 @@ env:
   DECIDIM_MODULE: decidim-budgets
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -23,6 +23,10 @@ env:
   DECIDIM_MODULE: decidim-comments
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -24,6 +24,10 @@ env:
   DECIDIM_MODULE: decidim-conferences
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -24,6 +24,10 @@ env:
   DECIDIM_MODULE: decidim-consultations
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_core_lib.yml
+++ b/.github/workflows/ci_core_lib.yml
@@ -23,6 +23,10 @@ env:
   DECIDIM_MODULE: decidim-core
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -23,6 +23,10 @@ env:
   PARALLEL_TEST_PROCESSORS: 2
   DECIDIM_SERVICE_WORKER_ENABLED: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_core_system_ssl.yml
+++ b/.github/workflows/ci_core_system_ssl.yml
@@ -23,6 +23,10 @@ env:
   DECIDIM_SERVICE_WORKER_ENABLED: true
   TEST_SSL: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_core_unit.yml
+++ b/.github/workflows/ci_core_unit.yml
@@ -22,6 +22,10 @@ env:
   DECIDIM_MODULE: decidim-core
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -24,6 +24,10 @@ env:
   DECIDIM_MODULE: decidim-debates
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_dev_system.yml
+++ b/.github/workflows/ci_dev_system.yml
@@ -21,6 +21,10 @@ env:
   DECIDIM_MODULE: decidim-dev
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_elections_system_admin.yml
+++ b/.github/workflows/ci_elections_system_admin.yml
@@ -26,6 +26,10 @@ env:
   DECIDIM_MODULE: decidim-elections
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_elections_system_public.yml
+++ b/.github/workflows/ci_elections_system_public.yml
@@ -26,6 +26,10 @@ env:
   DECIDIM_MODULE: decidim-elections
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_elections_unit_tests.yml
+++ b/.github/workflows/ci_elections_unit_tests.yml
@@ -26,6 +26,10 @@ env:
   DECIDIM_MODULE: decidim-elections
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -23,6 +23,10 @@ env:
   DECIDIM_MODULE: decidim-forms
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -21,6 +21,10 @@ env:
   DECIDIM_MODULE: decidim-generators
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests
@@ -44,10 +48,6 @@ jobs:
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
     steps:
-      - uses: rokroskar/workflow-run-cleanup-action@v0.3.3
-        if: "github.ref != 'refs/heads/develop'"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0
         with:
           fetch-depth: 1

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -25,6 +25,10 @@ env:
   DECIDIM_MODULE: decidim-initiatives
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_initiatives_system_admin.yml
+++ b/.github/workflows/ci_initiatives_system_admin.yml
@@ -25,6 +25,10 @@ env:
   DECIDIM_MODULE: decidim-initiatives
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_initiatives_system_public.yml
+++ b/.github/workflows/ci_initiatives_system_public.yml
@@ -25,6 +25,10 @@ env:
   DECIDIM_MODULE: decidim-initiatives
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_javascript.yml
+++ b/.github/workflows/ci_javascript.yml
@@ -20,6 +20,10 @@ env:
   CI: "true"
   NODE_VERSION: 16.9.1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests
@@ -27,10 +31,6 @@ jobs:
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     steps:
-      - uses: rokroskar/workflow-run-cleanup-action@v0.3.3
-        if: "github.ref != 'refs/heads/develop'"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0
         with:
           fetch-depth: 1

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -14,16 +14,16 @@ env:
   RUBY_VERSION: 3.1.1
   NODE_VERSION: 16.9.1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: rokroskar/workflow-run-cleanup-action@v0.3.3
-        if: "github.ref != 'refs/heads/develop'"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0
         with:
           fetch-depth: 1

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -26,6 +26,10 @@ env:
   DECIDIM_MODULE: decidim-meetings
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -26,6 +26,10 @@ env:
   DECIDIM_MODULE: decidim-meetings
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_meetings_unit_tests.yml
+++ b/.github/workflows/ci_meetings_unit_tests.yml
@@ -26,6 +26,10 @@ env:
   DECIDIM_MODULE: decidim-meetings
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -23,6 +23,10 @@ env:
   DECIDIM_MODULE: decidim-pages
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -24,6 +24,10 @@ env:
   DECIDIM_MODULE: decidim-participatory_processes
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -22,6 +22,10 @@ env:
   NODE_VERSION: 16.9.1
   RAILS_ENV: development
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests
@@ -45,10 +49,6 @@ jobs:
       DATABASE_HOST: localhost
       RUBYOPT: '-W:no-deprecated'
     steps:
-      - uses: rokroskar/workflow-run-cleanup-action@v0.3.3
-        if: "github.ref != 'refs/heads/develop'"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0
         with:
           fetch-depth: 1

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -28,6 +28,10 @@ env:
   DECIDIM_MODULE: decidim-proposals
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_proposals_system_public.yml
+++ b/.github/workflows/ci_proposals_system_public.yml
@@ -28,6 +28,10 @@ env:
   DECIDIM_MODULE: decidim-proposals
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -28,6 +28,10 @@ env:
   DECIDIM_MODULE: decidim-proposals
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -25,6 +25,10 @@ env:
   DECIDIM_MODULE: decidim-sortitions
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -26,6 +26,10 @@ env:
   DECIDIM_MODULE: decidim-surveys
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -22,6 +22,10 @@ env:
   DECIDIM_MODULE: decidim-system
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -25,6 +25,10 @@ env:
   DECIDIM_MODULE: decidim-templates
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -23,6 +23,10 @@ env:
   DECIDIM_MODULE: decidim-verifications
   PARALLEL_TEST_PROCESSORS: 2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Tests

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -15,6 +15,10 @@ env:
   RUBY_VERSION: 3.1.1
   NODE_VERSION: 16.9.1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint code
@@ -22,10 +26,6 @@ jobs:
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     steps:
-      - uses: rokroskar/workflow-run-cleanup-action@v0.3.3
-        if: "github.ref != 'refs/heads/develop'"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2.0.0
         with:
           fetch-depth: 1

--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -5,15 +5,15 @@ on:
       - "chore/l10n*"
     types: [opened, edited, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check_title:
     name: Check PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: rokroskar/workflow-run-cleanup-action@v0.3.3
-        if: "github.ref != 'refs/heads/develop'"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: deepakputhraya/action-pr-title@master
         with:
           disallowed_prefixes: "feat/,chore/,build/,ci/,refactor/,docs/,wip/"


### PR DESCRIPTION
#### :tophat: What? Why?
The GitHub action we are using to cancel concurrent workflow runs is deprecated:
https://github.com/rokroskar/workflow-run-cleanup-action

GitHub now supports the `concurrency` option natively:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

We should switch to this.

The pattern I'm using here takes into account the following:
- The workflow itself
- For pull requests, `head_ref` which points to the source branch of the pull request, i.e. unique per PR
- The run ID itself which is always unique, meaning that at `develop` or other "main" branches, the groups will always get a unique ID, so all commits to `develop` will always run all workflows, even if there are multiple commits at the same time

#### :pushpin: Related Issues
- Related to
  * #9750 
  * https://github.com/decidim/decidim/projects/19#card-85669295

#### Testing
See that the previous runs are cancelled for the same PR.

There's no easy way to test that, though (except for pushing a new commit, which I will do for this).