### PR TITLE
Remove the deprecated `optional` option from the file upload modal

### DIFF
--- a/decidim-core/app/cells/decidim/upload_modal/files.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/files.erb
@@ -45,7 +45,6 @@
         resource_name: resource_name,
         resource_class: resource_class,
         required: required?,
-        optional: optional, # @deprecated use `required` instead
         max_file_size: max_file_size,
         multiple: multiple,
         titled: has_title?,

--- a/decidim-core/app/cells/decidim/upload_modal_cell.rb
+++ b/decidim-core/app/cells/decidim/upload_modal_cell.rb
@@ -83,16 +83,7 @@ module Decidim
       options[:multiple] || false
     end
 
-    # @deprecated Please use `required?` instead.
-    #
-    # NOTE: When this is removed, also the `optional` option should be removed.
-    def optional
-      !required?
-    end
-
     def required?
-      return !options[:optional] if options.has_key?(:optional)
-
       options[:required] == true
     end
 

--- a/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
@@ -110,27 +110,6 @@ describe Decidim::UploadModalCell, type: :cell do
     end
   end
 
-  # @deprecated Remove after removing the `optional` option.
-  context "when file is not optional" do
-    let(:options) do
-      {
-        attribute:,
-        resource_name:,
-        attachments:,
-        optional: false,
-        titled:
-      }
-    end
-
-    it "renders hidden checkbox" do
-      expect(subject).to have_css("input[name='dummy[#{attribute}_validation]']")
-    end
-
-    it "renders the required field indicator" do
-      expect(subject).to have_css("label .label-required", text: "Required field")
-    end
-  end
-
   context "when attachment is present" do
     let(:filename) { "Exampledocument.pdf" }
     let(:file) { Decidim::Dev.test_file(filename, "application/pdf") }

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -692,10 +692,10 @@ module Decidim
           )
         )
       end
-      let(:optional) { true }
+      let(:required) { false }
       let(:attributes) do
         {
-          optional:
+          required:
         }
       end
       let(:output) do


### PR DESCRIPTION
#### :tophat: What? Why?
For the next version, we can remove the deprecated `optional` option that was left behind on purpose at #10497 for the backports.

#### :pushpin: Related Issues
- Related to #10497

#### Testing
- Find a required file upload field
- See that it has the required indicator as expected

Also, you can search for the optional matches and see that we don't have any relevant matches to this particular functionality:

```bash
$ grep -B3 -ri "optional:" --exclude-dir={models,packs} decidim-*
```

The only matches should be the concerns attached to models within `decidim-core/lib/decidim`. They are not related to these changes.