### PR TITLE
Sync release branch with remote before backporting

### DIFF
--- a/lib/decidim/git_backport_manager.rb
+++ b/lib/decidim/git_backport_manager.rb
@@ -69,6 +69,9 @@ module Decidim
     # @return [void]
     def create_backport_branch!
       `git checkout #{release_branch}`
+
+      diff_count = `git rev-list HEAD..#{remote}/#{release_branch} --count`.strip.to_i
+      `git pull #{remote} #{release_branch}` if diff_count.positive?
       `git checkout -b #{backport_branch}`
 
       error_message = <<-EOERROR

--- a/spec/lib/decidim/git_backport_manager_spec.rb
+++ b/spec/lib/decidim/git_backport_manager_spec.rb
@@ -47,6 +47,19 @@ describe Decidim::GitBackportManager do
   end
 
   describe ".create_backport_branch!" do
+    let(:remote_repository_dir) { "#{tmp_repository_dir}/fake-remote/decidim/decidim/repository.git" }
+
+    before do
+      `
+        git init --bare #{remote_repository_dir}
+        git remote add origin #{remote_repository_dir}
+      `
+    end
+
+    after do
+      FileUtils.rm_rf(remote_repository_dir)
+    end
+
     context "when there's a branch already with that name" do
       it "exits" do
         `
@@ -54,6 +67,31 @@ describe Decidim::GitBackportManager do
         `
 
         expect { manager.send(:create_backport_branch!) }.to raise_error(SystemExit).and output(/Branch already exists locally/).to_stdout
+      end
+    end
+
+    context "when the local repository is not up to date with the remote" do
+      before do
+        # Create a new commit and push it to the origin
+        `
+          git checkout #{release_branch}
+          touch b_file.txt
+          git add b_file.txt
+          git commit -m "Another commit (#2345)"
+          git push origin #{release_branch}
+        `
+      end
+
+      it "pulls the remote changes before branching off" do
+        sha_commit = `git rev-parse --short HEAD`.strip
+
+        # Reset the last commit locally, so that the local repository is behind remote
+        `git reset --hard @~`
+
+        manager.send(:create_backport_branch!)
+
+        # After the method the local release branch should be up to date with remote
+        expect(`git rev-parse --short HEAD`.strip).to eq(sha_commit)
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The backporter currently has a problem that it does not pull the remote changes for the release branch before doing the backport. This causes the backports to be off sync in case the person doing the backports forgot to sync the release branches before starting with the backports.

This PR checks if the release branch is in sync with the remote before creating the backport.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/9680#issuecomment-1246741711
- Related to https://github.com/decidim/decidim/projects/19#card-85693460

#### Testing
See the added spec.

You can make your local branch off sync by removing the latest commit using `git reset --hard @~`. See the added spec for details.