### PR TITLE
Fix flaky spec in elections (`admin_manages_election_steps_spec`)

### DIFF
--- a/decidim-elections/spec/shared/full_election_process_shared_context.rb
+++ b/decidim-elections/spec/shared/full_election_process_shared_context.rb
@@ -58,7 +58,7 @@ module Decidim
       end
 
       def access_trustee_zone(trustee_index, upload_keys = true) # rubocop:disable Style/OptionalBooleanParameter
-        trustee = election.trustees[trustee_index]
+        trustee = election.trustees.order(:id)[trustee_index]
 
         relogin_as trustee.user, scope: :user
         visit decidim.decidim_elections_trustee_zone_path

--- a/decidim-elections/spec/shared/full_election_process_shared_context.rb
+++ b/decidim-elections/spec/shared/full_election_process_shared_context.rb
@@ -62,12 +62,15 @@ module Decidim
 
         relogin_as trustee.user, scope: :user
         visit decidim.decidim_elections_trustee_zone_path
+        expect(page).to have_content("Participant settings")
+        expect(page).to have_css("#user-settings-tabs li a[aria-current='page']", text: "Trustee zone")
 
         if upload_keys
           expect(page).to have_content("Upload your identification keys")
           attach_file(private_keys[trustee_index]) do
             click_button "Upload your identification keys"
           end
+          expect(page).to have_content("You have been assigned to act as a Trustee in some of the elections celebrated in this platform.")
         end
 
         expect(page).not_to have_content("Upload your identification keys")

--- a/decidim-elections/spec/system/admin/admin_manages_election_steps_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_election_steps_spec.rb
@@ -311,5 +311,16 @@ describe "Admin manages election steps", :slow, type: :system do
     within find("tr", text: translated(election.title)) do
       page.find(".action-icon--manage-steps").click
     end
+
+    # Ensure the correct page is loaded before proceeding further
+    if election.bb_status.nil?
+      within ".form.step.create_election .card .card-divider", match: :first do
+        expect(page).to have_css(".card-title", text: "Setup election")
+      end
+    else
+      within ".process-content .card .card-divider", match: :first do
+        expect(page).to have_css(".card-title", text: translated(election.title))
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
The specs at `admin_manages_election_steps_spec.rb` are flaky and they are occasionally failing at the CI, rather often.

The reason seems to be exactly the same as in #10601. This seems to fix the issue at least locally (where I could also replicate the issue). I also ran it multiple times at the CI to ensure it is fixed properly (50 runs with 100% success rate).

There was also another issue which is the order of the trustees. Occasionally PostgreSQL can return the results in different order which causes fluctuation between the test runs.

#### :pushpin: Related Issues
- Fixes #8764

#### Testing
```bash
$ cd decidim-elections
$ for i in {1..20}; do bundle exec rspec spec/system/admin/admin_manages_election_steps_spec.rb || break; done
```

Note that you will need to run the bulletin board server with `RAILS_ENV=test` and port 5017 for this spec to work.