### PR TITLE
Fix an edge case with the attribute object forms with arrays/enumerables passed to non-array types

### DIFF
--- a/decidim-core/lib/decidim/attribute_object/form.rb
+++ b/decidim-core/lib/decidim/attribute_object/form.rb
@@ -48,6 +48,15 @@ module Decidim
               value.attachment.try(:blob)
             when ActiveStorage::Attached::Many
               value.attachments.map(&:blob)
+            when ActiveRecord::Associations::CollectionProxy, ActiveRecord::Relation, Array
+              if attribute_types[key].type == :array
+                value
+              else
+                # This is a sub-form that needs to read the properties directly
+                # from the original model. We cannot pass an array here as it
+                # would be passed to the form constructor causing an error.
+                model
+              end
             else
               value
             end


### PR DESCRIPTION
#### :tophat: What? Why?
In case collection/array data was passed to a non-array type attribute, this would fail previously.

This situation came across when we were updating our `decidim-tags` module where we have the following structure (as an example for proposals):

```ruby
# The model which we associate with the form
class Decidim::Proposals::Proposal < Decidim::Proposals::ApplicationRecord
  include Decidim::Tags::Taggable

  # The above module adds the following relation(s) to the record:
  # has_many :taggings, as: :taggable, (... etc.)
  # has_many :tags, through: :taggings

  # ... everything else as before ...
end

# The form where we are applying tagging possibility
class Decidim::Proposals::Admin::ProposalForm < Decidim::Proposals::Admin::ProposalBaseForm
  include Decidim::Tags::TaggableForm

  # The above module adds the following method to the form:
  # attribute :taggings, Decidim::Tags::TaggingsForm

  # ... everything else as before ...
end

# The taggings form
class Decidim::Tags::TaggingsForm < Decidim::Form
  # Should read the `tags` through the parent record, i.e. in this case the proposal
  attribute :tags, Array[Integer]
end
```

This used to work fine with the Rectify forms.

#### :pushpin: Related Issues
- Related to #8669

#### Testing
If you create the form and model structure as described above, you can try the following in the console:

```ruby
> pr = Decidim::Proposals::Proposal.last
> Decidim::Tags::Tag.create!(decidim_organization_id: 1, name: "apples")
> Decidim::Tags::Tag.create!(decidim_organization_id: 1, name: "oranges")
> Decidim::Tags::Tag.create!(decidim_organization_id: 1, name: "kiwis")
> Decidim::Tags::Tagging.create!(decidim_tags_tag_id: 1, taggable: pr)
> Decidim::Tags::Tagging.create!(decidim_tags_tag_id: 2, taggable: pr)
> Decidim::Tags::Tagging.create!(decidim_tags_tag_id: 3, taggable: pr)
> f = Decidim::Proposals::Admin::ProposalForm.from_model(pr)
> f.taggings
```

The reason why this fails is that the `taggings` has `Decidim::Tags::TaggingsForm` as its type.

The current form functionality then tries to pass `proposal.taggings` to the `.new` method of that form, i.e. tries to run the following code:

```ruby
> pr = Decidim::Proposals::Proposal.last
> Decidim::Tags::TaggingsForm.new(pr.taggings)
```

This fails because the `initialize` method is expecting arguments, not a collection.

The proposed fix checks if the provided value is one of `ActiveRecord::Associations::CollectionProxy`, `ActiveRecord::Relation` or `Array`. If it is, it will pass the parent record itself instead of the array value fixing the described issue.

You can also try the above code with the legacy Rectify forms and notice that they work fine.