### PR TITLE
Fix issues with unexpected date filter params for the process listing

### DIFF
--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_filters_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_filters_cell.rb
@@ -13,7 +13,7 @@ module Decidim
       end
 
       def current_filter
-        get_filter(:with_date, model[:default_filter])
+        get_filter_in(:with_date, ALL_FILTERS, model[:default_filter])
       end
 
       def current_type_filter_name
@@ -23,6 +23,11 @@ module Decidim
 
       def get_filter(filter_name, default = nil)
         params&.dig(:filter, filter_name) || default
+      end
+
+      def get_filter_in(filter_name, options, default = nil)
+        value = get_filter(filter_name)
+        options.include?(value) ? value : default
       end
 
       def filter_params(date_filter, type_filter)

--- a/decidim-participatory_processes/spec/cells/decidim/participatory_processes/process_filters_cell_spec.rb
+++ b/decidim-participatory_processes/spec/cells/decidim/participatory_processes/process_filters_cell_spec.rb
@@ -10,17 +10,51 @@ module Decidim::ParticipatoryProcesses
     let!(:participatory_process_list1) { create_list(:participatory_process, 2, :published, organization: organization1) }
     let!(:participatory_process_list2) { create_list(:participatory_process, 2, :published, organization: organization2) }
 
-    subject { cell("decidim/participatory_processes/process_filters", default_filter: "active") }
+    let(:my_cell) { cell("decidim/participatory_processes/process_filters", default_filter:) }
+    let(:default_filter) { "active" }
+    let(:filter_params) { { with_date: "all" } }
+
+    subject { my_cell }
     controller Decidim::ParticipatoryProcesses::ParticipatoryProcessesController
 
     before do
       allow(controller).to receive(:current_organization).and_return(organization1)
-      allow(subject).to receive(:controller).and_return(controller)
-      allow(subject).to receive(:params).and_return(ActionController::Parameters.new({ filter: { with_date: "all" } }))
+      allow(my_cell).to receive(:controller).and_return(controller)
+      allow(my_cell).to receive(:params).and_return(ActionController::Parameters.new({ filter: filter_params }))
     end
 
     it "counts the processes" do
       expect(subject.filtered_processes("all", filter_with_type: false).count).to eq(2)
+    end
+
+    describe "#current_filter" do
+      subject { my_cell.current_filter }
+
+      let(:filter_params) { { with_date: date_filter } }
+
+      shared_examples "expected current_filter value" do |given_value|
+        let(:date_filter) { given_value }
+
+        it { is_expected.to eq(given_value) }
+      end
+
+      shared_examples "unexpected current_filter_value" do |given_value|
+        let(:date_filter) { given_value }
+
+        it { is_expected.to eq(default_filter) }
+      end
+
+      it_behaves_like "expected current_filter value", "active"
+      it_behaves_like "expected current_filter value", "upcoming"
+      it_behaves_like "expected current_filter value", "past"
+      it_behaves_like "expected current_filter value", "all"
+
+      it_behaves_like "unexpected current_filter_value", nil
+      it_behaves_like "unexpected current_filter_value", ["upcoming"]
+      it_behaves_like "unexpected current_filter_value", { 1 => "upcoming" }
+      it_behaves_like "unexpected current_filter_value", "unknown"
+      it_behaves_like "unexpected current_filter_value", "upcomingfoobar"
+      it_behaves_like "unexpected current_filter_value", "upcoming foobar"
     end
   end
 end

--- a/decidim-participatory_processes/spec/requests/participatory_process_search_spec.rb
+++ b/decidim-participatory_processes/spec/requests/participatory_process_search_spec.rb
@@ -117,5 +117,22 @@ RSpec.describe "Participatory process search", type: :request do
         expect(subject).to include(translated(upcoming_process.title))
       end
     end
+
+    context "and the date is set to an unknown value" do
+      let(:date) { "foobar" }
+      let(:dom) { Nokogiri::HTML(subject) }
+
+      it "displays all public processes" do
+        expect(subject).to include(translated(process1.title))
+        expect(subject).to include(translated(process2.title))
+        expect(subject).to include(translated(past_process.title))
+        expect(subject).to include(translated(upcoming_process.title))
+      end
+
+      it "does not cause any display issues" do
+        expect(dom.css("#processes-grid .processes-grid-order-by .section-heading").text).to include("2 active processes")
+        expect(dom.css("#processes-grid .processes-grid-order-by .section-heading").text).not_to include("foobar")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently the passing some unexpected values to the process date filter can cause some errors.

This fixes the issue by ensuring the date filter is always one of the expected values.