### PR TITLE
Remove decidim-design public reference from documentation

### DIFF
--- a/docs/modules/develop/pages/guide.adoc
+++ b/docs/modules/develop/pages/guide.adoc
@@ -8,6 +8,5 @@
 
 == Good to know
 
-* There is an application with current designs at: https://decidim-design.herokuapp.com/
 * We follow https://12factor.net/[12factor recommendations]
 * For testing, refer to the xref:develop:testing.adoc[testing] guide.


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

Today in a meeting with @rxnetwalker and @carolromero we agreed that the public web of `decidim_app-design` will be deprecated in the short term, so we need to remove the reference to https://decidim-design.herokuapp.com/ shortly. 

:hearts: Thank you!
