### PR TITLE
Add context argument to the SMS gateway initializer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -434,3 +434,5 @@ class MySMSGatewayService
   # ...
 end
 ```
+
+You can read more about this change at PR [\#10760](https://github.com/decidim/decidim/pull/10760).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -403,3 +403,34 @@ end
 ```
 
 You can read more about this change at PR [\#10111](https://github.com/decidim/decidim/pull/10111).
+
+### 5.4. Extra context argument added to SMS gateway implementations
+
+If you have integrated any [SMS gateways](https://docs.decidim.org/en/develop/services/sms), there is a small change in the API that needs to be reflected to the SMS integrations. An extra `context` attribute is passed to the SMS gateway's initializer which can be used to pass e.g. the correct organization for the gateway to utilize.
+
+In previous versions your SMS gateway initializer might have looked like the following:
+
+```ruby
+class MySMSGatewayService
+  attr_reader :mobile_phone_number, :code
+  def initialize(mobile_phone_number, code)
+    @mobile_phone_number = mobile_phone_number
+    @code = code
+  end
+  # ...
+end
+```
+
+From now on, you will need to change it as follows (note the extra `context` attribute):
+
+```ruby
+class MySMSGatewayService
+  attr_reader :mobile_phone_number, :code, :context
+  def initialize(mobile_phone_number, code, context = {})
+    @mobile_phone_number = mobile_phone_number
+    @code = code
+    @context = context
+  end
+  # ...
+end
+```

--- a/decidim-elections/app/commands/decidim/votings/send_access_code.rb
+++ b/decidim-elections/app/commands/decidim/votings/send_access_code.rb
@@ -30,7 +30,7 @@ module Decidim
         when "email"
           AccessCodeMailer.send_access_code(datum).deliver_later
         when "sms"
-          sms_gateway.new(datum.mobile_phone_number, access_code).deliver_code
+          sms_gateway.new(datum.mobile_phone_number, access_code, sms_gateway_context).deliver_code
         else
           raise ArgumentError, "Medium parameter is invalid"
         end
@@ -38,6 +38,10 @@ module Decidim
 
       def sms_gateway
         Decidim.sms_gateway_service.to_s.safe_constantize
+      end
+
+      def sms_gateway_context
+        { organization: try(:current_organization) }
       end
 
       def access_code

--- a/decidim-elections/spec/commands/decidim/votings/send_access_code_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/send_access_code_spec.rb
@@ -4,8 +4,9 @@ require "spec_helper"
 
 module Decidim::Votings
   describe SendAccessCode do
-    subject { described_class.new(datum, medium) }
+    subject { command }
 
+    let(:command) { described_class.new(datum, medium) }
     let(:voting) { create(:voting) }
     let(:datum) { create(:datum, :with_access_code, dataset:) }
     let(:mobile_phone_number) { datum.mobile_phone_number }
@@ -46,8 +47,9 @@ module Decidim::Votings
         end
 
         it "sends a SMS" do
+          allow(command).to receive(:current_organization).and_return(voting.organization)
           expect(Decidim::Verifications::Sms::ExampleGateway)
-            .to(receive(:new).with(mobile_phone_number, access_code))
+            .to(receive(:new).with(mobile_phone_number, access_code, { organization: voting.organization }))
             .and_return(double(deliver_code: true))
           subject.call
         end

--- a/decidim-verifications/app/forms/decidim/verifications/sms/mobile_phone_form.rb
+++ b/decidim-verifications/app/forms/decidim/verifications/sms/mobile_phone_form.rb
@@ -43,13 +43,17 @@ module Decidim
           return unless sms_gateway
           return @verification_code if defined?(@verification_code)
 
-          return unless sms_gateway.new(mobile_phone_number, generated_code).deliver_code
+          return unless sms_gateway.new(mobile_phone_number, generated_code, sms_gateway_context).deliver_code
 
           @verification_code = generated_code
         end
 
         def sms_gateway
           Decidim.sms_gateway_service.to_s.safe_constantize
+        end
+
+        def sms_gateway_context
+          { organization: user&.organization }
         end
 
         def generated_code

--- a/decidim-verifications/lib/decidim/verifications/sms/example_gateway.rb
+++ b/decidim-verifications/lib/decidim/verifications/sms/example_gateway.rb
@@ -4,11 +4,12 @@ module Decidim
   module Verifications
     module Sms
       class ExampleGateway
-        attr_reader :mobile_phone_number, :code
+        attr_reader :mobile_phone_number, :code, :context
 
-        def initialize(mobile_phone_number, code)
+        def initialize(mobile_phone_number, code, context = {})
           @mobile_phone_number = mobile_phone_number
           @code = code
+          @context = context
         end
 
         def deliver_code

--- a/decidim-verifications/spec/forms/decidim/verifications/sms/mobile_phone_form_spec.rb
+++ b/decidim-verifications/spec/forms/decidim/verifications/sms/mobile_phone_form_spec.rb
@@ -54,7 +54,7 @@ module Decidim::Verifications::Sms
       context "when the code delivery fails" do
         before do
           allow(Decidim::Verifications::Sms::ExampleGateway)
-            .to(receive(:new).with(mobile_phone_number, kind_of(String)))
+            .to(receive(:new).with(mobile_phone_number, kind_of(String), { organization: kind_of(Decidim::Organization) }))
             .and_return(double(deliver_code: nil))
         end
 

--- a/docs/modules/configure/pages/initializer.adoc
+++ b/docs/modules/configure/pages/initializer.adoc
@@ -268,10 +268,11 @@ An example class would be something like:
 [source,ruby]
 ....
 class MySMSGatewayService
-  attr_reader :mobile_phone_number, :code
-  def initialize(mobile_phone_number, code)
+  attr_reader :mobile_phone_number, :code, :context
+  def initialize(mobile_phone_number, code, context = {})
     @mobile_phone_number = mobile_phone_number
     @code = code
+    @context = context
   end
   def deliver_code
     # Actual code to deliver the code

--- a/docs/modules/services/pages/sms.adoc
+++ b/docs/modules/services/pages/sms.adoc
@@ -22,6 +22,12 @@ class MySMSGatewayService
 end
 ....
 
+The arguments provided for the initialize method are:
+
+- `mobile_phone_number` - The full mobile phone number to send the message to, containing the country code.
+- `code` - The code or the message to be sent to the given mobile phone number.
+- `context` - An extra context attribute which can be used to pass e.g. the correct organization for the gateway to utilize.
+
 Then you will need to configure it in the Decidim initializer:
 
 [source,ruby]
@@ -31,3 +37,5 @@ Then you will need to configure it in the Decidim initializer:
 
 You can find an example on how this is set up at https://github.com/AjuntamentdeBarcelona/decidim-barcelona/blob/672f5a8938d884940899b4304f0a17e25d42d2a0/app/services/sms_gateway.rb[DecidimBarcelona's app/services/sms_gateway.rb]. Your final implementation will depend on how your SMS provider works.
 
+Another example which also utilizes the `context` argument can be found from the Twilio SMS integration available at:
+https://github.com/Pipeline-to-Power/decidim-module-ptp/blob/aa82286d91d404e83ea16a55d281a1b049bbaca2/decidim-sms-twilio/lib/decidim/sms/twilio/gateway.rb

--- a/docs/modules/services/pages/sms.adoc
+++ b/docs/modules/services/pages/sms.adoc
@@ -9,10 +9,11 @@ An example class would be something like:
 [source,ruby]
 ....
 class MySMSGatewayService
-  attr_reader :mobile_phone_number, :code
-  def initialize(mobile_phone_number, code)
+  attr_reader :mobile_phone_number, :code, :context
+  def initialize(mobile_phone_number, code, context = {})
     @mobile_phone_number = mobile_phone_number
     @code = code
+    @context = context
   end
   def deliver_code
     # Actual code to deliver the code


### PR DESCRIPTION
#### :tophat: What? Why?
Some SMS gateways need to generate paths back to the correct organization, e.g. for passing the correct callback URLs for the SMS sending API.

An actual example of this is the Twilio SMS integration and particularly this part of that integration:
https://github.com/Pipeline-to-Power/decidim-module-ptp/blob/aa82286d91d404e83ea16a55d281a1b049bbaca2/decidim-sms-twilio/lib/decidim/sms/twilio/gateway.rb#L91-L94

We needed this so this might be useful to have as a default argument also in the core.

#### Testing
See that CI is green.