### PR TITLE
Fix deleting all content from help section triggers error

### DIFF
--- a/decidim-core/app/services/decidim/traceability.rb
+++ b/decidim-core/app/services/decidim/traceability.rb
@@ -117,6 +117,7 @@ module Decidim
       return unless user.is_a?(Decidim::User)
       # If the record is not valid, it may not yet have an ID causing an
       # exception when trying to save the log record.
+      return if resource.nil?
       return unless resource.valid?
 
       Decidim::ActionLogger.log(


### PR DESCRIPTION
When deleting all content for one field in all languages of the help_sections (/admin/help_sections), the log method of traceability.rb crashes, because `resource` is nil.

The error is triggered by this action: https://github.com/decidim/decidim/blob/develop/decidim-admin/app/commands/decidim/admin/update_help_sections.rb#L23

It happens because resource.valid? does not work if resource is nil:

https://github.com/decidim/decidim/blob/develop/decidim-core/app/services/decidim/traceability.rb#L120

This PR just adds one more check if resource is nil.

Fixes: #10444