### PR TITLE
Fix meeting form for admin to update registrations_enabled field

### DIFF
--- a/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
@@ -52,6 +52,7 @@ module Decidim
             transparent: form.transparent,
             author: form.current_organization,
             registration_terms: form.current_component.settings.default_registration_terms,
+            registrations_enabled: form.registrations_enabled,
             component: form.current_component,
             questionnaire: Decidim::Forms::Questionnaire.new,
             iframe_embed_type: form.iframe_embed_type,

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
@@ -51,6 +51,7 @@ module Decidim
             online_meeting_url: form.online_meeting_url,
             registration_type: form.registration_type,
             registration_url: form.registration_url,
+            registrations_enabled: form.registrations_enabled,
             type_of_meeting: form.clean_type_of_meeting,
             address: form.address,
             latitude: form.latitude,

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -13,6 +13,7 @@ module Decidim
         attribute :private_meeting, Boolean
         attribute :transparent, Boolean
         attribute :registration_type, String
+        attribute :registrations_enabled, Boolean, default: false
         attribute :registration_url, String
         attribute :customize_registration_email, Boolean
         attribute :iframe_embed_type, String, default: "none"
@@ -130,6 +131,10 @@ module Decidim
               type
             ]
           end
+        end
+
+        def registrations_enabled
+          on_this_platform?
         end
 
         def embeddable_meeting_url

--- a/decidim-meetings/spec/commands/admin/create_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/create_meeting_spec.rb
@@ -24,6 +24,7 @@ module Decidim::Meetings
     let(:online_meeting_url) { "http://decidim.org" }
     let(:registration_url) { "http://decidim.org" }
     let(:registration_type) { "on_this_platform" }
+    let(:registrations_enabled) { true }
     let(:iframe_embed_type) { "embed_in_meeting_page" }
     let(:iframe_access_level) { "all" }
     let(:services) do
@@ -64,6 +65,7 @@ module Decidim::Meetings
         current_organization: organization,
         registration_type:,
         registration_url:,
+        registrations_enabled:,
         clean_type_of_meeting: type_of_meeting,
         online_meeting_url:,
         iframe_embed_type:,
@@ -102,6 +104,11 @@ module Decidim::Meetings
       it "sets the author" do
         subject.call
         expect(meeting.author).to eq organization
+      end
+
+      it "sets the registration enabled flag" do
+        subject.call
+        expect(meeting.registrations_enabled).to eq registrations_enabled
       end
 
       it "sets the component" do

--- a/decidim-meetings/spec/commands/admin/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/update_meeting_spec.rb
@@ -28,6 +28,7 @@ module Decidim::Meetings
     let(:online_meeting_url) { "http://decidim.org" }
     let(:registration_url) { "http://decidim.org" }
     let(:registration_type) { "on_this_platform" }
+    let(:registrations_enabled) { true }
     let(:iframe_embed_type) { "none" }
     let(:iframe_access_level) { nil }
 
@@ -52,6 +53,7 @@ module Decidim::Meetings
         current_organization: organization,
         registration_type:,
         registration_url:,
+        registrations_enabled:,
         clean_type_of_meeting: type_of_meeting,
         online_meeting_url:,
         iframe_embed_type:,
@@ -95,6 +97,11 @@ module Decidim::Meetings
       it "sets the author" do
         subject.call
         expect(meeting.author).to eq organization
+      end
+
+      it "sets the registration enabled flag" do
+        subject.call
+        expect(meeting.registrations_enabled).to eq registrations_enabled
       end
 
       it "sets the services" do
@@ -149,6 +156,7 @@ module Decidim::Meetings
             current_organization: organization,
             registration_type:,
             registration_url:,
+            registrations_enabled:,
             clean_type_of_meeting: type_of_meeting,
             online_meeting_url:,
             iframe_embed_type:,

--- a/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
@@ -53,6 +53,7 @@ module Decidim::Meetings
     let(:online_meeting_url) { "http://decidim.org" }
     let(:registration_url) { "http://decidim.org" }
     let(:registration_type) { "on_this_platform" }
+    let(:registrations_enabled) { true }
     let(:available_slots) { 0 }
     let(:iframe_embed_type) { "none" }
     let(:attributes) do
@@ -73,6 +74,7 @@ module Decidim::Meetings
         registration_type:,
         available_slots:,
         registration_url:,
+        registrations_enabled:,
         type_of_meeting:,
         online_meeting_url:,
         iframe_embed_type:

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -162,6 +162,36 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
     end
   end
 
+  it "sets registration enabled to true when registration type is on this platform" do
+    within find("tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title) do
+      click_link "Edit"
+    end
+
+    within ".edit_meeting" do
+      select "On this platform", from: :meeting_registration_type
+
+      find("*[type=submit]").click
+    end
+
+    expect(page).to have_admin_callout("successfully")
+    expect(meeting.reload.registrations_enabled).to be true
+  end
+
+  it "sets registration enabled to false when registration type is not on this platform" do
+    within find("tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title) do
+      click_link "Edit"
+    end
+
+    within ".edit_meeting" do
+      select "Registration disabled", from: :meeting_registration_type
+
+      find("*[type=submit]").click
+    end
+
+    expect(page).to have_admin_callout("successfully")
+    expect(meeting.reload.registrations_enabled).to be false
+  end
+
   it "adds a few services to the meeting", :serves_geocoding_autocomplete do
     within find("tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title) do
       click_link "Edit"


### PR DESCRIPTION
#### :tophat: What? Why?

Update `registrations_enabled` field for `Decidim::Meetings::Meeting` when it is being created or updated in the Admin Dashboard.

#### :pushpin: Related Issues

- Fixes #10436

#### Testing

1. On a fresh installation of decidim:
2. Create or update a meeting in Admin Dashboard:
3. Fill in the required fields and select the `registration_type` field either `on_this_platform` or `on_different_platform`.
4. Submit the form.
5. If the `registration_type` is `on_this_platform` the `registrations_enabled` for the meeting will be true, else it will be false.

:hearts: Thank you!