### PR TITLE
Fix resource_icon with component or manifest nil

### DIFF
--- a/decidim-core/app/helpers/decidim/icon_helper.rb
+++ b/decidim-core/app/helpers/decidim/icon_helper.rb
@@ -42,7 +42,7 @@ module Decidim
     #
     # Returns an HTML tag with the icon.
     def manifest_icon(manifest, options = {})
-      if manifest.icon
+      if manifest.respond_to?(:icon) && manifest.icon.present?
         external_icon manifest.icon, options
       else
         icon "question-mark", options
@@ -60,9 +60,9 @@ module Decidim
     def resource_icon(resource, options = {})
       if resource.instance_of?(Decidim::Comments::Comment)
         icon "comment-square", options
-      elsif resource.respond_to?(:component)
+      elsif resource.respond_to?(:component) && resource.component.present?
         component_icon(resource.component, options)
-      elsif resource.respond_to?(:manifest)
+      elsif resource.respond_to?(:manifest) && resource.manifest.present?
         manifest_icon(resource.manifest, options)
       elsif resource.is_a?(Decidim::User)
         icon "person", options

--- a/decidim-core/spec/helpers/decidim/icon_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/icon_helper_spec.rb
@@ -85,6 +85,30 @@ module Decidim
           end
         end
 
+        context "when the resource component and manifest are nil" do
+          let(:resource) { build :dummy_resource }
+
+          before do
+            allow(resource).to receive(:component).and_return(nil)
+          end
+
+          it "renders a generic icon" do
+            expect(result).to include("svg#icon-bell")
+          end
+        end
+
+        context "when the manifest icon is nil" do
+          let(:resource) { build(:component, manifest_name: :dummy) }
+
+          before do
+            allow(resource.manifest).to receive(:icon).and_return(nil)
+          end
+
+          it "renders a generic icon" do
+            expect(result).to include("svg#icon-question-mark")
+          end
+        end
+
         context "and in other cases" do
           let(:resource) { "Something" }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fix errors `undefined method manifest for nil:NilClass` and `undefined method icon for nil:NilClass` when the resource component is nil (e.g., initiatives).

#### Testing
In a fresh installation of decidim 0.27 with the initiatives module installed. Log in with a user and leave a comment in an initiative. Log in with another user and reply to the comment previously created. Log in again with the first user and go to the notifications page. You will see an `undefined method for nil:NilClass` error.

### :camera: Screenshots
![Error displayed before applying the changes proposed in this PR](https://user-images.githubusercontent.com/6973564/204822606-cc5d9235-0057-41c7-b3e4-d86ff45fb256.png)


:hearts: Thank you!