### PR TITLE
Fix images URL in newsletters

### DIFF
--- a/decidim-core/app/helpers/decidim/newsletters_helper.rb
+++ b/decidim-core/app/helpers/decidim/newsletters_helper.rb
@@ -8,28 +8,28 @@ module Decidim
     # for example transform "https://es.lipsum.com/" to "https://es.lipsum.com/?utm_source=localhost&utm_campaign=newsletter_11"
     # And replace "%{name}" on the subject or content of newsletter to the user Name
     # for example transform "%{name}" to "User Name"
+    #
+    # @param content [String] - the string to convert
+    # @param user [Decidim::User] - the user to replace
+    # @param id [Integer] - the id of the newsletter to change
+    #
+    # @return [String] - the content converted
     def parse_interpolations(content, user = nil, id = nil)
-      if Decidim.config.track_newsletter_links && id.present? && user.present?
-        host = user.organization.host.to_s
-        campaign = "newsletter_#{id}"
+      host = user&.organization&.host&.to_s
 
-        links = content.scan(/href\s*=\s*"([^"]*)"/)
-
-        links.each do |link|
-          link_replaced = link.first + utm_codes(host, campaign)
-          content = content.gsub(/href\s*=\s*"([^"]*#{link.first})"/, %(href="#{link_replaced}"))
-        end
-      end
-
-      if user.present?
-        content.gsub("%{name}", user.name)
-      else
-        content.gsub("%{name}", "")
-      end
+      content = interpret_name(content, user)
+      content = track_newsletter_links(content, id, host)
+      transform_image_urls(content, host)
     end
 
     # this method is used to generate the root link on mail with the utm_codes
     # If the newsletter_id is nil, it returns the root_url
+    #
+    # @param organization [Decidim::Organization] - the Organization of this newsletter
+    # @param newsletter_id [Integer] - the id of the newsletter
+    #
+    # @return [String] - the root_url converted
+    #
     def custom_url_for_mail_root(organization, newsletter_id = nil)
       decidim = EngineRouter.new("decidim", {})
       if newsletter_id.present?
@@ -39,10 +39,77 @@ module Decidim
       end
     end
 
+    private
+
     # Method to specify the utm_codes.
     # You can change or add utm_codes for track
+    #
+    # @param host [String] - the Decidim::Organization host add to the URL
+    # @param newsletter_id [String] - the ID of the newsletter
+    #
+    # @return [String] - the UTM codes to be added
+    #
     def utm_codes(host, newsletter_id)
       "?utm_source=#{host}&utm_campaign=#{newsletter_id}"
+    end
+
+    # Interpret placeholder '%{name}' and replace by the user name
+    # If user is not define, it returns content with blank instead of the placeholder
+    #
+    # @param content [String] - the string to convert
+    # @param user [Decidim::User] - the user to replace
+    #
+    # @return [String] - the content converted
+    #
+    def interpret_name(content, user)
+      return content.gsub("%{name}", "") if user.blank?
+
+      content.gsub("%{name}", user.name)
+    end
+
+    # Find each img HTML tag with relative path in src attribute
+    # For each URL, prepends the decidim.root_url
+    #   If host is not defined it returns full content
+    #
+    # @param content [String] - the string to convert
+    # @param host [String] - the Decidim::Organization host to replace
+    #
+    # @return [String] - the content converted
+    #
+    def transform_image_urls(content, host)
+      return content if host.blank?
+
+      content.scan(/src\s*=\s*"([^"]*)"/).each do |src|
+        root_url = decidim.root_url(host:)[0..-2]
+        src_replaced = "#{root_url}#{src.first}"
+        content = content.gsub(/src\s*=\s*"([^"]*#{src.first})"/, %(src="#{src_replaced}"))
+      end
+
+      content
+    end
+
+    # Add tracking query params to each links
+    #
+    # @param content [String] - the string to convert
+    # @param id [Integer] - the id of the newsletter
+    # @param host [String] - the Decidim::Organization host
+    #
+    # @return [String] - the content converted
+    #
+    def track_newsletter_links(content, id, host)
+      return content unless Decidim.config.track_newsletter_links
+      return content if id.blank?
+      return content if host.blank?
+
+      campaign = "newsletter_#{id}"
+      links = content.scan(/href\s*=\s*"([^"]*)"/)
+
+      links.each do |link|
+        link_replaced = link.first + utm_codes(host, campaign)
+        content = content.gsub(/href\s*=\s*"([^"]*#{link.first})"/, %(href="#{link_replaced}"))
+      end
+
+      content
     end
   end
 end

--- a/decidim-core/spec/helpers/decidim/newsletters_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/newsletters_helper_spec.rb
@@ -7,24 +7,56 @@ require "spec_helper"
 #
 module Decidim
   describe NewslettersHelper do
+    let(:user) { create(:user, name: "Jane Doe", organization:) }
+    let(:organization) { create(:organization, host: "localhost") }
+    let(:newsletter) { create(:newsletter) }
+    let(:text) do
+      %{(<p>Hello, %{name}</p>
+<a href="https://meta.decidim.org">Link</a>
+<img src="/rails/active_storage/blobs/redirect/12345.JPG" alt="image" />
+<a href="https://meta.decidim.org/">Link</a>
+<img src="/rails/active_storage/blobs/redirect/56789.JPG" alt="second image" />)}
+    end
+
     describe "#parse_interpolations" do
-      describe "when the user is present" do
-        subject { helper.parse_interpolations(text, user, newsletter.id) }
+      subject { helper.parse_interpolations(text, user, newsletter.id) }
 
-        let(:text) { %{(<p>Hello, %{name} <a href="https://google.com">Link</a></p>)} }
-        let(:user) { create(:user, name: "User Name") }
-        let(:organization) { create(:organization, host: "localhost") }
-        let(:newsletter) { create(:newsletter) }
-
-        it { is_expected.to eq(%{(<p>Hello, User Name <a href="https://google.com?utm_source=#{user.organization.host}&utm_campaign=newsletter_#{newsletter.id}">Link</a></p>)}) }
+      it "replaces %{name} with user name" do
+        expect(subject).to include("Hello, Jane Doe")
       end
 
-      describe "when the user is not present" do
+      it "replaces links with utm codes" do
+        expect(subject).to include("https://meta.decidim.org?utm_source=#{organization.host}&utm_campaign=newsletter_#{newsletter.id}")
+        expect(subject).to include("https://meta.decidim.org/?utm_source=#{organization.host}&utm_campaign=newsletter_#{newsletter.id}")
+      end
+
+      it "transforms image URLs with the host" do
+        expect(subject).to include('<img src="http://localhost/rails/active_storage/blobs/redirect/12345.JPG"')
+        expect(subject).to include('<img src="http://localhost/rails/active_storage/blobs/redirect/56789.JPG"')
+      end
+
+      context "when track_newsletter_links is false" do
+        before do
+          allow(Decidim.config).to receive(:track_newsletter_links).and_return(false)
+        end
+
+        it "does not replace links with utm codes" do
+          expect(subject).to include('<a href="https://meta.decidim.org">Link</a>')
+          expect(subject).to include('<a href="https://meta.decidim.org/">Link</a>')
+          expect(subject).not_to include("?utm_source=#{organization.host}&utm_campaign=newsletter_#{newsletter.id}")
+        end
+      end
+
+      context "when the user is not present" do
         subject { helper.parse_interpolations(text) }
 
-        let(:text) { "<p>Hello, %{name}</p>" }
+        it { is_expected.to include("<p>Hello, </p>") }
 
-        it { is_expected.to eq("<p>Hello, </p>") }
+        it "does not replace links with utm codes" do
+          expect(subject).to include('<a href="https://meta.decidim.org">Link</a>')
+          expect(subject).to include('<a href="https://meta.decidim.org/">Link</a>')
+          expect(subject).not_to include("?utm_source=#{organization.host}&utm_campaign=newsletter_#{newsletter.id}")
+        end
       end
     end
 
@@ -43,6 +75,45 @@ module Decidim
         subject { helper.custom_url_for_mail_root(organization) }
 
         it { is_expected.to eq(decidim.root_url(host: organization.host, port: Capybara.server_port)) }
+      end
+    end
+
+    describe "#utm_codes" do
+      subject { helper.send(:utm_codes, organization.host, newsletter.id) }
+
+      it "returns the utm codes" do
+        expect(subject).to eq("?utm_source=#{organization.host}&utm_campaign=#{newsletter.id}")
+      end
+    end
+
+    describe "#interpret_name" do
+      subject { helper.send(:interpret_name, text, user) }
+
+      it "replaces '%{name}' with user name" do
+        expect(subject).to include("Hello, Jane Doe")
+      end
+
+      context "when user is not present" do
+        subject { helper.send(:interpret_name, text, nil) }
+
+        it { is_expected.to include("<p>Hello, </p>") }
+      end
+    end
+
+    describe "#transform_image_urls" do
+      subject { helper.send(:transform_image_urls, text, organization.host) }
+
+      it "transforms image URLs with the host" do
+        expect(subject).to include('<img src="http://localhost/rails/active_storage/blobs/redirect/12345.JPG"')
+        expect(subject).to include('<img src="http://localhost/rails/active_storage/blobs/redirect/56789.JPG"')
+      end
+
+      context "when host is not present" do
+        subject { helper.send(:transform_image_urls, text, nil) }
+
+        it "returns the full content" do
+          expect(subject).to eq text
+        end
       end
     end
   end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
*Please describe your pull request.*

Images uploaded with the WYSWYG editor are not accessible out of the application like images uploaded in newsletter. 

At the moment, `EditorImagesController#create` returns the path of the newly uploaded image. Source will be correctly resolved from the application, however we should return a full URL for external resources like newsletter. 

This PR allows to rewrite source url in `img` HTML tags of newsletters content on the fly. Uploaded images url will be stored as relative path in database, and organization host with protocol will be interpolated on each image of the content just before being sent.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10465 

#### Testing
*Describe the best way to test or validate your PR.*

1. Upload a new image in newsletter content editor
2. Send newsletter
3. Verify HTML and see full URL in img src

:hearts: Thank you!
