### PR TITLE
Fix menu spec after #9928

### DIFF
--- a/decidim-core/spec/system/menu_spec.rb
+++ b/decidim-core/spec/system/menu_spec.rb
@@ -19,11 +19,9 @@ describe "Menu", type: :system do
 
   it "renders the default main menu" do
     within ".main-nav" do
-      expect(page).to \
-        have_selector("li", count: 3) &
-        have_link("Home", href: "/") &
-        have_link("Initiatives", href: "/initiatives") &
-        have_link("Help", href: "/pages")
+      expect(page).to have_selector("li", count: 2)
+      expect(page).to have_link("Home", href: "/")
+      expect(page).to have_link("Help", href: "/pages")
     end
   end
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
After we have merged https://github.com/decidim/decidim/pull/9928, we have noticed that the test suite started to fail. #9928 added a condition in the menu rendering of the initiatives, which prevents the Initiative menu entry to be displayed if the system is not configured. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #9928

#### Testing
Make sure the test suite is green. 

:hearts: Thank you!
