### PR TITLE
Update the upload-artifact GitHub action to v3

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -81,7 +81,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -72,7 +72,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_admin_system.yml
+++ b/.github/workflows/ci_admin_system.yml
@@ -76,7 +76,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -73,7 +73,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -76,7 +76,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -79,7 +79,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -78,7 +78,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -76,7 +76,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -77,7 +77,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -77,7 +77,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_core_lib.yml
+++ b/.github/workflows/ci_core_lib.yml
@@ -72,7 +72,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-core-lib
           flags: decidim-core-lib
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -79,7 +79,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-core-system
           flags: decidim-core-system
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_core_system_ssl.yml
+++ b/.github/workflows/ci_core_system_ssl.yml
@@ -79,7 +79,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-core-system-ssl
           flags: decidim-core-system-ssl
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_core_unit.yml
+++ b/.github/workflows/ci_core_unit.yml
@@ -71,7 +71,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -77,7 +77,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_dev_system.yml
+++ b/.github/workflows/ci_dev_system.yml
@@ -70,7 +70,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_elections_system_admin.yml
+++ b/.github/workflows/ci_elections_system_admin.yml
@@ -91,7 +91,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-elections-system-admin
           flags: decidim-elections-system-admin
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_elections_system_public.yml
+++ b/.github/workflows/ci_elections_system_public.yml
@@ -91,7 +91,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-elections-system-public
           flags: decidim-elections-system-public
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_elections_unit_tests.yml
+++ b/.github/workflows/ci_elections_unit_tests.yml
@@ -87,7 +87,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -72,7 +72,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -74,7 +74,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_initiatives_system_admin.yml
+++ b/.github/workflows/ci_initiatives_system_admin.yml
@@ -78,7 +78,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-initiatives-system-admin
           flags: decidim-initiatives-system-admin
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_initiatives_system_public.yml
+++ b/.github/workflows/ci_initiatives_system_public.yml
@@ -78,7 +78,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-initiatives-system-public
           flags: decidim-initiatives-system-public
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -79,7 +79,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-meetings-system-admin
           flags: decidim-meetings-system-admin
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -79,7 +79,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-meetings-system-public
           flags: decidim-meetings-system-public
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_meetings_unit_tests.yml
+++ b/.github/workflows/ci_meetings_unit_tests.yml
@@ -75,7 +75,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -76,7 +76,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -77,7 +77,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -81,7 +81,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-proposals-system-admin
           flags: decidim-proposals-system-admin
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_proposals_system_public.yml
+++ b/.github/workflows/ci_proposals_system_public.yml
@@ -81,7 +81,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-proposals-system-public
           flags: decidim-proposals-system-public
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -77,7 +77,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -78,7 +78,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -79,7 +79,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -75,7 +75,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -78,7 +78,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -76,7 +76,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/decidim-generators/lib/decidim/generators/component_templates/github/ci.yml.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/github/ci.yml.erb
@@ -69,7 +69,7 @@ jobs:
       - run: bundle exec rspec
         name: RSpec
       - uses: codecov/codecov-action@v1
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots


### PR DESCRIPTION
#### :tophat: What? Why?
Updates the `upload-artifact` action to version 3 because we are currently getting some deprecation errors:

```
Tests
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: nanasess/setup-chromedriver@v1.0.1, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

#### :pushpin: Related Issues
- Related to
  * #10567
  * #10568
  * #10570
  * #10596