### PR TITLE
Fix double parentheses in the titled upload modal with existing attachment

### DIFF
--- a/decidim-core/app/cells/decidim/upload_modal_cell.rb
+++ b/decidim-core/app/cells/decidim/upload_modal_cell.rb
@@ -150,11 +150,7 @@ module Decidim
     end
 
     def file_name_for(attachment)
-      filename = determine_filename(attachment)
-
-      return "(#{filename})" if has_title?
-
-      filename
+      determine_filename(attachment)
     end
 
     def determine_filename(attachment)

--- a/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
@@ -115,7 +115,8 @@ describe Decidim::UploadModalCell, type: :cell do
 
   context "when attachment is present" do
     let(:filename) { "Exampledocument.pdf" }
-    let(:attachments) { [upload_test_file(Decidim::Dev.test_file(filename, "application/pdf"))] }
+    let(:file) { Decidim::Dev.test_file(filename, "application/pdf") }
+    let(:attachments) { [upload_test_file(file)] }
 
     it "renders the attachments" do
       expect(subject).to have_css(".attachment-details")
@@ -127,6 +128,25 @@ describe Decidim::UploadModalCell, type: :cell do
 
       it "renders preview" do
         expect(subject).to have_selector("img[alt='#{attribute}']")
+      end
+    end
+
+    context "when attachment is titled" do
+      let(:attachments) { [create(:attachment, file:)] }
+      let(:titled) { true }
+
+      before do
+        allow(form).to receive(:hidden_field).and_return(
+          %(<input type="hidden" name="#{attribute}[]" value="#{attachments[0].id}">)
+        )
+      end
+
+      it "renders the attachments" do
+        expect(subject).to have_css(".attachment-details")
+        expect(subject).to have_selector("[data-filename='#{filename}']")
+
+        details = subject.find(".attachment-details")
+        expect(details).to have_content("#{attachments[0].title["en"]} (#{filename})")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently the "titled" upload modal shows double parentheses for existing attachments. E.g. when a proposal already has an attachment and then you go to edit that proposal.

#### :pushpin: Related Issues
- Related to #8681

#### Testing
- Create the default development app
- Go to one of the processes and open configuration of the proposals component
- Enable attachments for the component and save it
- Go to create a new proposal
- Add an attachment to it (image or document)
- Click the "Preview" button
- From preview, go back to edit and you will see double parentheses printed out

### :camera: Screenshots

![Double parentheses in the proposal file name](https://user-images.githubusercontent.com/864340/212356162-eead5a10-a575-4a31-bfe3-f6bdd307ed09.png)