### PR TITLE
Fix deprecation warning in the `html5sortable` NPM package

### DIFF
--- a/decidim-admin/app/packs/src/decidim/admin/draggable-list.js
+++ b/decidim-admin/app/packs/src/decidim/admin/draggable-list.js
@@ -5,7 +5,7 @@ export default function createSortableList(lists) {
   createSortList(lists, {
     handle: "li",
     forcePlaceholderSize: true,
-    connectWith: ".js-connect"
+    acceptFrom: ".js-connect"
   })
 }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Right now we have the following deprecation warning from the `html5sortable` NPM package:
```
2023-02-23 21:45:10 +0200 WARNING: http://4.lvh.me:6183/packs-test/js/vendors-node_modules_html5sortable_dist_html5sortable_es_js.js 929:24 "HTML5Sortable: You are using the deprecated configuration \"connectWith\". This will be removed in an upcoming version, make sure to migrate to the new options when updating."
```

The `connectWith` option has changed to `acceptFrom` as described at:
https://github.com/lukasoppermann/html5sortable#connectwith-

> Use [acceptFrom](https://github.com/lukasoppermann/html5sortable#acceptFrom) instead.

#### Testing
Run the following spec:
```
$ cd decidim-admin
$ bundle exec rspec spec/system/admin_manages_organization_homepage_spec.rb
```

Expect not to see any described errors printed out to the console.

Also in the user interface, rebuild the assets and try the homepage management in the admin panel. You should be able to drag the content blocks from left to right and from right to left.