### PR TITLE
Fix flaky spec for questionnaire templates

### DIFF
--- a/decidim-templates/lib/decidim/templates/test/shared_examples/uses_questionnaire_templates.rb
+++ b/decidim-templates/lib/decidim/templates/test/shared_examples/uses_questionnaire_templates.rb
@@ -91,6 +91,10 @@ shared_examples_for "uses questionnaire templates" do |_questionnaire_for|
 
       select(template.name["en"], from: "select-template")
 
+      within ".questionnaire-template-preview" do
+        expect(page).to have_content(template.templatable.title["en"].upcase)
+      end
+
       within ".create-from-template" do
         find("*[type=submit]").click
       end


### PR DESCRIPTION
#### :tophat: What? Why?
The survey templates spec is failing occasionally because it is not waiting for the async request to finish that displays the survey preview. That request needs to finish before the form is submitted.

This is a limitation we currently have with the Capybara tests because of this configuration:

https://github.com/decidim/decidim/blob/0a73269cc371e2147e837795bc465a57e2c9a25e/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb#L102

The option in question is `queue_requests: false`.

This option was originally added because of other flaky specs in the multithreaded mode (see #9422). It is needed because of running multi-threaded Puma and how Warden consumes the test environment session variables it sets as explained in that linked PR (not compatible with the default multi-threaded mode).

#### :pushpin: Related Issues
- Fixes #10543

#### Testing
See #10543.