### PR TITLE
Redesign: Add a new <aside> to layout item

### DIFF
--- a/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
@@ -42,7 +42,7 @@ module Decidim
       end
 
       def nav_paths
-        return if result.blank?
+        return {} if result.blank?
 
         { prev_path: prev_result, next_path: next_result }.compact_blank.transform_values { |result| result_path(result) }.merge(back_path: results_path)
       end

--- a/decidim-accountability/app/views/decidim/accountability/results/_project.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_project.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: "layouts/decidim/shared/layout_item", locals: nav_paths do %>
+<%= render layout: "layouts/decidim/shared/layout_item", locals: nav_paths.merge(commentable: result) do %>
   <%= cell("decidim/accountability/project", result) %>
 
   <div class="mt-8 accountability__project-actions">
@@ -11,7 +11,6 @@
   </div>
 
   <%# REDESIGN_PENDING: Both comments and attachments sections are pending %>
-  <%= comments_for result %>
   <%= attachments_for result %>
 
   <div class="mt-8">

--- a/decidim-accountability/app/views/decidim/accountability/results/_project.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_project.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: "layouts/decidim/shared/layout_item", locals: nav_paths.merge(commentable: result) do %>
+<%= render layout: "layouts/decidim/shared/layout_item", locals: nav_paths do %>
   <%= cell("decidim/accountability/project", result) %>
 
   <div class="mt-8 accountability__project-actions">
@@ -13,10 +13,6 @@
   <%# REDESIGN_PENDING: Both comments and attachments sections are pending %>
   <%= attachments_for result %>
 
-  <div class="mt-8">
-    <%= cell "decidim/accountability/result_metadata", result, template: :show_footer %>
-  </div>
-
   <% content_for :aside do %>
     <div class="accountability__project-aside">
       <% if component_settings.display_progress_enabled? %>
@@ -30,5 +26,9 @@
 
     <%= cell("decidim/accountability/result_metadata", result, template: :project_aside) %>
     </div>
+  <% end %>
+  <% content_for :item_footer do %>
+    <%= comments_for result %>
+    <%= cell "decidim/accountability/result_metadata", result, template: :show_footer %>
   <% end %>
 <% end %>

--- a/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
+++ b/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
@@ -26,7 +26,7 @@
   <aside class="layout-item__aside">
     <%= yield :aside %>
   </aside>
-  <%# this aside is for move comments and versions at the bottom of the page only in responsive. %>
+  <%# this aside is for moving comments and versions at the bottom of the page only in responsive. %>
   <% if content_for?(:item_footer) %>
     <aside class="layout-item__main layout-item__aside--footer">
       <%= yield(:item_footer) %>

--- a/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
+++ b/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
@@ -26,6 +26,7 @@
   <aside class="layout-item__aside">
     <%= yield :aside %>
   </aside>
+  <%# this aside is for move comments and versions at the bottom of the page only in responsive. %>
   <% if content_for?(:item_footer) %>
     <aside class="layout-item__main layout-item__aside--footer">
       <%= yield(:item_footer) %>

--- a/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
+++ b/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
@@ -23,5 +23,12 @@
 
     <%= yield %>
   </main>
-  <aside class="layout-item__aside"><%= yield :aside %></aside>
+  <aside class="layout-item__aside">
+    <%= yield :aside %>
+  </aside>
+  <% if local_assigns.has_key?(:commentable) %>
+    <aside class="layout-item__main layout-item__aside--coments">
+      <%= comments_for commentable %>
+    </aside>
+  <% end %>
 </div>

--- a/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
+++ b/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
@@ -26,9 +26,9 @@
   <aside class="layout-item__aside">
     <%= yield :aside %>
   </aside>
-  <% if local_assigns.has_key?(:commentable) %>
-    <aside class="layout-item__main layout-item__aside--coments">
-      <%= comments_for commentable %>
+  <% if content_for?(:item_footer) %>
+    <aside class="layout-item__main layout-item__aside--footer">
+      <%= yield(:item_footer) %>
     </aside>
   <% end %>
 </div>

--- a/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
+++ b/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
@@ -29,7 +29,7 @@
   <%# this aside is for moving comments and versions at the bottom of the page only in responsive. %>
   <% if content_for?(:item_footer) %>
     <aside class="layout-item__main layout-item__aside--footer">
-      <%= yield(:item_footer) %>
+      <%= yield :item_footer %>
     </aside>
   <% end %>
 </div>

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -152,7 +152,7 @@ module Decidim
       end
 
       def nav_paths
-        return if meeting.blank?
+        return {} if meeting.blank?
 
         { prev_path: prev_meeting, next_path: next_meeting }.compact_blank.transform_values { |meeting| meeting_path(meeting) }.merge(back_path: meetings_path)
       end

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: "layouts/decidim/shared/layout_item", locals: nav_paths do %>
+<%= render layout: "layouts/decidim/shared/layout_item", locals: nav_paths.merge(commentable: meeting) do %>
   <div class="meeting__container">
 
     <h1 class="h2 decorator"><%= present(meeting).title(links: true, html_escape: true ) %></h1>
@@ -48,7 +48,6 @@
       <%= cell "decidim/tags", meeting %>
     </div>
 
-    <%= comments_for meeting %>
     <%= pad_iframe_for meeting %>
 
     <div class="mt-8">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: "layouts/decidim/shared/layout_item", locals: nav_paths.merge(commentable: meeting) do %>
+<%= render layout: "layouts/decidim/shared/layout_item", locals: nav_paths do %>
   <div class="meeting__container">
 
     <h1 class="h2 decorator"><%= present(meeting).title(links: true, html_escape: true ) %></h1>
@@ -49,14 +49,6 @@
     </div>
 
     <%= pad_iframe_for meeting %>
-
-    <div class="mt-8">
-      <ul class="drawer-metadata__container" data-metadata-footer>
-        <%= content_tag :li, resource_reference(meeting), class: "drawer-metadata__item" %>
-        <%= content_tag :li, resource_version(meeting, versions_path: meeting_version_path(meeting, meeting.versions.count)), class: "drawer-metadata__item" %>
-        <%= content_tag :li, link_to(t("add_to_calendar", scope: "decidim.meetings.meetings.calendar_modal"), nil, remote: true, data: { dialog_open: "calendarShare_#{meeting.id}" }), class: "drawer-metadata__item" %>
-      </ul>
-    </div>
 
     <%# REDESIGN_PENDING: deprecated, now it's always in the layout %>
     <%#= cell("decidim/flag_modal", meeting) %>
@@ -137,6 +129,17 @@
         <% end %>
       <% end %>
     <% end %>
+  <% end %>
+
+  <% content_for :item_footer do %>
+    <%= comments_for meeting %>
+    <div class="mt-8">
+      <ul class="drawer-metadata__container" data-metadata-footer>
+        <%= content_tag :li, resource_reference(meeting), class: "drawer-metadata__item" %>
+        <%= content_tag :li, resource_version(meeting, versions_path: meeting_version_path(meeting, meeting.versions.count)), class: "drawer-metadata__item" %>
+        <%= content_tag :li, link_to(t("add_to_calendar", scope: "decidim.meetings.meetings.calendar_modal"), nil, remote: true, data: { dialog_open: "calendarShare_#{meeting.id}" }), class: "drawer-metadata__item" %>
+      </ul>
+    </div>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Add the comment block as a new aside in layout-item. This way, the comment block in the detail of an item is always displayed at the bottom. It fixes a common problem for all items that use the layout-item.



### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

![Screenshot 2023-03-23 at 15-03-43 Ut reiciendis  - Rediseño decidim](https://user-images.githubusercontent.com/2649175/227229083-31f48292-37aa-4e0e-a9d1-2fb607349619.png)


- Item accountability: https://decidim-redesign.populate.tools/processes/smile-cutting/f/16/results/42
- Meeting: https://decidim-redesign.populate.tools/processes/smile-cutting/f/12/meetings/11

:hearts: Thank you!
