### PR TITLE
Fix budget summary mail when a scope is defined and enabled

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/order_summary_mailer/order_summary.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/order_summary_mailer/order_summary.html.erb
@@ -1,6 +1,7 @@
 <% if @component.try(:scopes_enabled) %>
 <%= t(
   ".voted_on_space_with_scope",
+  budget_name: translated_attribute(@budget.title),
   space_name: translated_attribute(@space.title),
   scope_name: translated_attribute(@component.scope.name),
   scope_type: translated_attribute(@component.scope.scope_type.name)

--- a/decidim-budgets/spec/mailers/decidim/budgets/order_summary_mailer_spec.rb
+++ b/decidim-budgets/spec/mailers/decidim/budgets/order_summary_mailer_spec.rb
@@ -7,31 +7,51 @@ module Decidim::Budgets
     let(:order) { create :order, :with_projects }
     let(:user) { order.user }
     let(:space) { order.budget.participatory_space }
-    let(:organization) { space.participatory_space.organization }
+    let(:organization) { space.organization }
     let(:budget) { order.budget }
 
-    describe "order_summary" do
+    describe "#order_summary" do
       let(:mail) { described_class.order_summary(order) }
 
-      it "delivers the email to the user" do
-        expect(mail.to).to eq([user.email])
+      shared_examples "working order summary mail" do
+        it "delivers the email to the user" do
+          expect(mail.to).to eq([user.email])
+        end
+
+        it "includes the organization data" do
+          expect(mail.body.encoded).to include(user.organization.name)
+        end
+
+        it "includes the budget title" do
+          expect(mail.body.encoded).to include(translated(budget.title))
+        end
+
+        it "includes the participatory space title" do
+          expect(mail.body).to include(translated(space.title))
+        end
+
+        it "includes the projects names" do
+          order.projects.each do |project|
+            expect(mail.body).to include(translated(project.title))
+          end
+        end
       end
 
-      it "includes the organization data" do
-        expect(mail.body.encoded).to include(user.organization.name)
-      end
+      it_behaves_like "working order summary mail"
 
-      it "includes the budget title" do
-        expect(mail.body.encoded).to include(translated(budget.title))
-      end
+      context "when scopes are enabled and the component has a scope defined" do
+        let(:scope) { create(:scope, organization:) }
+        let(:component) { budget.component }
 
-      it "includes the participatory space title" do
-        expect(mail.body).to include(translated(space.title))
-      end
+        before do
+          component.update(settings: { scopes_enabled: true, scope_id: scope.id })
+        end
 
-      it "includes the projects names" do
-        order.projects.each do |project|
-          expect(mail.body).to include(translated(project.title))
+        it_behaves_like "working order summary mail"
+
+        it "includes the scope name and scope type name" do
+          expect(mail.body.encoded).to include(translated(scope.name))
+          expect(mail.body.encoded).to include(translated(scope.scope_type.name))
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
When a scopes are enabled and a scope is defined for a budget component, the order summary mail will not deliver and it will cause an exception instead.

This fixes the issue and adds a spec to ensure this bug will not reappear.

The following error was raised:
```
     ActionView::Template::Error:
       missing interpolation argument :budget_name in "You have voted on the %{budget_name} budget for the %{space_name} participatory space on %{scope_name} (%{scope_type})." ({:space_name=>"Aut quae voluptate. 379", :scope_name=>"Calcar decor balbuz. 1", :scope_type=>"similique"} given)
     # ./app/views/decidim/budgets/order_summary_mailer/order_summary.html.erb:2:in `__decidim_decidim_budgets_app_views_decidim_budgets_order_summary_mailer_order_summary_html_erb___214726410992373771_137900'
     # ./app/mailers/decidim/budgets/order_summary_mailer.rb:31:in `block in order_summary'
     # /.../dev/rails/decidim/decidim-core/app/mailers/concerns/decidim/localised_mailer.rb:19:in `block in with_user'
     # /.../dev/rails/decidim/decidim-core/app/mailers/concerns/decidim/localised_mailer.rb:18:in `with_user'
     # ./app/mailers/decidim/budgets/order_summary_mailer.rb:17:in `order_summary'
     # <internal:kernel>:90:in `tap'
     # ./spec/mailers/decidim/budgets/order_summary_mailer_spec.rb:47:in `block (4 levels) in <module:Budgets>'
     # ------------------
     # --- Caused by: ---
     # I18n::MissingInterpolationArgument:
     #   missing interpolation argument :budget_name in "You have voted on the %{budget_name} budget for the %{space_name} participatory space on %{scope_name} (%{scope_type})." ({:space_name=>"Aut quae voluptate. 379", :scope_name=>"Calcar decor balbuz. 1", :scope_type=>"similique"} given)
     #   ./app/views/decidim/budgets/order_summary_mailer/order_summary.html.erb:2:in `__decidim_decidim_budgets_app_views_decidim_budgets_order_summary_mailer_order_summary_html_erb___214726410992373771_137900'

```

#### Testing
- Create a budgets component with scopes enabled and a scope defined
- Enable voting in that component
- Go to vote in that budget
- Look that the order summary mail was sent from letter opener (if testing locally)