### PR TITLE
Fix documentation repository branch in the docs update workflow

### DIFF
--- a/.github/workflows/on_docs_update.yml
+++ b/.github/workflows/on_docs_update.yml
@@ -20,4 +20,4 @@ jobs:
         --header "Accept: application/vnd.github.everest-preview+json" \
         --header "Content-Type: application/json" \
         https://api.github.com/repos/decidim/documentation/actions/workflows/trigger_build.yml/dispatches \
-        --data '{"ref": "master"}'
+        --data '{"ref": "develop"}'


### PR DESCRIPTION
#### :tophat: What? Why?
When changes happen in the documentation, the documentation update workflow is failing because of wrong branch where it is trying to push.

Example workflow run that failed:
https://github.com/decidim/decidim/actions/runs/4341881245/jobs/7629341069

Another thing we need to do is that we need to exclude the pushing user from the branch protection rule at `decidim/documentation`.

#### Testing
Let's see that the workflow passes during the next update to the documentation.