### PR TITLE
Fix welcome mails not being sent

### DIFF
--- a/decidim-core/app/services/decidim/email_notification_generator.rb
+++ b/decidim-core/app/services/decidim/email_notification_generator.rb
@@ -63,7 +63,8 @@ module Decidim
     # Returns nothing.
     def send_email_to(recipient, user_role:)
       return unless recipient
-      return unless recipient.notifications_sending_frequency == "real_time"
+      # With the following line welcome mails won't be sent anymore
+      # return unless recipient.notifications_sending_frequency == "real_time"
       return if resource.respond_to?(:can_participate?) && !resource.can_participate?(recipient)
 
       wait_time = 0


### PR DESCRIPTION
10 Months ago there was a check added, that only allows notification mails to be sent to users with notifications_sending_frequency == "real_time"

The problem with that is, that in decidim 0.27 new users don't get any welcome notification mails anymore, because new users by default have notifications_sending_frequency set as "daily".

I just commented out the line that breaks welcome mails for my decidim installation.

A better fix would probably be to make an exception for the event "decidim.events.core.welcome_notification".