### PR TITLE
Fix generators after user moderation templates

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/application_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/application_controller.rb
@@ -31,6 +31,7 @@ module Decidim
       helper Decidim::LanguageChooserHelper
       helper Decidim::ComponentPathHelper
       helper Decidim::SanitizeHelper
+      helper Decidim::Templates::Admin::ApplicationHelper if Decidim::Admin.enable_templates
 
       default_form_builder Decidim::Admin::FormBuilder
 

--- a/decidim-admin/lib/decidim/admin.rb
+++ b/decidim-admin/lib/decidim/admin.rb
@@ -27,6 +27,10 @@ module Decidim
       [15, 50, 100]
     end
 
+    config_accessor :enable_templates do
+      Decidim.const_defined?("Templates")
+    end
+
     Kaminari.configure do |config|
       config.default_per_page = Decidim::Admin.per_page_range.first
       config.max_per_page = Decidim::Admin.per_page_range.last

--- a/decidim-generators/spec/runtime/generators_spec.rb
+++ b/decidim-generators/spec/runtime/generators_spec.rb
@@ -144,7 +144,9 @@ module Decidim
     end
 
     def json_secrets_for(path, env)
-      JSON.parse cmd_capture(path, "bin/rails runner 'puts Rails.application.secrets.to_json'", env:)
+      output = cmd_capture(path, "bin/rails runner 'puts Rails.application.secrets.to_json'", env:)
+      puts output
+      JSON.parse output
     end
 
     def initializer_config_for(path, env, mod = "Decidim")

--- a/decidim-generators/spec/runtime/generators_spec.rb
+++ b/decidim-generators/spec/runtime/generators_spec.rb
@@ -144,9 +144,7 @@ module Decidim
     end
 
     def json_secrets_for(path, env)
-      output = cmd_capture(path, "bin/rails runner 'puts Rails.application.secrets.to_json'", env:)
-      puts output
-      JSON.parse output
+      JSON.parse cmd_capture(path, "bin/rails runner 'puts Rails.application.secrets.to_json'", env:)
     end
 
     def initializer_config_for(path, env, mod = "Decidim")

--- a/decidim-templates/lib/decidim/templates/admin_engine.rb
+++ b/decidim-templates/lib/decidim/templates/admin_engine.rb
@@ -38,13 +38,13 @@ module Decidim
         root to: "questionnaire_templates#index"
       end
 
-      initializer "decidim_templates.action_controller" do |_app|
-        config.to_prepare do
-          ActiveSupport.on_load :action_controller do
-            Decidim::Admin::ApplicationController.helper Decidim::Templates::Admin::ApplicationHelper if respond_to?(:helper)
-          end
-        end
-      end
+      # initializer "decidim_templates.action_controller" do |_app|
+      #   config.to_prepare do
+      #     ActiveSupport.on_load :action_controller do
+      #       Decidim::Admin::ApplicationController.helper Decidim::Templates::Admin::ApplicationHelper if respond_to?(:helper)
+      #     end
+      #   end
+      # end
 
       initializer "decidim_participatory_processes.admin_participatory_processes_menu" do
         Decidim.menu :admin_template_types_menu do |menu|

--- a/decidim-templates/lib/decidim/templates/admin_engine.rb
+++ b/decidim-templates/lib/decidim/templates/admin_engine.rb
@@ -38,14 +38,6 @@ module Decidim
         root to: "questionnaire_templates#index"
       end
 
-      # initializer "decidim_templates.action_controller" do |_app|
-      #   config.to_prepare do
-      #     ActiveSupport.on_load :action_controller do
-      #       Decidim::Admin::ApplicationController.helper Decidim::Templates::Admin::ApplicationHelper if respond_to?(:helper)
-      #     end
-      #   end
-      # end
-
       initializer "decidim_participatory_processes.admin_participatory_processes_menu" do
         Decidim.menu :admin_template_types_menu do |menu|
           menu.add_item :questionnaires,


### PR DESCRIPTION
#### :tophat: What? Why?
After merging #10016, the generators are broken. This is happening when the generator spec is trying to load the secrets from the module through Rails runner which causes this kind of errors during the tests:

```
  1) Decidim::Generators with an application without flags behaves like an application with configurable env vars env vars generate secrets application
     Failure/Error: JSON.parse cmd_capture(path, "bin/rails runner 'puts Rails.application.secrets.to_json'", env:)

     JSON::ParserError:
       859: unexpected token at ''
     Shared Example Group: "an application with configurable env vars" called from ./spec/runtime/generators_spec.rb:61
     # ./spec/runtime/generators_spec.rb:147:in `json_secrets_for'
     # ./lib/decidim/generators/test/generator_examples.rb:702:in `block (2 levels) in <top (required)>'
```

The relevant parts of the stacktrace look something as follows in this situation:

```
class DecidimController < ApplicationController
                          ^^^^^^^^^^^^^^^^^^^^^
Did you mean?  ApplicationRecord
	...
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/kernel.rb:30:in `require'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/decidim-templates-0.28.0.dev/lib/decidim/templates/admin_engine.rb:44:in `block (3 levels) in <class:AdminEngine>'
	...
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/activesupport-6.1.6/lib/active_support/lazy_load_hooks.rb:51:in `run_load_hooks'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/actionpack-6.1.6/lib/action_controller/base.rb:271:in `<class:Base>'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/actionpack-6.1.6/lib/action_controller/base.rb:166:in `<module:ActionController>'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/actionpack-6.1.6/lib/action_controller/base.rb:7:in `<main>'
	...
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/loader/helpers.rb:25:in `ls'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/loader/eager_load.rb:164:in `actual_eager_load_dir'
	...
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/loader/eager_load.rb:10:in `eager_load'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/loader.rb:296:in `block in eager_load_all'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/loader.rb:294:in `each'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/zeitwerk-2.6.6/lib/zeitwerk/loader.rb:294:in `eager_load_all'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/railties-6.1.6/lib/rails/application/finisher.rb:133:in `block in <module:Finisher>'
	...
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/railties-6.1.6/lib/rails/initializable.rb:60:in `run_initializers'
	from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/railties-6.1.6/lib/rails/application.rb:391:in `initialize!'
	from /home/runner/work/decidim/decidim/decidim-generators/spec/generator_test_app/config/environment.rb:5:in `<main>'
	...
```

Turns out that the current approach of adding the helper to the admin controller does not work. So in this PR I am changing the approach to be more in line with some of the other modules that have interconnections between the modules (such as accountability module's connection with proposals, i.e. linking proposals).

#### :pushpin: Related Issues
- Related to #10016

#### Testing
See that the generators tests are passing and CI is green.