### PR TITLE
Fix Security policy file link

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -11,7 +11,7 @@ Come find us at https://matrix.to/#/#decidim:matrix.org[our Matrix.org space]. W
 == Did you find a bug?
 
 * *Do not open up a GitHub issue if the bug is a security vulnerability in Decidim*, and instead send us an email to security [at] decidim.org.
-See https://github.com/decidim/decidim/blob/develop/SECURITY.adoc[full security policy].
+See https://github.com/decidim/decidim/blob/develop/SECURITY.md[full security policy].
 * *Ensure the bug was not already reported* by searching on GitHub under https://github.com/decidim/decidim/issues[Issues] and on https://meta.decidim.org/processes/bug-report/f/210/proposals[Metadecidim].
 * If you are unable to find an open issue addressing the problem, https://github.com/decidim/decidim/issues/new?template=Bug_report.md[open a new one on GitHub].
 Be sure to include a *title and clear description*, as much relevant information as possible, and a *code sample* or an *executable test case* demonstrating the expected behavior that is not occurring.

--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@
 :uri-propose-new-features: https://meta.decidim.org/processes/roadmap
 :uri-releases: https://github.com/decidim/decidim/releases
 :uri-roadmap: https://github.com/decidim/decidim/projects/16
-:uri-security: xref:SECURITY.adoc
+:uri-security: https://github.com/decidim/decidim/blob/develop/SECURITY.md
 :uri-social-contract: http://www.decidim.org/contract/
 :uri-website: https://decidim.org
 :uri-yard-docs: http://rubydoc.info/github/decidim/decidim/develop

--- a/docs/modules/develop/pages/security.adoc
+++ b/docs/modules/develop/pages/security.adoc
@@ -5,7 +5,7 @@
 Until we have the version 1.0 we support only the last minor and major
 version with security updates.
 
-https://github.com/decidim/decidim/blob/doc/security-keyserver/SECURITY.adoc[See the last supported version].
+https://github.com/decidim/decidim/blob/develop/SECURITY.md[See the last supported version].
 
 == Reporting a Vulnerability
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

After merging #10879, we need to fix the links to this file as it has changed where it is.

#### :pushpin: Related Issues
 
- Related to #10879 

#### Testing
All these links should be correct when clicking on it

:hearts: Thank you!
