### PR TITLE
Backport 'Add missing translations in consultations' to v0.27

### DIFF
--- a/decidim-consultations/config/locales/en.yml
+++ b/decidim-consultations/config/locales/en.yml
@@ -362,6 +362,10 @@ en:
         actions:
           comment: Comment
           vote: Vote
+      question:
+        actions:
+          comment: Comment
+          vote: Vote
     statistics:
       consultations_count: Consultations
       votes_count: Votes


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #10773 to v0.27

:hearts: Thank you!