### PR TITLE
Fix iframes stripped from admin entered proposals, meetings and debates

### DIFF
--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -112,9 +112,10 @@ module Decidim
     #
     # @return ActiveSupport::SafeBuffer
     def render_sanitized_content(resource, method)
-      content = present(resource).send(method, links: true, strip_tags: !safe_content?)
+      content = present(resource).send(method, links: true, strip_tags: !try(:safe_content?))
 
-      return decidim_sanitize(content, {}) unless safe_content?
+      return decidim_sanitize(content, {}) unless try(:safe_content?)
+      return decidim_sanitize_editor_admin(content, {}) if try(:safe_content_admin?)
 
       decidim_sanitize_editor(content)
     end

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -8,6 +8,7 @@ module Decidim
     class DebatePresenter < Decidim::ResourcePresenter
       include Decidim::TranslationsHelper
       include Decidim::ResourceHelper
+      include Decidim::SanitizeHelper
       include ActionView::Helpers::DateHelper
 
       def debate
@@ -30,16 +31,10 @@ module Decidim
         super debate.title, links, html_escape, all_locales
       end
 
-      def description(strip_tags: false, links: false, all_locales: false)
+      def description(strip_tags: false, extras: true, links: false, all_locales: false)
         return unless debate
 
-        handle_locales(debate.description, all_locales) do |content|
-          content = strip_tags(content) if strip_tags
-          renderer = Decidim::ContentRenderers::HashtagRenderer.new(content)
-          content = renderer.render(links:).html_safe
-          content = Decidim::ContentRenderers::LinkRenderer.new(content).render if links
-          content
-        end
+        content_handle_locale(debate.description, all_locales, extras, links, strip_tags)
       end
 
       def last_comment_at

--- a/decidim-debates/spec/helpers/decidim/debates/application_helper_spec.rb
+++ b/decidim-debates/spec/helpers/decidim/debates/application_helper_spec.rb
@@ -3,20 +3,20 @@
 require "spec_helper"
 
 module Decidim
-  module Meetings
+  module Debates
     describe ApplicationHelper do
-      describe "#render_meeting_body" do
-        subject { helper.render_meeting_body(meeting) }
+      describe "#render_debate_description" do
+        subject { helper.render_debate_description(debate) }
 
         before do
-          allow(helper).to receive(:present).with(meeting).and_return(Decidim::Meetings::MeetingPresenter.new(meeting))
-          allow(helper).to receive(:current_organization).and_return(meeting.organization)
-          helper.instance_variable_set(:@meeting, meeting)
+          allow(helper).to receive(:present).with(debate).and_return(Decidim::Debates::DebatePresenter.new(debate))
+          allow(helper).to receive(:current_organization).and_return(debate.organization)
+          allow(helper).to receive(:debate).and_return(debate)
         end
 
         let(:description) { "<ul><li>First</li><li>Second</li><li>Third</li></ul><script>alert('OK');</script>" }
-        let(:meeting_trait) { :not_official }
-        let(:meeting) { create(:meeting, meeting_trait, description: { "en" => description }) }
+        let(:debate_trait) { :participant_author }
+        let(:debate) { create(:debate, debate_trait, description: { "en" => description }) }
 
         it "renders a sanitized body" do
           expect(subject).to eq(
@@ -29,8 +29,8 @@ module Decidim
           )
         end
 
-        context "with official meeting" do
-          let(:meeting_trait) { :official }
+        context "with official debate" do
+          let(:debate_trait) { :official }
 
           it "renders a sanitized body" do
             expect(subject).to eq(

--- a/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
@@ -60,7 +60,13 @@ module Decidim
       # frontend, the meeting body is considered as safe content; that's unless
       # the meeting comes from a collaborative_draft or a participatory_text.
       def safe_content?
-        rich_text_editor_in_public_views? || @meeting.official?
+        rich_text_editor_in_public_views? || safe_content_admin?
+      end
+
+      # For admin entered content, the meeting body can contain certain extra
+      # tags, such as iframes.
+      def safe_content_admin?
+        @meeting.official?
       end
 
       # If the content is safe, HTML tags are sanitized, otherwise, they are stripped.

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -95,7 +95,13 @@ module Decidim
       # the proposal comes from a collaborative_draft or a participatory_text.
       def safe_content?
         (rich_text_editor_in_public_views? && not_from_collaborative_draft(@proposal)) ||
-          ((@proposal.official? || @proposal.official_meeting?) && not_from_participatory_text(@proposal))
+          safe_content_admin?
+      end
+
+      # For admin entered content, the proposal body can contain certain extra
+      # tags, such as iframes.
+      def safe_content_admin?
+        (@proposal.official? || @proposal.official_meeting?) && not_from_participatory_text(@proposal)
       end
 
       # If the content is safe, HTML tags are sanitized, otherwise, they are stripped.

--- a/decidim-proposals/spec/helpers/application_helper_spec.rb
+++ b/decidim-proposals/spec/helpers/application_helper_spec.rb
@@ -57,7 +57,7 @@ module Decidim
           )
         end
 
-        context "with official meeting" do
+        context "with official proposal" do
           let(:proposal_trait) { :official }
 
           it "renders a sanitized body" do
@@ -70,6 +70,32 @@ module Decidim
                 </ul>alert('OK');</div>
               HTML
             )
+          end
+
+          context "when the body includes images and iframes" do
+            let(:body) do
+              <<~HTML.strip
+                <p><img src="/path/to/image.jpg" alt="Image"></p>
+                <div class="editor-content-videoEmbed">
+                  <div>
+                    <iframe src="https://example.org/video/xyz" title="Video" frameborder="0" allowfullscreen="true"></iframe>
+                  </div>
+                </div>
+              HTML
+            end
+
+            it "renders the image and iframe embed" do
+              expect(subject).to eq(
+                <<~HTML.strip
+                  <div class="ql-editor-display"><p><img src="/path/to/image.jpg" alt="Image"></p>
+                  <div class="editor-content-videoEmbed">
+                    <div>
+                      <div class="disabled-iframe"><!-- <iframe src="https://example.org/video/xyz" title="Video" frameborder="0" allowfullscreen="true"></iframe> --></div>
+                    </div>
+                  </div></div>
+                HTML
+              )
+            end
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
It was noticed during the review of #10196 by @alecslupu that the iframes are stripped from admin entered proposals due to the way we are sanitizing the content.

This fixes the issue for admin entered proposals, meetings and debates.

Note that this is a different bug than #10130, although somewhat related.

#### Testing
- Create the following from the admin panel: proposal, meeting and debate
- For each item, add a video embed within the content
- Check them from the front-end
- Make sure that the source code of each of those pages contain `<div class="disabled-iframe">`
  * Note that in case the iframe is not displaying, it is likely due to redesign (see #9753)
  * As long as the `disabled-iframe` tag exists on the page, it should indicate that the content parsers are working correctly