### PR TITLE
Fix pipeline asset router bug regarding for manifests containing the host

### DIFF
--- a/decidim-core/lib/decidim/asset_router/pipeline.rb
+++ b/decidim-core/lib/decidim/asset_router/pipeline.rb
@@ -28,6 +28,8 @@ module Decidim
       #   resolved, the asset path.
       def url(**options)
         path = ActionController::Base.helpers.asset_pack_path(asset, **options)
+        return path if path.match?(%r{\A(https?:)?//})
+
         "#{asset_host}#{path}"
       end
 

--- a/decidim-core/spec/lib/asset_router/pipeline_spec.rb
+++ b/decidim-core/spec/lib/asset_router/pipeline_spec.rb
@@ -17,13 +17,13 @@ module Decidim::AssetRouter
 
       it { is_expected.to eq("//localhost:#{Capybara.server_port}#{correct_asset_path}") }
 
-      context "when using the default HTTP port" do
+      context "when using the default HTTP port 80" do
         before do
           allow(ENV).to receive(:fetch).and_call_original
-          allow(ENV).to receive(:fetch).with("PORT", Capybara.server_port).and_return(80)
+          allow(ENV).to receive(:fetch).with("HTTP_PORT", Capybara.server_port).and_return(80)
         end
 
-        it { is_expected.to eq("//localhost:#{Capybara.server_port}#{correct_asset_path}") }
+        it { is_expected.to eq("//localhost#{correct_asset_path}") }
       end
 
       context "when the system is configured to be served over HTTPS" do
@@ -36,10 +36,10 @@ module Decidim::AssetRouter
         context "and using the default HTTPS port" do
           before do
             allow(ENV).to receive(:fetch).and_call_original
-            allow(ENV).to receive(:fetch).with("PORT", Capybara.server_port).and_return(443)
+            allow(ENV).to receive(:fetch).with("HTTP_PORT", Capybara.server_port).and_return(443)
           end
 
-          it { is_expected.to eq("https://localhost:#{Capybara.server_port}#{correct_asset_path}") }
+          it { is_expected.to eq("https://localhost#{correct_asset_path}") }
         end
       end
 

--- a/decidim-core/spec/lib/asset_router/pipeline_spec.rb
+++ b/decidim-core/spec/lib/asset_router/pipeline_spec.rb
@@ -26,6 +26,16 @@ module Decidim::AssetRouter
         it { is_expected.to eq("//localhost#{correct_asset_path}") }
       end
 
+      context "when the asset URL is included in the assets manifest" do
+        let(:custom_url) { "https://example.org/decidim-packs/media/images/decidim-logo.svg" }
+
+        before do
+          allow(ActionController::Base.helpers).to receive(:asset_pack_path).with(asset).and_return(custom_url)
+        end
+
+        it { is_expected.to eq(custom_url) }
+      end
+
       context "when the system is configured to be served over HTTPS" do
         before do
           allow(Rails.application.config).to receive(:force_ssl).and_return(true)


### PR DESCRIPTION
#### :tophat: What? Why?
When you compile Decidim assets with webpacker with the `HOSTNAME` ENV variable available, the generated `manifest.json` file will contain the host names already.

In this situation, we do not need to manually detect the hostname and add it to the beginning of the string. Currently this produces the following kind of URLs:

`https://decidim.example.orghttps://decidim.example.org/decidim-packs/media/images/default-avatar-aaabbbccc.svg`

And this is wrong and causes 404s where these images are shown (e.g. default avatar image).

At the same time, I noticed some of the specs were incorrect regarding the pipeline assets router after fixing #9598.

#### :pushpin: Related Issues
- Related to
  * #9597
  * #9598

#### Testing
- Build the assets through webpacker with a `HOSTNAME` environment variable set
- Check the generated `manifest.json` -> it contains the hostnames already
  * You can find this file at the `public/decidim-packs` folder
- Go to any page in that instance that lists user avatars
- Find any user without an avatar when the default avatar should be shown
- See that the avatar is not being displayed correctly

### :camera: Screenshots
The default avatar images will display like this:
![Default avatar 404](https://user-images.githubusercontent.com/864340/220112419-65c5cebc-80a8-4d0a-971e-b48c9afd52b8.png)