### PR TITLE
FIx sorting question choice validations

### DIFF
--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -18,7 +18,7 @@ module Decidim
       validates :selected_choices, presence: true, if: :mandatory_choices?
 
       validate :max_choices, if: -> { question.max_choices }
-      validate :all_choices, if: -> { question.sorting? && question.mandatory }
+      validate :all_choices, if: -> { question.sorting? && question.mandatory? }
       validate :min_choices, if: -> { question.matrix? && question.mandatory? }
       validate :documents_present, if: -> { question.question_type == "files" && question.mandatory? }
       validate :max_characters, if: -> { question.max_characters.positive? }

--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -18,7 +18,7 @@ module Decidim
       validates :selected_choices, presence: true, if: :mandatory_choices?
 
       validate :max_choices, if: -> { question.max_choices }
-      validate :all_choices, if: -> { question.question_type == "sorting" }
+      validate :all_choices, if: -> { question.question_type == "sorting" && question.mandatory }
       validate :min_choices, if: -> { question.matrix? && question.mandatory? }
       validate :documents_present, if: -> { question.question_type == "files" && question.mandatory? }
       validate :max_characters, if: -> { question.max_characters.positive? }
@@ -61,6 +61,7 @@ module Decidim
       def display_conditions_fulfilled?
         question.display_conditions.all? do |condition|
           answer = context.responses&.find { |r| r.question_id&.to_i == condition.condition_question.id }
+          raise answer.inspect
           condition.fulfilled?(answer)
         end
       end

--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -18,7 +18,7 @@ module Decidim
       validates :selected_choices, presence: true, if: :mandatory_choices?
 
       validate :max_choices, if: -> { question.max_choices }
-      validate :all_choices, if: -> { question.question_type == "sorting" && question.mandatory }
+      validate :all_choices, if: -> { question.sorting? && question.mandatory? }
       validate :min_choices, if: -> { question.matrix? && question.mandatory? }
       validate :documents_present, if: -> { question.question_type == "files" && question.mandatory? }
       validate :max_characters, if: -> { question.max_characters.positive? }

--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -18,7 +18,7 @@ module Decidim
       validates :selected_choices, presence: true, if: :mandatory_choices?
 
       validate :max_choices, if: -> { question.max_choices }
-      validate :all_choices, if: -> { question.sorting? && question.mandatory? }
+      validate :all_choices, if: -> { question.sorting? && question.mandatory }
       validate :min_choices, if: -> { question.matrix? && question.mandatory? }
       validate :documents_present, if: -> { question.question_type == "files" && question.mandatory? }
       validate :max_characters, if: -> { question.max_characters.positive? }

--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -61,7 +61,6 @@ module Decidim
       def display_conditions_fulfilled?
         question.display_conditions.all? do |condition|
           answer = context.responses&.find { |r| r.question_id&.to_i == condition.condition_question.id }
-          raise answer.inspect
           condition.fulfilled?(answer)
         end
       end

--- a/decidim-forms/app/models/decidim/forms/question.rb
+++ b/decidim-forms/app/models/decidim/forms/question.rb
@@ -70,6 +70,10 @@ module Decidim
         mandatory? && !multiple_choice? && !has_attachments?
       end
 
+      def sorting?
+        question_type == "sorting"
+      end
+
       def mandatory_choices?
         mandatory? && multiple_choice? && !has_attachments?
       end

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -538,12 +538,13 @@ shared_examples_for "has questionnaire" do
       end
     end
 
-    context "when question type is sorting" do
+    context "when question type is sorting and mandatory" do
       let!(:question) do
         create(
           :questionnaire_question,
           questionnaire: questionnaire,
           question_type: "sorting",
+          mandatory: true,
           options: [
             { "body" => { "en" => "chocolate" } },
             { "body" => { "en" => "like" } },

--- a/decidim-forms/spec/forms/decidim/forms/answer_form_spec.rb
+++ b/decidim-forms/spec/forms/decidim/forms/answer_form_spec.rb
@@ -194,23 +194,46 @@ module Decidim
       context "when the question is sorting" do
         let(:question_type) { "sorting" }
 
-        it "is valid if all options checked" do
-          subject.choices = [
-            { "answer_option_id" => "1", "body" => "foo" },
-            { "answer_option_id" => "2", "body" => "bar" },
-            { "answer_option_id" => "3", "body" => "baz" }
-          ]
+        context "when the question is not mandatory" do
+          it "is valid if all options checked" do
+            subject.choices = [
+              { "answer_option_id" => "1", "body" => "foo" },
+              { "answer_option_id" => "2", "body" => "bar" },
+              { "answer_option_id" => "3", "body" => "baz" }
+            ]
 
-          expect(subject).to be_valid
+            expect(subject).to be_valid
+          end
+
+          it "is valid if not all options checked" do
+            subject.choices = [
+              { "answer_option_id" => "1", "body" => "foo" }
+            ]
+
+            expect(subject).to be_valid
+          end
         end
 
-        it "is not valid if not all options checked" do
-          subject.choices = [
-            { "answer_option_id" => "1", "body" => "foo" },
-            { "answer_option_id" => "2", "body" => "bar" }
-          ]
+        context "when the question is mandatory" do
+          let(:mandatory) { true }
 
-          expect(subject).not_to be_valid
+          it "is valid if all options checked" do
+            subject.choices = [
+              { "answer_option_id" => "1", "body" => "foo" },
+              { "answer_option_id" => "2", "body" => "bar" },
+              { "answer_option_id" => "3", "body" => "baz" }
+            ]
+
+            expect(subject).to be_valid
+          end
+
+          it "is not valid if not all options checked" do
+            subject.choices = [
+              { "answer_option_id" => "1", "body" => "foo" }
+            ]
+
+            expect(subject).not_to be_valid
+          end
         end
       end
 


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
In Decidim version 0.27 (0.26 too at least) you couldn't leave sorting questions unanswered even if they were non-mandatory. This PR's change is made for 0.27 specifically, since "develop" is under re-design and survey differs from the older versions there, this bug is also fixed in "develop" thanks to re-design.

#### :pushpin: Related Issues
- Fixes #9350

#### Testing
1. Go to a survey with a sorting question which is non-mandatory (Create a new one if non-existant).
2. Leave sorting question unsorted and try to submit the form.

### :camera: Screenshots
*Screenshot from Issue #9350*
![image](https://user-images.githubusercontent.com/110532525/213107763-ede5fa7b-145f-4bce-9214-08d921965ef0.png)

:hearts: Thank you!
