### PR TITLE
Add ability to pass extra attributes for authorization creation

### DIFF
--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -37,10 +37,7 @@ module Decidim
         name: handler.handler_name
       )
 
-      authorization.attributes = {
-        unique_id: handler.unique_id,
-        metadata: handler.metadata
-      }
+      authorization.attributes = handler.authorization_attributes
 
       authorization.grant!
     end

--- a/decidim-core/spec/models/decidim/authorization_spec.rb
+++ b/decidim-core/spec/models/decidim/authorization_spec.rb
@@ -114,5 +114,32 @@ module Decidim
         let(:authorization_status) { :pending }
       end
     end
+
+    describe ".create_or_update_from" do
+      subject { described_class.create_or_update_from(handler) }
+
+      let(:user) { create(:user) }
+      let(:handler_class) do
+        Class.new(Decidim::AuthorizationHandler) do
+          def authorization_attributes
+            super.merge(created_at: Time.zone.local(2022, 1, 31, 16, 21))
+          end
+
+          def handler_name
+            "foobar"
+          end
+        end
+      end
+      let(:handler) { handler_class.from_params(user:) }
+
+      let(:authorization) { Decidim::Authorization.last }
+
+      context "when the handler provides additional arguments for the authorization" do
+        it "adds the extra attributes for the created authorization" do
+          expect(subject).to be(true)
+          expect(authorization.created_at).to eq(Time.zone.local(2022, 1, 31, 16, 21))
+        end
+      end
+    end
   end
 end

--- a/decidim-verifications/app/services/decidim/authorization_handler.rb
+++ b/decidim-verifications/app/services/decidim/authorization_handler.rb
@@ -84,6 +84,13 @@ module Decidim
       "#{handler_name.sub!(/_handler$/, "")}/form"
     end
 
+    def authorization_attributes
+      {
+        unique_id:,
+        metadata:
+      }
+    end
+
     # Any data that the developer would like to inject to the `metadata` field
     # of an authorization when it's created. Can be useful if some of the
     # params the user sent with the authorization form want to be persisted for


### PR DESCRIPTION
#### :tophat: What? Why?
After we introduced the authorization metadata encryption at #6947, it became really slow trying to search through the authorizations matching the same metadata.

We need to do this as we provide two alternative ways for the users to authorize themselves:
1. Suomi.fi digital identity (e-identity), through the `decidim-suomifi` module
2. Document authorization as an alternative for people who are unable to use the digital system

When using this combined logic, we need to check that the same user has not already been identified using document authorization when using Suomi.fi and vice-versa.

We could search through the `unique_id` columns but the problem is that these are two separate authorization methods that create different `unique_id`s for the similar metadata.

Therefore, we added a new column in the `decidim_authorizations` table to be able to identify the same person across different authorization strategies. We call this column `pseudonymized_pin` (PIN = personal identity number) and we store it as-is without encryption because it's already pseudonymized which means it doesn't need encryption. This allows us to search through the database across different authorization strategies that implement the personal identity numbers similarly, as in the described use case.

So, in order to accommodate the core to store this information in the correct column, we need to provide a way for the individual authorization handlers to take control of the attributes passed to the authorization record. Therefore, this PR.

#### :pushpin: Related Issues
- Related to #6947

#### Testing
See the added spec, it should describe what we are aiming to do.

For additional context, you can take a look at this migration at the `decidim-suomifi` module where we add an extra column to the authorizations table:
https://github.com/mainio/decidim-module-suomifi/blob/master/db/migrate/20220412122947_add_pseudonimized_pin_to_authorizations.rb