### PR TITLE
Fix survey conditional display

### DIFF
--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -59,14 +59,12 @@ module Decidim
       end
 
       def display_conditions_fulfilled?
-        return true if mandatory_conditions_fulfilled?
+        return optional_conditions_fulfilled? unless question.display_conditions.where(mandatory: true).any?
 
-        optional_conditions_fulfilled?
+        mandatory_conditions_fulfilled?
       end
 
       def mandatory_conditions_fulfilled?
-        return false unless question.display_conditions.where(mandatory: true).any?
-
         question.display_conditions.where(mandatory: true).all? do |condition|
           answer = context.responses&.find { |r| r.question_id&.to_i == condition.condition_question.id }
           condition.fulfilled?(answer)

--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -59,7 +59,24 @@ module Decidim
       end
 
       def display_conditions_fulfilled?
-        question.display_conditions.all? do |condition|
+        return true if mandatory_conditions_fulfilled?
+
+        optional_conditions_fulfilled?
+      end
+
+      def mandatory_conditions_fulfilled?
+        return false unless question.display_conditions.where(mandatory: true).any?
+
+        question.display_conditions.where(mandatory: true).all? do |condition|
+          answer = context.responses&.find { |r| r.question_id&.to_i == condition.condition_question.id }
+          condition.fulfilled?(answer)
+        end
+      end
+
+      def optional_conditions_fulfilled?
+        return true unless question.display_conditions.where(mandatory: false).any?
+
+        question.display_conditions.where(mandatory: false).any? do |condition|
           answer = context.responses&.find { |r| r.question_id&.to_i == condition.condition_question.id }
           condition.fulfilled?(answer)
         end

--- a/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
@@ -4,6 +4,8 @@ module Decidim
   module Forms
     # This class holds a Form to answer a questionnaire from Decidim's public page.
     class QuestionnaireForm < Decidim::Form
+      include ActiveModel::Validations::Callbacks
+
       # as questionnaire uses "answers" for the database relationships is
       # important not to use the same word here to avoid querying all the entries, resulting in a high performance penalty
       attribute :responses, Array[AnswerForm]
@@ -11,6 +13,8 @@ module Decidim
       attribute :public_participation, Boolean, default: false
 
       attribute :tos_agreement, Boolean
+
+      before_validation :before_validation
 
       validates :tos_agreement, allow_nil: false, acceptance: true
       validate :session_token_in_context

--- a/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
+++ b/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
@@ -196,10 +196,10 @@ module Decidim
 
         context "when display_conditions are not mandatory on the same question but are fulfilled" do
           let(:questionnaire_conditionned) { create(:questionnaire, questionnaire_for: participatory_process) }
-          let!(:option1) { create :answer_option, question: }
-          let!(:option2) { create :answer_option, question: }
-          let!(:option3) { create :answer_option, question: }
-          let!(:question) do
+          let!(:option1) { create :answer_option, question: condition_question }
+          let!(:option2) { create :answer_option, question: condition_question }
+          let!(:option3) { create :answer_option, question: condition_question }
+          let!(:condition_question) do
             create(
               :questionnaire_question,
               questionnaire: questionnaire_conditionned,
@@ -207,9 +207,9 @@ module Decidim
               question_type: "single_option"
             )
           end
-          let!(:condition_question) { create(:questionnaire_question, questionnaire: questionnaire_conditionned, question_type: "short_answer") }
-          let!(:display_condition) { create(:display_condition, question:, condition_question:, condition_type: :equal, answer_option: option1) }
-          let!(:display_condition2) { create(:display_condition, question:, condition_question:, condition_type: :equal, answer_option: option3) }
+          let!(:question) { create(:questionnaire_question, questionnaire: questionnaire_conditionned, question_type: "short_answer") }
+          let!(:display_condition) { create(:display_condition, question:, condition_question:, condition_type: :equal, answer_option: option1, mandatory: false) }
+          let!(:display_condition2) { create(:display_condition, question:, condition_question:, condition_type: :equal, answer_option: option3, mandatory: false) }
           let(:form_params) do
             {
               "responses" => [
@@ -217,11 +217,11 @@ module Decidim
                   "choices" => [
                     { "body" => option1.body, "answer_option_id" => option1.id }
                   ],
-                  "question_id" => question.id
+                  "question_id" => condition_question.id
                 },
                 {
                   "body" => "answer_test",
-                  "question_id" => condition_question.id
+                  "question_id" => question.id
                 }
               ],
               "tos_agreement" => "1"


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
*Please describe your pull request.*
This PR fixes the behaviour of display conditions regarding the saves in db : 
It was considerating every condition as mandatory, and the responses were not linked in the context.
It now works well.

It appears that since the 0.27, every question with a display condition was never saved in db.
They now are

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10238 

#### Testing
*Describe the best way to test or validate your PR.*

- Open answers on a questionnaire
- Check it contains display conditions
- Answer 100% of the questionnaire
- Check answers
- See you have 100% of the questionnaire completed

:hearts: Thank you!
