### PR TITLE
Add gid to cache hash

### DIFF
--- a/decidim-core/app/cells/decidim/flag_modal_cell.rb
+++ b/decidim-core/app/cells/decidim/flag_modal_cell.rb
@@ -15,6 +15,7 @@ module Decidim
       hash.push(model.reported_by?(current_user) ? 1 : 0)
       hash.push(model.class.name.gsub("::", ":"))
       hash.push(model.id)
+      hash.push(model.to_sgid.to_s)
       hash.join(Decidim.cache_key_separator)
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
WHen using the flag modal, the cache hash is no refreshed when the GID has expired. It means that if you do not restart your server after 1 months, you will not be able to flag content.
This P.R. adds the gid string to cache hash.

#### :pushpin: Related Issues
- no related issue

#### Testing
create an initializer
```ruby
# config/initializers/global_id.rb
Rails.application.config.global_id.expires_in = 1.minute
```

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Description](URL)

:hearts: Thank you!
