### PR TITLE
Fix edit form in intitiatives

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -88,6 +88,7 @@ module Decidim
         enforce_permission_to :update, :initiative, initiative: current_initiative
 
         params[:id] = params[:slug]
+        params[:type_id] = current_initiative.type&.id
         @form = form(Decidim::Initiatives::InitiativeForm)
                 .from_params(params, initiative_type: current_initiative.type, initiative: current_initiative)
 

--- a/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
@@ -9,8 +9,8 @@ module Decidim
 
       mimic :initiative
 
-      attribute :title, String
-      attribute :description, String
+      translatable_attribute :title, String
+      translatable_attribute :description, String
       attribute :type_id, Integer
       attribute :scope_id, Integer
       attribute :area_id, Integer
@@ -39,6 +39,7 @@ module Decidim
       def map_model(model)
         self.type_id = model.type.id
         self.scope_id = model.scope&.id
+        self.signature_type = model.signature_type
       end
 
       def signature_type_updatable?

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
@@ -34,7 +34,7 @@
   <%= form.hidden_field :signature_type %>
 <% else %>
   <div class="field">
-    <%= form.select :signature_type, [], {}, { disabled: !@form.signature_type_updatable? } %>
+    <%= form.select :signature_type, signature_type_options, {}, { disabled: !@form.signature_type_updatable? } %>
   </div>
 <% end %>
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR aims to fix the edit initiative form that is currently not handling the translation field. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10723
- Related to #10006
- Fixes #9923

#### Testing
1. Create an initiative 
2. See the fill in data step
3. Check the edit initiative step 
4. See the Text appears like `{"en"=> "The text you've entered"}` in title and description fields
5. Apply patch 
6. See the input value changed to the previously entered value. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
