### PR TITLE
Log author on accept, discard, and reject initiative

### DIFF
--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/accept_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/accept_initiative.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      # A command with all the business logic that accepts an
+      # existing initiative.
+      class AcceptInitiative < Decidim::Command
+        # Public: Initializes the command.
+        #
+        # initiative - Decidim::Initiative
+        # current_user - the user performing the action
+        def initialize(initiative, current_user)
+          @initiative = initiative
+          @current_user = current_user
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form was not valid and we could not proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) if initiative.accepted?
+
+          @initiative = Decidim.traceability.perform_action!(:accept, initiative, current_user) do
+            initiative.accepted!
+            initiative
+          end
+          broadcast(:ok, initiative)
+        end
+
+        private
+
+        attr_reader :initiative, :current_user
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/discard_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/discard_initiative.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      # A command with all the business logic that discards an
+      # existing initiative.
+      class DiscardInitiative < Decidim::Command
+        # Public: Initializes the command.
+        #
+        # initiative - Decidim::Initiative
+        # current_user - the user performing the action
+        def initialize(initiative, current_user)
+          @initiative = initiative
+          @current_user = current_user
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form was not valid and we could not proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) if initiative.discarded?
+
+          @initiative = Decidim.traceability.perform_action!(:discard, initiative, current_user) do
+            initiative.discarded!
+            initiative
+          end
+          broadcast(:ok, initiative)
+        end
+
+        private
+
+        attr_reader :initiative, :current_user
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/reject_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/reject_initiative.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      # A command with all the business logic that rejects an
+      # existing initiative.
+      class RejectInitiative < Decidim::Command
+        # Public: Initializes the command.
+        #
+        # initiative - Decidim::Initiative
+        # current_user - the user performing the action
+        def initialize(initiative, current_user)
+          @initiative = initiative
+          @current_user = current_user
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form was not valid and we could not proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) if initiative.rejected?
+
+          @initiative = Decidim.traceability.perform_action!(:reject, initiative, current_user) do
+            initiative.rejected!
+            initiative
+          end
+          broadcast(:ok, initiative)
+        end
+
+        private
+
+        attr_reader :initiative, :current_user
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -83,22 +83,31 @@ module Decidim
         # DELETE /admin/initiatives/:id/discard
         def discard
           enforce_permission_to :discard, :initiative, initiative: current_initiative
-          current_initiative.discarded!
-          redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
+          DiscardInitiative.call(current_initiative, current_user) do
+            on(:ok) do
+              redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
+            end
+          end
         end
 
         # POST /admin/initiatives/:id/accept
         def accept
           enforce_permission_to :accept, :initiative, initiative: current_initiative
-          current_initiative.accepted!
-          redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
+          AcceptInitiative.call(current_initiative, current_user) do
+            on(:ok) do
+              redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
+            end
+          end
         end
 
         # DELETE /admin/initiatives/:id/reject
         def reject
           enforce_permission_to :reject, :initiative, initiative: current_initiative
-          current_initiative.rejected!
-          redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
+          RejectInitiative.call(current_initiative, current_user) do
+            on(:ok) do
+              redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
+            end
+          end
         end
 
         # GET /admin/initiatives/:id/send_to_technical_validation

--- a/decidim-initiatives/spec/commands/decidim/initiatives/admin/accept_initiative_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/admin/accept_initiative_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    module Admin
+      describe AcceptInitiative do
+        subject { described_class.new(initiative, user) }
+
+        let(:initiative) { create :initiative, :validating }
+        let(:user) { create :user, :admin, :confirmed, organization: initiative.organization }
+
+        context "when the initiative is already accepted" do
+          let(:initiative) { create :initiative, :accepted }
+
+          it "broadcasts :invalid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when everything is ok" do
+          it "accepts the initiative" do
+            expect { subject.call }.to change(initiative, :state).from("validating").to("accepted")
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:perform_action!)
+              .with(:accept, initiative, user)
+              .and_call_original
+
+            expect { subject.call }.to change(Decidim::ActionLog, :count)
+            action_log = Decidim::ActionLog.last
+            expect(action_log.version).to be_present
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/commands/decidim/initiatives/admin/discard_initiative_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/admin/discard_initiative_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    module Admin
+      describe DiscardInitiative do
+        subject { described_class.new(initiative, user) }
+
+        let(:initiative) { create :initiative, :validating }
+        let(:user) { create :user, :admin, :confirmed, organization: initiative.organization }
+
+        context "when the initiative is already discarded" do
+          let(:initiative) { create :initiative, :discarded }
+
+          it "broadcasts :invalid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when everything is ok" do
+          it "discards the initiative" do
+            expect { subject.call }.to change(initiative, :state).from("validating").to("discarded")
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:perform_action!)
+              .with(:discard, initiative, user)
+              .and_call_original
+
+            expect { subject.call }.to change(Decidim::ActionLog, :count)
+            action_log = Decidim::ActionLog.last
+            expect(action_log.version).to be_present
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/commands/decidim/initiatives/admin/reject_initiative_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/admin/reject_initiative_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    module Admin
+      describe RejectInitiative do
+        subject { described_class.new(initiative, user) }
+
+        let(:initiative) { create :initiative, :validating }
+        let(:user) { create :user, :admin, :confirmed, organization: initiative.organization }
+
+        context "when the initiative is already rejected" do
+          let(:initiative) { create :initiative, :rejected }
+
+          it "broadcasts :invalid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when everything is ok" do
+          it "rejects the initiative" do
+            expect { subject.call }.to change(initiative, :state).from("validating").to("rejected")
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:perform_action!)
+              .with(:reject, initiative, user)
+              .and_call_original
+
+            expect { subject.call }.to change(Decidim::ActionLog, :count)
+            action_log = Decidim::ActionLog.last
+            expect(action_log.version).to be_present
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Register the author when accepting, rejecting, and discarding initiatives.

#### :pushpin: Related Issues
- Fixes #10739

#### Testing
1. Go to the admin page of an initiative with the status "validating"
2. Click on "Discard"
3. Check the last entry of the `versions` table and see the column `whodunnit` is filled with the author id

:hearts: Thank you!
