### PR TITLE
Improve the getting started manual

### DIFF
--- a/docs/modules/customize/pages/authorizations.adoc
+++ b/docs/modules/customize/pages/authorizations.adoc
@@ -11,15 +11,21 @@ There are several use cases for this, such as
 * Checking some information through other systems (as a Municipal Census on the case of Municipalities, Cities or Towns)
 * Having a list of valid users emails
 
-Right now Decidim supports only a few of these cases, but we have an internal API where you can program your own kind of authorizations.
-Introduction
+Currently Decidim supports only a few of these cases, but we have an internal API where you can program your own kind of authorizations.
 
-Each decidim instance is in full control of its authorizations, and can customize:
+== Introduction
+
+Each Decidim instance is in full control of its authorizations, and can customize:
 
 * The different methods to be used by users to get verified. For example, through a census, by uploading their identity documents, or by receiving a verification home at their address.
 * The different actions in decidim that require authorization, and which authorization method they require. For example, a decidim instance might choose to require census authorization to create proposals, but a fully verified address via a verification code sent by postal mail for voting on proposals.
 
 See https://github.com/decidim/decidim/blob/develop/decidim-verifications/README.md[decidim-verifications's README] and https://decidim.org/modules[Decidim's Modules page].
+
+The default Decidim application comes pre-configured with some example authorization strategies that you can test to get familiar with the system. If you want to verify yourself with these strategies, please follow these instructions:
+
+- For the "Example authorization" strategy, use a document number ended with "X". Other details can be as you wish.
+- For the "Another example authorization", use a passport number starting with "A". Other details can be as you wish.
 
 == Examples
 

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -1,21 +1,21 @@
 = Getting started with Decidim
 :source-highlighter: highlightjs
 
-== What is and what is not Decidim?
+== What is Decidim?
 
-Decidim is a set of Ruby on Rails engines to create a participatory democracy framework on top of a Ruby on Rails app. This system allows having Decidim code separated from custom code for each installation and still enabling easy updates.
+Decidim is a participatory democracy framework based on multiple Ruby on Rails engines that are mounted on top of a Ruby on Rails application. This system allows separating the Decidim core code from any custom code needed in Decidim installations. This approach also makes it easy to keep the core code updated while maintaining any custom functionality added to the platform separated from the core code.
 
-These libraries are published to Rubygems.org, so you can add Decidim to your Ruby on Rails app as external dependencies.
+These libraries (gems) are published to Rubygems.org, and they are added to the Decidim applications by defining them as external dependencies within the Ruby on Rails application.
 
-If you want to start your own installation of Decidim, you do not need to clone this repo. Keep reading to find out how to install Decidim.
+If you want to start your own installation of Decidim, you do not need to clone the Decidim source code repository. Keep reading to find out how to install Decidim.
 
 == Creating your Decidim app
 
 === A. Recommended: manual installation
 
-If you know Ruby and have already worked with Ruby on Rails, you need to know that decidim is a gem and a command line that generates an application that consumes this gem 😅.
+If you know Ruby and have already worked with Ruby on Rails, you need to know that `decidim` is a gem and a command line utility that generates a Decidim application. The generated application utilizes the other gems provided by the Decidim project to benefit from the functionality provided by each gem.
 
-The flow is: install gem, generate a Ruby on Rails app, enjoy.
+The flow is: install the `decidim` gem, generate a Ruby on Rails app, enjoy.
 
 [source,console]
 ----
@@ -27,7 +27,7 @@ You can see the xref:install:manual.adoc[official manual installation tutorial],
 
 === B. Installation script [experimental]
 
-There's also an installation script made by http://www.platoniq.net/[Platoniq] that allows you to install Decidim automatically. You can even check it on a Vagrant virtual machine if you want to. https://platoniq.github.io/decidim-install/script/[More information].
+There is also an installation script made by http://www.platoniq.net/[Platoniq] that allows you to install Decidim automatically. You can even check it on a Vagrant virtual machine if you want to. https://platoniq.github.io/decidim-install/script/[More information].
 
 [source,console]
 ----
@@ -36,7 +36,7 @@ chmod +x install-decidim.sh
 ./install-decidim.sh decidim_application
 ----
 
-== Initializing your app for local development
+== Initializing your application for local development
 
 You should now setup your database:
 
@@ -45,7 +45,7 @@ You should now setup your database:
 bin/rails db:create db:migrate db:seed
 ----
 
-This will also create some default data so you can start testing the app:
+This will also create some example data through the seeds so that you can start testing the application straight away. The following table contains some example user accounts that you can start testing the system with.
 
 .Default seed's users
 |===
@@ -71,9 +71,7 @@ This will also create some default data so you can start testing the app:
 
 |===
 
-This data will not be created in production environments, if you still want to do it, run: `$ SEED=true rails db:setup`. We recomend that you first login as system user and edit the host for the organization. Set it to you production host, without the protocol and the port (so if your host is `+https://example.org:3001+`, you need to write `example.org`). After it'd be good to execute the `seed` command, as that would be created with the first Organization created.
-
-If you want to verify yourself against the default authorization handler use a document number ended with "X".
+This data will not be created in production environments. If you insist adding it in production, run: `$ SEED=true rails db:setup`. We recomend that you first login as a system user and edit the hostname for the organization. Set it as your production environment's domain, without the protocol and the port (so if your domain/hostname is `+https://example.org:3001+`, you need to write `example.org` in the organization's host field).
 
 You can now start your server!
 
@@ -86,13 +84,13 @@ Visit http://localhost:3000 to see your app running.
 
 == Configuration & setup
 
-Decidim comes pre-configured with some safe defaults, but can be changed through xref:configure:environment_variables.adoc[Environment Variables] or the xref:configure:initializer.adoc[Initializer] file in your app.
+Decidim comes pre-configured with some sane and safe defaults, but those configurations can be changed through xref:configure:environment_variables.adoc[Environment Variables] or the xref:configure:initializer.adoc[Initializer] file in your app.
 
 === Scheduled tasks
 
-For Decidim to function as expected, there are some background tasks that should be scheduled to be executed regularly. Alternatively you could use `whenever` gem or the scheduled jobs of your hosting provider.
+For Decidim to function as expected, there are some background tasks that should be scheduled to be executed regularly. Alternatively you could use `whenever` gem or the scheduled jobs of your hosting provider. When you are locally testing Decidim for development purposes, you can omit this step or run these tasks manually one by one if you want to test them out.
 
-You can configure it with `crontab -e`, for instance if you've created your Decidim application on /home/user/decidim_application:
+For production environments, you can configure these tasks with `crontab -e`. For instance, if you have created your Decidim application at `/home/user/decidim_application`, you can use the following crontab configuration:
 
 [source,console]
 ----
@@ -130,23 +128,33 @@ We also have other guides on how to configure some extra mandatory components:
 * xref:services:maps.adoc[Maps]: How to enable geocoding for proposals and meetings.
 * xref:services:smtp.adoc[SMTP]: For sending emails for account registrations, password reminders, notifications, etc.
 * xref:services:social_providers.adoc[Social providers integration]: Enable sign up from social networks.
+* xref:customize:authorizations.adoc[Authorizations]: Configure authorizations to verify people's identities
 
 == Deploy
 
-Once you've successfully deployed your app to your favorite platform, you'll need to create your `System` user. First you'll need to create your `Decidim::System` user in your terminal:
+Once you have successfully deployed your applicaton to your favorite platform, you will need to create your `System` user. You can do this using the following command in your terminal:
 
 [source,console]
 ----
 bin/rails decidim_system:create_admin
 ----
 
-You'll be asked for an email and a password. For security, the password will not get displayed back at you and you'll need to confirm it.
+The command asks for an email and a password. For security, the password will not be displayed in the terminal at you and you need to confirm it by typing it twice.
 
-This will create a system user with the email and password you set. We recommend using a random password generator and saving it to a password manager, so you have a more secure login.
+This will create a system user with the email and password you provided. We recommend using a random password generator and saving it to a password manager, so you have a more secure credentials.
 
-Then, visit the `/system` dashboard and login with the email and passwords you just entered and create your organization. You're done! 🎉
+After this, visit the `/system` panel and login with the email and passwords you just entered and create your organization. Now you are ready to setup your organization and after that you are done! 🎉
 
-You can check the https://github.com/decidim/decidim/tree/develop/decidim-system/README.md[`decidim-system` README file] for more info on how organizations work.
+=== What are organizations?
+
+Decidim is a https://en.wikipedia.org/wiki/Multitenancy[multitenant] application that allows you to host multiple different Decidim-based websites within the same system. Organizations are isolated from each other and users in those organizations cannot see any data from other organizations. This allows you to simplify your hosting configuration if you want to use the same codebase for running multiple websites, with each website having their own content and data. To get started with Decidim, you only need to configure one organization.
+
+Note that the system panel admin user you created earlier is also separated from the user accounts on the organization. When you create the organization, you also provided its admin user's name and email. Decidim will send an email to that address asking that user to create a password for their admin account within the organization. To clarify the difference:
+
+* *System admin* - Manages the organizations on the same platform, does not necessarily have to be involved in any organization
+* *Organization admin* - Administers a single organization, i.e. manages its content, sets up processes, adds components, manages user accounts, etc.
+
+You can check the https://github.com/decidim/decidim/tree/develop/decidim-system/README.md[`decidim-system` README file] for more info on what are organizations and how they work.
 
 == Checklist
 


### PR DESCRIPTION
#### :tophat: What? Why?
I tried to read this through with fresh pair of eyes and do some improvements to the getting started manual.

Particularly one thing we noticed before was that the "organization" concept can be confusing when you are first starting with Decidim. Of course, we should eventually also improve the guidance within the system itself but as the first step I'd like to improve this documentation.

Another thing I noticed is that the "getting started" manual is talking about authorizations which I don't see relevant when first starting with Decidim. I moved that line to the authorizations manual and also added a link to that page to the getting started manual, within the "Further configuration" section.