### PR TITLE
Backport 'Fix budget summary mail when a scope is defined and enabled' to v0.26

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/order_summary_mailer/order_summary.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/order_summary_mailer/order_summary.html.erb
@@ -1,6 +1,7 @@
 <% if @component.try(:scopes_enabled) %>
 <%= t(
   ".voted_on_space_with_scope",
+  budget_name: translated_attribute(@budget.title),
   space_name: translated_attribute(@space.title),
   scope_name: translated_attribute(@component.scope.name),
   scope_type: translated_attribute(@component.scope.scope_type.name)

--- a/decidim-budgets/spec/mailers/decidim/budgets/order_summary_mailer_spec.rb
+++ b/decidim-budgets/spec/mailers/decidim/budgets/order_summary_mailer_spec.rb
@@ -7,31 +7,51 @@ module Decidim::Budgets
     let(:order) { create :order, :with_projects }
     let(:user) { order.user }
     let(:space) { order.budget.participatory_space }
-    let(:organization) { space.participatory_space.organization }
+    let(:organization) { space.organization }
     let(:budget) { order.budget }
 
-    describe "order_summary" do
+    describe "#order_summary" do
       let(:mail) { described_class.order_summary(order) }
 
-      it "delivers the email to the user" do
-        expect(mail.to).to eq([user.email])
+      shared_examples "working order summary mail" do
+        it "delivers the email to the user" do
+          expect(mail.to).to eq([user.email])
+        end
+
+        it "includes the organization data" do
+          expect(mail.body.encoded).to include(user.organization.name)
+        end
+
+        it "includes the budget title" do
+          expect(mail.body.encoded).to include(translated(budget.title))
+        end
+
+        it "includes the participatory space title" do
+          expect(mail.body).to include(translated(space.title))
+        end
+
+        it "includes the projects names" do
+          order.projects.each do |project|
+            expect(mail.body).to include(translated(project.title))
+          end
+        end
       end
 
-      it "includes the organization data" do
-        expect(mail.body.encoded).to include(user.organization.name)
-      end
+      it_behaves_like "working order summary mail"
 
-      it "includes the budget title" do
-        expect(mail.body.encoded).to include(translated(budget.title))
-      end
+      context "when scopes are enabled and the component has a scope defined" do
+        let(:scope) { create(:scope, organization: organization) }
+        let(:component) { budget.component }
 
-      it "includes the participatory space title" do
-        expect(mail.body).to include(translated(space.title))
-      end
+        before do
+          component.update(settings: { scopes_enabled: true, scope_id: scope.id })
+        end
 
-      it "includes the projects names" do
-        order.projects.each do |project|
-          expect(mail.body).to include(translated(project.title))
+        it_behaves_like "working order summary mail"
+
+        it "includes the scope name and scope type name" do
+          expect(mail.body.encoded).to include(translated(scope.name))
+          expect(mail.body.encoded).to include(translated(scope.scope_type.name))
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #10830 to v0.26

:hearts: Thank you!