### PR TITLE
Allow custom session store and remove samesite protection config

### DIFF
--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -344,9 +344,10 @@ module Decidim
         end
       end
 
-      initializer "Expire sessions" do
-        Rails.application.config.session_store :cookie_store, secure: Decidim.config.force_ssl, expire_after: Decidim.config.expire_session_after
-        Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
+      initializer "decidim.core.session_store" do |app|
+        next if app.config.session_store?
+
+        app.config.session_store :cookie_store, secure: Decidim.config.force_ssl, expire_after: Decidim.config.expire_session_after
       end
 
       initializer "decidim.core.register_resources" do

--- a/decidim-core/spec/lib/engine_spec.rb
+++ b/decidim-core/spec/lib/engine_spec.rb
@@ -37,52 +37,77 @@ module Decidim::Core
         end
       end
 
-      context "when running the 'Expire sessions' initializer" do
-        let(:initializer_name) { "Expire sessions" }
+      context "when running the 'decidim.core.session_store' initializer" do
+        let(:initializer_name) { "decidim.core.session_store" }
         let(:decidim_force_ssl) { false }
         let(:decidim_expire_session_after) { 30.minutes }
+        let(:app) { Rails.application }
+
+        around do |example|
+          current_store = Rails.application.config.session_store
+          current_options = Rails.application.config.session_options
+          Rails.application.config.remove_instance_variable(:@session_store)
+          example.run
+          Rails.application.config.session_store current_store, **current_options
+        end
 
         before do
           allow(Decidim.config).to receive(:force_ssl).and_return(decidim_force_ssl)
           allow(Decidim.config).to receive(:expire_session_after).and_return(decidim_expire_session_after)
-          initializer.run
         end
 
-        after do
-          Rails.application.config.force_ssl = false
-          Rails.application.config.expire_session_after = 30.minutes
-        end
+        context "when the session store has not been configured" do
+          before { initializer.run(app) }
 
-        context "when Decidim.config.force_ssl is true" do
-          let(:decidim_force_ssl) { true }
+          after do
+            Rails.application.config.force_ssl = false
+            Rails.application.config.expire_session_after = 30.minutes
+          end
 
-          it "configures the session cookie store with the secure flag" do
-            expect(Rails.application.config.session_options).to eq(
-              secure: true,
-              expire_after: 30.minutes
-            )
+          context "when Decidim.config.force_ssl is true" do
+            let(:decidim_force_ssl) { true }
+
+            it "configures the session cookie store with the secure flag" do
+              expect(Rails.application.config.session_options).to eq(
+                secure: true,
+                expire_after: 30.minutes
+              )
+            end
+          end
+
+          context "when Decidim.config.force_ssl is false" do
+            let(:decidim_force_ssl) { false }
+
+            it "configures the session cookie store without the secure flag" do
+              expect(Rails.application.config.session_options).to eq(
+                secure: false,
+                expire_after: 30.minutes
+              )
+            end
+          end
+
+          context "when expire session after is set to a custom amount" do
+            let(:decidim_expire_session_after) { 1.hour }
+
+            it "configures the session cookie store with the correct expire after value" do
+              expect(Rails.application.config.session_options).to eq(
+                secure: false,
+                expire_after: 1.hour
+              )
+            end
           end
         end
 
-        context "when Decidim.config.force_ssl is false" do
-          let(:decidim_force_ssl) { false }
-
-          it "configures the session cookie store without the secure flag" do
-            expect(Rails.application.config.session_options).to eq(
-              secure: false,
-              expire_after: 30.minutes
-            )
+        context "when the session store has already been configured" do
+          before do
+            Rails.application.config.session_store :cache_store, expire_after: 36.minutes
           end
-        end
 
-        context "when expire session after is set to a custom amount" do
-          let(:decidim_expire_session_after) { 1.hour }
+          it "does not reconfigure it" do
+            initializer.run(app)
 
-          it "configures the session cookie store with the correct expire after value" do
-            expect(Rails.application.config.session_options).to eq(
-              secure: false,
-              expire_after: 1.hour
-            )
+            expect(Rails.application.config.session_store).to eq(ActionDispatch::Session::CacheStore)
+            expect(Rails.application.config.session_options).to eq(expire_after: 36.minutes)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
If the environment config has already configured the session store, do not override this configuration.

This also renames the initializer for better alignment with the naming conventions and also removes the unnecessary same site protection config since Rails 6.1:

![Same site configuration defaults for Rails 6.1](https://github.com/decidim/decidim/assets/864340/f39e91a6-5351-4f5d-9c1e-f6ed5118e03d)

https://edgeguides.rubyonrails.org/configuring.html#default-values-for-target-version-6-1

#### Testing
- Configure the session store in the Rails environment configurations, e.g. change to cache store or change the session storage options
- Restart the server and see that Decidim is no longer overriding these configurations

As an example use case, I needed to change the `SameSite` protection for the session cookie due to it breaking the user redirection back to the correct page after returning from the authentication service. Some implementors could also want to use a different session store than the cookie store.