### PR TITLE
Update locked Bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -841,4 +841,4 @@ RUBY VERSION
    ruby 3.1.1p18
 
 BUNDLED WITH
-   2.2.31
+   2.4.6

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -841,4 +841,4 @@ RUBY VERSION
    ruby 3.1.1p18
 
 BUNDLED WITH
-   2.2.31
+   2.4.6

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -841,4 +841,4 @@ RUBY VERSION
    ruby 3.1.1p18
 
 BUNDLED WITH
-   2.2.31
+   2.4.6


### PR DESCRIPTION
#### :tophat: What? Why?
After the recent Bundler release, we should finally have solved issues running on newer Bundler versions.

This PR only updates the locked bundler versions we are using in the Decidim repository. Just to see if we can get the `decidim-generators` specs running green.

After this is done, we can continue on updating `psych`, Rails, etc.

#### :pushpin: Related Issues
- Related to #9849
- Supersedes #9849

#### Testing
See that generators CI is green.