### PR TITLE
votes-enabled-check/tests

### DIFF
--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -669,9 +669,40 @@ describe "Orders", type: :system do
         click_link translated(project.title)
 
         proposals.each do |proposal|
+          expect(page).to have_content("tesi")
           expect(page).to have_content(translated(proposal.title))
           expect(page).to have_content(proposal.creator_author.name)
           expect(page).to have_content(proposal.votes.size)
+        end
+      end
+
+      context "with supports enabled" do
+        let(:proposal_component) do
+          create(:proposal_component, :with_votes_enabled, participatory_space: project.component.participatory_space)
+        end
+
+        let(:proposals) { create_list(:proposal, 1, :with_votes, component: proposal_component) }
+
+        it "shows the amount of supports" do
+          visit_budget
+          click_link translated(project.title)
+
+          expect(page.find('span[class="card--list__data__number"]')).to have_content("5")
+        end
+      end
+
+      context "with supports disabled" do
+        let(:proposal_component) do
+          create(:proposal_component, participatory_space: project.component.participatory_space)
+        end
+
+        let(:proposals) { create_list(:proposal, 1, :with_votes, component: proposal_component) }
+
+        it "doesn't show supports" do
+          visit_budget
+          click_link translated(project.title)
+
+          expect(page).not_to have_selector('span[class="card--list__data__number"]')
         end
       end
     end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
@@ -22,7 +22,8 @@
           <% end %>
         </div>
       </div>
-      <% if !current_settings.try(:votes_hidden?) && !proposal.component.current_settings.votes_hidden? %>
+      <% if !current_settings.try(:votes_hidden?) && !proposal.component.current_settings.votes_hidden? &&
+      proposal.component.current_settings.votes_enabled?%>
         <div class="card--list__data">
           <span class="card--list__data__number">
             <%= proposal.votes.size %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
If a proposal component didn't have supports enabled, you could still see the amount of supports in budget -> project -> linked proposals, which naturally was "0". This information wasn't needed in this case, so a checker was added to the code which hides the "supports" -indicator from the view if supports weren't enabled in the specific proposal component.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10645

#### Testing
1. Create a proposals component with "supports enabled" unchecked
2. Create few proposals
3. Create a budgets component + one budget within it
4. Add a project and link it to one of the proposals
5. Go to the project's page and see the linked proposals section
6. See that the linked proposal indicates a number of supports (0)

### :camera: Screenshots

*Before the fix:*
![image](https://user-images.githubusercontent.com/110532525/229433935-3f9baf38-e4e6-4d73-88fc-4dac01b25c37.png)

*After the fix:*
![image](https://user-images.githubusercontent.com/110532525/229434290-2adb5db1-60dc-4a66-b365-dc17762271c9.png)


:hearts: Thank you!
