### PR TITLE
Fix participatory texts sections required field indicators

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/_article-preview.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/_article-preview.html.erb
@@ -1,13 +1,13 @@
 <div class="grid-x">
   <div class="cell">
     <%= form.hidden_field :position, class: "position" %>
-    <%= form.text_field :title, optional: false %>
+    <%= form.text_field :title, required: true %>
   </div>
 </div>
 <% if proposal.article? %>
 <div class="grid-x">
   <div class="cell">
-    <%= form.text_area :body, optional: false, rows: 5 %>
+    <%= form.text_area :body, required: true, rows: 5 %>
   </div>
 </div>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
While fixing #10497, I also noticed we have a similar issue at participatory texts. Both `title` and `position` are required for the text sections but they do not appear as required in the view.

#### :pushpin: Related Issues
- Related to #10497

#### Testing
- Create a participatory text import
- See that both "Title" and "Body" are marked as required fields in the preview

### :camera: Screenshots

#### Before

![Required field indicator not visible at participatory texts import](https://user-images.githubusercontent.com/864340/224104864-d14348ad-08b8-44b0-a0ad-912b2e8cf9b5.png)

#### After

![Required field indicator visible at participatory texts import](https://user-images.githubusercontent.com/864340/224104637-2de79bc9-8978-4121-8f31-b1d2d1a538d6.png)