### PR TITLE
User's group endorsement no longer disappears after personal endorsement removed

### DIFF
--- a/decidim-blogs/spec/system/endorse_posts_spec.rb
+++ b/decidim-blogs/spec/system/endorse_posts_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "endorse posts", type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "blogs" }
+  let(:organization) { create(:organization) }
+  let(:author) { create(:user, :confirmed, name: "Tester", organization:) }
+  let!(:post) { create(:post, component:, title: { en: "Blog post title" }) }
+
+  before do
+    sign_in author
+    visit_component
+    click_link "Blog post title"
+  end
+
+  context "when liking the post without belonging to a user group" do
+    it "likes the post" do
+      click_button "Like"
+      expect(page).to have_content("Dislike")
+    end
+  end
+
+  context "when liking the post while being a part of a group" do
+    let!(:user_group) do
+      create(
+        :user_group,
+        :verified,
+        name: "Tester's Organization",
+        nickname: "test_org",
+        email: "t.mail.org@example.org",
+        users: [author],
+        organization:
+      )
+    end
+
+    it "opens a modal where you select identity as a user or a group" do
+      click_button "Like"
+      expect(page).to have_content("Select identity")
+      expect(page).to have_content("Tester's Organization")
+      expect(page).to have_content("Tester")
+    end
+
+    def add_likes
+      click_button "Like"
+      click_button "Tester's Organization"
+      click_button "Tester"
+      click_button "Done"
+      visit current_path
+      click_button "Dislike"
+    end
+
+    context "when both identities picked" do
+      it "likes the post as a group and a user" do
+        add_likes
+
+        within ".identities-modal__list" do
+          expect(page).to have_css(".is-selected", count: 2)
+        end
+      end
+    end
+
+    context "when like cancelled as a user" do
+      it "doesn't cancel group like" do
+        add_likes
+        find(".is-selected", match: :first).click
+        click_button "Done"
+        visit current_path
+        click_button "Like"
+
+        within ".identities-modal__list" do
+          expect(page).to have_css(".is-selected", count: 1)
+          within ".is-selected" do
+            expect(page).to have_content("Tester's Organization")
+          end
+        end
+      end
+    end
+
+    context "when like cancelled as a group" do
+      it "doesn't cancel user like" do
+        add_likes
+        page.all(".is-selected")[1].click
+        click_button "Done"
+        visit current_path
+        click_button "Dislike"
+
+        within ".identities-modal__list" do
+          expect(page).to have_css(".is-selected", count: 1)
+          within ".is-selected" do
+            expect(page).to have_text("Tester", exact: true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-blogs/spec/system/endorse_posts_spec.rb
+++ b/decidim-blogs/spec/system/endorse_posts_spec.rb
@@ -10,6 +10,8 @@ describe "endorse posts", type: :system do
   let!(:post) { create(:post, component:, title: { en: "Blog post title" }) }
 
   before do
+    allow(Decidim).to receive(:redesign_active).and_return(true)
+
     sign_in author
     visit_component
     click_link "Blog post title"

--- a/decidim-core/app/commands/decidim/unendorse_resource.rb
+++ b/decidim-core/app/commands/decidim/unendorse_resource.rb
@@ -31,7 +31,7 @@ module Decidim
       query = if @current_group.present?
                 @resource.endorsements.where(decidim_user_group_id: @current_group&.id)
               else
-                @resource.endorsements.where(author: @current_user)
+                @resource.endorsements.where(author: @current_user, decidim_user_group_id: nil)
               end
       query.destroy_all
     end


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
When logged in as a user that belongs to a user group and endorsing for example a blog post with two identities (the user and the group), there is a bug that removes the group endorsement if you only want to remove your personal endorsement.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10160

#### Testing
Taken from the github issue by Antti (#10160)

1. Go to try.decidim.org
2. Login as a user that belongs to a group (e.g. the example admin)
3. Find a blog article anywhere on the site (e.g. inside a process)
4. When on the blog article page, click the "Endorse" button
5.Select endorsement for both: the user and the group
6. Remove the endorsement from the user (and the user only, leave group endorsement active)
7. Reload the page
8. Click the "Endorse" button again

### :camera: Screenshots

**Fix screenshots**
*Both endorsements:**
![image](https://user-images.githubusercontent.com/110532525/212619837-8707e524-d7ee-4a24-9b0d-868332b6aeb0.png)

*Personal endorsement removed:*
![image](https://user-images.githubusercontent.com/110532525/212619949-a47980ed-29e9-4795-a7f7-49b25f74a0f9.png)

*After refresh:*
![image](https://user-images.githubusercontent.com/110532525/212620049-a845e4ab-d604-4e54-ab32-9dfdd858d08e.png)

:hearts: Thank you!
