### PR TITLE
Standardize the format of the words "did not"

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,7 +1,7 @@
 # Configuration for request-info - https://github.com/behaviorbot/request-info
 #
 requestInfoReplyComment: >
-  It seems like you didn't give us much information about what you're trying to do here.
+  It seems like you did not give us much information about what you're trying to do here.
   We would appreciate it if you could provide us with more info about this issue/PR!
 
 checkIssueTemplate: true

--- a/decidim-admin/app/views/decidim/admin/devise/mailers/reset_password_instructions.html.erb
+++ b/decidim-admin/app/views/decidim/admin/devise/mailers/reset_password_instructions.html.erb
@@ -4,5 +4,5 @@
 
 <p><%= link_to "Change my password", edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
+<p>If you did not request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>

--- a/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
@@ -24,7 +24,7 @@ describe "Space admin manages global moderations", type: :system do
     login_as user, scope: :user
   end
 
-  context "when the user didn't accepted the admin ToS" do
+  context "when the user did not accepted the admin ToS" do
     before do
       user.update(admin_terms_accepted_at: nil)
       visit decidim_admin.moderations_path

--- a/decidim-core/app/services/decidim/send_push_notification.rb
+++ b/decidim-core/app/services/decidim/send_push_notification.rb
@@ -11,7 +11,7 @@ module Decidim
   class SendPushNotification
     include ActionView::Helpers::UrlHelper
 
-    # Send the push notification. Returns `nil` if the user didn't allowed push notifications
+    # Send the push notification. Returns `nil` if the user did not allowed push notifications
     # or if the subscription to push notifications doesn't exist
     #
     # Returns the result of the dispatch or nil if user or subscription are empty

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1657,7 +1657,7 @@ en:
         action: Change my password
         greeting: Hello %{recipient}!
         instruction: Someone has requested a link to change your password, and you can do this through the link below.
-        instruction_2: If you didn't request this, please ignore this email.
+        instruction_2: If you did not request this, please ignore this email.
         instruction_3: Your password won't change until you access the link above and create a new one.
         subject: Reset password instructions
       unlock_instructions:
@@ -1704,8 +1704,8 @@ en:
     shared:
       links:
         back: Back
-        didn_t_receive_confirmation_instructions: Didn't receive confirmation instructions?
-        didn_t_receive_unlock_instructions: Didn't receive unlock instructions?
+        didn_t_receive_confirmation_instructions: Did not receive confirmation instructions?
+        didn_t_receive_unlock_instructions: Did not receive unlock instructions?
         forgot_your_password: Forgot your password?
         sign_in: Log in
         sign_in_with_provider: Sign in with %{provider}

--- a/decidim-core/spec/commands/decidim/messaging/reply_to_conversation_spec.rb
+++ b/decidim-core/spec/commands/decidim/messaging/reply_to_conversation_spec.rb
@@ -68,7 +68,7 @@ module Decidim::Messaging
     end
 
     shared_examples "send emails" do |num_emails|
-      context "and the receiver didn't have unread messages in the conversation" do
+      context "and the receiver did not have unread messages in the conversation" do
         it "sends a notification to the recipient" do
           expect do
             perform_enqueued_jobs { command.call }

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -241,7 +241,7 @@ module Decidim
         end
       end
 
-      context "when user didn't accepted ToS" do
+      context "when user did not accepted ToS" do
         let(:accepted_tos_version) { nil }
 
         it { is_expected.to be_falsey }

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -1342,7 +1342,7 @@ en:
       votings:
         access_code_modal:
           email: Send by email to %{email}
-          info: You need an Access Code to participate. If you didn't get one by postal mail, we can send you a new one.
+          info: You need an Access Code to participate. If you did not get one by postal mail, we can send you a new one.
           no_email: No email available
           no_sms: No phone number available
           sms: Send by SMS to %{sms}

--- a/decidim-elections/spec/forms/decidim/elections/admin/vote_period_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/vote_period_form_spec.rb
@@ -57,7 +57,7 @@ describe Decidim::Elections::Admin::VotePeriodForm do
                                      })
     end
 
-    context "when the election didn't finish yet" do
+    context "when the election did not finish yet" do
       let(:end_time) { 1.day.from_now }
 
       it { is_expected.to be_invalid }

--- a/decidim-elections/spec/system/admin/admin_manages_election_steps_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_election_steps_spec.rb
@@ -108,7 +108,7 @@ describe "Admin manages election steps", :slow, type: :system do
       visit_steps_page
       expect(page).to have_content("Key ceremony")
       expect(page).to have_css(".loading-spinner") # It shows the loading icon
-      expect(page).not_to have_css("svg.icon--task") # The trustees didn't participate yet
+      expect(page).not_to have_css("svg.icon--task") # The trustees did not participate yet
       expect(page).to have_link("Continue", class: "disabled")
 
       download_election_keys(0)

--- a/decidim-generators/lib/decidim/generators/app_templates/budgets_workflow_random.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/budgets_workflow_random.rb
@@ -5,7 +5,7 @@
 # Note: random selection should be deterministic for the same user and the same budgets component.
 # As the budget resources list could change and affect the random selection, it also allows to finish orders created on other budgets.
 class BudgetsWorkflowRandom < Decidim::Budgets::Workflows::Base
-  # Highlight the resource if the user didn't vote and is allowed to vote on it.
+  # Highlight the resource if the user did not vote and is allowed to vote on it.
   def highlighted?(resource)
     vote_allowed?(resource)
   end

--- a/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
+++ b/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
@@ -318,7 +318,7 @@ describe Decidim::Meetings::Permissions do
         context "when meeting is not closed" do
           let(:closed_at) { nil }
 
-          context "when meeting didn't finish" do
+          context "when meeting did not finish" do
             before do
               allow(meeting).to receive(:past?).and_return(false)
             end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/notify_proposal_answer.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/notify_proposal_answer.rb
@@ -16,7 +16,7 @@ module Decidim
 
         # Executes the command. Broadcasts these events:
         #
-        # - :noop when the answer is not published or the state didn't changed.
+        # - :noop when the answer is not published or the state did not changed.
         # - :ok when everything is valid.
         #
         # Returns nothing.

--- a/decidim-system/app/views/decidim/system/devise/mailers/reset_password_instructions.html.erb
+++ b/decidim-system/app/views/decidim/system/devise/mailers/reset_password_instructions.html.erb
@@ -4,5 +4,5 @@
 
 <p><%= link_to "Change my password", edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
+<p>If you did not request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>

--- a/decidim-system/app/views/decidim/system/devise/shared/_links.html.erb
+++ b/decidim-system/app/views/decidim/system/devise/shared/_links.html.erb
@@ -11,11 +11,11 @@
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br>
+  <%= link_to "Did not receive confirmation instructions?", new_confirmation_path(resource_name) %><br>
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br>
+  <%= link_to "Did not receive unlock instructions?", new_unlock_path(resource_name) %><br>
 <% end -%>
 
 <%- if devise_mapping.omniauthable? %>

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -270,7 +270,7 @@ en:
           edit:
             confirm_destroy: Are you sure you want to reset the verification code?
             destroy: Reset verification code
-            resend: Didn't receive the verification code?
+            resend: Did not receive the verification code?
             send: Confirm
             title: Introduce the verification code you received
           new:

--- a/decidim_app-design/app/views/public/partials/_evote_access_code_modal.html.erb
+++ b/decidim_app-design/app/views/public/partials/_evote_access_code_modal.html.erb
@@ -6,7 +6,7 @@
     </button>
   </div>
   <p>
-    You need an Access Code to participate. If you didn't get one by postal mail, we can send you a new one.
+    You need an Access Code to participate. If you did not get one by postal mail, we can send you a new one.
   </p>
   <div class="row">
     <div class="columns medium-8 medium-offset-2">

--- a/decidim_app-design/app/views/public/partials/_evote_participating-rights.html.erb
+++ b/decidim_app-design/app/views/public/partials/_evote_participating-rights.html.erb
@@ -7,7 +7,7 @@
         <div class="callout success mt-s">
           <h5>Your census data is correct!</h5>
           <p>In order to vote, you will need an Access Code.</p>
-          <p>If you didn't receive one by postal mail, you can <button type="button" class="link" data-open="evote-access-code-modal">ask for one here</button>.</p>
+          <p>If you did not receive one by postal mail, you can <button type="button" class="link" data-open="evote-access-code-modal">ask for one here</button>.</p>
         </div>
         <%= partial "evote_access_code_modal" %>
       <% elsif locals[:blocked] %>


### PR DESCRIPTION
#### :tophat: What? Why?
As a follow up for #10504, I am also suggesting to standardize the written format of "did not".

#### :pushpin: Related Issues
- Related to #10504

#### Testing
Run the following command at the root of the repository:
```bash
$ grep -ril "didn't" decidim-*
```

Expect to see no matches.