### PR TITLE
Fix typo with package-lock.json in Webpacker instance migration guide

### DIFF
--- a/docs/modules/develop/pages/guide_migrate_webpacker_app.adoc
+++ b/docs/modules/develop/pages/guide_migrate_webpacker_app.adoc
@@ -244,7 +244,7 @@ In some case it might be that some packages are not well resolved when installin
 ...
 ----
 
-These might be due some kind of corruption in your `package-json.lock` file, you can try either to remove this file and recreate it with `npm install` or to add the package `@rails/webpacker` manually in your `package.json` file next to the `@decidim/webpacker` package:
+These might be due some kind of corruption in your `package-lock.json` file, you can try either to remove this file and recreate it with `npm install` or to add the package `@rails/webpacker` manually in your `package.json` file next to the `@decidim/webpacker` package:
 
 [source,json]
 ----


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Fix a typo I figured it out while following the guide to update an instance.

:hearts: Thank you!
