### PR TITLE
Backport 'Fix Empty participatory process group is created when importing a PP …' to v0.27

### DIFF
--- a/.rubocop_rails.yml
+++ b/.rubocop_rails.yml
@@ -91,3 +91,6 @@ Rails/SkipsModelValidations:
 Rails/Validation:
   Include:
     - decidim-*/app/models/**/*.rb
+
+Rails/CompactBlank:
+  Enabled: false

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -53,6 +53,11 @@ module Decidim
       end
 
       def import_process_group(attributes)
+        title = compact_translation(attributes["title"] || attributes["name"])
+        description = compact_translation(attributes["description"])
+
+        return if title.blank? && description.blank?
+
         Decidim.traceability.perform_action!("create", ParticipatoryProcessGroup, @user) do
           group = ParticipatoryProcessGroup.find_or_initialize_by(
             title: attributes["title"] || attributes["name"],
@@ -151,6 +156,11 @@ module Decidim
       end
 
       private
+
+      def compact_translation(translation)
+        translation["machine_translations"] = translation["machine_translations"].reject { |_k, v| v.blank? } if translation["machine_translations"].present?
+        translation.reject { |_k, v| v.blank? }
+      end
 
       def create_attachment_collection(attributes)
         return unless attributes.compact.any?

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
@@ -94,6 +94,19 @@ module Decidim::ParticipatoryProcesses
           expect(group.title).to eq(group_data["name"])
         end
       end
+
+      context "when the process group is empty" do
+        let(:group_data) do
+          {
+            "title" => Decidim::Faker::Localized.localized { "" },
+            "description" => Decidim::Faker::Localized.localized { "" }
+          }
+        end
+
+        it "does not create a process group" do
+          expect { subject }.not_to change(Decidim::ParticipatoryProcessGroup, :count)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #10692 to v0.27

:hearts: Thank you!