### PR TITLE
Add seeded Trustees

### DIFF
--- a/decidim-elections/lib/decidim/elections/component.rb
+++ b/decidim-elections/lib/decidim/elections/component.rb
@@ -519,10 +519,10 @@ Decidim.register_component(:elections) do |component|
 
     %w(admin@example.org user@example.org user2@example.org).each do |email|
       trustee = Decidim::Elections::Trustee.create!(
-        user: Decidim::User.find_by(email: email),
+        user: Decidim::User.find_by(email:),
         organization: participatory_space.organization
       )
-      trustee.trustees_participatory_spaces.create!(participatory_space: participatory_space)
+      trustee.trustees_participatory_spaces.create!(participatory_space:)
     end
   end
 end

--- a/decidim-elections/lib/decidim/elections/component.rb
+++ b/decidim-elections/lib/decidim/elections/component.rb
@@ -516,6 +516,14 @@ Decidim.register_component(:elections) do |component|
         question.answer_options.create!(body: Decidim::Faker::Localized.sentence)
       end
     end
+
+    %w(admin@example.org user@example.org user2@example.org).each do |email|
+      trustee = Decidim::Elections::Trustee.create!(
+        user: Decidim::User.find_by(email: email),
+        organization: participatory_space.organization
+      )
+      trustee.trustees_participatory_spaces.create!(participatory_space: participatory_space)
+    end
   end
 end
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

Every time you set up a new installation and you want to try Elections you need to add at least 3 Trustees so it works.

This PR adds three users (admin@example.org, user@example.org, and user2@example.org) as Trustees in all the Participatory Spaces (ie an Assembly), so it's easier/faster to test this out. 

#### Testing


1. Create a new development_app (or re-do the seeds/database with `bin/rails db:drop db:create db:migrate db:seed`)
2. Sign in as admin
3. Go to any Participatory Space (ie an Assembly)
4. Go to  Trustees section in the sidebar
5. See that you have 3 Trustees

### :camera: Screenshots

![Screenshot of three trustees](https://github.com/decidim/decidim/assets/717367/b51c5123-23b0-4bf4-8cd9-331bdb4d3ca0)


:hearts: Thank you!
