### PR TITLE
Make buttons respect the organizations' primary color

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/modules/_buttons.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_buttons.scss
@@ -123,6 +123,10 @@
     }
   }
 
+  &.primary{
+    @include button-hollow-variant(var(--primary));
+  }
+
   &.secondary{
     @include button-hollow-variant(var(--secondary));
   }


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

The copy button on the share modal doesn't respect the "Primary" color configuration of the Organization appeareance. 

This PR fixes that.
 

#### Testing
1. Sign in as admin
2. Change the Primary color in the [Organization's Appeareance](http://localhost:3000/admin/organization/appearance/edit) form
3. Go to a resource shareable (for instance a Participatory Process)
4. Click on the "Share" link
5. Click on "Share link" button
6. See that the "Copy" button has the default primary color

### :camera: Screenshots

####  Before
![Selection_567](https://user-images.githubusercontent.com/717367/224644915-ba1092c7-e574-4005-b1ed-3fb69556e1f7.png)


#### After

![Selection_566](https://user-images.githubusercontent.com/717367/224644926-d3e1d514-fb41-44f1-ac89-bfdc1ffe0331.png)


:hearts: Thank you!
