### PR TITLE
Use local placeholder instead of fillmurray

### DIFF
--- a/decidim-core/app/views/layouts/decidim/header/_redesigned_menu_breadcrumb_last_activity.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_redesigned_menu_breadcrumb_last_activity.html.erb
@@ -7,7 +7,7 @@
         <span class="text-gray-2">Pressupostos Participatius 2020-21</span>
       </div>
       <div class="overflow-hidden w-6 h-6 rounded-full flex-none">
-        <%= image_tag "https://www.fillmurray.com/640/360", alt: t("decidim.author.avatar", name: "James"), class: "object-cover w-full h-full" %>
+        <%= image_pack_tag "media/images/placeholder.jpg", alt: t("decidim.author.avatar", name: "James"), class: "object-cover w-full h-full" %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
See: https://www.fillmurray.com/640/360

It's down. And it's causing JS console errors when running some of the system specs.

So let's replace it with a local placeholder?

#### Testing
```
cd decidim-core
bundle exec rspec spec/system/messaging/profile_conversations_spec.rb
```

See that there are no references to fillmurray.com in the test output.

It will still contain the Turbo warnings but that's another issue (see #10090).