### PR TITLE
Add "Vulnerability disclosure policy" section to SECURITY file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,3 +29,22 @@ To download our key:
 ```bash
 gpg --keyserver pgp.mit.edu --recv 84B935C4
 ```
+
+## Vulnerability disclosure policy
+
+Working with security issues in an open source project can be challenging, as
+we are required to disclose potential problems that could be exploited by
+attackers. With this in mind, our security fix policy is as follows:
+
+1. The Maintainers team will handle the fix as usual (Pull Request, backport,
+release).
+1. In the release notes, we will include the identification numbers from the
+GitHub Advisory Database (GHSA) and, if applicable, the Common Vulnerabilities
+and Exposures (CVE) identifier for the vulnerability.
+1. We will provide a grace period of 2 months for implementers to update to a
+patched version. In the case of critical security issues, the grace period will
+be extended to 4 months.
+1. Once this grace period has passed, we will publish the vulnerability.
+
+By adhering to this security policy, we aim to address security concerns
+effectively and responsibly in our open source software project.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,23 +1,16 @@
-= Security Policy
+# Security Policy
 
-== Supported Versions
+## Supported Versions
 
 Until we have the version 1.0 we support only the last two minor versions with security updates.
 
-|===
-| Version | Supported
+| Version  | Supported          |
+| -------- | ------------------ |
+| 0.27.x   | :white_check_mark: |
+| 0.26.x   | :white_check_mark: |
+| \<= 0.25 | :x:                |
 
-| 0.27.x
-| :white_check_mark:
-
-| 0.26.x
-| :white_check_mark:
-
-| \<= 0.25
-| :x:
-|===
-
-== Reporting a Vulnerability
+## Reporting a Vulnerability
 
 Security is very important to us.
 
@@ -27,7 +20,6 @@ We appreciate your effort to make Decidim more secure.
 We recommend to use GPG for these kind of communications, the fingerprint is `C1BD 8981 D83C 23F9 D419 FE42 149A D0F9 84B9 35C4`.
 To download our key:
 
-[source,bash]
-----
+```bash
 gpg --keyserver pgp.mit.edu --recv 84B935C4
-----
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,8 @@
 
 ## Supported Versions
 
-Until we have the version 1.0 we support only the last two minor versions with security updates.
+Until we have the version 1.0 we support only the last two minor versions with
+security updates.
 
 | Version  | Supported          |
 | -------- | ------------------ |
@@ -14,10 +15,15 @@ Until we have the version 1.0 we support only the last two minor versions with s
 
 Security is very important to us.
 
-If you have any issue regarding security, please disclose the information responsibly by sending an email to security [at] decidim [dot] org and not by creating a github/metadecidim issue.
+If you have any issue regarding security, please disclose the information
+responsibly by sending an email to security [at] decidim [dot] org and not by
+creating a github/metadecidim issue.
+
 We appreciate your effort to make Decidim more secure.
 
-We recommend to use GPG for these kind of communications, the fingerprint is `C1BD 8981 D83C 23F9 D419 FE42 149A D0F9 84B9 35C4`.
+We recommend to use GPG for these kind of communications, the fingerprint is
+`C1BD 8981 D83C 23F9 D419 FE42 149A D0F9 84B9 35C4`.
+
 To download our key:
 
 ```bash


### PR DESCRIPTION

#### :tophat: What? Why?

As in the last release we have a couple of security fixes, we (@decidim/maintainers) want to introduce a "Vulnerability disclosure policy", with a grace period for updates. 

At the same time, I detected that this file wasn't detected by some tools, such as the "Security policy" feature in GitHub: https://github.com/decidim/decidim/security/policy. By changing the format and extension from AsciiDoc to Markdown, that should be fixed. 

:hearts: Thank you!
