### PR TITLE
Fix flaky specs in the user answer serializer spec

### DIFF
--- a/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -105,7 +105,7 @@ module Decidim
         end
 
         context "and includes the attributes" do
-          let!(:an_answer) { create(:answer, questionnaire:, question: questions.sample, user:) }
+          let(:an_answer) { answers.first }
 
           it "the id of the answer" do
             key = I18n.t(:id, scope: "decidim.forms.user_answers_serializer")


### PR DESCRIPTION
#### :tophat: What? Why?
While fixing #10418, I bumped into a flaky spec in the `decidim-forms` specs which I am fixing with this PR.

The flaky spec is this one:

https://github.com/decidim/decidim/blob/9e2989e2f033c54bc80de7144ae1baa85eedbc43/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb#L115-L118

The `created_at` stamp for the `an_answer` variable can sometimes differ from the one produced by the serializer because it always fetches the `created_at` time from the first answer in the set. In case the first answer was created during the previous second compared to the `an_answer`, this spec can fail.

#### :pushpin: Related Issues
- Related to #10418

#### Testing
Run the `decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb` multiple times in a row and you should expect to see it failing occasionally.

The command to run this:
```bash
$ cd decidim-forms
$ for i in {1..20}; do bundle exec rspec spec/serializers/decidim/forms/user_answers_serializer_spec.rb ; done
```

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
