### PR TITLE
Fix initiative creation without fallback hash attribute

### DIFF
--- a/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
@@ -9,8 +9,8 @@ module Decidim
 
       mimic :initiative
 
-      translatable_attribute :title, String
-      translatable_attribute :description, String
+      attribute :title, String
+      attribute :description, String
       attribute :type_id, Integer
       attribute :scope_id, Integer
       attribute :area_id, Integer
@@ -40,6 +40,8 @@ module Decidim
         self.type_id = model.type.id
         self.scope_id = model.scope&.id
         self.signature_type = model.signature_type
+        self.title = translated_attribute(model.title)
+        self.description = translated_attribute(model.description)
       end
 
       def signature_type_updatable?


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
In the review of #10782, @ahukkanen pointed out the previous proposed fix for the initiative creation in #10724, works due to a backwards compatibility within the hash attribute. The issue was revealed only when backport to 0.26 happened as it is using Virtus for attribute handling. 

https://github.com/decidim/decidim/blob/e4f5f83f656b3d0fc89727a9d46f710b06a3e79e/decidim-core/lib/decidim/attributes/hash.rb#L25-L28

Please see the following comment: https://github.com/decidim/decidim/pull/10782#issuecomment-1528789598 

This fix was developed with the backwards compatibility feature disabled (commended out). 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10782 
- Related to #10724

#### Testing
1. Create an initiative 
2. See the fill in data step
3. Check the edit initiative step 
4. See the input value changed to the previously entered value. 

:hearts: Thank you!
