### PR TITLE
Add more disallowed prefixes in the 'Check PR title' workflow

### DIFF
--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
-          disallowed_prefixes: "feat/,chore/,build/,ci/,refactor/,docs/,wip/"
+          disallowed_prefixes: "feat/,feature/,fix/,chore/,build/,ci/,refactor/,docs/,wip/,fix:"
           prefix_case_sensitive: false
           min_length: 5
           max_length: 100


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

I see that there are a couple PRs opened with a wrong title (i.e. the same prefix as the branch name, like "Feature/xxx"). This PR tunes the configuration so the CI kicks in, and we actually see that as an error. 

#### :pushpin: Related Issues

- Related to #10637, #10441 and #10892
 
:hearts: Thank you!
