### PR TITLE
A Valuator should not be able to access Global Moderation

### DIFF
--- a/decidim-admin/app/permissions/decidim/admin/permissions.rb
+++ b/decidim-admin/app/permissions/decidim/admin/permissions.rb
@@ -73,7 +73,7 @@ module Decidim
       private
 
       def user_valuator?
-        user && !user.admin? && Decidim::ParticipatoryProcessUserRole.exists?(user: , role: "valuator")
+        user && !user.admin? && Decidim::ParticipatoryProcessUserRole.exists?(user:, role: "valuator")
       end
 
       def user_manager?

--- a/decidim-admin/app/permissions/decidim/admin/permissions.rb
+++ b/decidim-admin/app/permissions/decidim/admin/permissions.rb
@@ -29,7 +29,13 @@ module Decidim
         read_admin_dashboard_action?
         apply_newsletter_permissions_for_admin!
 
-        allow! if permission_action.subject == :global_moderation && admin_terms_accepted?
+        if permission_action.subject == :global_moderation && admin_terms_accepted?
+          if user_valuator?
+            disallow!
+          else
+            allow!
+          end
+        end
 
         if user.admin? && admin_terms_accepted?
           allow! if read_admin_log_action?
@@ -65,6 +71,10 @@ module Decidim
       end
 
       private
+
+      def user_valuator?
+        user && !user.admin? && Decidim::ParticipatoryProcessUserRole.exists?(user: , role: "valuator")
+      end
 
       def user_manager?
         user && !user.admin? && user.role?("user_manager")

--- a/decidim-admin/app/permissions/decidim/admin/permissions.rb
+++ b/decidim-admin/app/permissions/decidim/admin/permissions.rb
@@ -29,13 +29,7 @@ module Decidim
         read_admin_dashboard_action?
         apply_newsletter_permissions_for_admin!
 
-        if permission_action.subject == :global_moderation && admin_terms_accepted?
-          if user_valuator?
-            disallow!
-          else
-            allow!
-          end
-        end
+        apply_global_moderations_permission_for_admin!
 
         if user.admin? && admin_terms_accepted?
           allow! if read_admin_log_action?
@@ -72,10 +66,6 @@ module Decidim
 
       private
 
-      def user_valuator?
-        user && !user.admin? && Decidim::ParticipatoryProcessUserRole.exists?(user:, role: "valuator")
-      end
-
       def user_manager?
         user && !user.admin? && user.role?("user_manager")
       end
@@ -87,6 +77,23 @@ module Decidim
         return user_manager_permissions if user_manager?
 
         toggle_allow(user.admin? || space_allows_admin_access_to_current_action?)
+      end
+
+      def apply_global_moderations_permission_for_admin!
+        return unless admin_terms_accepted?
+        return unless permission_action.subject == :global_moderation
+        return allow! if user.admin?
+
+        return allow! if Decidim.participatory_space_manifests.flat_map.any? do |manifest|
+          Decidim
+                         .find_participatory_space_manifest(manifest.name)
+                         .participatory_spaces
+                         .call(user.organization)&.any? do |space|
+            space.respond_to?(:user_roles) && space.user_roles(:admin).where(user:).or(space.user_roles(:moderator).where(user:)).any?
+          end
+        end
+
+        disallow!
       end
 
       def apply_newsletter_permissions_for_admin!

--- a/decidim-admin/app/views/decidim/admin/dashboard/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/dashboard/show.html.erb
@@ -11,7 +11,7 @@
     <%= cell("decidim/announcement", announcement_body, callout_class: current_user.admin_terms_accepted? ? "success" : "warning" ) %>
   <% end %>
 
-  <% if count_pending_moderations.positive? %>
+  <% if count_pending_moderations.positive? && allowed_to?(:read, :global_moderation) %>
     <div class="grid-x grid-margin-x">
       <div class="cell small-12 medium-6 large-4">
         <%= render "pending_moderations" %>

--- a/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
@@ -105,6 +105,7 @@ FactoryBot.define do
     end
 
     organization { assembly.organization }
+    admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
       create :assembly_user_role,
@@ -120,6 +121,7 @@ FactoryBot.define do
     end
 
     organization { assembly.organization }
+    admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
       create :assembly_user_role,
@@ -135,6 +137,7 @@ FactoryBot.define do
     end
 
     organization { assembly.organization }
+    admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
       create :assembly_user_role,
@@ -150,6 +153,7 @@ FactoryBot.define do
     end
 
     organization { assembly.organization }
+    admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
       create :assembly_user_role,

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -74,6 +74,23 @@ describe Decidim::Assemblies::Permissions do
       )
     end
 
+    context "when accessing global moderation" do
+      subject { Decidim::Admin::Permissions.new(user, permission_action, context).permissions.allowed? }
+
+      let(:action) do
+        { scope: :admin, action: :read, subject: :global_moderation }
+      end
+
+      it_behaves_like(
+        "access for roles",
+        org_admin: true,
+        admin: true,
+        collaborator: false,
+        moderator: true,
+        valuator: false
+      )
+    end
+
     context "when reading a assembly" do
       let(:action) do
         { scope: :public, action: :read, subject: :assembly }

--- a/decidim-conferences/lib/decidim/conferences/test/factories.rb
+++ b/decidim-conferences/lib/decidim/conferences/test/factories.rb
@@ -59,6 +59,7 @@ FactoryBot.define do
     end
 
     organization { conference.organization }
+    admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
       create :conference_user_role,
@@ -74,6 +75,7 @@ FactoryBot.define do
     end
 
     organization { conference.organization }
+    admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
       create :conference_user_role,
@@ -89,6 +91,7 @@ FactoryBot.define do
     end
 
     organization { conference.organization }
+    admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
       create :conference_user_role,
@@ -104,6 +107,7 @@ FactoryBot.define do
     end
 
     organization { conference.organization }
+    admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
       create :conference_user_role,

--- a/decidim-conferences/spec/permissions/decidim/conferences/permissions_spec.rb
+++ b/decidim-conferences/spec/permissions/decidim/conferences/permissions_spec.rb
@@ -72,6 +72,23 @@ describe Decidim::Conferences::Permissions do
       )
     end
 
+    context "when accessing global moderation" do
+      subject { Decidim::Admin::Permissions.new(user, permission_action, context).permissions.allowed? }
+
+      let(:action) do
+        { scope: :admin, action: :read, subject: :global_moderation }
+      end
+
+      it_behaves_like(
+        "access for roles",
+        org_admin: true,
+        admin: true,
+        collaborator: false,
+        moderator: true,
+        valuator: false
+      )
+    end
+
     context "when reading a conference" do
       let(:action) do
         { scope: :public, action: :read, subject: :conference }

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -167,6 +167,7 @@ FactoryBot.define do
     end
 
     organization { participatory_process.organization }
+    admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
       create :participatory_process_user_role,
@@ -182,6 +183,7 @@ FactoryBot.define do
     end
 
     organization { participatory_process.organization }
+    admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
       create :participatory_process_user_role,
@@ -197,6 +199,7 @@ FactoryBot.define do
     end
 
     organization { participatory_process.organization }
+    admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
       create :participatory_process_user_role,

--- a/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
+++ b/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
@@ -93,7 +93,7 @@ describe Decidim::ParticipatoryProcesses::Permissions do
         "access for roles",
         org_admin: true,
         admin: true,
-        collaborator: true,
+        collaborator: false,
         moderator: true,
         valuator: false
       )

--- a/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
+++ b/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
@@ -82,6 +82,23 @@ describe Decidim::ParticipatoryProcesses::Permissions do
       )
     end
 
+    context "when accessing global moderation" do
+      subject { Decidim::Admin::Permissions.new(user, permission_action, context).permissions.allowed? }
+
+      let(:action) do
+        { scope: :admin, action: :read, subject: :global_moderation }
+      end
+
+      it_behaves_like(
+        "access for roles",
+        org_admin: true,
+        admin: true,
+        collaborator: true,
+        moderator: true,
+        valuator: false
+      )
+    end
+
     context "when reading a process" do
       let(:action) do
         { scope: :public, action: :read, subject: :process }


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
A Valuator should not be able to access global moderation panel. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10186

#### Testing
1. Create a user with valuator role in a process, in the default development app you should already have user [participatory_process_1_valuator@example.org](mailto:participatory_process_1_valuator@example.org) with the default example password
2. Sign in as the valuator
3. Go to admin panel and accept the terms
4. You should not be able to see Global Moderation menu entry
5. You should not be able to see Moderation info on Dashboard

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
