### PR TITLE
Fix display of existing images in the upload modal files list

### DIFF
--- a/decidim-core/app/cells/decidim/upload_modal/files.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/files.erb
@@ -12,8 +12,8 @@
 
         <div class="attachment-details" data-title="<%= title_for(attachment) %>" data-filename="<%= file_name_for(attachment) %>" data-state="uploaded">
           <div>
-            <% if file_attachment_path(attachments.first) && blob(attachments.first).image? %>
-              <%= image_tag(file_attachment_path(attachments.first), alt: attribute) %>
+            <% if file_attachment_path(attachment) && blob(attachment).image? %>
+              <%= image_tag(file_attachment_path(attachment), alt: title_for(attachment)) %>
             <% elsif uploader_default_image_path(attribute).present? %>
               <%= image_tag uploader_default_image_path(attribute) %>
             <% end %>

--- a/decidim-core/app/cells/decidim/upload_modal/files.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/files.erb
@@ -13,7 +13,7 @@
         <div class="attachment-details" data-title="<%= title_for(attachment) %>" data-filename="<%= file_name_for(attachment) %>" data-state="uploaded">
           <div>
             <% if file_attachment_path(attachment) && blob(attachment).image? %>
-              <%= image_tag(file_attachment_path(attachment), alt: title_for(attachment)) %>
+              <%= image_tag(file_attachment_path(attachment), alt: title_for(attachment) || file_name_for(attachment)) %>
             <% elsif uploader_default_image_path(attribute).present? %>
               <%= image_tag uploader_default_image_path(attribute) %>
             <% end %>

--- a/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
@@ -125,9 +125,10 @@ describe Decidim::UploadModalCell, type: :cell do
 
     context "when attachment is image" do
       let(:filename) { "city.jpeg" }
+      let(:file) { Decidim::Dev.test_file(filename, "image/jpeg") }
 
       it "renders preview" do
-        expect(subject).to have_selector("img[alt='#{attribute}']")
+        expect(subject.find("img")["src"]).to match(%r{/city.jpeg$})
       end
     end
 
@@ -147,6 +148,32 @@ describe Decidim::UploadModalCell, type: :cell do
 
         details = subject.find(".attachment-details")
         expect(details).to have_content("#{attachments[0].title["en"]} (#{filename})")
+      end
+    end
+  end
+
+  context "when multiple attachments are present" do
+    let(:file1) { Decidim::Dev.test_file("Exampledocument.pdf", "application/pdf") }
+    let(:file2) { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
+    let(:attachments) { [upload_test_file(file1), upload_test_file(file2)] }
+
+    it "renders the attachments" do
+      expect(subject).to have_css(".attachment-details", count: 2)
+      expect(subject).to have_selector("[data-filename='Exampledocument.pdf']")
+      expect(subject).to have_selector("[data-filename='city.jpeg']")
+      expect(subject).to have_css("img")
+      expect(subject.find("img")["src"]).to match(%r{/city.jpeg$})
+    end
+
+    context "when all attachments are images" do
+      let(:file1) { Decidim::Dev.test_file("city.jpeg", "application/pdf") }
+      let(:file2) { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") }
+
+      it "renders preview" do
+        images = subject.all("img")
+        expect(images.count).to be(2)
+        expect(images[0]["src"]).to match(%r{/city.jpeg$})
+        expect(images[1]["src"]).to match(%r{/city2.jpeg$})
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently the upload modal preview images will display the same image for all image attachments, i.e. the first attachment.

This fixes the issue so that each image displays the correct preview.

#### Testing
- Create a budgeting project
- Add two different images to that project
- Go back to editing that project
- See that both preview images are the same (for the first image)

### :camera: Screenshots

#### Before

![Preview images before the fix](https://user-images.githubusercontent.com/864340/220894084-fd6a2a40-80ef-4188-bb3d-7a62a39b7494.png)

#### After

![Preview images after the fix](https://user-images.githubusercontent.com/864340/220894123-92e13f97-65d8-4792-abc1-8e2e4b2bea78.png)