### PR TITLE
Backport 'Fix empty proposals component configuration limits' to v0.26

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+shared_examples "has mandatory config setting" do |mandatory_field|
+  let(:edit_component_path) do
+    Decidim::EngineRouter.admin_proxy(component.participatory_space).edit_component_path(component.id)
+  end
+
+  before do
+    visit edit_component_path
+    component.update(settings: { mandatory_field => "" })
+    visit edit_component_path
+  end
+
+  it "does not allow updating the component" do
+    click_button "Update"
+
+    within ".#{mandatory_field}_container" do
+      expect(page).to have_content("There's an error in this field")
+    end
+  end
+end
+
 shared_context "with a component" do
   let(:manifest) { Decidim.find_component_manifest(manifest_name) }
   let(:user) { create :user, :confirmed, organization: organization }

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -28,19 +28,19 @@ Decidim.register_component(:proposals) do |component|
   component.settings(:global) do |settings|
     settings.attribute :scopes_enabled, type: :boolean, default: false
     settings.attribute :scope_id, type: :scope
-    settings.attribute :vote_limit, type: :integer, default: 0
-    settings.attribute :minimum_votes_per_user, type: :integer, default: 0
+    settings.attribute :vote_limit, type: :integer, default: 0, required: true
+    settings.attribute :minimum_votes_per_user, type: :integer, default: 0, required: true
     settings.attribute :proposal_limit, type: :integer, default: 0, required: true
     settings.attribute :proposal_length, type: :integer, default: 500
     settings.attribute :proposal_edit_time, type: :enum, default: "limited", choices: -> { %w(limited infinite) }
-    settings.attribute :proposal_edit_before_minutes, type: :integer, default: 5
-    settings.attribute :threshold_per_proposal, type: :integer, default: 0
+    settings.attribute :proposal_edit_before_minutes, type: :integer, default: 5, required: true
+    settings.attribute :threshold_per_proposal, type: :integer, default: 0, required: true
     settings.attribute :can_accumulate_supports_beyond_threshold, type: :boolean, default: false
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
     settings.attribute :default_sort_order, type: :select, default: "default", choices: -> { POSSIBLE_SORT_ORDERS }
     settings.attribute :official_proposals_enabled, type: :boolean, default: true
     settings.attribute :comments_enabled, type: :boolean, default: true
-    settings.attribute :comments_max_length, type: :integer, required: false
+    settings.attribute :comments_max_length, type: :integer, required: true
     settings.attribute :geocoding_enabled, type: :boolean, default: false
     settings.attribute :attachments_allowed, type: :boolean, default: false
     settings.attribute :resources_permissions_enabled, type: :boolean, default: true

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -136,16 +136,27 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
     end
 
     context "when proposal limit is empty" do
-      before do
-        visit edit_component_path
-        component.update(settings: { proposal_limit: "" })
-        visit edit_component_path
-      end
+      it_behaves_like "has mandatory config setting", :proposal_limit
+    end
 
-      it "does NOT allow updating proposal component" do
-        click_button "Update"
-        expect(page).to have_content("There's an error in this field")
-      end
+    context "when support limit per participant is empty" do
+      it_behaves_like "has mandatory config setting", :vote_limit
+    end
+
+    context "when minimum supports per user is empty" do
+      it_behaves_like "has mandatory config setting", :minimum_votes_per_user
+    end
+
+    context "when proposal_edit_before_minutes is empty" do
+      it_behaves_like "has mandatory config setting", :proposal_edit_before_minutes
+    end
+
+    context "when comments_max_length is empty" do
+      it_behaves_like "has mandatory config setting", :comments_max_length
+    end
+
+    context "when threshold_per_proposal is empty" do
+      it_behaves_like "has mandatory config setting", :threshold_per_proposal
     end
 
     describe "participatory_texts_enabled" do
@@ -161,7 +172,7 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
           visit edit_component_path
         end
 
-        it "does NOT allow creating new proposals with the proposal form" do
+        it "does not allow creating new proposals with the proposal form" do
           expect(page.find(".creation_enabled_container")[:class]).to include("readonly")
           expect(page).to have_content("This setting is disabled when you activate the Participatory Texts functionality. To upload proposals as participatory text click on the Participatory Texts button and follow the instructions.")
         end
@@ -188,12 +199,12 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
           visit edit_component_path
         end
 
-        it "does NOT allow to check the setting" do
+        it "does not allow to check the setting" do
           expect(participatory_texts_enabled_container[:class]).to include("readonly")
           expect(page).to have_content("Cannot interact with this setting if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.")
         end
 
-        it "does NOT change the setting value after updating" do
+        it "does not change the setting value after updating" do
           expect do # rubocop:disable Lint/AmbiguousBlockAssociation
             click_button "Update"
           end.not_to change { component.reload.settings.participatory_texts_enabled }


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #10551 to v0.26

:hearts: Thank you!