### PR TITLE
Standardize the format of the words "should not"

### DIFF
--- a/decidim-accountability/app/models/decidim/accountability/result.rb
+++ b/decidim-accountability/app/models/decidim/accountability/result.rb
@@ -96,7 +96,7 @@ module Decidim
 
       private
 
-      # Private: When a row uses weight 1 and there's more than one, weight shouldn't be considered
+      # Private: When a row uses weight 1 and there's more than one, weight should not be considered
       # Handle special case when all children weight are nil
       def children_use_weighted_progress?
         return false if children.pluck(:weight).all?(&:nil?)

--- a/decidim-accountability/app/presenters/decidim/accountability/admin_log/result_presenter.rb
+++ b/decidim-accountability/app/presenters/decidim/accountability/admin_log/result_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Accountability::Result`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-accountability/app/presenters/decidim/accountability/admin_log/status_presenter.rb
+++ b/decidim-accountability/app/presenters/decidim/accountability/admin_log/status_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Accountability::Status`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-accountability/app/presenters/decidim/accountability/admin_log/timeline_entry_presenter.rb
+++ b/decidim-accountability/app/presenters/decidim/accountability/admin_log/timeline_entry_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Accountability::TimelineEntry`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assemblies_setting_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assemblies_setting_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::AssembliesSetting`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assemblies_type_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assemblies_type_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::AssembliesType`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assembly_member_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assembly_member_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::AssemblyMember`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assembly_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assembly_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Assembly`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assembly_user_role_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assembly_user_role_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::AssemblyUserRole`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-blogs/app/presenters/decidim/blogs/admin_log/post_presenter.rb
+++ b/decidim-blogs/app/presenters/decidim/blogs/admin_log/post_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Blogs::Post`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-budgets/app/presenters/decidim/budgets/admin_log/budget_presenter.rb
+++ b/decidim-budgets/app/presenters/decidim/budgets/admin_log/budget_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Budgets::Budget`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-budgets/app/presenters/decidim/budgets/admin_log/project_presenter.rb
+++ b/decidim-budgets/app/presenters/decidim/budgets/admin_log/project_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Budgets::Project``
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_invite_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_invite_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Conferences::Invite`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Conference`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_registration_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_registration_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Conferences::ConferenceRegistration`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_speaker_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_speaker_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::ConferenceSpeaker`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_user_role_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_user_role_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::ConferenceUserRole`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-conferences/app/presenters/decidim/conferences/admin_log/media_link_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/admin_log/media_link_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Conferences::MediaLink`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-conferences/app/presenters/decidim/conferences/admin_log/partner_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/admin_log/partner_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Conferences::Partner`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-conferences/app/presenters/decidim/conferences/admin_log/registration_type_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/admin_log/registration_type_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Conferences::RegistrationType`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/packs/src/decidim/redesigned_identity_selector_dialog.js
+++ b/decidim-core/app/packs/src/decidim/redesigned_identity_selector_dialog.js
@@ -1,6 +1,6 @@
 /**
  * Send a request to select which identity want to use
- * NOTE: this shouldn't be done using javascript
+ * NOTE: this should not be done using javascript
  *
  * @param {HTMLElement} node target node
  * @returns {void}

--- a/decidim-core/app/presenters/decidim/admin_log/area_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/area_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::Area`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/area_type_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/area_type_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::AreaType`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/attachment_collection_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/attachment_collection_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::AttachmentCollection`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/attachment_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/attachment_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::Attachment`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/category_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/category_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::Category`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/component_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/component_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::Component`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/contextual_help_section_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/contextual_help_section_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::ContextualHelpSection`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/impersonation_log_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/impersonation_log_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::ImpersonationLog`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/moderation_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/moderation_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::Moderation`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/newsletter_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/newsletter_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::Newsletter`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/oauth_application_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/oauth_application_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::OAuthApplication`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/organization_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/organization_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::Organization`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/participatory_space_private_user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/participatory_space_private_user_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::ParticipatorySpacePrivateUserPresenter`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/scope_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/scope_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::Scope`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/scope_type_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/scope_type_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::ScopeType`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/static_page_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/static_page_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::StaticPage`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/user_group_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/user_group_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::UserGroup`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/user_moderation_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/user_moderation_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::UserModeration`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/admin_log/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/user_presenter.rb
@@ -5,7 +5,7 @@ module Decidim
     # This class holds the logic to present a `Decidim::User`
     # for the `AdminLog` log.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/presenters/decidim/log/base_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/base_presenter.rb
@@ -15,7 +15,7 @@ module Decidim
     # See `Decidim::ActionLog#render_log` for more info on the log types and
     # presenters.
     #
-    # Usage should be automatic and you shouldn't need to call this class
+    # Usage should be automatic and you should not need to call this class
     # directly, but here's an example:
     #
     #    action_log = Decidim::ActionLog.last

--- a/decidim-core/app/services/decidim/action_logger.rb
+++ b/decidim-core/app/services/decidim/action_logger.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Decidim
-  # Use this class to log actions by any user. You probably shouldn't
+  # Use this class to log actions by any user. You probably should not
   # use this class dfirectly, but rather use `Decidim.traceability` instead.
   # Check the docs on `Decidim::Traceability` for more info.
   #

--- a/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
+++ b/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
@@ -9,7 +9,7 @@ const withOpacity =
 
 module.exports = {
   // This content is generated automatically by decidim:webpacker:install task, it
-  // shouldn't be updated manually.
+  // should not be updated manually.
   // The array must contain all the decidim modules active in the application
   content: [<%= tailwind_content_directories %>].flatMap(directory => [
     `${directory}/app/views/**/*.html.erb`,

--- a/decidim-core/lib/decidim/core/test/shared_examples/controller_render_views.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/controller_render_views.rb
@@ -5,13 +5,13 @@ shared_context "with controller rendering the view" do
   before do
     controller.view_context_class.class_eval do
       # Needed for the form_for to work (through decidim_form_for)
-      # The path shouldn't matter in the controller specs.
+      # The path should not matter in the controller specs.
       def polymorphic_path(_record, _options)
         "/"
       end
 
       # Needed for the head and link_to helpers to work
-      # The URL shouldn't matter in the controller specs.
+      # The URL should not matter in the controller specs.
       def url_for(_options)
         "/"
       end

--- a/decidim-core/lib/decidim/resource_manifest.rb
+++ b/decidim-core/lib/decidim/resource_manifest.rb
@@ -4,7 +4,7 @@ module Decidim
   # Components inside a component can expose different Resources, these resources
   # will be used to be linked between each other and other possible components.
   #
-  # This class sets a scheme to expose these resources. It shouldn't be
+  # This class sets a scheme to expose these resources. It should not be
   # used directly, you should use `register_resource` inside a component.
   #
   # Example:

--- a/decidim-core/lib/decidim/settings_manifest.rb
+++ b/decidim-core/lib/decidim/settings_manifest.rb
@@ -82,7 +82,7 @@ module Decidim
     end
 
     # Semi-private: Attributes are an abstraction used by SettingsManifest
-    # to encapsulate behavior related to each individual settings field. Shouldn't
+    # to encapsulate behavior related to each individual settings field. Should not
     # be used from the outside.
     class Attribute
       include Decidim::AttributeObject::Model

--- a/decidim-core/spec/content_parsers/decidim/hashtag_parser_spec.rb
+++ b/decidim-core/spec/content_parsers/decidim/hashtag_parser_spec.rb
@@ -98,8 +98,8 @@ module Decidim
     end
 
     context "when content contains an URL with a fragment (aka anchor link)" do
-      let(:content) { "You can add an URL and this shouldn't be parsed http://www.example.org/path##{hashtag.name}" }
-      let(:parsed_content) { "You can add an URL and this shouldn't be parsed http://www.example.org/path#fragment" }
+      let(:content) { "You can add an URL and this should not be parsed http://www.example.org/path##{hashtag.name}" }
+      let(:parsed_content) { "You can add an URL and this should not be parsed http://www.example.org/path#fragment" }
 
       it "doesn't find the hashtag" do
         expect(parser.metadata).to be_a(Decidim::ContentParsers::HashtagParser::Metadata)
@@ -108,8 +108,8 @@ module Decidim
     end
 
     context "when written with an slash before the fragment" do
-      let(:content) { "You can add an URL and this shouldn't be parsed http://www.example.org/path/#fragment" }
-      let(:parsed_content) { "You can add an URL and this shouldn't be parsed http://www.example.org/path/#fragment" }
+      let(:content) { "You can add an URL and this should not be parsed http://www.example.org/path/#fragment" }
+      let(:parsed_content) { "You can add an URL and this should not be parsed http://www.example.org/path/#fragment" }
 
       it "doesn't find the hashtag" do
         expect(parser.metadata).to be_a(Decidim::ContentParsers::HashtagParser::Metadata)

--- a/decidim-core/spec/services/decidim/notifications_digest_sending_decider_spec.rb
+++ b/decidim-core/spec/services/decidim/notifications_digest_sending_decider_spec.rb
@@ -48,7 +48,7 @@ describe Decidim::NotificationsDigestSendingDecider do
       end
     end
 
-    # This particular case shouldn't happen on daily runs but in case sending
+    # This particular case should not happen on daily runs but in case sending
     # takes a long time, those users should be also included who were notified
     # a bit later than the exact time when the scheduled task was run as we
     # cannot know precicely on which second the scheduled task was run exactly
@@ -88,7 +88,7 @@ describe Decidim::NotificationsDigestSendingDecider do
       end
     end
 
-    # This particular case shouldn't happen on weekly runs but in case sending
+    # This particular case should not happen on weekly runs but in case sending
     # takes a long time, those users should be also included who were notified
     # a bit later than the exact time when the scheduled task was run as we
     # cannot know precicely on which second the scheduled task was run exactly

--- a/decidim-debates/app/presenters/decidim/debates/admin_log/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/admin_log/debate_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Debate`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-elections/app/presenters/decidim/elections/admin_log/election_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/elections/admin_log/election_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Election`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-elections/app/presenters/decidim/elections/admin_log/trustee_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/elections/admin_log/trustee_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Trustee`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-elections/app/presenters/decidim/votings/admin_log/ballot_style_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/votings/admin_log/ballot_style_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Votings::Voting`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-elections/app/presenters/decidim/votings/admin_log/monitoring_committee_member_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/votings/admin_log/monitoring_committee_member_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Votings::Voting`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-elections/app/presenters/decidim/votings/admin_log/polling_officer_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/votings/admin_log/polling_officer_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Votings::Voting`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-elections/app/presenters/decidim/votings/admin_log/polling_station_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/votings/admin_log/polling_station_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Votings::Voting`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-elections/app/presenters/decidim/votings/admin_log/voting_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/votings/admin_log/voting_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Votings::Voting`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-elections/app/presenters/decidim/votings/census/admin_log/dataset_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/votings/census/admin_log/dataset_presenter.rb
@@ -7,7 +7,7 @@ module Decidim
         # This class holds the logic to present a `Decidim::Votings::Census::Dataset`
         # for the `AdminLog` log.
         #
-        # Usage should be automatic and you shouldn't need to call this class
+        # Usage should be automatic and you should not need to call this class
         # directly, but here's an example:
         #
         #    action_log = Decidim::ActionLog.last

--- a/decidim-elections/spec/lib/tasks/decidim_election_scheduled_tasks_spec.rb
+++ b/decidim-elections/spec/lib/tasks/decidim_election_scheduled_tasks_spec.rb
@@ -31,7 +31,7 @@ describe "decidim_elections:scheduled_tasks", type: :task do
     end
   end
 
-  context "with elections that shouldn't be affected" do
+  context "with elections that should not be affected" do
     let!(:election1) { create :election, :key_ceremony_ended, start_time: 1.day.from_now }
     let!(:election2) { create :election, :vote, :upcoming }
     let!(:election3) { create :election, :vote, :ongoing }
@@ -55,7 +55,7 @@ describe "decidim_elections:scheduled_tasks", type: :task do
     end
   end
 
-  context "with votes that shouldn't be affected" do
+  context "with votes that should not be affected" do
     let!(:vote) { create :vote, status: "accepted" }
 
     before { task.execute }

--- a/decidim-forms/app/presenters/decidim/forms/admin_log/questionnaire_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin_log/questionnaire_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Forms::Questionnaire`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiative_presenter.rb
+++ b/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiative_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Initiative`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiatives_settings_presenter.rb
+++ b/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiatives_settings_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::InitiativesSettings`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiatives_type_presenter.rb
+++ b/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiatives_type_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::InitiativesType`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -65,7 +65,7 @@ en:
             attachment:
               file: File is invalid
               needs_to_be_reattached: Needs to be reattached
-              title: Title shouldn't be empty
+              title: Title should not be empty
   activerecord:
     models:
       decidim/initiative:

--- a/decidim-meetings/app/presenters/decidim/meetings/admin_log/invite_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/admin_log/invite_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Meetings::Invite`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-meetings/app/presenters/decidim/meetings/admin_log/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/admin_log/meeting_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Meetings::Meeting`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-meetings/app/presenters/decidim/meetings/admin_log/questionnaire_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/admin_log/questionnaire_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Meetings::Questionnaire`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-meetings/spec/requests/meeting_search_spec.rb
+++ b/decidim-meetings/spec/requests/meeting_search_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Meeting search", type: :request do
       description: Decidim::Faker::Localized.literal("Curabitur arcu erat, accumsan id imperdiet et.")
     )
   end
-  # Meeting not published, shouldn't appear
+  # Meeting not published, should not appear
   let!(:meeting3) do
     create(
       :meeting,
@@ -43,7 +43,7 @@ RSpec.describe "Meeting search", type: :request do
       description: Decidim::Faker::Localized.literal("Nulla TestCheck accumsan tincidunt.")
     )
   end
-  # Meeting withdrawn, shouldn't appear
+  # Meeting withdrawn, should not appear
   let!(:meeting4) do
     create(
       :meeting,

--- a/decidim-pages/app/presenters/decidim/pages/admin_log/page_presenter.rb
+++ b/decidim-pages/app/presenters/decidim/pages/admin_log/page_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Page`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-participatory_processes/README.md
+++ b/decidim-participatory_processes/README.md
@@ -25,7 +25,7 @@ This module provides:
 
 ## Installation
 
-This is on the default Decidim installation so you shouldn't change anything to use this participatory space.
+This is on the default Decidim installation so you should not change anything to use this participatory space.
 
 ## Screenshots
 

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/participatory_process_group_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/participatory_process_group_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::ParticipatoryProcess`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/participatory_process_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::ParticipatoryProcess`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/participatory_process_type_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/participatory_process_type_presenter.rb
@@ -7,7 +7,7 @@ module Decidim
       # `Decidim::ParticipatoryProcessType`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/participatory_process_user_role_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/participatory_process_user_role_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::ParticipatoryProcessUserRole`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/step_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/step_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Step`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-proposals/app/presenters/decidim/proposals/admin_log/proposal_note_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/admin_log/proposal_note_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Proposals::ProposalNote`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-proposals/app/presenters/decidim/proposals/admin_log/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/admin_log/proposal_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Proposals::Proposal`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-proposals/app/presenters/decidim/proposals/admin_log/valuation_assignment_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/admin_log/valuation_assignment_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Proposals::ValuationAssignment`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-sortitions/app/presenters/decidim/sortitions/admin_log/sortition_presenter.rb
+++ b/decidim-sortitions/app/presenters/decidim/sortitions/admin_log/sortition_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Sortitions::Sortition`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-surveys/README.md
+++ b/decidim-surveys/README.md
@@ -14,7 +14,7 @@ Surveys will be available as a Component for a Participatory Process.
 
 ## Installation
 
-This is on the default Decidim installation so you shouldn't change anything to use this component.
+This is on the default Decidim installation so you should not change anything to use this component.
 
 ## Screenshots
 

--- a/decidim-templates/app/presenters/decidim/templates/admin_log/template_presenter.rb
+++ b/decidim-templates/app/presenters/decidim/templates/admin_log/template_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       # This class holds the logic to present a `Decidim::Template`
       # for the `AdminLog` log.
       #
-      # Usage should be automatic and you shouldn't need to call this class
+      # Usage should be automatic and you should not need to call this class
       # directly, but here's an example:
       #
       #    action_log = Decidim::ActionLog.last

--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Verifications
     # This controller allows users to create and destroy their authorizations. It
-    # shouldn't be necessary to expand it to add new authorization schemes.
+    # should not be necessary to expand it to add new authorization schemes.
     class AuthorizationsController < Verifications::ApplicationController
       helper_method :handler, :unauthorized_methods, :authorization_method, :authorization
       before_action :valid_handler, only: [:new, :create]

--- a/docs/modules/develop/pages/guide_development_app.adoc
+++ b/docs/modules/develop/pages/guide_development_app.adoc
@@ -51,11 +51,11 @@ On creation, these steps are automatically invoked by the generator:
 * `bin/rails db:migrate`
 * `bin/rails db:seed`
 
-Mind that if everything went well you shouldn't need to run these commands manually.
+Mind that if everything went well you should not need to run these commands manually.
 ====
 
 If the default database.yml does not suit your needs you can always configure it at your will and run these steps manually, although
-we recommend that you make the database configurations with environment variables (ENV VARs) so it's easy for you to regenerate the database. 
+we recommend that you make the database configurations with environment variables (ENV VARs) so it's easy for you to regenerate the database.
 
 The last command will set your database and add some example data (called "seed data") so that you can start trying Decidim.
 We don't recommend using seed data for production environments, but it's useful for local development and staging environments.


### PR DESCRIPTION
#### :tophat: What? Why?
As a follow up for #10504, I am also suggesting to standardize the written format of "should not".

#### :pushpin: Related Issues
- Related to #10504

#### Testing
Run the following command at the root of the repository:
```bash
$ grep -ril "shouldn't" decidim-*
```

Expect to see no matches.