### PR TITLE
Fix for exporting hidden moderated proposals

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -131,6 +131,7 @@ Decidim.register_component(:proposals) do |component|
 
       collection = Decidim::Proposals::Proposal
                    .published
+                   .not_hidden
                    .where(component: component_instance)
                    .includes(:scope, :category, :component)
 

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -285,5 +285,19 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
         expect(subject).to match_array([unassigned_proposal, assigned_proposal])
       end
     end
+
+    context "when proposal is moderated" do
+      let(:hidden_proposal) { create :proposal, component: }
+      let!(:moderation) { create(:moderation, hidden_at: 6.hours.ago, reportable: hidden_proposal) }
+      let!(:user) { create :user, admin: true, organization: }
+
+      it "exports all proposals from the component" do
+        expect(subject).to include(unassigned_proposal, assigned_proposal)
+      end
+
+      it "excludes hidden comments" do
+        expect(subject).not_to include(hidden_proposal)
+      end
+    end
   end
 end

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -295,7 +295,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
         expect(subject).to include(unassigned_proposal, assigned_proposal)
       end
 
-      it "excludes hidden comments" do
+      it "excludes the hidden proposals" do
         expect(subject).not_to include(hidden_proposal)
       end
     end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Currently, exports in Decidim will also expose the moderated content. 

#### :pushpin: Related Issues

- Fixes #6398

#### Testing

1. Go to public interface of a proposal
2. Report the proposal
3. Go to admin space in the moderated section, and hide it 
4. Export the proposals in the space admin, and see the moderated content is there
5. Apply patch
6. Repeat step 4
7. The exported archive should NOT contain moderated and hidden resources


:hearts: Thank you!
