### PR TITLE
Fix ImageMagick errors when trying to identify image dimensions

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -78,6 +78,7 @@ en:
     'true': 'Yes'
   carrierwave:
     errors:
+      file_cannot_be_processed: File cannot be processed
       file_resolution_too_large: File resolution is too large
       file_size_too_large: File size is too large
       not_inside_organization: The file is not attached to any organization

--- a/decidim-core/spec/models/decidim/attachment_spec.rb
+++ b/decidim-core/spec/models/decidim/attachment_spec.rb
@@ -40,7 +40,10 @@ module Decidim
 
         it "shows the correct error" do
           expect(subject.valid?).to be(false)
-          expect(subject.errors[:file]).to match_array(["File cannot be processed"])
+          # Note: After update to Ubuntu 22.04, the expectation needs to be
+          # changed to the one below.
+          expect(subject.errors[:file]).to match_array(["File resolution is too large"])
+          # expect(subject.errors[:file]).to match_array(["File cannot be processed"])
         end
       end
     end

--- a/decidim-core/spec/models/decidim/attachment_spec.rb
+++ b/decidim-core/spec/models/decidim/attachment_spec.rb
@@ -37,6 +37,11 @@ module Decidim
         let(:attachment_path) { Decidim::Dev.asset("malicious.jpg") }
 
         it { is_expected.not_to be_valid }
+
+        it "shows the correct error" do
+          expect(subject.valid?).to be(false)
+          expect(subject.errors[:file]).to match_array(["File cannot be processed"])
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Newer ImageMagick versions have changed the default security policy to allow maximum image sizes of 8192 in either dimension as per:
https://imagemagick.org/script/security-policy.php

The Decidim default dev images ship an image named `malicious.jpg` originating from #334 which is testing that the Decidim is not vulnerable against the pixel flood attack:
https://hackerone.com/reports/390

The test itself is valid but we should handle the ImageMagick errors properly and rescue from them. I am adding a new error to be shown to the user in these cased: `File cannot be processed`. This makes it easier for admins to try to identify the issue why users might not be able to upload certain images than just showing `File resolution is too large` in these cases.

This should also help us towards making Decidim work out of the box with Ubuntu 22.04 and other distros alike.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #390
- Related to #10139
- Related to #10143
- Related to https://hackerone.com/reports/390

#### Testing
- Install Decidim on Ubuntu 22.04
- Try to upload the `malicious.jpg` shipped with the `decidim-dev` gem as the default user's avatar image
- See that there is no longer an error