### PR TITLE
Add date format to Conversation

### DIFF
--- a/decidim-core/app/views/decidim/messaging/conversations/_conversation.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_conversation.html.erb
@@ -9,7 +9,7 @@
             <%= image_tag present(current_user).avatar.default_multiuser_url, alt: t("decidim.author.avatar_multiuser") %>
           <% end %>
         </div>
-        <span class="text-medium mt-xs"><%= Date::ABBR_DAYNAMES[conversation.created_at.wday] %> <%= conversation.created_at.wday %></span>
+        <span class="text-medium mt-xs"><%= Date::ABBR_DAYNAMES[conversation.created_at.wday] %> <%= l conversation.created_at, format: :decidim_short %></span>
       </div>
     </li>
     <li class="card-data__item card--list__item card-data__item--expand absolutes">

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -117,6 +117,7 @@ describe "Conversations", type: :system do
       visit_inbox
 
       within ".conversations" do
+        expect(page).to have_content(conversation.created_at.strftime("%d/%m/%Y %H:%M"))
         expect(page).to have_selector(".card.card--widget", text: /#{interlocutor.name}/i)
         expect(page).to have_selector(".card.card--widget", text: "who wants apples?")
       end


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Decidim version 0.27 was missing some localizations that were also missing from the "develop" -branch (PR #10210 , added in this PR). Because of Redesign, "Conversations" -view's missing localization cannot be backported to 0.27 from "develop" which is why that view's localize method is added in this PR.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #9057 

#### Testing
1. Go to Conversations on Decidim version 0.27 (You must have messages(s), so send one for example)
2. Check the message-thread's preview window and look under the profile picture where there is a date.
3.  It is a weekday accompanied with it's corresponding weekday-number, for example "Mon 1", instead of the date

### :camera: Screenshots
Broken localization
![image](https://user-images.githubusercontent.com/110532525/212859131-5dbd3f92-5edf-4232-ac5f-4108ce89d151.png)

Fixed localization
![image](https://user-images.githubusercontent.com/110532525/212859034-422d43d6-ea7e-44a9-a6b3-2821c6cfabb8.png)

:hearts: Thank you!
