### PR TITLE
Standardize the format of the words "have not"

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1740,7 +1740,7 @@ en:
       load: Failed to load emojis
     recents:
       clear: Clear recent emojis
-      none: You haven't selected any emojis yet.
+      none: You have not selected any emojis yet.
     retry: Try again
     search:
       _: Search emojis...

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -421,7 +421,7 @@ en:
           ok: Ok
           title: Not authorized
         unconfirmed:
-          confirmation_instructions: 'If you haven''t received the confirmation instructions you can request them again:'
+          confirmation_instructions: 'If you have not received the confirmation instructions you can request them again:'
           explanation_html: In order to perform this action you need to be authorized, before doing that you need to confirm your email <strong>%{email}</strong>.
           request_confirmation_instructions: Request confirmation instructions
           title: Confirm your email

--- a/decidim-core/spec/helpers/decidim/endorsable_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/endorsable_helper_spec.rb
@@ -65,7 +65,7 @@ module Decidim
       end
 
       context "when it's a user" do
-        context "and they haven't endorsed yet" do
+        context "and they have not endorsed yet" do
           it { is_expected.not_to include("is-selected") }
         end
 
@@ -82,7 +82,7 @@ module Decidim
         let!(:membership) { create(:user_group_membership, user_group:, user:, role: "admin") }
         let!(:another_membership) { create(:user_group_membership, user_group:, user: another_user, role: "admin") }
 
-        context "and they haven't endorsed yet" do
+        context "and they have not endorsed yet" do
           it { is_expected.not_to include("is-selected") }
         end
 

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -232,7 +232,7 @@ en:
           name: Debates
           next_level_in: Participate in %{score} more debates to reach the next level!
           unearned_another: This participant has not yet taken part in any debate.
-          unearned_own: You haven't participated in any debates yet.
+          unearned_own: You have not participated in any debates yet.
     metrics:
       debates:
         description: Number of debates created

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -207,7 +207,7 @@ en:
           name: Attended meetings
           next_level_in: Attend %{score} more meetings to reach the next level!
           unearned_another: This participant hasn't attended any meeting yet.
-          unearned_own: You haven't attended any meeting yet.
+          unearned_own: You have not attended any meeting yet.
     meetings:
       actions:
         agenda: Agenda

--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -91,7 +91,7 @@ module Decidim
 
         msg = <<-MSG
         Invalid authorization handler given: #{handler_name} doesn't
-        exist or you haven't added it to `Decidim.authorization_handlers.
+        exist or you have not added it to `Decidim.authorization_handlers.
 
         Make sure this name matches with your registrations:\n\n
         Decidim::Verifications.register_workflow(:#{handler_name}) do


### PR DESCRIPTION
#### :tophat: What? Why?
As a follow up for #10504, I am also suggesting to standardize the written format of "have not".

#### :pushpin: Related Issues
- Related to #10504

#### Testing
Run the following command at the root of the repository:
```bash
$ grep -ril "haven't" decidim-*
```

Expect to see no matches.