### PR TITLE
Fix Inconsistent datetime distance_in_words translations

### DIFF
--- a/decidim-core/app/presenters/decidim/notification_presenter.rb
+++ b/decidim-core/app/presenters/decidim/notification_presenter.rb
@@ -11,7 +11,7 @@ module Decidim
 
     def created_at_in_words
       if created_at.between?(1.month.ago, Time.current)
-        time_ago_in_words(created_at)
+        I18n.t("decidim.user_conversations.index.time_ago", time: time_ago_in_words(created_at))
       else
         format = created_at.year == Time.current.year ? :ddmm : :ddmmyyyy
         I18n.l(created_at, format:)

--- a/decidim-core/app/views/decidim/messaging/conversations/_conversation.html.erb
+++ b/decidim-core/app/views/decidim/messaging/conversations/_conversation.html.erb
@@ -27,11 +27,7 @@
     <p class="conversation__item-snippet-message"><%= truncate conversation.last_message.body, length: 150 %></p>
 
     <div class="conversation__item-snippet-time">
-      <% if I18n.locale != :en %>
-        <%= t("ago", scope: "decidim.messaging.conversations.index") %> <%= time_ago_in_words(Time.zone.parse(conversation.last_message.created_at.to_s)) %>
-      <% else %>
-        <%= time_ago_in_words(Time.zone.parse(conversation.last_message.created_at.to_s)) %>
-      <% end %>
+      <%= t("decidim.user_conversations.index.time_ago", time: time_ago_in_words(Time.zone.parse(conversation.last_message.created_at.to_s))) %>
     </div>
   </div>
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -99,24 +99,26 @@ en:
         other: about %{count} months
       half_a_minute: half a minute
       less_than_x_minutes:
-        one: less than a min.
-        other: less than %{count} min.
+        one: less than a minute
+        other: less than %{count} minutes
       less_than_x_seconds:
-        one: right now
-        other: less than %{count} sec.
+        one: less than 1 second
+        other: less than %{count} seconds
       x_days:
-        one: 1 day ago
-        other: "%{count} days ago"
+        one: 1 day
+        other: "%{count} days"
       x_hours:
-        one: 1 hour ago
-        other: "%{count} hours ago"
+        one: 1 hour
+        other: "%{count} hours"
       x_minutes:
-        one: 1 min. ago
-        other: "%{count} min. ago"
+        one: 1 minute
+        other: "%{count} minutes"
+      x_months:
+        one: 1 month
+        other: "%{count} months"
       x_seconds:
-        one: 1 sec. ago
-        other: "%{count} sec. ago"
-        zero: right now
+        one: 1 second
+        other: "%{count} seconds"
   decidim:
     accessibility:
       external_link: External link
@@ -1098,7 +1100,6 @@ en:
           intro: 'There were the following errors with your message:'
           ok: OK
         index:
-          ago: ago
           new_conversation: New conversation
           next: Next
           no_conversations: You have no conversations yet.

--- a/decidim-core/spec/presenters/decidim/notification_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/notification_presenter_spec.rb
@@ -14,33 +14,33 @@ module Decidim
       describe "#created_at_in_words" do
         context "when created_at is between zero and 59 seconds" do
           it "returns the date formated" do
-            travel_to(creating_date) { expect(subject.created_at_in_words).to eq("less than a min.") }
-            travel_to(creating_date + 1.second) { expect(subject.created_at_in_words).to eq("less than a min.") }
-            travel_to(creating_date + 10.seconds) { expect(subject.created_at_in_words).to eq("less than a min.") }
-            travel_to(creating_date + 59.seconds) { expect(subject.created_at_in_words).to eq("1 min. ago") }
+            travel_to(creating_date) { expect(subject.created_at_in_words).to eq("less than a minute ago") }
+            travel_to(creating_date + 1.second) { expect(subject.created_at_in_words).to eq("less than a minute ago") }
+            travel_to(creating_date + 10.seconds) { expect(subject.created_at_in_words).to eq("less than a minute ago") }
+            travel_to(creating_date + 59.seconds) { expect(subject.created_at_in_words).to eq("1 minute ago") }
           end
         end
 
         context "when created_at is between 1 minute and 59 minutes" do
           it "returns the date formated" do
-            travel_to(creating_date + 1.minute) { expect(subject.created_at_in_words).to eq("1 min. ago") }
-            travel_to(creating_date + 6.minutes) { expect(subject.created_at_in_words).to eq("6 min. ago") }
-            travel_to(creating_date + 59.minutes) { expect(subject.created_at_in_words).to eq("about 1 hour") }
+            travel_to(creating_date + 1.minute) { expect(subject.created_at_in_words).to eq("1 minute ago") }
+            travel_to(creating_date + 6.minutes) { expect(subject.created_at_in_words).to eq("6 minutes ago") }
+            travel_to(creating_date + 59.minutes) { expect(subject.created_at_in_words).to eq("about 1 hour ago") }
           end
         end
 
         context "when created_at is between 1 hour and 24 hours" do
           it "returns the date formated" do
-            travel_to(creating_date + 1.hour) { expect(subject.created_at_in_words).to eq("about 1 hour") }
-            travel_to(creating_date + 12.hours) { expect(subject.created_at_in_words).to eq("about 12 hours") }
-            travel_to(creating_date + 23.hours) { expect(subject.created_at_in_words).to eq("about 23 hours") }
+            travel_to(creating_date + 1.hour) { expect(subject.created_at_in_words).to eq("about 1 hour ago") }
+            travel_to(creating_date + 12.hours) { expect(subject.created_at_in_words).to eq("about 12 hours ago") }
+            travel_to(creating_date + 23.hours) { expect(subject.created_at_in_words).to eq("about 23 hours ago") }
           end
         end
 
         context "when created_at is between 1 day and 1 month" do
           it "returns the date formated" do
             travel_to(creating_date + 1.day) { expect(subject.created_at_in_words).to eq("1 day ago") }
-            travel_to(creating_date + 30.days) { expect(subject.created_at_in_words).to eq("about 1 month") }
+            travel_to(creating_date + 30.days) { expect(subject.created_at_in_words).to eq("about 1 month ago") }
           end
         end
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While browsing meta decidim, i have noticed that in the conversations area, we could see that a message was sent "10 days ago ago". duplicating the ago word. On a deeper inspection i have seen the https://github.com/decidim/decidim/issues/9581 opened by @entantoencuanto .

This PR tries to fix the date issue on the **develop**.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10793
- Related to #10795
- Fixes #9581

#### Testing
- Go to local installation
- Visit the conversations and start a conversation with someone else
- Wait for one minute or so, and you should see the message "1 min. ago ago"
- Apply patch
- You should see "1 minute ago"


### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
