### PR TITLE
Fix styling bug with the remove/close buttons for attachments

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/modules/_input-gallery.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_input-gallery.scss
@@ -26,7 +26,8 @@
       top: 2px;
       width: 2rem;
       height: 2rem;
-      background: rgba(var(--primary-rgb), .8);
+      background: var(--primary);
+      opacity: .8;
       color: $white;
       border-radius: 50%;
     }


### PR DESCRIPTION
#### :tophat: What? Why?
The "remove" button (close button) with the image attachments may not be always visible with the current styling (see screenshots).

This fixes the issue.

#### Testing
- Add images to a budgeting project (one of them having a white background in its top right corner)
- Go to edit the project
- See that the remove button is not visible

### :camera: Screenshots

#### Before

![Remove button before the fix](https://user-images.githubusercontent.com/864340/220889930-2d693b67-9e59-4095-801a-995d80fd90c6.png)

#### After

![Remove button after the fix](https://user-images.githubusercontent.com/864340/220889976-342e8039-cb60-46e5-8a16-16ce177b4eaa.png)