### PR TITLE
Standardize the format of the words "are not"

### DIFF
--- a/decidim-assemblies/app/packs/src/decidim/assemblies/orgchart.js
+++ b/decidim-assemblies/app/packs/src/decidim/assemblies/orgchart.js
@@ -339,7 +339,7 @@ const renderOrgCharts = () => {
 
         // -------------------- handle drag end event ---------------
         function dragended() {
-          // we are doing nothing, here , aren't we?
+          // we are doing nothing, here , are not we?
         }
 
         // -------------------------- node mouse hover handler ---------------

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
@@ -23,7 +23,7 @@ jest.useFakeTimers();
 import { createCharacterCounter } from "../../../../../../decidim-core/app/packs/src/decidim/input_character_counter";
 import Configuration from "../../../../../../decidim-core/app/packs/src/decidim/configuration";
 // Component is loaded with require because using import loads it before $ has been mocked
-// so tests aren't able to check the spied behaviours
+// so tests are not able to check the spied behaviours
 const CommentsComponent = require("./comments.component_for_testing.js");
 
 

--- a/decidim-core/spec/forms/notifications_settings_form_spec.rb
+++ b/decidim-core/spec/forms/notifications_settings_form_spec.rb
@@ -206,7 +206,7 @@ module Decidim
         end
       end
 
-      context "when the notifications requirements aren't met" do
+      context "when the notifications requirements are not met" do
         before do
           Rails.application.secrets[:vapid] = { enabled: false }
         end

--- a/decidim-debates/spec/jobs/decidim/debates/settings_change_job_spec.rb
+++ b/decidim-debates/spec/jobs/decidim/debates/settings_change_job_spec.rb
@@ -54,7 +54,7 @@ module Decidim
         end
       end
 
-      context "when there aren't any changes" do
+      context "when there are not any changes" do
         let(:previously_allowing_creation) { true }
         let(:currently_allowing_creation) { true }
 

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -460,7 +460,7 @@ en:
           verifiable_results:
             checksum: 'File SHA256 checksum:'
             description:
-              not_ready: The verifiable election file and SHA256 checksum aren't available yet. As soon as the results are published, you'll be able to verify this election.
+              not_ready: The verifiable election file and SHA256 checksum are not available yet. As soon as the results are published, you'll be able to verify this election.
               ready: 'Here, you have the option to verify the election. First, you have to download the file and make sure it has not been corrupted. To do so, run the following command and check that the ouput matches the checksum:'
             how_to_verify: 'Once you downloaded the file and made sure it is ok, you can proceed to run the universal verifier. Clone <a href=''https://github.com/decidim/decidim-bulletin-board''>this repository</a> and, from the root folder, run the following command:'
             title: Verify Election results

--- a/decidim-elections/spec/system/election_log_spec.rb
+++ b/decidim-elections/spec/system/election_log_spec.rb
@@ -155,7 +155,7 @@ describe "Election log", :slow, type: :system do
 
       it "does not show instructions to verify election" do
         expect(page).to have_content("Verify Election results")
-        expect(page).to have_content("The verifiable election file and SHA256 checksum aren't available yet")
+        expect(page).to have_content("The verifiable election file and SHA256 checksum are not available yet")
         expect(page).to have_content("NOT READY")
       end
     end

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -1196,7 +1196,7 @@ shared_examples_for "has questionnaire" do
             it "shows the question only if the condition is fulfilled" do
               expect_question_to_be_visible(false)
 
-              fill_in "questionnaire_responses_0", with: "Aren't we all expecting #{condition_value[:en]}?"
+              fill_in "questionnaire_responses_0", with: "Are not we all expecting #{condition_value[:en]}?"
               change_focus
 
               expect_question_to_be_visible(true)
@@ -1219,7 +1219,7 @@ shared_examples_for "has questionnaire" do
             it "shows the question only if the condition is fulfilled" do
               expect_question_to_be_visible(false)
 
-              fill_in "questionnaire_responses_0", with: "Aren't we all expecting #{condition_value[:en]}?"
+              fill_in "questionnaire_responses_0", with: "Are not we all expecting #{condition_value[:en]}?"
               change_focus
 
               expect_question_to_be_visible(true)

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -67,7 +67,7 @@ describe "Initiative", type: :system do
             end
           end
 
-          context "and they aren't verified" do
+          context "and they are not verified" do
             let(:authorization) { nil }
 
             it "they need to verify" do
@@ -118,7 +118,7 @@ describe "Initiative", type: :system do
         end
       end
 
-      context "when they aren't logged in" do
+      context "when they are not logged in" do
         let(:login) { false }
 
         it "they need to login in" do
@@ -153,7 +153,7 @@ describe "Initiative", type: :system do
             end
           end
 
-          context "and they aren't verified" do
+          context "and they are not verified" do
             let(:authorization) { nil }
 
             it "they are shown an error" do
@@ -216,7 +216,7 @@ describe "Initiative", type: :system do
             end
           end
 
-          context "and they aren't verified" do
+          context "and they are not verified" do
             let(:authorization) { nil }
 
             it "they need to verify" do
@@ -270,7 +270,7 @@ describe "Initiative", type: :system do
         end
       end
 
-      context "when they aren't logged in" do
+      context "when they are not logged in" do
         let(:login) { false }
 
         it "they need to login in" do
@@ -305,7 +305,7 @@ describe "Initiative", type: :system do
             end
           end
 
-          context "and they aren't verified" do
+          context "and they are not verified" do
             let(:authorization) { nil }
 
             it "they are shown an error" do

--- a/decidim-participatory_processes/spec/controllers/participatory_process_groups_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/participatory_process_groups_controller_spec.rb
@@ -26,7 +26,7 @@ module Decidim
         context "when the process group do not belong to the organization" do
           let!(:process_group) { create :participatory_process_group }
 
-          it "redirects to 404 if there aren't any" do
+          it "redirects to 404 if there are not any" do
             expect { get :show, params: { id: process_group.id } }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end

--- a/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/participatory_processes_controller_spec.rb
@@ -36,7 +36,7 @@ module Decidim
           expect(controller.helpers.participatory_processes.to_a).not_to include(unpublished_process)
         end
 
-        it "redirects to 404 if there aren't any" do
+        it "redirects to 404 if there are not any" do
           expect { get :index }.to raise_error(ActionController::RoutingError)
         end
       end

--- a/decidim-proposals/app/models/decidim/proposals/proposal_vote.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal_vote.rb
@@ -15,7 +15,7 @@ module Decidim
       after_destroy :update_proposal_votes_count
 
       # Temporary votes are used when a minimum amount of votes is configured in
-      # a component. They aren't taken into account unless the amount of votes
+      # a component. They are not taken into account unless the amount of votes
       # exceeds a threshold - meanwhile, they're marked as temporary.
       def self.temporary
         where(temporary: true)

--- a/decidim-surveys/spec/jobs/decidim/surveys/settings_change_job_spec.rb
+++ b/decidim-surveys/spec/jobs/decidim/surveys/settings_change_job_spec.rb
@@ -56,7 +56,7 @@ module Decidim
         end
       end
 
-      context "when there aren't relevant changes" do
+      context "when there are not relevant changes" do
         let(:previously_allowing_answers) { true }
         let(:currently_allowing_answers) { true }
 

--- a/decidim-system/README.md
+++ b/decidim-system/README.md
@@ -27,9 +27,9 @@ When using Decidim as multi-tenant, you should keep these in mind:
 
 * All organizations share the same database.
 * Each organization must have a different hostname.
-* Users aren't shared between each organization (the same email can be registered in different organizations and it will be considered as different users).
+* Users are not shared between each organization (the same email can be registered in different organizations and it will be considered as different users).
 * All configuration related to Decidim (`Decidim.config`) is shared between the organizations.
-* Stylesheets aren't customizable per-tenant so UI styles (colors and other variables) are shared.
+* Stylesheets are not customizable per-tenant so UI styles (colors and other variables) are shared.
 
 ## Glossary
 


### PR DESCRIPTION
#### :tophat: What? Why?
As a follow up for #10504, I am also suggesting to standardize the written format of "are not".

#### :pushpin: Related Issues
- Related to #10504

#### Testing
Run the following command at the root of the repository:
```bash
$ grep -ril "aren't" decidim-*
```

Expect to see no matches.