### PR TITLE
Add link to ActiveStorage to the getting started manual

### DIFF
--- a/docs/modules/install/pages/checklist.adoc
+++ b/docs/modules/install/pages/checklist.adoc
@@ -22,6 +22,7 @@ As a technopolitical project, Decidim needs several things to work. This is a no
 . Comply with our License (Affero GPL 3) and *publish your code* to http://github.com[GitHub] or wherever you want.
 . Review your *decidim initializer* on your application (config/initializers/decidim.rb).
 . Configure your xref:services:activejob.adoc[*ActiveJob*] background queue.
+. Configure your xref:services:activestorage.adoc[*ActiveStorage*] dynamic uploads.
 . If you want, configure your xref:services:social_providers.adoc[*social providers*] to enable login using external applications.
 . Check that you don't have any *default users, emails and passwords*, neither on the admin or on the system panel.
 . Configure xref:install:index.adoc#scheduled_tasks[scheduled tasks].

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -126,6 +126,7 @@ You can configure it with `crontab -e`, for instance if you've created your Deci
 We also have other guides on how to configure some extra mandatory components:
 
 * xref:services:activejob.adoc[ActiveJob]: For background jobs (like sending emails).
+* xref:services:activestorage.adoc[ActiveStorage]: For uploading and storing files (like attachments, images, etc.).
 * xref:services:maps.adoc[Maps]: How to enable geocoding for proposals and meetings.
 * xref:services:smtp.adoc[SMTP]: For sending emails for account registrations, password reminders, notifications, etc.
 * xref:services:social_providers.adoc[Social providers integration]: Enable sign up from social networks.


### PR DESCRIPTION
#### :tophat: What? Why?
This documentation page was created to instruct how to configure the dynamic uploads correctly. But I think it is not linked to anywhere right now.

#### Testing
See the page on the live documentation site.