### PR TITLE
Fix Empty participatory process group is created when importing a PP …

### DIFF
--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -53,6 +53,11 @@ module Decidim
       end
 
       def import_process_group(attributes)
+        title = compact_translation(attributes["title"] || attributes["name"])
+        description = compact_translation(attributes["description"])
+
+        return if title.blank? && description.blank?
+
         Decidim.traceability.perform_action!("create", ParticipatoryProcessGroup, @user) do
           group = ParticipatoryProcessGroup.find_or_initialize_by(
             title: attributes["title"] || attributes["name"],
@@ -151,6 +156,11 @@ module Decidim
       end
 
       private
+
+      def compact_translation(translation)
+        translation["machine_translations"] = translation["machine_translations"].compact_blank if translation["machine_translations"].present?
+        translation.compact_blank
+      end
 
       def create_attachment_collection(attributes)
         return unless attributes.compact.any?

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
@@ -94,6 +94,19 @@ module Decidim::ParticipatoryProcesses
           expect(group.title).to eq(group_data["name"])
         end
       end
+
+      context "when the process group is empty" do
+        let(:group_data) do
+          {
+            "title" => Decidim::Faker::Localized.localized { "" },
+            "description" => Decidim::Faker::Localized.localized { "" }
+          }
+        end
+
+        it "does not create a process group" do
+          expect { subject }.not_to change(Decidim::ParticipatoryProcessGroup, :count)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
When exporting the participatory processes, the ParticipatoryProcessGroup is either set to an existing one if is linked in the exporting platform, or set to empty result, if the ParticipatoryProcess is not tied to any group. 
When importing the ParticipatoryProcess, the system is checking if there is a Group defined in the platform, otherwise it will create the group. When the group in the json file is blank, the importer script will try to find the group, and because is empty a new Group will be created each time. 

This PR, checks to see if the exported group is defined ( title and description ), and if is not, it will skip the Group generation. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10689 

#### Testing
*Describe the best way to test or validate your PR.*
1. Login to admin panel 
2. Visit the participatory process and export one that is not bound to a group
3. Take the exported file, and import it in the system 
4. See that a Group has been created 
5. Apply patch 
6. Repeat the import process 
7. See there is no Group created. 

:hearts: Thank you!
