### PR TITLE
Sort the file names in spelling check to ensure consistent results order

### DIFF
--- a/.github/run_spelling_check.sh
+++ b/.github/run_spelling_check.sh
@@ -52,6 +52,6 @@ while read -r match; do
       echo "::error file=${file},line=${line},col=${spos},endColumn=${epos}::Use \"$preferred\" instead of \"$word\"."
     done < <(echo "$text" | grep -owib "$word")
   done
-done < <(find decidim-* docs/ -type f | grep -vP "$exclude_paths_pattern" | xargs -n1000 grep -Hnwif "$forbidden_words_file")
+done < <(find decidim-* docs/ -type f | sort | grep -vP "$exclude_paths_pattern" | xargs -n1000 grep -Hnwif "$forbidden_words_file")
 
 exit $status

--- a/spec/spellcheck_spec.rb
+++ b/spec/spellcheck_spec.rb
@@ -70,8 +70,16 @@ describe "Spellcheck utility" do
     it "returns the correct errors" do
       expect(exitstatus).to be(1)
 
+      invalid_locale_lines = output_lines[0..2]
+      expect(invalid_locale_lines[0]).to eq(
+        %(::error file=decidim-test/config/locales/en.yml,line=2,col=10,endColumn=15::Use "is not" instead of "isn't".)
+      )
+      expect(invalid_locale_lines[1]).to eq(
+        %(::error file=decidim-test/config/locales/en.yml,line=2,col=34,endColumn=41::Use "does not" instead of "doesn't".)
+      )
+
       start_lines = [5, 5 + config["forbidden"].length]
-      invalid_code_lines = output_lines[0..(2 * config["forbidden"].length)]
+      invalid_code_lines = output_lines[2..((2 * config["forbidden"].length) + 2)]
       config["forbidden"].each_with_index do |(word, preferred), idx|
         expect(invalid_code_lines[idx]).to eq(
           %(::error file=decidim-test/lib/invalid.rb,line=#{start_lines[0] + idx},col=27,endColumn=#{27 + word.length}::Use "#{preferred}" instead of "#{word}".)
@@ -80,14 +88,6 @@ describe "Spellcheck utility" do
           %(::error file=decidim-test/lib/invalid.rb,line=#{start_lines[1] + idx},col=5,endColumn=#{5 + word.length}::Use "#{preferred}" instead of "#{word}".)
         )
       end
-
-      invalid_locale_lines = output_lines[(2 * config["forbidden"].length)..((2 * config["forbidden"].length) + 2)]
-      expect(invalid_locale_lines[0]).to eq(
-        %(::error file=decidim-test/config/locales/en.yml,line=2,col=10,endColumn=15::Use "is not" instead of "isn't".)
-      )
-      expect(invalid_locale_lines[1]).to eq(
-        %(::error file=decidim-test/config/locales/en.yml,line=2,col=34,endColumn=41::Use "does not" instead of "doesn't".)
-      )
 
       start_lines = [5, 6 + config["forbidden"].length]
       invalid_doc_lines = output_lines[((2 * config["forbidden"].length) + 2)..((4 * config["forbidden"].length) + 2)]


### PR DESCRIPTION
#### :tophat: What? Why?
Apparently the spelling check specs are flaky because the script does not sort the problematic file names which can lead to different ordering of the results. The spec testing the script is expecting the files to be in consistent order, so sorting the file names should fix this issue.

Example workflow run that failed because of this:
https://github.com/decidim/decidim/actions/runs/4627662991/jobs/8185847377

#### :pushpin: Related Issues
- Related to #10553

#### Testing
See that the CI is green.

### :camera: Screenshots
![CI error](https://user-images.githubusercontent.com/864340/230363939-c06985e3-932e-4a34-98c7-7c28259aeebc.png)