### PR TITLE
Backport 'Fix destroying scope types that have been associated with processes' to v0.27

### DIFF
--- a/decidim-core/app/models/decidim/scope_type.rb
+++ b/decidim-core/app/models/decidim/scope_type.rb
@@ -17,8 +17,32 @@ module Decidim
 
     validates :name, presence: true
 
+    before_destroy :detach_dynamic_associations
+
     def self.log_presenter_class_for(_log)
       Decidim::AdminLog::ScopeTypePresenter
+    end
+
+    private
+
+    # This method detaches all records that may have association with the scope
+    # type. This cannot be done directly using the `dependent` option in the
+    # `has_many` relation in order to avoid tight coupling between the modules.
+    #
+    # This logic does not have to be applied to any classes that have been
+    # defined as `has_many` associations within this model already as they are
+    # already handled by the `dependent` option.
+    def detach_dynamic_associations
+      ActiveRecord::Base.descendants.each do |cls|
+        next if cls.abstract_class? || !cls.name&.match?(/^Decidim::/)
+        next if cls == self.class || cls == Decidim::Scope
+
+        cls.reflect_on_all_associations(:belongs_to).each do |ref|
+          next unless ref.options[:class_name] == self.class.name
+
+          cls.where(ref.options[:foreign_key] => id).update_all(ref.options[:foreign_key] => nil) # rubocop:disable Rails/SkipsModelValidations
+        end
+      end
     end
   end
 end

--- a/decidim-participatory_processes/spec/models/decidim/participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/models/decidim/participatory_process_spec.rb
@@ -35,6 +35,17 @@ module Decidim
       it { is_expected.to be_valid }
     end
 
+    context "when a process is attached to a scope type" do
+      let!(:participatory_process) { create(:participatory_process, :with_scope, slug: "my-slug", scope_type_max_depth: scope_type, organization: organization) }
+      let(:organization) { create(:organization) }
+      let(:scope_type) { create(:scope_type, organization: organization) }
+
+      it "allows destroying the scope type" do
+        scope_type.destroy!
+        expect(participatory_process.reload.scope_type_max_depth).to be_nil
+      end
+    end
+
     describe "#active?" do
       context "when it ends in the past" do
         it "returns false" do


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #10496 to v0.27

:hearts: Thank you!