### PR TITLE
Fix "No activity" message in Last Activities isn't shown sometimes

### DIFF
--- a/decidim-core/app/cells/decidim/activities_cell.rb
+++ b/decidim-core/app/cells/decidim/activities_cell.rb
@@ -27,13 +27,7 @@ module Decidim
     end
 
     def activities
-      @activities ||= last_activities.select do |activity|
-        activity.visible_for?(current_user)
-      end
-    end
-
-    def last_activities
-      @last_activities ||= model.map do |activity|
+      @activities ||= model.map do |activity|
         activity.organization_lazy
         activity.resource_lazy
         activity.participatory_space_lazy

--- a/decidim-core/app/cells/decidim/content_blocks/last_activity_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/last_activity_cell.rb
@@ -56,7 +56,7 @@ module Decidim
       end
 
       def activities
-        @activities ||= LastActivity.new(current_organization).query.limit(activities_to_show * 6)
+        @activities ||= LastActivity.new(current_organization, current_user:).query.limit(activities_to_show * 6)
       end
 
       def activities_to_show

--- a/decidim-core/app/controllers/decidim/last_activities_controller.rb
+++ b/decidim-core/app/controllers/decidim/last_activities_controller.rb
@@ -32,7 +32,7 @@ module Decidim
     end
 
     def search_collection
-      LastActivity.new(current_organization).query
+      LastActivity.new(current_organization, current_user:).query
     end
 
     def default_filter_params

--- a/decidim-core/app/queries/decidim/last_activity.rb
+++ b/decidim-core/app/queries/decidim/last_activity.rb
@@ -7,17 +7,89 @@ module Decidim
   # and also in the "Last activities" page, to retrieve public activity of this
   # organization.
   class LastActivity < Decidim::Query
-    def initialize(organization)
+    def initialize(organization, options = {})
       @organization = organization
+      @current_user = options[:current_user]
     end
 
     def query
+      @query ||= begin
+        query = base_query
+        query = filter_moderated(query)
+        query = filter_spaces(query)
+        query = filter_deleted(query)
+        query.with_new_resource_type("all")
+      end
+    end
+
+    private
+
+    attr_reader :organization, :current_user
+
+    def filter_deleted(query)
+      conditions = []
+
+      ActionLog.public_resource_types.each do |resource_type|
+        klass = resource_type.constantize
+
+        condition = if klass.respond_to?(:not_deleted)
+                      Arel.sql(
+                        [
+                          "decidim_action_logs.resource_type = '#{resource_type}'",
+                          "decidim_action_logs.resource_id IN (#{Arel.sql(klass.not_deleted.select(:id).to_sql)})"
+                        ].join(" AND ")
+                      ).to_s
+                    else
+                      Arel.sql("decidim_action_logs.resource_type = '#{resource_type}'").to_s
+                    end
+
+        conditions << "(#{condition})"
+      end
+
+      query.where(Arel.sql(conditions.join(" OR ")).to_s)
+    end
+
+    def filter_spaces(query)
+      conditions = []
+
+      Decidim.participatory_space_manifests.map do |manifest|
+        klass = manifest.model_class_name.constantize
+
+        condition = if klass.include?(Decidim::HasPrivateUsers)
+                      Arel.sql(
+                        [
+                          "decidim_action_logs.participatory_space_type = '#{manifest.model_class_name}'",
+                          "decidim_action_logs.participatory_space_id IN (#{Arel.sql(klass.visible_for(current_user).select(:id).to_sql)})"
+                        ].join(" AND ")
+                      ).to_s
+                    else
+                      Arel.sql("decidim_action_logs.participatory_space_type = '#{manifest.model_class_name}'").to_s
+                    end
+
+        conditions << "(#{condition})"
+      end
+      query.where(Arel.sql(conditions.join(" OR ")).to_s)
+    end
+
+    def visibility
+      %w(public-only all)
+    end
+
+    def filter_moderated(query)
+      # Filter out the items that have been moderated.
+      query.joins(
+        <<~SQL.squish
+          LEFT JOIN decidim_moderations
+            ON decidim_moderations.decidim_reportable_type = decidim_action_logs.resource_type
+            AND decidim_moderations.decidim_reportable_id = decidim_action_logs.resource_id
+            AND decidim_moderations.hidden_at IS NOT NULL
+      SQL
+      ).where(decidim_moderations: { id: nil })
+    end
+
+    def base_query
       ActionLog
-        .where(
-          organization: @organization,
-          visibility: %w(public-only all)
-        )
-        .with_new_resource_type("all")
+        .where(organization:, visibility:)
         .order(created_at: :desc)
     end
   end

--- a/decidim-core/app/queries/decidim/public_activities.rb
+++ b/decidim-core/app/queries/decidim/public_activities.rb
@@ -22,7 +22,7 @@ module Decidim
   #   contained in any of them as spaces.
   # :scopes - a collection of `Decidim::Scope`. It will return any activity that
   #   took place in any of those scopes.
-  class PublicActivities < Decidim::Query
+  class PublicActivities < LastActivity
     def initialize(organization, options = {})
       @organization = organization
       @resource_name = options[:resource_name]
@@ -33,26 +33,19 @@ module Decidim
     end
 
     def query
-      query = ActionLog
-              .where(visibility:)
-              .where(organization:)
+      query = base_query
 
       query = query.where(user:) if user
       query = query.where(resource_type: resource_name) if resource_name.present?
 
       query = filter_follows(query)
-      query = filter_hidden(query)
-
-      query.order(created_at: :desc)
+      query = filter_moderated(query)
+      filter_spaces(query)
     end
 
     private
 
-    attr_reader :organization, :resource_name, :user, :current_user, :follows, :scopes
-
-    def visibility
-      %w(public-only all)
-    end
+    attr_reader :resource_name, :user, :follows, :scopes
 
     def filter_follows(query)
       conditions = []
@@ -77,51 +70,6 @@ module Decidim
       end
 
       query.where(chained_conditions)
-    end
-
-    def filter_hidden(query)
-      # Filter out the items that have been moderated.
-      query = query.joins(
-        <<~SQL.squish
-          LEFT JOIN decidim_moderations
-            ON decidim_moderations.decidim_reportable_type = decidim_action_logs.resource_type
-            AND decidim_moderations.decidim_reportable_id = decidim_action_logs.resource_id
-            AND decidim_moderations.hidden_at IS NOT NULL
-        SQL
-      ).where(decidim_moderations: { id: nil })
-
-      # Filter out the private space items that should not be visible for the
-      # current user.
-      current_user_id = current_user&.id.to_i
-      Decidim.participatory_space_manifests.map do |manifest|
-        klass = manifest.model_class_name.constantize
-        next unless klass.include?(Decidim::HasPrivateUsers)
-
-        table = klass.table_name
-        query = query.joins(
-          Arel.sql(
-            <<~SQL.squish
-              LEFT JOIN #{table}
-                ON decidim_action_logs.participatory_space_type = '#{manifest.model_class_name}'
-                AND #{table}.id = decidim_action_logs.participatory_space_id
-              LEFT JOIN decidim_participatory_space_private_users AS #{manifest.name}_private_users
-                ON #{manifest.name}_private_users.privatable_to_type = '#{manifest.model_class_name}'
-                AND #{table}.id = #{manifest.name}_private_users.privatable_to_id
-                AND #{table}.private_space = 't'
-            SQL
-          ).to_s
-        ).where(
-          Arel.sql(
-            <<~SQL.squish
-              #{table}.id IS NULL OR
-              #{table}.private_space = 'f' OR
-              #{manifest.name}_private_users.decidim_user_id = #{current_user_id}
-            SQL
-          ).to_s
-        )
-      end
-
-      query
     end
 
     def followed_users_conditions(follows)

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -654,7 +654,8 @@ FactoryBot.define do
 
     organization { user.organization }
     user
-    participatory_space { resource.try(:participatory_space) || resource.try(:component).try(:participatory_space) }
+    participatory_space { build :participatory_process, organization: }
+    component { build(:component, participatory_space:) }
     resource { build(:dummy_resource, component:) }
     action { "create" }
     visibility { "admin-only" }
@@ -677,6 +678,11 @@ FactoryBot.define do
           nickname: user.try(:nickname)
         }.compact
       }.deep_merge(extra_data)
+    end
+    after(:build) do |action_log, evaluator|
+      if action_log.participatory_space != action_log.try(:resource).try(:participatory_space)
+        action_log.participatory_space = action_log.try(:resource).try(:participatory_space)
+      end
     end
   end
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -654,8 +654,7 @@ FactoryBot.define do
 
     organization { user.organization }
     user
-    participatory_space { build :participatory_process, organization: }
-    component { build :component, participatory_space: }
+    participatory_space { resource.try(:participatory_space) || resource.try(:component).try(:participatory_space) }
     resource { build(:dummy_resource, component:) }
     action { "create" }
     visibility { "admin-only" }

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -679,11 +679,6 @@ FactoryBot.define do
         }.compact
       }.deep_merge(extra_data)
     end
-    after(:build) do |action_log, evaluator|
-      if action_log.participatory_space != action_log.try(:resource).try(:participatory_space)
-        action_log.participatory_space = action_log.try(:resource).try(:participatory_space)
-      end
-    end
   end
 
   factory :oauth_application, class: "Decidim::OAuthApplication" do

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -129,6 +129,7 @@ describe "Last activity", type: :system do
 
         it "does not show the activities" do
           expect(page).to have_css("[data-activity]", count: 0)
+          expect(page).to have_content "No activity"
         end
       end
     end

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -7,16 +7,31 @@ describe "Last activity", type: :system do
   let(:commentable) { create(:dummy_resource, component:) }
   let(:comment) { create(:comment, commentable:) }
   let!(:action_log) do
-    create(:action_log, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: comment, organization:)
+    create(:action_log,
+           created_at: 1.day.ago,
+           visibility: "public-only",
+           participatory_space: comment.participatory_space,
+           resource: comment,
+           organization:)
+  end
+  let!(:another_action_log) do
+    create(:action_log,
+           created_at: 2.days.ago,
+           visibility: "public-only",
+           participatory_space: another_comment.participatory_space,
+           resource: another_comment,
+           organization:)
   end
   let!(:other_action_log) do
-    create(:action_log, action: "publish", visibility: "all", resource:, organization:)
+    create(:action_log,
+           action: "publish",
+           visibility: "all",
+           resource:,
+           participatory_space: resource.participatory_space,
+           organization:)
   end
   let(:long_body_comment) { "This is my very long comment for Last Activity card that must be shorten up because is more than 100 chars" }
   let(:another_comment) { create(:comment, body: long_body_comment) }
-  let!(:another_action_log) do
-    create(:action_log, created_at: 2.days.ago, action: "create", visibility: "public-only", resource: another_comment, organization:)
-  end
   let(:component) do
     create(:component, :published, organization:)
   end

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -121,9 +121,9 @@ describe "Last activity", type: :system do
 
       context "when there are activities from private spaces" do
         before do
-          component.participatory_space.update(private_space: true)
-          comment.participatory_space.update(private_space: true)
-          another_comment.participatory_space.update(private_space: true)
+          Decidim::ActionLog.find_each do |action_log|
+            action_log.participatory_space.update(private_space: true)
+          end
           visit current_path
         end
 

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -10,7 +10,7 @@ describe "Last activity", type: :system do
     create(:action_log, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: comment, organization:)
   end
   let!(:other_action_log) do
-    create(:action_log, action: "publish", visibility: "all", resource:, organization:, participatory_space: component.participatory_space)
+    create(:action_log, action: "publish", visibility: "all", resource:, organization:)
   end
   let(:long_body_comment) { "This is my very long comment for Last Activity card that must be shorten up because is more than 100 chars" }
   let(:another_comment) { create(:comment, body: long_body_comment) }
@@ -121,9 +121,13 @@ describe "Last activity", type: :system do
 
       context "when there are activities from private spaces" do
         before do
-          Decidim::ActionLog.find_each do |action_log|
-            action_log.participatory_space.update(private_space: true)
-          end
+          comment.update(body: { es: "this is a private comment" })
+          another_comment.update(body: { es: "this is another private comment" })
+
+          component.participatory_space.update(private_space: true)
+          comment.participatory_space.update(private_space: true)
+          another_comment.participatory_space.update(private_space: true)
+
           visit current_path
         end
 


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
As per #10384 has been described that participatory spaces do not display any activity cards, nor the message there are no activities. 
This Pr fixes this. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10384

#### Testing
1. Go to last activities page 
2. Select a participatory space
3. See there is no message 
4. Apply the patch 
5. refresh the page and see the improvement

:hearts: Thank you!
