### PR TITLE
Backport 'Fix deprecation warning in the `html5sortable` NPM package' to v0.27

### DIFF
--- a/decidim-admin/app/packs/src/decidim/admin/draggable-list.js
+++ b/decidim-admin/app/packs/src/decidim/admin/draggable-list.js
@@ -5,7 +5,7 @@ export default function createSortableList(lists) {
   createSortList(lists, {
     handle: "li",
     forcePlaceholderSize: true,
-    connectWith: ".js-connect"
+    acceptFrom: ".js-connect"
   })
 }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #10434 to v0.27

:hearts: Thank you!