### PR TITLE
Remove parallel spec from the core system specs

### DIFF
--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -68,7 +68,7 @@ jobs:
           node_version: ${{ env.NODE_VERSION }}
       - run: |
           sudo Xvfb -ac $DISPLAY -screen 0 1920x1084x24 > /dev/null 2>&1 & # optional
-          bundle exec rake parallel:spec[^spec/system]
+          bundle exec rspec spec/system
         name: RSpec
         working-directory: ${{ env.DECIDIM_MODULE }}
         env:


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Recently we have noticed that the release 0.27 is failing due to VAPID tests in the user account. 
While investigating we ruled out:
- Github environment being changed (we ran same chrome driver and other tools)
- Those particular tests randomly failing

We also noticed that running old pipelines that previously passed, now are failing. 

In the investigation performed by me (@alecslupu ) and @ahukkanen we noticed that running specs using plain rspec the tests are successfully passing. 

In order to release faster, and due to fact that we could not find the root cause, we agreed in the @decidim/maintainers 's meeting that we could switch it back to plain Rspec, at least temporarily. 

:hearts: Thank you!
