### PR TITLE
Fix reminder already registered with the name :close_meeting

### DIFF
--- a/decidim-budgets/lib/decidim/budgets/engine.rb
+++ b/decidim-budgets/lib/decidim/budgets/engine.rb
@@ -44,7 +44,7 @@ module Decidim
       end
 
       initializer "decidim_budgets.register_reminders" do
-        config.to_prepare do
+        config.after_initialize do
           Decidim.reminders_registry.register(:orders) do |reminder_registry|
             reminder_registry.generator_class_name = "Decidim::Budgets::OrderReminderGenerator"
             reminder_registry.form_class_name = "Decidim::Budgets::Admin::OrderReminderForm"

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -125,7 +125,7 @@ module Decidim
       end
 
       initializer "decidim_meetings.register_reminders" do
-        config.to_prepare do
+        config.after_initialize do
           Decidim.reminders_registry.register(:close_meeting) do |reminder_registry|
             reminder_registry.generator_class_name = "Decidim::Meetings::CloseMeetingReminderGenerator"
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
After #10858  has been merged, @andreslucena noticed some errors. I could replicate this at console level, and this PR fixes the issue.
The PR aims to change the behavior by moving the registration of reminders from [Autoload on Boot and on Each Reload](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoload-on-boot-and-on-each-reload) to [Autoload on Boot Only](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoload-on-boot-only)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10858 
- Fixes #10910

#### Testing
1. To validate the bug, open a rails console, and type `reload!`
2. See the error
3. Repeat 1+2 to see the error is there every time 
4. Apply the patch 
5. Enter the console and type `reload!`
6. See the application reloads without any issues. 
7. Repeat 4+5 several times to see the error is not there. 
8. In the same console type `Decidim.reminders_registry` and see the registry is being populated. 

:hearts: Thank you!
