### PR TITLE
Fix sass syntax errors

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/modules/_buttons.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_buttons.scss
@@ -257,12 +257,12 @@
 
 .button--shadow{
   $shadows: (
-    primary: shade($primary, 50),
-    secondary: shade($secondary, 50),
-    success: shade($success, 50),
-    warning: shade($warning, 50),
-    alert: shade($alert, 50),
-    muted: shade($muted, 50),
+    primary: shade($primary, 50%),
+    secondary: shade($secondary, 50%),
+    success: shade($success, 50%),
+    warning: shade($warning, 50%),
+    alert: shade($alert, 50%),
+    muted: shade($muted, 50%),
   );
 
   @include modifiers(background-color, $shadows){

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_cards.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_cards.scss
@@ -934,7 +934,7 @@ a .card__title{
   @include modifiers(
     color,
     (
-      muted: tint($muted, 50),
+      muted: tint($muted, 50%),
     )
   ){
     margin-top: -$global-margin * .95;

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_upload_modal.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_upload_modal.scss
@@ -32,10 +32,6 @@
         border-width: 2px;
         border-radius: 4px;
 
-        * >{
-          display: none;
-        }
-
         .form-error{
           margin: 0;
         }

--- a/decidim-core/app/packs/stylesheets/decidim/vizzs/_linechart.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/vizzs/_linechart.scss
@@ -36,8 +36,8 @@
   @mixin loop-colors-types($color, $max: 12){
     @for $i from 0 through ($max - 1){
       $interval: ($i % 4) * 24 + 1;
-      $tints: tint($color, $interval);
-      $shades: shade($color, $interval);
+      $tints: tint($color, $interval * 1%);
+      $shades: shade($color, $interval * 1%);
       $adjusts: adjust-color($color, $lightness: $interval * 1%, $hue: -$interval);
 
       .type-#{$i}:not(.legend){

--- a/decidim-core/app/packs/stylesheets/decidim/vizzs/_rowchart.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/vizzs/_rowchart.scss
@@ -27,8 +27,8 @@
   @mixin loop-colors-types($color, $max: 12){
     @for $i from 0 through ($max - 1){
       $interval: ($i % 4) * 24 + 1;
-      $tints: tint($color, $interval);
-      $shades: shade($color, $interval);
+      $tints: tint($color, $interval * 1%);
+      $shades: shade($color, $interval * 1%);
       $adjusts: adjust-color($color, $lightness: $interval * 1%, $hue: -$interval);
 
       .type-#{$i}{


### PR DESCRIPTION
#### :tophat: What? Why?
When building the CSS files, we have several sass syntax errors due to some deprecations added in newer versions of sass.

Most of the errors are caused by `sass-embedded` version 1.56.0 and newer as described in their changelog:

> Emit a deprecation warning when passing a $weight value with no units or with units other than % to color.mix(). This will be an error in Dart Sass 2.0.0.
>
> See [the Sass website](https://sass-lang.com/d/function-units#weight) for details.

Every time building the CSS we will see the following errors in the console:

```
Deprecation Warning: $weight: Passing a number without unit % (50) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
40 │   @return mix(black, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 40:11      shade()
    stylesheets/decidim/modules/_buttons.scss 260:14  @import
    stylesheets/decidim/modules/_modules.scss 5:9     @import
    stylesheets/decidim/_decidim.scss 16:9            @import
    stylesheets/decidim/application.scss 2:9          @import
    - 1:9                                             root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (50) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
35 │   @return mix(white, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 35:11    tint()
    stylesheets/decidim/modules/_cards.scss 937:14  @import
    stylesheets/decidim/modules/_modules.scss 22:9  @import
    stylesheets/decidim/_decidim.scss 16:9          @import
    stylesheets/decidim/application.scss 2:9        @import
    - 1:9                                           root stylesheet

Deprecation Warning: The selector ".upload-modal .dropzone-container label.dropzone * >" is only valid for nesting and shouldn't
have children other than style rules. It will be omitted from the generated CSS.
This will be an error in Dart Sass 2.0.0.

More info: https://sass-lang.com/d/bogus-combinators

   ╷
35 │         * >{
   │         ^^^ invalid selector
36 │           display: none;
   │           ━━━━━━━━━━━━━ this is not a style rule
   ╵
    stylesheets/decidim/modules/_upload_modal.scss 35:9  @import
    stylesheets/decidim/modules/_modules.scss 94:9       @import
    stylesheets/decidim/_decidim.scss 16:9               @import
    stylesheets/decidim/application.scss 2:9             @import
    - 1:9                                                root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (1) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
35 │   @return mix(white, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 35:11     tint()
    stylesheets/decidim/vizzs/_linechart.scss 39:15  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/_decidim.scss 19:9           @import
    stylesheets/decidim/application.scss 2:9         @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (1) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
40 │   @return mix(black, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 40:11     shade()
    stylesheets/decidim/vizzs/_linechart.scss 40:16  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/_decidim.scss 19:9           @import
    stylesheets/decidim/application.scss 2:9         @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (25) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
35 │   @return mix(white, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 35:11     tint()
    stylesheets/decidim/vizzs/_linechart.scss 39:15  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/_decidim.scss 19:9           @import
    stylesheets/decidim/application.scss 2:9         @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (25) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
40 │   @return mix(black, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 40:11     shade()
    stylesheets/decidim/vizzs/_linechart.scss 40:16  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/_decidim.scss 19:9           @import
    stylesheets/decidim/application.scss 2:9         @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (49) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
35 │   @return mix(white, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 35:11     tint()
    stylesheets/decidim/vizzs/_linechart.scss 39:15  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/_decidim.scss 19:9           @import
    stylesheets/decidim/application.scss 2:9         @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (49) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
40 │   @return mix(black, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 40:11     shade()
    stylesheets/decidim/vizzs/_linechart.scss 40:16  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/_decidim.scss 19:9           @import
    stylesheets/decidim/application.scss 2:9         @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (73) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
35 │   @return mix(white, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 35:11     tint()
    stylesheets/decidim/vizzs/_linechart.scss 39:15  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/_decidim.scss 19:9           @import
    stylesheets/decidim/application.scss 2:9         @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (73) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
40 │   @return mix(black, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 40:11     shade()
    stylesheets/decidim/vizzs/_linechart.scss 40:16  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/_decidim.scss 19:9           @import
    stylesheets/decidim/application.scss 2:9         @import
    - 1:9                                            root stylesheet

Deprecation Warning: The selector ".upload-modal .dropzone-container label.dropzone * >" is only valid for nesting and shouldn't
have children other than style rules. It will be omitted from the generated CSS.
This will be an error in Dart Sass 2.0.0.

More info: https://sass-lang.com/d/bogus-combinators

   ╷
35 │         * >{
   │         ^^^ invalid selector
36 │           display: none;
   │           ━━━━━━━━━━━━━ this is not a style rule
   ╵
    stylesheets/decidim/modules/_upload_modal.scss 35:9       @import
    stylesheets/decidim/admin/modules/_upload_modal.scss 1:9  @import
    stylesheets/decidim/admin/modules/_modules.scss 34:9      @import
    stylesheets/decidim/admin/_decidim.scss 17:9              @import
    stylesheets/decidim/admin/application.scss 1:9            @import
    - 1:9                                                     root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (1) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
35 │   @return mix(white, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 35:11     tint()
    stylesheets/decidim/vizzs/_linechart.scss 39:15  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/vizzs.scss 8:9               @import
    stylesheets/decidim/admin/_decidim.scss 22:9     @import
    stylesheets/decidim/admin/application.scss 1:9   @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (1) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
40 │   @return mix(black, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 40:11     shade()
    stylesheets/decidim/vizzs/_linechart.scss 40:16  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/vizzs.scss 8:9               @import
    stylesheets/decidim/admin/_decidim.scss 22:9     @import
    stylesheets/decidim/admin/application.scss 1:9   @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (25) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
35 │   @return mix(white, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 35:11     tint()
    stylesheets/decidim/vizzs/_linechart.scss 39:15  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/vizzs.scss 8:9               @import
    stylesheets/decidim/admin/_decidim.scss 22:9     @import
    stylesheets/decidim/admin/application.scss 1:9   @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (25) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
40 │   @return mix(black, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 40:11     shade()
    stylesheets/decidim/vizzs/_linechart.scss 40:16  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/vizzs.scss 8:9               @import
    stylesheets/decidim/admin/_decidim.scss 22:9     @import
    stylesheets/decidim/admin/application.scss 1:9   @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (49) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
35 │   @return mix(white, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 35:11     tint()
    stylesheets/decidim/vizzs/_linechart.scss 39:15  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/vizzs.scss 8:9               @import
    stylesheets/decidim/admin/_decidim.scss 22:9     @import
    stylesheets/decidim/admin/application.scss 1:9   @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (49) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
40 │   @return mix(black, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 40:11     shade()
    stylesheets/decidim/vizzs/_linechart.scss 40:16  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/vizzs.scss 8:9               @import
    stylesheets/decidim/admin/_decidim.scss 22:9     @import
    stylesheets/decidim/admin/application.scss 1:9   @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (73) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
35 │   @return mix(white, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 35:11     tint()
    stylesheets/decidim/vizzs/_linechart.scss 39:15  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/vizzs.scss 8:9               @import
    stylesheets/decidim/admin/_decidim.scss 22:9     @import
    stylesheets/decidim/admin/application.scss 1:9   @import
    - 1:9                                            root stylesheet

Deprecation Warning: $weight: Passing a number without unit % (73) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
40 │   @return mix(black, $color, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    stylesheets/decidim/utils/_mixins.scss 40:11     shade()
    stylesheets/decidim/vizzs/_linechart.scss 40:16  loop-colors-types()
    stylesheets/decidim/vizzs/_linechart.scss 104:3  @import
    stylesheets/decidim/vizzs/_vizzs.scss 3:9        @import
    stylesheets/decidim/vizzs.scss 8:9               @import
    stylesheets/decidim/admin/_decidim.scss 22:9     @import
    stylesheets/decidim/admin/application.scss 1:9   @import
    - 1:9                                            root stylesheet

34% building 33/74 entries 1102/1177 dependencies 424/705 modulesDeprecation Warning: The selector ".upload-modal .dropzone-container label.dropzone * >" is only valid for nesting and shouldn't
have children other than style rules. It will be omitted from the generated CSS.
This will be an error in Dart Sass 2.0.0.

More info: https://sass-lang.com/d/bogus-combinators

   ╷
35 │         * >{
   │         ^^^ invalid selector
36 │           display: none;
   │           ━━━━━━━━━━━━━ this is not a style rule
   ╵
    stylesheets/decidim/modules/_upload_modal.scss 35:9  @import
    stylesheets/decidim/system/application.scss 18:9     @import
    - 1:9                                                root stylesheet

```

This fixes these errors.

#### :pushpin: Related Issues

- Related to https://github.com/sass/dart-sass-embedded/blob/main/CHANGELOG.md#1560
  * See changes at version 1.56.0

#### Testing
Run the `webpack-dev-server` with this patch applied.

You should expect to see no deprecation warnings or build errors in the console.