### PR TITLE
Fix: Set required to proposal limit field in Proposal component

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -30,7 +30,7 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :scope_id, type: :scope
     settings.attribute :vote_limit, type: :integer, default: 0
     settings.attribute :minimum_votes_per_user, type: :integer, default: 0
-    settings.attribute :proposal_limit, type: :integer, default: 0
+    settings.attribute :proposal_limit, type: :integer, default: 0, required: true
     settings.attribute :proposal_length, type: :integer, default: 500
     settings.attribute :proposal_edit_time, type: :enum, default: "limited", choices: -> { %w(limited infinite) }
     settings.attribute :proposal_edit_before_minutes, type: :integer, default: 5

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -135,6 +135,19 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
       login_as current_user, scope: :user
     end
 
+    context "when proposal limit is empty" do
+      before do
+        visit edit_component_path
+        component.update(settings: { proposal_limit: "" })
+        visit edit_component_path
+      end
+
+      it "does NOT allow updating proposal component" do
+        click_button "Update"
+        expect(page).to have_content("There's an error in this field")
+      end
+    end
+
     describe "participatory_texts_enabled" do
       let(:participatory_texts_enabled_container) { page.find(".participatory_texts_enabled_container") }
 


### PR DESCRIPTION
#### :tophat: What? Why?
In Proposal components, when field `proposal_limit` is empty (admin remove the zero, p.e) and save the component, then, in proposal creation gives an error.

![unnamed](https://user-images.githubusercontent.com/75725233/224626845-6727da2a-2a5b-431f-8289-330d0029ebe0.png)

To solve that, in component settings a required is added to proposal limit field.

#### Testing
1. Go to Proposal component configuration
2. Remove zero from Proposal limit field
3. Save component
4. See required validation

### :camera: Screenshots
![imagen](https://user-images.githubusercontent.com/75725233/224627932-0ff4d44d-885e-42fd-928a-5fdeb096f120.png)


:hearts: Thank you!
