### PR TITLE
Remove unused preset-env dependencies

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -21,7 +21,6 @@
       }
     ],
     ["@babel/plugin-transform-regenerator", { "async": false }],
-    ["@babel/plugin-proposal-private-methods", { "loose": true }],
     ["@babel/plugin-proposal-class-properties", { "loose": true }]
   ]
 }

--- a/babel.config.json
+++ b/babel.config.json
@@ -20,7 +20,6 @@
         "corejs": false
       }
     ],
-    ["@babel/plugin-transform-regenerator", { "async": false }],
-    ["@babel/plugin-proposal-class-properties", { "loose": true }]
+    ["@babel/plugin-transform-regenerator", { "async": false }]
   ]
 }

--- a/babel.config.json
+++ b/babel.config.json
@@ -20,8 +20,7 @@
         "corejs": false
       }
     ],
-    [ "@babel/plugin-transform-regenerator", { "async": false }],
-    [ "@babel/plugin-proposal-private-property-in-object", { "loose": true }],
+    ["@babel/plugin-transform-regenerator", { "async": false }],
     ["@babel/plugin-proposal-private-methods", { "loose": true }],
     ["@babel/plugin-proposal-class-properties", { "loose": true }]
   ]


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
While working on #10727 i have noticed the pipeline failed, due to some babel configuration as per below stacktrace: 

Since @babel/preset-env has been updated to 7.22.0, it has removed the dependency to `@babel/plugin-proposal-private-property-in-object`. 

Since I have added `@babel/plugin-proposal-private-property-in-object`, `@babel/plugin-proposal-private-methods` and `@babel/plugin-proposal-class-properties` back in #8670, and I do not remember why, i am removing it in the current PR. 

#### Testing
Make sure the pipeline is green.

:hearts: Thank you!
