### PR TITLE
Remove email from initiative's print page

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/print.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/print.html.erb
@@ -60,7 +60,7 @@
 
       <div class="print-table-cell">
         <div class="cell-header"><%= t ".email" %></div>
-        <div class="cell-content"><%= current_initiative.author.email %></div>
+        <div class="cell-content"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

We've received an email to our security email last week: 

> It appears that email addresses of authors are available publicly when wanting to print the initiative information.
> 
> It appears that the PR introducing such behavior ages for about 3 years : https://github.com/decidim/decidim/pull/6790.
> 
> We think it's an important issue since email address aren't by design available publicly (if so, it means it's unconsistent with open data exports).

I mentioned this issue to @decidim/product to see how we should handle this, and we agreed that it's better to just drop it. 

#### :pushpin: Related Issues

- Related to #6790

#### Testing

1. Go to an Initiative show page 
2. Add "/print" to the URL 

For instance, see https://try.decidim.org/initiatives/i-4/print (mind that this URL can change as it's a database that's regenerated daily, but you can check it out with others published IDs) 

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/717367/220335605-ac18193a-5114-429c-868b-ad8fe5fef15a.png)


:hearts: Thank you!
