### PR TITLE
Remove Decidim::AttachmentMethods calls

### DIFF
--- a/decidim-budgets/app/commands/decidim/budgets/admin/create_project.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/create_project.rb
@@ -6,7 +6,6 @@ module Decidim
       # This command is executed when the user creates a Project from the admin
       # panel.
       class CreateProject < Decidim::Command
-        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(form)

--- a/decidim-budgets/app/commands/decidim/budgets/admin/create_project.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/create_project.rb
@@ -6,7 +6,7 @@ module Decidim
       # This command is executed when the user creates a Project from the admin
       # panel.
       class CreateProject < Decidim::Command
-        include ::Decidim::AttachmentMethods
+        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(form)

--- a/decidim-budgets/app/commands/decidim/budgets/admin/update_project.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/update_project.rb
@@ -6,7 +6,6 @@ module Decidim
       # This command is executed when the user changes a Project from the admin
       # panel.
       class UpdateProject < Decidim::Command
-        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         # Initializes an UpdateProject Command.

--- a/decidim-budgets/app/commands/decidim/budgets/admin/update_project.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/update_project.rb
@@ -6,7 +6,7 @@ module Decidim
       # This command is executed when the user changes a Project from the admin
       # panel.
       class UpdateProject < Decidim::Command
-        include ::Decidim::AttachmentMethods
+        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         # Initializes an UpdateProject Command.

--- a/decidim-core/app/commands/decidim/attachment_methods.rb
+++ b/decidim-core/app/commands/decidim/attachment_methods.rb
@@ -17,10 +17,6 @@ module Decidim
       )
     end
 
-    def delete_attachment(attachment)
-      Attachment.find(attachment.id).delete if attachment.id.to_i == proposal.documents.first.id
-    end
-
     def attachment_invalid?
       if attachment.invalid? && attachment.errors.has_key?(:file)
         @form.attachment.errors.add :file, attachment.errors[:file]

--- a/decidim-dev/app/commands/decidim/dummy_resources/create_dummy_resource.rb
+++ b/decidim-dev/app/commands/decidim/dummy_resources/create_dummy_resource.rb
@@ -3,7 +3,7 @@
 module Decidim
   module DummyResources
     class CreateDummyResource < Decidim::Command
-      include Decidim::AttachmentMethods
+      # include Decidim::AttachmentMethods
       include Decidim::GalleryMethods
 
       def initialize(form)

--- a/decidim-dev/app/commands/decidim/dummy_resources/create_dummy_resource.rb
+++ b/decidim-dev/app/commands/decidim/dummy_resources/create_dummy_resource.rb
@@ -3,7 +3,6 @@
 module Decidim
   module DummyResources
     class CreateDummyResource < Decidim::Command
-      # include Decidim::AttachmentMethods
       include Decidim::GalleryMethods
 
       def initialize(form)

--- a/decidim-elections/app/commands/decidim/elections/admin/create_answer.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/create_answer.rb
@@ -6,7 +6,7 @@ module Decidim
       # This command is executed when the user creates an Answer
       # from the admin panel.
       class CreateAnswer < Decidim::Command
-        include ::Decidim::AttachmentMethods
+        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(form)

--- a/decidim-elections/app/commands/decidim/elections/admin/create_answer.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/create_answer.rb
@@ -6,7 +6,6 @@ module Decidim
       # This command is executed when the user creates an Answer
       # from the admin panel.
       class CreateAnswer < Decidim::Command
-        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(form)

--- a/decidim-elections/app/commands/decidim/elections/admin/create_election.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/create_election.rb
@@ -6,7 +6,6 @@ module Decidim
       # This command is executed when the user creates an Election
       # from the admin panel.
       class CreateElection < Decidim::Command
-        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(form)

--- a/decidim-elections/app/commands/decidim/elections/admin/create_election.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/create_election.rb
@@ -6,7 +6,7 @@ module Decidim
       # This command is executed when the user creates an Election
       # from the admin panel.
       class CreateElection < Decidim::Command
-        include ::Decidim::AttachmentMethods
+        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(form)

--- a/decidim-elections/app/commands/decidim/elections/admin/destroy_answer.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/destroy_answer.rb
@@ -6,7 +6,6 @@ module Decidim
       # This command is executed when the user destroys an Answer
       # from the admin panel.
       class DestroyAnswer < Decidim::Command
-        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(answer, current_user)

--- a/decidim-elections/app/commands/decidim/elections/admin/destroy_answer.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/destroy_answer.rb
@@ -6,7 +6,7 @@ module Decidim
       # This command is executed when the user destroys an Answer
       # from the admin panel.
       class DestroyAnswer < Decidim::Command
-        include ::Decidim::AttachmentMethods
+        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(answer, current_user)

--- a/decidim-elections/app/commands/decidim/elections/admin/destroy_election.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/destroy_election.rb
@@ -6,7 +6,6 @@ module Decidim
       # This command is executed when the user destroys an Election
       # from the admin panel.
       class DestroyElection < Decidim::Command
-        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(election, current_user)

--- a/decidim-elections/app/commands/decidim/elections/admin/destroy_election.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/destroy_election.rb
@@ -6,7 +6,7 @@ module Decidim
       # This command is executed when the user destroys an Election
       # from the admin panel.
       class DestroyElection < Decidim::Command
-        include ::Decidim::AttachmentMethods
+        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(election, current_user)

--- a/decidim-elections/app/commands/decidim/elections/admin/update_answer.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/update_answer.rb
@@ -6,7 +6,6 @@ module Decidim
       # This command is executed when the user updates an Answer
       # from the admin panel.
       class UpdateAnswer < Decidim::Command
-        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(form, answer)

--- a/decidim-elections/app/commands/decidim/elections/admin/update_answer.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/update_answer.rb
@@ -6,7 +6,7 @@ module Decidim
       # This command is executed when the user updates an Answer
       # from the admin panel.
       class UpdateAnswer < Decidim::Command
-        include ::Decidim::AttachmentMethods
+        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(form, answer)

--- a/decidim-elections/app/commands/decidim/elections/admin/update_election.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/update_election.rb
@@ -6,7 +6,7 @@ module Decidim
       # This command is executed when the user updates an Election
       # from the admin panel.
       class UpdateElection < Decidim::Command
-        include ::Decidim::AttachmentMethods
+        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(form, election)

--- a/decidim-elections/app/commands/decidim/elections/admin/update_election.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/update_election.rb
@@ -6,7 +6,6 @@ module Decidim
       # This command is executed when the user updates an Election
       # from the admin panel.
       class UpdateElection < Decidim::Command
-        # include ::Decidim::AttachmentMethods
         include ::Decidim::GalleryMethods
 
         def initialize(form, election)

--- a/decidim-elections/app/commands/decidim/votings/certify_polling_station_closure.rb
+++ b/decidim-elections/app/commands/decidim/votings/certify_polling_station_closure.rb
@@ -4,7 +4,7 @@ module Decidim
   module Votings
     # A command with all the business logic when signing a closure of a polling station
     class CertifyPollingStationClosure < Decidim::Command
-      include ::Decidim::AttachmentMethods
+      # include ::Decidim::AttachmentMethods
       include ::Decidim::GalleryMethods
       # Public: Initializes the command.
       #

--- a/decidim-elections/app/commands/decidim/votings/certify_polling_station_closure.rb
+++ b/decidim-elections/app/commands/decidim/votings/certify_polling_station_closure.rb
@@ -4,7 +4,6 @@ module Decidim
   module Votings
     # A command with all the business logic when signing a closure of a polling station
     class CertifyPollingStationClosure < Decidim::Command
-      # include ::Decidim::AttachmentMethods
       include ::Decidim::GalleryMethods
       # Public: Initializes the command.
       #

--- a/decidim-initiatives/app/commands/decidim/initiatives/attachment_methods.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/attachment_methods.rb
@@ -3,31 +3,9 @@
 module Decidim
   module Initiatives
     module AttachmentMethods
+      include Decidim::AttachmentMethods
+
       private
-
-      def build_attachment(attached_to = nil)
-        attached_to = @attached_to if attached_to.blank?
-        attached_to = form.current_organization if attached_to.blank? && form.respond_to?(:current_organization)
-
-        @attachment = Attachment.new(
-          title: { I18n.locale => @form.attachment.title },
-          attached_to:,
-          file: @form.attachment.file, # Define attached_to before this
-          content_type: @form.attachment.file.content_type
-        )
-      end
-
-      def attachment_invalid?
-        if attachment.invalid? && attachment.errors.has_key?(:file)
-          @form.attachment.errors.add :file, attachment.errors[:file]
-          true
-        end
-      end
-
-      def create_attachment
-        attachment.attached_to = @attached_to
-        attachment.save!
-      end
 
       def process_attachments?
         @form.attachment && @form.attachment.file.present? &&

--- a/decidim-initiatives/spec/shared/update_initiative_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_example.rb
@@ -67,10 +67,17 @@ shared_examples "update an initiative" do
       end
 
       context "when attachment is present" do
+        let(:blob) do
+          ActiveStorage::Blob.create_and_upload!(
+            io: File.open(Decidim::Dev.test_file("city.jpeg", "image/jpeg"), "rb"),
+            filename: "city.jpeg",
+            content_type: "image/jpeg" # Or figure it out from `name` if you have non-JPEGs
+          )
+        end
         let(:attachment_params) do
           {
             title: "My attachment",
-            file: Decidim::Dev.test_file("city.jpeg", "image/jpeg")
+            file: blob.signed_id
           }
         end
 

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
@@ -57,6 +57,10 @@ module Decidim
 
         attr_reader :form, :proposal, :attachment, :gallery
 
+        def delete_attachment(attachment)
+          Attachment.find(attachment.id).delete if attachment.id.to_i == proposal.documents.first.id
+        end
+
         def update_proposal
           parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: form.current_organization).rewrite
           parsed_body = Decidim::ContentProcessor.parse(form.body, current_organization: form.current_organization).rewrite

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -4,7 +4,6 @@ module Decidim
   module Proposals
     # A command with all the business logic when a user creates a new proposal.
     class CreateProposal < Decidim::Command
-      # include ::Decidim::AttachmentMethods
       include HashtagsMethods
 
       # Public: Initializes the command.

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -4,7 +4,7 @@ module Decidim
   module Proposals
     # A command with all the business logic when a user creates a new proposal.
     class CreateProposal < Decidim::Command
-      include ::Decidim::AttachmentMethods
+      # include ::Decidim::AttachmentMethods
       include HashtagsMethods
 
       # Public: Initializes the command.


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR aims to clean up various modules to remove obsolete attachment methods, that were not being used.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10285
 


:hearts: Thank you!
