### PR TITLE
Fix Moderated comments are displayed in notifications

### DIFF
--- a/decidim-comments/app/events/decidim/comments/comment_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_event.rb
@@ -11,6 +11,8 @@ module Decidim
 
       included do
         def resource_text(override_translation = nil)
+          return I18n.t("decidim.components.comment.moderated_at", date: comment.moderation&.hidden_at) if comment&.hidden?
+
           translated_body = translated_attribute(comment.body, comment.organization, override_translation)
           Decidim::ContentProcessor.render(sanitize_content(render_markdown(translated_body)), "div")
         end

--- a/decidim-comments/app/events/decidim/comments/comment_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_event.rb
@@ -12,6 +12,7 @@ module Decidim
       included do
         def resource_text(override_translation = nil)
           return I18n.t("decidim.components.comment.moderated_at", date: comment.moderation&.hidden_at) if comment&.hidden?
+          return I18n.t("decidim.components.comment.deleted_at", date: comment.deleted_at) if comment&.deleted?
 
           translated_body = translated_attribute(comment.body, comment.organization, override_translation)
           Decidim::ContentProcessor.render(sanitize_content(render_markdown(translated_body)), "div")

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/comment_event.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/comment_event.rb
@@ -42,4 +42,21 @@ shared_examples_for "a comment event" do
       expect(subject.resource_text).to eq comment.formatted_body
     end
   end
+
+  context "when is deleted" do
+    let(:comment) { create :comment, :deleted }
+
+    it "outputs the comment body" do
+      expect(subject.resource_text).to include("Comment deleted on")
+    end
+  end
+
+  context "when is moderated" do
+    let(:comment) { create :comment, :deleted }
+    let!(:moderation) { create(:moderation, hidden_at: 6.hours.ago, reportable: comment) }
+
+    it "outputs the comment body" do
+      expect(subject.resource_text).to include("Comment moderated on")
+    end
+  end
 end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR prevents moderated and deleted comments to be displayed in the notification area. This is a PR that affects only Decidim prior version 0.28-dev.

#### Testing
Within any instance < 0.28-dev
1. Login as admin , and follow a proposal, then logout 
2. Login as a second user 
3. Visit the proposal page followed by admin 
4. Post a comment that will be moderated 
5. Post a comment, then delete it 
6. Logout 
7. Login as admin and moderate the comment 
8. Visit the notification section, and see the way the notifications look like

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
Before:
![image](https://user-images.githubusercontent.com/105683/234550363-26918c9c-9f4f-48da-982f-3d1deb92d3c2.png)


After
![image](https://user-images.githubusercontent.com/105683/234550733-be89ad62-217c-44f7-9bca-f5120bac4bfe.png)


:hearts: Thank you!
