### PR TITLE
Removed "disabled" status from proposals' main categories

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/bulk_actions_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/bulk_actions_helper.rb
@@ -10,9 +10,8 @@ module Decidim
       # Returns a String.
       def bulk_categories_select(collection)
         categories = bulk_categories_for_select collection
-        disabled = bulk_disabled_categories_for collection
         prompt = t("decidim.proposals.admin.proposals.index.change_category")
-        select(:category, :id, options_for_select(categories, selected: [], disabled:), prompt:)
+        select(:category, :id, options_for_select(categories, selected: []), prompt:)
       end
 
       def bulk_categories_for_select(scope)
@@ -33,10 +32,6 @@ module Decidim
 
           parent
         end
-      end
-
-      def bulk_disabled_categories_for(scope)
-        scope.first_class.joins(:subcategories).pluck(:id)
       end
 
       # Public: Generates a select field with the components.

--- a/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
@@ -59,7 +59,7 @@ describe "Admin edits proposals", type: :system do
       end
     end
 
-    context "when the proposal has attachement" do
+    context "when the proposal has attachment" do
       let!(:component) do
         create(:proposal_component,
                :with_creation_enabled,


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
In Admin panel - Proposals, when changing categories in bulk, couldn't pick a main category for proposal, they were disabled. Removed the "disabled" status from main categories.
#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #9206

#### Testing
1. Go to Admin panel
2. Go to Processes
3. Choose a process with proposals and categories
4. Pick one or more proposals from the list and press "actions"
5. Select "Choose category"
6. See main categories colored as grey, and -subcategories as normal

:hearts: Thank you!
