### PR TITLE
Update sass-embedded NPM package

### DIFF
--- a/decidim_app-design/package-lock.json
+++ b/decidim_app-design/package-lock.json
@@ -1758,6 +1758,11 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.0.0.tgz",
+      "integrity": "sha512-oH3jHBrZ6to8Qf4zLg7O8KqSY42kQZNBRXJRMp5uSi0mqE4L8NbyMnZHeOsbXmTb0xpptRyH11LfS+KeVhXzAA=="
+    },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -8150,11 +8155,6 @@
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/google-protobuf": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
-      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw=="
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
@@ -15128,12 +15128,12 @@
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.57.1.tgz",
-      "integrity": "sha512-O0s796x76bRSJIdmJ4lrK+zJLtF3XeP+0tbJzR4NAPSDnWqHLk2boUYSdfx4DnF4x9rGmcVlMWFE8UvnLMNCmw==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.58.3.tgz",
+      "integrity": "sha512-PKU971G3mRgHfimkUJ9rGcYNkviz36muU/QtxTfkPB/YLWyVwHmlU+vvZ7WsBiauvWJapEwAoBDdJ5FlTYm3lQ==",
       "dependencies": {
+        "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
-        "google-protobuf": "^3.11.4",
         "immutable": "^4.0.0",
         "rxjs": "^7.4.0",
         "supports-color": "^8.1.1"
@@ -15142,20 +15142,20 @@
         "node": ">=14.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-darwin-arm64": "1.57.1",
-        "sass-embedded-darwin-x64": "1.57.1",
-        "sass-embedded-linux-arm": "1.57.1",
-        "sass-embedded-linux-arm64": "1.57.1",
-        "sass-embedded-linux-ia32": "1.57.1",
-        "sass-embedded-linux-x64": "1.57.1",
-        "sass-embedded-win32-ia32": "1.57.1",
-        "sass-embedded-win32-x64": "1.57.1"
+        "sass-embedded-darwin-arm64": "1.58.3",
+        "sass-embedded-darwin-x64": "1.58.3",
+        "sass-embedded-linux-arm": "1.58.3",
+        "sass-embedded-linux-arm64": "1.58.3",
+        "sass-embedded-linux-ia32": "1.58.3",
+        "sass-embedded-linux-x64": "1.58.3",
+        "sass-embedded-win32-ia32": "1.58.3",
+        "sass-embedded-win32-x64": "1.58.3"
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.57.1.tgz",
-      "integrity": "sha512-YSfrLZkM2HdXETQdSznv2DN2GdkmBNWLAlHfDWe0toSEIB2C2YGuoqHYZtl6PBYqu8k8FH4TDyct8VzoIa+rMw==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.58.3.tgz",
+      "integrity": "sha512-6CrksxvM10xKAQJX3KTJzrW6gfz21ExxUQnV6w5Ggje0adsq+QQu+BBgoPO2ziBVq+UiupcP7apcbmEHvyuZ7w==",
       "cpu": [
         "arm64"
       ],
@@ -15168,9 +15168,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.57.1.tgz",
-      "integrity": "sha512-xq2Au8CRLHQ+MqH2p8gQn9rYGtfQ8voCWMRz7klYmmh5kXHFjefG3opPPB8mJeSc3SIqE35SQxQEIhUbsxozpg==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.58.3.tgz",
+      "integrity": "sha512-clajXOWN0YP/WItxZJnmAvIiUBts6G28X8Oy/TPcNNzRSwRORHyHXKetbTazULWAkaSBJFFg95aP8sqJvmo+Iw==",
       "cpu": [
         "x64"
       ],
@@ -15183,9 +15183,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.57.1.tgz",
-      "integrity": "sha512-s+roBIgiQSg8124JmYmiSw4THWRvkF2BOclBZCb+OFLa8ZTak2WZdGs0PhqkMmZypxQ7cewh9ts+sOWN24yIrw==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.58.3.tgz",
+      "integrity": "sha512-FhXfAkeVIqClbSziaMWENjy4CJNeZlKVHTML037hVyxntWAmi86OJ9+J13QmlDILiB8bw9BSpRJEkly8O15Tzw==",
       "cpu": [
         "arm"
       ],
@@ -15198,9 +15198,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.57.1.tgz",
-      "integrity": "sha512-R0GqVqf0xEhQ5nDbj7vqmKw+/1kqiURNBl0pD4uv4inBed2YKg+7agn7Y5XE5GUWbgOz7ubjL2kt4Glr7K7xeA==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.58.3.tgz",
+      "integrity": "sha512-dDaYRmV2vWxxZTiVFosfcgA6qJ+VEmHCFIO2XPO03W+uUmIGxa0G9oxdWxhLWjtUu2Z4R57sKKLj3eHI8Lj38Q==",
       "cpu": [
         "arm64"
       ],
@@ -15213,9 +15213,9 @@
       }
     },
     "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.57.1.tgz",
-      "integrity": "sha512-gKqMpfcjrW4S1m+cuRn88oUkr/HMv48CqyCHnfGCsrkTpIft33a1ZKW2jWm09rwmR0g/G6yGstoQO0iHWJWxuQ==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.58.3.tgz",
+      "integrity": "sha512-UClCoXgaLNGHTLBRqUTQAgQXZQFkrGIaWVLIfkVN2AEyLmYJzZ31bQfq1B6mLZPBANuFQaeg3eOcdCTpNaXaOg==",
       "cpu": [
         "ia32"
       ],
@@ -15228,9 +15228,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.57.1.tgz",
-      "integrity": "sha512-AI6CrcuLWP22RXhVrZUN2JfdQ7YdFR30dA4twYwp/Q4hUfj85dJrVD5ORi8G04haMWPOQiFV6pBcMgzpiY2Bog==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.58.3.tgz",
+      "integrity": "sha512-/waLcKwkWQp4QJrNz6EqTS44IdGYup5TGh/qmv3iz9UeL4LtgeM4lVHrFsknsF7viDPLuCOARdrHNSjqKkLRPw==",
       "cpu": [
         "x64"
       ],
@@ -15243,9 +15243,9 @@
       }
     },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.57.1.tgz",
-      "integrity": "sha512-s7EhJLG9AnJNBga3I+W0rk6y/1n/i0XD34rvqR3yJgBhNKkI5rVCxFN7FAcGR50vQQbCO1MrUCmuVvld+2qvyQ==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.58.3.tgz",
+      "integrity": "sha512-T6QYEf1NUDZY+9htvE7Zn9/Ixg0bXGQ54NcHBRSkyVY2n2KBLwQ2ZKp48AlSNxsvJiSOb9lqDE4U7VjH7WJSXg==",
       "cpu": [
         "ia32"
       ],
@@ -15258,9 +15258,9 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.57.1.tgz",
-      "integrity": "sha512-b/Kgz7ADPTlPITk8e47Zf3eiuXlTGhi/eWsAoesUmkjR7jayvFNLHPhThgiRAxkzT6UlWI3Dzr+E3OBqUjegEg==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.58.3.tgz",
+      "integrity": "sha512-Jc6Q1Rx5+cxk/yIsI8trkpNQEHjVM9I65p7ArpCLfMU33YRQWUm35QCFH2Szaue3HnTtwXl3ZDQdgo0ZHCHLzg==",
       "cpu": [
         "x64"
       ],
@@ -18233,7 +18233,7 @@
         "postcss-loader": "^6.2.1",
         "postcss-preset-env": "^7.1.0",
         "postcss-scss": "^4.0.2",
-        "sass-embedded": "~1.57.1",
+        "sass-embedded": "^1.58.3",
         "source-map-loader": "^0.2.4",
         "style-loader": "^3.0.0",
         "tailwindcss": "^3.0.24",
@@ -20832,6 +20832,11 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@bufbuild/protobuf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.0.0.tgz",
+      "integrity": "sha512-oH3jHBrZ6to8Qf4zLg7O8KqSY42kQZNBRXJRMp5uSi0mqE4L8NbyMnZHeOsbXmTb0xpptRyH11LfS+KeVhXzAA=="
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -21136,7 +21141,7 @@
         "postcss-loader": "^6.2.1",
         "postcss-preset-env": "^7.1.0",
         "postcss-scss": "^4.0.2",
-        "sass-embedded": "~1.57.1",
+        "sass-embedded": "^1.58.3",
         "source-map-loader": "^0.2.4",
         "style-loader": "^3.0.0",
         "tailwindcss": "^3.0.24",
@@ -26892,11 +26897,6 @@
       "dev": true,
       "peer": true
     },
-    "google-protobuf": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
-      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw=="
-    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -31989,22 +31989,22 @@
       }
     },
     "sass-embedded": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.57.1.tgz",
-      "integrity": "sha512-O0s796x76bRSJIdmJ4lrK+zJLtF3XeP+0tbJzR4NAPSDnWqHLk2boUYSdfx4DnF4x9rGmcVlMWFE8UvnLMNCmw==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.58.3.tgz",
+      "integrity": "sha512-PKU971G3mRgHfimkUJ9rGcYNkviz36muU/QtxTfkPB/YLWyVwHmlU+vvZ7WsBiauvWJapEwAoBDdJ5FlTYm3lQ==",
       "requires": {
+        "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
-        "google-protobuf": "^3.11.4",
         "immutable": "^4.0.0",
         "rxjs": "^7.4.0",
-        "sass-embedded-darwin-arm64": "1.57.1",
-        "sass-embedded-darwin-x64": "1.57.1",
-        "sass-embedded-linux-arm": "1.57.1",
-        "sass-embedded-linux-arm64": "1.57.1",
-        "sass-embedded-linux-ia32": "1.57.1",
-        "sass-embedded-linux-x64": "1.57.1",
-        "sass-embedded-win32-ia32": "1.57.1",
-        "sass-embedded-win32-x64": "1.57.1",
+        "sass-embedded-darwin-arm64": "1.58.3",
+        "sass-embedded-darwin-x64": "1.58.3",
+        "sass-embedded-linux-arm": "1.58.3",
+        "sass-embedded-linux-arm64": "1.58.3",
+        "sass-embedded-linux-ia32": "1.58.3",
+        "sass-embedded-linux-x64": "1.58.3",
+        "sass-embedded-win32-ia32": "1.58.3",
+        "sass-embedded-win32-x64": "1.58.3",
         "supports-color": "^8.1.1"
       },
       "dependencies": {
@@ -32024,51 +32024,51 @@
       }
     },
     "sass-embedded-darwin-arm64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.57.1.tgz",
-      "integrity": "sha512-YSfrLZkM2HdXETQdSznv2DN2GdkmBNWLAlHfDWe0toSEIB2C2YGuoqHYZtl6PBYqu8k8FH4TDyct8VzoIa+rMw==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.58.3.tgz",
+      "integrity": "sha512-6CrksxvM10xKAQJX3KTJzrW6gfz21ExxUQnV6w5Ggje0adsq+QQu+BBgoPO2ziBVq+UiupcP7apcbmEHvyuZ7w==",
       "optional": true
     },
     "sass-embedded-darwin-x64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.57.1.tgz",
-      "integrity": "sha512-xq2Au8CRLHQ+MqH2p8gQn9rYGtfQ8voCWMRz7klYmmh5kXHFjefG3opPPB8mJeSc3SIqE35SQxQEIhUbsxozpg==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.58.3.tgz",
+      "integrity": "sha512-clajXOWN0YP/WItxZJnmAvIiUBts6G28X8Oy/TPcNNzRSwRORHyHXKetbTazULWAkaSBJFFg95aP8sqJvmo+Iw==",
       "optional": true
     },
     "sass-embedded-linux-arm": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.57.1.tgz",
-      "integrity": "sha512-s+roBIgiQSg8124JmYmiSw4THWRvkF2BOclBZCb+OFLa8ZTak2WZdGs0PhqkMmZypxQ7cewh9ts+sOWN24yIrw==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.58.3.tgz",
+      "integrity": "sha512-FhXfAkeVIqClbSziaMWENjy4CJNeZlKVHTML037hVyxntWAmi86OJ9+J13QmlDILiB8bw9BSpRJEkly8O15Tzw==",
       "optional": true
     },
     "sass-embedded-linux-arm64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.57.1.tgz",
-      "integrity": "sha512-R0GqVqf0xEhQ5nDbj7vqmKw+/1kqiURNBl0pD4uv4inBed2YKg+7agn7Y5XE5GUWbgOz7ubjL2kt4Glr7K7xeA==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.58.3.tgz",
+      "integrity": "sha512-dDaYRmV2vWxxZTiVFosfcgA6qJ+VEmHCFIO2XPO03W+uUmIGxa0G9oxdWxhLWjtUu2Z4R57sKKLj3eHI8Lj38Q==",
       "optional": true
     },
     "sass-embedded-linux-ia32": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.57.1.tgz",
-      "integrity": "sha512-gKqMpfcjrW4S1m+cuRn88oUkr/HMv48CqyCHnfGCsrkTpIft33a1ZKW2jWm09rwmR0g/G6yGstoQO0iHWJWxuQ==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.58.3.tgz",
+      "integrity": "sha512-UClCoXgaLNGHTLBRqUTQAgQXZQFkrGIaWVLIfkVN2AEyLmYJzZ31bQfq1B6mLZPBANuFQaeg3eOcdCTpNaXaOg==",
       "optional": true
     },
     "sass-embedded-linux-x64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.57.1.tgz",
-      "integrity": "sha512-AI6CrcuLWP22RXhVrZUN2JfdQ7YdFR30dA4twYwp/Q4hUfj85dJrVD5ORi8G04haMWPOQiFV6pBcMgzpiY2Bog==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.58.3.tgz",
+      "integrity": "sha512-/waLcKwkWQp4QJrNz6EqTS44IdGYup5TGh/qmv3iz9UeL4LtgeM4lVHrFsknsF7viDPLuCOARdrHNSjqKkLRPw==",
       "optional": true
     },
     "sass-embedded-win32-ia32": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.57.1.tgz",
-      "integrity": "sha512-s7EhJLG9AnJNBga3I+W0rk6y/1n/i0XD34rvqR3yJgBhNKkI5rVCxFN7FAcGR50vQQbCO1MrUCmuVvld+2qvyQ==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.58.3.tgz",
+      "integrity": "sha512-T6QYEf1NUDZY+9htvE7Zn9/Ixg0bXGQ54NcHBRSkyVY2n2KBLwQ2ZKp48AlSNxsvJiSOb9lqDE4U7VjH7WJSXg==",
       "optional": true
     },
     "sass-embedded-win32-x64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.57.1.tgz",
-      "integrity": "sha512-b/Kgz7ADPTlPITk8e47Zf3eiuXlTGhi/eWsAoesUmkjR7jayvFNLHPhThgiRAxkzT6UlWI3Dzr+E3OBqUjegEg==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.58.3.tgz",
+      "integrity": "sha512-Jc6Q1Rx5+cxk/yIsI8trkpNQEHjVM9I65p7ArpCLfMU33YRQWUm35QCFH2Szaue3HnTtwXl3ZDQdgo0ZHCHLzg==",
       "optional": true
     },
     "saxes": {

--- a/decidim_app-design/packages/webpacker/package.json
+++ b/decidim_app-design/packages/webpacker/package.json
@@ -38,7 +38,7 @@
     "postcss-loader": "^6.2.1",
     "postcss-preset-env": "^7.1.0",
     "postcss-scss": "^4.0.2",
-    "sass-embedded": "~1.57.1",
+    "sass-embedded": "^1.58.3",
     "source-map-loader": "^0.2.4",
     "style-loader": "^3.0.0",
     "tailwindcss": "^3.0.24",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1758,6 +1758,11 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.0.0.tgz",
+      "integrity": "sha512-oH3jHBrZ6to8Qf4zLg7O8KqSY42kQZNBRXJRMp5uSi0mqE4L8NbyMnZHeOsbXmTb0xpptRyH11LfS+KeVhXzAA=="
+    },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -8150,11 +8155,6 @@
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/google-protobuf": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
-      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw=="
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
@@ -15128,12 +15128,12 @@
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.57.1.tgz",
-      "integrity": "sha512-O0s796x76bRSJIdmJ4lrK+zJLtF3XeP+0tbJzR4NAPSDnWqHLk2boUYSdfx4DnF4x9rGmcVlMWFE8UvnLMNCmw==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.58.3.tgz",
+      "integrity": "sha512-PKU971G3mRgHfimkUJ9rGcYNkviz36muU/QtxTfkPB/YLWyVwHmlU+vvZ7WsBiauvWJapEwAoBDdJ5FlTYm3lQ==",
       "dependencies": {
+        "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
-        "google-protobuf": "^3.11.4",
         "immutable": "^4.0.0",
         "rxjs": "^7.4.0",
         "supports-color": "^8.1.1"
@@ -15142,20 +15142,20 @@
         "node": ">=14.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-darwin-arm64": "1.57.1",
-        "sass-embedded-darwin-x64": "1.57.1",
-        "sass-embedded-linux-arm": "1.57.1",
-        "sass-embedded-linux-arm64": "1.57.1",
-        "sass-embedded-linux-ia32": "1.57.1",
-        "sass-embedded-linux-x64": "1.57.1",
-        "sass-embedded-win32-ia32": "1.57.1",
-        "sass-embedded-win32-x64": "1.57.1"
+        "sass-embedded-darwin-arm64": "1.58.3",
+        "sass-embedded-darwin-x64": "1.58.3",
+        "sass-embedded-linux-arm": "1.58.3",
+        "sass-embedded-linux-arm64": "1.58.3",
+        "sass-embedded-linux-ia32": "1.58.3",
+        "sass-embedded-linux-x64": "1.58.3",
+        "sass-embedded-win32-ia32": "1.58.3",
+        "sass-embedded-win32-x64": "1.58.3"
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.57.1.tgz",
-      "integrity": "sha512-YSfrLZkM2HdXETQdSznv2DN2GdkmBNWLAlHfDWe0toSEIB2C2YGuoqHYZtl6PBYqu8k8FH4TDyct8VzoIa+rMw==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.58.3.tgz",
+      "integrity": "sha512-6CrksxvM10xKAQJX3KTJzrW6gfz21ExxUQnV6w5Ggje0adsq+QQu+BBgoPO2ziBVq+UiupcP7apcbmEHvyuZ7w==",
       "cpu": [
         "arm64"
       ],
@@ -15168,9 +15168,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.57.1.tgz",
-      "integrity": "sha512-xq2Au8CRLHQ+MqH2p8gQn9rYGtfQ8voCWMRz7klYmmh5kXHFjefG3opPPB8mJeSc3SIqE35SQxQEIhUbsxozpg==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.58.3.tgz",
+      "integrity": "sha512-clajXOWN0YP/WItxZJnmAvIiUBts6G28X8Oy/TPcNNzRSwRORHyHXKetbTazULWAkaSBJFFg95aP8sqJvmo+Iw==",
       "cpu": [
         "x64"
       ],
@@ -15183,9 +15183,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.57.1.tgz",
-      "integrity": "sha512-s+roBIgiQSg8124JmYmiSw4THWRvkF2BOclBZCb+OFLa8ZTak2WZdGs0PhqkMmZypxQ7cewh9ts+sOWN24yIrw==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.58.3.tgz",
+      "integrity": "sha512-FhXfAkeVIqClbSziaMWENjy4CJNeZlKVHTML037hVyxntWAmi86OJ9+J13QmlDILiB8bw9BSpRJEkly8O15Tzw==",
       "cpu": [
         "arm"
       ],
@@ -15198,9 +15198,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.57.1.tgz",
-      "integrity": "sha512-R0GqVqf0xEhQ5nDbj7vqmKw+/1kqiURNBl0pD4uv4inBed2YKg+7agn7Y5XE5GUWbgOz7ubjL2kt4Glr7K7xeA==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.58.3.tgz",
+      "integrity": "sha512-dDaYRmV2vWxxZTiVFosfcgA6qJ+VEmHCFIO2XPO03W+uUmIGxa0G9oxdWxhLWjtUu2Z4R57sKKLj3eHI8Lj38Q==",
       "cpu": [
         "arm64"
       ],
@@ -15213,9 +15213,9 @@
       }
     },
     "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.57.1.tgz",
-      "integrity": "sha512-gKqMpfcjrW4S1m+cuRn88oUkr/HMv48CqyCHnfGCsrkTpIft33a1ZKW2jWm09rwmR0g/G6yGstoQO0iHWJWxuQ==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.58.3.tgz",
+      "integrity": "sha512-UClCoXgaLNGHTLBRqUTQAgQXZQFkrGIaWVLIfkVN2AEyLmYJzZ31bQfq1B6mLZPBANuFQaeg3eOcdCTpNaXaOg==",
       "cpu": [
         "ia32"
       ],
@@ -15228,9 +15228,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.57.1.tgz",
-      "integrity": "sha512-AI6CrcuLWP22RXhVrZUN2JfdQ7YdFR30dA4twYwp/Q4hUfj85dJrVD5ORi8G04haMWPOQiFV6pBcMgzpiY2Bog==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.58.3.tgz",
+      "integrity": "sha512-/waLcKwkWQp4QJrNz6EqTS44IdGYup5TGh/qmv3iz9UeL4LtgeM4lVHrFsknsF7viDPLuCOARdrHNSjqKkLRPw==",
       "cpu": [
         "x64"
       ],
@@ -15243,9 +15243,9 @@
       }
     },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.57.1.tgz",
-      "integrity": "sha512-s7EhJLG9AnJNBga3I+W0rk6y/1n/i0XD34rvqR3yJgBhNKkI5rVCxFN7FAcGR50vQQbCO1MrUCmuVvld+2qvyQ==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.58.3.tgz",
+      "integrity": "sha512-T6QYEf1NUDZY+9htvE7Zn9/Ixg0bXGQ54NcHBRSkyVY2n2KBLwQ2ZKp48AlSNxsvJiSOb9lqDE4U7VjH7WJSXg==",
       "cpu": [
         "ia32"
       ],
@@ -15258,9 +15258,9 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.57.1.tgz",
-      "integrity": "sha512-b/Kgz7ADPTlPITk8e47Zf3eiuXlTGhi/eWsAoesUmkjR7jayvFNLHPhThgiRAxkzT6UlWI3Dzr+E3OBqUjegEg==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.58.3.tgz",
+      "integrity": "sha512-Jc6Q1Rx5+cxk/yIsI8trkpNQEHjVM9I65p7ArpCLfMU33YRQWUm35QCFH2Szaue3HnTtwXl3ZDQdgo0ZHCHLzg==",
       "cpu": [
         "x64"
       ],
@@ -18233,7 +18233,7 @@
         "postcss-loader": "^6.2.1",
         "postcss-preset-env": "^7.1.0",
         "postcss-scss": "^4.0.2",
-        "sass-embedded": "~1.57.1",
+        "sass-embedded": "^1.58.3",
         "source-map-loader": "^0.2.4",
         "style-loader": "^3.0.0",
         "tailwindcss": "^3.0.24",
@@ -20832,6 +20832,11 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@bufbuild/protobuf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.0.0.tgz",
+      "integrity": "sha512-oH3jHBrZ6to8Qf4zLg7O8KqSY42kQZNBRXJRMp5uSi0mqE4L8NbyMnZHeOsbXmTb0xpptRyH11LfS+KeVhXzAA=="
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -21136,7 +21141,7 @@
         "postcss-loader": "^6.2.1",
         "postcss-preset-env": "^7.1.0",
         "postcss-scss": "^4.0.2",
-        "sass-embedded": "~1.57.1",
+        "sass-embedded": "^1.58.3",
         "source-map-loader": "^0.2.4",
         "style-loader": "^3.0.0",
         "tailwindcss": "^3.0.24",
@@ -26892,11 +26897,6 @@
       "dev": true,
       "peer": true
     },
-    "google-protobuf": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
-      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw=="
-    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -31989,22 +31989,22 @@
       }
     },
     "sass-embedded": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.57.1.tgz",
-      "integrity": "sha512-O0s796x76bRSJIdmJ4lrK+zJLtF3XeP+0tbJzR4NAPSDnWqHLk2boUYSdfx4DnF4x9rGmcVlMWFE8UvnLMNCmw==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.58.3.tgz",
+      "integrity": "sha512-PKU971G3mRgHfimkUJ9rGcYNkviz36muU/QtxTfkPB/YLWyVwHmlU+vvZ7WsBiauvWJapEwAoBDdJ5FlTYm3lQ==",
       "requires": {
+        "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
-        "google-protobuf": "^3.11.4",
         "immutable": "^4.0.0",
         "rxjs": "^7.4.0",
-        "sass-embedded-darwin-arm64": "1.57.1",
-        "sass-embedded-darwin-x64": "1.57.1",
-        "sass-embedded-linux-arm": "1.57.1",
-        "sass-embedded-linux-arm64": "1.57.1",
-        "sass-embedded-linux-ia32": "1.57.1",
-        "sass-embedded-linux-x64": "1.57.1",
-        "sass-embedded-win32-ia32": "1.57.1",
-        "sass-embedded-win32-x64": "1.57.1",
+        "sass-embedded-darwin-arm64": "1.58.3",
+        "sass-embedded-darwin-x64": "1.58.3",
+        "sass-embedded-linux-arm": "1.58.3",
+        "sass-embedded-linux-arm64": "1.58.3",
+        "sass-embedded-linux-ia32": "1.58.3",
+        "sass-embedded-linux-x64": "1.58.3",
+        "sass-embedded-win32-ia32": "1.58.3",
+        "sass-embedded-win32-x64": "1.58.3",
         "supports-color": "^8.1.1"
       },
       "dependencies": {
@@ -32024,51 +32024,51 @@
       }
     },
     "sass-embedded-darwin-arm64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.57.1.tgz",
-      "integrity": "sha512-YSfrLZkM2HdXETQdSznv2DN2GdkmBNWLAlHfDWe0toSEIB2C2YGuoqHYZtl6PBYqu8k8FH4TDyct8VzoIa+rMw==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.58.3.tgz",
+      "integrity": "sha512-6CrksxvM10xKAQJX3KTJzrW6gfz21ExxUQnV6w5Ggje0adsq+QQu+BBgoPO2ziBVq+UiupcP7apcbmEHvyuZ7w==",
       "optional": true
     },
     "sass-embedded-darwin-x64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.57.1.tgz",
-      "integrity": "sha512-xq2Au8CRLHQ+MqH2p8gQn9rYGtfQ8voCWMRz7klYmmh5kXHFjefG3opPPB8mJeSc3SIqE35SQxQEIhUbsxozpg==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.58.3.tgz",
+      "integrity": "sha512-clajXOWN0YP/WItxZJnmAvIiUBts6G28X8Oy/TPcNNzRSwRORHyHXKetbTazULWAkaSBJFFg95aP8sqJvmo+Iw==",
       "optional": true
     },
     "sass-embedded-linux-arm": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.57.1.tgz",
-      "integrity": "sha512-s+roBIgiQSg8124JmYmiSw4THWRvkF2BOclBZCb+OFLa8ZTak2WZdGs0PhqkMmZypxQ7cewh9ts+sOWN24yIrw==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.58.3.tgz",
+      "integrity": "sha512-FhXfAkeVIqClbSziaMWENjy4CJNeZlKVHTML037hVyxntWAmi86OJ9+J13QmlDILiB8bw9BSpRJEkly8O15Tzw==",
       "optional": true
     },
     "sass-embedded-linux-arm64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.57.1.tgz",
-      "integrity": "sha512-R0GqVqf0xEhQ5nDbj7vqmKw+/1kqiURNBl0pD4uv4inBed2YKg+7agn7Y5XE5GUWbgOz7ubjL2kt4Glr7K7xeA==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.58.3.tgz",
+      "integrity": "sha512-dDaYRmV2vWxxZTiVFosfcgA6qJ+VEmHCFIO2XPO03W+uUmIGxa0G9oxdWxhLWjtUu2Z4R57sKKLj3eHI8Lj38Q==",
       "optional": true
     },
     "sass-embedded-linux-ia32": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.57.1.tgz",
-      "integrity": "sha512-gKqMpfcjrW4S1m+cuRn88oUkr/HMv48CqyCHnfGCsrkTpIft33a1ZKW2jWm09rwmR0g/G6yGstoQO0iHWJWxuQ==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.58.3.tgz",
+      "integrity": "sha512-UClCoXgaLNGHTLBRqUTQAgQXZQFkrGIaWVLIfkVN2AEyLmYJzZ31bQfq1B6mLZPBANuFQaeg3eOcdCTpNaXaOg==",
       "optional": true
     },
     "sass-embedded-linux-x64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.57.1.tgz",
-      "integrity": "sha512-AI6CrcuLWP22RXhVrZUN2JfdQ7YdFR30dA4twYwp/Q4hUfj85dJrVD5ORi8G04haMWPOQiFV6pBcMgzpiY2Bog==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.58.3.tgz",
+      "integrity": "sha512-/waLcKwkWQp4QJrNz6EqTS44IdGYup5TGh/qmv3iz9UeL4LtgeM4lVHrFsknsF7viDPLuCOARdrHNSjqKkLRPw==",
       "optional": true
     },
     "sass-embedded-win32-ia32": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.57.1.tgz",
-      "integrity": "sha512-s7EhJLG9AnJNBga3I+W0rk6y/1n/i0XD34rvqR3yJgBhNKkI5rVCxFN7FAcGR50vQQbCO1MrUCmuVvld+2qvyQ==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.58.3.tgz",
+      "integrity": "sha512-T6QYEf1NUDZY+9htvE7Zn9/Ixg0bXGQ54NcHBRSkyVY2n2KBLwQ2ZKp48AlSNxsvJiSOb9lqDE4U7VjH7WJSXg==",
       "optional": true
     },
     "sass-embedded-win32-x64": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.57.1.tgz",
-      "integrity": "sha512-b/Kgz7ADPTlPITk8e47Zf3eiuXlTGhi/eWsAoesUmkjR7jayvFNLHPhThgiRAxkzT6UlWI3Dzr+E3OBqUjegEg==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.58.3.tgz",
+      "integrity": "sha512-Jc6Q1Rx5+cxk/yIsI8trkpNQEHjVM9I65p7ArpCLfMU33YRQWUm35QCFH2Szaue3HnTtwXl3ZDQdgo0ZHCHLzg==",
       "optional": true
     },
     "saxes": {

--- a/packages/webpacker/package.json
+++ b/packages/webpacker/package.json
@@ -38,7 +38,7 @@
     "postcss-loader": "^6.2.1",
     "postcss-preset-env": "^7.1.0",
     "postcss-scss": "^4.0.2",
-    "sass-embedded": "~1.57.1",
+    "sass-embedded": "^1.58.3",
     "source-map-loader": "^0.2.4",
     "style-loader": "^3.0.0",
     "tailwindcss": "^3.0.24",


### PR DESCRIPTION
#### :tophat: What? Why?
We recently had some issues with a recent release of the `sass-embedded` NPM package, particularly its release 1.58.2. Because of this issue, the version was locked at 1.57.X in the core (#10392).

The issue should be fixed by the 1.58.3 release so we should be able to update safely to this version.

#### :pushpin: Related Issues
- Related to sass/embedded-host-node#206
- Fixes #10391

#### Testing
See that CI is green.