### PR TITLE
Show message on the Election form about the Organization time zone

### DIFF
--- a/decidim-elections/app/views/decidim/elections/admin/elections/_form.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/_form.html.erb
@@ -13,6 +13,11 @@
     </div>
 
     <div class="row">
+      <div class="callout warning">
+        <p><%= t(".organization_time_zone",
+                 time_zone: current_organization.time_zone,
+                 time: Time.zone.now) %></p>
+      </div>
       <div class="column xlarge-6">
         <%= form.datetime_field :start_time %>
       </div>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -199,6 +199,8 @@ en:
           edit:
             title: Edit election
             update: Update election
+          form:
+            organization_time_zone: Check that the organization time zone is correct in the organization settings. The current configuration is %{time_zone} (%{time}).
           index:
             no_bulletin_board: There is no <a href="https://github.com/decidim/decidim-bulletin-board">Bulletin Board server</a> configured, which is needed to use this module. This task should be done by the System Administrator.
             title: Elections


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

Sometimes you make a mistake while configuring an Election related to the admin timezone and the current_organization timezone. This is something that we already fixed on an external module that's based on some code of decidim-elections (see https://github.com/decidim-vocdoni/decidim-module-vocdoni/pull/21):

> This is a small one, related to a possible bug while setting up the Election and a lack of synchronization between the time zone of the Decidim Organization and the admin that's setting it put.
>
> Basically, I've set up and Election and my Decidim Organization (aka Tenant) wasn't configured (as it's the default on a seeded database), so I think it's nice to at least have a message while creating the Election in the form. (The credit for this idea goes to @carolromero, as my initial proposal was to adding it as a check while setting up the Election, but it actually was difficult to check that out programmatically, so this message is the best approach IMHO).
 
#### Testing


2. Sign in as admin
3. Go to an Election inside of a Participatory Space (ie an Assembly)
4. Go to the "Edit" or "New" pages
5. See that there's a new callout with the message about the timezone 

### :camera: Screenshots

![image](https://github.com/decidim/decidim/assets/717367/4ebca538-b908-4af9-9023-43c6b18daeeb)


:hearts: Thank you!
