### PR TITLE
Backport 'Fix double parentheses in the titled upload modal with existing attachment' to v0.27

### DIFF
--- a/decidim-core/app/cells/decidim/upload_modal_cell.rb
+++ b/decidim-core/app/cells/decidim/upload_modal_cell.rb
@@ -145,11 +145,7 @@ module Decidim
     end
 
     def file_name_for(attachment)
-      filename = determine_filename(attachment)
-
-      return "(#{filename})" if has_title?
-
-      filename
+      determine_filename(attachment)
     end
 
     def determine_filename(attachment)

--- a/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
@@ -73,7 +73,8 @@ describe Decidim::UploadModal, type: :cell do
 
   context "when attachment is present" do
     let(:filename) { "Exampledocument.pdf" }
-    let(:attachments) { [upload_test_file(Decidim::Dev.test_file(filename, "application/pdf"))] }
+    let(:file) { Decidim::Dev.test_file(filename, "application/pdf") }
+    let(:attachments) { [upload_test_file(file)] }
 
     it "renders the attachments" do
       expect(subject).to have_css(".attachment-details")
@@ -85,6 +86,25 @@ describe Decidim::UploadModal, type: :cell do
 
       it "renders preview" do
         expect(subject).to have_selector("img[alt='#{attribute}']")
+      end
+    end
+
+    context "when attachment is titled" do
+      let(:attachments) { [create(:attachment, file: file)] }
+      let(:titled) { true }
+
+      before do
+        allow(form).to receive(:hidden_field).and_return(
+          %(<input type="hidden" name="#{attribute}[]" value="#{attachments[0].id}">)
+        )
+      end
+
+      it "renders the attachments" do
+        expect(subject).to have_css(".attachment-details")
+        expect(subject).to have_selector("[data-filename='#{filename}']")
+
+        details = subject.find(".attachment-details")
+        expect(details).to have_content("#{attachments[0].title["en"]} (#{filename})")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #10221 to v0.27

:hearts: Thank you!