### PR TITLE
Backport 'Supports no longer visible for linked proposals if supports are disabled' to v0.27

### DIFF
--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -674,6 +674,36 @@ describe "Orders", type: :system do
           expect(page).to have_content(proposal.votes.size)
         end
       end
+
+      context "with supports enabled" do
+        let(:proposal_component) do
+          create(:proposal_component, :with_votes_enabled, participatory_space: project.component.participatory_space)
+        end
+
+        let(:proposals) { create_list(:proposal, 1, :with_votes, component: proposal_component) }
+
+        it "shows the amount of supports" do
+          visit_budget
+          click_link translated(project.title)
+
+          expect(page.find('span[class="card--list__data__number"]')).to have_content("5")
+        end
+      end
+
+      context "with supports disabled" do
+        let(:proposal_component) do
+          create(:proposal_component, participatory_space: project.component.participatory_space)
+        end
+
+        let(:proposals) { create_list(:proposal, 1, :with_votes, component: proposal_component) }
+
+        it "does not show supports" do
+          visit_budget
+          click_link translated(project.title)
+
+          expect(page).not_to have_selector('span[class="card--list__data__number"]')
+        end
+      end
     end
   end
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
@@ -22,7 +22,8 @@
           <% end %>
         </div>
       </div>
-      <% if !current_settings.try(:votes_hidden?) && !proposal.component.current_settings.votes_hidden? %>
+      <% if !current_settings.try(:votes_hidden?) && !proposal.component.current_settings.votes_hidden? &&
+      proposal.component.current_settings.votes_enabled? %>
         <div class="card--list__data">
           <span class="card--list__data__number">
             <%= proposal.votes.size %>


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #10671 to v0.27

:hearts: Thank you!