### PR TITLE
Use `login_as` in system specs instead of `sign_in`

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -97,6 +97,14 @@ plugins:
           severity: minor
           categories: Style
 
+        no-sing-in-for-system-specs:
+          pattern: \s+sign_in[\s\(]
+          annotation: "Use login_as instead of sign_in at system specs"
+          severity: minor
+          categories: Style
+          path_patterns:
+            - "decidim-*/spec/system/**/*.rb"
+
     exclude_patterns:
       - "decidim_app-design/**/*"
       - "**/*/locales/*.yml"

--- a/decidim-accountability/spec/system/admin/admin_imports_projects_to_accountability_spec.rb
+++ b/decidim-accountability/spec/system/admin/admin_imports_projects_to_accountability_spec.rb
@@ -14,7 +14,7 @@ describe "Admin imports projects to accountability", type: :system do
 
   before do
     switch_to_host(organization.host)
-    login_as user
+    login_as user, scope: :user
     visit_component_admin
   end
 

--- a/decidim-blogs/spec/system/endorse_posts_spec.rb
+++ b/decidim-blogs/spec/system/endorse_posts_spec.rb
@@ -12,7 +12,7 @@ describe "endorse posts", type: :system do
   before do
     allow(Decidim).to receive(:redesign_active).and_return(true)
 
-    sign_in author
+    login_as author, scope: :user
     visit_component
     click_link "Blog post title"
   end

--- a/decidim-consultations/spec/system/consultation_spec.rb
+++ b/decidim-consultations/spec/system/consultation_spec.rb
@@ -44,7 +44,7 @@ describe "Consultation", type: :system do
         let!(:user) { create(:user, :confirmed, organization:) }
 
         before do
-          sign_in user, scope: :user
+          login_as user, scope: :user
         end
 
         it "redirects to root path" do

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -182,7 +182,7 @@ describe "Conversations", type: :system do
         before do
           click_button "Send"
           expect(page).to have_selector(".conversation__message:last-child", text: message_body)
-          relogin_as interlocutor
+          relogin_as interlocutor, scope: :user
           visit_inbox
         end
 

--- a/decidim-core/spec/system/messaging/profile_conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/profile_conversations_spec.rb
@@ -260,7 +260,7 @@ describe "ProfileConversations", type: :system do
         before do
           click_button "Send"
           expect(page).to have_selector("#messages .conversation-chat:last-child", text: "Please reply!")
-          relogin_as interlocutor
+          relogin_as interlocutor, scope: :user
           visit decidim.conversations_path
         end
 

--- a/decidim-core/spec/system/social_share_button_spec.rb
+++ b/decidim-core/spec/system/social_share_button_spec.rb
@@ -55,7 +55,7 @@ describe "Social share button", type: :system do
 
     context "when the user is logged in" do
       before do
-        sign_in resource.author
+        login_as resource.author, scope: :user
         visit resource_path
       end
 

--- a/decidim-elections/spec/system/voting_spec.rb
+++ b/decidim-elections/spec/system/voting_spec.rb
@@ -50,7 +50,7 @@ describe "Voting", type: :system do
         let!(:user) { create(:user, :confirmed, organization:) }
 
         before do
-          sign_in user, scope: :user
+          login_as user, scope: :user
         end
 
         it "redirects to root path" do

--- a/decidim-initiatives/spec/system/authorized_comments_spec.rb
+++ b/decidim-initiatives/spec/system/authorized_comments_spec.rb
@@ -21,7 +21,7 @@ describe "Authorized comments", type: :system do
 
   before do
     switch_to_host(organization.host)
-    sign_in user
+    login_as user, scope: :user
   end
 
   shared_examples_for "allowed to comment" do

--- a/decidim-proposals/spec/system/authorized_comments_spec.rb
+++ b/decidim-proposals/spec/system/authorized_comments_spec.rb
@@ -20,7 +20,7 @@ describe "Authorized comments", type: :system do
 
   before do
     switch_to_host(organization.host)
-    sign_in user
+    login_as user, scope: :user
   end
 
   shared_examples_for "allowed to comment" do

--- a/decidim-proposals/spec/system/collaborative_drafts_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_spec.rb
@@ -226,7 +226,7 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
 
       context "when visits an non author user" do
         before do
-          sign_in user, scope: :user
+          login_as user, scope: :user
           visit current_path
         end
 
@@ -259,7 +259,7 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
             expect(page).not_to have_css("[data-alert-box].secondary")
           end
 
-          it "shows that acces has been requested" do
+          it "shows that access has been requested" do
             within ".view-side" do
               expect(page).to have_css(".button.expanded.button--sc.mt-s", text: "ACCESS REQUESTED")
             end
@@ -267,7 +267,7 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
 
           context "when the author receives the request" do
             before do
-              sign_in author, scope: :user
+              login_as author, scope: :user
               visit current_path
             end
 
@@ -293,7 +293,7 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
             context "when the request is accepted and the contributor visits the draft" do
               before do
                 click_button "Accept"
-                sign_in user, scope: :user
+                login_as user, scope: :user
                 visit current_path
               end
 
@@ -327,7 +327,7 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
 
       context "when the author visits the collaborative draft" do
         before do
-          sign_in author, scope: :user
+          login_as author, scope: :user
           visit current_path
         end
 
@@ -354,7 +354,7 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
       visit main_component_path(component)
     end
 
-    it "does not show the Collaborative drafts acces button" do
+    it "does not show the Collaborative drafts access button" do
       expect(page).to have_no_content("Access collaborative drafts")
     end
   end

--- a/decidim-verifications/spec/system/postal_letter/code_request_spec.rb
+++ b/decidim-verifications/spec/system/postal_letter/code_request_spec.rb
@@ -36,7 +36,7 @@ describe "Postal letter code request", type: :system do
 
     context "and getting it sent" do
       before do
-        relogin_as admin
+        relogin_as admin, scope: :user
         visit decidim_admin_postal_letter.root_path
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
I was trying to debug some flaky tests we have right now that seem to be constantly failing.

Meanwhile I noticed that we are using `login_as` and `sign_in` mixed in the system specs.

Note that this will not fix the issue at hand because they are essentially the same. The `sign_in` method is calling the `login_as` as provided by Devise:

https://github.com/heartcombo/devise/blob/232c855c54cc3e471afbd48b6eda8ff164638c09/lib/devise/test/integration_helpers.rb#L37-L41

And the `login_as` is coming from Warden:

https://github.com/wardencommunity/warden/blob/3f197cee0511c9b3c940204bab706407170d9611/lib/warden/test/helpers.rb#L18-L23

But I would still like to make their use consistent.

#### Testing
See the added Codeclimate rule.