### PR TITLE
Standarize the format of the word "cannot"

### DIFF
--- a/decidim-accountability/app/controllers/concerns/decidim/accountability/admin/filterable.rb
+++ b/decidim-accountability/app/controllers/concerns/decidim/accountability/admin/filterable.rb
@@ -39,7 +39,7 @@ module Decidim
             }
           end
 
-          # Can't user `super` here, because it does not belong to a superclass
+          # Cannot user `super` here, because it does not belong to a superclass
           # but to a concern.
           def dynamically_translated_filters
             [:scope_id_eq, :category_id_eq, :status_id_eq]

--- a/decidim-accountability/lib/decidim/accountability/component.rb
+++ b/decidim-accountability/lib/decidim/accountability/component.rb
@@ -11,7 +11,7 @@ Decidim.register_component(:accountability) do |component|
   component.query_type = "Decidim::Accountability::AccountabilityType"
 
   component.on(:before_destroy) do |instance|
-    raise StandardError, "Can't remove this component" if Decidim::Accountability::Result.where(component: instance).any?
+    raise StandardError, "Cannot remove this component" if Decidim::Accountability::Result.where(component: instance).any?
   end
 
   # These actions permissions can be configured in the admin panel

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -881,7 +881,7 @@ en:
         new:
           destroy:
             button: Delete all private participants
-            confirm: Are you sure you want to delete all private participants? This action can't be undone, you will not be able to recover them.
+            confirm: Are you sure you want to delete all private participants? This action cannot be undone, you will not be able to recover them.
             empty: You have no private participants.
             explanation: You have %{count} private participants.
             title: Delete private participants

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -179,7 +179,7 @@ shared_examples "manage moderations" do
       end
     end
 
-    it "user can't unreport them" do
+    it "user cannot unreport them" do
       expect(page).not_to have_css(".action-icon--unreport")
     end
 

--- a/decidim-admin/spec/commands/decidim/admin/update_newsletter_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_newsletter_spec.rb
@@ -33,7 +33,7 @@ module Decidim::Admin
         end
       end
 
-      describe "when the newsletter can't be edited by this user" do
+      describe "when the newsletter cannot be edited by this user" do
         let(:user) { create(:user) }
 
         it "broadcasts invalid" do

--- a/decidim-admin/spec/lib/decidim/admin/import/creator_spec.rb
+++ b/decidim-admin/spec/lib/decidim/admin/import/creator_spec.rb
@@ -7,7 +7,7 @@ module Decidim::Admin::Import
     subject { described_class.new(unknown_resource) }
     let(:unknown_resource) { { field: "foo" } }
 
-    it "cant finish without implementation for a resource" do
+    it "cannot finish without implementation for a resource" do
       expect { subject.finish! }.to raise_error(NotImplementedError)
     end
   end

--- a/decidim-admin/spec/system/admin_manage_moderated_users_spec.rb
+++ b/decidim-admin/spec/system/admin_manage_moderated_users_spec.rb
@@ -110,7 +110,7 @@ describe "Admin manages moderated users", type: :system do
       visit decidim_admin.moderated_users_path(blocked: true)
     end
 
-    it "user can't unreport them" do
+    it "user cannot unreport them" do
       expect(page).not_to have_css(".action-icon--unreport")
     end
 

--- a/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
@@ -95,7 +95,7 @@ describe "Space admin manages global moderations", type: :system do
       create :participatory_process, organization:
     end
 
-    it "can't see any moderation" do
+    it "cannot see any moderation" do
       visit decidim_admin.moderations_path
 
       within ".container" do

--- a/decidim-admin/spec/system/space_moderator_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_moderator_manages_global_moderations_spec.rb
@@ -38,7 +38,7 @@ describe "Space moderator manages global moderations", type: :system do
       end
     end
 
-    it "can't access to the Global moderations page" do
+    it "cannot access to the Global moderations page" do
       visit decidim_admin.moderations_path
 
       within ".callout.alert" do
@@ -63,7 +63,7 @@ describe "Space moderator manages global moderations", type: :system do
       create :participatory_process, organization:
     end
 
-    it "can't see any moderation" do
+    it "cannot see any moderation" do
       visit decidim_admin.moderations_path
 
       within ".container" do

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -445,9 +445,6 @@ en:
         related_assemblies: Related assemblies
     statistics:
       assemblies_count: Assemblies
-  errors:
-    messages:
-      cannot_be_blank: can not be blank
   layouts:
     decidim:
       assemblies:

--- a/decidim-blogs/lib/decidim/blogs/component.rb
+++ b/decidim-blogs/lib/decidim/blogs/component.rb
@@ -11,7 +11,7 @@ Decidim.register_component(:blogs) do |component|
   component.query_type = "Decidim::Blogs::BlogsType"
 
   component.on(:before_destroy) do |instance|
-    raise StandardError, "Can't remove this component" if Decidim::Blogs::Post.where(component: instance).any?
+    raise StandardError, "Cannot remove this component" if Decidim::Blogs::Post.where(component: instance).any?
   end
 
   component.register_stat :posts_count, primary: true, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |components, _start_at, _end_at|

--- a/decidim-budgets/app/cells/decidim/budgets/limit_announcement_cell.rb
+++ b/decidim-budgets/app/cells/decidim/budgets/limit_announcement_cell.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Budgets
-    # This cell renders information when current user can't create more budgets orders.
+    # This cell renders information when current user cannot create more budgets orders.
     class LimitAnnouncementCell < BaseCell
       alias budget model
       delegate :voted?, :vote_allowed?, :discardable, :limit_reached?, to: :current_workflow

--- a/decidim-budgets/app/controllers/concerns/decidim/budgets/admin/filterable.rb
+++ b/decidim-budgets/app/controllers/concerns/decidim/budgets/admin/filterable.rb
@@ -39,7 +39,7 @@ module Decidim
             }
           end
 
-          # Can't user `super` here, because it does not belong to a superclass
+          # Cannot user `super` here, because it does not belong to a superclass
           # but to a concern.
           def dynamically_translated_filters
             [:scope_id_eq, :category_id_eq]

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -180,7 +180,7 @@ en:
       last_activity:
         new_vote_at: New budgeting vote at
       limit_announcement:
-        cant_vote: You can't vote on this budget. <a href="%{landing_path}">Try on another budget</a>.
+        cant_vote: You cannot vote on this budget. <a href="%{landing_path}">Try on another budget</a>.
         limit_reached: You have active votes in %{links}. To vote on this budget you must <a href="%{landing_path}">delete your vote and start over</a>.
       models:
         budget:

--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -19,7 +19,7 @@ Decidim.register_component(:budgets) do |component|
   component.actions = %w(vote comment)
 
   component.on(:before_destroy) do |instance|
-    raise StandardError, "Can't remove this component" if Decidim::Budgets::Budget.where(component: instance).any?
+    raise StandardError, "Cannot remove this component" if Decidim::Budgets::Budget.where(component: instance).any?
   end
 
   component.register_resource(:budget) do |resource|

--- a/decidim-budgets/spec/models/order_spec.rb
+++ b/decidim-budgets/spec/models/order_spec.rb
@@ -25,7 +25,7 @@ shared_examples "an order" do |*options|
     end
 
     if options.include?(:with_maximum_budget)
-      it "can't exceed a maximum order value" do
+      it "cannot exceed a maximum order value" do
         project1 = create(:project, budget:, budget_amount: 100)
         project2 = create(:project, budget:, budget_amount: 20)
 
@@ -82,7 +82,7 @@ module Decidim::Budgets
 
       it_behaves_like "an order", :with_maximum_budget
 
-      it "can't be lower than a minimum order value when checked out" do
+      it "cannot be lower than a minimum order value when checked out" do
         project1 = create(:project, budget:, budget_amount: 20)
 
         subject.projects << project1
@@ -101,7 +101,7 @@ module Decidim::Budgets
 
       it_behaves_like "an order", :with_maximum_budget
 
-      it "can't be lower than a minimum projects number when checked out" do
+      it "cannot be lower than a minimum projects number when checked out" do
         project1 = create(:project, budget:, budget_amount: 100)
 
         subject.projects << project1
@@ -138,7 +138,7 @@ module Decidim::Budgets
 
       it_behaves_like "an order"
 
-      it "can't be higher than a maximum projects number when checked out" do
+      it "cannot be higher than a maximum projects number when checked out" do
         projects = create_list(:project, 7, budget:, budget_amount: 100)
 
         subject.projects << projects
@@ -185,7 +185,7 @@ module Decidim::Budgets
 
       it_behaves_like "an order"
 
-      it "can't be higher than a maximum projects number when checked out" do
+      it "cannot be higher than a maximum projects number when checked out" do
         projects = create_list(:project, 7, budget:, budget_amount: 100)
 
         subject.projects << projects
@@ -195,7 +195,7 @@ module Decidim::Budgets
         expect(subject).to be_invalid
       end
 
-      it "can't be lower than a minimum projects number when checked out" do
+      it "cannot be lower than a minimum projects number when checked out" do
         project1 = create(:project, budget: subject.budget, budget_amount: 100)
 
         subject.projects << project1

--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -354,7 +354,7 @@ describe "Orders", type: :system do
         end
       end
 
-      context "and in project show page cant exceed the budget" do
+      context "and in project show page cannot exceed the budget" do
         let!(:expensive_project) { create(:project, budget:, budget_amount: 250_000_000) }
 
         it "cannot add the project" do

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -46,7 +46,7 @@ en:
           body:
             label: Comment
             placeholder: What do you think about this?
-          form_error: The text is required and it can't be longer than %{length} characters.
+          form_error: The text is required and it cannot be longer than %{length} characters.
           submit: Send
           user_group_id:
             label: Comment as
@@ -168,4 +168,4 @@ en:
         title: Comments
   errors:
     messages:
-      cannot_have_comments: can't have comments
+      cannot_have_comments: cannot have comments

--- a/decidim-conferences/spec/shared/manage_diplomas_examples.rb
+++ b/decidim-conferences/spec/shared/manage_diplomas_examples.rb
@@ -70,7 +70,7 @@ shared_examples "manage diplomas" do
           conference.reload
         end
 
-        it "can't send the diplomas" do
+        it "cannot send the diplomas" do
           within find("tr", text: translated(conference.title)) do
             click_link "Configure"
           end
@@ -86,7 +86,7 @@ shared_examples "manage diplomas" do
     context "and registration has not been confirmed" do
       let!(:conference_registrations) { create_list :conference_registration, 10, :unconfirmed, conference: }
 
-      it "can't send the diplomas" do
+      it "cannot send the diplomas" do
         within find("tr", text: translated(conference.title)) do
           click_link "Configure"
         end

--- a/decidim-consultations/app/cells/decidim/consultations/consultation_m_cell.rb
+++ b/decidim-consultations/app/cells/decidim/consultations/consultation_m_cell.rb
@@ -15,7 +15,7 @@ module Decidim
         state_data[:state_classes]
       end
 
-      # Even though we need to render the badge, we can't do it in the normal
+      # Even though we need to render the badge, we cannot do it in the normal
       # way, because the paragraph comes from a user input and contains HTML.
       # This causes the badge and the paragraph to appear in different lines.
       # In order to fix it, check the `description` method.

--- a/decidim-core/app/cells/decidim/content_blocks/last_activity_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/last_activity_cell.rb
@@ -19,7 +19,7 @@ module Decidim
       # polymorphic relations to different kind of models, and these models
       # might not be available (a proposal might have been hidden or withdrawn).
       #
-      # Since these conditions can't always be filtered with a database search
+      # Since these conditions cannot always be filtered with a database search
       # we ask for more activities than we actually need and then loop until there
       # are enough of them.
       #

--- a/decidim-core/app/cells/decidim/endorsement_buttons_cell.rb
+++ b/decidim-core/app/cells/decidim/endorsement_buttons_cell.rb
@@ -65,7 +65,7 @@ module Decidim
     end
 
     # Renders the endorsements button but disabled.
-    # To be used to let the user know that endorsements are enabled but are blocked or cant participate.
+    # To be used to let the user know that endorsements are enabled but are blocked or cannot participate.
     def render_disabled_endorsements_button
       content_tag :span, class: "#{card_button_html_class} #{endorsement_button_classes(from_resourcess_list: false)} disabled", disabled: true, title: endorse_translated do
         endorse_translated + render_screen_reader_context_title

--- a/decidim-core/app/jobs/decidim/event_publisher_job.rb
+++ b/decidim-core/app/jobs/decidim/event_publisher_job.rb
@@ -37,7 +37,7 @@ module Decidim
     #
     # It returns false when the resource or any element in the chain is a
     # `Decidim::Publicable` and it isn't published or participatory_space
-    # is a `Decidim::Participable` and the user can't participate.
+    # is a `Decidim::Participable` and the user cannot participate.
     def notifiable?
       return false if resource.is_a?(Decidim::Publicable) && !resource.published?
       return false if participatory_space.is_a?(Decidim::Publicable) && !participatory_space&.published?

--- a/decidim-core/app/models/decidim/action_log.rb
+++ b/decidim-core/app/models/decidim/action_log.rb
@@ -119,7 +119,7 @@ module Decidim
     validates :resource, presence: true, if: ->(log) { log.action != "delete" }
     validates :visibility, presence: true, inclusion: { in: %w(private-only admin-only public-only all) }
 
-    # To ensure records can't be deleted
+    # To ensure records cannot be deleted
     before_destroy { |_record| raise ActiveRecord::ReadOnlyRecord }
 
     # A scope that filters all the logs that should be visible at the admin panel.

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -37,8 +37,8 @@ module Decidim
 
     # Users registration mode. Whether users can register or access the system. Doesn't affect users that access through Omniauth integrations.
     #  enabled: Users registration and sign in are enabled (default value).
-    #  existing: Users can't be registered in the system. Only existing users can sign in.
-    #  disable: Users can't register or sign in.
+    #  existing: Users cannot be registered in the system. Only existing users can sign in.
+    #  disable: Users cannot register or sign in.
     enum users_registration_mode: [:enabled, :existing, :disabled], _prefix: true
 
     validates :name, :host, uniqueness: true

--- a/decidim-core/app/models/decidim/user_base_entity.rb
+++ b/decidim-core/app/models/decidim/user_base_entity.rb
@@ -36,7 +36,7 @@ module Decidim
 
     # Public: Returns a collection with all the public entities this user is following.
     #
-    # This can't be done as with a `has_many :following, through: :following_follows`
+    # This cannot be done as with a `has_many :following, through: :following_follows`
     # since it's a polymorphic relation and Rails doesn't know how to load it. With
     # this implementation we only query the database once for each kind of following.
     #

--- a/decidim-core/config/initializers/devise.rb
+++ b/decidim-core/config/initializers/devise.rb
@@ -136,7 +136,7 @@ Devise.setup do |config|
   # Number of invitations users can send.
   # - If invitation_limit is nil, there is no limit for invitations, users can
   # send unlimited invitations, invitation_limit column is not used.
-  # - If invitation_limit is 0, users can't send invitations by default.
+  # - If invitation_limit is 0, users cannot send invitations by default.
   # - If invitation_limit n > 0, users can send n invitations.
   # You can change invitation_limit column for some users so they can send more
   # or less invitations, even with global invitation_limit = 0
@@ -178,7 +178,7 @@ Devise.setup do |config|
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm
   # their account within 3 days after the mail was sent, but on the fourth day
-  # their account can't be confirmed with the token any more.
+  # their account cannot be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
   # config.confirm_within = 3.days

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -416,7 +416,7 @@ en:
           resume: Check your "%{authorization}" authorization progress
           title: Authorization is still in progress
         unauthorized:
-          explanation: Sorry, you can't perform this action as some of your authorization data doesn't match.
+          explanation: Sorry, you cannot perform this action as some of your authorization data doesn't match.
           invalid_field: "%{field} value %{value} isn't valid."
           ok: Ok
           title: Not authorized
@@ -642,7 +642,7 @@ en:
       not_found:
         back_home: Back home
         content_doesnt_exist: This address is incorrect or has been removed.
-        title: The page you're looking for can't be found
+        title: The page you're looking for cannot be found
     events:
       amendments:
         amendment_accepted:
@@ -970,7 +970,7 @@ en:
         success: Join request successfully created. An admin will review your request before accepting you to the group.
       leave:
         error: There was a problem leaving the group
-        last_admin: You can't remove yourself from this group as you're the last administrator. Make another member an administrator in order to leave the group.
+        last_admin: You cannot remove yourself from this group as you're the last administrator. Make another member an administrator in order to leave the group.
         success: Group successfully abandoned.
       members:
         accept_or_reject_join_requests: 'The following users have applied to join this group. Accept or reject their requests:'
@@ -1108,7 +1108,7 @@ en:
         show:
           back: Back to all conversations
           chat_with: Conversation with
-          deleted_accounts: You can't have a conversation with deleted accounts.
+          deleted_accounts: You cannot have a conversation with deleted accounts.
           not_allowed: This participant does not accept direct messages.
           title: Conversation with %{usernames}
         start:
@@ -1526,7 +1526,7 @@ en:
         title_reply: Reply
       show:
         back: Show all conversations
-        deleted_accounts: You can't have a conversation with deleted accounts.
+        deleted_accounts: You cannot have a conversation with deleted accounts.
         not_allowed: This user does not accept any more direct messages.
         title: Conversation with %{usernames}
       update:
@@ -1680,7 +1680,7 @@ en:
       new:
         forgot_your_password: Forgot your password?
         send_me_reset_password_instructions: Send me reset password instructions
-      no_token: You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.
+      no_token: You cannot access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.
       send_instructions: You will receive an email with instructions on how to reset your password in a few minutes.
       send_paranoid_instructions: If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.
       updated: Your password has been successfully changed. You are now signed in.
@@ -1751,15 +1751,18 @@ en:
     messages:
       allowed_file_content_types: 'only files with the following extensions are allowed: %{types}'
       already_confirmed: was already confirmed, please try signing in
+      blank: cannot be blank
+      cannot_be_blank: cannot be blank
       confirmation_period_expired: needs to be confirmed within %{period}, please request a new one
       content_type_allowlist_error: the file type is not valid
-      cycle_detected: a scope's parent can't be one of its descendants
+      cycle_detected: a scope's parent cannot be one of its descendants
+      empty: cannot be empty
       expired: has expired, please request a new one
       file_size_is_less_than_or_equal_to: file size must be less than or equal to %{count}
       invalid_time_zone: is not a valid time zone
       long_words: contains words that are too long (over 35 characters)
       must_start_with_caps: must start with a capital letter
-      nesting_too_deep: can't be inside of a subcategory
+      nesting_too_deep: cannot be inside of a subcategory
       not_found: could not be found. Did you sign up previously?
       not_locked: was not locked
       not_saved:

--- a/decidim-core/lib/decidim/coauthorable.rb
+++ b/decidim-core/lib/decidim/coauthorable.rb
@@ -75,7 +75,7 @@ module Decidim
 
       # Returns all the authors of a coauthorable.
       #
-      # We need to do it this ways since the authors are polymorphic, and we can't have a has_many through relation
+      # We need to do it this ways since the authors are polymorphic, and we cannot have a has_many through relation
       # with polymorphic objects.
       def authors
         return @authors if defined?(@authors)

--- a/decidim-core/lib/decidim/core/test/shared_examples/errors.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/errors.rb
@@ -15,7 +15,7 @@ shared_examples_for "a 404 page" do
     end
 
     it "leads to a 404" do
-      expect(page).to have_content("The page you're looking for can't be found")
+      expect(page).to have_content("The page you're looking for cannot be found")
 
       expect(page).to have_http_status(:not_found)
     end

--- a/decidim-core/lib/decidim/db/common-passwords.txt
+++ b/decidim-core/lib/decidim/db/common-passwords.txt
@@ -5543,7 +5543,7 @@ capricorn1
 capilla951
 canoncanon
 candycandy
-cannotremember
+can'tremember
 campagnolo
 calenicno1
 cactusjack

--- a/decidim-core/lib/decidim/db/common-passwords.txt
+++ b/decidim-core/lib/decidim/db/common-passwords.txt
@@ -5543,7 +5543,7 @@ capricorn1
 capilla951
 canoncanon
 candycandy
-can'tremember
+cannotremember
 campagnolo
 calenicno1
 cactusjack

--- a/decidim-core/lib/decidim/gamification.rb
+++ b/decidim-core/lib/decidim/gamification.rb
@@ -111,7 +111,7 @@ module Decidim
             set_score(user, badge.name, badge.reset.call(user)) if badge.valid_for?(user)
           end
         else
-          Rails.logger.info "Badge can't be reset since it doesn't have a reset method."
+          Rails.logger.info "Badge cannot be reset since it doesn't have a reset method."
         end
       end
     end

--- a/decidim-core/lib/decidim/has_reference.rb
+++ b/decidim-core/lib/decidim/has_reference.rb
@@ -31,7 +31,7 @@ module Decidim
       # Internal: Sets the unique reference to the model. Note that if the resource
       # implements `Decidim::Traceable` then any normal update (or `update`)
       # will create a new version through an ActiveRecord update callback, but here
-      # we can't track the author of the version, so we use the `update_column` method
+      # we cannot track the author of the version, so we use the `update_column` method
       # which does not trigger callbacks.
       #
       # Returns nothing.

--- a/decidim-core/spec/commands/decidim/leave_user_group_spec.rb
+++ b/decidim-core/spec/commands/decidim/leave_user_group_spec.rb
@@ -17,7 +17,7 @@ module Decidim
         context "when the user is the creator" do
           let(:role) { :creator }
 
-          it "broadcasts last admin cant leave group" do
+          it "broadcasts last admin cannot leave group" do
             expect { command.call }.to broadcast(:last_admin)
           end
 

--- a/decidim-core/spec/content_parsers/decidim/hashtag_parser_spec.rb
+++ b/decidim-core/spec/content_parsers/decidim/hashtag_parser_spec.rb
@@ -75,8 +75,8 @@ module Decidim
     end
 
     context "when content contains non-hash characters next to the hashtag name" do
-      let(:content) { "You can't add some characters to hashtags: ##{hashtag.name}+extra" }
-      let(:parsed_content) { "You can't add some characters to hashtags: #{hashtag.to_global_id}/#{hashtag.name}+extra" }
+      let(:content) { "You cannot add some characters to hashtags: ##{hashtag.name}+extra" }
+      let(:parsed_content) { "You cannot add some characters to hashtags: #{hashtag.to_global_id}/#{hashtag.name}+extra" }
 
       it_behaves_like "find and stores the hashtags references"
     end

--- a/decidim-core/spec/controllers/registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/registrations_controller_spec.rb
@@ -59,7 +59,7 @@ module Decidim
 
         it "adds the flash message" do
           post :create, params: params
-          expect(controller.flash.now[:alert]).to have_content("Your email can't be blank")
+          expect(controller.flash.now[:alert]).to have_content("Your email cannot be blank")
         end
 
         context "when all params are invalid" do
@@ -82,10 +82,10 @@ module Decidim
             post :create, params: params
             expect(controller.flash.now[:alert]).to have_content(
               [
-                "Your name can't be blank",
-                "Nickname can't be blank",
+                "Your name cannot be blank",
+                "Nickname cannot be blank",
                 "Nickname is invalid",
-                "Your email can't be blank",
+                "Your email cannot be blank",
                 "Confirm your password doesn't match Password",
                 "Password is too short",
                 "Password does not have enough unique characters",

--- a/decidim-core/spec/forms/translatable_presence_validator_spec.rb
+++ b/decidim-core/spec/forms/translatable_presence_validator_spec.rb
@@ -66,7 +66,7 @@ module Decidim
       it "does not validate the record" do
         subject
         expect(record.errors).not_to be_empty
-        expect(record.errors[:description_en]).to eq ["can't be blank"]
+        expect(record.errors[:description_en]).to eq ["cannot be blank"]
       end
     end
 
@@ -93,7 +93,7 @@ module Decidim
       it "does not validate the record" do
         subject
         expect(record.errors).not_to be_empty
-        expect(record.errors[:current_organization]).to eq ["can't be blank"]
+        expect(record.errors[:current_organization]).to eq ["cannot be blank"]
       end
     end
   end

--- a/decidim-core/spec/models/decidim/action_log_spec.rb
+++ b/decidim-core/spec/models/decidim/action_log_spec.rb
@@ -108,7 +108,7 @@ describe Decidim::ActionLog do
       it { is_expected.to be_falsey }
     end
 
-    context "when the user can't participate" do
+    context "when the user cannot participate" do
       before do
         action_log.participatory_space.private_space = true
         action_log.participatory_space.save!

--- a/decidim-core/spec/models/decidim/category_spec.rb
+++ b/decidim-core/spec/models/decidim/category_spec.rb
@@ -24,7 +24,7 @@ module Decidim
 
       it "adds an error" do
         subject.valid?
-        expect(subject.errors[:parent_id]).to eq ["can't be inside of a subcategory"]
+        expect(subject.errors[:parent_id]).to eq ["cannot be inside of a subcategory"]
       end
     end
 

--- a/decidim-core/spec/models/decidim/user_group_membership_spec.rb
+++ b/decidim-core/spec/models/decidim/user_group_membership_spec.rb
@@ -26,7 +26,7 @@ module Decidim
         expect(membership).not_to be_valid
       end
 
-      it "can't have multiple creators for the same user group" do
+      it "cannot have multiple creators for the same user group" do
         membership = create :user_group_membership, role: :creator
         failing_membership = build :user_group_membership, role: :creator, user_group: membership.user_group
 

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -74,10 +74,10 @@ module Decidim
 
         it "is not valid" do
           expect(user).not_to be_valid
-          expect(user.errors[:nickname]).to include("can't be blank")
+          expect(user.errors[:nickname]).to include("cannot be blank")
         end
 
-        it "can't be empty backed by an index" do
+        it "cannot be empty backed by an index" do
           expect { user.save(validate: false) }.not_to raise_error
         end
 
@@ -139,7 +139,7 @@ module Decidim
           expect(user.save).to be(true)
         end
 
-        it "can't have duplicates even when skipping validations" do
+        it "cannot have duplicates even when skipping validations" do
           user.save!
 
           expect do

--- a/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
@@ -87,7 +87,7 @@ describe Decidim::EmailNotificationGenerator do
           end
         end
 
-        context "and the user can't participate" do
+        context "and the user cannot participate" do
           before do
             allow(resource).to receive(:can_participate?).with(kind_of(Decidim::User)).and_return(false)
           end

--- a/decidim-core/spec/services/decidim/notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_spec.rb
@@ -135,7 +135,7 @@ describe Decidim::NotificationGenerator do
           end
         end
 
-        context "and the user can't participate" do
+        context "and the user cannot participate" do
           before do
             allow(resource).to receive(:can_participate?).with(kind_of(Decidim::User)).and_return(false)
           end

--- a/decidim-core/spec/system/admin_passwords_spec.rb
+++ b/decidim-core/spec/system/admin_passwords_spec.rb
@@ -51,7 +51,7 @@ describe "Admin passwords", type: :system do
     context "when user has strong password" do
       let(:password) { new_password }
 
-      it "cant reuse old password" do
+      it "cannot reuse old password" do
         manual_login(user.email, password)
         expect(page).to have_content("Password change")
         fill_in :password_user_password, with: new_password

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -287,7 +287,7 @@ describe "Conversations", type: :system do
       context "when someone direct messages disabled" do
         let!(:interlocutor2) { create(:user, :confirmed, organization:, direct_message_types: "followed-only") }
 
-        it "can't be selected on the mentioned list", :slow do
+        it "cannot be selected on the mentioned list", :slow do
           visit_inbox
           expect(page).to have_content("New conversation")
           click_button "New conversation"

--- a/decidim-core/spec/system/messaging/profile_conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/profile_conversations_spec.rb
@@ -305,7 +305,7 @@ describe "ProfileConversations", type: :system do
       context "when someone direct messages disabled" do
         let!(:interlocutor2) { create(:user, :confirmed, organization:, direct_message_types: "followed-only") }
 
-        it "can't be selected on the mentioned list", :slow do
+        it "cannot be selected on the mentioned list", :slow do
           skip "REDESIGN_PENDING: The profile conversations functionality is going to be removed and it's not necessary to fix this because the modal used here will be deprecated" do
             visit_profile_inbox
             expect(page).to have_content("New conversation")

--- a/decidim-core/spec/system/user_group_leaving_spec.rb
+++ b/decidim-core/spec/system/user_group_leaving_spec.rb
@@ -16,7 +16,7 @@ describe "User group leaving", type: :system do
     context "when the user is the creator" do
       let!(:user_group) { create(:user_group, users: [user], organization: user.organization) }
 
-      it "cant leave group" do
+      it "cannot leave group" do
         accept_confirm { click_link "Leave group" }
 
         expect(page).to have_content("You cannot remove yourself from this group as you're the last administrator")

--- a/decidim-core/spec/system/user_group_leaving_spec.rb
+++ b/decidim-core/spec/system/user_group_leaving_spec.rb
@@ -19,7 +19,7 @@ describe "User group leaving", type: :system do
       it "cant leave group" do
         accept_confirm { click_link "Leave group" }
 
-        expect(page).to have_content("You can't remove yourself from this group as you're the last administrator")
+        expect(page).to have_content("You cannot remove yourself from this group as you're the last administrator")
       end
 
       context "when there is another admin in the group" do

--- a/decidim-debates/lib/decidim/debates/component.rb
+++ b/decidim-debates/lib/decidim/debates/component.rb
@@ -14,7 +14,7 @@ Decidim.register_component(:debates) do |component|
   component.newsletter_participant_entities = ["Decidim::Debates::Debate"]
 
   component.on(:before_destroy) do |instance|
-    raise StandardError, "Can't remove this component" if Decidim::Debates::Debate.where(component: instance).any?
+    raise StandardError, "Cannot remove this component" if Decidim::Debates::Debate.where(component: instance).any?
   end
 
   component.settings(:global) do |settings|

--- a/decidim-debates/spec/system/user_closes_debate_spec.rb
+++ b/decidim-debates/spec/system/user_closes_debate_spec.rb
@@ -47,7 +47,7 @@ describe "User closes a debate", type: :system do
       )
     end
 
-    it "can't be edited" do
+    it "cannot be edited" do
       expect(page).to have_no_content("Edit debate")
     end
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -6,7 +6,7 @@ module Decidim
   # Helpers meant to be used only during capybara test runs.
   module CapybaraTestHelpers
     def switch_to_host(host = "lvh.me")
-      raise "Can't switch to a custom host unless it really exists. Use `whatever.lvh.me` as a workaround." unless /lvh\.me$/.match?(host)
+      raise "Cannot switch to a custom host unless it really exists. Use `whatever.lvh.me` as a workaround." unless /lvh\.me$/.match?(host)
 
       app_host = (host ? "#{protocol}://#{host}" : nil)
       Capybara.app_host = app_host
@@ -57,7 +57,7 @@ Capybara.register_driver :headless_chrome do |app|
   )
 end
 
-# In order to work with PWA apps, Chrome can't be run in headless mode, and requires
+# In order to work with PWA apps, Chrome cannot be run in headless mode, and requires
 # setting up special prefs and flags
 Capybara.register_driver :pwa_chrome do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new

--- a/decidim-elections/app/cells/decidim/elections/election_m_cell.rb
+++ b/decidim-elections/app/cells/decidim/elections/election_m_cell.rb
@@ -25,7 +25,7 @@ module Decidim
         icon "elections", class: "icon--big"
       end
 
-      # Even though we need to render the badge, we can't do it in the normal
+      # Even though we need to render the badge, we cannot do it in the normal
       # way, because the paragraph comes from a user input and contains HTML.
       # This causes the badge and the paragraph to appear in different lines.
       # In order to fix it, check the `description` method.

--- a/decidim-elections/app/cells/decidim/votings/voting_m_cell.rb
+++ b/decidim-elections/app/cells/decidim/votings/voting_m_cell.rb
@@ -21,7 +21,7 @@ module Decidim
         end
       end
 
-      # Even though we need to render the badge, we can't do it in the normal
+      # Even though we need to render the badge, we cannot do it in the normal
       # way, because the paragraph comes from a user input and contains HTML.
       # This causes the badge and the paragraph to appear in different lines.
       # In order to fix it, check the `description` method.

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -58,9 +58,9 @@ en:
         trustee:
           attributes:
             name:
-              cant_be_changed: can't be changed
+              cant_be_changed: cannot be changed
             public_key:
-              cant_be_changed: can't be changed
+              cant_be_changed: cannot be changed
         voting:
           attributes:
             voting_type:
@@ -334,7 +334,7 @@ en:
             continue: Continue
             invalid: There was a problem reporting the missing trustee
             mark_as_missing: Mark as missing
-            mark_as_missing_description: All the trustees should participate in this process, but if a trustee can't take part in the process, you can mark it as missing.
+            mark_as_missing_description: All the trustees should participate in this process, but if a trustee cannot take part in the process, you can mark it as missing.
             success: Missing trustee report was successfully sent to the Bulletin Board
             tally_completion: The process will be completed when all the trustees are active or marked as missing. At least %{quorum} trustees are required to complete the process.
             title: Tally process
@@ -641,10 +641,10 @@ en:
               upload: Upload your identification keys
               upload_error:
                 invalid_format: The uploaded file doesn't contain any identification key.
-                invalid_key: The identification keys in the uploaded file can't be loaded.
+                invalid_key: The identification keys in the uploaded file cannot be loaded.
                 invalid_public_key: The identification keys in the uploaded file doesn't match the public identification key stored.
               upload_legend: The server has your public identification keys, but your browser still doesn't have it. You need to import the file with your identification keys to your computer from the backup you created after generating them.
-            not_supported_browser_description: It looks like you are using a web browser that can't be used to act as a Trustee. Make sure you're using the most recent version of your browser, or try using any of the most popular browsers to be able to complete your Trustee tasks.
+            not_supported_browser_description: It looks like you are using a web browser that cannot be used to act as a Trustee. Make sure you're using the most recent version of your browser, or try using any of the most popular browsers to be able to complete your Trustee tasks.
             not_supported_browser_title: Upgrade browser to act as a Trustee
             trustee_role_description: You have been assigned to act as a Trustee in some of the elections celebrated in this platform.
           update:
@@ -1246,10 +1246,10 @@ en:
             confirm: Ok, continue
             error: An error occurred, please try again.
             heading: Vote recount - Sign closure
-            info_text: If you continue you can no longer modify any of the information, this action can't be undone.
+            info_text: If you continue you can no longer modify any of the information, this action cannot be undone.
             submit: Sign the closure
             success: Closure signed successfully.
-            title: Action can't be undone
+            title: Action cannot be undone
           update:
             error: An error occurred updating the closure results, please try again later.
             success: Closure results successfully updated.

--- a/decidim-elections/lib/decidim/elections/component.rb
+++ b/decidim-elections/lib/decidim/elections/component.rb
@@ -11,7 +11,7 @@ Decidim.register_component(:elections) do |component|
   component.query_type = "Decidim::Elections::ElectionsType"
 
   component.on(:before_destroy) do |instance|
-    raise StandardError, "Can't remove this component" if Decidim::Elections::Election.where(component: instance).any?
+    raise StandardError, "Cannot remove this component" if Decidim::Elections::Election.where(component: instance).any?
   end
 
   # These actions permissions can be configured in the admin panel

--- a/decidim-elections/spec/forms/decidim/elections/admin/answer_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/answer_form_spec.rb
@@ -58,7 +58,7 @@ describe Decidim::Elections::Admin::AnswerForm do
 
       it "adds an error to the `:attachment` field" do
         expect(subject).not_to be_valid
-        expect(subject.errors.full_messages).to match_array(["Title en can't be blank", "Attachment Needs to be reattached"])
+        expect(subject.errors.full_messages).to match_array(["Title en cannot be blank", "Attachment Needs to be reattached"])
         expect(subject.errors.attribute_names).to match_array([:title_en, :attachment])
       end
     end

--- a/decidim-elections/spec/forms/decidim/elections/admin/election_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/election_form_spec.rb
@@ -82,7 +82,7 @@ describe Decidim::Elections::Admin::ElectionForm do
 
       it "adds an error to the `:attachment` field" do
         expect(subject).not_to be_valid
-        expect(subject.errors.full_messages).to match_array(["Title en can't be blank", "Attachment Needs to be reattached"])
+        expect(subject.errors.full_messages).to match_array(["Title en cannot be blank", "Attachment Needs to be reattached"])
         expect(subject.errors.attribute_names).to match_array([:title_en, :attachment])
       end
     end

--- a/decidim-elections/spec/lib/decidim/elections/component_spec.rb
+++ b/decidim-elections/spec/lib/decidim/elections/component_spec.rb
@@ -22,7 +22,7 @@ describe "Elections component" do # rubocop:disable RSpec/DescribeClass
       it "raises an error" do
         expect { subject.manifest.run_hooks(:before_destroy, subject) }.to raise_error(
           StandardError,
-          "Can't remove this component"
+          "Cannot remove this component"
         )
       end
     end

--- a/decidim-elections/spec/system/polling_officer_zone_spec.rb
+++ b/decidim-elections/spec/system/polling_officer_zone_spec.rb
@@ -31,7 +31,7 @@ describe "Polling Officer zone", type: :system do
   context "when the user is not a polling officer" do
     let(:polling_officers) { [create(:polling_officer)] }
 
-    it "can't access to the polling officer zone" do
+    it "cannot access to the polling officer zone" do
       visit decidim.account_path
 
       expect(page).not_to have_content("Polling Officer zone")

--- a/decidim-elections/spec/system/trustee_zone_spec.rb
+++ b/decidim-elections/spec/system/trustee_zone_spec.rb
@@ -17,7 +17,7 @@ describe "Trustee zone", type: :system do
   context "when the user name exists in this organization", download: true do
     let!(:other_trustee) { create(:trustee, :with_public_key, name: user.name, organization: user.organization) }
 
-    it "can't generate identification keys" do
+    it "cannot generate identification keys" do
       visit decidim.decidim_elections_trustee_zone_path
 
       expect(page).to have_content("Generate identification keys")
@@ -89,7 +89,7 @@ describe "Trustee zone", type: :system do
       "a public_key" => "public_key.jwk",
       "an image" => "city.jpeg"
     }.each do |description, filename|
-      it "can't upload #{description}" do
+      it "cannot upload #{description}" do
         visit decidim.decidim_elections_trustee_zone_path
 
         expect(page).to have_content("Upload your identification keys")
@@ -108,7 +108,7 @@ describe "Trustee zone", type: :system do
   context "when the user is not a trustee" do
     let(:trustee) { create(:trustee) }
 
-    it "can't access to the trustee zone" do
+    it "cannot access to the trustee zone" do
       visit decidim.account_path
 
       expect(page).not_to have_content("Trustee zone")

--- a/decidim-elections/spec/system/vote_online_inside_a_voting_spec.rb
+++ b/decidim-elections/spec/system/vote_online_inside_a_voting_spec.rb
@@ -130,7 +130,7 @@ describe "Vote online in an election inside a Voting", type: :system do
   end
 
   context "when the census data is not right" do
-    it "can't vote", :slow do
+    it "cannot vote", :slow do
       visit_component
       click_link translated(election.title)
       click_link "Start voting"

--- a/decidim-forms/config/locales/en.yml
+++ b/decidim-forms/config/locales/en.yml
@@ -129,7 +129,7 @@ en:
           update: "%{user_name} updated the %{resource_name} questionnaire"
       errors:
         answer:
-          body: Body can't be blank
+          body: Body cannot be blank
       images:
         dimensions: "%{width} x %{height} px"
         processors:

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -231,7 +231,7 @@ shared_examples_for "has questionnaire" do
           expect(page).to have_content("problem")
         end
 
-        expect(page).to have_content("can't be blank")
+        expect(page).to have_content("cannot be blank")
       end
     end
 
@@ -248,7 +248,7 @@ shared_examples_for "has questionnaire" do
         expect(different_error).to eq("There are too many choices selected")
         expect(page).not_to have_content(different_error)
 
-        expect(page).to have_content("can't be blank")
+        expect(page).to have_content("cannot be blank")
       end
     end
 
@@ -280,7 +280,7 @@ shared_examples_for "has questionnaire" do
           expect(page).to have_content("problem")
         end
 
-        expect(page).to have_content("can't be blank")
+        expect(page).to have_content("cannot be blank")
       end
     end
 

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/update_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/update_questions.rb
@@ -53,7 +53,7 @@ shared_examples_for "update questions" do
       expand_all_questions
 
       expect(page).to have_admin_callout("There was a problem saving")
-      expect(page).to have_content("can't be blank", count: 5) # emtpy question, 2 empty default answer options, 2 empty default matrix rows
+      expect(page).to have_content("cannot be blank", count: 5) # emtpy question, 2 empty default answer options, 2 empty default matrix rows
       expect(page).to have_content("must be greater than or equal to 0", count: 1)
 
       expect(page).to have_selector("input[value='']")
@@ -157,7 +157,7 @@ shared_examples_for "update questions" do
       expand_all_questions
 
       expect(page).to have_admin_callout("There was a problem saving")
-      expect(page).to have_content("can't be blank", count: 1)
+      expect(page).to have_content("cannot be blank", count: 1)
       expect(page).to have_selector("input[value='']")
       expect(page).to have_no_selector("input[value='This is the first title and description']")
     end

--- a/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
@@ -111,7 +111,7 @@ module Decidim
 
       def initialize_pages(component)
         Decidim::Pages::CreatePage.call(component) do
-          on(:invalid) { raise "Can't create page" }
+          on(:invalid) { raise "Cannot create page" }
         end
       end
 

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -156,7 +156,7 @@ module Decidim
                         datetime: :published_at
                       },
                       index_on_create: ->(_initiative) { false },
-                      # is Resourceable instead of ParticipatorySpaceResourceable so we can't use `visible?`
+                      # is Resourceable instead of ParticipatorySpaceResourceable so we cannot use `visible?`
                       index_on_update: ->(initiative) { initiative.published? })
 
     def self.log_presenter_class_for(_log)

--- a/decidim-initiatives/db/migrate/20171017095143_update_initiative_scoped_type.rb
+++ b/decidim-initiatives/db/migrate/20171017095143_update_initiative_scoped_type.rb
@@ -52,6 +52,6 @@ class UpdateInitiativeScopedType < ActiveRecord::Migration[5.1]
   end
 
   def down
-    raise ActiveRecord::IrreversibleMigration, "Can't undo initialization of mandatory attribute"
+    raise ActiveRecord::IrreversibleMigration, "Cannot undo initialization of mandatory attribute"
   end
 end

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -131,7 +131,7 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
         next unless component_name == :pages
 
         Decidim::Pages::CreatePage.call(component) do
-          on(:invalid) { raise "Can't create page" }
+          on(:invalid) { raise "Cannot create page" }
         end
       end
     end

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/initiative_signatures_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/initiative_signatures_controller_spec.rb
@@ -19,7 +19,7 @@ module Decidim
       context "when POST create" do
         context "and authorized user" do
           context "and initiative with user extra fields required" do
-            it "can't vote" do
+            it "cannot vote" do
               sign_in initiative_with_user_extra_fields.author, scope: :user
               post :create, params: { initiative_slug: initiative_with_user_extra_fields.slug, format: :js }
               expect(response).to have_http_status(:unprocessable_entity)

--- a/decidim-initiatives/spec/forms/initiative_form_spec.rb
+++ b/decidim-initiatives/spec/forms/initiative_form_spec.rb
@@ -168,7 +168,7 @@ module Decidim
 
           it "adds an error to the `:attachment` field" do
             expect(subject).not_to be_valid
-            expect(subject.errors.full_messages).to match_array(["Title can't be blank", "Attachment Needs to be reattached"])
+            expect(subject.errors.full_messages).to match_array(["Title cannot be blank", "Attachment Needs to be reattached"])
             expect(subject.errors.attribute_names).to match_array([:title, :attachment])
           end
         end

--- a/decidim-initiatives/spec/models/decidim/initiative_spec.rb
+++ b/decidim-initiatives/spec/models/decidim/initiative_spec.rb
@@ -190,7 +190,7 @@ module Decidim
           expect(initiative).not_to be_supports_goal_reached
         end
 
-        it "can't be greater than 100" do
+        it "cannot be greater than 100" do
           initiative.update(online_votes: { scope_id => initiative.scoped_type.supports_required, "total" => initiative.scoped_type.supports_required * 2 })
           expect(initiative.percentage).to eq(100)
           expect(initiative).to be_supports_goal_reached
@@ -209,7 +209,7 @@ module Decidim
           expect(initiative).not_to be_supports_goal_reached
         end
 
-        it "can't be greater than 100" do
+        it "cannot be greater than 100" do
           online_votes = initiative.scoped_type.supports_required * 4
           offline_votes = initiative.scoped_type.supports_required * 4
           initiative.update(offline_votes: { scope_id => offline_votes, "total" => offline_votes },

--- a/decidim-initiatives/spec/services/decidim/initiatives/data_encryptor_spec.rb
+++ b/decidim-initiatives/spec/services/decidim/initiatives/data_encryptor_spec.rb
@@ -37,7 +37,7 @@ module Decidim
           expect(encryptor.decrypt(encrypted_hash_data)).to eq(hash_payload)
         end
 
-        it "invalid data can't be decrypted" do
+        it "invalid data cannot be decrypted" do
           expect { encryptor.decrypt("wadus") }.to raise_error(ActiveSupport::MessageEncryptor::InvalidMessage)
         end
       end

--- a/decidim-initiatives/spec/system/edit_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/edit_initiative_spec.rb
@@ -55,7 +55,7 @@ describe "Edit initiative", type: :system do
     context "when initiative is published" do
       let(:initiative) { create(:initiative, author: user, scoped_type:, organization:) }
 
-      it "can't be updated" do
+      it "cannot be updated" do
         visit decidim_initiatives.initiative_path(initiative)
 
         expect(page).not_to have_content "Edit initiative"

--- a/decidim-initiatives/spec/system/filter_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/filter_initiatives_spec.rb
@@ -295,7 +295,7 @@ describe "Filter Initiatives", :slow, type: :system do
         visit decidim_initiatives.initiatives_path
       end
 
-      it "can't be filtered by author" do
+      it "cannot be filtered by author" do
         within "form.new_filter" do
           expect(page).not_to have_content(/Author/i)
         end

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -56,7 +56,7 @@ en:
         meeting:
           attributes:
             iframe_embed_type:
-              not_embeddable: This URL can't be embedded in meeting or live event page
+              not_embeddable: This URL cannot be embedded in meeting or live event page
         meeting_agenda:
           attributes:
             base:
@@ -287,7 +287,7 @@ en:
             filter_by: Filter by
             invite_attendee: Invite attendee
             invites: Invites
-            registrations_disabled: You can't invite an attendee because the registrations are disabled.
+            registrations_disabled: You cannot invite an attendee because the registrations are disabled.
             search: Search
         meeting_closes:
           edit:

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -12,7 +12,7 @@ Decidim.register_component(:meetings) do |component|
   component.data_portable_entities = ["Decidim::Meetings::Registration"]
 
   component.on(:before_destroy) do |instance|
-    raise StandardError, "Can't remove this component" if Decidim::Meetings::Meeting.where(component: instance).any?
+    raise StandardError, "Cannot remove this component" if Decidim::Meetings::Meeting.where(component: instance).any?
   end
 
   component.register_resource(:meeting) do |resource|

--- a/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
@@ -224,7 +224,7 @@ module Decidim::Meetings
       it { is_expected.not_to be_valid }
     end
 
-    describe "when online meeting url is present and the meeting is embedded and the url can't be embedded" do
+    describe "when online meeting url is present and the meeting is embedded and the url cannot be embedded" do
       let(:online_meeting_url) { "https://meet.jit.si/decidim" }
       let(:iframe_embed_type) { "embed_in_meeting_page" }
 

--- a/decidim-meetings/spec/forms/meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/meeting_form_spec.rb
@@ -188,7 +188,7 @@ module Decidim::Meetings
       end
     end
 
-    describe "when online meeting url is present and the meeting is embedded and the url can't be embedded" do
+    describe "when online meeting url is present and the meeting is embedded and the url cannot be embedded" do
       let(:online_meeting_url) { "https://example.org/decidim" }
       let(:iframe_embed_type) { "embed_in_meeting_page" }
 

--- a/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
+++ b/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
@@ -95,7 +95,7 @@ describe Decidim::Meetings::Permissions do
         .and_return(can_be_joined)
     end
 
-    context "when meeting can't be joined" do
+    context "when meeting cannot be joined" do
       let(:can_be_joined) { false }
 
       it { is_expected.to be false }
@@ -120,7 +120,7 @@ describe Decidim::Meetings::Permissions do
         .and_return(can_be_registered)
     end
 
-    context "when meeting can't be joined" do
+    context "when meeting cannot be joined" do
       let(:can_be_registered) { false }
 
       it { is_expected.to be false }

--- a/decidim-meetings/spec/shared/manage_registrations_examples.rb
+++ b/decidim-meetings/spec/shared/manage_registrations_examples.rb
@@ -82,7 +82,7 @@ shared_examples "manage registrations" do
       expect(page).to have_admin_callout("Registration code successfully validated")
     end
 
-    it "can't validate an invalid registration code" do
+    it "cannot validate an invalid registration code" do
       visit_edit_registrations_page
 
       within ".validate_meeting_registration_code" do

--- a/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
+++ b/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
@@ -321,7 +321,7 @@ describe "Explore meeting directory", type: :system do
     it "allows filtering by space" do
       expect(page).to have_content(assembly_meeting.title["en"])
 
-      # Since in the first load all the meeting are present, we need can't rely on
+      # Since in the first load all the meeting are present, we need cannot rely on
       # have_content to wait for the card list to change. This is a hack to
       # reset the contents to no meetings at all, and then showing only the upcoming
       # assembly meetings.

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -57,7 +57,7 @@ describe "Meeting registrations", type: :system do
     context "and registration form is also enabled" do
       let(:registration_form_enabled) { true }
 
-      it "can't answer the registration form" do
+      it "cannot answer the registration form" do
         visit questionnaire_public_path
 
         expect(page).to have_i18n_content(questionnaire.title)
@@ -94,7 +94,7 @@ describe "Meeting registrations", type: :system do
           login_as user, scope: :user
         end
 
-        it "can't answer the registration form" do
+        it "cannot answer the registration form" do
           visit questionnaire_public_path
 
           expect(page).to have_i18n_content(questionnaire.title)
@@ -477,7 +477,7 @@ describe "Meeting registrations", type: :system do
       context "and registration form is enabled" do
         let(:registration_form_enabled) { true }
 
-        it "can't answer the registration again" do
+        it "cannot answer the registration again" do
           visit questionnaire_public_path
 
           expect(page).to have_i18n_content(questionnaire.title)

--- a/decidim-pages/lib/decidim/pages/component.rb
+++ b/decidim-pages/lib/decidim/pages/component.rb
@@ -15,19 +15,19 @@ Decidim.register_component(:pages) do |component|
 
   component.on(:create) do |instance|
     Decidim::Pages::CreatePage.call(instance) do
-      on(:invalid) { raise "Can't create page" }
+      on(:invalid) { raise "Cannot create page" }
     end
   end
 
   component.on(:destroy) do |instance|
     Decidim::Pages::DestroyPage.call(instance) do
-      on(:error) { raise "Can't destroy page" }
+      on(:error) { raise "Cannot destroy page" }
     end
   end
 
   component.on(:copy) do |context|
     Decidim::Pages::CopyPage.call(context) do
-      on(:invalid) { raise "Can't duplicate page" }
+      on(:invalid) { raise "Cannot duplicate page" }
     end
   end
 

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -230,8 +230,8 @@ en:
         default_title: Introduction
         destroy:
           error:
-            active_step: Can't delete the active phase.
-            last_step: Can't delete the last phase of a process.
+            active_step: Cannot delete the active phase.
+            last_step: Cannot delete the last phase of a process.
           success: Participatory process phase successfully deleted.
         edit:
           title: Edit participatory process phase

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/admin/filterable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/admin/filterable.rb
@@ -53,7 +53,7 @@ module Decidim
             }
           end
 
-          # Can't user `super` here, because it does not belong to a superclass
+          # Cannot user `super` here, because it does not belong to a superclass
           # but to a concern.
           def dynamically_translated_filters
             [:scope_id_eq, :category_id_eq, :valuator_role_ids_has]

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -32,7 +32,7 @@ en:
         cost_report: Cost report
         execution_period: Execution period
       proposals_copy:
-        copy_proposals: I understand that this will import all proposals from the selected component to the current one and that this action can't be reversed.
+        copy_proposals: I understand that this will import all proposals from the selected component to the current one and that this action cannot be reversed.
         origin_component_id: Component to copy the proposals from
       proposals_import:
         import_proposals: Import proposals
@@ -761,7 +761,7 @@ en:
             valuators: Valuators
             votes: Votes
       new:
-        limit_reached: You can't create new proposals since you've exceeded the limit.
+        limit_reached: You cannot create new proposals since you've exceeded the limit.
       participatory_text_proposal:
         alternative_title: There are no participatory texts at the moment
         buttons:

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -10,7 +10,7 @@ Decidim.register_component(:proposals) do |component|
   component.icon = "media/images/decidim_proposals.svg"
 
   component.on(:before_destroy) do |instance|
-    raise "Can't destroy this component when there are proposals" if Decidim::Proposals::Proposal.where(component: instance).any?
+    raise "Cannot destroy this component when there are proposals" if Decidim::Proposals::Proposal.where(component: instance).any?
   end
 
   component.data_portable_entities = ["Decidim::Proposals::Proposal"]

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/publish_participatory_text_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/publish_participatory_text_spec.rb
@@ -78,7 +78,7 @@ module Decidim
               it "does not persist modifications and broadcasts invalid" do
                 failures = {}
                 proposals.each do |proposal|
-                  failures[proposal.id] = ["Title can't be blank"]
+                  failures[proposal.id] = ["Title cannot be blank"]
                 end
                 expect { command.call }.to broadcast(:invalid, failures)
               end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/update_participatory_text_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/update_participatory_text_spec.rb
@@ -77,7 +77,7 @@ module Decidim
               it "does not persist modifications and broadcasts invalid" do
                 failures = {}
                 proposals.each do |proposal|
-                  failures[proposal.id] = ["Title can't be blank"]
+                  failures[proposal.id] = ["Title cannot be blank"]
                 end
                 expect { command.call }.to broadcast(:invalid, failures)
               end

--- a/decidim-proposals/spec/shared/merge_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/merge_proposals_examples.rb
@@ -68,7 +68,7 @@ shared_examples "merge proposals" do
           let!(:target_component) { current_component }
           let!(:proposal_ids) { proposals.map(&:id) }
 
-          context "when the proposals can't be merged" do
+          context "when the proposals cannot be merged" do
             let!(:proposals) { create_list :proposal, 3, :with_endorsements, :with_votes, component: current_component }
 
             it "doesn't create a new proposal and displays a validation fail message" do

--- a/decidim-proposals/spec/shared/proposal_form_examples.rb
+++ b/decidim-proposals/spec/shared/proposal_form_examples.rb
@@ -289,10 +289,10 @@ shared_examples "a proposal form" do |options|
         expect(subject).not_to be_valid
 
         if options[:i18n]
-          expect(subject.errors.full_messages).to match_array(["Title en can't be blank", "Add photos Needs to be reattached"])
+          expect(subject.errors.full_messages).to match_array(["Title en cannot be blank", "Add photos Needs to be reattached"])
           expect(subject.errors.attribute_names).to match_array([:title_en, :add_photos])
         else
-          expect(subject.errors.full_messages).to match_array(["Title can't be blank", "Title is too short (under 15 characters)", "Add photos Needs to be reattached"])
+          expect(subject.errors.full_messages).to match_array(["Title cannot be blank", "Title is too short (under 15 characters)", "Add photos Needs to be reattached"])
           expect(subject.errors.attribute_names).to match_array([:title, :add_photos])
         end
       end

--- a/decidim-proposals/spec/shared/publish_answers_examples.rb
+++ b/decidim-proposals/spec/shared/publish_answers_examples.rb
@@ -35,7 +35,7 @@ shared_examples "publish answers" do
       expect(page).to have_content("Accepted", count: 3)
     end
 
-    it "can't publish answers for non answered proposals" do
+    it "cannot publish answers for non answered proposals" do
       page.find("#proposals_bulk.js-check-all").set(true)
       page.all("[data-published-state=false] .js-proposal-list-check").each { |c| c.set(false); }
 

--- a/decidim-proposals/spec/shared/split_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/split_proposals_examples.rb
@@ -54,7 +54,7 @@ shared_examples "split proposals" do
         context "when splitting to the same component" do
           let!(:target_component) { current_component }
 
-          context "and the proposals can't be splitted" do
+          context "and the proposals cannot be splitted" do
             let!(:proposals) { create_list :proposal, 3, :with_endorsements, :with_votes, component: current_component }
 
             it "doesn't create a new proposal and displays a validation fail message" do

--- a/decidim-sortitions/app/cells/decidim/sortitions/sortition_m_cell.rb
+++ b/decidim-sortitions/app/cells/decidim/sortitions/sortition_m_cell.rb
@@ -18,7 +18,7 @@ module Decidim
         true
       end
 
-      # Even though we need to render the badge, we can't do it in the normal
+      # Even though we need to render the badge, we cannot do it in the normal
       # way, because the paragraph comes from a user input and contains HTML.
       # This causes the badge and the paragraph to appear in different lines.
       # In order to fix it, check the `description` method.

--- a/decidim-sortitions/lib/decidim/sortitions/component.rb
+++ b/decidim-sortitions/lib/decidim/sortitions/component.rb
@@ -9,7 +9,7 @@ Decidim.register_component(:sortitions) do |component|
   component.query_type = "Decidim::Sortitions::SortitionsType"
 
   component.on(:before_destroy) do |instance|
-    raise StandardError, "Can't remove this component" if Decidim::Sortitions::Sortition.where(component: instance).any?
+    raise StandardError, "Cannot remove this component" if Decidim::Sortitions::Sortition.where(component: instance).any?
   end
 
   # These actions permissions can be configured in the admin panel

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -15,13 +15,13 @@ Decidim.register_component(:surveys) do |component|
 
   component.on(:copy) do |context|
     Decidim::Surveys::CreateSurvey.call(context[:new_component]) do
-      on(:invalid) { raise "Can't create survey" }
+      on(:invalid) { raise "Cannot create survey" }
     end
   end
 
   component.on(:create) do |instance|
     Decidim::Surveys::CreateSurvey.call(instance) do
-      on(:invalid) { raise "Can't create survey" }
+      on(:invalid) { raise "Cannot create survey" }
     end
   end
 
@@ -33,7 +33,7 @@ Decidim.register_component(:surveys) do |component|
     survey = Decidim::Surveys::Survey.find_by(decidim_component_id: instance.id)
     survey_answers_for_component = Decidim::Forms::Answer.where(questionnaire: survey.questionnaire)
 
-    raise "Can't destroy this component when there are survey answers" if survey_answers_for_component.any?
+    raise "Cannot destroy this component when there are survey answers" if survey_answers_for_component.any?
   end
 
   component.register_resource(:survey) do |resource|

--- a/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
+++ b/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
@@ -28,7 +28,7 @@ describe "Surveys component" do # rubocop:disable RSpec/DescribeClass
       it "raises an error" do
         expect { subject.manifest.run_hooks(:before_destroy, subject) }.to raise_error(
           RuntimeError,
-          "Can't destroy this component when there are survey answers"
+          "Cannot destroy this component when there are survey answers"
         )
       end
     end

--- a/decidim-system/README.md
+++ b/decidim-system/README.md
@@ -76,7 +76,7 @@ system_admin.save
 Once you have your system admin setup you can also start managing the organizations in your deploy. To do it, login at the system dashboard and create a new organization
 following the form instructions. After creating it, a new admin user will be created and invited to start managing it.
 
-Remember that System admins and regular Admins are completely different users (they don't even share the same database table), so you can't use your
+Remember that System admins and regular Admins are completely different users (they don't even share the same database table), so you cannot use your
 system user to login in as an organization admin.
 
 ## Contributing

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -98,7 +98,7 @@ Decidim implements two type of authorization methods:
     authorization process.
 
 * _Renewable authorizations_.
-  By default a participant can't renew its authorization, but this can be enabled when registering the workflow, the time between renewals can be configured (one day by default).
+  By default a participant cannot renew its authorization, but this can be enabled when registering the workflow, the time between renewals can be configured (one day by default).
 
   Optionally to change the renew modal content part of the data stored, you can set a new value for the cell used to render the metadata.
 

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -62,7 +62,7 @@ en:
           - Users fill in their identity information and upload a copy of their document.
           - You fill in the information present in the uploaded image.
           - The information should match whatever the user filled in.
-          - If you can't clearly see the information or you can't get it verified, you can reject the request and the user will be able to fix it.
+          - If you cannot clearly see the information or you cannot get it verified, you can reject the request and the user will be able to fix it.
         postal_letter:
           help:
           - Participants request a verification code to be sent to their address.

--- a/decidim-verifications/spec/forms/decidim/verifications/id_documents/admin/config_form_spec.rb
+++ b/decidim-verifications/spec/forms/decidim/verifications/id_documents/admin/config_form_spec.rb
@@ -39,7 +39,7 @@ module Decidim::Verifications::IdDocuments::Admin
       it "is not valid without an explanation" do
         expect(subject).not_to be_valid
         expect(subject.errors[:offline_explanation_en])
-          .to include("can't be blank")
+          .to include("cannot be blank")
       end
     end
   end

--- a/decidim-verifications/spec/system/action_authorization_spec.rb
+++ b/decidim-verifications/spec/system/action_authorization_spec.rb
@@ -111,7 +111,7 @@ describe "Action Authorization", type: :system do
           click_link "New proposal"
 
           expect(page).to have_content("Not authorized")
-          expect(page).to have_content("Sorry, you can't perform this action as some of your authorization data doesn't match.")
+          expect(page).to have_content("Sorry, you cannot perform this action as some of your authorization data doesn't match.")
           expect(page).to have_content("Participation is restricted to participants with the scope #{scope.name["en"]}, and your scope is #{other_scope.name["en"]}.")
         end
       end
@@ -131,7 +131,7 @@ describe "Action Authorization", type: :system do
             click_link "New proposal"
 
             expect(page).to have_content("Not authorized")
-            expect(page).to have_content("Sorry, you can't perform this action as some of your authorization data doesn't match.")
+            expect(page).to have_content("Sorry, you cannot perform this action as some of your authorization data doesn't match.")
             expect(page).to have_content("Participation is restricted to participants with any of the following postal codes: 1234, 4567.")
             expect(page).to have_content("Participation is restricted to participants with the scope #{scope.name["en"]}, and your scope is #{user_scope.name["en"]}.")
           end
@@ -144,7 +144,7 @@ describe "Action Authorization", type: :system do
             click_link "New proposal"
 
             expect(page).to have_content("Not authorized")
-            expect(page).to have_content("Sorry, you can't perform this action as some of your authorization data doesn't match.")
+            expect(page).to have_content("Sorry, you cannot perform this action as some of your authorization data doesn't match.")
             expect(page).to have_content("Participation is restricted to participants with the scope #{scope.name["en"]}.")
           end
         end
@@ -157,7 +157,7 @@ describe "Action Authorization", type: :system do
             click_link "New proposal"
 
             expect(page).to have_content("Not authorized")
-            expect(page).to have_content("Sorry, you can't perform this action as some of your authorization data doesn't match.")
+            expect(page).to have_content("Sorry, you cannot perform this action as some of your authorization data doesn't match.")
             expect(page).to have_content("Participation is restricted to participants with any of the following postal codes: 1234, 4567.")
             expect(page).to have_content("Participation is restricted to participants with the scope #{scope.name["en"]}.")
           end

--- a/decidim-verifications/spec/system/authorizations_spec.rb
+++ b/decidim-verifications/spec/system/authorizations_spec.rb
@@ -203,7 +203,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
             create(:authorization, name: "dummy_authorization_handler", user:, granted_at: 1.minute.ago)
           end
 
-          it "can't be renewed yet" do
+          it "cannot be renewed yet" do
             visit_authorizations
 
             within ".authorizations-list" do
@@ -258,7 +258,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
           create(:authorization, name: "dummy_authorization_handler", user:, granted_at: 2.seconds.ago)
         end
 
-        it "can't be renewed yet" do
+        it "cannot be renewed yet" do
           visit_authorizations
 
           within ".authorizations-list" do

--- a/decidim_app-design/config/environments/development.rb
+++ b/decidim_app-design/config/environments/development.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
 
   config.cache_store = :null_store
 
-  # Don't care if the mailer can't send.
+  # Don't care if the mailer cannot send.
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false

--- a/docs/modules/develop/pages/api.adoc
+++ b/docs/modules/develop/pages/api.adoc
@@ -8,4 +8,4 @@ Documentation for this API is auto-generated in each instance of Decidim, usuall
 
 Accessing that URL will give a full details of all the objects that can be requested and how. It includes the full field types reference.
 
-As an alternative, if you can't access that URL on your instance you can read about how this work https://github.com/decidim/decidim/blob/develop/decidim-api/docs/usage.md[Using the Decidim GraphQL API].
+As an alternative, if you cannot access that URL on your instance you can read about how this work https://github.com/decidim/decidim/blob/develop/decidim-api/docs/usage.md[Using the Decidim GraphQL API].

--- a/docs/modules/develop/pages/permissions.adoc
+++ b/docs/modules/develop/pages/permissions.adoc
@@ -18,7 +18,7 @@ We wrap the permission and its context in a `PermissionsAction` object. It also 
 
 Each component and space must define a `Permissions` class, inheriting from `Decidim::DefaultPermissions`. The `Permissions` class must define a `permissions` instance method. this class will receive the permission action, and the `permissions` method must return the permission action. The `Permissions` class can set the action as allowed or disallowed.
 
-There's a small limitation in the permission action state machine: once it's been disallowed it can't be reallowed. This is to avoid mischievous modules modifying permissions.
+There's a small limitation in the permission action state machine: once it's been disallowed it cannot be reallowed. This is to avoid mischievous modules modifying permissions.
 
 Permission actions have a scope. It's usually either `:public` or `:admin`, and the `Permissions` class usually handles the `:public` scope, while it delegates the `:admin` one to another specialized class.
 

--- a/docs/modules/develop/pages/releases.adoc
+++ b/docs/modules/develop/pages/releases.adoc
@@ -9,7 +9,7 @@ Remember to follow the Gitflow branching workflow.
 . Merge all the https://github.com/decidim/decidim/pulls?q=is%3Apr+is%3Aopen+author%3Adecidim-bot+sort%3Aupdated-desc+base%3Adevelop[Crowdin pull requests created by the user `decidim-bot`], specially the one that's going to be marged against `develop` that should be returned by the provided example search.
 . Go to develop with `git checkout develop`
 . Create the release branch `git checkout -b release/x.y-stable && git push origin release/x.y-stable`.
-. Add the release branch to Crowdin so that any pending translations will generate a PR to this branch. This needs to be done with the generic user `decidim` in the GitHub's Crowdin integration, as this is the user that initially configured the installation and other admins in the Crowdin organization can't change it. See instructions for this on the "Create the stable branch in Crowdin". Note that after the branch is configured at Crowdin, it takes some time for the synchronization to happen, so be prepared to wait a couple of hours.
+. Add the release branch to Crowdin so that any pending translations will generate a PR to this branch. This needs to be done with the generic user `decidim` in the GitHub's Crowdin integration, as this is the user that initially configured the installation and other admins in the Crowdin organization cannot change it. See instructions for this on the "Create the stable branch in Crowdin". Note that after the branch is configured at Crowdin, it takes some time for the synchronization to happen, so be prepared to wait a couple of hours.
 
 Mark `develop` as the reference to the next release:
 

--- a/docs/modules/services/pages/maps.adoc
+++ b/docs/modules/services/pages/maps.adoc
@@ -9,7 +9,7 @@ Decidim has built-in support for the following map service providers:
  ** <<configuring-here-maps,Configuring HERE Maps>>
 * https://wiki.openstreetmap.org/wiki/Commercial_OSM_Software_and_Services[Open Street Maps based services]
  ** Please pick a service provider that provides all needed services (map tiles, static map images, geocoding and geocoding autocompletion)
- ** We can't use the OSM's own services by their https://operations.osmfoundation.org/policies/tiles/[tile usage policy].
+ ** We cannot use the OSM's own services by their https://operations.osmfoundation.org/policies/tiles/[tile usage policy].
  ** In case your service provider does not offer static map images, Decidim will use the dynamic map tiles to generate a similar map element.
  ** As an alternative, you may also want to use your own self-hosted map servers (see <<hosting-your-own-map-services,Hosting your own map services>> for more information)
  ** <<configuring-open-street-maps-based-service-providers,Configuring Open Street Maps based service providers>>

--- a/lib/decidim/git_backport_manager.rb
+++ b/lib/decidim/git_backport_manager.rb
@@ -46,7 +46,7 @@ module Decidim
     end
 
     # Switch to the develop branch
-    # In case that it can't do that, exits
+    # In case that it cannot do that, exits
     #
     # @return [void]
     def self.checkout_develop


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing the bug report #10495, I noticed that we are using a mixed formatting of the words "can't" and "cannot".

These are interchangeable but we should be consistent with their use. The format "cannot" is more formal and also "cannot" is more common compared to "can not" according to Merriam-Webster, which is why I'm suggesting to use that format.

#### :pushpin: Related Issues
- Related to #10495

#### Testing
Run the following command at the root of the repository:
```bash
$ grep -ril "can't" decidim-*
```

Expect to see no matches.