### PR TITLE
Fix dependency resolver trying to fetch gem paths from lazy specifications

### DIFF
--- a/decidim-core/spec/lib/dependency_resolver_spec.rb
+++ b/decidim-core/spec/lib/dependency_resolver_spec.rb
@@ -138,8 +138,8 @@ module Decidim
         describe "#lookup" do
           subject { resolver.lookup(gem) }
 
-          it "returns Bundler::LazySpecification" do
-            expect(subject).to be_instance_of(Bundler::LazySpecification)
+          it "returns Gem::Specification" do
+            expect(subject).to be_instance_of(Gem::Specification)
             expect(subject.name).to eq(gem)
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently we have problems running the Decidim generator or even starting Decidim since version 0.27 after we introduced the environment variable configurations and later the dependency resolver to check which modules we need to configure.

It was identified that this problem applies when you have multiple Bundler versions installed and the system bundler version is newer than the bundler version locked to your `Gemfile.lock`.

Later it was confirmed by the RubyGems/Bundler maintainer @deivid-rodriguez that they identified a similar issue which was fixed with the RubyGems 3.4.0 release including Bundler 2.4.0 (see #9849).

Turns out that upgrading RubyGems and Bundler won't fix the issue for Decidim but the fixed done there surely made debugging this issue way easier and I was able to identify the problem simply by upgrading RubyGems and locking a newer version of Bundler locally.

After this fix, we should not experience the described issue anymore (see #9839) and Decidim should also work under the latest Bundler (currently it will be broken).

#### Testing
- Upgrade to latest bundler (`gem update --system && bundle update --bundler`)
- Try to start up Decidim (or e.g. run any spec trying to start the dummy app, such as the spec related to the dependency resolver)
- See exception