### PR TITLE
Viewing correct partners in Conferences edit

### DIFF
--- a/decidim-conferences/app/views/decidim/conferences/admin/partners/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/partners/_form.html.erb
@@ -11,8 +11,7 @@
     </div>
 
     <div class="row column">
-      <%= form.label :partner_type %>
-      <%= select :conference_partner, :partner_type, @form.types, include_blank: false %>
+      <%= form.select :partner_type, @form.types, { multiple: false, prompt: ""  } %>
     </div>
 
     <div class="row column">

--- a/decidim-conferences/spec/shared/manage_partners_examples.rb
+++ b/decidim-conferences/spec/shared/manage_partners_examples.rb
@@ -32,6 +32,11 @@ shared_examples "manage partners examples" do
           with: "Partner name"
         )
 
+        select(
+          "Collaborator",
+          from: :conference_partner_partner_type
+        )
+
         find("*[type=submit]").click
       end
 
@@ -40,6 +45,21 @@ shared_examples "manage partners examples" do
 
       within "#partners table" do
         expect(page).to have_content("Partner name")
+        expect(page).to have_content("Collaborator")
+      end
+    end
+
+    context "when the partner type is already a Collaborator" do
+      let!(:conference_partner) { create(:partner, partner_type: "collaborator", conference:) }
+
+      it "returns the correct partner type in the edit" do
+        visit decidim_admin_conferences.edit_conference_partner_path(conference, conference_partner)
+        within ".edit_partner" do
+          expect(page).to have_select(
+            :conference_partner_partner_type,
+            selected: "Collaborator"
+          )
+        end
       end
     end
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR is a fix to an issue within Conferences in which editing a Partner which is set to a "Collaborator" reverts back to a "Main Promotor". 

Thanks to a solution provided by @alecslupu, we have changed the snippet of code within ´´´decidim-conferences/app/views/decidim/conferences/admin/partners/_form.html.erb```, from:

```
<%= form.label :partner_type %>
      <%= select :conference_partner, :partner_type, @form.types, include_blank: false %>
```

to 

```
<%= form.select :partner_type, @form.types, { multiple: false, prompt: ""  } %>
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10868 

#### Testing
1. Login as an admin and head over to edit.
2. Click on "Conferences" on the left panel and choose one available.
3. Click on "Partners" under Conferences and create a "New Partner".
4. Pre-fill all the necessary information and under "Partner type" click Collaborator and save by clicking "Create" on the bottom of the page.
5. On the index of the Partners click edit again on your newly created Partner. 
6. View in edit that the Partner type is now called a "Collaborator" and not "Main Promotor".

An Rspec test has also been created in ```decidim-conferences/spec/shared/manage_partners_examples.rb``` to test this functionality. 

Call ```decidim-conferences/spec/system/admin/admin_manages_partners_spec.rb``` to test this file.

### :camera: Screenshots

Viewing the changed partner type:
![image](https://github.com/decidim/decidim/assets/101816158/9957704d-49b5-469e-bb26-5a029b61327e)

Viewing the changed the partner type, "Collaborator", back in edit correctly : 
![image](https://github.com/decidim/decidim/assets/101816158/8ba338e3-0f0d-4de3-b696-587aa87c50c1)

:hearts: Thank you!
