### PR TITLE
Added links and nickname fields to User Group Admin panel

### DIFF
--- a/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
@@ -20,8 +20,8 @@
         <tbody>
           <% @users.each do |user| %>
             <tr data-user-id="<%= user.id %>">
-              <td><%= link_to user.nickname.present?, user.name, decidim.profile_path(user.nickname) %></td>
-              <td><%= link_to user.nickname.present?, user.nickname, decidim.profile_path(user.nickname) %></td>
+              <td><%= link_to_if user.nickname.present?, user.name, decidim.profile_path(user.nickname) %></td>
+              <td><%= link_to_if user.nickname.present?, user.nickname, decidim.profile_path(user.nickname) %></td>
               <td><%= l user.created_at, format: :short %></td>
               <td><%= user.officialized? ? t(".officialized") : t(".not_officialized") %></td>
               <td><%= translated_attribute(user.officialized_as) %></td>

--- a/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
@@ -20,13 +20,8 @@
         <tbody>
           <% @users.each do |user| %>
             <tr data-user-id="<%= user.id %>">
-              <% if user.nickname.present? %>
-                <td><%= link_to user.name, decidim.profile_path(user.nickname) %></td>
-                <td><%= link_to user.nickname, decidim.profile_path(user.nickname) %></td>
-              <% else %>
-                <td><%= user.name %></td>
-                <td><%= user.nickname %></td>
-              <% end %>
+              <td><%= link_to user.nickname.present?, user.name, decidim.profile_path(user.nickname) %></td>
+              <td><%= link_to user.nickname.present?, user.nickname, decidim.profile_path(user.nickname) %></td>
               <td><%= l user.created_at, format: :short %></td>
               <td><%= user.officialized? ? t(".officialized") : t(".not_officialized") %></td>
               <td><%= translated_attribute(user.officialized_as) %></td>

--- a/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
@@ -25,13 +25,8 @@
         <tbody>
           <% @user_groups.each do |user_group| %>
             <tr data-user-group-id="<%= user_group.id %>">
-              <% if user_group.nickname.present? %>
-                <td><%= link_to user_group.name, decidim.profile_path(user_group.nickname) %></td>
-                <td><%= link_to user_group.nickname, decidim.profile_path(user_group.nickname) %></td>
-              <% else %>
-                <td><%= user_group.name %></td>
-                <td><%= user_group.nickname %></td>
-              <% end %>
+              <td><%= link_to user_group.nickname.present?, user_group.name, decidim.profile_path(user_group.nickname) %></td>
+              <td><%= link_to user_group.nickname.present?, user_group.nickname, decidim.profile_path(user_group.nickname) %></td>
               <td><%= user_group.document_number %></td>
               <td><%= user_group.phone %></td>
               <td><%= user_group.users.size %></td>

--- a/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
@@ -13,6 +13,7 @@
         <thead>
           <tr>
             <th><%= sort_link(query, :name, t("models.user_group.fields.name", scope: "decidim.admin"), default_order: :desc) %></th>
+            <th><%= sort_link(query, :nickname, t("models.user_group.fields.nickname", scope: "decidim.admin"), default_order: :desc) %></th>
             <th><%= sort_link(query, :document_number, t("models.user_group.fields.document_number", scope: "decidim.admin"), default_order: :desc) %></th>
             <th><%= sort_link(query, :phone, t("models.user_group.fields.phone", scope: "decidim.admin"), default_order: :desc) %></th>
             <th><%= sort_link(query, :users_count, t("models.user_group.fields.users_count", scope: "decidim.admin"), default_order: :desc) %></th>
@@ -24,7 +25,13 @@
         <tbody>
           <% @user_groups.each do |user_group| %>
             <tr data-user-group-id="<%= user_group.id %>">
-              <td><%= user_group.name %></td>
+              <% if user_group.nickname.present? %>
+                <td><%= link_to user_group.name, decidim.profile_path(user_group.nickname) %></td>
+                <td><%= link_to user_group.nickname, decidim.profile_path(user_group.nickname) %></td>
+              <% else %>
+                <td><%= user_group.name %></td>
+                <td><%= user_group.nickname %></td>
+              <% end %>
               <td><%= user_group.document_number %></td>
               <td><%= user_group.phone %></td>
               <td><%= user_group.users.size %></td>

--- a/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
@@ -25,8 +25,8 @@
         <tbody>
           <% @user_groups.each do |user_group| %>
             <tr data-user-group-id="<%= user_group.id %>">
-              <td><%= link_to user_group.nickname.present?, user_group.name, decidim.profile_path(user_group.nickname) %></td>
-              <td><%= link_to user_group.nickname.present?, user_group.nickname, decidim.profile_path(user_group.nickname) %></td>
+              <td><%= link_to_if user_group.nickname.present?, user_group.name, decidim.profile_path(user_group.nickname) %></td>
+              <td><%= link_to_if user_group.nickname.present?, user_group.nickname, decidim.profile_path(user_group.nickname) %></td>
               <td><%= user_group.document_number %></td>
               <td><%= user_group.phone %></td>
               <td><%= user_group.users.size %></td>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -652,6 +652,7 @@ en:
             created_at: Created at
             document_number: Document number
             name: Name
+            nickname: Nickname
             phone: Phone
             state: State
             users_count: Participants count

--- a/decidim-admin/spec/system/admin_filters_user_groups_spec.rb
+++ b/decidim-admin/spec/system/admin_filters_user_groups_spec.rb
@@ -85,6 +85,7 @@ describe "Admin filters user_groups", type: :system do
     let!(:group) do
       create(:user_group, organization:, users: [user, another_user],
                           name: "ZZZupper group",
+                          nickname: "ZZZupper",
                           document_number: "9999999999",
                           phone: "999.999.9999").reload
     end
@@ -170,6 +171,24 @@ describe "Admin filters user_groups", type: :system do
 
     context "with name asc" do
       before { visit decidim_admin.user_groups_path(q: { s: "name asc" }) }
+
+      it "hides the result" do
+        expect(group.users.size).to eq(2)
+        expect(page).not_to have_content(group.name)
+      end
+    end
+
+    context "with nickname desc" do
+      before { visit decidim_admin.user_groups_path(q: { s: "nickname desc" }) }
+
+      it "displays the result" do
+        expect(group.users.size).to eq(2)
+        expect(page).to have_content(group.name)
+      end
+    end
+
+    context "with nickname asc" do
+      before { visit decidim_admin.user_groups_path(q: { s: "nickname asc" }) }
 
       it "hides the result" do
         expect(group.users.size).to eq(2)


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Usergroup listing didn't have a link to the corresponding profile page, those were added, with a field for the nickname. If you wanted to visit a group's profile page you would have to write the nickname of the group to the URL and that wasn't pleasant.

#### Testing
1. Log in as Admin user
2. Open "Dashboard"
3. Open "Participants" tab
4. Go to "Groups"
5. See no links to profile pages and no nickname fields

### :camera: Screenshots
Nickname field:
![image](https://user-images.githubusercontent.com/110532525/213668238-e23926e2-0bf6-4cf2-a0d3-dc8bd5e0b009.png)

:hearts: Thank you!
