### PR TITLE
Standardize the format of the words "was not"

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/content_blocks/create_content_block.rb
+++ b/decidim-admin/app/commands/decidim/admin/content_blocks/create_content_block.rb
@@ -22,7 +22,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-admin/app/commands/decidim/admin/content_blocks/destroy_content_block.rb
+++ b/decidim-admin/app/commands/decidim/admin/content_blocks/destroy_content_block.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-admin/app/commands/decidim/admin/content_blocks/reorder_content_blocks.rb
+++ b/decidim-admin/app/commands/decidim/admin/content_blocks/reorder_content_blocks.rb
@@ -22,7 +22,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-admin/app/commands/decidim/admin/create_area.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_area.rb
@@ -14,7 +14,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/create_area_type.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_area_type.rb
@@ -15,7 +15,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/create_attachment.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_attachment.rb
@@ -18,7 +18,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/create_attachment_collection.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_attachment_collection.rb
@@ -18,7 +18,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/create_category.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_category.rb
@@ -19,7 +19,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/create_participatory_space_admin_user_actions.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_space_admin_user_actions.rb
@@ -8,7 +8,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/create_participatory_space_private_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_space_private_user.rb
@@ -20,7 +20,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/create_scope.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_scope.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/create_scope_type.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_scope_type.rb
@@ -15,7 +15,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/create_static_page.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_static_page.rb
@@ -15,7 +15,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/create_static_page_topic.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_static_page_topic.rb
@@ -14,7 +14,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/destroy_area.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_area.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/destroy_category.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_category.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the data wasn't valid and we couldn't proceed.
+      # - :invalid if the data was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_participatory_space_private_user.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/destroy_scope.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_scope.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/destroy_share_token.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_share_token.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/process_participatory_space_private_user_import_csv.rb
+++ b/decidim-admin/app/commands/decidim/admin/process_participatory_space_private_user_import_csv.rb
@@ -21,7 +21,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/process_user_group_verification_csv.rb
+++ b/decidim-admin/app/commands/decidim/admin/process_user_group_verification_csv.rb
@@ -19,7 +19,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/promote_managed_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/promote_managed_user.rb
@@ -22,7 +22,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/reject_user_group.rb
+++ b/decidim-admin/app/commands/decidim/admin/reject_user_group.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/update_area.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_area.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/update_area_type.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_area_type.rb
@@ -17,7 +17,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/update_attachment.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_attachment.rb
@@ -22,7 +22,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/update_attachment_collection.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_attachment_collection.rb
@@ -17,7 +17,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/update_category.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_category.rb
@@ -20,7 +20,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -17,7 +17,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
@@ -19,7 +19,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/update_organization_tos_version.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization_tos_version.rb
@@ -19,7 +19,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid or not the TOS page.
+      # - :invalid if the form was not valid or not the TOS page.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/update_scope.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_scope.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/update_scope_type.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_scope_type.rb
@@ -17,7 +17,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/update_static_page.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_static_page.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/update_static_page_topic.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_static_page_topic.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-admin/app/commands/decidim/admin/update_user_groups.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_user_groups.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
@@ -19,7 +19,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assemblies_type.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assemblies_type.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly_member.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly_member.rb
@@ -21,7 +21,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/destroy_assemblies_type.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/destroy_assemblies_type.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/destroy_assembly_admin.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/destroy_assembly_admin.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/destroy_assembly_member.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/destroy_assembly_member.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/import_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/import_assembly.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/publish_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/publish_assembly.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/unpublish_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/unpublish_assembly.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assemblies_type.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assemblies_type.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly.rb
@@ -21,7 +21,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly_admin.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly_admin.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly_member.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly_member.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-comments/app/commands/decidim/comments/create_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/create_comment.rb
@@ -15,7 +15,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-comments/app/commands/decidim/comments/update_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/update_comment.rb
@@ -18,7 +18,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-comments/app/commands/decidim/comments/vote_comment.rb
+++ b/decidim-comments/app/commands/decidim/comments/vote_comment.rb
@@ -19,7 +19,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the vote wasn't create
+      # - :invalid if the vote was not create
       #
       # Returns nothing.
       def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/copy_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/copy_conference.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/create_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/create_conference.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/create_conference_admin.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/create_conference_admin.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/create_conference_speaker.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/create_conference_speaker.rb
@@ -21,7 +21,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/create_media_link.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/create_media_link.rb
@@ -19,7 +19,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/create_partner.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/create_partner.rb
@@ -19,7 +19,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/create_registration_type.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/create_registration_type.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/destroy_conference_admin.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/destroy_conference_admin.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/destroy_conference_speaker.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/destroy_conference_speaker.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/destroy_media_link.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/destroy_media_link.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/destroy_partner.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/destroy_partner.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/destroy_registration_type.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/destroy_registration_type.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/invite_user_to_join_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/invite_user_to_join_conference.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/send_conference_diplomas.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/send_conference_diplomas.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/unpublish_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/unpublish_conference.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/update_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/update_conference.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/update_conference_admin.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/update_conference_admin.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/update_conference_speaker.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/update_conference_speaker.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/update_media_link.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/update_media_link.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/update_partner.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/update_partner.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/app/commands/decidim/conferences/admin/update_registration_type.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/update_registration_type.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-conferences/spec/commands/send_conferences_diplomas_spec.rb
+++ b/decidim-conferences/spec/commands/send_conferences_diplomas_spec.rb
@@ -23,7 +23,7 @@ module Decidim::Conferences
         end
       end
 
-      describe "when diplomas wasn't sent" do
+      describe "when diplomas was not sent" do
         it "broadcasts ok" do
           expect { command.call }.to broadcast(:ok)
         end

--- a/decidim-consultations/app/commands/decidim/consultations/admin/create_consultation.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/create_consultation.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/create_question.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/create_question.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/create_response.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/create_response.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/create_response_group.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/create_response_group.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/destroy_response_group.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/destroy_response_group.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/publish_consultation.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/publish_consultation.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/publish_consultation_results.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/publish_consultation_results.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/publish_question.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/publish_question.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/unpublish_consultation.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/unpublish_consultation.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/unpublish_consultation_results.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/unpublish_consultation_results.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/unpublish_question.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/unpublish_question.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/update_consultation.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/update_consultation.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/update_question.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/update_question.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/update_question_configuration.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/update_question_configuration.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/update_response.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/update_response.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/admin/update_response_group.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/admin/update_response_group.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-consultations/app/commands/decidim/consultations/multiple_vote_question.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/multiple_vote_question.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the vote.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-consultations/app/commands/decidim/consultations/unvote_question.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/unvote_question.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the question.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-consultations/app/commands/decidim/consultations/vote_question.rb
+++ b/decidim-consultations/app/commands/decidim/consultations/vote_question.rb
@@ -15,7 +15,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the vote.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-core/app/commands/decidim/amendable/accept.rb
+++ b/decidim-core/app/commands/decidim/amendable/accept.rb
@@ -20,7 +20,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the amend.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-core/app/commands/decidim/amendable/create_draft.rb
+++ b/decidim-core/app/commands/decidim/amendable/create_draft.rb
@@ -17,7 +17,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the amend.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-core/app/commands/decidim/amendable/reject.rb
+++ b/decidim-core/app/commands/decidim/amendable/reject.rb
@@ -18,7 +18,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the amend.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-core/app/commands/decidim/create_editor_image.rb
+++ b/decidim-core/app/commands/decidim/create_editor_image.rb
@@ -13,7 +13,7 @@ module Decidim
     # Executes the command. Broadcasts these events:
     #
     # - :ok when everything is valid.
-    # - :invalid if the form wasn't valid and we couldn't proceed.
+    # - :invalid if the form was not valid and we couldn't proceed.
     #
     # Returns nothing.
     def call

--- a/decidim-core/app/commands/decidim/create_follow.rb
+++ b/decidim-core/app/commands/decidim/create_follow.rb
@@ -15,7 +15,7 @@ module Decidim
     # Executes the command. Broadcasts these events:
     #
     # - :ok when everything is valid, together with the follow.
-    # - :invalid if the form wasn't valid and we couldn't proceed.
+    # - :invalid if the form was not valid and we couldn't proceed.
     #
     # Returns nothing.
     def call

--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -14,7 +14,7 @@ module Decidim
     # Executes the command. Broadcasts these events:
     #
     # - :ok when everything is valid.
-    # - :invalid if the form wasn't valid and we couldn't proceed.
+    # - :invalid if the form was not valid and we couldn't proceed.
     #
     # Returns nothing.
     def call

--- a/decidim-core/app/commands/decidim/create_registration.rb
+++ b/decidim-core/app/commands/decidim/create_registration.rb
@@ -13,7 +13,7 @@ module Decidim
     # Executes the command. Broadcasts these events:
     #
     # - :ok when everything is valid.
-    # - :invalid if the form wasn't valid and we couldn't proceed.
+    # - :invalid if the form was not valid and we couldn't proceed.
     #
     # Returns nothing.
     def call

--- a/decidim-core/app/commands/decidim/create_report.rb
+++ b/decidim-core/app/commands/decidim/create_report.rb
@@ -17,7 +17,7 @@ module Decidim
     # Executes the command. Broadcasts these events:
     #
     # - :ok when everything is valid, together with the report.
-    # - :invalid if the form wasn't valid and we couldn't proceed.
+    # - :invalid if the form was not valid and we couldn't proceed.
     #
     # Returns nothing.
     def call

--- a/decidim-core/app/commands/decidim/create_user_group.rb
+++ b/decidim-core/app/commands/decidim/create_user_group.rb
@@ -13,7 +13,7 @@ module Decidim
     # Executes the command. Broadcasts these events:
     #
     # - :ok when everything is valid.
-    # - :invalid if the form wasn't valid and we couldn't proceed.
+    # - :invalid if the form was not valid and we couldn't proceed.
     #
     # Returns nothing.
     def call

--- a/decidim-core/app/commands/decidim/create_user_report.rb
+++ b/decidim-core/app/commands/decidim/create_user_report.rb
@@ -17,7 +17,7 @@ module Decidim
     # Executes the command. Broadcasts these events:
     #
     # - :ok when everything is valid, together with the report.
-    # - :invalid if the form wasn't valid and we couldn't proceed.
+    # - :invalid if the form was not valid and we couldn't proceed.
     #
     # Returns nothing.
     def call

--- a/decidim-core/app/commands/decidim/delete_follow.rb
+++ b/decidim-core/app/commands/decidim/delete_follow.rb
@@ -15,7 +15,7 @@ module Decidim
     # Executes the command. Broadcasts these events:
     #
     # - :ok when everything is valid, together with the follow.
-    # - :invalid if the form wasn't valid and we couldn't proceed.
+    # - :invalid if the form was not valid and we couldn't proceed.
     #
     # Returns nothing.
     def call

--- a/decidim-core/app/commands/decidim/endorse_resource.rb
+++ b/decidim-core/app/commands/decidim/endorse_resource.rb
@@ -18,7 +18,7 @@ module Decidim
     # Executes the command. Broadcasts these events:
     #
     # - :ok when everything is valid, together with the resource vote.
-    # - :invalid if the form wasn't valid and we couldn't proceed.
+    # - :invalid if the form was not valid and we couldn't proceed.
     #
     # Returns nothing.
     def call

--- a/decidim-core/app/commands/decidim/invite_user_to_group.rb
+++ b/decidim-core/app/commands/decidim/invite_user_to_group.rb
@@ -15,7 +15,7 @@ module Decidim
     # Executes the command. Broadcasts these events:
     #
     # - :ok when everything is valid.
-    # - :invalid if the form wasn't valid and we couldn't proceed.
+    # - :invalid if the form was not valid and we couldn't proceed.
     #
     # Returns nothing.
     def call

--- a/decidim-core/app/commands/decidim/messaging/reply_to_conversation.rb
+++ b/decidim-core/app/commands/decidim/messaging/reply_to_conversation.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the message.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-core/app/commands/decidim/messaging/start_conversation.rb
+++ b/decidim-core/app/commands/decidim/messaging/start_conversation.rb
@@ -14,7 +14,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the message.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-core/app/commands/decidim/unendorse_resource.rb
+++ b/decidim-core/app/commands/decidim/unendorse_resource.rb
@@ -17,7 +17,7 @@ module Decidim
     # Executes the command. Broadcasts these events:
     #
     # - :ok when everything is valid, together with the resource.
-    # - :invalid if the form wasn't valid and we couldn't proceed.
+    # - :invalid if the form was not valid and we couldn't proceed.
     #
     # Returns nothing.
     def call

--- a/decidim-core/app/commands/decidim/update_user_group.rb
+++ b/decidim-core/app/commands/decidim/update_user_group.rb
@@ -15,7 +15,7 @@ module Decidim
     # Executes the command. Broadcasts these events:
     #
     # - :ok when everything is valid.
-    # - :invalid if the form wasn't valid and we couldn't proceed.
+    # - :invalid if the form was not valid and we couldn't proceed.
     #
     # Returns nothing.
     def call

--- a/decidim-debates/app/commands/decidim/debates/admin/close_debate.rb
+++ b/decidim-debates/app/commands/decidim/debates/admin/close_debate.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid, together with the debate.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-debates/app/commands/decidim/debates/close_debate.rb
+++ b/decidim-debates/app/commands/decidim/debates/close_debate.rb
@@ -14,7 +14,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the debate.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-debates/app/commands/decidim/debates/update_debate.rb
+++ b/decidim-debates/app/commands/decidim/debates/update_debate.rb
@@ -14,7 +14,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the debate.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-elections/app/commands/decidim/elections/admin/import_proposals_to_elections.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/import_proposals_to_elections.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-elections/app/commands/decidim/votings/admin/create_ballot_style.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/create_ballot_style.rb
@@ -11,7 +11,7 @@ module Decidim
 
         # Executes the command. Broadcast this events:
         # - :ok when everything is valid
-        # - :invalid when the form wasn't valid and couldn't proceed
+        # - :invalid when the form was not valid and couldn't proceed
         #
         # Returns nothing.
         def call

--- a/decidim-elections/app/commands/decidim/votings/admin/create_monitoring_committee_member.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/create_monitoring_committee_member.rb
@@ -19,7 +19,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-elections/app/commands/decidim/votings/admin/create_polling_officer.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/create_polling_officer.rb
@@ -19,7 +19,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-elections/app/commands/decidim/votings/admin/create_polling_station.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/create_polling_station.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-elections/app/commands/decidim/votings/admin/create_voting.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/create_voting.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-elections/app/commands/decidim/votings/admin/destroy_ballot_style.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/destroy_ballot_style.rb
@@ -12,7 +12,7 @@ module Decidim
 
         # Executes the command. Broadcast this events:
         # - :ok when everything is valid
-        # - :invalid when the form wasn't valid and couldn't proceed
+        # - :invalid when the form was not valid and couldn't proceed
         #
         # Returns nothing.
         def call

--- a/decidim-elections/app/commands/decidim/votings/admin/destroy_monitoring_committee_member.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/destroy_monitoring_committee_member.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-elections/app/commands/decidim/votings/admin/destroy_polling_officer.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/destroy_polling_officer.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-elections/app/commands/decidim/votings/admin/monitoring_committee_validate_polling_station_closure.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/monitoring_committee_validate_polling_station_closure.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-elections/app/commands/decidim/votings/admin/update_ballot_style.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/update_ballot_style.rb
@@ -12,7 +12,7 @@ module Decidim
 
         # Executes the command. Broadcast this events:
         # - :ok when everything is valid
-        # - :invalid when the form wasn't valid and couldn't proceed
+        # - :invalid when the form was not valid and couldn't proceed
         #
         # Returns nothing.
         def call

--- a/decidim-elections/app/commands/decidim/votings/admin/update_voting.rb
+++ b/decidim-elections/app/commands/decidim/votings/admin/update_voting.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-elections/app/commands/decidim/votings/census/admin/create_dataset.rb
+++ b/decidim-elections/app/commands/decidim/votings/census/admin/create_dataset.rb
@@ -20,7 +20,7 @@ module Decidim
 
           # Executes the command. Broadcast this events:
           # - :ok when everything is valid
-          # - :invalid when the form wasn't valid and couldn't proceed-
+          # - :invalid when the form was not valid and couldn't proceed-
           #
           # Returns nothing.
           def call

--- a/decidim-elections/app/commands/decidim/votings/census/admin/create_datum.rb
+++ b/decidim-elections/app/commands/decidim/votings/census/admin/create_datum.rb
@@ -14,7 +14,7 @@ module Decidim
 
           # Executes the command. Broadcast this events:
           # - :ok when everything is valid
-          # - :invalid when the form wasn't valid and couldn't proceed-
+          # - :invalid when the form was not valid and couldn't proceed-
           #
           # Returns nothing.
           def call

--- a/decidim-elections/app/commands/decidim/votings/census/admin/destroy_dataset.rb
+++ b/decidim-elections/app/commands/decidim/votings/census/admin/destroy_dataset.rb
@@ -16,7 +16,7 @@ module Decidim
 
           # Executes the command. Broadcast this events:
           # - :ok when everything is valid
-          # - :invalid when the form wasn't valid and couldn't proceed-
+          # - :invalid when the form was not valid and couldn't proceed-
           #
           # Returns nothing.
           def call

--- a/decidim-elections/app/commands/decidim/votings/census/admin/increment_dataset_processed_rows.rb
+++ b/decidim-elections/app/commands/decidim/votings/census/admin/increment_dataset_processed_rows.rb
@@ -13,7 +13,7 @@ module Decidim
 
           # Executes the command. Broadcast this events:
           # - :ok when everything is valid
-          # - :invalid when the form wasn't valid and couldn't proceed-
+          # - :invalid when the form was not valid and couldn't proceed-
           #
           # Returns nothing.
           def call

--- a/decidim-elections/app/commands/decidim/votings/census/admin/update_dataset.rb
+++ b/decidim-elections/app/commands/decidim/votings/census/admin/update_dataset.rb
@@ -20,7 +20,7 @@ module Decidim
 
           # Executes the command. Broadcast this events:
           # - :ok when everything is valid
-          # - :invalid when the input wasn't valid and couldn't proceed
+          # - :invalid when the input was not valid and couldn't proceed
           #
           # Returns nothing.
           def call

--- a/decidim-elections/app/commands/decidim/votings/certify_polling_station_closure.rb
+++ b/decidim-elections/app/commands/decidim/votings/certify_polling_station_closure.rb
@@ -19,7 +19,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-elections/app/commands/decidim/votings/create_polling_station_closure.rb
+++ b/decidim-elections/app/commands/decidim/votings/create_polling_station_closure.rb
@@ -14,7 +14,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-elections/app/commands/decidim/votings/create_polling_station_results.rb
+++ b/decidim-elections/app/commands/decidim/votings/create_polling_station_results.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-elections/app/commands/decidim/votings/sign_polling_station_closure.rb
+++ b/decidim-elections/app/commands/decidim/votings/sign_polling_station_closure.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -605,7 +605,7 @@ en:
               processing: Processing
             title: Tally for %{election}
           update:
-            error: The election status wasn't updated.
+            error: The election status was not updated.
             success: 'The election status is: %{status}'
         menu:
           trustee_zone: Trustee zone

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type_scope.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type_scope.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/publish_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/publish_initiative.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/send_initiative_to_technical_validation.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/send_initiative_to_technical_validation.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/unpublish_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/unpublish_initiative.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative.rb
@@ -22,7 +22,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_answer.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_answer.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
@@ -21,7 +21,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type_scope.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type_scope.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
@@ -19,7 +19,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/send_initiative_to_technical_validation.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/send_initiative_to_technical_validation.rb
@@ -17,7 +17,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/spawn_committee_request.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/spawn_committee_request.rb
@@ -17,7 +17,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/unvote_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/unvote_initiative.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the initiative.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/update_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/update_initiative.rb
@@ -23,7 +23,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-initiatives/app/commands/decidim/initiatives/vote_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/vote_initiative.rb
@@ -14,7 +14,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the proposal vote.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-meetings/app/commands/decidim/meetings/admin/publish_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/publish_meeting.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-meetings/app/commands/decidim/meetings/admin/unpublish_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/unpublish_meeting.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/activate_participatory_process_step.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/activate_participatory_process_step.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
@@ -19,7 +19,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process_group.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process_group.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process_step.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process_step.rb
@@ -19,7 +19,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process_type.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process_type.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/destroy_participatory_process_admin.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/destroy_participatory_process_admin.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/destroy_participatory_process_step.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/destroy_participatory_process_step.rb
@@ -18,7 +18,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/destroy_participatory_process_type.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/destroy_participatory_process_type.rb
@@ -19,7 +19,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/import_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/import_participatory_process.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/publish_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/publish_participatory_process.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/reorder_participatory_process_steps.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/reorder_participatory_process_steps.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/unpublish_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/unpublish_participatory_process.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the data wasn't valid and we couldn't proceed.
+        # - :invalid if the data was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_admin.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_admin.rb
@@ -19,7 +19,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_group.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_group.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_step.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_step.rb
@@ -20,7 +20,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_type.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_type.rb
@@ -19,7 +19,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/accept_access_to_collaborative_draft.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/accept_access_to_collaborative_draft.rb
@@ -21,7 +21,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if it wasn't valid and we couldn't proceed.
+      # - :invalid if it was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-proposals/app/commands/decidim/proposals/admin/answer_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/answer_proposal.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/admin/assign_proposals_to_valuator.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/assign_proposals_to_valuator.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal.rb
@@ -19,7 +19,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid, together with the proposal.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal_note.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/create_proposal_note.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid, together with the note proposal.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/admin/discard_participatory_text.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/discard_participatory_text.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/admin/import_participatory_text.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/import_participatory_text.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/import_proposals.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/admin/merge_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/merge_proposals.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/admin/publish_participatory_text.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/publish_participatory_text.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/admin/split_proposals.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/split_proposals.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/admin/unassign_proposals_from_valuator.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/unassign_proposals_from_valuator.rb
@@ -16,7 +16,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_participatory_text.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_participatory_text.rb
@@ -17,7 +17,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/update_proposal.rb
@@ -22,7 +22,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid, together with the proposal.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-proposals/app/commands/decidim/proposals/create_collaborative_draft.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_collaborative_draft.rb
@@ -20,7 +20,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the collaborative draft.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -21,7 +21,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the proposal.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-proposals/app/commands/decidim/proposals/reject_access_to_collaborative_draft.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/reject_access_to_collaborative_draft.rb
@@ -21,7 +21,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if it wasn't valid and we couldn't proceed.
+      # - :invalid if it was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-proposals/app/commands/decidim/proposals/request_access_to_collaborative_draft.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/request_access_to_collaborative_draft.rb
@@ -19,7 +19,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if it wasn't valid and we couldn't proceed.
+      # - :invalid if it was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-proposals/app/commands/decidim/proposals/unvote_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/unvote_proposal.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the proposal.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-proposals/app/commands/decidim/proposals/update_collaborative_draft.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/update_collaborative_draft.rb
@@ -20,7 +20,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the collaborative_draft.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/update_proposal.rb
@@ -23,7 +23,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the proposal.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-proposals/app/commands/decidim/proposals/vote_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/vote_proposal.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid, together with the proposal vote.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-proposals/spec/presenters/decidim/proposals/proposal_presenter_spec.rb
+++ b/decidim-proposals/spec/presenters/decidim/proposals/proposal_presenter_spec.rb
@@ -138,7 +138,7 @@ module Decidim
 
         it { is_expected.to eq(proposal.versions) }
 
-        context "when proposal has an answer that wasn't published yet" do
+        context "when proposal has an answer that was not published yet" do
           before do
             proposal.update!(answer: "an answer", state: "accepted", answered_at: Time.current)
           end

--- a/decidim-sortitions/app/commands/decidim/sortitions/admin/create_sortition.rb
+++ b/decidim-sortitions/app/commands/decidim/sortitions/admin/create_sortition.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-sortitions/app/commands/decidim/sortitions/admin/destroy_sortition.rb
+++ b/decidim-sortitions/app/commands/decidim/sortitions/admin/destroy_sortition.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-sortitions/app/commands/decidim/sortitions/admin/update_sortition.rb
+++ b/decidim-sortitions/app/commands/decidim/sortitions/admin/update_sortition.rb
@@ -15,7 +15,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-system/app/commands/decidim/system/create_admin.rb
+++ b/decidim-system/app/commands/decidim/system/create_admin.rb
@@ -15,7 +15,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-system/app/commands/decidim/system/update_admin.rb
+++ b/decidim-system/app/commands/decidim/system/update_admin.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-system/app/commands/decidim/system/update_organization.rb
+++ b/decidim-system/app/commands/decidim/system/update_organization.rb
@@ -17,7 +17,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the form wasn't valid and we couldn't proceed.
+      # - :invalid if the form was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-templates/app/commands/decidim/templates/admin/apply_questionnaire_template.rb
+++ b/decidim-templates/app/commands/decidim/templates/admin/apply_questionnaire_template.rb
@@ -19,7 +19,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-templates/app/commands/decidim/templates/admin/copy_template.rb
+++ b/decidim-templates/app/commands/decidim/templates/admin/copy_template.rb
@@ -12,7 +12,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-templates/app/commands/decidim/templates/admin/create_template.rb
+++ b/decidim-templates/app/commands/decidim/templates/admin/create_template.rb
@@ -14,7 +14,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-templates/app/commands/decidim/templates/admin/update_template.rb
+++ b/decidim-templates/app/commands/decidim/templates/admin/update_template.rb
@@ -19,7 +19,7 @@ module Decidim
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid.
-        # - :invalid if the form wasn't valid and we couldn't proceed.
+        # - :invalid if the form was not valid and we couldn't proceed.
         #
         # Returns nothing.
         def call

--- a/decidim-verifications/app/commands/decidim/verifications/authorize_user.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/authorize_user.rb
@@ -15,7 +15,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the handler wasn't valid and we couldn't proceed.
+      # - :invalid if the handler was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-verifications/app/commands/decidim/verifications/confirm_user_authorization.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/confirm_user_authorization.rb
@@ -20,7 +20,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the handler wasn't valid and we couldn't proceed.
+      # - :invalid if the handler was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-verifications/app/commands/decidim/verifications/csv_census/admin/create_census_data.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/csv_census/admin/create_census_data.rb
@@ -14,7 +14,7 @@ module Decidim
 
           # Executes the command. Broadcast this events:
           # - :ok when everything is valid
-          # - :invalid when the form wasn't valid and couldn't proceed-
+          # - :invalid when the form was not valid and couldn't proceed-
           #
           # Returns nothing.
           def call

--- a/decidim-verifications/app/commands/decidim/verifications/id_documents/admin/confirm_user_offline_authorization.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/id_documents/admin/confirm_user_offline_authorization.rb
@@ -16,7 +16,7 @@ module Decidim
           # Executes the command. Broadcasts these events:
           #
           # - :ok when everything is valid.
-          # - :invalid if the handler wasn't valid and we couldn't proceed.
+          # - :invalid if the handler was not valid and we couldn't proceed.
           #
           # Returns nothing.
           def call

--- a/decidim-verifications/app/commands/decidim/verifications/perform_authorization_step.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/perform_authorization_step.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the handler wasn't valid and we couldn't proceed.
+      # - :invalid if the handler was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-verifications/app/commands/decidim/verifications/revoke_all_authorizations.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/revoke_all_authorizations.rb
@@ -16,7 +16,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the handler wasn't valid and we couldn't proceed.
+      # - :invalid if the handler was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/decidim-verifications/app/commands/decidim/verifications/revoke_by_condition_authorizations.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/revoke_by_condition_authorizations.rb
@@ -18,7 +18,7 @@ module Decidim
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
-      # - :invalid if the handler wasn't valid and we couldn't proceed.
+      # - :invalid if the handler was not valid and we couldn't proceed.
       #
       # Returns nothing.
       def call

--- a/docs/modules/develop/pages/managing_translations_i18n.adoc
+++ b/docs/modules/develop/pages/managing_translations_i18n.adoc
@@ -12,7 +12,7 @@ Decidim uses https://crowdin.com/[Crowdin] to manage the translations.
 
 * Setup the new language in https://crowdin.com/project/decidim[_Crowdin's Decidim project_] (or open an issue on Github asking an admin to do that).
 * Add the locale mapping in the `crowdin.yml` file
-* Translate at least one key from every engine, so, your _yaml_ files are not empty. The easiest way to do this is to automatically translate and sync all the content. Later you'll be able to fix the content that wasn't properly translated.
+* Translate at least one key from every engine, so, your _yaml_ files are not empty. The easiest way to do this is to automatically translate and sync all the content. Later you'll be able to fix the content that was not properly translated.
 * Add https://github.com/najlepsiwebdesigner/foundation-datepicker/tree/master/js/locales[Foundation Datepicker]'s translations (https://github.com/decidim/decidim/pull/2039[PR]).
 * Add the new language to `available_locales` (https://github.com/decidim/decidim/pull/1991[PR]).
 * Add the language in https://github.com/decidim/decidim/pull/5080/files#diff-9c9dc1c8c25dcecdfb8ce555d5ef5e47R15[decidim-core/spec/lib/available_locales_spec.rb].


### PR DESCRIPTION
#### :tophat: What? Why?
As a follow up for #10504, I am also suggesting to standardize the written format of "was not".

#### :pushpin: Related Issues
- Related to #10504

#### Testing
Run the following command at the root of the repository:
```bash
$ grep -ril "wasn't" decidim-*
```

Expect to see no matches.