### PR TITLE
Remove reference to unexisting class `DocxToMarkdown`

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/doc_to_markdown.rb
+++ b/decidim-proposals/lib/decidim/proposals/doc_to_markdown.rb
@@ -17,7 +17,6 @@ module Decidim
       # sometimes markdown documents are classified as text/plain
       TEXT_PLAIN_MIME_TYPE = "text/plain"
       ODT_MIME_TYPE = "application/vnd.oasis.opendocument.text"
-      DOCX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 
       # Accepted mime types
       # keys: are used for dynamic help text on admin form.
@@ -36,9 +35,6 @@ module Decidim
                        when ODT_MIME_TYPE
                          # convert libreoffice odt to markdown
                          OdtToMarkdown.new(doc)
-                       when DOCX_MIME_TYPE
-                         # convert word 2013 docx to markdown
-                         DocxToMarkdown.new(doc)
                        end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing #10713, I was wondering why this class did not have any tests. Turned out this class doesn't even exist or is not used anywhere.

This is not used anywhere in the codebase because the valid mime types are only those of `MD` and `ODT` type files as defined here:
https://github.com/decidim/decidim/blob/a1cfe8f486126a8753e508816ec3c780db9ce690/decidim-proposals/lib/decidim/proposals/doc_to_markdown.rb#L25-L28

These are used in the validator that checks that the submitted file is of correct type:
https://github.com/decidim/decidim/blob/a1cfe8f486126a8753e508816ec3c780db9ce690/decidim-proposals/app/forms/decidim/proposals/admin/import_participatory_text_form.rb#L39


#### :pushpin: Related Issues
- Related to #10713

#### Testing
1. See that CI is green
2. Search the code base for any references for `DocxToMarkdown` or `DOCX_MIME_TYPE` and see that none exist