### PR TITLE
Update the setup-node GitHub action to v3

### DIFF
--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -27,7 +27,7 @@ runs:
       with:
         ruby-version: ${{ inputs.ruby_version }}
         bundler-cache: true
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node_version }}
     - name: Get npm cache directory path

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,7 +23,7 @@ Individual workflows with changes:
 - `ci_javascript.yml`: Runs tests for the JS files. Tests must run from the project root folder. You'll need to install NodeJS and the JS dependencies:
 
 ```yml
-- uses: actions/setup-node@main
+- uses: actions/setup-node@v3
   with:
     node-version: ${{ env.NODE_VERSION }}
 - run: npm ci

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,7 +23,7 @@ Individual workflows with changes:
 - `ci_javascript.yml`: Runs tests for the JS files. Tests must run from the project root folder. You'll need to install NodeJS and the JS dependencies:
 
 ```yml
-- uses: actions/setup-node@master
+- uses: actions/setup-node@main
   with:
     node-version: ${{ env.NODE_VERSION }}
 - run: npm ci

--- a/.github/workflows/ci_generators_flags.yml
+++ b/.github/workflows/ci_generators_flags.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path

--- a/.github/workflows/ci_generators_main.yml
+++ b/.github/workflows/ci_generators_main.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path

--- a/.github/workflows/ci_generators_rest.yml
+++ b/.github/workflows/ci_generators_rest.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path

--- a/.github/workflows/ci_javascript.yml
+++ b/.github/workflows/ci_javascript.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path


### PR DESCRIPTION
#### :tophat: What? Why?
We should keep the GitHub actions up to date, so let's update this.

I started to get some mysterious 404 errors on this but apparently it was just some temporary issue. Nevertheless, we should update this.