### PR TITLE
Change I18n captions on moderation module

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -558,7 +558,7 @@ en:
         area_types: Area types
         areas: Areas
         configuration: Configuration
-        content: Content
+        content: Reported content
         dashboard: Dashboard
         external_domain_whitelist: Allowed external domains
         help_sections: Help sections
@@ -678,7 +678,7 @@ en:
           unblocked: Not Blocked
       moderations:
         index:
-          title: Moderations
+          title: Reported content
         report:
           reasons:
             does_not_belong: Does not belong
@@ -1141,7 +1141,7 @@ en:
     decidim:
       admin:
         global_moderations:
-          title: Content moderations
+          title: Global moderations
         newsletters:
           title: Newsletters
         settings:

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -667,7 +667,7 @@ en:
           nickname: Nickname
           reason: Reason
           reports: Reports count
-          title: Listing participants
+          title: Reported participants
         report:
           reasons:
             does_not_belong: Does not belong

--- a/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
@@ -63,7 +63,7 @@ describe "Space admin manages global moderations", type: :system do
       visit decidim_admin.moderations_path
 
       within "body", wait: 2 do
-        expect(page).to have_content("Moderations")
+        expect(page).to have_content("Reported content")
         expect(page).to have_link("Visit URL")
 
         find_link("Visit URL").hover
@@ -99,7 +99,7 @@ describe "Space admin manages global moderations", type: :system do
       visit decidim_admin.moderations_path
 
       within ".container" do
-        expect(page).to have_content("Moderations")
+        expect(page).to have_content("Reported content")
 
         expect(page).to have_no_selector("table.table-list tbody tr")
       end

--- a/decidim-admin/spec/system/space_moderator_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_moderator_manages_global_moderations_spec.rb
@@ -67,7 +67,7 @@ describe "Space moderator manages global moderations", type: :system do
       visit decidim_admin.moderations_path
 
       within ".container" do
-        expect(page).to have_content("Moderations")
+        expect(page).to have_content("Reported content")
 
         expect(page).to have_no_selector("table.table-list tbody tr")
       end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR changes some of the admin labels as requested in the acceptance [comment](https://github.com/decidim/decidim/issues/10034#issuecomment-1412300417) of #10034
![image](https://user-images.githubusercontent.com/23509895/216089897-0acbe795-3d3b-473f-9baa-9472c90d5d45.png)
#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10034

#### Testing
Visit Global moderation panel, and observe the admin reflects the changes requested in the above image.


:hearts: Thank you!
