### PR TITLE
Backport 'Fix Redundant notifications when a component is (re)published' to v0.27

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/publish_component.rb
+++ b/decidim-admin/app/commands/decidim/admin/publish_component.rb
@@ -18,7 +18,7 @@ module Decidim
       # Broadcasts :ok if published, :invalid otherwise.
       def call
         publish_component
-        publish_event
+        publish_event unless component.previously_published?
 
         broadcast(:ok)
       end

--- a/decidim-admin/spec/commands/decidim/admin/publish_component_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/publish_component_spec.rb
@@ -40,5 +40,21 @@ module Decidim::Admin
 
       subject.call
     end
+
+    context "when the component is being republished" do
+      let!(:component) { create(:component, :unpublished, participatory_space: participatory_process) }
+      let!(:follower) { create :follow, followable: participatory_process, user: user }
+
+      it "does not fire an event", versioning: true do
+        subject.call
+        component.unpublish!
+        component.reload
+
+        expect(component.previously_published?).to be true
+        expect(Decidim::EventsManager).not_to receive(:publish)
+
+        subject.call
+      end
+    end
   end
 end

--- a/decidim-core/lib/decidim/publicable.rb
+++ b/decidim-core/lib/decidim/publicable.rb
@@ -45,5 +45,9 @@ module Decidim
     def unpublish!
       update!(published_at: nil)
     end
+
+    def previously_published?
+      respond_to?(:versions) && versions.where(event: "update").where("object ->> 'published_at' IS NOT NULL").any?
+    end
   end
 end

--- a/decidim-elections/app/commands/decidim/elections/admin/publish_election.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/publish_election.rb
@@ -19,7 +19,7 @@ module Decidim
         # Broadcasts :ok if published, :invalid otherwise.
         def call
           publish_election
-          publish_event
+          publish_event unless election.previously_published?
 
           broadcast(:ok, election)
         end

--- a/decidim-elections/spec/commands/decidim/elections/admin/publish_election_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/publish_election_spec.rb
@@ -40,5 +40,20 @@ module Decidim::Elections::Admin
 
       subject.call
     end
+
+    context "when the meeting is being republished" do
+      let!(:follower) { create :follow, followable: participatory_process, user: user }
+
+      it "does not fire an event", versioning: true do
+        subject.call
+        election.unpublish!
+        election.reload
+
+        expect(election.previously_published?).to be true
+        expect(Decidim::EventsManager).not_to receive(:publish)
+
+        subject.call
+      end
+    end
   end
 end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/publish_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/publish_meeting.rb
@@ -26,7 +26,7 @@ module Decidim
 
           transaction do
             publish_meeting
-            send_notification
+            send_notification unless meeting.previously_published?
             schedule_upcoming_meeting_notification
           end
 

--- a/decidim-meetings/spec/commands/admin/publish_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/publish_meeting_spec.rb
@@ -61,6 +61,22 @@ module Decidim
 
             subject.call
           end
+
+          context "when the meeting is being republished" do
+            let(:user) { create(:user, organization: organization) }
+            let!(:follower) { create :follow, followable: participatory_process, user: user }
+
+            it "does not fire an event", versioning: true do
+              subject.call
+              meeting.unpublish!
+              meeting.reload
+
+              expect(meeting.previously_published?).to be true
+              expect(Decidim::EventsManager).not_to receive(:publish)
+
+              subject.call
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #10690 to v0.27

:hearts: Thank you!