### PR TITLE
Add translation string for URL error message

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -135,6 +135,10 @@ en:
         file: File
     errors:
       models:
+        meeting:
+          attributes:
+            online_meeting_url:
+              url_format: Must be a valid URL
         newsletter:
           attributes:
             base:

--- a/decidim-core/app/forms/url_validator.rb
+++ b/decidim-core/app/forms/url_validator.rb
@@ -6,7 +6,7 @@
 #
 class UrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors.add attribute, (options[:message] || "must be a valid URL") unless url_valid?(value)
+    record.errors.add attribute, :url_format, **options unless url_valid?(value)
   end
 
   # a URL may be technically well-formed but may


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Admin users creating online meetings under **processes/meetings**, were presented a hard coded error message in English when editing the url: " http://example.org". Thanks to a patch by @alecslupu, we have updated the URL validator as seen below: 

<img width="1023" alt="image" src="https://github.com/decidim/decidim/assets/101816158/9d3d3dba-d435-4ba7-9da0-eabcef8f8ccd">

A key has been added in the en.yml file under **decidim-admin**, with the error message to the problem, see screenshot below: 

<img width="1224" alt="image" src="https://github.com/decidim/decidim/assets/101816158/e32e53fd-826c-49f4-a8a4-0bd6200c1d6f">

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10833 

#### Testing
1. Login as admin then pick a different language than english, for instance spanish (es)
2. Go to Participatory Process
3. Select or create an Online Meeting
4. In the Online Meeting URL field add a URL with an error (for example put a space before the url: " http://example.org")
5. Try to save the meeting
6. See the error
7. Apply the patch 
8. To check the translation, add this on the decidim-admin/locales/config/es.yml
es:  
  activemodel:
    errors:
      models:
        meeting:
          attributes:
            online_meeting_url:
              url_format: Tiene que ser una URL valida

9. Try to save the meeting again
10. See that the translation applies

💻 **Some extra data on the fix:** 

- Device: Apple Macbook Pro 2020 M1 
- Operating System: MacOS - Ventura V13.2.1
- Browser: Firefox 112.0.2 (64-bit)
- Decidim version: 0.27.2 

:hearts: Thank you!
