### PR TITLE
Fix flaky tests at proposals

### DIFF
--- a/decidim-proposals/spec/system/amendable/amend_proposal_spec.rb
+++ b/decidim-proposals/spec/system/amendable/amend_proposal_spec.rb
@@ -184,6 +184,7 @@ describe "Amend Proposal", versioning: true, type: :system do
 
         before do
           visit proposal_path
+          expect(page).to have_content(proposal_title)
         end
 
         it "is NOT shown a link to Amend it" do
@@ -208,6 +209,7 @@ describe "Amend Proposal", versioning: true, type: :system do
       context "and visits an amendable proposal" do
         before do
           visit proposal_path
+          expect(page).to have_content(proposal_title)
         end
 
         it "is shown a link to Amend it" do
@@ -231,6 +233,7 @@ describe "Amend Proposal", versioning: true, type: :system do
           before do
             login_as user, scope: :user
             visit proposal_path
+            expect(page).to have_content(proposal_title)
             click_link "Amend Proposal"
           end
 

--- a/decidim-proposals/spec/system/amendable/amendment_diff_spec.rb
+++ b/decidim-proposals/spec/system/amendable/amendment_diff_spec.rb
@@ -139,7 +139,6 @@ describe "Amendment Diff", versioning: true, type: :system do
         proposal.update(title: { en: "Updated long enough title" }, body: { en: "Updated one liner body" })
         # The last version of the emendation should hold the amending attribute values.
         emendation.update(title: { en: "Amended long enough title" }, body: { en: "Amended one liner body" })
-        visit emendation_path
         login_as user, scope: :user
         visit decidim.review_amend_path(amendment)
       end

--- a/decidim-proposals/spec/system/filter_proposals_spec.rb
+++ b/decidim-proposals/spec/system/filter_proposals_spec.rb
@@ -121,6 +121,7 @@ describe "Filter Proposals", :slow, type: :system do
       create(:proposal, component:, scope: scope2)
       create(:proposal, component:, scope: nil)
       visit_component
+      expect(page).to have_content("4 PROPOSALS")
     end
 
     it "can be filtered by scope" do
@@ -525,6 +526,7 @@ describe "Filter Proposals", :slow, type: :system do
               let(:user) { new_amendment.amender }
 
               before do
+                expect(page).to have_content("3 PROPOSALS")
                 login_as user, scope: :user
                 visit_component
               end
@@ -549,6 +551,7 @@ describe "Filter Proposals", :slow, type: :system do
 
             context "and has NOT amended a proposal" do
               before do
+                expect(page).to have_content("2 PROPOSALS")
                 login_as user, scope: :user
                 visit_component
               end
@@ -598,6 +601,7 @@ describe "Filter Proposals", :slow, type: :system do
               let(:user) { new_amendment.amender }
 
               before do
+                expect(page).to have_content("3 PROPOSALS")
                 login_as user, scope: :user
                 visit_component
               end
@@ -622,6 +626,7 @@ describe "Filter Proposals", :slow, type: :system do
 
             context "and has NOT amended a proposal" do
               before do
+                expect(page).to have_content("2 PROPOSALS")
                 login_as user, scope: :user
                 visit_component
               end

--- a/decidim-proposals/spec/system/proposal_show_spec.rb
+++ b/decidim-proposals/spec/system/proposal_show_spec.rb
@@ -19,6 +19,7 @@ describe "Show a Proposal", type: :system do
     context "when requesting the proposal path" do
       before do
         visit_proposal
+        expect(page).to have_content(translated(proposal.title))
       end
 
       it_behaves_like "share link"


### PR DESCRIPTION
#### :tophat: What? Why?
After some recent commits, I noticed some proposals system specs are failing quite often. I assume this is related to bumping the dependencies but not 100% sure.

This should fix the issues.

#### Testing
Run the following specs 20 times in a row and expect to see no failures:

```bash
$ cd decidim-proposals
$ for i in {1..20}; do bundle exec rspec spec/system/proposal_show_spec.rb -e "show when requesting the proposal path extra admin link when I'm an admin user has a link to answer to the proposal at the admin" || break; done
$ for i in {1..20}; do bundle exec rspec spec/system/filter_proposals_spec.rb -e "when filtering proposals by TYPE when there are amendments to proposals when amendments_enabled component setting is enabled and amendments_visbility component step_setting is set to 'participants' when the user is logged in and has amended a proposal can be filtered by type" || break; done
$ for i in {1..20}; do bundle exec rspec spec/system/amendable/amend_proposal_spec.rb -e "with amendments enabled when amendment CREATION is enabled and visits an amendable proposal from a private yet transparent space when a private user is logged in is shown a link to Amend it" || break; done
$ for i in {1..20}; do bundle exec rspec spec/system/amendable/amend_proposal_spec.rb -e "with amendments enabled when amendment CREATION is enabled and visits an amendable proposal when the user is logged in and clicks when the form is filled incorrectly is shown the field error message" || break; done
$ for i in {1..20}; do bundle exec rspec spec/system/amendable/amendment_diff_spec.rb -e "when amendment REACTION is enabled and the proposal author is reviewing an emendation to their proposal before accepting it shows the changed attributes compared to the last version of the amended proposal" || break; done
```