### PR TITLE
Fix edge case in initiative creation

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -23,6 +23,8 @@ module Decidim
       helper_method :initiative_type
       helper_method :promotal_committee_required?
 
+      before_action :authenticate_user!
+
       steps :select_initiative_type,
             :previous_form,
             :show_similar_initiatives,

--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -34,6 +34,8 @@ module Decidim
             :promotal_committee,
             :finish
 
+      before_action :ensure_type_exists, only: :show
+
       def show
         send("#{step}_step", initiative: session_initiative)
       end
@@ -44,6 +46,15 @@ module Decidim
       end
 
       private
+
+      def ensure_type_exists
+        destination_step = single_initiative_type? ? :previous_form : :select_initiative_type
+
+        return if step == destination_step
+        return if initiative_type_id.present? && initiative_type.present?
+
+        redirect_to wizard_path(destination_step)
+      end
 
       def select_initiative_type_step(_parameters)
         @form = form(Decidim::Initiatives::SelectInitiativeTypeForm).instance
@@ -162,7 +173,7 @@ module Decidim
       end
 
       def initiative_type_from_params
-        Decidim::InitiativesType.find_by(id: params["initiative"]["type_id"])
+        @initiative_type ||= Decidim::InitiativesType.find_by(id: params["initiative"]["type_id"])
       end
 
       def initiative_type_id

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -363,7 +363,7 @@ en:
         fill_data:
           back: Back
           continue: Continue
-          decidim_user_group_id_help: It's not possible to change initiative authorship after creation
+          decidim_user_group_id_help: It is not possible to change initiative authorship after creation
           fill_data_help: "<ul> <li>Review the content of your initiative. Is your title easy to understand? Is the objective of your initiative clear?</li> <li>You have to choose the type of signature. In-person, online or a combination of both</li> <li>Which is the geographic scope of the initiative?</li> </ul>"
           more_information: "(More information)"
           select_area: Select an area

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -85,6 +85,47 @@ describe "Initiative", type: :system do
     end
   end
 
+  context "when user requests a page not having all the data required" do
+    let(:do_not_require_authorization) { false }
+    let(:signature_type) { "online" }
+
+    context "when there is only one initiative type" do
+      let!(:other_initiative_type) { nil }
+      let!(:other_initiative_type_scope) { nil }
+
+      [
+        :select_initiative_type,
+        :previous_form,
+        :show_similar_initiatives,
+        :fill_data,
+        :promotal_committee,
+        :finish
+      ].each do |step|
+        it "redirects to the previous_form page when landing on #{step}" do
+          expect(Decidim::InitiativesType.count).to eq(1)
+          visit decidim_initiatives.create_initiative_path(step)
+          expect(page).to have_current_path(decidim_initiatives.create_initiative_path(:previous_form))
+        end
+      end
+    end
+
+    context "when there are more initiative types" do
+      [
+        :previous_form,
+        :show_similar_initiatives,
+        :fill_data,
+        :promotal_committee,
+        :finish
+      ].each do |step|
+        it "redirects to the select_initiative_type page when landing on #{step}" do
+          expect(Decidim::InitiativesType.count).to eq(2)
+          visit decidim_initiatives.create_initiative_path(step)
+          expect(page).to have_current_path(decidim_initiatives.create_initiative_path(:select_initiative_type))
+        end
+      end
+    end
+  end
+
   describe "create initiative verification" do
     context "when there is just one initiative type" do
       let!(:other_initiative_type) { nil }
@@ -633,6 +674,7 @@ describe "Initiative", type: :system do
         let(:initiative) { build(:initiative, organization:, scoped_type: initiative_type_scope) }
 
         before do
+          expect(page).to have_content("I want to promote this initiative")
           find_button("I want to promote this initiative").click
 
           fill_in "Title", with: translated(initiative.title, locale: :en)


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
There is an edge case in the initiatives wizard, when having a single initiative type available, and the user's session expires, then the initiative wizard will throw an 500 error, instead of redirecting the user to login. 

This issues has been found while working on #10467

#### Testing
1. Login as a user 
2. Go to Initiatives , click "New Initiative"
3. Start filling your form 
4. When passing to the next window ( validate the form)
5. Open the console and remove the session cookies 
6. On refresh you should get a 500 error on an url like `/create_initiative/fill_data`
7. Apply the patch 
8. See there is no error on refresh ( you should be redirected to login screen)


:hearts: Thank you!
