### PR TITLE
Fix fetching apt packages in gitpod build

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,7 +3,8 @@ USER root
 
 # Install PostgreSQL
 ENV PGVERSION=14
-RUN apt-get install -y postgresql postgresql-client postgresql-server-dev-${PGVERSION} libpq-dev
+RUN apt-get update \
+  && apt-get install -y postgresql postgresql-client postgresql-server-dev-${PGVERSION} libpq-dev
 
 # Setup the database user env vars, drop the default database cluster and change the folders to the workspace
 # This makes it possible to persist the database within the workspace


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While setting up a gitpod, I found an error on build:

``` 
Get:35 http://archive.ubuntu.com/ubuntu jammy/main amd64 postgresql all 14+238 [3,288 B]
Get:36 http://archive.ubuntu.com/ubuntu jammy/main amd64 postgresql-client all 14+238 [3,292 B]
Get:37 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 postgresql-server-dev-14 amd64 14.7-0ubuntu0.22.04.1 [1,174 kB]
Get:38 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 sysstat amd64 12.5.2-2ubuntu0.1 [487 kB]
Fetched 132 MB in 30s (4,340 kB/s)
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/g/gcc-11/libobjc-11-dev_11.3.0-1ubuntu1%7e22.04_amd64.deb  404  Not Found [IP: 91.189.91.39 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The command '/bin/sh -c apt-get install -y postgresql postgresql-client postgresql-server-dev-${PGVERSION} libpq-dev' returned a non-zero code: 100
```


This PR fixes it.

#### :pushpin: Related Issues

- Related to #10641

#### Testing

Run the following command before and after the patch: 

`
docker build --file .gitpod.Dockerfile --tag decidim-gitpod .
`
 

:hearts: Thank you!
