### PR TITLE
Rename "terms and conditions" to "terms of service"

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -265,8 +265,8 @@ ignore_unused:
   - decidim.proposals.proposals.filters.*
   - decidim.admin.filters.*
   - decidim.proposals.models.proposal.fields.*
-  - decidim.admin_terms_of_use.default_body
-  - decidim.admin.admin_terms_of_use.required_review.alert
+  - decidim.admin_terms_of_service.default_body
+  - decidim.admin.admin_terms_of_service.required_review.alert
   - decidim.budgets.projects.orders.*
   - forms.length_validator.*
   - layouts.decidim.widget.*

--- a/decidim-admin/README.md
+++ b/decidim-admin/README.md
@@ -29,14 +29,14 @@ bundle
 This component allows an admin to create pages to serve static content. Some
 example of this kind of pages could be:
 
-* Terms and Conditions
+* Terms of service
 * FAQ
 * Accessibility guidelines
 * About the project
 
 All the pages can be created with I18n support and will be accessible as
 `/pages/:page-slug`. You can link them at your website the same way you link
-other Rails models: `pages_path("terms-and-conditions")`.
+other Rails models: `pages_path("terms-of-service")`.
 
 There are some pages that exist by default and cannot be deleted since there
 are links to them inside the Decidim framework, see `Decidim::StaticPage` for

--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -55,7 +55,7 @@ module Decidim
           user_groups_enabled: form.user_groups_enabled,
           comments_max_length: form.comments_max_length,
           enable_machine_translations: form.enable_machine_translations,
-          admin_terms_of_use_body: form.admin_terms_of_use_body,
+          admin_terms_of_service_body: form.admin_terms_of_service_body,
           rich_text_editor_in_public_views: form.rich_text_editor_in_public_views,
           enable_participatory_space_filters: form.enable_participatory_space_filters
         }.merge(welcome_notification_attributes)

--- a/decidim-admin/app/commands/decidim/admin/update_organization_tos_version.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization_tos_version.rb
@@ -8,7 +8,7 @@ module Decidim
       # Public: Initializes the command.
       #
       # organization - The Organization that will be updated.
-      # page - A static_page instance (slug = "terms-and-conditions").
+      # page - A static_page instance (slug = "terms-of-service").
       # form - A form object with the params.
       def initialize(organization, page, form)
         @organization = organization
@@ -25,7 +25,7 @@ module Decidim
       def call
         return broadcast(:invalid) if @form.nil?
         return broadcast(:invalid) if @page.nil?
-        return broadcast(:invalid) unless @page.slug == "terms-and-conditions"
+        return broadcast(:invalid) unless @page.slug == "terms-of-service"
 
         update_organization_tos_version
         broadcast(:ok)

--- a/decidim-admin/app/controllers/decidim/admin/admin_terms_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/admin_terms_controller.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Admin
     # The controller to handle the Admin
-    # Terms of use agreement.
+    # Terms of service agreement.
     class AdminTermsController < Decidim::Admin::ApplicationController
       def accept
         current_user.admin_terms_accepted_at = Time.current

--- a/decidim-admin/app/controllers/decidim/admin/admin_terms_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/admin_terms_controller.rb
@@ -8,10 +8,10 @@ module Decidim
       def accept
         current_user.admin_terms_accepted_at = Time.current
         if current_user.save!
-          flash[:notice] = t("accept.success", scope: "decidim.admin.admin_terms_of_use")
+          flash[:notice] = t("accept.success", scope: "decidim.admin.admin_terms_of_service")
           redirect_to decidim_admin.root_path
         else
-          flash[:alert] = t("accept.error", scope: "decidim.admin.admin_terms_of_use")
+          flash[:alert] = t("accept.error", scope: "decidim.admin.admin_terms_of_service")
           redirect_to decidim_admin.admin_terms_show_path
         end
       end

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -33,7 +33,7 @@ module Decidim
       translatable_attribute :welcome_notification_subject, String
       translatable_attribute :welcome_notification_body, String
 
-      translatable_attribute :admin_terms_of_use_body, String
+      translatable_attribute :admin_terms_of_service_body, String
 
       validates :welcome_notification_subject, :welcome_notification_body, translatable_presence: true, if: proc { |form| form.customize_welcome_notification }
 
@@ -42,7 +42,7 @@ module Decidim
       validates :time_zone, time_zone: true
       validates :default_locale, :reference_prefix, presence: true
       validates :default_locale, inclusion: { in: :available_locales }
-      validates :admin_terms_of_use_body, translatable_presence: true
+      validates :admin_terms_of_service_body, translatable_presence: true
       validates :comments_max_length, presence: true, numericality: { greater_than_or_equal_to: 0 }
       validates :machine_translation_display_priority,
                 inclusion: { in: Decidim::Organization::AVAILABLE_MACHINE_TRANSLATION_DISPLAY_PRIORITIES },

--- a/decidim-admin/app/helpers/decidim/admin/admin_terms_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/admin_terms_helper.rb
@@ -2,23 +2,23 @@
 
 module Decidim
   module Admin
-    # This module includes helpers to show admin terms of use
+    # This module includes helpers to show admin terms of service
     module AdminTermsHelper
-      def admin_terms_of_use_body
-        current_organization.admin_terms_of_use_body.symbolize_keys[I18n.locale].html_safe
+      def admin_terms_of_service_body
+        current_organization.admin_terms_of_service_body.symbolize_keys[I18n.locale].html_safe
       end
 
       def announcement_body
         if current_user.admin_terms_accepted?
-          t("accept.success", scope: "decidim.admin.admin_terms_of_use")
+          t("accept.success", scope: "decidim.admin.admin_terms_of_service")
         else
-          t("required_review.callout", scope: "decidim.admin.admin_terms_of_use")
+          t("required_review.callout", scope: "decidim.admin.admin_terms_of_service")
         end
       end
 
       def button_to_accept_admin_terms
         button_to(
-          t("decidim.admin.admin_terms_of_use.actions.accept"),
+          t("decidim.admin.admin_terms_of_service.actions.accept"),
           admin_terms_accept_path,
           class: "button success",
           method: :put
@@ -27,11 +27,11 @@ module Decidim
 
       def button_to_refuse_admin_terms
         link_to(
-          t("decidim.admin.admin_terms_of_use.actions.refuse"),
+          t("decidim.admin.admin_terms_of_service.actions.refuse"),
           decidim.root_path,
           class: "button clear",
           data: {
-            confirm: t("actions.are_you_sure", scope: "decidim.admin.admin_terms_of_use")
+            confirm: t("actions.are_you_sure", scope: "decidim.admin.admin_terms_of_service")
           }
         )
       end

--- a/decidim-admin/app/helpers/decidim/admin/dashboard_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/dashboard_helper.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Admin
-    # This module includes helpers to be used in the admin dashboard, including helper methods to show the admin terms of use.
+    # This module includes helpers to be used in the admin dashboard, including helper methods to show the admin terms of service.
     module DashboardHelper
       def admin_terms_announcement_args
         {
@@ -12,10 +12,10 @@ module Decidim
       end
 
       def announcement_body
-        body = t("required_review.callout", scope: "decidim.admin.admin_terms_of_use")
+        body = t("required_review.callout", scope: "decidim.admin.admin_terms_of_service")
         body += " "
         body += link_to(
-          t("required_review.cta", scope: "decidim.admin.admin_terms_of_use"),
+          t("required_review.cta", scope: "decidim.admin.admin_terms_of_service"),
           admin_terms_show_path
         )
         body

--- a/decidim-admin/app/permissions/decidim/admin/permissions.rb
+++ b/decidim-admin/app/permissions/decidim/admin/permissions.rb
@@ -147,7 +147,7 @@ module Decidim
         when :update_slug, :destroy
           static_page.present? && !StaticPage.default?(static_page.slug)
         when :update_notable_changes
-          static_page.slug == "terms-and-conditions" && static_page.persisted?
+          static_page.slug == "terms-of-service" && static_page.persisted?
         else
           true
         end

--- a/decidim-admin/app/views/decidim/admin/admin_terms/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/admin_terms/show.html.erb
@@ -5,13 +5,13 @@
     <div class="cell medium-12">
 
       <div class="content">
-        <%= admin_terms_of_use_body %>
+        <%= admin_terms_of_service_body %>
       </div>
     </div>
 
     <% unless current_user.admin_terms_accepted? %>
       <h4 class="cell medium-12 text-center">
-        <%= t("decidim.admin.admin_terms_of_use.actions.title") %>
+        <%= t("decidim.admin.admin_terms_of_service.actions.title") %>
       </h4>
 
       <div class="cell medium-6 small-order-2 medium-order-1 text-center">

--- a/decidim-admin/app/views/decidim/admin/dashboard/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/dashboard/show.html.erb
@@ -58,7 +58,7 @@
   <% if current_user.admin_terms_accepted? %>
     <p class="text-right">
       <small>
-        <%= link_to( t("title", scope: "decidim.admin.admin_terms_of_use"), admin_terms_show_path) %>
+        <%= link_to( t("title", scope: "decidim.admin.admin_terms_of_service"), admin_terms_show_path) %>
       </small>
     </p>
   <% end %>

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -103,6 +103,6 @@
 
 <div class="row">
   <div class="columns xlarge-6">
-    <%= form.translated :editor, :admin_terms_of_use_body %>
+    <%= form.translated :editor, :admin_terms_of_service_body %>
   </div>
 </div>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
         body: Body
         subject: Subject
       organization:
-        admin_terms_of_use_body: Body for the admin terms of use
+        admin_terms_of_service_body: Body for the admin terms of service
         alert_color: Alert
         available_authorizations: Available authorizations
         badges_enabled: Enable badges
@@ -199,20 +199,20 @@ en:
         user:
           new: New admin
         verify: Verify
-      admin_terms_of_use:
+      admin_terms_of_service:
         accept:
-          error: There is been an error while accepting the admin terms of use.
-          success: Great! You have accepted the admin terms of use.
+          error: There is been an error while accepting the admin terms of service.
+          success: Great! You have accepted the admin terms of service.
         actions:
           accept: I agree with the terms
-          are_you_sure: Are you sure you want to refuse the admin terms of use?
+          are_you_sure: Are you sure you want to refuse the admin terms of service?
           refuse: Refuse the admin terms
-          title: Agree to the terms of use
+          title: Agree to the terms of service
         required_review:
-          alert: 'Required: Review our admin terms of use'
-          callout: Please take a moment to review the admin terms of use. Otherwise you will not be able to manage the platform.
+          alert: 'Required: Review our admin terms of service'
+          callout: Please take a moment to review the admin terms of service. Otherwise you will not be able to manage the platform.
           cta: Review them now.
-        title: Admin terms of use
+        title: Admin terms of service
       area_types:
         create:
           error: There was a problem creating a new area type.
@@ -997,7 +997,7 @@ en:
         destroy:
           success: Page successfully destroyed
         edit:
-          changed_notably_help: If checked, participants will be notified to accept the new terms and conditions.
+          changed_notably_help: If checked, participants will be notified to accept the new terms of service.
           title: Edit page
           update: Update
         form:

--- a/decidim-admin/spec/commands/decidim/admin/update_organization_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_organization_spec.rb
@@ -17,7 +17,7 @@ module Decidim::Admin
             badges_enabled: true,
             user_groups_enabled: true,
             send_welcome_notification: false,
-            admin_terms_of_use_body: { en: Faker::Lorem.paragraph },
+            admin_terms_of_service_body: { en: Faker::Lorem.paragraph },
             rich_text_editor_in_public_views: true,
             machine_translation_display_priority: "translation",
             enable_machine_translations: true

--- a/decidim-admin/spec/commands/decidim/admin/update_organization_tos_version_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_organization_tos_version_spec.rb
@@ -6,11 +6,11 @@ module Decidim::Admin
   describe UpdateOrganizationTosVersion do
     describe "call" do
       let(:organization) { create(:organization) }
-      let(:tos_page) { Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization:) }
+      let(:tos_page) { Decidim::StaticPage.find_by(slug: "terms-of-service", organization:) }
       let(:other_page) { create(:static_page, slug: "other-page", organization:) }
       let(:user) { create(:user, organization:) }
 
-      describe "when the page is not the terms-and-conditions page" do
+      describe "when the page is not the terms-of-service page" do
         let(:form) do
           StaticPageForm.from_params(
             static_page: other_page.attributes.merge(
@@ -31,7 +31,7 @@ module Decidim::Admin
           expect { command.call }.to broadcast(:invalid)
         end
 
-        it "does not update the organization's terms-and-conditions updated at setting" do
+        it "does not update the organization's terms-of-service updated at setting" do
           previous_tos_version = organization.tos_version.strftime("%F %T.%L")
           command.call
           organization.reload
@@ -40,7 +40,7 @@ module Decidim::Admin
         end
       end
 
-      describe "when the page is the terms-and-conditions page" do
+      describe "when the page is the terms-of-service page" do
         let(:form) do
           StaticPageForm.from_params(
             static_page: tos_page.attributes.merge(
@@ -74,7 +74,7 @@ module Decidim::Admin
           expect(action_log.action).to eq "update"
         end
 
-        it "updates the the organization's terms-and-conditions updated at setting" do
+        it "updates the the organization's terms-of-service updated at setting" do
           command.call
           tos_page.reload
           organization.reload

--- a/decidim-admin/spec/commands/decidim/admin/update_static_page_changed_notably_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_static_page_changed_notably_spec.rb
@@ -6,7 +6,7 @@ module Decidim::Admin
   describe UpdateStaticPage do
     describe "call" do
       let(:organization) { create(:organization) }
-      let(:page) { Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization:) }
+      let(:page) { Decidim::StaticPage.find_by(slug: "terms-of-service", organization:) }
       let(:user) { create :user, :admin, :confirmed, organization: }
       let(:form) do
         StaticPageForm.from_params(
@@ -38,7 +38,7 @@ module Decidim::Admin
           expect(action_log.version.object_changes).to include "tos_version"
         end
 
-        it "updates the the organization's terms-and-conditions version setting" do
+        it "updates the the organization's terms-of-service version setting" do
           command.call
           organization.reload
           page.reload

--- a/decidim-admin/spec/forms/organization_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_form_spec.rb
@@ -22,7 +22,7 @@ module Decidim
       let(:default_locale) { :en }
       let(:translation_priority) { "original" }
       let(:comments_max_length) { 100 }
-      let(:admin_terms_of_use_body) do
+      let(:admin_terms_of_service_body) do
         {
           ca: "",
           en: "<p>Dummy admin terms body en</p>",
@@ -45,9 +45,9 @@ module Decidim
             "github_handler" => github_handler,
             "comments_max_length" => comments_max_length,
             "machine_translation_display_priority" => translation_priority,
-            "admin_terms_of_use_body_ca" => admin_terms_of_use_body[:ca],
-            "admin_terms_of_use_body_en" => admin_terms_of_use_body[:en],
-            "admin_terms_of_use_body_es" => admin_terms_of_use_body[:es]
+            "admin_terms_of_service_body_ca" => admin_terms_of_service_body[:ca],
+            "admin_terms_of_service_body_en" => admin_terms_of_service_body[:en],
+            "admin_terms_of_service_body_es" => admin_terms_of_service_body[:es]
           }
         }
       end
@@ -68,8 +68,8 @@ module Decidim
         it { is_expected.to be_invalid }
       end
 
-      context "when admin_terms_of_use_body is missing" do
-        let(:admin_terms_of_use_body) do
+      context "when admin_terms_of_service_body is missing" do
+        let(:admin_terms_of_service_body) do
           {
             ca: nil,
             en: nil,
@@ -80,8 +80,8 @@ module Decidim
         it { is_expected.to be_invalid }
       end
 
-      context "when default language in admin_terms_of_use_body is missing" do
-        let(:admin_terms_of_use_body) do
+      context "when default language in admin_terms_of_service_body is missing" do
+        let(:admin_terms_of_service_body) do
           {
             ca: "Termes i condicions de l'administrador (ca)"
           }

--- a/decidim-admin/spec/permissions/decidim/admin/permissions_spec.rb
+++ b/decidim-admin/spec/permissions/decidim/admin/permissions_spec.rb
@@ -16,17 +16,17 @@ describe Decidim::Admin::Permissions do
   let(:action_name) { :foo }
   let(:action_subject) { :bar }
 
-  shared_examples "needs to accept Terms of Use for" do |action_subject_name, action_name|
+  shared_examples "needs to accept Terms of Service for" do |action_subject_name, action_name|
     let(:action_subject) { action_subject_name }
     let(:action_name) { action_name }
 
-    context "when admin has accepted Terms of Use" do
+    context "when admin has accepted Terms of Service" do
       let(:user) { build :user, :admin, admin_terms_accepted_at: Time.current, organization: }
 
       it { is_expected.to be true }
     end
 
-    context "when admin has not accepted Terms of Use" do
+    context "when admin has not accepted Terms of Service" do
       let(:user) { build :user, :admin, admin_terms_accepted_at: nil, organization: }
 
       it_behaves_like "permission is not set"
@@ -172,7 +172,7 @@ describe Decidim::Admin::Permissions do
   end
 
   describe "global moderation" do
-    it_behaves_like "needs to accept Terms of Use for", :global_moderation, :read
+    it_behaves_like "needs to accept Terms of Service for", :global_moderation, :read
   end
 
   describe "share tokens" do
@@ -228,7 +228,7 @@ describe Decidim::Admin::Permissions do
       context "when organization available authorizations are not empty" do
         let(:authorizations) { [:foo] }
 
-        it_behaves_like "needs to accept Terms of Use for", :managed_user, :create
+        it_behaves_like "needs to accept Terms of Service for", :managed_user, :create
 
         it { is_expected.to be true }
       end

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -27,7 +27,7 @@ describe "Admin manages organization", type: :system do
       select "Castellano", from: "Default locale"
       fill_in "Reference prefix", with: "ABC"
 
-      fill_in_i18n_editor :organization_admin_terms_of_use_body, "#organization-admin_terms_of_use_body-tabs",
+      fill_in_i18n_editor :organization_admin_terms_of_service_body, "#organization-admin_terms_of_service_body-tabs",
                           en: "<p>Respect the privacy of others.</p>",
                           es: "<p>Spanish - Respect the privacy of others.</p>"
 
@@ -49,50 +49,50 @@ describe "Admin manages organization", type: :system do
         visit decidim_admin.edit_organization_path
 
         # Makes sure in the error screenshots the editor is visible
-        page.scroll_to(find("#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor"))
+        page.scroll_to(find("#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor"))
       end
 
-      context "when the admin terms of use content is empty" do
+      context "when the admin terms of service content is empty" do
         let(:organization) do
           create(
             :organization,
-            admin_terms_of_use_body: Decidim::Faker::Localized.localized { "" }
+            admin_terms_of_service_body: Decidim::Faker::Localized.localized { "" }
           )
         end
 
         it "renders the editor" do
           expect(page).to have_selector(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor.ql-blank",
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor.ql-blank",
             text: ""
           )
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("<p><br></p>")
         end
 
         it "deletes paragraph changes pressing backspace" do
           find('div[contenteditable="true"].ql-editor').native.send_keys "ef", [:enter], "gh", [:backspace], [:backspace], [:backspace], [:backspace]
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("<p>e</p>".gsub("\n", ""))
         end
 
         it "deletes linebreaks when pressing backspace" do
           find('div[contenteditable="true"].ql-editor').native.send_keys "a", [:left], [:enter], [:shift, :enter], [:backspace], [:backspace]
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("<p>a</p>".gsub("\n", ""))
         end
 
         it "creates and deletes linebreaks with enter, shift+enter and backspace" do
           find('div[contenteditable="true"].ql-editor').native.send_keys "acd", [:left], [:left], [:enter], [:shift, :enter], [:shift, :enter], "b", [:left], [:backspace], [:backspace]
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("<p>abcd</p>".gsub("\n", ""))
         end
       end
 
-      context "when the admin terms of use content has a list" do
+      context "when the admin terms of service content has a list" do
         let(:terms_content) do
           # This is actually how the content is saved from quill.js to the Decidim
           # database.
@@ -106,24 +106,24 @@ describe "Admin manages organization", type: :system do
         let(:organization) do
           create(
             :organization,
-            admin_terms_of_use_body: Decidim::Faker::Localized.localized { terms_content }
+            admin_terms_of_service_body: Decidim::Faker::Localized.localized { terms_content }
           )
         end
 
         it "renders the correct content inside the editor" do
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq(terms_content.gsub("\n", ""))
         end
       end
 
-      context "when the admin terms of use content has an image with an alt tag" do
+      context "when the admin terms of service content has an image with an alt tag" do
         let(:another_organization) { create(:organization) }
         let(:image) { create(:attachment, attached_to: another_organization) }
         let(:organization) do
           create(
             :organization,
-            admin_terms_of_use_body: Decidim::Faker::Localized.localized { terms_content }
+            admin_terms_of_service_body: Decidim::Faker::Localized.localized { terms_content }
           )
         end
         let(:terms_content) do
@@ -135,18 +135,18 @@ describe "Admin manages organization", type: :system do
 
         it "renders an image and its attributes inside the editor" do
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq(terms_content.gsub("\n", ""))
         end
       end
 
-      context "when the admin terms of use content has an br tags" do
+      context "when the admin terms of service content has an br tags" do
         let(:another_organization) { create(:organization) }
         let(:image) { create(:attachment, attached_to: another_organization) }
         let(:organization) do
           create(
             :organization,
-            admin_terms_of_use_body: Decidim::Faker::Localized.localized { terms_content }
+            admin_terms_of_service_body: Decidim::Faker::Localized.localized { terms_content }
           )
         end
         let(:terms_content) do
@@ -159,12 +159,12 @@ describe "Admin manages organization", type: :system do
 
         it "renders br tags inside the editor" do
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq(terms_content.gsub("\n", ""))
         end
       end
 
-      context "when the admin terms of use content has a link" do
+      context "when the admin terms of service content has a link" do
         let(:terms_content) do
           <<~HTML
             <p>foo<br><a href="https://www.decidim.org" rel="noopener noreferrer" target="_blank">link</a></p>
@@ -173,26 +173,26 @@ describe "Admin manages organization", type: :system do
         let(:organization) do
           create(
             :organization,
-            admin_terms_of_use_body: Decidim::Faker::Localized.localized { terms_content }
+            admin_terms_of_service_body: Decidim::Faker::Localized.localized { terms_content }
           )
         end
 
         it "creates single br tag" do
           find('div[contenteditable="true"].ql-editor').native.send_keys([:left, :left, :left, :left, :left], [:shift, :enter])
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq('<p>foo<br><br><a href="https://www.decidim.org" rel="noopener noreferrer" target="_blank">link</a></p>')
         end
 
         it "does not create br tag inside a tag" do
           find('div[contenteditable="true"].ql-editor').native.send_keys([:left, :left, :left, :left], [:shift, :enter])
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq('<p>foo<br><br><a href="https://www.decidim.org" rel="noopener noreferrer" target="_blank">link</a></p>')
         end
       end
 
-      context "when the admin terms of use content has linebreaks inside different formattings" do
+      context "when the admin terms of service content has linebreaks inside different formattings" do
         let(:terms_content) do
           <<~HTML
             <p>foo</p>
@@ -206,7 +206,7 @@ describe "Admin manages organization", type: :system do
         let(:organization) do
           create(
             :organization,
-            admin_terms_of_use_body: Decidim::Faker::Localized.localized { terms_content }
+            admin_terms_of_service_body: Decidim::Faker::Localized.localized { terms_content }
           )
         end
 
@@ -215,7 +215,7 @@ describe "Admin manages organization", type: :system do
           click_button "Update"
           expect(page).to have_content("Organization updated successfully")
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("<p>bar baz</p>")
         end
       end
@@ -226,7 +226,7 @@ describe "Admin manages organization", type: :system do
         let(:organization) do
           create(
             :organization,
-            admin_terms_of_use_body: Decidim::Faker::Localized.localized { terms_content }
+            admin_terms_of_service_body: Decidim::Faker::Localized.localized { terms_content }
           )
         end
         let(:terms_content) do
@@ -240,7 +240,7 @@ describe "Admin manages organization", type: :system do
         it "renders new br tags inside the editor" do
           find('div[contenteditable="true"].ql-editor').native.send_keys [:enter], "Here shift+enter makes line change:", [:shift, :enter], "instead of new paragraph!"
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("#{terms_content}<p>Here shift+enter makes line change:<br>instead of new paragraph!</p>".gsub("\n", ""))
         end
 
@@ -249,7 +249,7 @@ describe "Admin manages organization", type: :system do
           click_button("⏎")
           find('div[contenteditable="true"].ql-editor').native.send_keys "bar"
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("#{terms_content}<p>foo<br>bar</p>".gsub("\n", ""))
         end
 
@@ -268,14 +268,14 @@ describe "Admin manages organization", type: :system do
               [:control, "z"]
             )
             expect(find(
-              "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+              "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
             )["innerHTML"]).to eq(terms_content.gsub("\n", ""))
           end
 
           it "has redo" do
             find('div[contenteditable="true"].ql-editor').native.send_keys [:shift, :enter], "X", [:control, "z"], [:control, :shift, "z"]
             expect(find(
-              "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+              "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
             )["innerHTML"]).to eq("<p>Paragraph</p><p>Some<br>text<br>here</p><p>Another paragraph<br>X</p>".gsub("\n", ""))
           end
         end
@@ -287,7 +287,7 @@ describe "Admin manages organization", type: :system do
         let(:organization) do
           create(
             :organization,
-            admin_terms_of_use_body: Decidim::Faker::Localized.localized { terms_content }
+            admin_terms_of_service_body: Decidim::Faker::Localized.localized { terms_content }
           )
         end
         let(:terms_content) do
@@ -302,63 +302,63 @@ describe "Admin manages organization", type: :system do
         it "renders new list item" do
           find('div[contenteditable="true"].ql-editor').native.send_keys [:enter], "List item 4"
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("<p>Paragraph</p><ul><li>List item 1</li><li>List item 2</li><li>List item 3</li><li>List item 4</li></ul>".gsub("\n", ""))
         end
 
         it "ends the list when pressing enter twice and starts new paragraph" do
           find('div[contenteditable="true"].ql-editor').native.send_keys [:enter, :enter], "Another paragraph"
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("#{terms_content}<p>Another paragraph</p>".gsub("\n", ""))
         end
 
         it "deletes empty list item when pressing backspace and starts new paragraph" do
           find('div[contenteditable="true"].ql-editor').native.send_keys [:enter, :backspace], "Another paragraph"
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("#{terms_content}<p>Another paragraph</p>".gsub("\n", ""))
         end
 
         it "deletes linebreaks (and smartbreaks) using the backspace" do
           find('div[contenteditable="true"].ql-editor').native.send_keys [:enter, :enter, :enter, :backspace, :backspace]
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq(terms_content.to_s.gsub("\n", ""))
         end
 
         it "keeps right curson position when using the backspace" do
           find('div[contenteditable="true"].ql-editor').native.send_keys [:enter, "bc", :left, :left, :enter, :backspace, :backspace, "a"]
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("<p>Paragraph</p><ul><li>List item 1</li><li>List item 2</li><li>List item 3</li><li>abc</li></ul>".to_s.gsub("\n", ""))
         end
 
         it "keeps right format when using the backspace" do
           find('div[contenteditable="true"].ql-editor').native.send_keys [:enter, :backspace, "abc", :left, :left, :left, :backspace]
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("<p>Paragraph</p><ul><li>List item 1</li><li>List item 2</li><li>List item 3abc</li></ul>".to_s.gsub("\n", ""))
         end
 
         it "keeps right cursor position when using backspace after empty list item" do
           find('div[contenteditable="true"].ql-editor').native.send_keys [:enter, "bcd", :left, :left, :left, :enter, :backspace, :enter, :enter, :backspace, :backspace, :backspace, "a"]
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("<p>Paragraph</p><ul><li>List item 1</li><li>List item 2</li><li>List item 3</li><li>abcd</li></ul>".to_s.gsub("\n", ""))
         end
 
         it "keeps right cursor position when using backspace after list item with text" do
           find('div[contenteditable="true"].ql-editor').native.send_keys [:enter, "acd", :left, :left, :enter, :backspace, :enter, :enter, :backspace, :backspace, :backspace, "b"]
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq("<p>Paragraph</p><ul><li>List item 1</li><li>List item 2</li><li>List item 3</li><li>abcd</li></ul>".to_s.gsub("\n", ""))
         end
 
         it "does not delete characters below when pressing backspace" do
           find('div[contenteditable="true"].ql-editor').native.send_keys [:up, :up, :up, :home, :enter, :enter, :enter, :backspace, :backspace, :backspace]
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq(terms_content.to_s.gsub("\n", ""))
         end
       end
@@ -367,7 +367,7 @@ describe "Admin manages organization", type: :system do
         let(:organization) do
           create(
             :organization,
-            admin_terms_of_use_body: Decidim::Faker::Localized.localized { "" }
+            admin_terms_of_service_body: Decidim::Faker::Localized.localized { "" }
           )
         end
 
@@ -430,19 +430,19 @@ describe "Admin manages organization", type: :system do
               dt.setData("text/html", #{clipboard_content_html.to_json});
               dt.setData("text/plain", #{clipboard_content_plain.to_json});
 
-              var element = document.querySelector("#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 div[contenteditable='true'].ql-editor");
+              var element = document.querySelector("#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 div[contenteditable='true'].ql-editor");
               element.dispatchEvent(new ClipboardEvent("paste", { clipboardData: dt }));
             JS
           )
 
           expect(find(
-            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+            "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ql-editor"
           )["innerHTML"]).to eq(parsed_content)
         end
       end
 
-      context "when the admin terms of use content has only a video" do
-        let(:organization) { create(:organization, admin_terms_of_use_body: {}) }
+      context "when the admin terms of service content has only a video" do
+        let(:organization) { create(:organization, admin_terms_of_service_body: {}) }
 
         it "saves the content correctly with the video" do
           within ".editor" do
@@ -458,7 +458,7 @@ describe "Admin manages organization", type: :system do
           click_button "Update"
 
           organization.reload
-          expect(translated(organization.admin_terms_of_use_body)).to eq(
+          expect(translated(organization.admin_terms_of_service_body)).to eq(
             %(<iframe class="ql-video" frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/f6JMgJAQ2tc?showinfo=0"></iframe>)
           )
         end

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -220,7 +220,7 @@ describe "Admin manages organization", type: :system do
         end
       end
 
-      context "when adding br tags to terms of use content" do
+      context "when adding br tags to terms of service content" do
         let(:another_organization) { create(:organization) }
         let(:image) { create(:attachment, attached_to: another_organization) }
         let(:organization) do

--- a/decidim-admin/spec/system/admin_manages_static_page_content_blocks_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_static_page_content_blocks_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Admin manages static page content blocks", type: :system do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, :confirmed, organization:) }
-  let!(:tos_page) { Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization:) }
+  let!(:tos_page) { Decidim::StaticPage.find_by(slug: "terms-of-service", organization:) }
 
   before do
     switch_to_host(organization.host)

--- a/decidim-admin/spec/system/admin_tos_acceptance_spec.rb
+++ b/decidim-admin/spec/system/admin_tos_acceptance_spec.rb
@@ -50,7 +50,7 @@ describe "AdminTosAcceptance", type: :system do
       end
 
       it "renders the TOS page" do
-        expect(page).to have_text("Agree to the terms of use")
+        expect(page).to have_text("Agree to the terms of service")
       end
 
       it "allows accepting the terms" do

--- a/decidim-admin/spec/system/admin_tos_acceptance_spec.rb
+++ b/decidim-admin/spec/system/admin_tos_acceptance_spec.rb
@@ -21,7 +21,7 @@ describe "AdminTosAcceptance", type: :system do
       end
 
       it "has a message that they need to accept the admin TOS" do
-        expect(page).to have_content("Please take a moment to review the admin terms of use. Otherwise you will not be able to manage the platform")
+        expect(page).to have_content("Please take a moment to review the admin terms of service. Otherwise you will not be able to manage the platform")
       end
 
       it "has only the Dashboard menu item in the main navigation" do

--- a/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
@@ -32,7 +32,7 @@ describe "Space admin manages global moderations", type: :system do
 
     it "has a message that they need to accept the admin TOS" do
       expect(page).to have_content("You are not authorized")
-      expect(page).to have_content("Please take a moment to review the admin terms of use. Otherwise you will not be able to manage the platform")
+      expect(page).to have_content("Please take a moment to review the admin terms of service. Otherwise you will not be able to manage the platform")
     end
 
     it "has only the Dashboard menu item in the main navigation" do

--- a/decidim-admin/spec/system/space_moderator_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_moderator_manages_global_moderations_spec.rb
@@ -25,7 +25,7 @@ describe "Space moderator manages global moderations", type: :system do
     login_as user, scope: :user
   end
 
-  context "when the user has not accepted the Terms of Use" do
+  context "when the user has not accepted the Terms of Service" do
     before do
       user.update(admin_terms_accepted_at: nil)
     end

--- a/decidim-admin/spec/views/decidim/static_pages/_form.html.erb_spec.rb
+++ b/decidim-admin/spec/views/decidim/static_pages/_form.html.erb_spec.rb
@@ -35,7 +35,7 @@ module Decidim
     end
 
     context "with a default static page" do
-      let(:slug) { Decidim::StaticPage::DEFAULT_PAGES.without("terms-and-conditions").sample }
+      let(:slug) { Decidim::StaticPage::DEFAULT_PAGES.without("terms-of-service").sample }
       let(:allowed?) { false }
 
       it { is_expected.not_to include("slug") }
@@ -43,7 +43,7 @@ module Decidim
     end
 
     context "with the TOS static page" do
-      let(:slug) { "terms-and-conditions" }
+      let(:slug) { "terms-of-service" }
       let(:allowed?) { false }
       let(:content_blocks?) { true }
 

--- a/decidim-admin/spec/views/decidim/static_pages/_form_notable_changes.html.erb_spec.rb
+++ b/decidim-admin/spec/views/decidim/static_pages/_form_notable_changes.html.erb_spec.rb
@@ -29,14 +29,14 @@ module Decidim
     end
 
     context "with a default static page" do
-      let(:slug) { Decidim::StaticPage::DEFAULT_PAGES.without("terms-and-conditions").sample }
+      let(:slug) { Decidim::StaticPage::DEFAULT_PAGES.without("terms-of-service").sample }
       let(:allowed?) { false }
 
       it { is_expected.to eq("") }
     end
 
     context "with the TOS static page" do
-      let(:slug) { "terms-and-conditions" }
+      let(:slug) { "terms-of-service" }
       let(:allowed?) { true }
 
       it { is_expected.to include("changed_notably") }

--- a/decidim-core/app/cells/decidim/tos_page/form.erb
+++ b/decidim-core/app/cells/decidim/tos_page/form.erb
@@ -1,13 +1,13 @@
 <div class="tos">
   <h2 class="h5 text-center">
-    <%= t("form.legend", scope: "decidim.pages.terms_and_conditions") %>
+    <%= t("form.legend", scope: "decidim.pages.terms_of_service") %>
   </h2>
 
   <div class="tos__buttons">
     <%= cell "decidim/tos_page", :refuse_btn_modal %>
 
     <%= button_to decidim.accept_tos_path, method: :put, class: "button button__sm button__secondary" do %>
-      <%= t("form.agreement", scope: "decidim.pages.terms_and_conditions") %>
+      <%= t("form.agreement", scope: "decidim.pages.terms_of_service") %>
     <% end %>
   </div>
 </div>

--- a/decidim-core/app/cells/decidim/tos_page/refuse_btn_modal.erb
+++ b/decidim-core/app/cells/decidim/tos_page/refuse_btn_modal.erb
@@ -1,15 +1,15 @@
 <button class="button button__sm button__transparent-secondary" type="button" data-open="tos-refuse-modal">
-  <%= t("refuse.modal_button", scope: "decidim.pages.terms_and_conditions") %>
+  <%= t("refuse.modal_button", scope: "decidim.pages.terms_of_service") %>
 </button>
 
 <%# REDESIGN_PENDING: missing design modal %>
-<div id="tos-refuse-modal" class="reveal" data-reveal aria-labelledby="<%= t("refuse.modal_title", scope: "decidim.pages.terms_and_conditions") %>" aria-hidden="true" role="dialog">
+<div id="tos-refuse-modal" class="reveal" data-reveal aria-labelledby="<%= t("refuse.modal_title", scope: "decidim.pages.terms_of_service") %>" aria-hidden="true" role="dialog">
   <div class="reveal__header">
     <h3 class="reveal__title">
-      <%= t("refuse.modal_title", scope: "decidim.pages.terms_and_conditions") %>
+      <%= t("refuse.modal_title", scope: "decidim.pages.terms_of_service") %>
     </h3>
 
-    <button class="close-button" data-close aria-label="<%= t("refuse.modal_close", scope: "decidim.pages.terms_and_conditions") %>"
+    <button class="close-button" data-close aria-label="<%= t("refuse.modal_close", scope: "decidim.pages.terms_of_service") %>"
       type="button">
       <span aria-hidden="true">&times;</span>
     </button>
@@ -17,18 +17,18 @@
 
   <div class="row">
     <p>
-      <%= t("refuse.modal_body", scope: "decidim.pages.terms_and_conditions", download_your_data_path: decidim.download_your_data_path, delete_path: decidim.delete_account_path) %>
+      <%= t("refuse.modal_body", scope: "decidim.pages.terms_of_service", download_your_data_path: decidim.download_your_data_path, delete_path: decidim.delete_account_path) %>
     </p>
   </div>
 
   <div class="row">
     <div class="column flex-center">
       <%= button_to decidim.destroy_user_session_path, method: :delete, class: "clear button secondary expanded" do %>
-        <%= t("refuse.modal_btn_exit", scope: "decidim.pages.terms_and_conditions") %>
+        <%= t("refuse.modal_btn_exit", scope: "decidim.pages.terms_of_service") %>
       <% end %>
 
       <%= button_to decidim.accept_tos_path, method: :put, class: "button expanded" do %>
-        <%= t("refuse.modal_btn_continue", scope: "decidim.pages.terms_and_conditions") %>
+        <%= t("refuse.modal_btn_continue", scope: "decidim.pages.terms_of_service") %>
       <% end %>
     </div>
   </div>

--- a/decidim-core/app/cells/decidim/tos_page_cell.rb
+++ b/decidim-core/app/cells/decidim/tos_page_cell.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Decidim
-  # This cell renders specific _partials_ for the `terms_and_conditions` StaticPage
+  # This cell renders specific _partials_ for the `terms_of_service` StaticPage
   # the `model` is the partial to render
   # - :announcement, the TOS updated announcement when redirected to the TOS page.
   # - :sticky_form, the Accept updated TOS form in the TOS page.
@@ -24,8 +24,8 @@ module Decidim
 
     def announcement
       {
-        title: t("required_review.title", scope: "decidim.pages.terms_and_conditions"),
-        body: t("required_review.body", scope: "decidim.pages.terms_and_conditions")
+        title: t("required_review.title", scope: "decidim.pages.terms_of_service"),
+        body: t("required_review.body", scope: "decidim.pages.terms_of_service")
       }
     end
 

--- a/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
@@ -22,7 +22,7 @@ module Decidim
     end
 
     def terms_and_conditions_page
-      @terms_and_conditions_page ||= Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: current_organization)
+      @terms_and_conditions_page ||= Decidim::StaticPage.find_by(slug: "terms-of-service", organization: current_organization)
     end
 
     def terms_and_conditions_summary_content_blocks

--- a/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
@@ -7,7 +7,7 @@ module Decidim
 
     included do
       before_action :tos_accepted_by_user
-      helper_method :terms_and_conditions_page, :terms_and_conditions_summary_content_blocks
+      helper_method :terms_of_service_page, :terms_of_service_summary_content_blocks
     end
 
     private
@@ -21,15 +21,15 @@ module Decidim
       redirect_to_tos
     end
 
-    def terms_and_conditions_page
-      @terms_and_conditions_page ||= Decidim::StaticPage.find_by(slug: "terms-of-service", organization: current_organization)
+    def terms_of_service_page
+      @terms_of_service_page ||= Decidim::StaticPage.find_by(slug: "terms-of-service", organization: current_organization)
     end
 
-    def terms_and_conditions_summary_content_blocks
-      @terms_and_conditions_summary_content_blocks ||= Decidim::ContentBlock.published
-                                                                            .for_scope(:static_page, organization: current_organization)
-                                                                            .where(scoped_resource_id: terms_and_conditions_page.id)
-                                                                            .reject { |content_block| content_block.manifest.nil? || content_block.manifest.name != :summary }
+    def terms_of_service_summary_content_blocks
+      @terms_of_service_summary_content_blocks ||= Decidim::ContentBlock.published
+                                                                        .for_scope(:static_page, organization: current_organization)
+                                                                        .where(scoped_resource_id: terms_of_service_page.id)
+                                                                        .reject { |content_block| content_block.manifest.nil? || content_block.manifest.name != :summary }
     end
 
     def permitted_paths?
@@ -44,7 +44,7 @@ module Decidim
     end
 
     def tos_path
-      decidim.page_path terms_and_conditions_page
+      decidim.page_path terms_of_service_page
     end
 
     def redirect_to_tos
@@ -56,7 +56,7 @@ module Decidim
       )
 
       flash[:notice] = flash[:notice] if flash[:notice]
-      flash[:secondary] = t("required_review.alert", scope: "decidim.pages.terms_and_conditions")
+      flash[:secondary] = t("required_review.alert", scope: "decidim.pages.terms_of_service")
       redirect_to tos_path
     end
   end

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -9,7 +9,7 @@ module Decidim
     helper CtaButtonHelper
     helper Decidim::SanitizeHelper
 
-    before_action :set_default_request_format
+    before_action :legacy_redirect, :set_default_request_format
 
     def index
       enforce_permission_to :read, :public_page
@@ -25,6 +25,10 @@ module Decidim
     end
 
     private
+
+    def legacy_redirect
+      return redirect_to decidim.page_path("terms-of-service") if params[:id] == "terms-and-conditions"
+    end
 
     def set_default_request_format
       request.format = :html

--- a/decidim-core/app/controllers/decidim/tos_controller.rb
+++ b/decidim-core/app/controllers/decidim/tos_controller.rb
@@ -9,10 +9,10 @@ module Decidim
     def accept_tos
       current_user.accepted_tos_version = Time.current
       if current_user.save!
-        flash[:notice] = t("accept.success", scope: "decidim.pages.terms_and_conditions")
+        flash[:notice] = t("accept.success", scope: "decidim.pages.terms_of_service")
         redirect_to after_sign_in_path_for current_user
       else
-        flash[:alert] = t("accept.error", scope: "decidim.pages.terms_and_conditions")
+        flash[:alert] = t("accept.error", scope: "decidim.pages.terms_of_service")
         redirect_to decidim.page_path tos_page
       end
     end

--- a/decidim-core/app/controllers/decidim/tos_controller.rb
+++ b/decidim-core/app/controllers/decidim/tos_controller.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   # The controller to handle the current user's
-  # Terms and Conditions agreement.
+  # Terms of service agreement.
   class TosController < Decidim::ApplicationController
     skip_before_action :store_current_location
 

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -18,7 +18,7 @@ module Decidim
     translatable_fields :description, :cta_button_text, :omnipresent_banner_title, :omnipresent_banner_short_description,
                         :highlighted_content_banner_title, :highlighted_content_banner_short_description, :highlighted_content_banner_action_title,
                         :highlighted_content_banner_action_subtitle, :welcome_notification_subject, :welcome_notification_body, :id_documents_explanation_text,
-                        :admin_terms_of_use_body
+                        :admin_terms_of_service_body
 
     has_many :static_pages, foreign_key: "decidim_organization_id", class_name: "Decidim::StaticPage", inverse_of: :organization, dependent: :destroy
     has_many :static_page_topics, class_name: "Decidim::StaticPageTopic", inverse_of: :organization, dependent: :destroy
@@ -111,9 +111,9 @@ module Decidim
         multi_translation("decidim.welcome_notification.default_body", available_locales)
     end
 
-    def admin_terms_of_use_body
-      self[:admin_terms_of_use_body] ||
-        multi_translation("decidim.admin_terms_of_use.default_body", available_locales)
+    def admin_terms_of_service_body
+      self[:admin_terms_of_service_body] ||
+        multi_translation("decidim.admin_terms_of_service.default_body", available_locales)
     end
 
     def sign_up_enabled?

--- a/decidim-core/app/models/decidim/static_page.rb
+++ b/decidim-core/app/models/decidim/static_page.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   # A page is used to add static content to the website, it can be useful so
-  # organization can add their own terms and conditions, privacy policy or
+  # organization can add their own terms of service, privacy policy or
   # other pages they might need from an admin panel.
   #
   # Pages with a default slug cannot be destroyed and its slug cannot be
@@ -22,7 +22,7 @@ module Decidim
 
     # These pages will be created by default when registering an organization
     # and cannot be deleted.
-    DEFAULT_PAGES = %w(terms-and-conditions).freeze
+    DEFAULT_PAGES = %w(terms-of-service).freeze
 
     after_create :update_organization_tos_version
     before_destroy :can_be_destroyed?
@@ -74,10 +74,10 @@ module Decidim
 
     private
 
-    # When creating a terms-and-conditions page
+    # When creating a terms-of-service page
     # set the organization tos_version
     def update_organization_tos_version
-      return unless slug == "terms-and-conditions"
+      return unless slug == "terms-of-service"
 
       organization.update!(tos_version: created_at)
     end

--- a/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
@@ -47,7 +47,7 @@
             </div>
 
             <div class="field">
-              <% link = link_to t("terms", scope: "decidim.devise.registrations.new"), page_path("terms-and-conditions"), target: "_blank" %>
+              <% link = link_to t("terms", scope: "decidim.devise.registrations.new"), page_path("terms-of-service"), target: "_blank" %>
               <% label = t("tos_agreement", scope: "decidim.devise.registrations.new", link: link) %>
               <%= f.check_box :tos_agreement, label: label, required: "required" %>
             </div>

--- a/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
@@ -41,7 +41,7 @@
             <h3><%= t("tos_title", scope: "decidim.devise.registrations.new") %></h3>
 
             <div class="tos-text">
-              <% terms_and_conditions_summary_content_blocks.each do |content_block| %>
+              <% terms_of_service_summary_content_blocks.each do |content_block| %>
                 <%= cell content_block.manifest.cell, content_block %>
               <% end %>
             </div>

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -48,7 +48,7 @@
       <h4 class="h4"><%= t("decidim.devise.registrations.new.tos_title") %></h4>
 
       <div class="tos-text">
-        <% terms_and_conditions_summary_content_blocks.each do |content_block| %>
+        <% terms_of_service_summary_content_blocks.each do |content_block| %>
           <%= cell content_block.manifest.cell, content_block %>
         <% end %>
       </div>

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -53,7 +53,7 @@
         <% end %>
       </div>
 
-      <%= f.check_box :tos_agreement, label: t("decidim.devise.registrations.new.tos_agreement", link: link_to(t("decidim.devise.registrations.new.terms"), page_path("terms-and-conditions"))), label_options: { class: "form__wrapper-checkbox-label" } %>
+      <%= f.check_box :tos_agreement, label: t("decidim.devise.registrations.new.tos_agreement", link: link_to(t("decidim.devise.registrations.new.terms"), page_path("terms-of-service"))), label_options: { class: "form__wrapper-checkbox-label" } %>
     </div>
 
     <div id="card__newsletter" class="form__wrapper-block">

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -255,7 +255,7 @@ en:
         verify_via_csv: "%{user_name} verified the group %{resource_name} via a CSV file"
       user_moderation:
         unreport: "%{user_name} unreported an %{resource_type} - %{unreported_user_name}"
-    admin_terms_of_use:
+    admin_terms_of_service:
       default_body: "<h2>ADMIN TERMS OF SERVICE</h2><p>We trust you have received the usual lecture from the local System Administrator. It usually boils down to these three things:</p><ol><li>Respect the privacy of others.</li><li>Think before you click.</li><li>With great power comes great responsibility.</li></ol>"
     alert:
       dismiss: Dismiss notification

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1273,7 +1273,7 @@ en:
         metrics:
           headline: Metrics
           link: Show all metrics
-      terms_and_conditions:
+      terms_of_service:
         accept:
           error: There was a problem accepting the terms of service.
           success: Great! You have accepted the terms of service.

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
         password_confirmation: Confirm your password
         personal_url: Personal URL
         remove_avatar: Remove avatar
-        tos_agreement: Terms and conditions of use agreement
+        tos_agreement: Terms of service agreement
     models:
       decidim/attachment_created_event: Attachment
       decidim/component_published_event: Active component
@@ -124,7 +124,7 @@ en:
       logo: "%{organization}'s official logo"
       skip_button: Skip to main content
     account:
-      blocked: This account has been blocked due to Terms and Conditions violation
+      blocked: This account has been blocked due to terms of service violation
       delete:
         alert: This action cannot be undone. If you delete your account you will not be able to log in with your credentials. The deletion of your account will result in the anonymization of your contributions. You will still be able to create a new account, but these contributions will not be associated with it.
         confirm:
@@ -256,7 +256,7 @@ en:
       user_moderation:
         unreport: "%{user_name} unreported an %{resource_type} - %{unreported_user_name}"
     admin_terms_of_use:
-      default_body: "<h2>ADMIN TERMS OF USE</h2><p>We trust you have received the usual lecture from the local System Administrator. It usually boils down to these three things:</p><ol><li>Respect the privacy of others.</li><li>Think before you click.</li><li>With great power comes great responsibility.</li></ol>"
+      default_body: "<h2>ADMIN TERMS OF SERVICE</h2><p>We trust you have received the usual lecture from the local System Administrator. It usually boils down to these three things:</p><ol><li>Respect the privacy of others.</li><li>Think before you click.</li><li>With great power comes great responsibility.</li></ol>"
     alert:
       dismiss: Dismiss notification
     amendments:
@@ -556,7 +556,7 @@ en:
           sign_up_as:
             legend: Sign up as
           subtitle: Sign up to participate in discussions and support proposals.
-          terms: the terms and conditions of use
+          terms: the terms of service
           tos_agreement: By signing up you agree to %{link}.
           tos_title: Terms of Service
           username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
@@ -1275,18 +1275,18 @@ en:
           link: Show all metrics
       terms_and_conditions:
         accept:
-          error: There was a problem accepting the terms and conditions.
-          success: Great! You have accepted the terms and conditions.
+          error: There was a problem accepting the terms of service.
+          success: Great! You have accepted the terms of service.
         form:
           agreement: I agree with these terms
-          legend: Agree to the terms and conditions
+          legend: Agree to the terms of service
         refuse:
           modal_body: If you refuse, you will not be able to use the platform, you can <a href="%{download_your_data_path}">download your data</a> and/or <a href="%{delete_path}">delete your account</a>.
           modal_btn_continue: Accept terms and continue
           modal_btn_exit: I'll review it later
           modal_button: Refuse the terms
           modal_close: Close modal
-          modal_title: Do you really refuse the updated Terms and Conditions?
+          modal_title: Do you really refuse the updated terms of service?
         required_review:
           alert: We have updated our Terms of Service, please review them.
           body: Please take a moment to review updates to our Terms of Services. Otherwise you will not be able to use the platform.
@@ -1299,7 +1299,7 @@ en:
         success: Password successfully updated.
     profile:
       deleted: Deleted participant
-      inaccessible_message: This profile is inaccessible due to Terms and Conditions violation!
+      inaccessible_message: This profile is inaccessible due to terms of service violation!
       view: View
     profiles:
       default_officialization_text_for_user_groups: This group is publicly verified, its name has been verified to correspond with its real name.

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -154,7 +154,7 @@ Decidim::Core::Engine.routes.draw do
   get "/scopes/picker", to: "scopes#picker", as: :scopes_picker
 
   get "/static_map", to: "static_map#show", as: :static_map
-  put "/pages/terms-and-conditions/accept", to: "tos#accept_tos", as: :accept_tos
+  put "/pages/terms-of-service/accept", to: "tos#accept_tos", as: :accept_tos
 
   match "/404", to: "errors#not_found", via: :all
   match "/500", to: "errors#internal_server_error", via: :all

--- a/decidim-core/db/migrate/20180508111640_add_tos_version_to_organization.rb
+++ b/decidim-core/db/migrate/20180508111640_add_tos_version_to_organization.rb
@@ -8,7 +8,7 @@ class AddTosVersionToOrganization < ActiveRecord::Migration[5.1]
   def up
     add_column :decidim_organizations, :tos_version, :datetime
     Organization.find_each do |organization|
-      tos_version = Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization:).updated_at
+      tos_version = Decidim::StaticPage.find_by(slug: ["terms-and-conditions", "terms-of-service"], organization:).updated_at
       organization.update(tos_version:)
     end
   end

--- a/decidim-core/db/migrate/20181022090732_add_columns_to_pages.rb
+++ b/decidim-core/db/migrate/20181022090732_add_columns_to_pages.rb
@@ -13,7 +13,7 @@ class AddColumnsToPages < ActiveRecord::Migration[5.2]
     end
 
     Decidim::StaticPage.where(
-      slug: ["faq", "terms-and-conditions", "accessibility"]
+      slug: ["faq", "terms-and-conditions", "terms-of-service", "accessibility"]
     ).update_all(show_in_footer: true)
     # rubocop:enable Rails/SkipsModelValidations
   end

--- a/decidim-core/db/migrate/20201128130723_add_allow_public_access_to_static_pages.rb
+++ b/decidim-core/db/migrate/20201128130723_add_allow_public_access_to_static_pages.rb
@@ -7,7 +7,7 @@ class AddAllowPublicAccessToStaticPages < ActiveRecord::Migration[5.2]
     reversible do |direction|
       direction.up do
         # rubocop:disable Rails/SkipsModelValidations
-        Decidim::StaticPage.where(slug: "terms-and-conditions").update_all(
+        Decidim::StaticPage.where(slug: ["terms-and-conditions", "terms-of-service"]).update_all(
           allow_public_access: true
         )
         # rubocop:enable Rails/SkipsModelValidations

--- a/decidim-core/db/migrate/20230322101707_rename_terms_of_use.rb
+++ b/decidim-core/db/migrate/20230322101707_rename_terms_of_use.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class RenameTermsOfUse < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :decidim_organizations, :admin_terms_of_use_body, :admin_terms_of_service_body
+
+    # rubocop:disable Rails/SkipsModelValidations
+    reversible do |dir|
+      dir.up do
+        Decidim::StaticPage.where(slug: "terms-and-conditions").update_all(
+          slug: "terms-of-service"
+        )
+      end
+
+      dir.down do
+        Decidim::StaticPage.where(slug: "terms-of-service").update_all(
+          slug: "terms-and-conditions"
+        )
+      end
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -518,7 +518,7 @@ module Decidim
 
   # List of static pages' slugs that can include content blocks
   config_accessor :page_blocks do
-    %w(terms-and-conditions)
+    %w(terms-of-service)
   end
 
   # Public: Registers a global engine. This method is intended to be used

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -95,7 +95,7 @@ FactoryBot.define do
     user_groups_enabled { true }
     send_welcome_notification { true }
     comments_max_length { 1000 }
-    admin_terms_of_use_body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    admin_terms_of_service_body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     force_users_to_authenticate_before_access_organization { false }
     machine_translation_display_priority { "original" }
     external_domain_whitelist { ["example.org", "twitter.com", "facebook.com", "youtube.com", "github.com", "mytesturl.me"] }
@@ -117,7 +117,7 @@ FactoryBot.define do
 
     after(:create) do |organization, evaluator|
       if evaluator.create_static_pages
-        tos_page = Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization:)
+        tos_page = Decidim::StaticPage.find_by(slug: "terms-of-service", organization:)
         create(:static_page, :tos, organization:) if tos_page.nil?
       end
     end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -331,7 +331,7 @@ FactoryBot.define do
     end
 
     trait :tos do
-      slug { "terms-and-conditions" }
+      slug { "terms-of-service" }
       after(:create) do |tos_page|
         tos_page.organization.tos_version = tos_page.updated_at
         tos_page.organization.save!

--- a/decidim-core/lib/tasks/decidim_active_storage_migration_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_active_storage_migration_tasks.rake
@@ -79,7 +79,7 @@ namespace :decidim do
         "Decidim::Assembly" => %w(short_description description purpose_of_action composition internal_organisation announcement closing_date_reason special_features),
         "Decidim::Forms::Questionnaire" => %w(description tos),
         "Decidim::Forms::Question" => %w(description),
-        "Decidim::Organization" => %w(welcome_notification_body admin_terms_of_use_body description highlighted_content_banner_short_description id_documents_explanation_text),
+        "Decidim::Organization" => %w(welcome_notification_body admin_terms_of_use_body admin_terms_of_service_body description highlighted_content_banner_short_description id_documents_explanation_text),
         "Decidim::StaticPage" => %w(content),
         "Decidim::ContextualHelpSection" => %w(content),
         "Decidim::Category" => %w(description),

--- a/decidim-core/lib/tasks/decidim_active_storage_migration_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_active_storage_migration_tasks.rake
@@ -79,7 +79,14 @@ namespace :decidim do
         "Decidim::Assembly" => %w(short_description description purpose_of_action composition internal_organisation announcement closing_date_reason special_features),
         "Decidim::Forms::Questionnaire" => %w(description tos),
         "Decidim::Forms::Question" => %w(description),
-        "Decidim::Organization" => %w(welcome_notification_body admin_terms_of_use_body admin_terms_of_service_body description highlighted_content_banner_short_description id_documents_explanation_text),
+        "Decidim::Organization" => %w(
+          welcome_notification_body
+          admin_terms_of_use_body
+          admin_terms_of_service_body
+          description
+          highlighted_content_banner_short_description
+          id_documents_explanation_text
+        ),
         "Decidim::StaticPage" => %w(content),
         "Decidim::ContextualHelpSection" => %w(content),
         "Decidim::Category" => %w(description),

--- a/decidim-core/spec/cells/decidim/profile_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/profile_cell_spec.rb
@@ -22,7 +22,7 @@ describe Decidim::ProfileCell, type: :cell do
       let(:user) { create :user, :managed, organization:, blocked: true, admin: true }
 
       it "shows the user profile" do
-        expect(subject).not_to have_text("This profile is inaccessible due to Terms and Conditions violation!")
+        expect(subject).not_to have_text("This profile is inaccessible due to terms of service violation!")
       end
     end
 
@@ -30,7 +30,7 @@ describe Decidim::ProfileCell, type: :cell do
       let(:user) { create :user, :managed, organization:, blocked: true, admin: false }
 
       it "shows the inaccessible profile alert" do
-        expect(subject).to have_text("This profile is inaccessible due to Terms and Conditions violation!")
+        expect(subject).to have_text("This profile is inaccessible due to terms of service violation!")
       end
     end
   end

--- a/decidim-core/spec/controllers/application_controller_spec.rb
+++ b/decidim-core/spec/controllers/application_controller_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   describe ApplicationController, type: :controller do
     let!(:organization) { create :organization }
     let!(:user) { create :user, :confirmed, organization: }
-    let(:tos_path) { "/pages/terms-and-conditions" }
+    let(:tos_path) { "/pages/terms-of-service" }
 
     controller Decidim::ApplicationController do
       def show
@@ -26,7 +26,7 @@ module Decidim
       request.env["decidim.current_organization"] = organization
       routes.draw do
         get "show" => "decidim/application#show"
-        get "pages/terms-and-conditions" => "decidim/application#tos"
+        get "pages/terms-of-service" => "decidim/application#tos"
         get "unauthorized" => "decidim/application#unauthorized"
       end
     end

--- a/decidim-core/spec/controllers/registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/registrations_controller_spec.rb
@@ -89,7 +89,7 @@ module Decidim
                 "Confirm your password does not match Password",
                 "Password is too short",
                 "Password does not have enough unique characters",
-                "Terms and conditions of use agreement must be accepted"
+                "Terms of service agreement must be accepted"
               ].join(", ")
             )
           end

--- a/decidim-core/spec/models/decidim/static_page_spec.rb
+++ b/decidim-core/spec/models/decidim/static_page_spec.rb
@@ -52,11 +52,11 @@ module Decidim
       after { I18n.locale = :en }
 
       it "orders by the title in the current locale" do
-        expect(described_class.where.not(slug: "terms-and-conditions").sorted_by_i18n_title).to eq [page2, page1]
+        expect(described_class.where.not(slug: "terms-of-service").sorted_by_i18n_title).to eq [page2, page1]
       end
 
       it "orders by the title in the specified locale" do
-        expect(described_class.where.not(slug: "terms-and-conditions").sorted_by_i18n_title(:en)).to eq [page1, page2]
+        expect(described_class.where.not(slug: "terms-of-service").sorted_by_i18n_title(:en)).to eq [page1, page2]
       end
     end
 

--- a/decidim-core/spec/system/registration_spec.rb
+++ b/decidim-core/spec/system/registration_spec.rb
@@ -17,7 +17,7 @@ end
 
 describe "Registration", type: :system do
   let(:organization) { create(:organization) }
-  let!(:terms_and_conditions_page) { Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization:) }
+  let!(:terms_and_conditions_page) { Decidim::StaticPage.find_by(slug: "terms-of-service", organization:) }
 
   before do
     switch_to_host(organization.host)

--- a/decidim-core/spec/system/registration_spec.rb
+++ b/decidim-core/spec/system/registration_spec.rb
@@ -17,7 +17,7 @@ end
 
 describe "Registration", type: :system do
   let(:organization) { create(:organization) }
-  let!(:terms_and_conditions_page) { Decidim::StaticPage.find_by(slug: "terms-of-service", organization:) }
+  let!(:terms_of_service_page) { Decidim::StaticPage.find_by(slug: "terms-of-service", organization:) }
 
   before do
     switch_to_host(organization.host)

--- a/decidim-core/spec/system/registration_unbundled_consent_spec.rb
+++ b/decidim-core/spec/system/registration_unbundled_consent_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe "TOS", type: :system do
   let(:organization) { create(:organization) }
-  let!(:terms_and_conditions_page) { Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization:) }
+  let!(:terms_and_conditions_page) { Decidim::StaticPage.find_by(slug: "terms-of-service", organization:) }
 
   before do
     switch_to_host(organization.host)

--- a/decidim-core/spec/system/registration_unbundled_consent_spec.rb
+++ b/decidim-core/spec/system/registration_unbundled_consent_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe "TOS", type: :system do
   let(:organization) { create(:organization) }
-  let!(:terms_and_conditions_page) { Decidim::StaticPage.find_by(slug: "terms-of-service", organization:) }
+  let!(:terms_of_service_page) { Decidim::StaticPage.find_by(slug: "terms-of-service", organization:) }
 
   before do
     switch_to_host(organization.host)

--- a/decidim-core/spec/system/user_tos_acceptance_spec.rb
+++ b/decidim-core/spec/system/user_tos_acceptance_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "UserTosAcceptance", type: :system do
   let!(:organization) { create(:organization) }
   let!(:user) { create(:user, :confirmed, organization:) }
-  let!(:tos_page) { Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization:) }
+  let!(:tos_page) { Decidim::StaticPage.find_by(slug: "terms-of-service", organization:) }
   let(:btn_accept) { "I agree with these terms" }
   let(:btn_refuse) { "Refuse the terms" }
 
@@ -50,7 +50,7 @@ describe "UserTosAcceptance", type: :system do
       end
 
       it "renders a success announcement" do
-        expect(page).to have_content("Great! You have accepted the terms and conditions.")
+        expect(page).to have_content("Great! You have accepted the terms of service.")
         expect(page).to have_css(".flash.success")
       end
     end
@@ -62,7 +62,7 @@ describe "UserTosAcceptance", type: :system do
 
       it "renders a modal" do
         expect(page).to have_css("#tos-refuse-modal")
-        expect(page).to have_content("Do you really refuse the updated Terms and Conditions?")
+        expect(page).to have_content("Do you really refuse the updated terms of service?")
       end
 
       context "with the refuse modal has different options" do

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -41,9 +41,9 @@ Decidim.configure do |config|
   config.service_worker_enabled = Rails.application.secrets.decidim[:service_worker_enabled].present?
 
   # Sets the list of static pages' slugs that can include content blocks.
-  # By default is only enabled in the terms-and-conditions static page to allow a summary to be added and include
+  # By default is only enabled in the terms-of-service static page to allow a summary to be added and include
   # sections with a two-pane view
-  config.page_blocks = Rails.application.secrets.decidim[:page_blocks].presence || %w(terms-and-conditions)
+  config.page_blocks = Rails.application.secrets.decidim[:page_blocks].presence || %w(terms-of-service)
 
   # Map and Geocoder configuration
   #

--- a/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
@@ -43,7 +43,7 @@ decidim_default: &decidim_default
   allow_open_redirects: <%%= Decidim::Env.new("DECIDIM_ALLOW_OPEN_REDIRECTS").to_boolean_string %>
   social_share_services: <%%= Decidim::Env.new("DECIDIM_SOCIAL_SHARE_SERVICES", "Twitter, Facebook, WhatsApp, Telegram").to_array.to_json %>
   service_worker_enabled: <%%= Decidim::Env.new("DECIDIM_SERVICE_WORKER_ENABLED", Rails.env.exclude?("development")).to_boolean_string %>
-  page_blocks: <%%= Decidim::Env.new("DECIDIM_PAGE_BLOCKS", "terms-and-conditions").to_array %>
+  page_blocks: <%%= Decidim::Env.new("DECIDIM_PAGE_BLOCKS", "terms-of-service").to_array %>
   admin_password:
     expiration_days: <%%= Decidim::Env.new("DECIDIM_ADMIN_PASSWORD_EXPIRATION_DAYS", 90).to_i %>
     min_length: <%%= Decidim::Env.new("DECIDIM_ADMIN_PASSWORD_MIN_LENGTH", 15).to_i %>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -141,7 +141,7 @@ en:
             resources_permissions_enabled: Actions permissions can be set for each meeting
             scope_id: Scope
             scopes_enabled: Scopes enabled
-            terms_and_conditions_url_for_meeting_creators: Terms and conditions URL for meeting creators
+            terms_and_conditions_url_for_meeting_creators: Terms of service URL for meeting creators
           step:
             announcement: Announcement
             comments_blocked: Comments blocked

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -141,7 +141,7 @@ en:
             resources_permissions_enabled: Actions permissions can be set for each meeting
             scope_id: Scope
             scopes_enabled: Scopes enabled
-            terms_and_conditions_url_for_meeting_creators: Terms of service URL for meeting creators
+            terms_and_conditions_url_for_meeting_creators: Terms and conditions URL for meeting creators
           step:
             announcement: Announcement
             comments_blocked: Comments blocked

--- a/decidim-system/app/commands/decidim/system/create_default_pages.rb
+++ b/decidim-system/app/commands/decidim/system/create_default_pages.rb
@@ -22,10 +22,10 @@ module Decidim
             page.title = localized_attribute(slug, :title)
             page.content = localized_attribute(slug, :content)
             page.show_in_footer = true
-            page.allow_public_access = true if slug == "terms-and-conditions"
+            page.allow_public_access = true if slug == "terms-of-service"
           end
 
-          create_summary_content_blocks_for(static_page) if slug == "terms-and-conditions"
+          create_summary_content_blocks_for(static_page) if slug == "terms-of-service"
         end
       end
 

--- a/decidim-system/spec/commands/decidim/system/create_default_pages_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/create_default_pages_spec.rb
@@ -30,24 +30,24 @@ module Decidim
         organization1.static_pages.each do |page|
           expect(page.title["en"]).not_to be_nil
           expect(page.title["ca"]).not_to be_nil
-          unless page.slug == "terms-and-conditions"
+          unless page.slug == "terms-of-service"
             expect(page.content["en"]).not_to be_nil
             expect(page.content["ca"]).not_to be_nil
           end
         end
       end
 
-      it "sets the terms-and-conditions page as allowed for public access" do
+      it "sets the terms-of-service page as allowed for public access" do
         described_class.new(organization1).call
 
         expect(
           organization1.static_pages.find_by(
-            slug: "terms-and-conditions"
+            slug: "terms-of-service"
           ).allow_public_access
         ).to be(true)
       end
 
-      it "creates the terms-and-conditions summary content block" do
+      it "creates the terms-of-service summary content block" do
         expect do
           described_class.new(organization1).call
         end.to change { Decidim::ContentBlock.where(organization: organization1, scope_name: :static_page).where.not(published_at: nil).count }.by 1

--- a/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
@@ -101,7 +101,7 @@ module Decidim
           it "sets the organizations TOS version" do
             command.call
             organization = Organization.last
-            tos_page = Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization:)
+            tos_page = Decidim::StaticPage.find_by(slug: "terms-of-service", organization:)
 
             expect(organization.tos_version).not_to be_nil
             expect(organization.tos_version).to eq(tos_page.updated_at)

--- a/docs/modules/install/pages/checklist.adoc
+++ b/docs/modules/install/pages/checklist.adoc
@@ -32,7 +32,7 @@ As a technopolitical project, Decidim needs several things to work. This is a no
 == Contents
 
 . Ideally you will have a *Team* formed with experts on IT, Communication, Participation, Design and Law.
-. Texts for at least, *terms of use, privacy policy and frequently asked questions*. To show the "Terms of service" body text in the "Sign Up Form", it is a requirement that the slug of this page to be equal `terms-of-service`.
+. Texts for at least, *terms of service, privacy policy and frequently asked questions*. To show the "Terms of service" body text in the "Sign Up Form", it is a requirement that the slug of this page to be equal `terms-of-service`.
 . Comply with your current *legal requirements*, like to registrate your privacy policy with the autorities (eg LOPD on Spain).
 . Fill the *Participatory Processes Configuration Form* to prepare your Participatory Process for Decidim.
 . Read the *xref:admin:index.adoc[Administration manual]*.

--- a/docs/modules/install/pages/checklist.adoc
+++ b/docs/modules/install/pages/checklist.adoc
@@ -32,7 +32,7 @@ As a technopolitical project, Decidim needs several things to work. This is a no
 == Contents
 
 . Ideally you will have a *Team* formed with experts on IT, Communication, Participation, Design and Law.
-. Texts for at least, *terms of use, privacy policy and frequently asked questions*. To show the "Terms and conditions" body text in the "Sign Up Form", it is a requirement that the slug of this page to be equal `terms-and-conditions`.
+. Texts for at least, *terms of use, privacy policy and frequently asked questions*. To show the "Terms of service" body text in the "Sign Up Form", it is a requirement that the slug of this page to be equal `terms-of-service`.
 . Comply with your current *legal requirements*, like to registrate your privacy policy with the autorities (eg LOPD on Spain).
 . Fill the *Participatory Processes Configuration Form* to prepare your Participatory Process for Decidim.
 . Read the *xref:admin:index.adoc[Administration manual]*.


### PR DESCRIPTION
#### :tophat: What? Why?
As discussed with the maintainers, we want to standardize the naming for "terms of service".

We are using a few different variations of this and it was decided that we will use the "terms of service" everywhere.

#### :pushpin: Related Issues
- Related to #10566

#### Testing
- Try the `/pages/terms-and-conditions` path and see that it redirects you to `/pages/terms-of-service`
- Create a new organization and see that the page slug is `/pages/terms-of-service`
- Update the admin user's accepted TOS version (e.g. `Decidim::User.first.update!(accepted_tos_version: nil)`) and see that the user can accept the terms