### PR TITLE
Fix notifications for the proposal answers importer

### DIFF
--- a/decidim-proposals/app/commands/decidim/proposals/admin/notify_proposal_answer.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/notify_proposal_answer.rb
@@ -21,6 +21,8 @@ module Decidim
         #
         # Returns nothing.
         def call
+          return broadcast(:invalid) if proposal.blank?
+
           if proposal.published_state? && state_changed?
             transaction do
               increment_score

--- a/decidim-proposals/lib/decidim/proposals/import/proposal_answer_creator.rb
+++ b/decidim-proposals/lib/decidim/proposals/import/proposal_answer_creator.rb
@@ -35,10 +35,12 @@ module Decidim
             resource.try(:save!)
           end
 
-          notify(resource, @initial_state)
+          notify
         end
 
         private
+
+        attr_reader :initial_state
 
         def resource
           @resource ||= fetch_resource
@@ -91,9 +93,9 @@ module Decidim
           context[:current_user]
         end
 
-        def notify(proposal, initial_state)
-          state = initial_state.presence || proposal.try(:state)
-          ::Decidim::Proposals::Admin::NotifyProposalAnswer.call(proposal, state)
+        def notify
+          state = initial_state || resource.try(:state)
+          ::Decidim::Proposals::Admin::NotifyProposalAnswer.call(resource, state)
         end
       end
     end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/notify_proposal_answer_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/notify_proposal_answer_spec.rb
@@ -109,6 +109,14 @@ module Decidim
             expect { subject }.not_to(change { Gamification.status_for(current_user, :accepted_proposals).score })
           end
         end
+
+        context "when the proposal is nil" do
+          let(:command) { described_class.new(nil, initial_state) }
+
+          it "broadcasts invalid" do
+            expect { subject }.to broadcast(:invalid)
+          end
+        end
       end
     end
   end

--- a/decidim-proposals/spec/lib/decidim/proposals/import/proposal_answer_creator_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/import/proposal_answer_creator_spec.rb
@@ -10,12 +10,12 @@ describe Decidim::Proposals::Import::ProposalAnswerCreator do
   let(:data) do
     {
       id: proposal.id,
-      state: state,
-      :"answer/en" => Faker::Lorem.paragraph
+      state:,
+      "answer/en": Faker::Lorem.paragraph
     }
   end
   let(:organization) { create(:organization, available_locales: [:en]) }
-  let(:user) { create(:user, organization: organization) }
+  let(:user) { create(:user, organization:) }
   let(:context) do
     {
       current_organization: organization,
@@ -24,7 +24,7 @@ describe Decidim::Proposals::Import::ProposalAnswerCreator do
       current_participatory_space: participatory_process
     }
   end
-  let(:participatory_process) { create :participatory_process, organization: organization }
+  let(:participatory_process) { create :participatory_process, organization: }
   let(:component) { create :component, manifest_name: :proposals, participatory_space: participatory_process }
   let(:state) { %w(evaluating accepted rejected).sample }
 
@@ -38,7 +38,7 @@ describe Decidim::Proposals::Import::ProposalAnswerCreator do
     it "returns the attributes hash" do
       expect(subject.resource_attributes).to eq(
         id: data[:id],
-        :"answer/en" => data[:"answer/en"],
+        "answer/en": data[:"answer/en"],
         state: data[:state]
       )
     end
@@ -56,8 +56,8 @@ describe Decidim::Proposals::Import::ProposalAnswerCreator do
     end
 
     context "with an emendation" do
-      let!(:amendable) { create(:proposal, component: component) }
-      let!(:amendment) { create(:amendment, amendable: amendable, emendation: proposal, state: "evaluating") }
+      let!(:amendable) { create(:proposal, component:) }
+      let!(:amendment) { create(:amendment, amendable:, emendation: proposal, state: "evaluating") }
 
       it "does not produce a record" do
         record = subject.produce
@@ -88,7 +88,7 @@ describe Decidim::Proposals::Import::ProposalAnswerCreator do
       let(:state) { "accepted" }
 
       it "returns broadcast :ok" do
-        expect(subject.finish!).to eq({:ok=>[]})
+        expect(subject.finish!).to eq({ ok: [] })
       end
 
       context "and notifies followers" do
@@ -106,28 +106,28 @@ describe Decidim::Proposals::Import::ProposalAnswerCreator do
     context "when proposal does not exists" do
       let(:data) do
         {
-          id: 99999999,
-          state: state,
-          :"answer/en" => Faker::Lorem.paragraph
+          id: 99_999_999,
+          state:,
+          "answer/en": Faker::Lorem.paragraph
         }
       end
 
       it "broadcasts invalid message" do
-        expect(subject.finish!).to eq({:invalid=>[]})
+        expect(subject.finish!).to eq({ invalid: [] })
       end
     end
 
     context "when state is unknown" do
       let(:data) do
         {
-          id: 99999999,
+          id: 99_999_999,
           state: "fakestate",
-          :"answer/en" => Faker::Lorem.paragraph
+          "answer/en": Faker::Lorem.paragraph
         }
       end
 
       it "broadcasts invalid message" do
-        expect(subject.finish!).to eq({:invalid=>[]})
+        expect(subject.finish!).to eq({ invalid: [] })
       end
     end
   end

--- a/decidim-proposals/spec/lib/decidim/proposals/import/proposal_answer_creator_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/import/proposal_answer_creator_spec.rb
@@ -116,19 +116,5 @@ describe Decidim::Proposals::Import::ProposalAnswerCreator do
         expect(subject.finish!).to eq({ invalid: [] })
       end
     end
-
-    context "when state is unknown" do
-      let(:data) do
-        {
-          id: 99_999_999,
-          state: "fakestate",
-          "answer/en": Faker::Lorem.paragraph
-        }
-      end
-
-      it "broadcasts invalid message" do
-        expect(subject.finish!).to eq({ invalid: [] })
-      end
-    end
   end
 end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
*Please describe your pull request.*

When admin imports proposal answers, followers are not notified. 
This PRs activate notifications on imports like the actual behaviour in backoffice 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10615 

#### Testing
*Describe the best way to test or validate your PR.*

* Log in as user
* Enable notifications by email in Real Time
* Follow three proposals
* As administrator
* Import answers in the previous proposals
* User should receive email in letter opener
* user and admin should receive in-app notification

:hearts: Thank you!
