### PR TITLE
Feature/redesign content blocks default filters

### DIFF
--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
@@ -1,3 +1,3 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, [4, 8, 12], prompt: "", label: label %>
+  <%= settings_fields.select :max_results, [3, 6, 9, 12, unlimited_label], prompt: "", label: max_results_label %>
 <% end %>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
@@ -1,3 +1,4 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
   <%= settings_fields.select :max_results, [3, 6, 9, 12, unlimited_label], prompt: "", label: max_results_label %>
+  <%= settings_fields.select(:default_filter, default_filter_options, prompt: "", label: default_filter_label) if include_default_filter_setting? %>
 <% end %>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form_cell.rb
@@ -10,8 +10,12 @@ module Decidim
           options[:content_block]
         end
 
-        def label
+        def max_results_label
           I18n.t("decidim.participatory_processes.admin.content_blocks.highlighted_processes.max_results")
+        end
+
+        def unlimited_label
+          I18n.t("decidim.participatory_processes.admin.content_blocks.highlighted_processes.unlimited")
         end
       end
     end

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form_cell.rb
@@ -17,6 +17,19 @@ module Decidim
         def unlimited_label
           I18n.t("decidim.participatory_processes.admin.content_blocks.highlighted_processes.unlimited")
         end
+
+        def default_filter_label
+          I18n.t("decidim.participatory_processes.admin.content_blocks.highlighted_processes.selection_criteria")
+        end
+
+        def include_default_filter_setting?
+          form.object.settings.attribute_names.include? "default_filter"
+        end
+
+        def default_filter_options
+          [[I18n.t("decidim.participatory_processes.admin.content_blocks.highlighted_processes.active"), "active"],
+           [I18n.t("decidim.participatory_processes.admin.content_blocks.highlighted_processes.all"), "all"]]
+        end
       end
     end
   end

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/related_processes/content.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/related_processes/content.erb
@@ -1,1 +1,1 @@
-<%= cell "decidim/participatory_processes/processes", related_processes.limit(limit), total_count: %>
+<%= cell "decidim/participatory_processes/processes", limited_processes, total_count: %>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/related_processes_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/related_processes_cell.rb
@@ -12,6 +12,12 @@ module Decidim
             .all
         end
 
+        def limited_processes
+          return related_processes unless limit?
+
+          related_processes.limit(limit)
+        end
+
         def total_count
           related_processes.size
         end
@@ -23,7 +29,11 @@ module Decidim
         end
 
         def limit
-          model.settings.try(:max_results)
+          @limit ||= model.settings.try(:max_results)
+        end
+
+        def limit?
+          limit.to_i.positive?
         end
       end
     end

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/related_processes_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/related_processes_cell.rb
@@ -43,7 +43,7 @@ module Decidim
         end
 
         def default_filter
-          model.settings.try(:default_filter) || "active"
+          model.settings.try(:default_filter)
         end
 
         def limit?

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/related_processes_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/related_processes_cell.rb
@@ -12,14 +12,20 @@ module Decidim
             .all
         end
 
-        def limited_processes
-          return related_processes unless limit?
+        def filtered_processes
+          return related_processes unless filter_active?
 
-          related_processes.limit(limit)
+          related_processes.active
+        end
+
+        def limited_processes
+          return filtered_processes unless limit?
+
+          filtered_processes.limit(limit)
         end
 
         def total_count
-          related_processes.size
+          filtered_processes.size
         end
 
         private
@@ -30,6 +36,14 @@ module Decidim
 
         def limit
           @limit ||= model.settings.try(:max_results)
+        end
+
+        def filter_active?
+          default_filter == "active"
+        end
+
+        def default_filter
+          model.settings.try(:default_filter) || "active"
         end
 
         def limit?

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -412,7 +412,10 @@ en:
       admin:
         content_blocks:
           highlighted_processes:
+            active: Active
+            all: All
             max_results: Maximum amount of elements to show
+            selection_criteria: Selection criteria
             unlimited: Unlimited
         new_import:
           accepted_types:

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -413,6 +413,7 @@ en:
         content_blocks:
           highlighted_processes:
             max_results: Maximum amount of elements to show
+            unlimited: Unlimited
         new_import:
           accepted_types:
             json: JSON


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

WIP This PR improves settings of processes content blocks by:
* Adding an unlimited option to show all processes of the query
* Including a default filter for the items: Active (default) or all.

*Please describe your pull request.*

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #10707?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
