### PR TITLE
Fix Shakapacker errors in conferences, consultations and initiatives

### DIFF
--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_invites/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_invites/_form.html.erb
@@ -35,4 +35,4 @@
   </div>
 </div>
 
-<%= javascript_pack_tag "decidim_conferences_admin" %>
+<%= append_javascript_pack_tag "decidim_conferences_admin" %>

--- a/decidim-consultations/app/views/decidim/consultations/admin/question_configuration/_form.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/admin/question_configuration/_form.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_pack_tag "decidim_consultations" %>
+<%= append_javascript_pack_tag "decidim_consultations" %>
 
 <div class="card">
   <div class="card-divider">

--- a/decidim-core/app/packs/src/decidim/map/factory.js
+++ b/decidim-core/app/packs/src/decidim/map/factory.js
@@ -14,7 +14,7 @@ import MapDragMarkerController from "src/decidim/map/controller/drag_marker"
  *
  * An example how to use in the ERB view:
  *   <%= dynamic_map_for type: "custom" do %>
- *     <%= javascript_pack_tag "map_customization" %>
+ *     <%= append_javascript_pack_tag "map_customization" %>
  *   <% end %>
  *
  * And then the actual customization at `map_customization.js.es6`:

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/committee_requests/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/committee_requests/index.html.erb
@@ -63,4 +63,4 @@
   </div>
 </div>
 
-<%= javascript_pack_tag "decidim_initiatives_admin" %>
+<%= append_javascript_pack_tag "decidim_initiatives_admin" %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/print.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/print.html.erb
@@ -154,5 +154,5 @@
   </p>
 
   <a href="#" onclick="window.print();return false;" class="button expanded"><%= t ".print" %></a>
-  <%= stylesheet_pack_tag "decidim_initiatives_print", media: "all" %>
+  <%= append_stylesheet_pack_tag "decidim_initiatives_print" %>
 </div>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Visiting the admin interface to the consultations / Questions / Configuration, we will get a Shakapacker related error. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10389

#### Testing
1. Visit the admin interface / consultation 
2. Click on a Consultation, then Questions , then select one entry 
3. You will see the Configuration option on the secondary menu, and navigate there 
4. You should get a Webpacker related error 
5. Apply the patch 
6. Refresh the page 
7. The error should be gone

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![image](https://user-images.githubusercontent.com/105683/231720815-1f4dde87-28c9-4073-842a-1a2b1a45b403.png)
![image](https://user-images.githubusercontent.com/105683/231720895-cd81461d-9870-42c3-bf68-1db668c1ddb2.png)

:hearts: Thank you!
