### PR TITLE
Update the setup-chromedriver GitHub action to latest v1

### DIFF
--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -47,7 +47,7 @@ runs:
     - run: mkdir -p ./spec/decidim_dummy_app/tmp/screenshots
       name: Create the screenshots folder
       shell: "bash"
-    - uses: nanasess/setup-chromedriver@v1.0.1
+    - uses: nanasess/setup-chromedriver@v1
     - run: RAILS_ENV=test bundle exec rails assets:precompile
       name: Precompile assets
       working-directory: ./spec/decidim_dummy_app/

--- a/decidim-generators/lib/decidim/generators/component_templates/github/ci.yml.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/github/ci.yml.erb
@@ -62,7 +62,7 @@ jobs:
         name: Create test app
       - run: mkdir -p ./spec/decidim_dummy_app/tmp/screenshots
         name: Create the screenshots folder
-      - uses: nanasess/setup-chromedriver@v1.0.1
+      - uses: nanasess/setup-chromedriver@v1
       - run: RAILS_ENV=test bundle exec rails assets:precompile
         name: Precompile assets
         working-directory: ./spec/decidim_dummy_app/


### PR DESCRIPTION
#### :tophat: What? Why?
Updates the `setup-chromedriver` action to latest version because we are currently getting some deprecation errors:

```
Tests
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: nanasess/setup-chromedriver@v1.0.1, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

#### :pushpin: Related Issues
- Related to
  * #10567
  * #10568
  * #10570