### PR TITLE
Fix initialization of autoloaded constants

### DIFF
--- a/decidim-blogs/lib/decidim/blogs/engine.rb
+++ b/decidim-blogs/lib/decidim/blogs/engine.rb
@@ -28,8 +28,10 @@ module Decidim
       end
 
       initializer "decidim_blogs.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:blogs) do |transfer|
-          transfer.move_records(Decidim::Blogs::Post, :decidim_author_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:blogs) do |transfer|
+            transfer.move_records(Decidim::Blogs::Post, :decidim_author_id)
+          end
         end
       end
     end

--- a/decidim-budgets/lib/decidim/budgets/engine.rb
+++ b/decidim-budgets/lib/decidim/budgets/engine.rb
@@ -44,25 +44,29 @@ module Decidim
       end
 
       initializer "decidim_budgets.register_reminders" do
-        Decidim.reminders_registry.register(:orders) do |reminder_registry|
-          reminder_registry.generator_class_name = "Decidim::Budgets::OrderReminderGenerator"
-          reminder_registry.form_class_name = "Decidim::Budgets::Admin::OrderReminderForm"
-          reminder_registry.command_class_name = "Decidim::Budgets::Admin::CreateOrderReminders"
+        config.to_prepare do
+          Decidim.reminders_registry.register(:orders) do |reminder_registry|
+            reminder_registry.generator_class_name = "Decidim::Budgets::OrderReminderGenerator"
+            reminder_registry.form_class_name = "Decidim::Budgets::Admin::OrderReminderForm"
+            reminder_registry.command_class_name = "Decidim::Budgets::Admin::CreateOrderReminders"
 
-          reminder_registry.settings do |settings|
-            settings.attribute :reminder_times, type: :array, default: [2.hours, 1.week, 2.weeks]
-          end
+            reminder_registry.settings do |settings|
+              settings.attribute :reminder_times, type: :array, default: [2.hours, 1.week, 2.weeks]
+            end
 
-          reminder_registry.messages do |msg|
-            msg.set(:title) { |count: 0| I18n.t("decidim.budgets.admin.reminders.orders.title", count:) }
-            msg.set(:description) { I18n.t("decidim.budgets.admin.reminders.orders.description") }
+            reminder_registry.messages do |msg|
+              msg.set(:title) { |count: 0| I18n.t("decidim.budgets.admin.reminders.orders.title", count:) }
+              msg.set(:description) { I18n.t("decidim.budgets.admin.reminders.orders.description") }
+            end
           end
         end
       end
 
       initializer "decidim_budgets.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:budgets) do |transfer|
-          transfer.move_records(Decidim::Budgets::Order, :decidim_user_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:budgets) do |transfer|
+            transfer.move_records(Decidim::Budgets::Order, :decidim_user_id)
+          end
         end
       end
     end

--- a/decidim-comments/lib/decidim/comments/engine.rb
+++ b/decidim-comments/lib/decidim/comments/engine.rb
@@ -72,9 +72,11 @@ module Decidim
       end
 
       initializer "decidim_comments.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:comments) do |transfer|
-          transfer.move_records(Decidim::Comments::Comment, :decidim_author_id)
-          transfer.move_records(Decidim::Comments::CommentVote, :decidim_author_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:comments) do |transfer|
+            transfer.move_records(Decidim::Comments::Comment, :decidim_author_id)
+            transfer.move_records(Decidim::Comments::CommentVote, :decidim_author_id)
+          end
         end
       end
 

--- a/decidim-consultations/lib/decidim/consultations/engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/engine.rb
@@ -95,8 +95,10 @@ module Decidim
       end
 
       initializer "decidim_consultations.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:consultations) do |transfer|
-          transfer.move_records(Decidim::Consultations::Vote, :decidim_author_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:consultations) do |transfer|
+            transfer.move_records(Decidim::Consultations::Vote, :decidim_author_id)
+          end
         end
       end
     end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -740,10 +740,12 @@ module Decidim
       end
 
       initializer "decidim_core.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:core) do |transfer|
-          transfer.move_records(Decidim::Coauthorship, :decidim_author_id)
-          transfer.move_records(Decidim::Endorsement, :decidim_author_id)
-          transfer.move_records(Decidim::Amendment, :decidim_user_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:core) do |transfer|
+            transfer.move_records(Decidim::Coauthorship, :decidim_author_id)
+            transfer.move_records(Decidim::Endorsement, :decidim_author_id)
+            transfer.move_records(Decidim::Amendment, :decidim_user_id)
+          end
         end
       end
 

--- a/decidim-debates/lib/decidim/debates/engine.rb
+++ b/decidim-debates/lib/decidim/debates/engine.rb
@@ -103,8 +103,10 @@ module Decidim
       end
 
       initializer "decidim_debates.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:debates) do |transfer|
-          transfer.move_records(Decidim::Debates::Debate, :decidim_author_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:debates) do |transfer|
+            transfer.move_records(Decidim::Debates::Debate, :decidim_author_id)
+          end
         end
       end
 

--- a/decidim-elections/lib/decidim/elections/engine.rb
+++ b/decidim-elections/lib/decidim/elections/engine.rb
@@ -36,8 +36,10 @@ module Decidim
       end
 
       initializer "decidim_elections.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:elections) do |transfer|
-          transfer.move_records(Decidim::Elections::Vote, :decidim_user_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:elections) do |transfer|
+            transfer.move_records(Decidim::Elections::Vote, :decidim_user_id)
+          end
         end
       end
     end

--- a/decidim-forms/lib/decidim/forms/engine.rb
+++ b/decidim-forms/lib/decidim/forms/engine.rb
@@ -17,8 +17,10 @@ module Decidim
       end
 
       initializer "decidim_forms.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:forms) do |transfer|
-          transfer.move_records(Decidim::Forms::Answer, :decidim_user_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:forms) do |transfer|
+            transfer.move_records(Decidim::Forms::Answer, :decidim_user_id)
+          end
         end
       end
     end

--- a/decidim-initiatives/lib/decidim/initiatives/engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/engine.rb
@@ -140,9 +140,11 @@ module Decidim
       end
 
       initializer "decidim_initiatives.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:initiatives) do |transfer|
-          transfer.move_records(Decidim::Initiative, :decidim_author_id)
-          transfer.move_records(Decidim::InitiativesVote, :decidim_author_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:initiatives) do |transfer|
+            transfer.move_records(Decidim::Initiative, :decidim_author_id)
+            transfer.move_records(Decidim::InitiativesVote, :decidim_author_id)
+          end
         end
       end
     end

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -125,20 +125,24 @@ module Decidim
       end
 
       initializer "decidim_meetings.register_reminders" do
-        Decidim.reminders_registry.register(:close_meeting) do |reminder_registry|
-          reminder_registry.generator_class_name = "Decidim::Meetings::CloseMeetingReminderGenerator"
+        config.to_prepare do
+          Decidim.reminders_registry.register(:close_meeting) do |reminder_registry|
+            reminder_registry.generator_class_name = "Decidim::Meetings::CloseMeetingReminderGenerator"
 
-          reminder_registry.settings do |settings|
-            settings.attribute :reminder_times, type: :array, default: [3.days, 7.days]
+            reminder_registry.settings do |settings|
+              settings.attribute :reminder_times, type: :array, default: [3.days, 7.days]
+            end
           end
         end
       end
 
       initializer "decidim_meetings.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:meetings) do |transfer|
-          transfer.move_records(Decidim::Meetings::Meeting, :decidim_author_id)
-          transfer.move_records(Decidim::Meetings::Registration, :decidim_user_id)
-          transfer.move_records(Decidim::Meetings::Answer, :decidim_user_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:meetings) do |transfer|
+            transfer.move_records(Decidim::Meetings::Meeting, :decidim_author_id)
+            transfer.move_records(Decidim::Meetings::Registration, :decidim_user_id)
+            transfer.move_records(Decidim::Meetings::Answer, :decidim_user_id)
+          end
         end
       end
 

--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -210,8 +210,10 @@ module Decidim
       end
 
       initializer "decidim_proposals.authorization_transfer" do
-        Decidim::AuthorizationTransfer.register(:proposals) do |transfer|
-          transfer.move_records(Decidim::Proposals::ProposalVote, :decidim_author_id)
+        config.to_prepare do
+          Decidim::AuthorizationTransfer.register(:proposals) do |transfer|
+            transfer.move_records(Decidim::Proposals::ProposalVote, :decidim_author_id)
+          end
         end
       end
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
When `spring` is booting, there are a few warnings regarding the autoloaded constants beings deprecated. This PR is trying to fix this. 

```
DEPRECATION WARNING: Initialization autoloaded the constants Decidim::ApplicationRecord, Decidim::AuthorizationTransfer, Decidim::Meetings::CloseMeetingReminderGenerator, and Decidim::Budgets::OrderReminderGenerator.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload Decidim::ApplicationRecord, for example,
the expected changes won't be reflected in that stale Class object.

These autoloaded constants have been unloaded.

In order to autoload safely at boot time, please wrap your code in a reloader
callback this way:

    Rails.application.reloader.to_prepare do
      # Autoload classes and modules needed at boot time here.
    end

That block runs when the application boots, and every time there is a reload.
For historical reasons, it may run twice, so it has to be idempotent.

Check the "Autoloading and Reloading Constants" guide to learn more about how
Rails autoloads and reloads.

```

:hearts: Thank you!
