### PR TITLE
Migrate to `GITHUB_OUTPUT` in components' template GitHub Actions

### DIFF
--- a/decidim-generators/lib/decidim/generators/component_templates/github/ci.yml.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/github/ci.yml.erb
@@ -50,7 +50,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get npm cache directory path
         id: npm-cache-dir-path
-        run: echo "::set-output name=dir::$(npm get cache)-<%= component_name %>"
+        run: echo "dir=$(npm get cache)-<%= component_name %>" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         id: npm-cache
         with:


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

I had a pending review on #10908 that I was going to send when it was merged. We're using an old an deprecated syntax in the components' template GitHub Actions configuration. This PR fixes it.  

#### :pushpin: Related Issues
 
- Related to #10571 and #10908

:hearts: Thank you!
