### PR TITLE
Add missing translations in consultations

### DIFF
--- a/decidim-consultations/config/locales/en.yml
+++ b/decidim-consultations/config/locales/en.yml
@@ -362,6 +362,10 @@ en:
         actions:
           comment: Comment
           vote: Vote
+      question:
+        actions:
+          comment: Comment
+          vote: Vote
     statistics:
       consultations_count: Consultations
       votes_count: Votes


### PR DESCRIPTION
#### :tophat: What? Why?
These translations are missing which causes the admin permissions view to break at consultation -> questions -> key sign next to each question in the question list.

#### Testing
- Create a default development app with seeds
- Go to admin -> consultations -> go inside one consultation
- Go to the questions view
- Click the key sign next to some question
- See exception

### :camera: Screenshots
![Key sign next to question](https://user-images.githubusercontent.com/864340/234325229-5a8cbf15-afe3-427c-a742-2d5a6cf28a05.png)