### PR TITLE
Fix flaky user base entity spec

### DIFF
--- a/decidim-core/spec/models/decidim/user_base_entity_spec.rb
+++ b/decidim-core/spec/models/decidim/user_base_entity_spec.rb
@@ -21,7 +21,7 @@ module Decidim
 
     describe "public followings" do
       it "return all the things followed unless the blocked users" do
-        expect(subject.public_followings).to eq([public_resource, user_followed])
+        expect(subject.public_followings).to match_array([public_resource, user_followed])
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Bumped into a flaky spec when fixing #10425, this fixes that.

The test run that failed:
https://github.com/decidim/decidim/actions/runs/4252786621/jobs/7396806348

With the following output:

```
Failures:

  1) Decidim::UserBaseEntity public followings return all the things followed unless the blocked users
     Failure/Error: expect(subject.public_followings).to eq([public_resource, user_followed])

       expected: [#<Decidim::DummyResources::DummyResource id: 196, translatable_text: nil, title: {"en"=>"Msgr. Galen..., previous_passwords: [], officialized_at: nil, officialized_as: nil, admin_terms_accepted_at: nil>]
            got: [#<Decidim::User id: 1559, email: "user1450@example.org", created_at: "2023-02-23 13:08:25.180898000 ...eated_at: "2023-02-23 13:08:25.513768000 +0000", updated_at: "2023-02-23 13:08:25.513768000 +0000">]

       (compared using ==)

       Diff:
       @@ -1,3 +1,3 @@
       -[#<Decidim::DummyResources::DummyResource id: 196, translatable_text: nil, title: {"en"=>"Msgr. Galen Collins", "ca"=>"Oleguer Taberner Magrans", "machine_translations"=>{"es"=>"Cristobal Páez Ureña"}}, body: nil, address: nil, latitude: nil, longitude: nil, published_at: "2023-02-23 13:08:25.511615937 +0000", coauthorships_count: 0, endorsements_count: 0, comments_count: 0, follows_count: 1, decidim_component_id: 562, decidim_author_id: 1561, decidim_author_type: "Decidim::UserBaseEntity", decidim_user_group_id: nil, decidim_category_id: nil, decidim_scope_id: 265, reference: "III-DUMM-2023-02-196", created_at: "2023-02-23 13:08:25.513768000 +0000", updated_at: "2023-02-23 13:08:25.513768000 +0000">,
       - #<Decidim::User id: 1559, email: "user1450@example.org", created_at: "2023-02-23 13:08:25.180898765 +0000", updated_at: "2023-02-23 13:08:25.207232317 +0000", decidim_organization_id: 1864, name: "Manual Ullrich", locale: "en", avatar: nil, delete_reason: nil, deleted_at: nil, admin: false, managed: false, roles: [], nickname: "9bedh_1573", personal_url: "http://bins-mcdermott.org/janett", about: "<script>alert(\"ABOUT\");</script>Dolorem commodi qu...", accepted_tos_version: "2023-02-23 13:08:25.076793672 +0000", newsletter_token: "", newsletter_notifications_at: nil, extended_data: {}, following_count: 0, followers_count: 1, notification_types: "all", session_token: nil, direct_message_types: "all", blocked: false, blocked_at: nil, block_id: nil, email_on_moderations: true, follows_count: 1, notification_settings: {}, notifications_sending_frequency: "real_time", digest_sent_at: nil, password_updated_at: "2023-02-23 13:08:25.[171](https://github.com/decidim/decidim/actions/runs/4252786621/jobs/7396806348#step:5:172)501904 +0000", previous_passwords: [], officialized_at: nil, officialized_as: nil, admin_terms_accepted_at: nil>]
       +[#<Decidim::User id: 1559, email: "user1450@example.org", created_at: "2023-02-23 13:08:25.[180](https://github.com/decidim/decidim/actions/runs/4252786621/jobs/7396806348#step:5:181)898000 +0000", updated_at: "2023-02-23 13:08:25.207232000 +0000", decidim_organization_id: 1864, name: "Manual Ullrich", locale: "en", avatar: nil, delete_reason: nil, deleted_at: nil, admin: false, managed: false, roles: [], nickname: "9bedh_1573", personal_url: "http://bins-mcdermott.org/janett", about: "<script>alert(\"ABOUT\");</script>Dolorem commodi qu...", accepted_tos_version: "2023-02-23 13:08:25.076793000 +0000", newsletter_token: "", newsletter_notifications_at: nil, extended_data: {}, following_count: 0, followers_count: 1, notification_types: "all", session_token: nil, direct_message_types: "all", blocked: false, blocked_at: nil, block_id: nil, email_on_moderations: true, follows_count: 1, notification_settings: {}, notifications_sending_frequency: "real_time", digest_sent_at: nil, password_updated_at: "2023-02-23 13:08:25.171501000 +0000", previous_passwords: [], officialized_at: nil, officialized_as: nil, admin_terms_accepted_at: nil>,
       + #<Decidim::DummyResources::DummyResource id: 196, translatable_text: nil, title: {"ca"=>"Oleguer Taberner Magrans", "en"=>"Msgr. Galen Collins", "machine_translations"=>{"es"=>"Cristobal Páez Ureña"}}, body: nil, address: nil, latitude: nil, longitude: nil, published_at: "2023-02-23 13:08:25.511615000 +0000", coauthorships_count: 0, endorsements_count: 0, comments_count: 0, follows_count: 1, decidim_component_id: 562, decidim_author_id: 1561, decidim_author_type: "Decidim::UserBaseEntity", decidim_user_group_id: nil, decidim_category_id: nil, decidim_scope_id: 265, reference: "III-DUMM-2023-02-196", created_at: "2023-02-23 13:08:25.513768000 +0000", updated_at: "2023-02-23 13:08:25.513768000 +0000">]
     # ./spec/models/decidim/user_base_entity_spec.rb:24:in `block (3 levels) in <module:Decidim>'
```

#### :pushpin: Related Issues
- Related to #10425

#### Testing
Run that spec a lot of times in a row, it may fail sometimes.