### PR TITLE
Fix updating budget projects or other records containing attachments

### DIFF
--- a/decidim-core/app/commands/decidim/gallery_methods.rb
+++ b/decidim-core/app/commands/decidim/gallery_methods.rb
@@ -24,7 +24,7 @@ module Decidim
     end
 
     def update_attachment_title_for(photo)
-      Decidim::Attachment.find(photo[:id]).update(title: title_for(photo))
+      Decidim::Attachment.find(photo[:id]).update(title: photos_title(photo))
     end
 
     def image?(signed_id)

--- a/decidim-core/spec/commands/decidim/create_dummy_resource_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_dummy_resource_spec.rb
@@ -87,6 +87,25 @@ module Decidim
             expect { subject.call }.to broadcast(:ok)
           end
         end
+
+        context "when existing attachments are updated" do
+          let(:attachment1) { create(:attachment, attached_to: current_component.organization) }
+          let(:attachment2) { create(:attachment, attached_to: current_component.organization) }
+
+          let(:uploaded_images) do
+            [
+              { id: attachment1.id, title: "Updated title for attachment 1" },
+              { id: attachment2.id, title: "Updated title for attachment 2" }
+            ]
+          end
+
+          it "broadcasts ok and updates the titles" do
+            expect { subject.call }.to broadcast(:ok)
+
+            expect(attachment1.reload.title).to include("en" => "Updated title for attachment 1")
+            expect(attachment2.reload.title).to include("en" => "Updated title for attachment 2")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Project updating was broken in case the project had existing attachments which were to be updated.

This fixes the issue.

#### :pushpin: Related Issues
- Fixes #10367

#### Testing
- Create a project in a budgeting component with an image
- Go to edit that project
- Add another image and leave the original image
- Send the form
- See exception