### PR TITLE
Fix flaky collaborative drafts specs

### DIFF
--- a/decidim-proposals/spec/system/collaborative_drafts_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_spec.rb
@@ -188,6 +188,9 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
         before do
           login_as author, scope: :user
           visit current_path
+          within ".header .title-bar .topbar__user__logged" do
+            expect(page).to have_content(author.name)
+          end
         end
 
         it "shows the publish button" do
@@ -196,14 +199,9 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
           end
         end
 
-        context "when the published" do
+        context "when the publish button is clicked" do
           before do
-            visit current_path
             click_button "Publish"
-          end
-
-          after do
-            click_button "Publish as a Proposal"
           end
 
           it "shows the a modal" do
@@ -211,6 +209,8 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
               expect(page).to have_css("h3", text: "The following action is irreversible")
               expect(page).to have_css("button", text: "Publish as a Proposal")
             end
+            click_button "Publish as a Proposal"
+            expect(page).to have_content("Collaborative draft published successfully as a proposal.")
           end
         end
       end
@@ -228,6 +228,9 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
         before do
           sign_in user, scope: :user
           visit current_path
+          within ".header .title-bar .topbar__user__logged" do
+            expect(page).to have_content(user.name)
+          end
         end
 
         it "shows an announcement to collaborate" do
@@ -267,8 +270,11 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
 
           context "when the author receives the request" do
             before do
-              sign_in author, scope: :user
+              relogin_as author, scope: :user
               visit current_path
+              within ".header .title-bar .topbar__user__logged" do
+                expect(page).to have_content(author.name)
+              end
             end
 
             it "lists the user in Collaboration Requests" do
@@ -293,12 +299,15 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
             context "when the request is accepted and the contributor visits the draft" do
               before do
                 click_button "Accept"
-                sign_in user, scope: :user
+                relogin_as user, scope: :user
                 visit current_path
+                within ".header .title-bar .topbar__user__logged" do
+                  expect(page).to have_content(user.name)
+                end
               end
 
               it "shows the user as a coauthor" do
-                expect(page).to have_content(user.name)
+                expect(page).to have_css("#content .wrapper .author--inline .author-data .author__name", text: user.name)
               end
 
               it "removes the announcement to collaborate" do
@@ -329,6 +338,9 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
         before do
           sign_in author, scope: :user
           visit current_path
+          within ".header .title-bar .topbar__user__logged" do
+            expect(page).to have_content(author.name)
+          end
         end
 
         it "removes the announcement to collaborate" do


### PR DESCRIPTION
#### :tophat: What? Why?
Currently we have few collaborative drafts specs that seem to be failing quite constantly.

After inspecting the screenshots and sources from the CI I noticed that either the expected user was not logged in or the wrong user was logged in during these tests. This is apparently because Capybara is not waiting for the last `visit` call to finish before running the spec.

So, to fix this, I added expectations that the correct user is logged in before running these specs.

Example test runs that failed:

https://github.com/decidim/decidim/actions/runs/4454895111/jobs/7824377983

```
Failures:

  1) Explore Collaborative Drafts with collaborative drafts enabled renders collaborative draft details when visits an non author user when the user requests access when the author receives the request when the request is accepted and the contributor visits the draft does not show the buttons to publish or withdraw
     Failure/Error: click_button "Request access"

     Capybara::ElementNotFound:
       Unable to find button "Request access" that is not disabled

     # ./spec/system/collaborative_drafts_spec.rb:248:in `block (6 levels) in <top (required)>'

  2) Explore Collaborative Drafts with collaborative drafts enabled renders collaborative draft details when visits an non author user when the user requests access when the author receives the request when the request is accepted and the contributor visits the draft does not show the Collaboration Requests from other users
     Failure/Error: expect(page).not_to have_content("COLLABORATION REQUESTS")
       expected not to find text "COLLABORATION REQUESTS" in "Johnson, Welch and Marks\nSearch\nSearch\nEnglish\nChoose language\nNotifications Conversations\nStanton Shanahan\nHome\nProcesses\nInitiatives\nHelp\nQuo fugit fuga. 11978\nVero iusto in. 11981\nPHASE 1 OF 1\nQuis aspernatur blanditiis. 12008\n18/02/2023 - 18/04/2023\nProcess phases\nTHE PROCESS\nPROPOSALS\nchevron-left Back\n<script>alert(\"TITLE\");</script> At ut et. 12035\nStanton Shanahan\nAustin Lueilwitz\n18/03/2023 11:13   flag\nReport\nOpen\nLabore magnam consequatur.\nSunt perferendis libero.\nNisi maxime architecto.\nprice-tag-3-lineFilter results for category: Nihil eos est. 12017Nihil eos est. 12017 price-tag-3-lineFilter results for scope: Valde creator uztulo. 132Valde creator uztulo. 132\nPUBLISH\nPublish this version of the draft or withdraw the draft\nVersion number 1\n(of 1)\nsee other versions\nEDIT COLLABORATIVE DRAFT\npeople 1\npencil 1\ncomment-square 0\nCOLLABORATION REQUESTS\nLenard Deckow\nAccept\nReject\nReference: DO-COLL-2023-03-206\nShare share\n0 COMMENTS\nOrder by:\nOlder\nADD YOUR COMMENT\nYour opinion about this topic\nthumb-up\nPositive\nNeutral\nthumb-down\nNegative\nComment\nSEND\n1000 characters left\n1000 characters left\nDownload Open Data files Cookie settings\nJohnson, Welch and Marks at Twitter\nTwitter\nJohnson, Welch and Marks at Facebook\nFacebook\nJohnson, Welch and Marks at Instagram\nInstagram\nJohnson, Welch and Marks at YouTube\nYouTube\nJohnson, Welch and Marks at GitHub\nGitHub\nWebsite made with free software \n(External link)\n."

     # ./spec/system/collaborative_drafts_spec.rb:321:in `block (8 levels) in <top (required)>'
```

https://github.com/decidim/decidim/actions/runs/4449305146/jobs/7824561773

```
Failures:

  1) Explore Collaborative Drafts with collaborative drafts enabled renders collaborative draft details when visits an non author user when the user requests access when the author receives the request shows the button to reject the request
     Failure/Error: click_button "Request access"

     Capybara::ElementNotFound:
       Unable to find button "Request access" that is not disabled

     # ./spec/system/collaborative_drafts_spec.rb:248:in `block (6 levels) in <top (required)>'

  2) Explore Collaborative Drafts with collaborative drafts enabled renders collaborative draft details when visits an non author user when the user requests access when the author receives the request when the request is accepted and the contributor visits the draft does not show the Collaboration Requests from other users
     Failure/Error: click_button "Accept"

     Capybara::ElementNotFound:
       Unable to find visible button "Accept" that is not disabled

     # ./spec/system/collaborative_drafts_spec.rb:295:in `block (8 levels) in <top (required)>'
```

https://github.com/decidim/decidim/actions/runs/4454930627/jobs/7824445194

```
Failures:

  1) Explore Collaborative Drafts with collaborative drafts enabled renders collaborative draft details when visits an non author user when the user requests access when the author receives the request shows the button to accept the request
     Failure/Error:
       within ".card.extra" do
         expect(page).to have_css(".button.hollow.secondary.small", text: "Accept")
       end

     Capybara::ElementNotFound:
       Unable to find css ".card.extra"

     # ./spec/system/collaborative_drafts_spec.rb:282:in `block (7 levels) in <top (required)>'

  2) Explore Collaborative Drafts with collaborative drafts enabled renders collaborative draft details when visits an non author user when the user requests access when the author receives the request when the request is accepted and the contributor visits the draft does not show the buttons to publish or withdraw
     Failure/Error: expect(page).not_to have_button("Publish")
       expected not to find visible button "Publish" that is not disabled, found 1 match: "PUBLISH". Also found "", which matched the selector but not all filters. 

     # ./spec/system/collaborative_drafts_spec.rb:309:in `block (8 levels) in <top (required)>'

  3) Explore Collaborative Drafts with collaborative drafts enabled renders collaborative draft details when visits an non author user when the user requests access when the author receives the request when the request is accepted and the contributor visits the draft shows the user as a coauthor
     Failure/Error: click_button "Accept"

     Capybara::ElementNotFound:
       Unable to find visible button "Accept" that is not disabled

     # ./spec/system/collaborative_drafts_spec.rb:295:in `block (8 levels) in <top (required)>'
```

#### Testing
See that CI is green