### PR TITLE
Do not display unpublished spaces in linked spaces

### DIFF
--- a/decidim-assemblies/spec/commands/create_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_spec.rb
@@ -204,6 +204,20 @@ module Decidim::Assemblies
           expect(linked_processes.first).to eq(process_two)
         end
       end
+
+      context "when linking draft processes" do
+        let!(:process_one) { create :participatory_process, :unpublished, organization:, weight: 2 }
+        let!(:process_two) { create :participatory_process, organization:, weight: 1 }
+        let(:related_process_ids) { [process_one.id, process_two.id] }
+
+        it "links processes in right way" do
+          subject.call
+
+          linked_processes = assembly.linked_participatory_space_resources(:participatory_process, "included_participatory_processes")
+          expect(linked_processes.size).to eq(1)
+          expect(linked_processes.first).to eq(process_two)
+        end
+      end
     end
   end
 end

--- a/decidim-conferences/spec/commands/create_conference_spec.rb
+++ b/decidim-conferences/spec/commands/create_conference_spec.rb
@@ -166,7 +166,7 @@ module Decidim::Conferences
           expect(linked_processes.first).to eq(consultation_two)
         end
 
-        it "sorts by weigth" do
+        it "sorts by weight" do
           subject.call
 
           linked_processes = conference.linked_participatory_space_resources(:participatory_process, "included_participatory_processes")
@@ -182,20 +182,12 @@ module Decidim::Conferences
         let!(:consultation_two) { create :consultation, organization: }
         let(:related_consultation_ids) { [consultation_one.id, consultation_two.id] }
 
-        it "sorts by created at" do
+        it "does not include unpublished meetings" do
           subject.call
 
           linked_processes = conference.linked_participatory_space_resources("Consultations", "included_consultations")
           expect(linked_processes.first).to eq(consultation_two)
           expect(linked_processes.size).to eq(1)
-        end
-
-        it "sorts by weigth" do
-          subject.call
-
-          linked_processes = conference.linked_participatory_space_resources(:participatory_process, "included_participatory_processes")
-          expect(linked_processes.size).to eq(1)
-          expect(linked_processes.first).to eq(process_two)
         end
       end
     end

--- a/decidim-conferences/spec/commands/create_conference_spec.rb
+++ b/decidim-conferences/spec/commands/create_conference_spec.rb
@@ -173,6 +173,31 @@ module Decidim::Conferences
           expect(linked_processes.first).to eq(process_two)
         end
       end
+
+      context "when linking unpublished linked_participatory_space_resources" do
+        let!(:process_one) { create :participatory_process, :unpublished, organization:, weight: 2 }
+        let!(:process_two) { create :participatory_process, organization:, weight: 1 }
+        let(:related_process_ids) { [process_one.id, process_two.id] }
+        let!(:consultation_one) { create :consultation, :unpublished, organization: }
+        let!(:consultation_two) { create :consultation, organization: }
+        let(:related_consultation_ids) { [consultation_one.id, consultation_two.id] }
+
+        it "sorts by created at" do
+          subject.call
+
+          linked_processes = conference.linked_participatory_space_resources("Consultations", "included_consultations")
+          expect(linked_processes.first).to eq(consultation_two)
+          expect(linked_processes.size).to eq(1)
+        end
+
+        it "sorts by weigth" do
+          subject.call
+
+          linked_processes = conference.linked_participatory_space_resources(:participatory_process, "included_participatory_processes")
+          expect(linked_processes.size).to eq(1)
+          expect(linked_processes.first).to eq(process_two)
+        end
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/participatory_space_resourceable.rb
+++ b/decidim-core/lib/decidim/participatory_space_resourceable.rb
@@ -47,7 +47,7 @@ module Decidim
              .joins(:participatory_space_resource_links_to)
              .where(decidim_participatory_space_links: { name: link_name, from_id: id, from_type: self.class.name })
 
-        query = klass.where(id: from).or(klass.where(id: to))
+        query = klass.where(id: from).or(klass.where(id: to)).published
 
         if klass.column_names.include?("weight")
           query.order(:weight)


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR prevents unpublished spaces to be displayed in linked spaces

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10158 

#### Testing
1. login as Org Admin
2. Create a participatory process and leave it unpublished 
3. Link the participatory process to an already published Assembly or Conference 
4. Visit the Assembly / Conference in frontend
5. See unpubished resource being displayed 
6. Apply patch 
7. See unpublished resources are *not* being displayed.
8. 
:hearts: Thank you!
