### PR TITLE
Fix budgets zero single view

### DIFF
--- a/decidim-budgets/app/forms/decidim/budgets/admin/budget_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/budget_form.rb
@@ -16,7 +16,8 @@ module Decidim
         attribute :decidim_scope_id, Integer
 
         validates :title, translatable_presence: true
-        validates :weight, :total_budget, numericality: { greater_than_or_equal_to: 0 }
+        validates :weight, numericality: { greater_than_or_equal_to: 0 }
+        validates :total_budget, numericality: { greater_than: 0 }
         validates :scope, presence: true, if: ->(form) { form.decidim_scope_id.present? }
         validates :decidim_scope_id, scope_belongs_to_component: true, if: ->(form) { form.decidim_scope_id.present? }
 

--- a/decidim-budgets/app/models/decidim/budgets/order.rb
+++ b/decidim-budgets/app/models/decidim/budgets/order.rb
@@ -108,6 +108,7 @@ module Decidim
       # enabled
       def budget_percent
         return (total_projects.to_f / maximum_projects) * 100 if projects_rule?
+        return 0 if total_budget.zero?
 
         (total_budget.to_f / budget.total_budget) * 100
       end

--- a/decidim-budgets/app/models/decidim/budgets/order.rb
+++ b/decidim-budgets/app/models/decidim/budgets/order.rb
@@ -108,7 +108,7 @@ module Decidim
       # enabled
       def budget_percent
         return (total_projects.to_f / maximum_projects) * 100 if projects_rule?
-        return 0 if total_budget.zero?
+        return 0 if budget.total_budget.zero?
 
         (total_budget.to_f / budget.total_budget) * 100
       end

--- a/decidim-budgets/spec/forms/decidim/budgets/admin/budget_form_spec.rb
+++ b/decidim-budgets/spec/forms/decidim/budgets/admin/budget_form_spec.rb
@@ -51,6 +51,12 @@ describe Decidim::Budgets::Admin::BudgetForm do
     it { is_expected.not_to be_valid }
   end
 
+  describe "when total_budget is equal to 0" do
+    let(:total_budget) { 0 }
+
+    it { is_expected.not_to be_valid }
+  end
+
   describe "when the scope does not exist" do
     let(:scope_id) { scope.id + 10 }
 

--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -121,6 +121,16 @@ describe "Orders", type: :system do
           end
         end
       end
+
+      context "when the total budget is zero" do
+        let(:budget) { create(:budget, total_budget: 0, component:) }
+
+        it "displays total budget" do
+          within ".budget-summary__total" do
+            expect(page).to have_content("TOTAL BUDGET €0")
+          end
+        end
+      end
     end
 
     context "and has not a pending order" do


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Component: Budgets 

Budgets that were set to zero as an admin in the view would **crash** when a user wished to view them on the front end facing view. 

A patch has been created in **decidim-budgets/apps/models/decidim/budgera/order.rb** in a form of a condition that takes this into account if the user wants a zero budget, allowing admins to view their budgets set at zero. 

The validation has also been updated to take this into account within **decidim-budgets/app/forms/decidim/budgets/admin/budget_form.rb**

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10710 

#### Testing
1. Login as a admin 
2. Head to edit under your admin acc
3. Click processes on the left and a select any open or create a new one.
4. Click budgets and create a new by pre-filling all the necessary information in the form.
5. Under the "Total Budget", make sure that value is set to 0. 
6. Save this by "Create Budget" at the bottom of the form.
7. You'll be taken back to the index of the budgets available and you'll notice you'll have your new budget set at 0.
8. Preview this budget by clicking the eye icon on the right panel under actions. 
9. You'll be taken to the front end view of your new budget set at zero. 

Rspec tests have also been created for patch, currently raking green for the following: 

- Budgets at zero patch: **decidim-budgets/spec/system/orders_spec.rb**
- Validation check: **decidim-budgets/spec/forms/decidim/budgets/admin/budget_form_spec.rb**

### :camera: Screenshots

![image](https://github.com/decidim/decidim/assets/101816158/5c0fdd0b-1883-4946-9d1d-db7f5a51baf4)

:hearts: Thank you!
