### PR TITLE
Fix meetings calendar filtering

### DIFF
--- a/decidim-meetings/app/controllers/concerns/decidim/meetings/component_filterable.rb
+++ b/decidim-meetings/app/controllers/concerns/decidim/meetings/component_filterable.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Meetings
+    # A controller concern to specify default filter parameters for the
+    # controller resources within a meetings component.
+    module ComponentFilterable
+      extend ActiveSupport::Concern
+
+      included do
+        private
+
+        def default_filter_params
+          {
+            search_text_cont: "",
+            with_any_date: "upcoming",
+            activity: "all",
+            with_availability: "",
+            with_any_scope: default_filter_scope_params,
+            with_any_category: default_filter_category_params,
+            with_any_state: nil,
+            with_any_origin: default_filter_origin_params,
+            with_any_type: default_filter_type_params
+          }
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/controllers/decidim/meetings/calendars_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/calendars_controller.rb
@@ -5,13 +5,17 @@ module Decidim
     # Exposes the meeting resources as an .ics file so users can import them
     # to their favorite calendar app
     class CalendarsController < Decidim::Meetings::ApplicationController
+      include FilterResource
+      include Filterable
+      include ComponentFilterable
+
       layout false
       helper_method :meetings
       before_action :set_default_request_format
       skip_around_action :use_organization_time_zone
 
       def show
-        render plain: CalendarRenderer.for(current_component, params[:filter]), content_type: "type/calendar"
+        render plain: CalendarRenderer.for(current_component, filter_params), content_type: "type/calendar"
       end
 
       def meeting_calendar

--- a/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/directory/meetings_controller.rb
@@ -20,7 +20,7 @@ module Decidim
         helper_method :meetings, :search
 
         def calendar
-          render plain: CalendarRenderer.for(current_organization, params[:filter]), content_type: "type/calendar"
+          render plain: CalendarRenderer.for(current_organization, filter_params), content_type: "type/calendar"
         end
 
         private

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -6,6 +6,7 @@ module Decidim
     class MeetingsController < Decidim::Meetings::ApplicationController
       include FilterResource
       include Filterable
+      include ComponentFilterable
       include Flaggable
       include Withdrawable
       include FormFactory
@@ -128,20 +129,6 @@ module Decidim
 
       def meeting_form
         form(Decidim::Meetings::MeetingForm)
-      end
-
-      def default_filter_params
-        {
-          search_text_cont: "",
-          with_any_date: "upcoming",
-          activity: "all",
-          with_availability: "",
-          with_any_scope: default_filter_scope_params,
-          with_any_category: default_filter_category_params,
-          with_any_state: nil,
-          with_any_origin: default_filter_origin_params,
-          with_any_type: default_filter_type_params
-        }
       end
     end
   end

--- a/decidim-meetings/spec/controllers/decidim/meetings/calendars_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/calendars_controller_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Meetings::CalendarsController, type: :controller do
+  routes { Decidim::Meetings::Engine.routes }
+
+  let(:organization) { create(:organization) }
+  let(:participatory_process) { create :participatory_process, organization: }
+  let(:meeting_component) { create(:meeting_component, :with_creation_enabled, participatory_space: participatory_process) }
+  let!(:meetings) do
+    [].tap do |list|
+      list << create(:meeting, :published, :upcoming, title: { en: "First meeting" }, attending_organizations: "Decidim", component: meeting_component)
+      list << create(:meeting, :published, :upcoming, title: { en: "Second meeting" }, component: meeting_component)
+      list << create(:meeting, :published, :upcoming, title: { en: "Third meeting" }, component: meeting_component)
+    end
+  end
+
+  before do
+    request.env["decidim.current_organization"] = organization
+  end
+
+  describe "#show" do
+    render_views
+
+    let(:params) do
+      {
+        participatory_process_slug: participatory_process.slug,
+        component_id: meeting_component.id,
+        filter: filter_params
+      }
+    end
+    let(:filter_params) { {} }
+
+    before do
+      request.env["decidim.current_participatory_space"] = participatory_process
+      request.env["decidim.current_component"] = meeting_component
+      get :show, params:
+    end
+
+    it { expect(response).to have_http_status(:success) }
+
+    context "with the component parameters" do
+      let(:filter_params) { { search_text_cont: "First meeting" } }
+
+      it "allows filtering" do
+        expect(response.body).to include("First meeting")
+        expect(response.body.scan("BEGIN:VEVENT").size).to eq(1)
+      end
+    end
+
+    context "with a disallowed parameter" do
+      let(:filter_params) { { attending_organizations_eq: "Decidim" } }
+
+      it "does not allow filtering" do
+        expect(response.body.scan("BEGIN:VEVENT").size).to eq(3)
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/controllers/decidim/meetings/directory/meetings_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/directory/meetings_controller_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Meetings::Directory::MeetingsController, type: :controller do
+  routes { Decidim::Meetings::DirectoryEngine.routes }
+
+  let(:organization) { create(:organization) }
+  let(:participatory_process1) { create :participatory_process, organization: }
+  let(:meeting_component1) { create(:meeting_component, :with_creation_enabled, participatory_space: participatory_process1) }
+  let(:participatory_process2) { create :participatory_process, organization: }
+  let(:meeting_component2) { create(:meeting_component, :with_creation_enabled, participatory_space: participatory_process2) }
+
+  let!(:meetings) do
+    [].tap do |list|
+      list << create(:meeting, :published, :upcoming, title: { en: "First meeting" }, attending_organizations: "Decidim", component: meeting_component1)
+      list << create(:meeting, :published, :upcoming, title: { en: "Second meeting" }, component: meeting_component1)
+      list << create(:meeting, :published, :upcoming, title: { en: "Third meeting" }, component: meeting_component2)
+    end
+  end
+
+  before do
+    request.env["decidim.current_organization"] = organization
+  end
+
+  describe "#show" do
+    render_views
+
+    let(:params) { { filter: filter_params } }
+    let(:filter_params) { {} }
+
+    before do
+      get :calendar, params:
+    end
+
+    it { expect(response).to have_http_status(:success) }
+
+    context "with an allowed parameter" do
+      let(:filter_params) { { title_or_description_cont: "First meeting" } }
+
+      it "allows filtering" do
+        expect(response.body).to include("First meeting")
+        expect(response.body.scan("BEGIN:VEVENT").size).to eq(1)
+      end
+    end
+
+    context "with a disallowed parameter" do
+      let(:filter_params) { { attending_organizations_eq: "Decidim" } }
+
+      it "does not allow filtering" do
+        expect(response.body.scan("BEGIN:VEVENT").size).to eq(3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently the meetings calendar passes all the URL filters to the ransack search which is not desired. Instead, we want to limit the available searching options for those that we provide within the user interface.

This PR refactors the meetings calendar filtering so that it works similarly to the form searches we use elsewhere for the search filtering seen in Decidim UIs.

#### :pushpin: Related Issues
- Related to
  * #9035
  * #8748

#### Testing
- Create a meetings component to test with
- Create few new meetings in the component or use the ones from the seeds
- Close one of the meetings and write "Decidim" in the "List of organizations that attended"
- Go to the meetings component
- At the end of the URL, write `?filter%5Battending_organizations_eq%5D=Decidim` (if the meeting is in the past, also add `&filter%5Bwith_any_date%5D=past` at the end of the URL)
- Note that this will have no effect in the list of results that you see in the UI
- Click the "Export calendar" link in the view and go into that link, the ical file will be downloaded to your downloads folder
- Inspect the file and see that it only contains the meeting that you closed with that text in the attending organizations
- After applying this patch, test again and see that the last step above is no longer the case