### PR TITLE
Survey sorting choice validations fixed

### DIFF
--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -18,7 +18,7 @@ module Decidim
       validates :selected_choices, presence: true, if: :mandatory_choices?
 
       validate :max_choices, if: -> { question.max_choices }
-      validate :all_choices, if: :sorting?
+      validate :all_choices, if: -> { :sorting? && question.mandatory? }
       validate :min_choices, if: -> { question.matrix? && question.mandatory? }
       validate :documents_present, if: -> { question.question_type == "files" && question.mandatory? }
       validate :max_characters, if: -> { question.max_characters.positive? }

--- a/decidim-forms/spec/forms/decidim/forms/answer_form_spec.rb
+++ b/decidim-forms/spec/forms/decidim/forms/answer_form_spec.rb
@@ -194,23 +194,46 @@ module Decidim
       context "when the question is sorting" do
         let(:question_type) { "sorting" }
 
-        it "is valid if all options checked" do
-          subject.choices = [
-            { "answer_option_id" => "1", "body" => "foo" },
-            { "answer_option_id" => "2", "body" => "bar" },
-            { "answer_option_id" => "3", "body" => "baz" }
-          ]
+        context "when the question is not mandatory" do
+          it "is valid if all options checked" do
+            subject.choices = [
+              { "answer_option_id" => "1", "body" => "foo" },
+              { "answer_option_id" => "2", "body" => "bar" },
+              { "answer_option_id" => "3", "body" => "baz" }
+            ]
 
-          expect(subject).to be_valid
+            expect(subject).to be_valid
+          end
+
+          it "is valid if not all options checked" do
+            subject.choices = [
+              { "answer_option_id" => "1", "body" => "foo" }
+            ]
+
+            expect(subject).to be_valid
+          end
         end
 
-        it "is not valid if not all options checked" do
-          subject.choices = [
-            { "answer_option_id" => "1", "body" => "foo" },
-            { "answer_option_id" => "2", "body" => "bar" }
-          ]
+        context "when the question is mandatory" do
+          let(:mandatory) { true }
 
-          expect(subject).not_to be_valid
+          it "is valid if all options checked" do
+            subject.choices = [
+              { "answer_option_id" => "1", "body" => "foo" },
+              { "answer_option_id" => "2", "body" => "bar" },
+              { "answer_option_id" => "3", "body" => "baz" }
+            ]
+
+            expect(subject).to be_valid
+          end
+
+          it "is not valid if not all options checked" do
+            subject.choices = [
+              { "answer_option_id" => "1", "body" => "foo" }
+            ]
+
+            expect(subject).not_to be_valid
+          end
         end
       end
 


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

**This PR is the same as #10227 but made for develop brach instead of 0.27, will be backported**

#### :tophat: What? Why?
There wasn't a mandatory checker for survey's sorting question, which in Decidim 0.27 and older caused an error when trying to submit survey without answering a non-mandatory sorting question.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10227
- Fixes #9350

#### Testing

**DECIDIM 0.27**

1. Go to a survey with a sorting question which is non-mandatory (Create a new one if non-existant).
2. Leave sorting question unsorted and try to submit the form.

### :camera: Screenshots
*Screenshot from Issue #9350*
![image](https://user-images.githubusercontent.com/110532525/213107763-ede5fa7b-145f-4bce-9214-08d921965ef0.png)


:hearts: Thank you!
