### PR TITLE
Display Published meetings in Assembly cell

### DIFF
--- a/decidim-assemblies/decidim-assemblies.gemspec
+++ b/decidim-assemblies/decidim-assemblies.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "decidim-admin", Decidim::Assemblies.version
   s.add_development_dependency "decidim-dev", Decidim::Assemblies.version
+  s.add_development_dependency "decidim-meetings", Decidim::Assemblies.version
+  s.add_development_dependency "decidim-proposals", Decidim::Assemblies.version
 end

--- a/decidim-assemblies/spec/factories.rb
+++ b/decidim-assemblies/spec/factories.rb
@@ -2,5 +2,6 @@
 
 require "decidim/core/test/factories"
 require "decidim/proposals/test/factories"
+require "decidim/meetings/test/factories"
 
 require "decidim/assemblies/test/factories"

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -237,6 +237,34 @@ describe "Assemblies", type: :system do
           expect(page).to have_selector("#assemblies-grid .row .column:first-child", text: child_assembly.title[:en])
           expect(page).to have_selector("#assemblies-grid .row .column:last-child", text: second_child_assembly.title[:en])
         end
+
+        context "when child assembly has a meeting" do
+          let(:meetings_component) { create(:meeting_component, :published, participatory_space: child_assembly) }
+
+          context "with unpublished meeting" do
+            let!(:meeting) { create(:meeting, :upcoming, component: meetings_component) }
+
+            it "is not displaying the widget" do
+              visit decidim_assemblies.assembly_path(assembly)
+
+              within("#assemblies-grid") do
+                expect(page).not_to have_content("Upcoming meeting")
+              end
+            end
+          end
+
+          context "with published meeting" do
+            let!(:meeting) { create(:meeting, :upcoming, :published, component: meetings_component) }
+
+            it "is displaying the widget" do
+              visit decidim_assemblies.assembly_path(assembly)
+
+              within("#assemblies-grid") do
+                expect(page).to have_content("Upcoming meeting")
+              end
+            end
+          end
+        end
       end
 
       context "when the assembly has children private and transparent assemblies" do

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -57,7 +57,7 @@ module Decidim
         # meeting for the given participatory space.
         Decidim.view_hooks.register(:upcoming_meeting_for_card, priority: Decidim::ViewHooks::LOW_PRIORITY) do |view_context|
           published_components = Decidim::Component.where(participatory_space: view_context.current_participatory_space).published
-          upcoming_meeting = Decidim::Meetings::Meeting.where(component: published_components).upcoming.order(:start_time, :end_time).first
+          upcoming_meeting = Decidim::Meetings::Meeting.where(component: published_components).published.upcoming.order(:start_time, :end_time).first
 
           next unless upcoming_meeting
 


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
The meeting is being displayed in assembly cell  when an admin creates a future meetinging and leaves it unpublished. This PR aims to fix this.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10169

#### Testing
1. Login as admin, and visit the admin area 
2. Select an assembly and create a future meeting without publish it
3. visit the public interface and see the meeting is displayed in the assembly card 
4. Apply the patch and restart the server 
5. Observe the draft meeting is not being displayed there 

:hearts: Thank you!
