### PR TITLE
Uploading files - Explanation %{attribute} not translate

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -332,6 +332,7 @@ ignore_unused:
   - ransack.predicates.*
   - decidim.profiles.user.actions.*
   - decidim.forms.questionnaires.show.answer_questionnaire.*
+  - decidim.forms.upload_help.explanation
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -115,6 +115,7 @@ ignore_missing:
   - decidim.budgets.projects_helper.current_rule_explanation.*
   - decidim.budgets.projects_helper.current_rule_description.*
   - decidim.debates.debate_m.footer.commented_time_ago
+  - explanation
 
 # Consider these keys used:
 ignore_unused:

--- a/decidim-core/app/cells/decidim/upload_modal_cell.rb
+++ b/decidim-core/app/cells/decidim/upload_modal_cell.rb
@@ -98,9 +98,15 @@ module Decidim
     end
 
     def explanation
-      return I18n.t("explanation", scope: options[:help_i18n_scope], attribute:) if options[:help_i18n_scope].present?
+      return I18n.t("explanation", scope: options[:help_i18n_scope], attribute: attribute_translation) if options[:help_i18n_scope].present?
 
-      I18n.t("explanation", scope: "decidim.forms.upload_help", attribute:)
+      I18n.t("explanation", scope: "decidim.forms.upload_help", attribute: attribute_translation)
+    end
+
+    def attribute_translation
+      I18n.t(attribute, scope: [:activemodel, :attributes, resource_class.constantize.model_name.param_key].join("."))
+    rescue NameError
+      I18n.t(attribute, scope: "decidim.forms")
     end
 
     def add_attribute

--- a/decidim-core/app/cells/decidim/upload_modal_cell.rb
+++ b/decidim-core/app/cells/decidim/upload_modal_cell.rb
@@ -98,15 +98,18 @@ module Decidim
     end
 
     def explanation
-      return I18n.t("explanation", scope: options[:help_i18n_scope], attribute: attribute_translation) if options[:help_i18n_scope].present?
+      i18n_options = {
+        scope: options[:help_i18n_scope].presence || "decidim.forms.upload_help",
+        attribute: attribute_translation
+      }
 
-      I18n.t("explanation", scope: "decidim.forms.upload_help", attribute: attribute_translation)
+      I18n.t("explanation", **i18n_options)
     end
 
     def attribute_translation
       I18n.t(attribute, scope: [:activemodel, :attributes, resource_class.constantize.model_name.param_key].join("."))
     rescue NameError
-      I18n.t(attribute, scope: "decidim.forms")
+      I18n.t(attribute, scope: "activemodel.attributes")
     end
 
     def add_attribute

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -12,7 +12,7 @@ module Decidim
     let(:redesign_enabled?) { false }
 
     let(:resource) do
-      klass = Class.new do
+      class DummyClass
         cattr_accessor :current_organization
 
         def self.model_name
@@ -68,8 +68,10 @@ module Decidim
           current_organization
         end
       end
+
+      klass = DummyClass.new
       klass.current_organization = organization
-      klass.new
+      klass
     end
 
     let(:builder) { FormBuilder.new(:resource, resource, helper, {}) }
@@ -821,7 +823,8 @@ module Decidim
 
         it "renders calls I18n.t() with the correct scope" do
           # Upload help messages
-          expect(I18n).to receive(:t).with("explanation", scope: "custom.scope", attribute: :image)
+          allow(I18n).to receive(:t).with(:image, scope: "activemodel.attributes.dummy").and_return("Image")
+          expect(I18n).to receive(:t).with("explanation", scope: "custom.scope", attribute: "Image")
           expect(I18n).to receive(:t).with("decidim.forms.upload.labels.add_image")
           expect(I18n).to receive(:t).with("decidim.forms.upload.labels.replace")
           expect(I18n).to receive(:t).with("message_1", scope: "custom.scope")
@@ -838,7 +841,8 @@ module Decidim
           # Upload help messages
           expect(I18n).to receive(:t).with("decidim.forms.upload.labels.add_image")
           expect(I18n).to receive(:t).with("decidim.forms.upload.labels.replace")
-          expect(I18n).to receive(:t).with("explanation", scope: "decidim.forms.upload_help", attribute: :image)
+          allow(I18n).to receive(:t).with(:image, scope: "activemodel.attributes.dummy").and_return("Image")
+          expect(I18n).to receive(:t).with("explanation", scope: "decidim.forms.upload_help", attribute: "Image")
           expect(I18n).to receive(:t).with("message_1", scope: "decidim.forms.file_help.file")
           expect(I18n).to receive(:t).with("message_2", scope: "decidim.forms.file_help.file")
           expect(I18n).to receive(:t).with("message_3", scope: "decidim.forms.file_help.file")
@@ -852,7 +856,8 @@ module Decidim
           it "renders calls I18n.t() with the correct messages" do
             # Upload help messages
 
-            expect(I18n).to receive(:t).with("explanation", scope: "decidim.forms.upload_help", attribute: :image)
+            allow(I18n).to receive(:t).with(:image, scope: "activemodel.attributes.dummy").and_return("Image")
+            expect(I18n).to receive(:t).with("explanation", scope: "decidim.forms.upload_help", attribute: "Image")
             expect(I18n).to receive(:t).with("message_1", scope: "decidim.forms.file_help.file")
             expect(I18n).not_to receive(:t).with("message_2", scope: "decidim.forms.file_help.file")
             output


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

The problem is  more complex than expected, as there are 2 issues : 

1. The attribute is not being shown as Human readable. This can be fixed by using something like: `I18n.t("explanation", attribute: resource_class.constantize.human_attribute_name(attribute)`  which will lead us to the second part of the problem
2. All the I18n keys related to fields are stored in the YAMLs under `en.activemodel.attributes.participatory_process.*` root, yet `human_attribute_name` will look into only under `en.activerecord.attributes.decidim/participatory_process.*`

We could fix the issue by using something like in the upload_modal_cell: 

```
    def explanation
      attribute_scope = [:activemodel, :attributes, resource_class.constantize.model_name.param_key].join(".")
      i18n_options = {
        attribute: I18n.t(attribute, scope: attribute_scope),
        scope: options[:help_i18n_scope].presence || "decidim.forms.upload_help"
      }
      I18n.t("explanation", **i18n_options)
    end
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes  #10242

#### Testing
Steps to check the fix:

1. Go to Participatory Process admin
2. Click on 'New Process'
3. Scroll down to 'Images'
4. Click on 'Add image' for Home Image or Banner image
5. See the label: "Guidance for hero_image" or "Guidance for banner_image"
6. Apply the patch 
7. Refresh 
8. Click on 'Add image' for Home Image or Banner image
9. See the label: "Guidance for Home image" or "Guidance for Banner image"

### :camera: Screenshots

Before: 

![image](https://user-images.githubusercontent.com/105821969/214108738-6abd5c25-0480-4308-bb9f-648d4c492848.png)

![image](https://user-images.githubusercontent.com/105821969/214108863-aca58253-1eb8-438b-a6cb-3d403b251773.png)

![image](https://user-images.githubusercontent.com/105821969/214109145-48650c52-c915-4c29-a510-049a0e006bea.png)

![image](https://user-images.githubusercontent.com/105821969/214111148-df1f6485-0419-45fe-9318-7928920cd943.png)

After: 
![image](https://user-images.githubusercontent.com/105683/214177151-18ac1549-6775-4958-8d55-6a267487f586.png)
Translated Home image (after)
![image](https://user-images.githubusercontent.com/105683/214177239-5084e255-f7b4-4ff7-8e6d-0fb48b7520ea.png)
Translated Banner image (after)
![image](https://user-images.githubusercontent.com/105683/214177341-56c6c52a-0aa9-412a-8496-d4f691df4a70.png)
Proposals FIle (after fix)
![image](https://user-images.githubusercontent.com/105683/214177843-3da92e48-d1a8-4a56-b4e6-996d0f3b734d.png)
Budgets (after):
![image](https://user-images.githubusercontent.com/105683/214177919-1fb8e4b7-f1f1-4278-a564-476723721132.png)



:hearts: Thank you!
