### PR TITLE
Add more spelling check rules for the new PRs

### DIFF
--- a/.spelling.yml
+++ b/.spelling.yml
@@ -41,3 +41,29 @@ forbidden:
   "that’s": that is
   "there's": there is
   "there’s": there is
+  # "we're": we are
+  # "we’re": we are
+  # "you've": you have
+  # "you’ve": you have
+  # "I've": I have
+  # "I’ve": I have
+  # "they've": they have
+  # "they’ve": they have
+  # "would've": would have
+  # "would’ve": would have
+  # "you're": you are
+  # "you’re": you are
+  # "they're": they are
+  # "they’re": they are
+  # "it's": it is
+  # "it’s": it is
+  # "here's": here is
+  # "here’s": here is
+  # "what's": what is
+  # "what’s": what is
+  # "where's": where is
+  # "where’s": where is
+  # "it'll": it will
+  # "it’ll": it will
+  # "you'll": you will
+  # "you’ll": you will


### PR DESCRIPTION
#### :tophat: What? Why?
Adds the added spelling check rules from the related PRs to the configuration file as commented out.

This is an effort to try to speed up the review process so that we wouldn't have conflict with this file after every merge.

#### :pushpin: Related Issues
- Related to
  * #10582
  * #10583
  * #10584
  * #10585
  * #10586
  * #10587
  * #10588
  * #10589
  * #10590
  * #10591
  * #10595
  * #10598
  * #10599