### PR TITLE
Fix File attachments in proposals

### DIFF
--- a/decidim-core/app/commands/decidim/attachment_methods.rb
+++ b/decidim-core/app/commands/decidim/attachment_methods.rb
@@ -12,8 +12,8 @@ module Decidim
       @attachment = Attachment.new(
         title: { I18n.locale => @form.attachment.title },
         attached_to:,
-        file: @form.attachment.file, # Define attached_to before this
-        content_type: @form.attachment.file.content_type
+        file: signed_id_for(@form.attachment.file),
+        content_type: content_type_for(@form.attachment.file)
       )
     end
 
@@ -52,6 +52,24 @@ module Decidim
 
     def delete_attachment?
       @form.attachment&.delete_file.present?
+    end
+
+    protected
+
+    def signed_id_for(attachment)
+      return attachment[:file] if attachment.is_a?(Hash)
+
+      attachment
+    end
+
+    def content_type_for(attachment)
+      return attachment.content_type if attachment.instance_of?(ActionDispatch::Http::UploadedFile)
+
+      blob(signed_id_for(attachment)).content_type
+    end
+
+    def blob(signed_id)
+      ActiveStorage::Blob.find_signed(signed_id)
     end
   end
 end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/create_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/create_proposal_spec.rb
@@ -197,10 +197,17 @@ module Decidim
 
             context "when attachments are allowed" do
               let(:component) { create(:proposal_component, :with_attachments_allowed) }
+              let(:blob) do
+                ActiveStorage::Blob.create_and_upload!(
+                  io: File.open(Decidim::Dev.test_file("city.jpeg", "image/jpeg"), "rb"),
+                  filename: "city.jpeg",
+                  content_type: "image/jpeg" # Or figure it out from `name` if you have non-JPEGs
+                )
+              end
               let(:attachment_params) do
                 {
                   title: "My attachment",
-                  file: Decidim::Dev.test_file("city.jpeg", "image/jpeg")
+                  file: blob.signed_id
                 }
               end
 

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/update_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/update_proposal_spec.rb
@@ -112,10 +112,19 @@ describe Decidim::Proposals::Admin::UpdateProposal do
 
       context "when attachments are allowed" do
         let(:component) { create(:proposal_component, :with_attachments_allowed) }
+
+        let(:blob) do
+          ActiveStorage::Blob.create_and_upload!(
+            io: File.open(Decidim::Dev.test_file("city.jpeg", "image/jpeg"), "rb"),
+            filename: "city.jpeg",
+            content_type: "image/jpeg" # Or figure it out from `name` if you have non-JPEGs
+          )
+        end
+
         let(:attachment_params) do
           {
             title: "My attachment",
-            file: Decidim::Dev.test_file("city.jpeg", "image/jpeg")
+            file: blob.signed_id
           }
         end
 

--- a/decidim-proposals/spec/system/admin/admin_creates_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_creates_proposal_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe "Admin creates proposals", type: :system do
   let(:manifest_name) { "proposals" }
+  let(:creation_enabled?) { true }
   let!(:component) do
     create(:proposal_component,
            :with_creation_enabled,
@@ -15,6 +16,17 @@ describe "Admin creates proposals", type: :system do
   let(:new_body) { "This is my proposal new body" }
 
   include_context "when managing a component as an admin"
+
+  before do
+    component.update!(
+      settings: { official_proposals_enabled: true, attachments_allowed: true, creation_enabled: true },
+      step_settings: {
+        component.participatory_space.active_step.id => {
+          creation_enabled: creation_enabled?
+        }
+      }
+    )
+  end
 
   it "can attach a file" do
     visit_component_admin

--- a/decidim-proposals/spec/system/admin/admin_creates_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_creates_proposal_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin creates proposals", type: :system do
+  let(:manifest_name) { "proposals" }
+  let!(:component) do
+    create(:proposal_component,
+           :with_creation_enabled,
+           :with_attachments_allowed,
+           manifest:,
+           participatory_space: participatory_process)
+  end
+  let(:new_title) { "This is my proposal new title" }
+  let(:new_body) { "This is my proposal new body" }
+
+  include_context "when managing a component as an admin"
+
+  it "can attach a file" do
+    visit_component_admin
+    click_link("New proposal")
+
+    fill_in_i18n :proposal_title, "#proposal-title-tabs", en: new_title
+    fill_in_i18n_editor :proposal_body, "#proposal-body-tabs", en: new_body
+    fill_in :proposal_attachment_title, with: "FOO BAR"
+    dynamically_attach_file(:proposal_attachment_file, Decidim::Dev.asset("city.jpeg"))
+    click_button("Create")
+    find("a.action-icon--edit-proposal").click
+
+    expect(page).to have_content("city.jpeg")
+    expect(page).to have_content("FOO BAR")
+  end
+end

--- a/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
@@ -90,6 +90,24 @@ describe "Admin edits proposals", type: :system do
         find("a.action-icon--edit-proposal").click
         expect(page).to have_no_content("Current file")
       end
+
+      it "can attach a file" do
+        visit_component_admin
+        find("a.action-icon--edit-proposal").click
+        fill_in :proposal_attachment_title, with: "FOO BAR"
+
+        find("input#proposal_attachment_delete_file").set(true)
+        click_button("Replace")
+        click_button("× Remove")
+        click_button("Save")
+        dynamically_attach_file(:proposal_attachment_file, Decidim::Dev.asset("city.jpeg"))
+
+        click_button("Update")
+        find("a.action-icon--edit-proposal").click
+
+        expect(page).to have_content("city.jpeg")
+        expect(page).to have_content("FOO BAR")
+      end
     end
   end
 


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
There is an error occurring when an Admin is trying to add an optional Attachment into a Proposal even though the Proposal component is configure to allow attachment.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #10285

#### Testing
1. Go to proposal configuration admin panel
2. Enable "Allow attachments"
3. Create a Admin proposal, and attach a file 
4. Observe error 
5. Apply patch 
6. Create a Admin proposal, and attach a file 
7. See there is no error , and file is attached.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
