### PR TITLE
Migrate GitHub actions to the `GITHUB_OUTPUT` environment variable

### DIFF
--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -32,7 +32,7 @@ runs:
         node-version: ${{ inputs.node_version }}
     - name: Get npm cache directory path
       id: npm-cache-dir-path
-      run: echo "::set-output name=dir::$(npm get cache)-${{ inputs.name }}"
+      run: echo "dir=$(npm get cache)-${{ inputs.name }}" >> $GITHUB_OUTPUT
       shell: "bash"
     - uses: actions/cache@v2
       id: npm-cache

--- a/.github/workflows/ci_generators_flags.yml
+++ b/.github/workflows/ci_generators_flags.yml
@@ -61,7 +61,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path
         id: npm-cache-dir-path
-        run: echo "::set-output name=dir::$(npm get cache)-${{ env.DECIDIM_MODULE }}"
+        run: echo "dir=$(npm get cache)-${{ env.DECIDIM_MODULE }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: npm-cache
         with:

--- a/.github/workflows/ci_generators_main.yml
+++ b/.github/workflows/ci_generators_main.yml
@@ -61,7 +61,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path
         id: npm-cache-dir-path
-        run: echo "::set-output name=dir::$(npm get cache)-${{ env.DECIDIM_MODULE }}"
+        run: echo "dir=$(npm get cache)-${{ env.DECIDIM_MODULE }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: npm-cache
         with:

--- a/.github/workflows/ci_generators_rest.yml
+++ b/.github/workflows/ci_generators_rest.yml
@@ -61,7 +61,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path
         id: npm-cache-dir-path
-        run: echo "::set-output name=dir::$(npm get cache)-${{ env.DECIDIM_MODULE }}"
+        run: echo "dir=$(npm get cache)-${{ env.DECIDIM_MODULE }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: npm-cache
         with:

--- a/.github/workflows/ci_javascript.yml
+++ b/.github/workflows/ci_javascript.yml
@@ -39,7 +39,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path
         id: npm-cache-dir-path
-        run: echo "::set-output name=dir::$(npm get cache)-javascript"
+        run: echo "dir=$(npm get cache)-javascript" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: npm-cache
         with:

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path
         id: npm-cache-dir-path
-        run: echo "::set-output name=dir::$(npm get cache)-main"
+        run: echo "dir=$(npm get cache)-main" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: npm-cache
         with:

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -61,7 +61,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path
         id: npm-cache-dir-path
-        run: echo "::set-output name=dir::$(npm get cache)-${{ env.DECIDIM_MODULE }}"
+        run: echo "dir=$(npm get cache)-${{ env.DECIDIM_MODULE }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: npm-cache
         with:

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path
         id: npm-cache-dir-path
-        run: echo "::set-output name=dir::$(npm get cache)-lint"
+        run: echo "dir=$(npm get cache)-lint" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: npm-cache
         with:


### PR DESCRIPTION
#### :tophat: What? Why?
The `set-output` command we are currently using is deprecated:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

We should migrate to the `GITHUB_OUTPUT` environment file as specified by that documentation.

See:
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files

Fixes:  #10140

### :camera: Screenshots
![Annotation warnings in a GitHub workflow run](https://user-images.githubusercontent.com/864340/225689361-76d70254-64dc-494b-a887-b64a40703c95.png)