### PR TITLE
Change the participant initiatives editor toolbars type

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -45,7 +45,7 @@
             </div>
 
             <div class="field">
-              <%= text_editor_for(f, :description, lines: 8, toolbar: :full) %>
+              <%= text_editor_for(f, :description, lines: 8, toolbar: :content) %>
             </div>
 
             <div class="field">

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/previous_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/previous_form.html.erb
@@ -27,7 +27,7 @@
           </div>
 
           <div class="field">
-            <%= text_editor_for(f, :description, lines: 8, toolbar: :full) %>
+            <%= text_editor_for(f, :description, lines: 8, toolbar: :content) %>
           </div>
 
           <div class="actions">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
@@ -22,7 +22,7 @@
 </div>
 
 <div class="field">
-  <%= text_editor_for(form, :description, toolbar: :full, lines: 8, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.description)) %>
+  <%= text_editor_for(form, :description, toolbar: :content, lines: 8, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.description)) %>
 </div>
 
 <div class="field">

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -442,7 +442,7 @@ describe "Initiative", type: :system do
       find_button("I want to promote this initiative").click
     end
 
-    it_behaves_like "having a rich text editor", "new_initiative_previous_form", "full"
+    it_behaves_like "having a rich text editor", "new_initiative_previous_form", "content"
   end
 
   describe "creating an initiative" do

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -667,6 +667,17 @@ describe "Initiative", type: :system do
               expect(page).to have_content("Area")
             end
           end
+
+          context "when rich text editor is enabled for participants" do
+            before do
+              expect(page).to have_content("Create")
+              organization.update(rich_text_editor_in_public_views: true)
+
+              visit current_path
+            end
+
+            it_behaves_like "having a rich text editor", "new_initiative_form", "content"
+          end
         end
       end
 

--- a/decidim-initiatives/spec/system/edit_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/edit_initiative_spec.rb
@@ -97,4 +97,19 @@ describe "Edit initiative", type: :system do
       expect(page).to have_content("not authorized")
     end
   end
+
+  context "when rich text editor is enabled for participants" do
+    let(:initiative) { create(:initiative, :created, author: user, scoped_type:, organization:) }
+    let(:organization) { create(:organization, rich_text_editor_in_public_views: true) }
+
+    before do
+      visit initiative_path
+
+      click_link("Edit", href: edit_initiative_path)
+
+      expect(page).to have_content "EDIT INITIATIVE"
+    end
+
+    it_behaves_like "having a rich text editor", "edit_initiative", "content"
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
With the several changes done to the editor toolbars around the application as per #10130, I believe the initiatives toolbar is incorrect as I previously mentioned at https://github.com/decidim/decidim/issues/10721#issuecomment-1534163161.

I believe the correct toolbar type here is `content` without the multimedia controls because this is how the description is displayed at the page:
https://github.com/decidim/decidim/blob/1eb6618e2c9a0d229be3c8d66ec71a528e6e0916/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb#L84

This means that all multimedia is stripped from the content, which renders these multimedia controls useless at the participant side.

However, it should be still possible to add multimedia to initiatives through the admin panel which is another issue described at #10721.

I noticed this issue during a review of a backport related to the initiatives (#10817).

#### :pushpin: Related Issues
- Related to
  * #10130
  * #10467
  * #10721

#### Testing
- Create a new initiative and see that the toolbar does not have multimedia controls for the participant
  * URL in this view should be `/create_initiative/previous_form`
- Proceed with the initiative creation up until the "Create" phase and see that the toolbar does not have multimedia controls for the participant
  * URL in this view should be `/create_initiative/fill_data`
- Complete the initiative creation and go back to edit that initiative and see that the toolbar does not have multimedia controls for the participant
  * URL in this view should be `/initiatives/i-123/edit` (replace `123` with the ID of the initiative)

### :camera: Screenshots

**Before**
![Initiative form before the PR](https://user-images.githubusercontent.com/864340/236247281-178b28bb-c6fb-4918-a161-9869bac2f3a6.png)

**After**
![Initiative form after the PR](https://user-images.githubusercontent.com/864340/236247323-c21efa65-30a6-4b87-b435-cb921a38233b.png)