### PR TITLE
Fix primary RGB color of the organization is being generated wrongly

### DIFF
--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -178,7 +178,7 @@ module Decidim
     # Example:
     #
     # --primary: #ff0000;
-    # --primary-rgb: 255 0 0
+    # --primary-rgb: 255,0,0
     #
     # Hexadecimal variables can be used as a normal CSS color:
     #
@@ -189,7 +189,7 @@ module Decidim
     #
     # background-color: rgba(var(--primary-rgb), 0.5)
     def organization_colors
-      css = current_organization.colors.each.map { |k, v| "--#{k}: #{v};--#{k}-rgb: #{v[1..2].hex} #{v[3..4].hex} #{v[5..6].hex};" }.join
+      css = current_organization.colors.each.map { |k, v| "--#{k}: #{v};--#{k}-rgb: #{v[1..2].hex},#{v[3..4].hex},#{v[5..6].hex};" }.join
       render partial: "layouts/decidim/organization_colors", locals: { css: }
     end
 

--- a/decidim-core/app/packs/stylesheets/decidim/modules/_input-gallery.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_input-gallery.scss
@@ -26,8 +26,7 @@
       top: 2px;
       width: 2rem;
       height: 2rem;
-      background: var(--primary);
-      opacity: 0.8;
+      background: rgba(var(--primary-rgb), 0.8);
       color: $white;
       border-radius: 50%;
     }


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR makes use of `--primary`` variable to display the metrics in a pretty form.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10687

#### Testing
1. Visit admin section 
2. Check the metrics
3. See the metrics area charts are not just a black svg

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
Before: 
![image](https://user-images.githubusercontent.com/6973564/230124072-e2f59176-6f40-4da1-8de5-6bc019e3c0d2.jpeg)
After: 
![image](https://user-images.githubusercontent.com/105683/230459753-8abf5045-38ad-4426-9b11-5a5517a61eef.png)

Revert #10424: 
![image](https://user-images.githubusercontent.com/105683/230459611-50a2211f-303d-4822-b4a9-a03c66301c08.png)


:hearts: Thank you!
