### PR TITLE
Formalize the usage of the phrase "let's"

### DIFF
--- a/decidim-api/docs/usage.md
+++ b/decidim-api/docs/usage.md
@@ -125,7 +125,7 @@ Finally, note that the returned object is an array, each item of which is a repr
 >
 > Each filter has its own properties, you should check any object in particular for details. The way they work with multi-languages fields, however, is the same:
 >
-> Let's say we have some searchable object with a multi-language field called *title*, and we have a filter that allows us to search through this field. How should it work? Should we look up content for every language in the field? or should we stick to a specific language?
+> We can say we have some searchable object with a multi-language field called *title*, and we have a filter that allows us to search through this field. How should it work? Should we look up content for every language in the field? or should we stick to a specific language?
 >
 > In our case, we've decided to search only one particular language of a multi-language field but we let you choose which language to search.
 > If no language is specified, the configured as default in the organization will be used. The keyword to specify the language is `locale`, and it should be provided in the 2 letters ISO 639-1 format (en = English, es = Spanish, ...).

--- a/decidim-assemblies/lib/decidim/assemblies/query_extensions.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/query_extensions.rb
@@ -20,8 +20,8 @@ module Decidim
                    [Decidim::Assemblies::AssemblyType],
                    null: true,
                    description: "Lists all assemblies" do
-          argument :filter, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputFilter, "This argument let's you filter the results", required: false
-          argument :order, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputSort, "This argument let's you order the results", required: false
+          argument :filter, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputFilter, "This argument lets you filter the results", required: false
+          argument :order, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputSort, "This argument lets you order the results", required: false
         end
 
         type.field :assembly,

--- a/decidim-budgets/README.md
+++ b/decidim-budgets/README.md
@@ -30,7 +30,7 @@ bundle
 
 ## Budget Workflows
 
-A budget workflow, let's an admin pick, at the component level, how a user can participate in it.
+A budget workflow, lets an admin pick, at the component level, how a user can participate in it.
 By default there are two workflows included in this module, `:one` and `:all` that can be found in the `lib/decidim/budgets/workflows/` directory, any app can add its own workflow.
 
 ### Adding a custom workflow

--- a/decidim-consultations/lib/decidim/consultations/query_extensions.rb
+++ b/decidim-consultations/lib/decidim/consultations/query_extensions.rb
@@ -15,8 +15,8 @@ module Decidim
                    [Decidim::Consultations::ConsultationType],
                    null: true,
                    description: "Lists all consultations" do
-          argument :filter, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputFilter, "This argument let's you filter the results", required: false
-          argument :order, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputSort, "This argument let's you order the results", required: false
+          argument :filter, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputFilter, "This argument lets you filter the results", required: false
+          argument :order, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputSort, "This argument lets you order the results", required: false
         end
 
         type.field :consultation,

--- a/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
+++ b/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
@@ -19,7 +19,7 @@ module Decidim
     def ensure_authenticated!
       return true unless current_organization.force_users_to_authenticate_before_access_organization
 
-      # Next stop: Let's check whether auth is ok
+      # Next stop: Check whether auth is ok
       unless user_signed_in?
         flash[:warning] = t("actions.login_before_access", scope: "decidim.core")
         redirect_to decidim.new_user_session_path

--- a/decidim-core/config/initializers/devise.rb
+++ b/decidim-core/config/initializers/devise.rb
@@ -303,7 +303,7 @@ Devise.setup do |config|
   end
 
   # ==> Mountable engine configurations
-  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # When using Devise inside an engine, we can call it `MyEngine`, and this engine
   # is mountable, there are some extra configurations to be taken into account.
   # The following options are available, assuming the engine is mounted as:
   #

--- a/decidim-core/lib/decidim/query_extensions.rb
+++ b/decidim-core/lib/decidim/query_extensions.rb
@@ -14,8 +14,8 @@ module Decidim
                  [Decidim::ParticipatoryProcesses::ParticipatoryProcessType],
                  null: true,
                  description: "Lists all participatory_processes" do
-        argument :filter, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputFilter, "This argument let's you filter the results", required: false
-        argument :order, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputSort, "This argument let's you order the results", required: false
+        argument :filter, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputFilter, "This argument lets you filter the results", required: false
+        argument :order, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputSort, "This argument lets you order the results", required: false
       end
 
       type.field :participatory_process,

--- a/decidim-elections/app/commands/decidim/elections/admin/setup_election.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/setup_election.rb
@@ -95,7 +95,7 @@ module Decidim
               max_selections: question.max_selections,
               title: flatten_translations(question.title),
               # the bulletin_board gem (ruby client) expects a description for the question
-              # as development is in a separate repository, let's send an empty content for the moment
+              # as development is in a separate repository, we send an empty content for the moment
               description: {},
               answers: question_answers_data(question)
             }

--- a/decidim-elections/lib/decidim/votings/query_extensions.rb
+++ b/decidim-elections/lib/decidim/votings/query_extensions.rb
@@ -15,8 +15,8 @@ module Decidim
                    [Decidim::Votings::VotingType],
                    null: true,
                    description: "Lists all votings" do
-          argument :filter, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputFilter, "This argument let's you filter the results", required: false
-          argument :order, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputSort, "This argument let's you order the results", required: false
+          argument :filter, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputFilter, "This argument lets you filter the results", required: false
+          argument :order, Decidim::ParticipatoryProcesses::ParticipatoryProcessInputSort, "This argument lets you order the results", required: false
         end
 
         type.field :voting,

--- a/decidim-proposals/spec/cells/decidim/proposals/reported_content_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/reported_content_cell_spec.rb
@@ -6,13 +6,13 @@ module Decidim::Proposals
   describe ReportedContentCell, type: :cell do
     controller Decidim::Proposals::ProposalsController
 
-    let!(:proposal) { create(:proposal, title: { "en" => "a nice title" }, body: { "en" => "let's do this!" }) }
+    let!(:proposal) { create(:proposal, title: { "en" => "a nice title" }, body: { "en" => "we can do this!" }) }
 
     context "when rendering" do
       it "renders the proposal's title and body" do
         html = cell("decidim/reported_content", proposal).call
         expect(html).to have_content("a nice title")
-        expect(html).to have_content("let's do this!")
+        expect(html).to have_content("we can do this!")
       end
     end
   end

--- a/docs/modules/customize/pages/logic.adoc
+++ b/docs/modules/customize/pages/logic.adoc
@@ -49,7 +49,7 @@ The benefit of using concerns is that when we update Decidim gems to new version
 
 Concerns should be placed into the `concerns` folder within the top-level folder where you want to apply these concerns. In this case, we are adding a concern for the forms classes, so we should place the concerns related to forms to `app/forms/concerns`. If you do not have this folder available, create it first `mkdir -p app/forms/concerns`.
 
-Now, let's move our modifications from the first copy-paste example into a concern.
+Now, we can move our modifications from the first copy-paste example into a concern.
 
 . Create the file `app/forms/concerns/admin_project_form_extensions.rb`, and make the desired changes in that file as follows:
 [source,ruby]

--- a/docs/modules/customize/pages/styles.adoc
+++ b/docs/modules/customize/pages/styles.adoc
@@ -55,7 +55,7 @@ Notice that you can resize this textarea.
 Decidim uses Webpacker to compile assets. There are two ways to customize CSS:
 
 1. if you want to redefine just CSS vars or Foundation settings, use _decidim-settings.scss
-2. if you want to redefine a specific snippet of CSS (let's say a few classes but not a whole file) you can use decidim_application.scss
+2. if you want to redefine a specific snippet of CSS (say a few classes but not a whole file) you can use decidim_application.scss
 3. and of course you can overwrite whole files by copying them into the application i.e: to replace `decidim-core/app/packs/stylesheets/decidim/modules/_data-consent.scss` you should create in your Rails app a file in
   `app/packs/stylesheets/decidim/modules/_data-consent.scss` and it will have more priority over the Decidim file.
 

--- a/docs/modules/develop/pages/content_blocks.adoc
+++ b/docs/modules/develop/pages/content_blocks.adoc
@@ -25,7 +25,7 @@ Decidim.content_blocks.register(:homepage, :stats) do |content_block|
 end
 ----
 
-Let's analyze the example. In the first line, we register a content block named `:stats` for the `:homepage` scope. Then we define the name of the `cell` that will be used to render the content block, and we define the i18n key that holds the name for the content block. These are the only required fields to register a content block.
+In the first line, we register a content block named `:stats` for the `:homepage` scope. Then we define the name of the `cell` that will be used to render the content block, and we define the i18n key that holds the name for the content block. These are the only required fields to register a content block.
 
 Note that content blocks need to be registered from an initializer. If you are adding a content block from a module, use this in the `engine.rb` file of your module:
 

--- a/docs/modules/develop/pages/newsletter_templates.adoc
+++ b/docs/modules/develop/pages/newsletter_templates.adoc
@@ -36,7 +36,7 @@ end
 
 You'll need to add this into an initializer. Note that if you're adding this from a module, then you need to add it from the `engine.rb` file (check the docs for content blocks for more info).
 
-This is the simplest template. It has a single attribute, in this case a translatable chunk of text. Let's go line by line.
+This is the simplest template. It has a single attribute, in this case a translatable chunk of text. We will analyze the example line by line.
 
 Inside the block, first we define the path of the cell we'll use to render the email publicly. This cell will receive the `Decidim::ContentBlock` object, which will contain the attributes and any image we have (one in this example). In order to render cells, please note that emails have a very picky HTML syntax, so we suggest using some specialized tools to design the template, export the layout to HTML and render that through the cell. We suggest you make this cell inherit from `Decidim::NewsletterTemplates::BaseCell` for convenience.
 

--- a/docs/modules/develop/pages/traceable.adoc
+++ b/docs/modules/develop/pages/traceable.adoc
@@ -21,7 +21,7 @@ The default presenter does not fulfill your needs? You might want to create your
 * You want to change the order of the factors in the log sentence
 * You want to change the format of the values in the diff
 
-Let's go ahead and see how to create your own resource presenter.
+Next, you will learn how to create your own resource presenter.
 
 Custom presenters should be named as `Decidim::<your module name>::<log name>::<your model name>Presenter`. There's currently only one log, `AdminLog`. This means that if your model is `Decidim::Accountability::Result`, then your admin log presenter is must be `Decidim::Accountability::AdminLog::ResultPresenter`. You can inherit from `Decidim::Log::BasePresenter` for simplicity:
 


### PR DESCRIPTION
#### :tophat: What? Why?
To continue the writing formalization efforts, this PR formalizes the usage of the phrase "let's".

Note that I am not adding this to the spell checking rules because I did not want to touch this instance of the phrase (used as a catchphrase):
> Let's build a more open, transparent and collaborative society.

I also don't want to exclude those files as it is included in source locale files + some documentation, so we would have to add some further logic to the spellchecker to ignore so called "false positives".

Another issue with this phrase is that there's not a direct replacement for the term that would apply to all cases. It depends on the context.

#### :pushpin: Related Issues
- Related to #10553

#### Testing
See that CI is green.