### PR TITLE
Prevent sending proposal create event until is commited

### DIFF
--- a/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
@@ -40,8 +40,9 @@ module Decidim
             create_gallery if process_gallery?
             create_attachment(weight: first_attachment_weight) if process_attachments?
             link_author_meeeting if form.created_in_meeting?
-            send_notification
           end
+
+          send_notification
 
           broadcast(:ok, proposal)
         end
@@ -81,11 +82,13 @@ module Decidim
         end
 
         def send_notification
+          return unless proposal
+
           Decidim::EventsManager.publish(
             event: "decidim.events.proposals.proposal_published",
             event_class: Decidim::Proposals::PublishProposalEvent,
             resource: proposal,
-            followers: @proposal.participatory_space.followers,
+            followers: proposal.participatory_space.followers,
             extra: {
               participatory_space: true
             }


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

I've recently been working with subscriptions with proposal creation and I've realized that a race condition can arise.
In some cases, it is possible to fire the event before the new proposal is recorded in the database and the job subscribed to process the event before the it. That leads to a "ActiveRecord Serialization" error which aborts the event.

This fires the event after the transaction is finished.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
