### PR TITLE
Fix for exporting deleted and hidden comments

### DIFF
--- a/decidim-comments/lib/decidim/comments/export.rb
+++ b/decidim-comments/lib/decidim/comments/export.rb
@@ -12,6 +12,8 @@ module Decidim
       # Returns an Arel::Relation with all the comments for that component and resource.
       def comments_for_resource(resource_class, component)
         Comment
+          .not_deleted
+          .not_hidden
           .where(decidim_root_commentable_id: resource_class.where(component:))
           .where(decidim_root_commentable_type: resource_class.to_s)
       end

--- a/decidim-comments/spec/lib/decidim/comments/export_spec.rb
+++ b/decidim-comments/spec/lib/decidim/comments/export_spec.rb
@@ -10,6 +10,9 @@ module Decidim
       let!(:dummy_resources) { create_list(:dummy_resource, 2, component:) }
       let!(:comments) { create_list(:comment, 5, commentable: dummy_resources[1], root_commentable: dummy_resources[1]) }
       let!(:other_comments) { create_list(:comment, 5) }
+      let!(:deleted_comment) { create(:comment, :deleted, commentable: dummy_resources[1], root_commentable: dummy_resources[1]) }
+      let!(:hidden_comment) { create(:comment, :deleted, commentable: dummy_resources[1], root_commentable: dummy_resources[1]) }
+      let!(:moderation) { create(:moderation, hidden_at: 6.hours.ago, reportable: hidden_comment) }
 
       describe "#comments_for_resource" do
         let(:collection) { subject.comments_for_resource(Decidim::DummyResources::DummyResource, component) }
@@ -20,6 +23,14 @@ module Decidim
 
         it "excludes other comments" do
           expect(collection).not_to include(*other_comments)
+        end
+
+        it "excludes deleted comments" do
+          expect(collection).not_to include(deleted_comment)
+        end
+
+        it "excludes hidden comments" do
+          expect(collection).not_to include(hidden_comment)
         end
       end
     end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
In all the decidim versions, you currently can export all the comments attached to a resource. This PR implements adds the `.not_hidden` and `.not_deleted` scopes, in order to remove from export the moderated and hidden comments.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10613

#### Testing
1. Go to public interface of a proposal
2. Add several comments, moderate or delete some of those
3. Go to admin space for that proposal, export all the comments 
4. See in the attached mail the exported comments containing moderated and hidden resources 
5. Apply patch 
6. Go to admin space for that proposal, export all the comments 
7. See in the attached mail the exported comments *NOT* containing moderated and hidden resources 

:hearts: Thank you!
