### PR TITLE
Fix missing translations for SMS confirmation when signing a petition

### DIFF
--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -7,6 +7,8 @@ en:
         offline: Offline
         offline_explanation: Instructions for offline verification
         online: Online
+      confirmation:
+        verification_code: Verification code
       id_document_information:
         document_number: Document number (with letter)
         document_type: Type of the document
@@ -15,6 +17,8 @@ en:
         document_type: Type of your document
         user: Participant
         verification_attachment: Scanned copy of your document
+      mobile_phone:
+        mobile_phone_number: Mobile phone number
       offline_confirmation:
         email: Participant email
       postal_letter_address:


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
*Please describe your pull request.*

This PR adds locales so you can translates or modify the form labels when requesting an sms after signing an initiative

#### :pushpin: Related Issues
- Fixes #10749 

#### Testing
*Describe the best way to test or validate your PR.*

1. add the sms verification in your initiative type setting
2. Change locale and try to sign an initiative
3. See the labels for the phone number and the verification code are now translated

:hearts: Thank you!
