### PR TITLE
Update stringio version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -751,7 +751,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     ssrf_filter (1.0.7)
-    stringio (3.0.5)
+    stringio (3.0.6)
     strscan (3.0.6)
     temple (0.8.2)
     terminal-table (3.0.2)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -751,7 +751,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     ssrf_filter (1.0.7)
-    stringio (3.0.5)
+    stringio (3.0.6)
     strscan (3.0.6)
     temple (0.8.2)
     terminal-table (3.0.2)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -751,7 +751,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     ssrf_filter (1.0.7)
-    stringio (3.0.5)
+    stringio (3.0.6)
     strscan (3.0.6)
     temple (0.8.2)
     terminal-table (3.0.2)


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This updates the stringio version. The latest release of sidekiq has broken the generators test suite. 

in https://github.com/decidim/decidim/actions/runs/4697301339/jobs/8328231697?pr=10673

we can observe that pipeline is failing with
 `You have already activated stringio 3.0.6, but your Gemfile requires stringio 3.0.5.` : 


```
bin/rails:3: warning: already initialized constant APP_PATH
/home/runner/work/decidim/decidim/decidim-generators/spec/generator_test_app/bin/rails:3: warning: previous definition of APP_PATH was here
/opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/runtime.rb:304:in `check_for_activated_spec!': You have already activated stringio 3.0.6, but your Gemfile requires stringio 3.0.5. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/runtime.rb:25:in `block in setup'
from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/spec_set.rb:155:in `each'
from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/spec_set.rb:155:in `each'
from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/runtime.rb:24:in `map'
from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/runtime.rb:24:in `setup'
from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler.rb:170:in `setup'
from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/setup.rb:20:in `block in <top (required)>'
from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/ui/shell.rb:159:in `with_level'
from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/ui/shell.rb:111:in `silence'
from /opt/hostedtoolcache/Ruby/3.1.1/x64/lib/ruby/gems/3.1.0/gems/bundler-2.4.6/lib/bundler/setup.rb:20:in `<top (required)>'
from /home/runner/work/decidim/decidim/decidim-generators/spec/generator_test_app/config/boot.rb:3:in `require'
from /home/runner/work/decidim/decidim/decidim-generators/spec/generator_test_app/config/boot.rb:3:in `<top (required)>'
from bin/rails:4:in `require_relative'
from bin/rails:4:in `<main>'
```



#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
