### PR TITLE
Standardize initializer naming and add tests to ensure consistency

### DIFF
--- a/decidim-accountability/spec/lib/decidim/accountability/engine_spec.rb
+++ b/decidim-accountability/spec/lib/decidim/accountability/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Accountability::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -80,7 +80,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_admin.admin_user_menu" do
+      initializer "decidim_admin.user_menu" do
         Decidim.menu :admin_user_menu do |menu|
           menu.add_item :users,
                         I18n.t("menu.admins", scope: "decidim.admin"), decidim_admin.users_path,
@@ -108,7 +108,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_admin.admin_settings_menu" do
+      initializer "decidim_admin.settings_menu" do
         Decidim.menu :admin_settings_menu do |menu|
           menu.add_item :edit_organization,
                         I18n.t("menu.configuration", scope: "decidim.admin"),

--- a/decidim-admin/spec/lib/decidim/admin/engine_spec.rb
+++ b/decidim-admin/spec/lib/decidim/admin/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Admin::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-api/lib/decidim/api/engine.rb
+++ b/decidim-api/lib/decidim/api/engine.rb
@@ -23,7 +23,7 @@ module Decidim
     class Engine < ::Rails::Engine
       isolate_namespace Decidim::Api
 
-      initializer "decidim-api.middleware" do |app|
+      initializer "decidim_api.middleware" do |app|
         app.config.middleware.insert_before 0, Rack::Cors do
           allow do
             origins "*"
@@ -32,7 +32,7 @@ module Decidim
         end
       end
 
-      initializer "decidim-api.graphiql" do
+      initializer "decidim_api.graphiql" do
         Decidim::GraphiQL::Rails.config.tap do |config|
           config.query_params = true
           config.initial_query = File.read(

--- a/decidim-api/spec/lib/decidim/api/engine_spec.rb
+++ b/decidim-api/spec/lib/decidim/api/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Api::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -88,7 +88,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_assemblies.action_controller" do |app|
+      initializer "decidim_assemblies_admin.action_controller" do |app|
         app.config.to_prepare do
           ActiveSupport.on_load :action_controller do
             helper Decidim::Assemblies::Admin::AssembliesAdminMenuHelper if respond_to?(:helper)
@@ -96,7 +96,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_assemblies.admin_menu" do
+      initializer "decidim_assemblies_admin.admin_menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim.admin"),
@@ -110,7 +110,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_assemblies.assemblies_admin_attachments_menu" do
+      initializer "decidim_assemblies_admin.assemblies_admin_attachments_menu" do
         Decidim.menu :assemblies_admin_attachments_menu do |menu|
           menu.add_item :assembly_attachment_collections,
                         I18n.t("attachment_collections", scope: "decidim.admin.menu.assemblies_submenu"),
@@ -125,7 +125,7 @@ module Decidim
                         if: allowed_to?(:read, :attachment, assembly: current_participatory_space)
         end
       end
-      initializer "decidim_assemblies.admin_assemblies_components_menu" do
+      initializer "decidim_assemblies_admin.admin_assemblies_components_menu" do
         Decidim.menu :admin_assemblies_components_menu do |menu|
           current_participatory_space.components.each do |component|
             caption = translated_attribute(component.name)
@@ -144,7 +144,7 @@ module Decidim
           end
         end
       end
-      initializer "decidim_assemblies.assemblies_admin_menu" do
+      initializer "decidim_assemblies_admin.assemblies_admin_menu" do
         Decidim.menu :admin_assembly_menu do |menu|
           menu.add_item :edit_assembly,
                         I18n.t("info", scope: "decidim.admin.menu.assemblies_submenu"),
@@ -200,7 +200,7 @@ module Decidim
                         active: is_active_link?(decidim_admin_assemblies.moderations_path(current_participatory_space))
         end
       end
-      initializer "decidim_assemblies.admin_assemblies_menu" do
+      initializer "decidim_assemblies_admin.admin_assemblies_menu" do
         Decidim.menu :admin_assemblies_menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim.admin"),

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -96,7 +96,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_assemblies_admin.admin_menu" do
+      initializer "decidim_assemblies_admin.menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim.admin"),
@@ -110,7 +110,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_assemblies_admin.assemblies_admin_attachments_menu" do
+      initializer "decidim_assemblies_admin.attachments_menu" do
         Decidim.menu :assemblies_admin_attachments_menu do |menu|
           menu.add_item :assembly_attachment_collections,
                         I18n.t("attachment_collections", scope: "decidim.admin.menu.assemblies_submenu"),
@@ -125,7 +125,7 @@ module Decidim
                         if: allowed_to?(:read, :attachment, assembly: current_participatory_space)
         end
       end
-      initializer "decidim_assemblies_admin.admin_assemblies_components_menu" do
+      initializer "decidim_assemblies_admin.components_menu" do
         Decidim.menu :admin_assemblies_components_menu do |menu|
           current_participatory_space.components.each do |component|
             caption = translated_attribute(component.name)
@@ -144,7 +144,7 @@ module Decidim
           end
         end
       end
-      initializer "decidim_assemblies_admin.assemblies_admin_menu" do
+      initializer "decidim_assemblies_admin.assembly_menu" do
         Decidim.menu :admin_assembly_menu do |menu|
           menu.add_item :edit_assembly,
                         I18n.t("info", scope: "decidim.admin.menu.assemblies_submenu"),
@@ -200,7 +200,7 @@ module Decidim
                         active: is_active_link?(decidim_admin_assemblies.moderations_path(current_participatory_space))
         end
       end
-      initializer "decidim_assemblies_admin.admin_assemblies_menu" do
+      initializer "decidim_assemblies_admin.assemblies_menu" do
         Decidim.menu :admin_assemblies_menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim.admin"),

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -44,7 +44,7 @@ module Decidim
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Assemblies::Engine.root}/app/views") # for partials
       end
 
-      initializer "decidim.stats" do
+      initializer "decidim_assemblies.stats" do
         Decidim.stats.register :assemblies_count, priority: StatsRegistry::HIGH_PRIORITY do |organization, _start_at, _end_at|
           Decidim::Assembly.where(organization:).public_spaces.count
         end

--- a/decidim-assemblies/spec/lib/decidim/assemblies/admin_engine_spec.rb
+++ b/decidim-assemblies/spec/lib/decidim/assemblies/admin_engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Assemblies::AdminEngine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-assemblies/spec/lib/decidim/assemblies/engine_spec.rb
+++ b/decidim-assemblies/spec/lib/decidim/assemblies/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Assemblies::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-blogs/spec/lib/decidim/blogs/engine_spec.rb
+++ b/decidim-blogs/spec/lib/decidim/blogs/engine_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe Decidim::Blogs::Engine do
+  it_behaves_like "clean engine"
+
   describe "decidim_blogs.authorization_transfer" do
     include_context "authorization transfer"
 

--- a/decidim-budgets/spec/lib/decidim/budgets/engine_spec.rb
+++ b/decidim-budgets/spec/lib/decidim/budgets/engine_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe Decidim::Budgets::Engine do
+  it_behaves_like "clean engine"
+
   describe "decidim_budgets.authorization_transfer" do
     include_context "authorization transfer"
 

--- a/decidim-comments/lib/decidim/comments/engine.rb
+++ b/decidim-comments/lib/decidim/comments/engine.rb
@@ -29,7 +29,7 @@ module Decidim
         Decidim::Api::MutationType.include MutationExtensions
       end
 
-      initializer "decidim.stats" do
+      initializer "decidim_comments.stats" do
         Decidim.stats.register :comments_count, priority: StatsRegistry::MEDIUM_PRIORITY do |organization|
           Decidim.component_manifests.sum do |component|
             component.stats.filter(tag: :comments).with_context(organization.published_components).map { |_name, value| value }.sum

--- a/decidim-comments/spec/lib/decidim/comments/engine_spec.rb
+++ b/decidim-comments/spec/lib/decidim/comments/engine_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe Decidim::Comments::Engine do
+  it_behaves_like "clean engine"
+
   describe "decidim_comments.authorization_transfer" do
     include_context "authorization transfer"
 

--- a/decidim-conferences/lib/decidim/conferences/admin_engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/admin_engine.rb
@@ -88,7 +88,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_conferences.admin_conferences_components_menu" do
+      initializer "decidim_conferences_admin.admin_conferences_components_menu" do
         Decidim.menu :admin_conferences_components_menu do |menu|
           current_participatory_space.components.each do |component|
             caption = translated_attribute(component.name)
@@ -107,7 +107,7 @@ module Decidim
           end
         end
       end
-      initializer "decidim_conferences.conferences_admin_registrations_menu" do
+      initializer "decidim_conferences_admin.conferences_admin_registrations_menu" do
         Decidim.menu :conferences_admin_registrations_menu do |menu|
           menu.add_item :conference_registration_types,
                         I18n.t("registration_types", scope: "decidim.admin.menu.conferences_submenu"),
@@ -134,7 +134,7 @@ module Decidim
                         if: allowed_to?(:update, :conference, conference: current_participatory_space)
         end
       end
-      initializer "decidim_conferences.conferences_admin_attachments_menu" do
+      initializer "decidim_conferences_admin.conferences_admin_attachments_menu" do
         Decidim.menu :conferences_admin_attachments_menu do |menu|
           menu.add_item :conference_attachment_collections,
                         I18n.t("attachment_collections", scope: "decidim.admin.menu.conferences_submenu"),
@@ -149,7 +149,7 @@ module Decidim
                         if: allowed_to?(:read, :attachment, conference: current_participatory_space)
         end
       end
-      initializer "decidim_conferences.conferences_admin_menu" do
+      initializer "decidim_conferences_admin.conferences_admin_menu" do
         Decidim.menu :conferences_admin_menu do |menu|
           menu.add_item :edit_conference,
                         I18n.t("info", scope: "decidim.admin.menu.conferences_submenu"),
@@ -221,7 +221,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_conferences.admin_menu" do
+      initializer "decidim_conferences_admin.admin_menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :conferences,
                         I18n.t("menu.conferences", scope: "decidim.admin"),

--- a/decidim-conferences/lib/decidim/conferences/admin_engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/admin_engine.rb
@@ -88,7 +88,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_conferences_admin.admin_conferences_components_menu" do
+      initializer "decidim_conferences_admin.components_menu" do
         Decidim.menu :admin_conferences_components_menu do |menu|
           current_participatory_space.components.each do |component|
             caption = translated_attribute(component.name)
@@ -107,7 +107,7 @@ module Decidim
           end
         end
       end
-      initializer "decidim_conferences_admin.conferences_admin_registrations_menu" do
+      initializer "decidim_conferences_admin.registrations_menu" do
         Decidim.menu :conferences_admin_registrations_menu do |menu|
           menu.add_item :conference_registration_types,
                         I18n.t("registration_types", scope: "decidim.admin.menu.conferences_submenu"),
@@ -134,7 +134,7 @@ module Decidim
                         if: allowed_to?(:update, :conference, conference: current_participatory_space)
         end
       end
-      initializer "decidim_conferences_admin.conferences_admin_attachments_menu" do
+      initializer "decidim_conferences_admin.attachments_menu" do
         Decidim.menu :conferences_admin_attachments_menu do |menu|
           menu.add_item :conference_attachment_collections,
                         I18n.t("attachment_collections", scope: "decidim.admin.menu.conferences_submenu"),
@@ -149,7 +149,7 @@ module Decidim
                         if: allowed_to?(:read, :attachment, conference: current_participatory_space)
         end
       end
-      initializer "decidim_conferences_admin.conferences_admin_menu" do
+      initializer "decidim_conferences_admin.conferences_menu" do
         Decidim.menu :conferences_admin_menu do |menu|
           menu.add_item :edit_conference,
                         I18n.t("info", scope: "decidim.admin.menu.conferences_submenu"),
@@ -221,7 +221,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_conferences_admin.admin_menu" do
+      initializer "decidim_conferences_admin.menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :conferences,
                         I18n.t("menu.conferences", scope: "decidim.admin"),

--- a/decidim-conferences/lib/decidim/conferences/engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/engine.rb
@@ -55,7 +55,7 @@ module Decidim
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Conferences::Engine.root}/app/views") # for partials
       end
 
-      initializer "decidim.stats" do
+      initializer "decidim_conferences.stats" do
         Decidim.stats.register :conferences_count, priority: StatsRegistry::HIGH_PRIORITY do |organization, _start_at, _end_at|
           Decidim::Conference.where(organization:).public_spaces.count
         end

--- a/decidim-conferences/spec/lib/decidim/conferences/admin_engine_spec.rb
+++ b/decidim-conferences/spec/lib/decidim/conferences/admin_engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Conferences::AdminEngine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-conferences/spec/lib/decidim/conferences/engine_spec.rb
+++ b/decidim-conferences/spec/lib/decidim/conferences/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Conferences::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-consultations/lib/decidim/consultations/admin_engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/admin_engine.rb
@@ -53,7 +53,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_consultations_admin.admin_consultation_menu" do
+      initializer "decidim_consultations_admin.consultation_menu" do
         Decidim.menu :admin_consultation_menu do |menu|
           menu.add_item :edit_consultation,
                         I18n.t("info", scope: "decidim.admin.menu.consultations_submenu"),
@@ -75,7 +75,7 @@ module Decidim
                         if: allowed_to?(:read, :question)
         end
       end
-      initializer "decidim_consultations_admin.admin_menu" do
+      initializer "decidim_consultations_admin.menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :consultations,
                         I18n.t("menu.consultations", scope: "decidim.admin"),
@@ -87,7 +87,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_consultations_admin.admin_question_menu" do
+      initializer "decidim_consultations_admin.question_menu" do
         Decidim.menu :admin_question_menu do |menu|
           menu.add_item :edit_consultation,
                         I18n.t("consultation", scope: "decidim.admin.menu.questions_submenu"),
@@ -109,7 +109,7 @@ module Decidim
                         active: is_active_link?(decidim_admin_consultations.results_consultation_path(current_participatory_space.consultation))
         end
       end
-      initializer "decidim_consultations_admin.admin_questions_menu" do
+      initializer "decidim_consultations_admin.questions_menu" do
         Decidim.menu :admin_questions_menu do |menu|
           menu.add_item :edit_question,
                         I18n.t("info", scope: "decidim.admin.menu.questions_submenu"),
@@ -154,7 +154,7 @@ module Decidim
                         if: allowed_to?(:read, :attachment)
         end
       end
-      initializer "decidim_consultations_admin.admin_consultation_components_menu" do
+      initializer "decidim_consultations_admin.consultation_components_menu" do
         Decidim.menu :admin_consultation_components_menu do |menu|
           current_participatory_space.components.each do |component|
             caption = translated_attribute(component.name)

--- a/decidim-consultations/lib/decidim/consultations/admin_engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/admin_engine.rb
@@ -53,7 +53,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_consultations.admin_consultation_menu" do
+      initializer "decidim_consultations_admin.admin_consultation_menu" do
         Decidim.menu :admin_consultation_menu do |menu|
           menu.add_item :edit_consultation,
                         I18n.t("info", scope: "decidim.admin.menu.consultations_submenu"),
@@ -75,7 +75,7 @@ module Decidim
                         if: allowed_to?(:read, :question)
         end
       end
-      initializer "decidim_consultations.admin_menu" do
+      initializer "decidim_consultations_admin.admin_menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :consultations,
                         I18n.t("menu.consultations", scope: "decidim.admin"),
@@ -87,7 +87,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_consultations.admin_question_menu" do
+      initializer "decidim_consultations_admin.admin_question_menu" do
         Decidim.menu :admin_question_menu do |menu|
           menu.add_item :edit_consultation,
                         I18n.t("consultation", scope: "decidim.admin.menu.questions_submenu"),
@@ -109,7 +109,7 @@ module Decidim
                         active: is_active_link?(decidim_admin_consultations.results_consultation_path(current_participatory_space.consultation))
         end
       end
-      initializer "decidim_consultations.admin_questions_menu" do
+      initializer "decidim_consultations_admin.admin_questions_menu" do
         Decidim.menu :admin_questions_menu do |menu|
           menu.add_item :edit_question,
                         I18n.t("info", scope: "decidim.admin.menu.questions_submenu"),
@@ -154,7 +154,7 @@ module Decidim
                         if: allowed_to?(:read, :attachment)
         end
       end
-      initializer "decidim_consultations.admin_consultation_components_menu" do
+      initializer "decidim_consultations_admin.admin_consultation_components_menu" do
         Decidim.menu :admin_consultation_components_menu do |menu|
           current_participatory_space.components.each do |component|
             caption = translated_attribute(component.name)

--- a/decidim-consultations/lib/decidim/consultations/engine.rb
+++ b/decidim-consultations/lib/decidim/consultations/engine.rb
@@ -52,7 +52,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.stats" do
+      initializer "decidim_consultations.stats" do
         Decidim.stats.register :consultations_count, priority: StatsRegistry::HIGH_PRIORITY do |organization, _start_at, _end_at|
           Decidim::Consultation.where(organization:).published.count
         end

--- a/decidim-consultations/spec/lib/decidim/consultations/admin_engine_spec.rb
+++ b/decidim-consultations/spec/lib/decidim/consultations/admin_engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Consultations::AdminEngine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-consultations/spec/lib/decidim/consultations/engine_spec.rb
+++ b/decidim-consultations/spec/lib/decidim/consultations/engine_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe Decidim::Consultations::Engine do
+  it_behaves_like "clean engine"
+
   describe "decidim_consultations.authorization_transfer" do
     include_context "authorization transfer"
 

--- a/decidim-core/README.md
+++ b/decidim-core/README.md
@@ -59,7 +59,7 @@ They should be registered as resources. In their manifest, in the `register_reso
 This can be done in an initializer (like user does), in a participatory_space manifest, or in a component manifest. i.e.:
 
 ```ruby
-      initializer "decidim.core.register_resources" do
+      initializer "decidim_core.register_resources" do
         Decidim.register_resource(:user) do |resource|
           resource.model_class_name = "Decidim::User"
           resource.card = "decidim/user_profile"

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -55,11 +55,11 @@ module Decidim
       isolate_namespace Decidim
       engine_name "decidim"
 
-      initializer "patch_webpacker", before: "webpacker.version_checker" do
+      initializer "decidim_core.patch_webpacker", before: "webpacker.version_checker" do
         ENV["WEBPACKER_CONFIG"] = Decidim::Webpacker.configuration.configuration_file
       end
 
-      initializer "decidim.action_controller" do |_app|
+      initializer "decidim_core.action_controller" do |_app|
         config.to_prepare do
           ActiveSupport.on_load :action_controller do
             helper Decidim::LayoutHelper if respond_to?(:helper)
@@ -67,36 +67,36 @@ module Decidim
         end
       end
 
-      initializer "decidim.action_mailer" do |app|
+      initializer "decidim_core.action_mailer" do |app|
         app.config.action_mailer.deliver_later_queue_name = :mailers
       end
 
-      initializer "decidim.middleware" do |app|
+      initializer "decidim_core.middleware" do |app|
         app.config.middleware.insert_before Warden::Manager, Decidim::Middleware::CurrentOrganization
         app.config.middleware.insert_before Warden::Manager, Decidim::Middleware::StripXForwardedHost
         app.config.middleware.use BatchLoader::Middleware
       end
 
-      initializer "decidim.default_form_builder" do |_app|
+      initializer "decidim_core.default_form_builder" do |_app|
         ActionView::Base.default_form_builder = Decidim::FormBuilder
       end
 
-      initializer "decidim.exceptions_app" do |app|
+      initializer "decidim_core.exceptions_app" do |app|
         app.config.exceptions_app = Decidim::Core::Engine.routes
       end
 
-      initializer "decidim.locales" do |app|
+      initializer "decidim_core.locales" do |app|
         app.config.i18n.fallbacks = true
       end
 
-      initializer "decidim.graphql_api" do
+      initializer "decidim_core.graphql_api" do
         Decidim::Api::QueryType.include Decidim::QueryExtensions
 
         Decidim::Api.add_orphan_type Decidim::Core::UserType
         Decidim::Api.add_orphan_type Decidim::Core::UserGroupType
       end
 
-      initializer "decidim.ransack" do
+      initializer "decidim_core.ransack" do
         Ransack.configure do |config|
           # Avoid turning parameter values such as user_id[]=1&user_id[]=2 into
           # { user_id: [true, "2"] }. This option allows us to handle the type
@@ -116,15 +116,15 @@ module Decidim
         end
       end
 
-      initializer "decidim.i18n_exceptions" do
+      initializer "decidim_core.i18n_exceptions" do
         ActionView::Base.raise_on_missing_translations = true unless Rails.env.production?
       end
 
-      initializer "decidim.geocoding", after: :load_config_initializers do
+      initializer "decidim_core.geocoding", after: :load_config_initializers do
         Geocoder.configure(Decidim.geocoder) if Decidim.geocoder.present?
       end
 
-      initializer "decidim.geocoding_extensions", after: "geocoder.insert_into_active_record" do
+      initializer "decidim_core.geocoding_extensions", after: "geocoder.insert_into_active_record" do
         # Include it in ActiveRecord base in order to apply it to all models
         # that may be using the `geocoded_by` or `reverse_geocoded_by` class
         # methods injected by the Geocoder gem.
@@ -133,7 +133,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.maps" do
+      initializer "decidim_core.maps" do
         Decidim::Map.register_category(:dynamic, Decidim::Map::Provider::DynamicMap)
         Decidim::Map.register_category(:static, Decidim::Map::Provider::StaticMap)
         Decidim::Map.register_category(:geocoding, Decidim::Map::Provider::Geocoding)
@@ -142,7 +142,7 @@ module Decidim
 
       # This keeps backwards compatibility with the old style of map
       # configuration through Decidim.geocoder.
-      initializer "decidim.maps_legacysupport", after: :load_config_initializers do
+      initializer "decidim_core.maps_legacysupport", after: :load_config_initializers do
         next if Decidim.maps.present?
         next if Decidim.geocoder.blank?
 
@@ -183,7 +183,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.stats" do
+      initializer "decidim_core.stats" do
         Decidim.stats.register :users_count, priority: StatsRegistry::HIGH_PRIORITY do |organization, start_at, end_at|
           StatsUsersCount.for(organization, start_at, end_at)
         end
@@ -197,7 +197,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.menu" do
+      initializer "decidim_core.menu" do
         Decidim.menu :menu do |menu|
           menu.add_item :root,
                         I18n.t("menu.home", scope: "decidim"),
@@ -213,7 +213,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.user_menu" do
+      initializer "decidim_core.user_menu" do
         Decidim.menu :user_menu do |menu|
           menu.add_item :account,
                         t("account", scope: "layouts.decidim.user_profile"),
@@ -258,7 +258,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.notifications" do
+      initializer "decidim_core.notifications" do
         config.to_prepare do
           Decidim::EventsManager.subscribe(/^decidim\.events\./) do |event_name, data|
             EventPublisherJob.perform_later(event_name, data)
@@ -266,26 +266,26 @@ module Decidim
         end
       end
 
-      initializer "decidim.validators" do
+      initializer "decidim_core.validators" do
         config.to_prepare do
           # Decidim overrides to the file content type validator
           require "file_content_type_validator"
         end
       end
 
-      initializer "decidim.content_processors" do |_app|
+      initializer "decidim_core.content_processors" do |_app|
         Decidim.configure do |config|
           config.content_processors += [:user, :user_group, :hashtag, :link]
         end
       end
 
-      initializer "add_cells_view_paths" do
+      initializer "decidim_core.add_cells_view_paths" do
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Core::Engine.root}/app/cells")
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Core::Engine.root}/app/cells/amendable")
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Core::Engine.root}/app/views") # for partials
       end
 
-      initializer "doorkeeper", before: "doorkeeper.params.filter" do
+      initializer "decidim_core.doorkeeper", before: "doorkeeper.params.filter" do
         Doorkeeper.configure do
           orm :active_record
 
@@ -326,30 +326,30 @@ module Decidim
         end
       end
 
-      initializer "OAuth inflections" do
+      initializer "decidim_core.oauth_inflections" do
         ActiveSupport::Inflector.inflections do |inflect|
           inflect.acronym "OAuth"
         end
       end
 
-      initializer "SSL and HSTS" do
+      initializer "decidim_core.ssl_and_hsts" do
         Rails.application.configure do
           config.force_ssl = Decidim.config.force_ssl
         end
       end
 
-      initializer "Disable Rack::Runtime" do
+      initializer "decidim_core.disable_rack_runtime" do
         Rails.application.configure do
           config.middleware.delete Rack::Runtime
         end
       end
 
-      initializer "Expire sessions" do
+      initializer "decidim_core.expire_sessions" do
         Rails.application.config.session_store :cookie_store, secure: Decidim.config.force_ssl, expire_after: Decidim.config.expire_session_after
         Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
       end
 
-      initializer "decidim.core.register_resources" do
+      initializer "decidim_core.register_resources" do
         Decidim.register_resource(:user) do |resource|
           resource.model_class_name = "Decidim::User"
           resource.card = "decidim/user_profile"
@@ -363,7 +363,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.core.register_metrics" do
+      initializer "decidim_core.register_metrics" do
         Decidim.metrics_registry.register(:users) do |metric_registry|
           metric_registry.manager_class = "Decidim::Metrics::UsersMetricManage"
 
@@ -427,7 +427,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.core.homepage_content_blocks" do
+      initializer "decidim_core.homepage_content_blocks" do
         Decidim.content_blocks.register(:homepage, :hero) do |content_block|
           content_block.cell = "decidim/content_blocks/hero"
           content_block.settings_form_cell = "decidim/content_blocks/hero_settings_form"
@@ -499,7 +499,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.core.static_page_blocks" do
+      initializer "decidim_core.static_page_blocks" do
         Decidim.content_blocks.register(:static_page, :summary) do |content_block|
           content_block.cell = "decidim/content_blocks/static_page/summary"
           content_block.settings_form_cell = "decidim/content_blocks/static_page/summary_settings_form"
@@ -538,7 +538,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.core.newsletter_templates" do
+      initializer "decidim_core.newsletter_templates" do
         Decidim.content_blocks.register(:newsletter_template, :basic_only_text) do |content_block|
           content_block.cell = "decidim/newsletter_templates/basic_only_text"
           content_block.settings_form_cell = "decidim/newsletter_templates/basic_only_text_settings_form"
@@ -600,7 +600,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.core.add_badges" do
+      initializer "decidim_core.add_badges" do
         Decidim::Gamification.register_badge(:followers) do |badge|
           badge.levels = [1, 15, 30, 60, 100]
           badge.reset = ->(user) { user.followers.count }
@@ -610,7 +610,7 @@ module Decidim
       # Icon library used: https://remixicon.com/
       # Just provide the respective icon name (unprefixed) and the brand color,
       # if a social-network icon is missing there, you can provide as well a SVG file as used to
-      initializer "decidim.core.add_social_share_services" do
+      initializer "decidim_core.add_social_share_services" do
         Decidim.register_social_share_service("Douban") do |service|
           service.icon = "douban-line"
           service.icon_color = "#2496cd"
@@ -693,7 +693,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.premailer" do
+      initializer "decidim_core.premailer" do
         Premailer::Adapter.use = :decidim
       end
 
@@ -739,7 +739,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.authorization_transfer" do
+      initializer "decidim_core.authorization_transfer" do
         Decidim::AuthorizationTransfer.register(:core) do |transfer|
           transfer.move_records(Decidim::Coauthorship, :decidim_author_id)
           transfer.move_records(Decidim::Endorsement, :decidim_author_id)

--- a/decidim-core/lib/decidim/geocodable.rb
+++ b/decidim-core/lib/decidim/geocodable.rb
@@ -10,8 +10,8 @@ module Decidim
   # for the Active Record models.
   #
   # NOTE: This module is automatically loaded for all active record models in
-  #       the "decidim.geocoding_extensions" initializer. It does not need to be
-  #       included separately into any models.
+  #       the "decidim_core.geocoding_extensions" initializer. It does not need
+  #       to be included separately into any models.
   module Geocodable
     extend ActiveSupport::Concern
 

--- a/decidim-core/spec/lib/engine_spec.rb
+++ b/decidim-core/spec/lib/engine_spec.rb
@@ -90,7 +90,7 @@ module Decidim::Core
       end
     end
 
-    describe "decidim.authorization_transfer" do
+    describe "decidim_core.authorization_transfer" do
       include_context "authorization transfer"
 
       let(:component) { create(:component, organization:) }

--- a/decidim-core/spec/lib/engine_spec.rb
+++ b/decidim-core/spec/lib/engine_spec.rb
@@ -4,12 +4,14 @@ require "spec_helper"
 
 module Decidim::Core
   describe Engine do
+    it_behaves_like "clean engine"
+
     describe "initializers" do
       let(:initializer_name) { nil }
       let(:initializer) { described_class.initializers.find { |i| i.name == initializer_name } }
 
-      context "when running the 'SSL and HSTS' initializer" do
-        let(:initializer_name) { "SSL and HSTS" }
+      context "when running the 'decidim_core.ssl_and_hsts' initializer" do
+        let(:initializer_name) { "decidim_core.ssl_and_hsts" }
 
         before do
           allow(Decidim.config).to receive(:force_ssl).and_return(decidim_force_ssl)
@@ -37,8 +39,8 @@ module Decidim::Core
         end
       end
 
-      context "when running the 'Expire sessions' initializer" do
-        let(:initializer_name) { "Expire sessions" }
+      context "when running the 'decidim_core.expire_sessions' initializer" do
+        let(:initializer_name) { "decidim_core.expire_sessions" }
         let(:decidim_force_ssl) { false }
         let(:decidim_expire_session_after) { 30.minutes }
 

--- a/decidim-debates/lib/decidim/debates/engine.rb
+++ b/decidim-debates/lib/decidim/debates/engine.rb
@@ -19,7 +19,7 @@ module Decidim
         root to: "debates#index"
       end
 
-      initializer "decidim_changes" do
+      initializer "decidim_debates.decidim_changes" do
         config.to_prepare do
           Decidim::SettingsChange.subscribe "debates" do |changes|
             Decidim::Debates::SettingsChangeJob.perform_later(
@@ -31,12 +31,12 @@ module Decidim
         end
       end
 
-      initializer "decidim_meetings.add_cells_view_paths" do
+      initializer "decidim_debates.add_cells_view_paths" do
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Debates::Engine.root}/app/cells")
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Debates::Engine.root}/app/views") # for partials
       end
 
-      initializer "decidim.debates.commented_debates_badge" do
+      initializer "decidim_debates.commented_debates_badge" do
         Decidim::Gamification.register_badge(:commented_debates) do |badge|
           badge.levels = [1, 5, 10, 30, 50]
 

--- a/decidim-debates/lib/decidim/debates/engine.rb
+++ b/decidim-debates/lib/decidim/debates/engine.rb
@@ -19,7 +19,7 @@ module Decidim
         root to: "debates#index"
       end
 
-      initializer "decidim_debates.decidim_changes" do
+      initializer "decidim_debates.settings_changes" do
         config.to_prepare do
           Decidim::SettingsChange.subscribe "debates" do |changes|
             Decidim::Debates::SettingsChangeJob.perform_later(

--- a/decidim-debates/spec/lib/decidim/debates/engine_spec.rb
+++ b/decidim-debates/spec/lib/decidim/debates/engine_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe Decidim::Debates::Engine do
+  it_behaves_like "clean engine"
+
   describe "decidim_debates.authorization_transfer" do
     include_context "authorization transfer"
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/engine_examples.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/engine_examples.rb
@@ -6,7 +6,7 @@ shared_examples_for "clean engine" do
       let(:initializer_name_prefix) { described_class.to_s.sub(/::([A-Za-z]+)?Engine$/, "\\1").gsub("::", "").underscore }
 
       it "is named correctly" do
-        expect(initializer.name).to start_with(initializer_name_prefix)
+        expect(initializer.name).to start_with("#{initializer_name_prefix}.")
         expect(initializer.name).to match(/^[a-z0-9_.]+$/)
         expect(initializer.name).not_to start_with(".")
       end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/engine_examples.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/engine_examples.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+shared_examples_for "clean engine" do
+  described_class.initializers.each do |initializer|
+    let(:initializer_name_prefix) { described_class.to_s.sub(/::([A-Za-z]+)?Engine$/, "\\1").gsub("::", "").underscore }
+
+    it "names the '#{initializer.name}' initializer correctly" do
+      expect(initializer.name).to start_with(initializer_name_prefix)
+      expect(initializer.name).to match(/^[a-z0-9_.]+$/)
+      expect(initializer.name).not_to start_with(".")
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/engine_examples.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/engine_examples.rb
@@ -2,12 +2,14 @@
 
 shared_examples_for "clean engine" do
   described_class.initializers.each do |initializer|
-    let(:initializer_name_prefix) { described_class.to_s.sub(/::([A-Za-z]+)?Engine$/, "\\1").gsub("::", "").underscore }
+    describe "'#{initializer.name}' initializer" do
+      let(:initializer_name_prefix) { described_class.to_s.sub(/::([A-Za-z]+)?Engine$/, "\\1").gsub("::", "").underscore }
 
-    it "names the '#{initializer.name}' initializer correctly" do
-      expect(initializer.name).to start_with(initializer_name_prefix)
-      expect(initializer.name).to match(/^[a-z0-9_.]+$/)
-      expect(initializer.name).not_to start_with(".")
+      it "is named correctly" do
+        expect(initializer.name).to start_with(initializer_name_prefix)
+        expect(initializer.name).to match(/^[a-z0-9_.]+$/)
+        expect(initializer.name).not_to start_with(".")
+      end
     end
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/geocoder.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/geocoder.rb
@@ -90,7 +90,7 @@ RSpec.configure do |config|
     # otherwise the utilities could remain unregistered which causes issues with
     # further tests.
     Decidim::Core::Engine.initializers.each do |i|
-      next unless i.name == "decidim.maps"
+      next unless i.name == "decidim_core.maps"
 
       i.run
       break

--- a/decidim-dev/spec/lib/decidim/dev/engine_spec.rb
+++ b/decidim-dev/spec/lib/decidim/dev/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Dev::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-elections/lib/decidim/elections/admin_engine.rb
+++ b/decidim-elections/lib/decidim/elections/admin_engine.rb
@@ -50,7 +50,7 @@ module Decidim
         [:trustees]
       end
 
-      initializer "decidim_admin_elections.menu_entry" do
+      initializer "decidim_elections_admin.menu_entry" do
         Decidim.participatory_space_registry.manifests.each do |participatory_space|
           menu_id = :"admin_#{participatory_space.name.to_s.singularize}_menu"
           Decidim.menu menu_id do |menu|

--- a/decidim-elections/lib/decidim/votings/admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/admin_engine.rb
@@ -70,7 +70,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_votings_admin.admin_menu" do
+      initializer "decidim_votings_admin.menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :votings,
                         I18n.t("menu.votings", scope: "decidim.votings.admin"),
@@ -82,7 +82,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_votings_admin.admin_votings_components_menu" do
+      initializer "decidim_votings_admin.votings_components_menu" do
         Decidim.menu :admin_votings_components_menu do |menu|
           current_participatory_space.components.each do |component|
             caption = translated_attribute(component.name)
@@ -99,7 +99,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_votings_admin.decidim_votings_attachments_menu" do
+      initializer "decidim_votings_admin.attachments_menu" do
         Decidim.menu :decidim_votings_attachments_menu do |menu|
           menu.add_item :voting_attachment_collections,
                         I18n.t("attachment_collections", scope: "decidim.votings.admin.menu.votings_submenu"),
@@ -115,7 +115,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_votings_admin.decidim_votings_monitoring_committee_menu" do
+      initializer "decidim_votings_admin.monitoring_committee_menu" do
         Decidim.menu :decidim_votings_monitoring_committee_menu do |menu|
           menu.add_item :voting_monitoring_committee_members,
                         I18n.t("monitoring_committee_members", scope: "decidim.votings.admin.menu.votings_submenu"),
@@ -140,7 +140,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_votings_admin.decidim_voting_menu" do
+      initializer "decidim_votings_admin.voting_menu" do
         Decidim.menu :admin_voting_menu do |menu|
           menu.add_item :edit_voting,
                         I18n.t("info", scope: "decidim.votings.admin.menu.votings_submenu"),

--- a/decidim-elections/lib/decidim/votings/admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/admin_engine.rb
@@ -70,7 +70,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_votings.admin_menu" do
+      initializer "decidim_votings_admin.admin_menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :votings,
                         I18n.t("menu.votings", scope: "decidim.votings.admin"),
@@ -82,7 +82,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_votings.admin_votings_components_menu" do
+      initializer "decidim_votings_admin.admin_votings_components_menu" do
         Decidim.menu :admin_votings_components_menu do |menu|
           current_participatory_space.components.each do |component|
             caption = translated_attribute(component.name)
@@ -99,7 +99,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_votings.decidim_votings_attachments_menu" do
+      initializer "decidim_votings_admin.decidim_votings_attachments_menu" do
         Decidim.menu :decidim_votings_attachments_menu do |menu|
           menu.add_item :voting_attachment_collections,
                         I18n.t("attachment_collections", scope: "decidim.votings.admin.menu.votings_submenu"),
@@ -115,7 +115,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_votings.decidim_votings_monitoring_committee_menu" do
+      initializer "decidim_votings_admin.decidim_votings_monitoring_committee_menu" do
         Decidim.menu :decidim_votings_monitoring_committee_menu do |menu|
           menu.add_item :voting_monitoring_committee_members,
                         I18n.t("monitoring_committee_members", scope: "decidim.votings.admin.menu.votings_submenu"),
@@ -140,7 +140,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_votings.decidim_voting_menu" do
+      initializer "decidim_votings_admin.decidim_voting_menu" do
         Decidim.menu :admin_voting_menu do |menu|
           menu.add_item :edit_voting,
                         I18n.t("info", scope: "decidim.votings.admin.menu.votings_submenu"),

--- a/decidim-elections/lib/decidim/votings/census_admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/census_admin_engine.rb
@@ -8,7 +8,7 @@ module Decidim
       paths["db/migrate"] = nil
       paths["lib/tasks"] = nil
 
-      initializer "decidim_votings_census.decidim_voting_menu" do
+      initializer "decidim_votings_census.admin_voting_menu" do
         Decidim.menu :admin_voting_menu do |menu|
           menu.add_item :voting_census,
                         I18n.t("census", scope: "decidim.votings.admin.menu.votings_submenu"),

--- a/decidim-elections/lib/decidim/votings/census_admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/census_admin_engine.rb
@@ -8,7 +8,7 @@ module Decidim
       paths["db/migrate"] = nil
       paths["lib/tasks"] = nil
 
-      initializer "decidim_votings.decidim_voting_menu" do
+      initializer "decidim_votings_census.decidim_voting_menu" do
         Decidim.menu :admin_voting_menu do |menu|
           menu.add_item :voting_census,
                         I18n.t("census", scope: "decidim.votings.admin.menu.votings_submenu"),

--- a/decidim-elections/lib/decidim/votings/engine.rb
+++ b/decidim-elections/lib/decidim/votings/engine.rb
@@ -41,7 +41,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.stats" do
+      initializer "decidim_votings.stats" do
         Decidim.stats.register :votings_count, priority: StatsRegistry::HIGH_PRIORITY do |organization, _start_at, _end_at|
           Decidim::Votings::Voting.where(organization:).published.count
         end

--- a/decidim-elections/spec/lib/decidim/elections/admin_engine_spec.rb
+++ b/decidim-elections/spec/lib/decidim/elections/admin_engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Elections::AdminEngine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-elections/spec/lib/decidim/elections/engine_spec.rb
+++ b/decidim-elections/spec/lib/decidim/elections/engine_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe Decidim::Elections::Engine do
+  it_behaves_like "clean engine"
+
   describe "decidim_elections.authorization_transfer" do
     include_context "authorization transfer"
 

--- a/decidim-elections/spec/lib/decidim/votings/admin_engine_spec.rb
+++ b/decidim-elections/spec/lib/decidim/votings/admin_engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Votings::AdminEngine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-elections/spec/lib/decidim/votings/census_engine_spec.rb
+++ b/decidim-elections/spec/lib/decidim/votings/census_engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Votings::CensusEngine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-elections/spec/lib/decidim/votings/engine_spec.rb
+++ b/decidim-elections/spec/lib/decidim/votings/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Votings::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-forms/spec/lib/decidim/forms/engine_spec.rb
+++ b/decidim-forms/spec/lib/decidim/forms/engine_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe Decidim::Forms::Engine do
+  it_behaves_like "clean engine"
+
   describe "decidim_forms.authorization_transfer" do
     include_context "authorization transfer"
 

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -83,7 +83,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_initiaves.admin_menu" do
+      initializer "decidim_initiatives_admin.admin_menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :initiatives,
                         I18n.t("menu.initiatives", scope: "decidim.admin"),
@@ -101,7 +101,7 @@ module Decidim
         end
       end
 
-      initializer "admin_decidim_initiatives.admin_components_menu" do
+      initializer "decidim_initiatives_admin.admin_components_menu" do
         Decidim.menu :admin_initiatives_components_menu do |menu|
           current_participatory_space.components.each do |component|
             caption = translated_attribute(component.name)
@@ -118,7 +118,7 @@ module Decidim
         end
       end
 
-      initializer "admin_decidim_initiative.admin_menu" do
+      initializer "decidim_initiatives_admin.admin_initiative_menu" do
         Decidim.menu :admin_initiative_menu do |menu|
           menu.add_item :edit_initiative,
                         I18n.t("menu.information", scope: "decidim.admin"),
@@ -153,7 +153,7 @@ module Decidim
         end
       end
 
-      initializer "admin_decidim_initiatives.admin_menu" do
+      initializer "decidim_initiatives_admin.admin_initiatives_menu" do
         Decidim.menu :admin_initiatives_menu do |menu|
           menu.add_item :initiatives,
                         I18n.t("menu.initiatives", scope: "decidim.admin"),

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -83,7 +83,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_initiatives_admin.admin_menu" do
+      initializer "decidim_initiatives_admin.menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :initiatives,
                         I18n.t("menu.initiatives", scope: "decidim.admin"),
@@ -101,7 +101,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_initiatives_admin.admin_components_menu" do
+      initializer "decidim_initiatives_admin.components_menu" do
         Decidim.menu :admin_initiatives_components_menu do |menu|
           current_participatory_space.components.each do |component|
             caption = translated_attribute(component.name)
@@ -118,7 +118,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_initiatives_admin.admin_initiative_menu" do
+      initializer "decidim_initiatives_admin.initiative_menu" do
         Decidim.menu :admin_initiative_menu do |menu|
           menu.add_item :edit_initiative,
                         I18n.t("menu.information", scope: "decidim.admin"),
@@ -153,7 +153,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_initiatives_admin.admin_initiatives_menu" do
+      initializer "decidim_initiatives_admin.initiatives_menu" do
         Decidim.menu :admin_initiatives_menu do |menu|
           menu.add_item :initiatives,
                         I18n.t("menu.initiatives", scope: "decidim.admin"),

--- a/decidim-initiatives/spec/lib/decidim/initiatives/admin_engine_spec.rb
+++ b/decidim-initiatives/spec/lib/decidim/initiatives/admin_engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Initiatives::AdminEngine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-initiatives/spec/lib/decidim/initiatives/engine_spec.rb
+++ b/decidim-initiatives/spec/lib/decidim/initiatives/engine_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe Decidim::Initiatives::Engine do
+  it_behaves_like "clean engine"
+
   it "loads engine mailer previews" do
     expect(ActionMailer::Preview.all).to include(Decidim::Initiatives::InitiativesMailerPreview)
   end

--- a/decidim-meetings/lib/decidim/meetings/directory_engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/directory_engine.rb
@@ -21,7 +21,7 @@ module Decidim
         nil
       end
 
-      initializer "decidim.meetings.content_blocks" do
+      initializer "decidim_meetings_directory.content_blocks" do
         Decidim.content_blocks.register(:homepage, :upcoming_meetings) do |content_block|
           content_block.cell = "decidim/meetings/content_blocks/upcoming_meetings"
           content_block.public_name_key = "decidim.meetings.content_blocks.upcoming_meetings.name"

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -42,7 +42,7 @@ module Decidim
         end
       end
 
-      initializer "decidim.content_processors" do |_app|
+      initializer "decidim_meetings.content_processors" do |_app|
         Decidim.configure do |config|
           config.content_processors += [:meeting]
         end

--- a/decidim-meetings/spec/lib/decidim/meetings/directory_engine_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/directory_engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Meetings::DirectoryEngine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-meetings/spec/lib/decidim/meetings/engine_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/engine_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe Decidim::Meetings::Engine do
+  it_behaves_like "clean engine"
+
   describe "decidim_meetings.authorization_transfer" do
     include_context "authorization transfer"
 

--- a/decidim-pages/spec/lib/decidim/pages/engine_spec.rb
+++ b/decidim-pages/spec/lib/decidim/pages/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Pages::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -95,7 +95,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_participatory_processes.admin_menu" do
+      initializer "decidim_participatory_processes_admin.admin_menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :participatory_processes,
                         I18n.t("menu.participatory_processes", scope: "decidim.admin"),
@@ -109,7 +109,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_participatory_processes.admin_participatory_processes_menu" do
+      initializer "decidim_participatory_processes_admin.admin_participatory_processes_menu" do
         Decidim.menu :admin_participatory_processes_menu do |menu|
           menu.add_item :participatory_processes,
                         I18n.t("menu.participatory_processes", scope: "decidim.admin"),
@@ -134,7 +134,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_participatory_processes.admin_process_attachments_menu" do
+      initializer "decidim_participatory_processes_admin.admin_process_attachments_menu" do
         Decidim.menu :admin_participatory_process_attachments_menu do |menu|
           menu.add_item :participatory_process_attachment_collections,
                         I18n.t("attachment_collections", scope: "decidim.admin.menu.participatory_processes_submenu"),
@@ -150,7 +150,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_participatory_processes.admin_process_components_menu" do
+      initializer "decidim_participatory_processes_admin.admin_process_components_menu" do
         Decidim.menu :admin_participatory_process_components_menu do |menu|
           current_participatory_space.components.each do |component|
             caption = translated_attribute(component.name)
@@ -170,7 +170,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_participatory_processes.admin_process_group_menu" do
+      initializer "decidim_participatory_processes_admin.admin_process_group_menu" do
         Decidim.menu :admin_participatory_process_menu do |menu|
           menu.add_item :edit_participatory_process,
                         I18n.t("info", scope: "decidim.admin.menu.participatory_processes_submenu"),
@@ -225,7 +225,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_participatory_processes.admin_process_group_menu" do
+      initializer "decidim_participatory_processes_admin.admin_process_group_menu" do
         Decidim.menu :admin_participatory_process_group_menu do |menu|
           menu.add_item :edit_participatory_process_group,
                         I18n.t("info", scope: "decidim.admin.menu.participatory_process_groups_submenu"),

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -95,7 +95,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_participatory_processes_admin.admin_menu" do
+      initializer "decidim_participatory_processes_admin.menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :participatory_processes,
                         I18n.t("menu.participatory_processes", scope: "decidim.admin"),
@@ -109,7 +109,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_participatory_processes_admin.admin_participatory_processes_menu" do
+      initializer "decidim_participatory_processes_admin.participatory_processes_menu" do
         Decidim.menu :admin_participatory_processes_menu do |menu|
           menu.add_item :participatory_processes,
                         I18n.t("menu.participatory_processes", scope: "decidim.admin"),
@@ -134,7 +134,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_participatory_processes_admin.admin_process_attachments_menu" do
+      initializer "decidim_participatory_processes_admin.process_attachments_menu" do
         Decidim.menu :admin_participatory_process_attachments_menu do |menu|
           menu.add_item :participatory_process_attachment_collections,
                         I18n.t("attachment_collections", scope: "decidim.admin.menu.participatory_processes_submenu"),
@@ -150,7 +150,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_participatory_processes_admin.admin_process_components_menu" do
+      initializer "decidim_participatory_processes_admin.process_components_menu" do
         Decidim.menu :admin_participatory_process_components_menu do |menu|
           current_participatory_space.components.each do |component|
             caption = translated_attribute(component.name)
@@ -170,7 +170,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_participatory_processes_admin.admin_process_group_menu" do
+      initializer "decidim_participatory_processes_admin.process_menu" do
         Decidim.menu :admin_participatory_process_menu do |menu|
           menu.add_item :edit_participatory_process,
                         I18n.t("info", scope: "decidim.admin.menu.participatory_processes_submenu"),
@@ -225,7 +225,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_participatory_processes_admin.admin_process_group_menu" do
+      initializer "decidim_participatory_processes_admin.process_group_menu" do
         Decidim.menu :admin_participatory_process_group_menu do |menu|
           menu.add_item :edit_participatory_process_group,
                         I18n.t("info", scope: "decidim.admin.menu.participatory_process_groups_submenu"),

--- a/decidim-participatory_processes/spec/lib/decidim/participatory_processes/admin_engine_spec.rb
+++ b/decidim-participatory_processes/spec/lib/decidim/participatory_processes/admin_engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ParticipatoryProcesses::AdminEngine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-participatory_processes/spec/lib/decidim/participatory_processes/engine_spec.rb
+++ b/decidim-participatory_processes/spec/lib/decidim/participatory_processes/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ParticipatoryProcesses::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -51,7 +51,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_proposals.decidim_changes" do
+      initializer "decidim_proposals.settings_changes" do
         config.to_prepare do
           Decidim::SettingsChange.subscribe "surveys" do |changes|
             Decidim::Proposals::SettingsChangeJob.perform_later(

--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -39,7 +39,7 @@ module Decidim
         root to: "proposals#index"
       end
 
-      initializer "decidim.content_processors" do |_app|
+      initializer "decidim_proposals.content_processors" do |_app|
         Decidim.configure do |config|
           config.content_processors += [:proposal]
         end
@@ -51,7 +51,7 @@ module Decidim
         end
       end
 
-      initializer "decidim_changes" do
+      initializer "decidim_proposals.decidim_changes" do
         config.to_prepare do
           Decidim::SettingsChange.subscribe "surveys" do |changes|
             Decidim::Proposals::SettingsChangeJob.perform_later(

--- a/decidim-proposals/spec/lib/decidim/proposals/engine_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/engine_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe Decidim::Proposals::Engine do
+  it_behaves_like "clean engine"
+
   describe "decidim_proposals.remove_space_admins" do
     let(:component) { create(:proposal_component, participatory_space: space) }
     let(:valuator) { create :user, organization: }

--- a/decidim-sortitions/spec/lib/decidim/sortitions/engine_spec.rb
+++ b/decidim-sortitions/spec/lib/decidim/sortitions/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Sortitions::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-surveys/lib/decidim/surveys/admin_engine.rb
+++ b/decidim-surveys/lib/decidim/surveys/admin_engine.rb
@@ -18,7 +18,7 @@ module Decidim
         root to: "surveys#edit"
       end
 
-      initializer "decidim.notifications.components" do
+      initializer "decidim_surveys_admin.notifications.components" do
         config.to_prepare do
           Decidim::EventsManager.subscribe(/^decidim\.events\.components/) do |event_name, data|
             CleanSurveyAnswersJob.perform_later(event_name, data)

--- a/decidim-surveys/lib/decidim/surveys/engine.rb
+++ b/decidim-surveys/lib/decidim/surveys/engine.rb
@@ -18,7 +18,7 @@ module Decidim
         root to: "surveys#show"
       end
 
-      initializer "decidim_surveys.decidim_changes" do
+      initializer "decidim_surveys.settings_changes" do
         config.to_prepare do
           Decidim::SettingsChange.subscribe "surveys" do |changes|
             Decidim::Surveys::SettingsChangeJob.perform_later(

--- a/decidim-surveys/lib/decidim/surveys/engine.rb
+++ b/decidim-surveys/lib/decidim/surveys/engine.rb
@@ -18,7 +18,7 @@ module Decidim
         root to: "surveys#show"
       end
 
-      initializer "decidim_changes" do
+      initializer "decidim_surveys.decidim_changes" do
         config.to_prepare do
           Decidim::SettingsChange.subscribe "surveys" do |changes|
             Decidim::Surveys::SettingsChangeJob.perform_later(

--- a/decidim-surveys/spec/lib/decidim/surveys/admin_engine_spec.rb
+++ b/decidim-surveys/spec/lib/decidim/surveys/admin_engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Surveys::AdminEngine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-surveys/spec/lib/decidim/surveys/engine_spec.rb
+++ b/decidim-surveys/spec/lib/decidim/surveys/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Surveys::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-system/spec/lib/decidim/system/engine_spec.rb
+++ b/decidim-system/spec/lib/decidim/system/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::System::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-templates/lib/decidim/templates/admin_engine.rb
+++ b/decidim-templates/lib/decidim/templates/admin_engine.rb
@@ -38,7 +38,7 @@ module Decidim
         root to: "questionnaire_templates#index"
       end
 
-      initializer "decidim_templates_admin.admin_participatory_processes_menu" do
+      initializer "decidim_templates_admin.participatory_processes_menu" do
         Decidim.menu :admin_template_types_menu do |menu|
           menu.add_item :questionnaires,
                         I18n.t("template_types.questionnaires", scope: "decidim.templates"),
@@ -57,13 +57,13 @@ module Decidim
         end
       end
 
-      initializer "decidim_templates_admin.admin_mount_routes" do
+      initializer "decidim_templates_admin.mount_routes" do
         Decidim::Core::Engine.routes do
           mount Decidim::Templates::AdminEngine, at: "/admin/templates", as: "decidim_admin_templates"
         end
       end
 
-      initializer "decidim_templates_admin.admin_menu" do
+      initializer "decidim_templates_admin.menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :questionnaire_templates,
                         I18n.t("menu.templates", scope: "decidim.admin", default: "Templates"),

--- a/decidim-templates/lib/decidim/templates/admin_engine.rb
+++ b/decidim-templates/lib/decidim/templates/admin_engine.rb
@@ -38,7 +38,7 @@ module Decidim
         root to: "questionnaire_templates#index"
       end
 
-      initializer "decidim_participatory_processes.admin_participatory_processes_menu" do
+      initializer "decidim_templates_admin.admin_participatory_processes_menu" do
         Decidim.menu :admin_template_types_menu do |menu|
           menu.add_item :questionnaires,
                         I18n.t("template_types.questionnaires", scope: "decidim.templates"),
@@ -57,13 +57,13 @@ module Decidim
         end
       end
 
-      initializer "decidim_templates.admin_mount_routes" do
+      initializer "decidim_templates_admin.admin_mount_routes" do
         Decidim::Core::Engine.routes do
           mount Decidim::Templates::AdminEngine, at: "/admin/templates", as: "decidim_admin_templates"
         end
       end
 
-      initializer "decidim_templates.admin_menu" do
+      initializer "decidim_templates_admin.admin_menu" do
         Decidim.menu :admin_menu do |menu|
           menu.add_item :questionnaire_templates,
                         I18n.t("menu.templates", scope: "decidim.admin", default: "Templates"),

--- a/decidim-templates/spec/lib/decidim/templates/admin_engine_spec.rb
+++ b/decidim-templates/spec/lib/decidim/templates/admin_engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Templates::AdminEngine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-templates/spec/lib/decidim/templates/engine_spec.rb
+++ b/decidim-templates/spec/lib/decidim/templates/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Templates::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-verifications/lib/decidim/verifications/sms/engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/sms/engine.rb
@@ -18,7 +18,7 @@ module Decidim
           root to: "authorizations#new"
         end
 
-        initializer "decidim.sms_verification_workflow" do |_app|
+        initializer "decidim_verifications_sms.sms_verification_workflow" do |_app|
           if Decidim.sms_gateway_service
             Decidim::Verifications.register_workflow(:sms) do |workflow|
               workflow.engine = Decidim::Verifications::Sms::Engine

--- a/decidim-verifications/lib/decidim/verifications/sms/engine.rb
+++ b/decidim-verifications/lib/decidim/verifications/sms/engine.rb
@@ -18,7 +18,7 @@ module Decidim
           root to: "authorizations#new"
         end
 
-        initializer "decidim_verifications_sms.sms_verification_workflow" do |_app|
+        initializer "decidim_verifications_sms.workflow" do |_app|
           if Decidim.sms_gateway_service
             Decidim::Verifications.register_workflow(:sms) do |workflow|
               workflow.engine = Decidim::Verifications::Sms::Engine

--- a/decidim-verifications/spec/lib/decidim/verifications/engine_spec.rb
+++ b/decidim-verifications/spec/lib/decidim/verifications/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Verifications::Engine do
+  it_behaves_like "clean engine"
+end

--- a/decidim-verifications/spec/lib/decidim/verifications/sms/engine_spec.rb
+++ b/decidim-verifications/spec/lib/decidim/verifications/sms/engine_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Verifications::Sms::Engine do
+  it_behaves_like "clean engine"
+end

--- a/docs/modules/customize/pages/logic.adoc
+++ b/docs/modules/customize/pages/logic.adoc
@@ -77,7 +77,7 @@ end
 This applies to almost all classes you want to change in Decidim but controllers and helpers are special cases due to order of how things are loaded in the Decidim boot process. If you want to add any changes to controllers or helpers, you need to wrap the `config.to_prepare` block within an initializer that is run at the correct phase of the boot process as follows:
 [source,ruby]
 ----
-  initializer "customizations", after: "decidim.action_controller" do
+  initializer "customizations", after: "decidim_core.action_controller" do
     config.to_prepare do
       # Add the controller/helper customizations here
     end

--- a/docs/modules/develop/pages/content_blocks.adoc
+++ b/docs/modules/develop/pages/content_blocks.adoc
@@ -34,7 +34,7 @@ Note that content blocks need to be registered from an initializer. If you are a
 module Decidim::MyModule::Engine < ::Rails::Engine
   # ...
 
-  initializer "decidim.my_module.content_blocks" do
+  initializer "decidim_my_module.content_blocks" do
     Decidim.content_blocks.register(:homepage, :my_content_block) do |content_block|
       # ...
     end

--- a/docs/modules/develop/pages/modules.adoc
+++ b/docs/modules/develop/pages/modules.adoc
@@ -141,7 +141,7 @@ module Decidim
         end
 
         # This is a Dedicim::Verifications specific initializer
-        initializer "decidim.my_verifier_verification_workflow" do |_app|
+        initializer "decidim_verifications_my_verifier.verification_workflow" do |_app|
           Decidim::Verifications.register_workflow(:my_verifier) do |workflow|
             workflow.engine = Decidim::Verifications::MyVerifier::Engine
           end


### PR DESCRIPTION
#### :tophat: What? Why?
While investigating an issue with the session cookie (#10864), I noticed that we do not have consistent initializer naming across the different engines.

This PR standardizes the naming and adds tests to ensure consistent naming in the future.

#### :pushpin: Related Issues
- Related to #10864

#### Testing
See that CI is green.