### PR TITLE
Fix promoted admin password change right after registration

### DIFF
--- a/decidim-core/app/commands/decidim/create_registration.rb
+++ b/decidim-core/app/commands/decidim/create_registration.rb
@@ -41,6 +41,7 @@ module Decidim
         nickname: form.nickname,
         password: form.password,
         password_confirmation: form.password_confirmation,
+        password_updated_at: Time.current,
         organization: form.current_organization,
         tos_agreement: form.tos_agreement,
         newsletter_notifications_at: form.newsletter_at,

--- a/decidim-core/app/commands/decidim/update_account.rb
+++ b/decidim-core/app/commands/decidim/update_account.rb
@@ -55,6 +55,7 @@ module Decidim
 
       @user.password = @form.password
       @user.password_confirmation = @form.password_confirmation
+      @user.password_updated_at = Time.current
     end
 
     def notify_followers

--- a/decidim-core/app/commands/decidim/update_password.rb
+++ b/decidim-core/app/commands/decidim/update_password.rb
@@ -16,6 +16,8 @@ module Decidim
       return broadcast(:invalid) if form.invalid?
 
       user.password = form.password
+      user.password_confirmation = form.password
+      user.password_updated_at = Time.current
 
       if user.save
         broadcast(:ok)

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -10,6 +10,24 @@ module Decidim
       before_action :check_sign_in_enabled, only: :create
       # rubocop: enable Rails/LexicallyScopedActionFilter
 
+      def create
+        super do |user|
+          if user.admin?
+            # Check that the admin password passes the validation and clear the
+            # `password_updated_at` field when the password is weak to force a
+            # password update on the user.
+            #
+            # Handles a case when the user registers through the registration
+            # form and they are promoted to an admin after that. In this case,
+            # the newly promoted admin user would otherwise have to change their
+            # password straight away even if they originally registered with a
+            # strong password.
+            validator = PasswordValidator.new({ attributes: :password })
+            user.update!(password_updated_at: nil) unless validator.validate_each(user, :password, sign_in_params[:password])
+          end
+        end
+      end
+
       def destroy
         current_user.invalidate_all_sessions!
         if params[:translation_suffix].present?

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -6,9 +6,7 @@ module Decidim
     class SessionsController < ::Devise::SessionsController
       include Decidim::DeviseControllers
 
-      # rubocop: disable Rails/LexicallyScopedActionFilter
       before_action :check_sign_in_enabled, only: :create
-      # rubocop: enable Rails/LexicallyScopedActionFilter
 
       def create
         super do |user|

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -87,6 +87,7 @@ module Decidim
               email: form.email,
               password: form.password,
               password_confirmation: form.password_confirmation,
+              password_updated_at: an_instance_of(ActiveSupport::TimeWithZone),
               tos_agreement: form.tos_agreement,
               newsletter_notifications_at: form.newsletter_at,
               organization:,
@@ -95,6 +96,11 @@ module Decidim
             ).and_call_original
 
             expect { command.call }.to change(User, :count).by(1)
+          end
+
+          it "sets the password_updated_at to the current time" do
+            expect { command.call }.to broadcast(:ok)
+            expect(User.last.password_updated_at).to be_between(2.seconds.ago, Time.current)
           end
 
           describe "when user keeps the newsletter unchecked" do

--- a/decidim-core/spec/commands/decidim/update_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_account_spec.rb
@@ -119,6 +119,8 @@ module Decidim
       end
 
       describe "when the password is present" do
+        let(:user) { create(:user, :confirmed, password_updated_at: 1.week.ago) }
+
         before do
           form.password = "pNY6h9crVtVHZbdE"
           form.password_confirmation = "pNY6h9crVtVHZbdE"
@@ -127,6 +129,11 @@ module Decidim
         it "updates the password" do
           expect { command.call }.to broadcast(:ok)
           expect(user.reload.valid_password?("pNY6h9crVtVHZbdE")).to be(true)
+        end
+
+        it "sets the password_updated_at to the current time" do
+          expect { command.call }.to broadcast(:ok)
+          expect(User.last.password_updated_at).to be_between(2.seconds.ago, Time.current)
         end
       end
 

--- a/decidim-core/spec/commands/decidim/update_password_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_password_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe UpdatePassword do
+    let(:command) { described_class.new(user, form) }
+    let(:user) { create(:user, :confirmed, password_updated_at: 1.week.ago) }
+    let(:password) { "updatedP4ssw0rd123456789" }
+    let(:password_confirmation) { "updatedP4ssw0rd123456789" }
+    let(:form) { Decidim::PasswordForm.from_params(password:, password_confirmation:) }
+
+    context "when invalid" do
+      let(:password_confirmation) { "foo" }
+
+      it "broadcasts invalid" do
+        expect { command.call }.to broadcast(:invalid)
+      end
+    end
+
+    context "when valid" do
+      it "broadcasts ok" do
+        expect { command.call }.to broadcast(:ok)
+      end
+
+      it "updates the users's password" do
+        expect { command.call }.to change(user, :password)
+      end
+
+      it "sets the password_updated_at to the current time" do
+        expect { command.call }.to broadcast(:ok)
+        expect(user.reload.password_updated_at).to be_between(2.seconds.ago, Time.current)
+      end
+    end
+  end
+end

--- a/decidim-core/spec/controllers/sessions_controller_spec.rb
+++ b/decidim-core/spec/controllers/sessions_controller_spec.rb
@@ -88,6 +88,58 @@ module Decidim
         end
       end
 
+      describe "POST create" do
+        let(:params) { { user: { email: user.email, password: } } }
+        let(:user) { create(:user, :confirmed, password:, password_confirmation: password) }
+        let(:password) { "decidim123456789" }
+
+        before do
+          request.env["decidim.current_organization"] = user.organization
+          request.env["devise.mapping"] = ::Devise.mappings[:user]
+        end
+
+        context "when participant" do
+          context "with weak password" do
+            let(:password) { "decidim123" }
+
+            it "does not update password_updated_at" do
+              post :create, params: params
+
+              expect(user.reload.password_updated_at).not_to be_nil
+            end
+          end
+        end
+
+        context "when admin" do
+          context "with strong password" do
+            let(:user) { create(:user, :confirmed, :admin) }
+
+            it "does not change password_updated_at" do
+              post :create, params: params
+
+              expect(user.reload.password_updated_at).not_to be_nil
+            end
+          end
+
+          context "with weak password" do
+            let(:user) { create(:user, :confirmed, password:, password_confirmation: password) }
+            let(:password) { "decidim123" }
+
+            # To avoid the password validation failing when creating the user
+            before do
+              user.password = user.password_confirmation = nil
+              user.update!(admin: true)
+            end
+
+            it "sets password_updated_at to nil" do
+              post :create, params: params
+
+              expect(user.reload.password_updated_at).to be_nil
+            end
+          end
+        end
+      end
+
       describe "DELETE destroy" do
         let(:user) { create(:user, :confirmed) }
 

--- a/decidim-core/spec/system/registration_spec.rb
+++ b/decidim-core/spec/system/registration_spec.rb
@@ -2,12 +2,17 @@
 
 require "spec_helper"
 
-def fill_registration_form
-  fill_in :registration_user_name, with: "Nikola Tesla"
-  fill_in :registration_user_nickname, with: "the-greatest-genius-in-history"
-  fill_in :registration_user_email, with: "nikola.tesla@example.org"
-  fill_in :registration_user_password, with: "sekritpass123"
-  fill_in :registration_user_password_confirmation, with: "sekritpass123"
+def fill_registration_form(
+  name: "Nikola Tesla",
+  nickname: "the-greatest-genius-in-history",
+  email: "nikola.tesla@example.org",
+  password: "sekritpass123"
+)
+  fill_in :registration_user_name, with: name
+  fill_in :registration_user_nickname, with: nickname
+  fill_in :registration_user_email, with: email
+  fill_in :registration_user_password, with: password
+  fill_in :registration_user_password_confirmation, with: password
 end
 
 describe "Registration", type: :system do
@@ -91,6 +96,49 @@ describe "Registration", type: :system do
       end
       expect(page).to have_current_path decidim.user_registration_path
       expect(page).to have_field("registration_user_newsletter", checked: true)
+    end
+  end
+
+  context "when the user is promoted to an admin after the registration" do
+    let(:user) { Decidim::User.last }
+
+    before do
+      # Add a content block to the home page to see if the user is there
+      create :content_block, organization:, scope_name: :homepage, manifest_name: :hero
+
+      # Register
+      fill_registration_form(password:)
+      page.check("registration_user_tos_agreement")
+      page.check("registration_user_newsletter")
+      within "form.new_user" do
+        find("*[type=submit]").click
+      end
+      expect(page).to have_content("A message with a confirmation link has been sent to your email address.")
+      user.admin = true
+      user.confirmed_at = Time.current
+      user.save!
+
+      # Sign in
+      click_link "Sign In"
+      fill_in :session_user_email, with: user.email
+      fill_in :session_user_password, with: password
+      click_button "Log in"
+    end
+
+    context "with a weak password" do
+      let(:password) { "sekritpass123" }
+
+      it "requires a password change" do
+        expect(page).to have_content("Password change")
+      end
+    end
+
+    context "with a strong password" do
+      let(:password) { "decidim123456789" }
+
+      it "does not require password change straight away" do
+        expect(page).not_to have_content("Password change")
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
If a participant registers to the platform with a strong password and they are promoted to admin straight after the account creation, the system requires them to change their password straight away.

This fixes the issue.

#### :pushpin: Related Issues
- Related to #9347

#### Testing
- Register a new user to the platform with password `decidim123456789`
- Confirm the registration by clicking the confirmation email's link
- Test that you can login with that user normally as a participant and log out after that
- Promote the new user to an admin (though the UI or the rails console)
- Try logging in again
- See that the system no longer requires you to change your password straight away

In current Decidim version, the password change is required right after the user is promoted to an admin.