### PR TITLE
Fix for initiative menu not active on creation

### DIFF
--- a/decidim-initiatives/lib/decidim/initiatives/engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/engine.rb
@@ -90,7 +90,7 @@ module Decidim
                         I18n.t("menu.initiatives", scope: "decidim"),
                         decidim_initiatives.initiatives_path,
                         position: 2.4,
-                        active: :inclusive,
+                        active: %r{^/(initiatives|create_initiative)},
                         if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).all.empty?
         end
       end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing #10727, I noticed that we had a mini-bug on this wizard: the menu item isn't active while on the Creation wizard. 

This PR fixes it. 

#### :pushpin: Related Issues
 
- Related to #10727


#### Testing

1. Sign in 
2. Go to http://localhost:3000/create_initiative/select_initiative_type?locale=es
3. See the menu  

### :camera: Screenshots

![Selection_638](https://github.com/decidim/decidim/assets/717367/60f5706b-9c2f-4cdf-9bb6-87be8540b16c)


:hearts: Thank you!
