### PR TITLE
Component settings attribute type addition - "Float"

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -11,6 +11,7 @@ module Decidim
         boolean: :check_box,
         integer: :number_field,
         string: :text_field,
+        float: :number_field,
         text: :text_area,
         select: :select_field,
         scope: :scope_field,

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -90,6 +90,15 @@ module Decidim
         end
       end
 
+      describe "float" do
+        let(:type) { :float }
+
+        it "is supported" do
+          expect(form).to receive(:number_field).with(:test, options)
+          render_input
+        end
+      end
+
       describe "texts" do
         let(:type) { :text }
         let(:extra_options) { options.merge(rows: 6) }

--- a/decidim-core/lib/decidim/settings_manifest.rb
+++ b/decidim-core/lib/decidim/settings_manifest.rb
@@ -92,6 +92,7 @@ module Decidim
         boolean: { klass: Boolean, default: false },
         integer: { klass: Integer, default: 0 },
         string: { klass: String, default: nil },
+        float: { klass: Float, default: nil },
         text: { klass: String, default: nil },
         array: { klass: Array, default: [] },
         enum: { klass: String, default: nil },

--- a/decidim-core/spec/lib/settings_manifest_spec.rb
+++ b/decidim-core/spec/lib/settings_manifest_spec.rb
@@ -108,6 +108,12 @@ module Decidim
           expect(attribute.default_value).to be_nil
         end
 
+        it "supports floats" do
+          attribute = SettingsManifest::Attribute.new(type: :float)
+          expect(attribute.type_class).to eq(Float)
+          expect(attribute.default_value).to be_nil
+        end
+
         it "supports texts" do
           attribute = SettingsManifest::Attribute.new(type: :text)
           expect(attribute.type_class).to eq(String)


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
For Component setting's attributes the type "Float" was not included, which didn't allow the user to add an attribute to any component with it. The changes in this pull request adds the type to attributes and also adds it to a list which is used to generate the corresponding input field for it.

#### :pushpin: Related Issues
- Fixes #10818

#### Testing
Add a component setting attribute with the type :float, and receive  an error message telling you it's not included in the type list.

:hearts: Thank you!
