### PR TITLE
Fix a proposals spec after word standardization

### DIFF
--- a/decidim-proposals/spec/events/decidim/proposals/publish_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/publish_proposal_event_spec.rb
@@ -23,7 +23,7 @@ module Decidim
 
       describe "email_subject" do
         context "when resource title contains apostrophes" do
-          let(:resource) { create :proposal, title: "It is a nice proposal" }
+          let(:resource) { create :proposal, title: "It is a 'nice' proposal" }
 
           it "is generated correctly" do
             expect(subject.email_subject).to eq("New proposal \"#{resource_title}\" by @#{author.nickname}")


### PR DESCRIPTION
#### :tophat: What? Why?
During the word standardization efforts, the apostrophe character was taken away from this spec.

This test needs it to make any sense which is why I'm adding it here in a way that passes the spelling rules.

#### :pushpin: Related Issues
- Related to #10589

#### Testing
See that CI is green.