### PR TITLE
Fix initiatives count in initiatives index page

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_count.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_count.html.erb
@@ -1,1 +1,1 @@
-<%= t(".title", count: initiatives.to_a.count) %>
+<%= t(".title", count: initiatives.total_count) %>

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -141,4 +141,17 @@ describe "Initiatives", type: :system do
       end
     end
   end
+
+  context "when there are more than 20 initiatives" do
+    before do
+      create_list(:initiative, 21, organization:)
+      visit decidim_initiatives.initiatives_path
+    end
+
+    it "shows the correct initiatives count" do
+      within "#initiatives-count" do
+        expect(page).to have_content("21")
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes an issue that on the initiatives page the initiatives-count is not correct if number of initiatives exceeds pagination badge size

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/10108

#### Testing
Add more then 20 initiatives and check initiatives-count