### PR TITLE
Enable new rubocop rules part 1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,9 +62,6 @@ Capybara/SpecificActions:
 Capybara/CurrentPathExpectation:
   Enabled: false
 
-Style/RedundantConstantBase:
-  Enabled: false
-
 Style/RedundantStringEscape:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,9 +71,6 @@ Style/MapToSet:
 Style/HashSyntax:
   Enabled: false
 
-Style/MagicCommentFormat:
-  Enabled: false
-
 Style/Semicolon:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -152,6 +152,4 @@ RSpec/BeEmpty:
 Rails/RootPathnameMethods:
   Enabled: false
 
-Lint/DuplicateMagicComment:
-  Enabled: false
 # EOF fix these rules later

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,9 +50,6 @@ Rails/Exit:
     - lib/decidim/git_backport_manager.rb
 
 # fix these rules later
-Capybara/NegationMatcher:
-  Enabled: false
-
 Capybara/SpecificMatcher:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -116,9 +116,6 @@ RSpec/MatchArray:
 Rails/ActionControllerFlashBeforeRender:
   Enabled: false
 
-Lint/RedundantCopDisableDirective:
-  Enabled: false
-
 RSpec/ContainExactly:
   Enabled: false
 

--- a/decidim-accountability/spec/cells/decidim/accountability/result_m_cell_spec.rb
+++ b/decidim-accountability/spec/cells/decidim/accountability/result_m_cell_spec.rb
@@ -43,7 +43,7 @@ module Decidim::Accountability
         let(:end_date) { nil }
 
         it "hides dates block" do
-          expect(subject).to have_no_css(".card-data__item--centerblock")
+          expect(subject).not_to have_css(".card-data__item--centerblock")
         end
       end
 
@@ -51,7 +51,7 @@ module Decidim::Accountability
         let(:progress) { nil }
 
         it "hides progress value and bar" do
-          expect(subject).to have_no_css(".progress__bar")
+          expect(subject).not_to have_css(".progress__bar")
         end
       end
     end

--- a/decidim-accountability/spec/shared/manage_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_examples.rb
@@ -118,7 +118,7 @@ shared_examples "manage results" do
       expect(page).to have_admin_callout("successfully")
 
       within "table" do
-        expect(page).to have_no_content(translated(result2.title))
+        expect(page).not_to have_content(translated(result2.title))
       end
     end
   end

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -62,9 +62,9 @@ describe "Explore results", versioning: true, type: :system do
       it "does not show progress" do
         visit path
 
-        expect(page).to have_no_content("Global execution status")
+        expect(page).not_to have_content("Global execution status")
         within("aside") do
-          expect(page).to have_no_selector(".accountability__status-value")
+          expect(page).not_to have_selector(".accountability__status-value")
         end
       end
     end
@@ -206,7 +206,7 @@ describe "Explore results", versioning: true, type: :system do
 
     context "without category or scope" do
       it "does not show any tag" do
-        expect(page).to have_no_selector("ul.tags.tag-container")
+        expect(page).not_to have_selector("ul.tags.tag-container")
       end
     end
 
@@ -357,7 +357,7 @@ describe "Explore results", versioning: true, type: :system do
         end
 
         it "disables filtering by scope" do
-          expect(page).to have_no_selector("[data-scope-filters]")
+          expect(page).not_to have_selector("[data-scope-filters]")
         end
       end
 

--- a/decidim-admin/app/events/decidim/attachment_created_event.rb
+++ b/decidim-admin/app/events/decidim/attachment_created_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class AttachmentCreatedEvent < Decidim::Events::SimpleEvent

--- a/decidim-admin/app/events/decidim/component_published_event.rb
+++ b/decidim-admin/app/events/decidim/component_published_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class ComponentPublishedEvent < Decidim::Events::SimpleEvent

--- a/decidim-admin/app/events/decidim/resource_hidden_event.rb
+++ b/decidim-admin/app/events/decidim/resource_hidden_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class ResourceHiddenEvent < Decidim::Events::SimpleEvent

--- a/decidim-admin/lib/decidim/admin/test/manage_attachment_collections_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_attachment_collections_examples.rb
@@ -95,7 +95,7 @@ shared_examples "manage attachment collections examples" do
         expect(page).to have_admin_callout("successfully")
 
         within "#attachment_collections table" do
-          expect(page).to have_no_content(translated(attachment_collection2.name))
+          expect(page).not_to have_content(translated(attachment_collection2.name))
         end
       end
     end
@@ -109,7 +109,7 @@ shared_examples "manage attachment collections examples" do
 
       it "cannot delete it" do
         within find("tr", text: translated(attachment_collection.name)) do
-          expect(page).to have_no_selector("a.action-icon--remove")
+          expect(page).not_to have_selector("a.action-icon--remove")
         end
       end
     end

--- a/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
@@ -116,7 +116,7 @@ shared_examples "manage attachments examples" do
 
       within "#attachments" do
         within find("tr", text: translated(attachment.title)) do
-          expect(page).to have_no_text(translated(attachment_collection.name, locale: :en))
+          expect(page).not_to have_text(translated(attachment_collection.name, locale: :en))
         end
       end
     end
@@ -128,7 +128,7 @@ shared_examples "manage attachments examples" do
 
       expect(page).to have_admin_callout("successfully")
 
-      expect(page).to have_no_content(translated(attachment.title, locale: :en))
+      expect(page).not_to have_content(translated(attachment.title, locale: :en))
     end
 
     it "can update an attachment" do

--- a/decidim-admin/lib/decidim/admin/test/manage_categories_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_categories_examples.rb
@@ -83,7 +83,7 @@ shared_examples "manage categories examples" do
           expect(page).to have_admin_callout("successfully")
 
           within "#categories table" do
-            expect(page).to have_no_content(translated(category2.name))
+            expect(page).not_to have_content(translated(category2.name))
           end
         end
       end
@@ -117,7 +117,7 @@ shared_examples "manage categories examples" do
         visit current_path
 
         within find("tr", text: translated(category.name)) do
-          expect(page).to have_no_selector("a.action-icon--remove")
+          expect(page).not_to have_selector("a.action-icon--remove")
         end
       end
     end

--- a/decidim-admin/lib/decidim/admin/test/manage_component_permissions_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_component_permissions_examples.rb
@@ -181,9 +181,9 @@ shared_examples "Managing component permissions" do
     end
 
     let(:edit_resource_permissions_path) do
-      ::Decidim::EngineRouter.admin_proxy(participatory_space).edit_component_permissions_path(component.id,
-                                                                                               resource_name: resource.resource_manifest.name,
-                                                                                               resource_id: resource.id)
+      Decidim::EngineRouter.admin_proxy(participatory_space).edit_component_permissions_path(component.id,
+                                                                                             resource_name: resource.resource_manifest.name,
+                                                                                             resource_id: resource.id)
     end
 
     let(:component_settings) { nil }

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -58,7 +58,7 @@ shared_examples "manage moderations" do
 
       visit current_path
 
-      expect(page).to have_no_selector("tr[data-id=\"#{external_moderation.id}\"]")
+      expect(page).not_to have_selector("tr[data-id=\"#{external_moderation.id}\"]")
     end
 
     it "user can review them" do
@@ -84,7 +84,7 @@ shared_examples "manage moderations" do
       end
 
       expect(page).to have_admin_callout("Resource successfully hidden")
-      expect(page).to have_no_content(moderation.reportable.reported_content_url)
+      expect(page).not_to have_content(moderation.reportable.reported_content_url)
     end
 
     it "user can sort by report count" do
@@ -134,7 +134,7 @@ shared_examples "manage moderations" do
         moderation.reportable.destroy
         visit current_path
 
-        expect(page).to have_no_selector("tr[data-id=\"#{moderation.id}\"]")
+        expect(page).not_to have_selector("tr[data-id=\"#{moderation.id}\"]")
       end
     end
 

--- a/decidim-admin/spec/permissions/decidim/admin/permissions_spec.rb
+++ b/decidim-admin/spec/permissions/decidim/admin/permissions_spec.rb
@@ -73,7 +73,7 @@ describe Decidim::Admin::Permissions do
       let(:participatory_process) { create(:participatory_process, organization: user.organization) }
 
       before do
-        ::Decidim::ParticipatoryProcessUserRole.create(user:, participatory_process:, role: :admin)
+        Decidim::ParticipatoryProcessUserRole.create(user:, participatory_process:, role: :admin)
       end
 
       it "allows users to enter the space area" do

--- a/decidim-admin/spec/shared/manage_impersonations_examples.rb
+++ b/decidim-admin/spec/shared/manage_impersonations_examples.rb
@@ -269,7 +269,7 @@ shared_examples "manage impersonations examples" do
       navigate_to_impersonations_page
 
       within find("tr", text: managed_user.name) do
-        expect(page).to have_no_link("Promote")
+        expect(page).not_to have_link("Promote")
       end
     end
   end

--- a/decidim-admin/spec/system/admin_manages_impersonatable_users_list_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_impersonatable_users_list_spec.rb
@@ -31,9 +31,9 @@ describe "Admin manages impersonatable users list", type: :system do
       expect(page).to have_selector("tr[data-user-id=\"#{managed.id}\"]", text: managed.name)
       expect(page).to have_selector("tr[data-user-id=\"#{managed.id}\"]", text: "Managed")
 
-      expect(page).to have_no_selector("tr[data-user-id=\"#{external_not_managed.id}\"]", text: not_managed.name)
-      expect(page).to have_no_selector("tr[data-user-id=\"#{another_admin.id}\"]", text: another_admin.name)
-      expect(page).to have_no_selector("tr[data-user-id=\"#{user_manager.id}\"]", text: user_manager.name)
+      expect(page).not_to have_selector("tr[data-user-id=\"#{external_not_managed.id}\"]", text: not_managed.name)
+      expect(page).not_to have_selector("tr[data-user-id=\"#{another_admin.id}\"]", text: another_admin.name)
+      expect(page).not_to have_selector("tr[data-user-id=\"#{user_manager.id}\"]", text: user_manager.name)
 
       expect(page).to have_selector("tr[data-user-id=\"#{not_managed.id}\"]", text: not_managed.name)
       expect(page).to have_selector("tr[data-user-id=\"#{not_managed.id}\"]", text: "Not managed")

--- a/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
@@ -327,7 +327,7 @@ describe "Admin manages newsletters", type: :system do
       end
 
       expect(page).to have_content("successfully")
-      expect(page).to have_no_css("tr[data-newsletter-id=\"#{newsletter.id}\"]")
+      expect(page).not_to have_css("tr[data-newsletter-id=\"#{newsletter.id}\"]")
     end
   end
 end

--- a/decidim-admin/spec/system/admin_manages_organization_admins_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_admins_spec.rb
@@ -87,7 +87,7 @@ describe "Organization admins", type: :system do
           accept_confirm { click_link "Delete" }
         end
 
-        expect(page).to have_no_content(other_admin.name)
+        expect(page).not_to have_content(other_admin.name)
       end
 
       it "cannot remove admin rights from self" do

--- a/decidim-admin/spec/system/admin_manages_organization_appearance_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_appearance_spec.rb
@@ -32,7 +32,7 @@ describe "Admin manages organization", type: :system do
       it "does not show the HTML header snippet form field" do
         visit decidim_admin.edit_organization_appearance_path
 
-        expect(page).to have_no_field(:organization_header_snippets)
+        expect(page).not_to have_field(:organization_header_snippets)
       end
     end
 

--- a/decidim-admin/spec/system/admin_manages_organization_area_types_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_area_types_spec.rb
@@ -94,7 +94,7 @@ describe "Admin manages area types", type: :system do
       expect(page).to have_admin_callout("successfully")
 
       within "table" do
-        expect(page).to have_no_content(translated(area_type.name))
+        expect(page).not_to have_content(translated(area_type.name))
       end
     end
   end

--- a/decidim-admin/spec/system/admin_manages_organization_areas_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_areas_spec.rb
@@ -80,7 +80,7 @@ describe "Organization Areas", type: :system do
         expect(page).to have_admin_callout("successfully")
 
         within ".card-section" do
-          expect(page).to have_no_content(translated(area.name))
+          expect(page).not_to have_content(translated(area.name))
         end
       end
 

--- a/decidim-admin/spec/system/admin_manages_organization_scope_types_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_scope_types_spec.rb
@@ -94,7 +94,7 @@ describe "Admin manages scope types", type: :system do
       expect(page).to have_admin_callout("successfully")
 
       within "table" do
-        expect(page).to have_no_content(translated(scope_type.name))
+        expect(page).not_to have_content(translated(scope_type.name))
       end
     end
   end

--- a/decidim-admin/spec/system/admin_manages_organization_scopes_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_scopes_spec.rb
@@ -76,7 +76,7 @@ describe "Organization scopes", type: :system do
         expect(page).to have_admin_callout("successfully")
 
         within ".card-section" do
-          expect(page).to have_no_content(translated(scope.name))
+          expect(page).not_to have_content(translated(scope.name))
         end
       end
 

--- a/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
@@ -101,7 +101,7 @@ describe "Space admin manages global moderations", type: :system do
       within ".container" do
         expect(page).to have_content("Reported content")
 
-        expect(page).to have_no_selector("table.table-list tbody tr")
+        expect(page).not_to have_selector("table.table-list tbody tr")
       end
     end
   end

--- a/decidim-admin/spec/system/space_moderator_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_moderator_manages_global_moderations_spec.rb
@@ -69,7 +69,7 @@ describe "Space moderator manages global moderations", type: :system do
       within ".container" do
         expect(page).to have_content("Reported content")
 
-        expect(page).to have_no_selector("table.table-list tbody tr")
+        expect(page).not_to have_selector("table.table-list tbody tr")
       end
     end
   end

--- a/decidim-admin/spec/system/static_pages_spec.rb
+++ b/decidim-admin/spec/system/static_pages_spec.rb
@@ -143,7 +143,7 @@ describe "Content pages", type: :system do
         expect(page).to have_admin_callout("successfully")
 
         within "table" do
-          expect(page).to have_no_content(translated(topic.title))
+          expect(page).not_to have_content(translated(topic.title))
         end
       end
     end
@@ -254,7 +254,7 @@ describe "Content pages", type: :system do
         expect(page).to have_admin_callout("successfully")
 
         within "table" do
-          expect(page).to have_no_content(translated(decidim_page.title))
+          expect(page).not_to have_content(translated(decidim_page.title))
         end
       end
 

--- a/decidim-assemblies/app/events/decidim/role_assigned_to_assembly_event.rb
+++ b/decidim-assemblies/app/events/decidim/role_assigned_to_assembly_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class RoleAssignedToAssemblyEvent < Decidim::Events::SimpleEvent

--- a/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
@@ -158,7 +158,7 @@ shared_examples "assembly admin manage assembly components" do
         click_link "Delete"
       end
 
-      expect(page).to have_no_content("My component")
+      expect(page).not_to have_content("My component")
     end
   end
 

--- a/decidim-assemblies/spec/shared/manage_assembly_admins_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_admins_examples.rb
@@ -75,7 +75,7 @@ shared_examples "manage assembly admins examples" do
       expect(page).to have_admin_callout("successfully")
 
       within "#assembly_admins table" do
-        expect(page).to have_no_content(other_user.email)
+        expect(page).not_to have_content(other_user.email)
       end
     end
 

--- a/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
@@ -158,7 +158,7 @@ shared_examples "manage assembly components" do
         click_link "Delete"
       end
 
-      expect(page).to have_no_content("My component")
+      expect(page).not_to have_content("My component")
     end
   end
 

--- a/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
@@ -140,7 +140,7 @@ shared_examples "manage assembly members examples" do
       expect(page).to have_admin_callout("successfully")
 
       within "#assembly_members table" do
-        expect(page).to have_no_content(assembly_member.full_name)
+        expect(page).not_to have_content(assembly_member.full_name)
       end
     end
   end

--- a/decidim-assemblies/spec/shared/manage_assembly_private_users_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_private_users_examples.rb
@@ -63,7 +63,7 @@ shared_examples "manage assembly private users examples" do
       expect(page).to have_admin_callout("successfully")
 
       within "#private_users table" do
-        expect(page).to have_no_content(other_user.email)
+        expect(page).not_to have_content(other_user.email)
       end
     end
 

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_types_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_types_spec.rb
@@ -70,7 +70,7 @@ describe "Admin manages assemblies", type: :system do
         expect(page).to have_admin_callout("successfully")
 
         within ".card-section" do
-          expect(page).to have_no_content(translated(assembly_type.title))
+          expect(page).not_to have_content(translated(assembly_type.title))
         end
       end
     end

--- a/decidim-assemblies/spec/system/admin/valuator_checks_components_spec.rb
+++ b/decidim-assemblies/spec/system/admin/valuator_checks_components_spec.rb
@@ -32,7 +32,7 @@ describe "Valuator checks components", type: :system do
     it "can only see the proposals component" do
       within ".layout-nav #components-list" do
         expect(page).to have_content(translated(current_component.name))
-        expect(page).to have_no_content(translated(another_component.name))
+        expect(page).not_to have_content(translated(another_component.name))
       end
     end
   end
@@ -45,7 +45,7 @@ describe "Valuator checks components", type: :system do
 
       within ".card" do
         expect(page).to have_content(translated(current_component.name))
-        expect(page).to have_no_content(translated(another_component.name))
+        expect(page).not_to have_content(translated(another_component.name))
       end
     end
   end

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -43,7 +43,7 @@ describe "Assemblies", type: :system do
       visit decidim.root_path
 
       within ".main-nav" do
-        expect(page).to have_no_content("Assemblies")
+        expect(page).not_to have_content("Assemblies")
       end
     end
   end
@@ -71,7 +71,7 @@ describe "Assemblies", type: :system do
         visit decidim.root_path
 
         within ".main-nav" do
-          expect(page).to have_no_content("Assemblies")
+          expect(page).not_to have_content("Assemblies")
         end
       end
     end
@@ -226,7 +226,7 @@ describe "Assemblies", type: :system do
         it "shows the components" do
           within ".process-nav" do
             expect(page).to have_content(translated(proposals_component.name, locale: :en).upcase)
-            expect(page).to have_no_content(translated(meetings_component.name, locale: :en).upcase)
+            expect(page).not_to have_content(translated(meetings_component.name, locale: :en).upcase)
           end
         end
       end
@@ -239,8 +239,8 @@ describe "Assemblies", type: :system do
             expect(page).to have_css("h2.h2", text: "Statistics")
             expect(page).to have_css(".statistic__title", text: "Proposals")
             expect(page).to have_css(".statistic__number", text: "3")
-            expect(page).to have_no_css(".statistic__title", text: "Meetings")
-            expect(page).to have_no_css(".statistic__number", text: "0")
+            expect(page).not_to have_css(".statistic__title", text: "Meetings")
+            expect(page).not_to have_css(".statistic__number", text: "0")
           end
         end
       end
@@ -249,9 +249,9 @@ describe "Assemblies", type: :system do
         let(:show_statistics) { false }
 
         it "does not render the stats for those components that are not visible" do
-          expect(page).to have_no_css("h2.h2", text: "Statistics")
-          expect(page).to have_no_css(".statistic__title", text: "Proposals")
-          expect(page).to have_no_css(".statistic__number", text: "3")
+          expect(page).not_to have_css("h2.h2", text: "Statistics")
+          expect(page).not_to have_css(".statistic__title", text: "Proposals")
+          expect(page).not_to have_css(".statistic__number", text: "3")
         end
       end
 

--- a/decidim-assemblies/spec/system/assembly_members_spec.rb
+++ b/decidim-assemblies/spec/system/assembly_members_spec.rb
@@ -21,7 +21,7 @@ describe "Assembly members", type: :system do
       visit decidim_assemblies.assembly_path(assembly)
 
       within ".main-nav" do
-        expect(page).to have_no_content("Members")
+        expect(page).not_to have_content("Members")
       end
     end
   end
@@ -49,7 +49,7 @@ describe "Assembly members", type: :system do
         visit decidim_assemblies.assembly_path(assembly)
 
         within ".process-header" do
-          expect(page).to have_no_content("MEMBERS")
+          expect(page).not_to have_content("MEMBERS")
         end
       end
     end

--- a/decidim-assemblies/spec/system/filter_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/filter_assemblies_spec.rb
@@ -42,7 +42,7 @@ describe "Filter Assemblies", type: :system do
 
     it "does not show the assemblies types filter" do
       within("#assemblies-filter") do
-        expect(page).to have_no_content("All types")
+        expect(page).not_to have_content("All types")
       end
     end
   end

--- a/decidim-assemblies/spec/system/private_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/private_assemblies_spec.rb
@@ -68,7 +68,7 @@ describe "Private Assemblies", type: :system do
           it "does not show the privacy warning in attachments admin" do
             visit decidim_admin_assemblies.assembly_attachments_path(private_assembly)
             within "#attachments" do
-              expect(page).to have_no_content("Any participant could share this document to others")
+              expect(page).not_to have_content("Any participant could share this document to others")
             end
           end
         end
@@ -93,7 +93,7 @@ describe "Private Assemblies", type: :system do
             expect(page).to have_content(translated(assembly.title, locale: :en))
             expect(page).to have_selector(".card--assembly", count: 1)
 
-            expect(page).to have_no_content(translated(private_assembly.title, locale: :en))
+            expect(page).not_to have_content(translated(private_assembly.title, locale: :en))
           end
         end
       end
@@ -115,7 +115,7 @@ describe "Private Assemblies", type: :system do
               expect(page).to have_content(translated(assembly.title, locale: :en))
               expect(page).to have_selector(".card--assembly", count: 1)
 
-              expect(page).to have_no_content(translated(private_assembly.title, locale: :en))
+              expect(page).not_to have_content(translated(private_assembly.title, locale: :en))
             end
           end
         end

--- a/decidim-blogs/spec/shared/manage_posts_examples.rb
+++ b/decidim-blogs/spec/shared/manage_posts_examples.rb
@@ -89,7 +89,7 @@ shared_examples "manage posts" do
       expect(page).to have_admin_callout("successfully")
 
       within "table" do
-        expect(page).to have_no_content(translated(post1.title))
+        expect(page).not_to have_content(translated(post1.title))
         expect(page).to have_content(translated(post2.title))
       end
     end

--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -111,9 +111,9 @@ Decidim.register_component(:budgets) do |component|
 
   component.seeds do |participatory_space|
     landing_page_content = Decidim::Faker::Localized.localized do
-      "<h2>#{::Faker::Lorem.sentence}</h2>" \
-        "<p>#{::Faker::Lorem.paragraph}</p>" \
-        "<p>#{::Faker::Lorem.paragraph}</p>"
+      "<h2>#{Faker::Lorem.sentence}</h2>" \
+        "<p>#{Faker::Lorem.paragraph}</p>" \
+        "<p>#{Faker::Lorem.paragraph}</p>"
     end
 
     component = Decidim::Component.create!(

--- a/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
+++ b/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
@@ -202,15 +202,15 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
         end
 
         it "is hidden the percent input" do
-          expect(page).to have_no_content("Vote threshold percent")
-          expect(page).to have_no_css("input#component_settings_vote_threshold_percent")
+          expect(page).not_to have_content("Vote threshold percent")
+          expect(page).not_to have_css("input#component_settings_vote_threshold_percent")
         end
 
         it "is hidden the project rule inputs" do
-          expect(page).to have_no_content("Minimum amount of projects to be selected")
-          expect(page).to have_no_content("Maximum amount of projects to be selected")
-          expect(page).to have_no_css("input#component_settings_vote_selected_projects_minimum")
-          expect(page).to have_no_css("input#component_settings_vote_selected_projects_maximum")
+          expect(page).not_to have_content("Minimum amount of projects to be selected")
+          expect(page).not_to have_content("Maximum amount of projects to be selected")
+          expect(page).not_to have_css("input#component_settings_vote_selected_projects_minimum")
+          expect(page).not_to have_css("input#component_settings_vote_selected_projects_maximum")
         end
       end
 
@@ -227,13 +227,13 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
         end
 
         it "is hidden the percent input" do
-          expect(page).to have_no_content("Vote threshold percent")
-          expect(page).to have_no_css("input#component_settings_vote_threshold_percent")
+          expect(page).not_to have_content("Vote threshold percent")
+          expect(page).not_to have_css("input#component_settings_vote_threshold_percent")
         end
 
         it "is hidden the number input" do
-          expect(page).to have_no_content("Minimum number of projects to vote")
-          expect(page).to have_no_css("input#component_settings_vote_minimum_budget_projects_number")
+          expect(page).not_to have_content("Minimum number of projects to vote")
+          expect(page).not_to have_css("input#component_settings_vote_minimum_budget_projects_number")
         end
       end
 
@@ -248,15 +248,15 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
         end
 
         it "is hidden the number input" do
-          expect(page).to have_no_content("Minimum number of projects to vote")
-          expect(page).to have_no_css("input#component_settings_vote_minimum_budget_projects_number")
+          expect(page).not_to have_content("Minimum number of projects to vote")
+          expect(page).not_to have_css("input#component_settings_vote_minimum_budget_projects_number")
         end
 
         it "is hidden the project rule inputs" do
-          expect(page).to have_no_content("Minimum amount of projects to be selected")
-          expect(page).to have_no_content("Maximum amount of projects to be selected")
-          expect(page).to have_no_css("input#component_settings_vote_selected_projects_minimum")
-          expect(page).to have_no_css("input#component_settings_vote_selected_projects_maximum")
+          expect(page).not_to have_content("Minimum amount of projects to be selected")
+          expect(page).not_to have_content("Maximum amount of projects to be selected")
+          expect(page).not_to have_css("input#component_settings_vote_selected_projects_minimum")
+          expect(page).not_to have_css("input#component_settings_vote_selected_projects_maximum")
         end
       end
     end

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -188,7 +188,7 @@ shared_examples "manage projects" do
       expect(page).to have_admin_callout("successfully")
 
       within "table" do
-        expect(page).to have_no_content(translated(project2.title))
+        expect(page).not_to have_content(translated(project2.title))
       end
     end
   end

--- a/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
@@ -115,7 +115,7 @@ describe "Admin manages budgets", type: :system do
 
       it "cannot delete the budget" do
         within find("tr", text: translated(budget.title)) do
-          expect(page).to have_no_selector(".action-icon--remove")
+          expect(page).not_to have_selector(".action-icon--remove")
         end
       end
     end

--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -43,8 +43,8 @@ describe "Admin manages projects", type: :system do
       within "tr[data-id='#{project.id}']" do
         expect(page).to have_content(translated(category.name))
       end
-      expect(::Decidim::Budgets::Project.find(project.id).category).to eq(category)
-      expect(::Decidim::Budgets::Project.find(project2.id).category).to be_nil
+      expect(Decidim::Budgets::Project.find(project.id).category).to eq(category)
+      expect(Decidim::Budgets::Project.find(project2.id).category).to be_nil
     end
 
     it "changes projects scope" do
@@ -57,8 +57,8 @@ describe "Admin manages projects", type: :system do
       within "tr[data-id='#{project.id}']" do
         expect(page).to have_content(translated(scope.name))
       end
-      expect(::Decidim::Budgets::Project.find(project.id).scope).to eq(scope)
-      expect(::Decidim::Budgets::Project.find(project2.id).scope).to be_nil
+      expect(Decidim::Budgets::Project.find(project.id).scope).to eq(scope)
+      expect(Decidim::Budgets::Project.find(project2.id).scope).to be_nil
     end
 
     it "selects projects to implementation" do
@@ -74,8 +74,8 @@ describe "Admin manages projects", type: :system do
       within "tr[data-id='#{project2.id}']" do
         expect(page).to have_content("Selected")
       end
-      expect(::Decidim::Budgets::Project.find(project.id).selected_at).to eq(Time.zone.today)
-      expect(::Decidim::Budgets::Project.find(project2.id).selected_at).to eq(Time.zone.today)
+      expect(Decidim::Budgets::Project.find(project.id).selected_at).to eq(Time.zone.today)
+      expect(Decidim::Budgets::Project.find(project2.id).selected_at).to eq(Time.zone.today)
     end
   end
 end

--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -311,14 +311,14 @@ describe "Orders", type: :system do
         end
 
         expect(page).to have_content "ASSIGNED: €0"
-        expect(page).to have_no_content "1 project selected"
-        expect(page).to have_no_selector ".budget-summary__selected"
+        expect(page).not_to have_content "1 project selected"
+        expect(page).not_to have_selector ".budget-summary__selected"
 
         within "#order-progress .budget-summary__progressbox" do
           expect(page).to have_content "0%"
         end
 
-        expect(page).to have_no_selector ".budget-list__data--added"
+        expect(page).not_to have_selector ".budget-list__data--added"
       end
 
       it "is alerted when trying to leave the component before completing" do
@@ -403,7 +403,7 @@ describe "Orders", type: :system do
           expect(page).to have_content("successfully")
 
           within "#order-progress .budget-summary__progressbox" do
-            expect(page).to have_no_selector("button.small")
+            expect(page).not_to have_selector("button.small")
           end
         end
       end
@@ -544,7 +544,7 @@ describe "Orders", type: :system do
         end
 
         within ".budget-summary" do
-          expect(page).to have_no_selector(".cancel-order")
+          expect(page).not_to have_selector(".cancel-order")
         end
       end
 
@@ -570,7 +570,7 @@ describe "Orders", type: :system do
       it "cannot create new orders" do
         visit_budget
 
-        expect(page).to have_no_selector("button.budget-list__action")
+        expect(page).not_to have_selector("button.budget-list__action")
       end
     end
 

--- a/decidim-budgets/spec/system/sorting_projects_spec.rb
+++ b/decidim-budgets/spec/system/sorting_projects_spec.rb
@@ -39,7 +39,7 @@ describe "Sorting projects", type: :system do
     it "lists the projects ordered by selected option" do
       # expect(page).to have_selector("#projects li.is-dropdown-submenu-parent a", text: selected_option)
       within "#projects li.is-dropdown-submenu-parent a" do
-        expect(page).to have_no_content("Random order", wait: 20)
+        expect(page).not_to have_content("Random order", wait: 20)
         expect(page).to have_content(selected_option)
       end
 

--- a/decidim-comments/app/events/decidim/comments/comment_by_followed_user_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_by_followed_user_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Comments

--- a/decidim-comments/app/events/decidim/comments/comment_by_followed_user_group_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_by_followed_user_group_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Comments

--- a/decidim-comments/app/events/decidim/comments/comment_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Comments

--- a/decidim-comments/app/events/decidim/comments/reply_created_event.rb
+++ b/decidim-comments/app/events/decidim/comments/reply_created_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Comments

--- a/decidim-comments/app/events/decidim/comments/user_group_mentioned_event.rb
+++ b/decidim-comments/app/events/decidim/comments/user_group_mentioned_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Comments

--- a/decidim-comments/app/events/decidim/comments/user_mentioned_event.rb
+++ b/decidim-comments/app/events/decidim/comments/user_mentioned_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Comments

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/create_comment_context.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/create_comment_context.rb
@@ -8,7 +8,7 @@ RSpec.shared_context "when creating a comment" do
   let(:author) { create(:user, organization:) }
   let(:dummy_resource) { create :dummy_resource, component: }
   let(:commentable) { dummy_resource }
-  let(:body) { ::Faker::Lorem.paragraph }
+  let(:body) { Faker::Lorem.paragraph }
   let(:alignment) { 1 }
   let(:user_group_id) { nil }
   let(:form_params) do

--- a/decidim-comments/spec/cells/decidim/comments/comment_activity_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comment_activity_cell_spec.rb
@@ -35,7 +35,7 @@ module Decidim::Comments
 
         it "correctly renders comments with mentions" do
           html = cell("decidim/comments/comment_activity", action_log).call
-          expect(html).to have_no_content("gid://")
+          expect(html).not_to have_content("gid://")
           expect(html).to have_content("@#{comment.author.nickname}")
         end
       end

--- a/decidim-comments/spec/cells/decidim/comments/comment_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comment_cell_spec.rb
@@ -41,17 +41,17 @@ module Decidim::Comments
           expect(subject).to have_css("#comment_#{comment.id}")
           expect(subject).to have_css("#comment-#{comment.id}-replies", text: "")
           expect(subject).to have_css(".comment__deleted")
-          expect(subject).to have_no_css("button[data-open='loginModal'][title='#{I18n.t("decidim.components.comment.report.title")}']")
-          expect(subject).to have_no_css("a[href='/processes/#{participatory_process.slug}/f/#{component.id}/dummy_resources/#{commentable.id}?commentId=#{comment.id}#comment_#{comment.id}']")
-          expect(subject).to have_no_content(comment.body.values.first)
-          expect(subject).to have_no_content(I18n.l(comment.created_at, format: :decidim_short))
+          expect(subject).not_to have_css("button[data-open='loginModal'][title='#{I18n.t("decidim.components.comment.report.title")}']")
+          expect(subject).not_to have_css("a[href='/processes/#{participatory_process.slug}/f/#{component.id}/dummy_resources/#{commentable.id}?commentId=#{comment.id}#comment_#{comment.id}']")
+          expect(subject).not_to have_content(comment.body.values.first)
+          expect(subject).not_to have_content(I18n.l(comment.created_at, format: :decidim_short))
           expect(subject).to have_content(I18n.l(comment.deleted_at, format: :decidim_short))
-          expect(subject).to have_no_content(comment.author.name)
+          expect(subject).not_to have_content(comment.author.name)
 
-          expect(subject).to have_no_css(".comment__additionalreply")
-          expect(subject).to have_no_css(".add-comment")
-          expect(subject).to have_no_css(".comment__reply")
-          expect(subject).to have_no_css("#flagModalComment#{comment.id}")
+          expect(subject).not_to have_css(".comment__additionalreply")
+          expect(subject).not_to have_css(".add-comment")
+          expect(subject).not_to have_css(".comment__reply")
+          expect(subject).not_to have_css("#flagModalComment#{comment.id}")
         end
       end
 
@@ -63,17 +63,17 @@ module Decidim::Comments
           expect(subject).to have_css("#comment_#{comment.id}")
           expect(subject).to have_css("#comment-#{comment.id}-replies", text: "")
           expect(subject).to have_css(".comment__moderated")
-          expect(subject).to have_no_css("button[data-open='loginModal'][title='#{I18n.t("decidim.components.comment.report.title")}']")
-          expect(subject).to have_no_css("a[href='/processes/#{participatory_process.slug}/f/#{component.id}/dummy_resources/#{commentable.id}?commentId=#{comment.id}#comment_#{comment.id}']")
-          expect(subject).to have_no_content(comment.body.values.first)
-          expect(subject).to have_no_content(I18n.l(comment.created_at, format: :decidim_short))
+          expect(subject).not_to have_css("button[data-open='loginModal'][title='#{I18n.t("decidim.components.comment.report.title")}']")
+          expect(subject).not_to have_css("a[href='/processes/#{participatory_process.slug}/f/#{component.id}/dummy_resources/#{commentable.id}?commentId=#{comment.id}#comment_#{comment.id}']")
+          expect(subject).not_to have_content(comment.body.values.first)
+          expect(subject).not_to have_content(I18n.l(comment.created_at, format: :decidim_short))
           expect(subject).to have_content(I18n.l(moderation.hidden_at, format: :decidim_short))
-          expect(subject).to have_no_content(comment.author.name)
+          expect(subject).not_to have_content(comment.author.name)
 
-          expect(subject).to have_no_css(".comment__additionalreply")
-          expect(subject).to have_no_css(".add-comment")
-          expect(subject).to have_no_css(".comment__reply")
-          expect(subject).to have_no_css("#flagModalComment#{comment.id}")
+          expect(subject).not_to have_css(".comment__additionalreply")
+          expect(subject).not_to have_css(".add-comment")
+          expect(subject).not_to have_css(".comment__reply")
+          expect(subject).not_to have_css("#flagModalComment#{comment.id}")
         end
       end
 
@@ -220,7 +220,7 @@ module Decidim::Comments
 
       context "when commentable has no permissions set for the vote_comment action" do
         it "renders a plain button" do
-          expect(subject).to have_no_css("[data-open=\"authorizationModal\"]")
+          expect(subject).not_to have_css("[data-open=\"authorizationModal\"]")
         end
       end
     end

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -19,7 +19,7 @@ module Decidim::Comments
       it "renders the thread" do
         expect(subject).to have_css(".section-heading", text: "1 comment")
         expect(subject).to have_css(".callout.primary.loading-comments p", text: "Loading comments ...")
-        expect(subject).to have_no_content(comment.body.values.first)
+        expect(subject).not_to have_content(comment.body.values.first)
         expect(subject).to have_css(".add-comment")
         expect(subject).to have_content("Sign in with your account or sign up to add your comment.")
 

--- a/decidim-conferences/app/events/decidim/conferences/conference_registration_notification_event.rb
+++ b/decidim-conferences/app/events/decidim/conferences/conference_registration_notification_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Conferences

--- a/decidim-conferences/app/events/decidim/conferences/conference_registrations_enabled_event.rb
+++ b/decidim-conferences/app/events/decidim/conferences/conference_registrations_enabled_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Conferences

--- a/decidim-conferences/app/events/decidim/conferences/conference_registrations_over_percentage_event.rb
+++ b/decidim-conferences/app/events/decidim/conferences/conference_registrations_over_percentage_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Conferences

--- a/decidim-conferences/app/events/decidim/conferences/conference_role_assigned_event.rb
+++ b/decidim-conferences/app/events/decidim/conferences/conference_role_assigned_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Conferences

--- a/decidim-conferences/spec/shared/manage_conference_admins_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_admins_examples.rb
@@ -75,7 +75,7 @@ shared_examples "manage conference admins examples" do
       expect(page).to have_admin_callout("successfully")
 
       within "#conference_admins table" do
-        expect(page).to have_no_content(other_user.email)
+        expect(page).not_to have_content(other_user.email)
       end
     end
 

--- a/decidim-conferences/spec/shared/manage_conference_components_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_components_examples.rb
@@ -158,7 +158,7 @@ shared_examples "manage conference components" do
         click_link "Delete"
       end
 
-      expect(page).to have_no_content("My component")
+      expect(page).not_to have_content("My component")
     end
   end
 

--- a/decidim-conferences/spec/shared/manage_conference_speakers_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_speakers_examples.rb
@@ -95,7 +95,7 @@ shared_examples "manage conference speakers examples" do
       expect(page).to have_admin_callout("successfully")
 
       within "#conference_speakers table" do
-        expect(page).to have_no_content(conference_speaker.full_name)
+        expect(page).not_to have_content(conference_speaker.full_name)
       end
     end
   end

--- a/decidim-conferences/spec/shared/manage_media_links_examples.rb
+++ b/decidim-conferences/spec/shared/manage_media_links_examples.rb
@@ -89,7 +89,7 @@ shared_examples "manage media links examples" do
       expect(page).to have_admin_callout("successfully")
 
       within "#media_links table" do
-        expect(page).to have_no_content(translated(media_link.title))
+        expect(page).not_to have_content(translated(media_link.title))
       end
     end
   end

--- a/decidim-conferences/spec/shared/manage_partners_examples.rb
+++ b/decidim-conferences/spec/shared/manage_partners_examples.rb
@@ -71,7 +71,7 @@ shared_examples "manage partners examples" do
       expect(page).to have_admin_callout("successfully")
 
       within "#partners table" do
-        expect(page).to have_no_content(conference_partner.name)
+        expect(page).not_to have_content(conference_partner.name)
       end
     end
   end

--- a/decidim-conferences/spec/shared/manage_registration_types_examples.rb
+++ b/decidim-conferences/spec/shared/manage_registration_types_examples.rb
@@ -54,7 +54,7 @@ shared_examples "manage registration types examples" do
       expect(page).to have_admin_callout("successfully")
 
       within "#registration_types table" do
-        expect(page).to have_no_content(translated(registration_type.title))
+        expect(page).not_to have_content(translated(registration_type.title))
       end
     end
   end

--- a/decidim-conferences/spec/system/admin/valuator_checks_components_spec.rb
+++ b/decidim-conferences/spec/system/admin/valuator_checks_components_spec.rb
@@ -32,7 +32,7 @@ describe "Valuator checks components", type: :system do
     it "can only see the proposals component" do
       within ".layout-nav #components-list" do
         expect(page).to have_content(translated(current_component.name))
-        expect(page).to have_no_content(translated(another_component.name))
+        expect(page).not_to have_content(translated(another_component.name))
       end
     end
   end
@@ -45,7 +45,7 @@ describe "Valuator checks components", type: :system do
 
       within ".card" do
         expect(page).to have_content(translated(current_component.name))
-        expect(page).to have_no_content(translated(another_component.name))
+        expect(page).not_to have_content(translated(another_component.name))
       end
     end
   end

--- a/decidim-conferences/spec/system/conference_program_spec.rb
+++ b/decidim-conferences/spec/system/conference_program_spec.rb
@@ -25,7 +25,7 @@ describe "Conference program", type: :system do
       visit decidim_conferences.conference_path(conference)
 
       within ".process-nav" do
-        expect(page).to have_no_content(translated_attribute(component.name))
+        expect(page).not_to have_content(translated_attribute(component.name))
       end
     end
   end

--- a/decidim-conferences/spec/system/conference_speakers_spec.rb
+++ b/decidim-conferences/spec/system/conference_speakers_spec.rb
@@ -20,7 +20,7 @@ describe "Conference speakers", type: :system do
     it "the menu link is not shown" do
       visit decidim_conferences.conference_path(conference)
 
-      expect(page).to have_no_content("SPEAKERS")
+      expect(page).not_to have_content("SPEAKERS")
     end
   end
 

--- a/decidim-conferences/spec/system/conferences_spec.rb
+++ b/decidim-conferences/spec/system/conferences_spec.rb
@@ -33,7 +33,7 @@ describe "Conferences", type: :system do
       visit decidim.root_path
 
       within ".main-nav" do
-        expect(page).to have_no_content("Conferences")
+        expect(page).not_to have_content("Conferences")
       end
     end
   end
@@ -61,7 +61,7 @@ describe "Conferences", type: :system do
         visit decidim.root_path
 
         within ".main-nav" do
-          expect(page).to have_no_content("Conferences")
+          expect(page).not_to have_content("Conferences")
         end
       end
     end
@@ -156,7 +156,7 @@ describe "Conferences", type: :system do
       it "shows the components" do
         within ".conference__nav" do
           expect(page).to have_content(translated(proposals_component.name, locale: :en))
-          expect(page).to have_no_content(translated(meetings_component.name, locale: :en))
+          expect(page).not_to have_content(translated(meetings_component.name, locale: :en))
         end
       end
 
@@ -164,8 +164,8 @@ describe "Conferences", type: :system do
         within "[data-statistics]" do
           expect(page).to have_css(".statistic__title", text: "Proposals")
           expect(page).to have_css(".statistic__number", text: "3")
-          expect(page).to have_no_css(".statistic__title", text: "Meetings")
-          expect(page).to have_no_css(".statistic__number", text: "0")
+          expect(page).not_to have_css(".statistic__title", text: "Meetings")
+          expect(page).not_to have_css(".statistic__number", text: "0")
         end
       end
 
@@ -173,8 +173,8 @@ describe "Conferences", type: :system do
         let(:show_statistics) { false }
 
         it "does not render the stats for those components that are not visible" do
-          expect(page).to have_no_css(".statistic__title", text: "Proposals")
-          expect(page).to have_no_css(".statistic__number", text: "3")
+          expect(page).not_to have_css(".statistic__title", text: "Proposals")
+          expect(page).not_to have_css(".statistic__number", text: "3")
         end
       end
     end

--- a/decidim-conferences/spec/system/media_spec.rb
+++ b/decidim-conferences/spec/system/media_spec.rb
@@ -26,7 +26,7 @@ describe "Conferences", type: :system do
     end
 
     it "the menu link is not shown" do
-      expect(page).to have_no_content("MEDIA")
+      expect(page).not_to have_content("MEDIA")
     end
   end
 

--- a/decidim-conferences/spec/system/partners_spec.rb
+++ b/decidim-conferences/spec/system/partners_spec.rb
@@ -14,7 +14,7 @@ describe "Conference partners", type: :system do
   context "when there are no partners" do
     it "the menu link is not shown" do
       visit decidim_conferences.conference_path(conference)
-      expect(page).to have_no_content("Partners")
+      expect(page).not_to have_content("Partners")
     end
   end
 

--- a/decidim-consultations/spec/system/admin/admin_manages_question_component_spec.rb
+++ b/decidim-consultations/spec/system/admin/admin_manages_question_component_spec.rb
@@ -165,7 +165,7 @@ describe "Admin manages consultation components", type: :system do
         click_link "Delete"
       end
 
-      expect(page).to have_no_content("My component")
+      expect(page).not_to have_content("My component")
     end
   end
 

--- a/decidim-core/app/events/decidim/amendable/amendment_accepted_event.rb
+++ b/decidim-core/app/events/decidim/amendable/amendment_accepted_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim::Amendable
   class AmendmentAcceptedEvent < Decidim::Amendable::AmendmentBaseEvent

--- a/decidim-core/app/events/decidim/amendable/amendment_base_event.rb
+++ b/decidim-core/app/events/decidim/amendable/amendment_base_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim::Amendable
   class AmendmentBaseEvent < Decidim::Events::SimpleEvent

--- a/decidim-core/app/events/decidim/amendable/amendment_created_event.rb
+++ b/decidim-core/app/events/decidim/amendable/amendment_created_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim::Amendable
   class AmendmentCreatedEvent < Decidim::Amendable::AmendmentBaseEvent

--- a/decidim-core/app/events/decidim/amendable/amendment_rejected_event.rb
+++ b/decidim-core/app/events/decidim/amendable/amendment_rejected_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim::Amendable
   class AmendmentRejectedEvent < Decidim::Amendable::AmendmentBaseEvent

--- a/decidim-core/app/events/decidim/amendable/emendation_promoted_event.rb
+++ b/decidim-core/app/events/decidim/amendable/emendation_promoted_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim::Amendable
   class EmendationPromotedEvent < Decidim::Amendable::AmendmentBaseEvent

--- a/decidim-core/app/events/decidim/change_nickname_event.rb
+++ b/decidim-core/app/events/decidim/change_nickname_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class ChangeNicknameEvent < Decidim::Events::SimpleEvent

--- a/decidim-core/app/events/decidim/demoted_membership_event.rb
+++ b/decidim-core/app/events/decidim/demoted_membership_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class DemotedMembershipEvent < Decidim::Events::SimpleEvent

--- a/decidim-core/app/events/decidim/invited_to_group_event.rb
+++ b/decidim-core/app/events/decidim/invited_to_group_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class InvitedToGroupEvent < Decidim::Events::SimpleEvent

--- a/decidim-core/app/events/decidim/join_request_accepted_event.rb
+++ b/decidim-core/app/events/decidim/join_request_accepted_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class JoinRequestAcceptedEvent < Decidim::Events::SimpleEvent

--- a/decidim-core/app/events/decidim/join_request_created_event.rb
+++ b/decidim-core/app/events/decidim/join_request_created_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class JoinRequestCreatedEvent < Decidim::Events::SimpleEvent

--- a/decidim-core/app/events/decidim/join_request_rejected_event.rb
+++ b/decidim-core/app/events/decidim/join_request_rejected_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class JoinRequestRejectedEvent < Decidim::Events::SimpleEvent

--- a/decidim-core/app/events/decidim/profile_updated_event.rb
+++ b/decidim-core/app/events/decidim/profile_updated_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class ProfileUpdatedEvent < Decidim::Events::SimpleEvent

--- a/decidim-core/app/events/decidim/promoted_to_admin_event.rb
+++ b/decidim-core/app/events/decidim/promoted_to_admin_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class PromotedToAdminEvent < Decidim::Events::SimpleEvent

--- a/decidim-core/app/events/decidim/removed_from_group_event.rb
+++ b/decidim-core/app/events/decidim/removed_from_group_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class RemovedFromGroupEvent < Decidim::Events::SimpleEvent

--- a/decidim-core/app/events/decidim/resource_endorsed_event.rb
+++ b/decidim-core/app/events/decidim/resource_endorsed_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class ResourceEndorsedEvent < Decidim::Events::SimpleEvent

--- a/decidim-core/app/events/decidim/user_group_admin_event.rb
+++ b/decidim-core/app/events/decidim/user_group_admin_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   # To be used by UserGroup related events that trigger a notification to the administrators.

--- a/decidim-core/app/events/decidim/user_group_created_event.rb
+++ b/decidim-core/app/events/decidim/user_group_created_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class UserGroupCreatedEvent < ::Decidim::UserGroupAdminEvent

--- a/decidim-core/app/events/decidim/user_group_updated_event.rb
+++ b/decidim-core/app/events/decidim/user_group_updated_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class UserGroupUpdatedEvent < ::Decidim::UserGroupAdminEvent

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -558,7 +558,7 @@ FactoryBot.define do
 
     after :build do |resource, evaluator|
       evaluator.authors_list.each do |coauthor|
-        resource.coauthorships << if coauthor.is_a?(::Decidim::UserGroup)
+        resource.coauthorships << if coauthor.is_a?(Decidim::UserGroup)
                                     build(:coauthorship, author: coauthor.users.first, user_group: coauthor, coauthorable: resource, organization: evaluator.component.organization)
                                   else
                                     build(:coauthorship, author: coauthor, coauthorable: resource, organization: evaluator.component.organization)

--- a/decidim-core/lib/decidim/core/test/shared_examples/announcements_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/announcements_examples.rb
@@ -51,7 +51,7 @@ shared_examples "manage announcements" do
       visit main_component_path(current_component)
 
       within "[class='callout '][data-announcement]" do
-        expect(page).to have_no_content("An important announcement")
+        expect(page).not_to have_content("An important announcement")
         expect(page).to have_content("An announcement for this step")
       end
     end

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -33,7 +33,7 @@ shared_examples "comments" do
 
     visit resource_path
 
-    expect(page).to have_no_content("Comments are disabled at this time")
+    expect(page).not_to have_content("Comments are disabled at this time")
 
     expect(page).to have_css(".comment", minimum: 1)
     page.find(".order-by .dropdown.menu .is-dropdown-submenu-parent").hover
@@ -59,12 +59,12 @@ shared_examples "comments" do
     it "shows only a deletion message for deleted comments" do
       expect(page).to have_selector("#comment_#{deleted_comment.id}")
 
-      expect(page).to have_no_content(deleted_comment.author.name)
-      expect(page).to have_no_content(deleted_comment.body.values.first)
+      expect(page).not_to have_content(deleted_comment.author.name)
+      expect(page).not_to have_content(deleted_comment.body.values.first)
       within "#comment_#{deleted_comment.id}" do
         expect(page).to have_content("Comment deleted on")
-        expect(page).to have_no_selector("comment__header")
-        expect(page).to have_no_selector("comment__footer")
+        expect(page).not_to have_selector("comment__header")
+        expect(page).not_to have_selector("comment__footer")
       end
     end
 
@@ -90,7 +90,7 @@ shared_examples "comments" do
   context "when not authenticated" do
     it "does not show form to add comments to user" do
       visit resource_path
-      expect(page).to have_no_selector(".add-comment form")
+      expect(page).not_to have_selector(".add-comment form")
     end
   end
 
@@ -524,7 +524,7 @@ shared_examples "comments" do
           within "#comment_#{comment.id}" do
             within ".comment__header__context-menu" do
               page.find("label").click
-              expect(page).to have_no_link("Delete")
+              expect(page).not_to have_link("Delete")
             end
           end
         end
@@ -557,12 +557,12 @@ shared_examples "comments" do
           end
 
           expect(page).to have_selector("#comment_#{comment.id}")
-          expect(page).to have_no_content(comment_body)
+          expect(page).not_to have_content(comment_body)
           within "#comment_#{comment.id}" do
             expect(page).to have_content("Comment deleted on")
-            expect(page).to have_no_content comment_author.name
-            expect(page).to have_no_selector("comment__header")
-            expect(page).to have_no_selector("comment__footer")
+            expect(page).not_to have_content comment_author.name
+            expect(page).not_to have_selector("comment__header")
+            expect(page).not_to have_selector("comment__footer")
           end
           expect(page).to have_selector("span.comments-count", text: "3 COMMENTS")
 
@@ -586,7 +586,7 @@ shared_examples "comments" do
           within "#comment_#{comment.id}" do
             within ".comment__header__context-menu" do
               page.find("label").click
-              expect(page).to have_no_button("Edit")
+              expect(page).not_to have_button("Edit")
             end
           end
         end
@@ -617,7 +617,7 @@ shared_examples "comments" do
           it "the comment body changes" do
             within "#comment_#{comment.id}" do
               expect(page).to have_content("This comment has been fixed")
-              expect(page).to have_no_content(comment_body)
+              expect(page).not_to have_content(comment_body)
             end
           end
 
@@ -698,7 +698,7 @@ shared_examples "comments" do
               expect(page).to have_selector "span.success.label", text: "In favor", wait: 20
             end
           else
-            expect(page).to have_no_selector(".opinion-toggle--ok")
+            expect(page).not_to have_selector(".opinion-toggle--ok")
           end
         end
       end
@@ -717,7 +717,7 @@ shared_examples "comments" do
               page.find(".comment__votes--up").click
               expect(page).to have_selector(".comment__votes--up", text: /1/)
             else
-              expect(page).to have_no_selector(".comment__votes--up", text: /0/)
+              expect(page).not_to have_selector(".comment__votes--up", text: /0/)
             end
           end
         end
@@ -731,7 +731,7 @@ shared_examples "comments" do
               page.find(".comment__votes--down").click
               expect(page).to have_selector(".comment__votes--down", text: /1/)
             else
-              expect(page).to have_no_selector(".comment__votes--down", text: /0/)
+              expect(page).not_to have_selector(".comment__votes--down", text: /0/)
             end
           end
         end

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_reports_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_reports_examples.rb
@@ -5,7 +5,7 @@ shared_examples "comments_reports" do
     it "gives the option to sign in" do
       visit reportable_path
 
-      expect(page).to have_no_css("html.is-reveal-open")
+      expect(page).not_to have_css("html.is-reveal-open")
 
       within ".comment__header__context-menu" do
         page.find("label").click

--- a/decidim-core/lib/decidim/core/test/shared_examples/conversations_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/conversations_examples.rb
@@ -2,7 +2,7 @@
 
 shared_examples_for "conversation field with maximum length" do |field|
   describe "character counter" do
-    let(:message) { "#{::Faker::Lorem.paragraph}\n#{::Faker::Lorem.paragraph}" }
+    let(:message) { "#{Faker::Lorem.paragraph}\n#{Faker::Lorem.paragraph}" }
     let(:max_length) { Decidim.config.maximum_conversation_message_length }
 
     before do

--- a/decidim-core/lib/decidim/core/test/shared_examples/has_contextual_help.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/has_contextual_help.rb
@@ -19,7 +19,7 @@ shared_examples "shows contextual help" do
 
     visit current_path
 
-    expect(page).to have_no_content("Some relevant help")
+    expect(page).not_to have_content("Some relevant help")
 
     find(".floating-helper__text").click
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/paginated_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/paginated_resource_examples.rb
@@ -22,6 +22,6 @@ shared_examples "a paginated resource" do
 
     sleep 2
     expect(page).to have_css(resource_selector, count: collection_size)
-    expect(page).to have_no_css("[data-pagination]")
+    expect(page).not_to have_css("[data-pagination]")
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
@@ -95,7 +95,7 @@ shared_examples "reports" do
     it "gives the option to sign in" do
       visit reportable_path
 
-      expect(page).to have_no_css("html.is-reveal-open")
+      expect(page).not_to have_css("html.is-reveal-open")
 
       click_button "Report"
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/searchable_participatory_space_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/searchable_participatory_space_examples.rb
@@ -7,7 +7,7 @@ shared_examples "global search of participatory spaces" do
     context "when on create" do
       context "when participatory_spaces are created" do
         it "does not index a SearchableResource after ParticipatorySpace creation" do
-          searchables = ::Decidim::SearchableResource.where(resource_type: participatory_space.class.name, resource_id: participatory_space.id)
+          searchables = Decidim::SearchableResource.where(resource_type: participatory_space.class.name, resource_id: participatory_space.id)
           expect(searchables).to be_empty
         end
       end
@@ -16,7 +16,7 @@ shared_examples "global search of participatory spaces" do
     context "when on update" do
       context "when it is NOT published" do
         it "does not index a SearchableResource when ParticipatorySpace changes but is not published" do
-          searchables = ::Decidim::SearchableResource.where(resource_type: participatory_space.class.name, resource_id: participatory_space.id)
+          searchables = Decidim::SearchableResource.where(resource_type: participatory_space.class.name, resource_id: participatory_space.id)
           expect(searchables).to be_empty
         end
       end
@@ -28,13 +28,13 @@ shared_examples "global search of participatory spaces" do
 
         it "inserts a SearchableResource after ParticipatorySpace is published" do
           organization.available_locales.each do |locale|
-            searchable = ::Decidim::SearchableResource.find_by(resource_type: participatory_space.class.name, resource_id: participatory_space.id, locale:)
+            searchable = Decidim::SearchableResource.find_by(resource_type: participatory_space.class.name, resource_id: participatory_space.id, locale:)
             expect_searchable_resource_to_correspond_to_participatory_space(searchable, participatory_space, locale)
           end
         end
 
         it "updates the associated SearchableResource after published ParticipatorySpace update" do
-          searchable = ::Decidim::SearchableResource.find_by(resource_type: participatory_space.class.name, resource_id: participatory_space.id)
+          searchable = Decidim::SearchableResource.find_by(resource_type: participatory_space.class.name, resource_id: participatory_space.id)
           created_at = searchable.created_at
           updated_title = { "en" => "Brand new title", "machine_translations" => {} }
           participatory_space.update(title: updated_title)
@@ -43,7 +43,7 @@ shared_examples "global search of participatory spaces" do
           searchable.reload
 
           organization.available_locales.each do |locale|
-            searchable = ::Decidim::SearchableResource.find_by(resource_type: participatory_space.class.name, resource_id: participatory_space.id, locale:)
+            searchable = Decidim::SearchableResource.find_by(resource_type: participatory_space.class.name, resource_id: participatory_space.id, locale:)
             expect(searchable.content_a).to eq updated_title[locale.to_s].to_s
             expect(searchable.updated_at).to be > created_at
           end
@@ -51,7 +51,7 @@ shared_examples "global search of participatory spaces" do
 
         it "removes the associated SearchableResource after unpublishing a published ParticipatorySpace on update" do
           participatory_space.unpublish!
-          searchables = ::Decidim::SearchableResource.where(resource_type: participatory_space.class.name, resource_id: participatory_space.id)
+          searchables = Decidim::SearchableResource.where(resource_type: participatory_space.class.name, resource_id: participatory_space.id)
           expect(searchables).to be_empty
         end
       end
@@ -62,7 +62,7 @@ shared_examples "global search of participatory spaces" do
         if participatory_space.respond_to?(:private_space?)
           participatory_space.update(published_at: Time.current, private_space: true)
           organization.available_locales.each do |locale|
-            searchables = ::Decidim::SearchableResource.where(resource_type: participatory_space.class.name, resource_id: participatory_space.id, locale:)
+            searchables = Decidim::SearchableResource.where(resource_type: participatory_space.class.name, resource_id: participatory_space.id, locale:)
             expect(searchables).to be_empty
           end
         end
@@ -73,7 +73,7 @@ shared_examples "global search of participatory spaces" do
       it "destroys the associated SearchableResource after ParticipatorySpace destroy" do
         participatory_space.destroy
 
-        searchables = ::Decidim::SearchableResource.where(resource_type: participatory_space.class.name, resource_id: participatory_space.id)
+        searchables = Decidim::SearchableResource.where(resource_type: participatory_space.class.name, resource_id: participatory_space.id)
 
         expect(searchables.any?).to be false
       end

--- a/decidim-core/lib/decidim/core/test/shared_examples/system_endorse_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/system_endorse_resource_examples.rb
@@ -15,8 +15,8 @@ end
 
 shared_examples "Endorse resource system specs" do
   def expect_page_not_to_include_endorsements
-    expect(page).to have_no_button("Like")
-    expect(page).to have_no_css("#resource-#{resource.id}-endorsements-count")
+    expect(page).not_to have_button("Like")
+    expect(page).not_to have_css("#resource-#{resource.id}-endorsements-count")
   end
 
   def expect_endorsements_count(count)
@@ -102,7 +102,7 @@ shared_examples "Endorse resource system specs" do
           visit_resource
           within ".buttons__row" do
             expect(page).to have_button("Dislike")
-            expect(page).to have_no_button("Like")
+            expect(page).not_to have_button("Like")
           end
 
           expect_endorsements_count(1)

--- a/decidim-core/lib/decidim/events/email_event.rb
+++ b/decidim-core/lib/decidim/events/email_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Events

--- a/decidim-core/lib/decidim/events/machine_translated_event.rb
+++ b/decidim-core/lib/decidim/events/machine_translated_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Events

--- a/decidim-core/lib/decidim/gamification/badge_earned_event.rb
+++ b/decidim-core/lib/decidim/gamification/badge_earned_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Gamification

--- a/decidim-core/spec/cells/decidim/address_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/address_cell_spec.rb
@@ -31,7 +31,7 @@ describe Decidim::AddressCell, type: :cell do
     expect(icondata_address).to have_content(hint_text)
     expect(icondata_address).to have_content(location_text)
     expect(icondata_address.to_s).not_to match("<script>")
-    expect(icondata_address).to have_no_content(model.latitude)
-    expect(icondata_address).to have_no_content(model.longitude)
+    expect(icondata_address).not_to have_content(model.latitude)
+    expect(icondata_address).not_to have_content(model.longitude)
   end
 end

--- a/decidim-core/spec/cells/decidim/amendable/announcement_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/amendable/announcement_cell_spec.rb
@@ -17,7 +17,7 @@ describe Decidim::Amendable::AnnouncementCell, type: :cell do
     emendation.link_resources(pr, "created_from_rejected_emendation")
     pr
   end
-  let(:link_to_amendable) { ::Decidim::ResourceLocatorPresenter.new(amendable).path }
+  let(:link_to_amendable) { Decidim::ResourceLocatorPresenter.new(amendable).path }
 
   it "renders the link to the amendable resource" do
     expect(subject.to_s).to include(

--- a/decidim-core/spec/cells/decidim/content_blocks/sub_hero_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/content_blocks/sub_hero_cell_spec.rb
@@ -14,7 +14,7 @@ describe Decidim::ContentBlocks::SubHeroCell, type: :cell do
     let(:description) { {} }
 
     it "displays nothing" do
-      expect(subject).to have_no_css(".subhero")
+      expect(subject).not_to have_css(".subhero")
     end
   end
 

--- a/decidim-core/spec/cells/decidim/newsletter_templates/basic_only_text_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/newsletter_templates/basic_only_text_cell_spec.rb
@@ -16,7 +16,7 @@ describe Decidim::NewsletterTemplates::BasicOnlyTextCell, type: :cell do
   let(:user) { create(:user, organization:) }
   let(:content_block) { create :content_block, organization:, manifest_name: :basic_only_text, scope_name: :newsletter_template, settings: }
   let(:newsletter) { create :newsletter, organization: }
-  let(:body) { ::Faker::Lorem.sentences.join("\n") }
+  let(:body) { Faker::Lorem.sentences.join("\n") }
   let(:settings) { { body_en: body } }
   let(:logo_url) { Rails.application.routes.url_helpers.rails_representation_path(organization.logo.variant(resize_to_fit: [600, 160]), host: organization.host) }
 

--- a/decidim-core/spec/cells/decidim/pad_iframe_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/pad_iframe_cell_spec.rb
@@ -26,7 +26,7 @@ describe Decidim::PadIframeCell, type: :cell do
       let(:current_user) { nil }
 
       it "renders nothing" do
-        expect(html).to have_no_css("iframe")
+        expect(html).not_to have_css("iframe")
       end
     end
 
@@ -36,7 +36,7 @@ describe Decidim::PadIframeCell, type: :cell do
       end
 
       it "renders nothing" do
-        expect(html).to have_no_css("iframe")
+        expect(html).not_to have_css("iframe")
       end
     end
 
@@ -56,7 +56,7 @@ describe Decidim::PadIframeCell, type: :cell do
         let(:pad_text) { nil }
 
         it "renders nothing" do
-          expect(html).to have_no_css("iframe")
+          expect(html).not_to have_css("iframe")
         end
       end
     end

--- a/decidim-core/spec/commands/decidim/search_spec.rb
+++ b/decidim-core/spec/commands/decidim/search_spec.rb
@@ -193,7 +193,6 @@ describe Decidim::Search do
       before do
         create_list(:searchable_resource, 5, organization: current_organization, resource_type:, content_a: "Where is your crown king nothing?")
 
-        # rubocop:disable RSpec/FactoryBot/CreateList
         3.times do
           create(
             :searchable_resource,
@@ -204,7 +203,6 @@ describe Decidim::Search do
             content_a: "Where is your crown king nothing?"
           )
         end
-        # rubocop:enable RSpec/FactoryBot/CreateList
       end
 
       context "when resource_type is setted" do

--- a/decidim-core/spec/lib/premailer/adapter/decidim_spec.rb
+++ b/decidim-core/spec/lib/premailer/adapter/decidim_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Premailer::Adapter::Decidim do
-  let(:document) { ::Nokogiri::HTML(document_template, nil, "UTF-8", &:recover) }
+  let(:document) { Nokogiri::HTML(document_template, nil, "UTF-8", &:recover) }
   let(:document_template) do
     <<~HTML
       <html>

--- a/decidim-core/spec/queries/decidim/public_activities_spec.rb
+++ b/decidim-core/spec/queries/decidim/public_activities_spec.rb
@@ -18,7 +18,7 @@ describe Decidim::PublicActivities do
     # Note that it is possible to add private users also to public processes
     # and assemblies, there is no programming logic forbidding that to happen.
     [process, assembly, private_process, private_assembly].each do |space|
-      10.times { create(:participatory_space_private_user, user: build(:user, :confirmed, organization:), privatable_to: space) } # rubocop:disable RSpec/FactoryBot/CreateList
+      10.times { create(:participatory_space_private_user, user: build(:user, :confirmed, organization:), privatable_to: space) }
     end
 
     # Add the user to both private spaces

--- a/decidim-core/spec/services/decidim/html_truncation_spec.rb
+++ b/decidim-core/spec/services/decidim/html_truncation_spec.rb
@@ -19,7 +19,7 @@ describe Decidim::HtmlTruncation do
   let(:count_tags) { false }
   let(:count_tail) { false }
   let(:tail_before_final_tag) { false }
-  let(:text) { ::Faker::Lorem.paragraph(sentence_count: 25) }
+  let(:text) { Faker::Lorem.paragraph(sentence_count: 25) }
 
   describe "empty content" do
     let(:text) { "" }

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -292,8 +292,8 @@ describe "Account", type: :system do
           find("*[type=submit]").click
         end
 
-        expect(page).to have_no_content("Signed in successfully")
-        expect(page).to have_no_content(user.name)
+        expect(page).not_to have_content("Signed in successfully")
+        expect(page).not_to have_content(user.name)
       end
 
       context "when the user has an authorization" do
@@ -363,7 +363,7 @@ describe "Account", type: :system do
       end
 
       it "does not show the push notifications switch" do
-        expect(page).to have_no_selector(".push-notifications")
+        expect(page).not_to have_selector(".push-notifications")
       end
     end
 
@@ -377,7 +377,7 @@ describe "Account", type: :system do
       end
 
       it "does not show the push notifications switch" do
-        expect(page).to have_no_selector(".push-notifications")
+        expect(page).not_to have_selector(".push-notifications")
       end
     end
   end

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -425,7 +425,7 @@ describe "Authentication", type: :system do
         end
 
         expect(page).to have_content("Signed out successfully.")
-        expect(page).to have_no_content(user.name)
+        expect(page).not_to have_content(user.name)
       end
     end
 

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -174,7 +174,7 @@ describe "Homepage", type: :system do
               expect(page).to have_content(static_page.title["en"])
             end
 
-            expect(page).to have_no_content(static_page3.title["en"])
+            expect(page).not_to have_content(static_page3.title["en"])
           end
 
           click_link static_page1.title["en"]
@@ -236,11 +236,11 @@ describe "Homepage", type: :system do
           it "displays only publicly accessible pages and topics in the footer" do
             within ".main-footer" do
               expect(page).to have_content(static_page1.title["en"])
-              expect(page).to have_no_content(static_page2.title["en"])
-              expect(page).to have_no_content(static_page3.title["en"])
+              expect(page).not_to have_content(static_page2.title["en"])
+              expect(page).not_to have_content(static_page3.title["en"])
               expect(page).to have_content(static_page_topic1.title["en"])
-              expect(page).to have_no_content(static_page_topic2.title["en"])
-              expect(page).to have_no_content(static_page_topic3.title["en"])
+              expect(page).not_to have_content(static_page_topic2.title["en"])
+              expect(page).not_to have_content(static_page_topic3.title["en"])
 
               expect(page).to have_link(
                 static_page_topic1.title["en"],
@@ -257,10 +257,10 @@ describe "Homepage", type: :system do
             it "displays all pages and topics in footer that are configured to display in footer" do
               expect(page).to have_content(static_page1.title["en"])
               expect(page).to have_content(static_page2.title["en"])
-              expect(page).to have_no_content(static_page3.title["en"])
+              expect(page).not_to have_content(static_page3.title["en"])
               expect(page).to have_content(static_page_topic1.title["en"])
               expect(page).to have_content(static_page_topic2.title["en"])
-              expect(page).to have_no_content(static_page_topic3.title["en"])
+              expect(page).not_to have_content(static_page_topic3.title["en"])
 
               expect(page).to have_link(
                 static_page_topic1.title["en"],
@@ -292,7 +292,7 @@ describe "Homepage", type: :system do
           let(:organization) { create(:organization) }
 
           it "does not show the statistics block" do
-            expect(page).to have_no_content("Current state of #{organization.name}")
+            expect(page).not_to have_content("Current state of #{organization.name}")
           end
         end
 
@@ -329,7 +329,7 @@ describe "Homepage", type: :system do
           let(:organization) { create(:organization) }
 
           it "does not show the statistics block" do
-            expect(page).to have_no_content("Participation in figures")
+            expect(page).not_to have_content("Participation in figures")
           end
         end
 
@@ -371,10 +371,10 @@ describe "Homepage", type: :system do
               within "#metrics" do
                 expect(page).to have_content("Metrics")
                 Decidim.metrics_registry.highlighted.each do |metric_registry|
-                  expect(page).to have_no_css("##{metric_registry.metric_name}_chart")
+                  expect(page).not_to have_css("##{metric_registry.metric_name}_chart")
                 end
                 Decidim.metrics_registry.not_highlighted.each do |metric_registry|
-                  expect(page).to have_no_css("##{metric_registry.metric_name}_chart")
+                  expect(page).not_to have_css("##{metric_registry.metric_name}_chart")
                 end
               end
             end

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -23,7 +23,7 @@ describe "Homepage", type: :system do
                             highlighted_content_banner_short_description: Decidim::Faker::Localized.sentence(word_count: 2),
                             highlighted_content_banner_action_title: Decidim::Faker::Localized.sentence(word_count: 2),
                             highlighted_content_banner_action_subtitle: Decidim::Faker::Localized.sentence(word_count: 2),
-                            highlighted_content_banner_action_url: ::Faker::Internet.url,
+                            highlighted_content_banner_action_url: Faker::Internet.url,
                             highlighted_content_banner_image: Decidim::Dev.test_file("city.jpeg", "image/jpeg"))
     end
 
@@ -434,7 +434,7 @@ describe "Homepage", type: :system do
                  highlighted_content_banner_short_description: Decidim::Faker::Localized.sentence(word_count: 2),
                  highlighted_content_banner_action_title: Decidim::Faker::Localized.sentence(word_count: 2),
                  highlighted_content_banner_action_subtitle: Decidim::Faker::Localized.sentence(word_count: 2),
-                 highlighted_content_banner_action_url: ::Faker::Internet.url,
+                 highlighted_content_banner_action_url: Faker::Internet.url,
                  highlighted_content_banner_image: Decidim::Dev.test_file("city.jpeg", "image/jpeg"))
         end
 

--- a/decidim-core/spec/system/internal_server_error_display_spec.rb
+++ b/decidim-core/spec/system/internal_server_error_display_spec.rb
@@ -79,7 +79,7 @@ describe "Internal server error display", type: :system do
   describe "generate reference" do
     before do
       allow(Rails.application.config).to receive(:log_level).and_return(:error)
-      allow(Rails.application.config).to receive(:log_formatter).and_return(::Logger::Formatter.new)
+      allow(Rails.application.config).to receive(:log_formatter).and_return(Logger::Formatter.new)
       allow(Rails.application.config).to receive(:log_tags).and_return([->(request) { "dummy changes-#{request.request_id}" }, :request_id, "normal_string"])
       visit "/"
     end

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -52,7 +52,7 @@ describe "Last activity", type: :system do
 
     it "shows activities long comment shorten text" do
       expect(page).to have_content(long_body_comment[0..79])
-      expect(page).to have_no_content(another_comment.translated_body)
+      expect(page).not_to have_content(another_comment.translated_body)
     end
 
     context "when there is a deleted comment" do
@@ -92,7 +92,7 @@ describe "Last activity", type: :system do
 
         expect(page).to have_content(translated(comment.commentable.title))
         expect(page).to have_content(translated(another_comment.commentable.title))
-        expect(page).to have_no_content(translated(resource.title))
+        expect(page).not_to have_content(translated(resource.title))
         expect(page).to have_css("[data-activity]", count: 2)
       end
 

--- a/decidim-core/spec/system/locales_spec.rb
+++ b/decidim-core/spec/system/locales_spec.rb
@@ -23,7 +23,7 @@ describe "Locales", type: :system do
       within_language_menu do
         expect(page).to have_content("Català")
         expect(page).to have_content("English")
-        expect(page).to have_no_content("Castellano")
+        expect(page).not_to have_content("Castellano")
       end
     end
 

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -23,7 +23,7 @@ describe "Conversations", type: :system do
 
     it "shows the topbar button as inactive" do
       within "#dropdown-summary-account" do
-        expect(page).to have_no_selector("span[data-unread-items]")
+        expect(page).not_to have_selector("span[data-unread-items]")
       end
     end
   end
@@ -53,7 +53,7 @@ describe "Conversations", type: :system do
     it_behaves_like "accessible page"
 
     it "shows an empty conversation page" do
-      expect(page).to have_no_selector(".card--list__item")
+      expect(page).not_to have_selector(".card--list__item")
       expect(page).to have_current_path decidim.new_conversation_path(recipient_id: recipient.id)
     end
 
@@ -153,7 +153,7 @@ describe "Conversations", type: :system do
 
       it "shows the topbar button as inactive" do
         within "#dropdown-summary-account" do
-          expect(page).to have_no_selector("span[data-unread-items]")
+          expect(page).not_to have_selector("span[data-unread-items]")
         end
       end
 
@@ -403,7 +403,7 @@ describe "Conversations", type: :system do
             expect(page).to have_css("img[alt='Avatar: #{user1.name}']")
             expect(page).to have_css("img[alt='Avatar: #{user2.name}']")
             expect(page).to have_css("img[alt='Avatar: #{user3.name}']")
-            expect(page).to have_no_css("img[alt='Avatar: #{user.name}']")
+            expect(page).not_to have_css("img[alt='Avatar: #{user.name}']")
           end
         end
       end

--- a/decidim-core/spec/system/messaging/profile_conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/profile_conversations_spec.rb
@@ -156,7 +156,7 @@ describe "ProfileConversations", type: :system do
         it_behaves_like "conversation field with maximum length", "message_body"
 
         describe "reply to conversation" do
-          let(:reply_message) { ::Faker::Lorem.sentence }
+          let(:reply_message) { Faker::Lorem.sentence }
 
           it "can reply to conversation" do
             fill_in "message_body", with: reply_message

--- a/decidim-core/spec/system/messaging/profile_conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/profile_conversations_spec.rb
@@ -73,7 +73,7 @@ describe "ProfileConversations", type: :system do
     end
 
     it "shows an empty conversation page" do
-      expect(page).to have_no_selector(".card.card--widget")
+      expect(page).not_to have_selector(".card.card--widget")
       expect(page).to have_current_path decidim.new_profile_conversation_path(nickname: profile.nickname, recipient_id: recipient.id)
     end
 
@@ -227,18 +227,18 @@ describe "ProfileConversations", type: :system do
 
       it "does not show the topbar button the number of unread messages" do
         within "#profile-tabs li.is-active a" do
-          expect(page).to have_no_selector(".badge")
+          expect(page).not_to have_selector(".badge")
         end
       end
 
       it "does not show an unread count" do
-        expect(page).to have_no_selector(".card.card--widget .unread_message__counter")
+        expect(page).not_to have_selector(".card.card--widget .unread_message__counter")
       end
 
       it "conversation page does not show the number of unread messages" do
         visit_inbox
 
-        expect(page).to have_no_selector(".user-groups .card--list__author .card--list__counter")
+        expect(page).not_to have_selector(".user-groups .card--list__author .card--list__counter")
       end
     end
 
@@ -273,7 +273,7 @@ describe "ProfileConversations", type: :system do
           expect(page).to have_content("Please reply!")
 
           visit decidim.conversations_path
-          expect(page).to have_no_selector(".card.card--widget .unread_message__counter")
+          expect(page).not_to have_selector(".card.card--widget .unread_message__counter")
         end
       end
     end

--- a/decidim-core/spec/system/notifications_spec.rb
+++ b/decidim-core/spec/system/notifications_spec.rb
@@ -25,7 +25,7 @@ describe "Notifications", type: :system do
       end
 
       expect(page).to have_current_path decidim.notifications_path
-      expect(page).to have_no_content("No notifications yet")
+      expect(page).not_to have_content("No notifications yet")
       expect(page).to have_content("An event occured")
     end
 
@@ -50,7 +50,7 @@ describe "Notifications", type: :system do
 
       it "the button is not shown as active" do
         within ".topbar__user__logged" do
-          expect(page).to have_no_selector("a.topbar__notifications.is-active")
+          expect(page).not_to have_selector("a.topbar__notifications.is-active")
           expect(page).to have_selector("a.topbar__notifications")
         end
       end
@@ -93,7 +93,7 @@ describe "Notifications", type: :system do
       it "hides the notification from the page" do
         expect(page).to have_content(translated(notification_title))
         find("[data-notification-read]").click
-        expect(page).to have_no_content(translated(notification_title))
+        expect(page).not_to have_content(translated(notification_title))
         expect(page).to have_content("No notifications yet")
       end
     end

--- a/decidim-core/spec/system/scopes_spec.rb
+++ b/decidim-core/spec/system/scopes_spec.rb
@@ -45,7 +45,7 @@ describe "Scopes picker", type: :system do
         let(:params) { { title:, required: true, current: scopes.first } }
 
         it "allows to choose it" do
-          expect(page).to have_no_selector(".scope-picker.picker-footer .buttons a.button[disabled='true']")
+          expect(page).not_to have_selector(".scope-picker.picker-footer .buttons a.button[disabled='true']")
         end
       end
     end
@@ -68,7 +68,7 @@ describe "Scopes picker", type: :system do
       let(:root) { scopes.first }
 
       it "does not show global scope in header" do
-        expect(page).to have_no_css(".scope-picker.picker-header li a", text: "Global scope")
+        expect(page).not_to have_css(".scope-picker.picker-header li a", text: "Global scope")
       end
 
       it "shows root scope in header" do
@@ -76,7 +76,7 @@ describe "Scopes picker", type: :system do
       end
 
       it "does not show root sibling scope in header" do
-        expect(page).to have_no_css(".scope-picker.picker-header li a", text: scopes.last.name["en"])
+        expect(page).not_to have_css(".scope-picker.picker-header li a", text: scopes.last.name["en"])
       end
 
       it "shows child scope in content" do
@@ -97,7 +97,7 @@ describe "Scopes picker", type: :system do
         end
 
         it "does not shows any scope in content" do
-          expect(page).to have_no_css(".scope-picker.picker-content li")
+          expect(page).not_to have_css(".scope-picker.picker-content li")
         end
       end
     end

--- a/decidim-core/spec/system/user_activity_spec.rb
+++ b/decidim-core/spec/system/user_activity_spec.rb
@@ -80,7 +80,7 @@ describe "User activity", type: :system do
           expect(page).to have_content(translated(resource.title))
           expect(page).to have_content(translated(comment.commentable.title))
           expect(page).to have_content(translated(resource3.title))
-          expect(page).to have_no_content(translated(resource2.title))
+          expect(page).not_to have_content(translated(resource2.title))
         end
       end
     end
@@ -97,8 +97,8 @@ describe "User activity", type: :system do
 
         expect(page).to have_content(translated(resource.title))
         expect(page).to have_content(translated(comment.commentable.title))
-        expect(page).to have_no_content(translated(resource2.title))
-        expect(page).to have_no_content(translated(resource3.title))
+        expect(page).not_to have_content(translated(resource2.title))
+        expect(page).not_to have_content(translated(resource3.title))
       end
     end
 

--- a/decidim-core/spec/system/user_group_email_confirmation_spec.rb
+++ b/decidim-core/spec/system/user_group_email_confirmation_spec.rb
@@ -18,7 +18,7 @@ describe "User group email confirmation", type: :system do
     end
 
     it "does not show the link to edit" do
-      expect(page).to have_no_content("Resend email confirmation instructions")
+      expect(page).not_to have_content("Resend email confirmation instructions")
     end
   end
 

--- a/decidim-core/spec/system/user_group_invite_to_join_spec.rb
+++ b/decidim-core/spec/system/user_group_invite_to_join_spec.rb
@@ -18,7 +18,7 @@ describe "User group invite to join", type: :system do
     end
 
     it "does not show the link to edit" do
-      expect(page).to have_no_content("Invite participant")
+      expect(page).not_to have_content("Invite participant")
     end
 
     it "rejects the user that accesses manually" do

--- a/decidim-core/spec/system/user_group_joining_spec.rb
+++ b/decidim-core/spec/system/user_group_joining_spec.rb
@@ -16,7 +16,7 @@ describe "User group joining", type: :system do
     let!(:user_group) { create(:user_group, users: [user], organization: user.organization) }
 
     it "does not show the link to join" do
-      expect(page).to have_no_content("Request to join group")
+      expect(page).not_to have_content("Request to join group")
     end
   end
 
@@ -25,7 +25,7 @@ describe "User group joining", type: :system do
       click_link "Request to join group"
 
       expect(page).to have_content("Join request successfully created")
-      expect(page).to have_no_content("Request to join group")
+      expect(page).not_to have_content("Request to join group")
     end
   end
 end

--- a/decidim-core/spec/system/user_group_leaving_spec.rb
+++ b/decidim-core/spec/system/user_group_leaving_spec.rb
@@ -60,7 +60,7 @@ describe "User group leaving", type: :system do
 
   context "when the user does not belong to the group" do
     it "does not show the link to leave" do
-      expect(page).to have_no_content("Leave group")
+      expect(page).not_to have_content("Leave group")
     end
   end
 end

--- a/decidim-core/spec/system/user_group_manage_admins_spec.rb
+++ b/decidim-core/spec/system/user_group_manage_admins_spec.rb
@@ -21,7 +21,7 @@ describe "User group manage admins", type: :system do
     end
 
     it "does not show the link to edit" do
-      expect(page).to have_no_content("Manage admins")
+      expect(page).not_to have_content("Manage admins")
     end
 
     it "rejects the user that accesses manually" do
@@ -41,7 +41,7 @@ describe "User group manage admins", type: :system do
     it "allows demoting a user" do
       accept_confirm { click_link "Remove admin" }
       expect(page).to have_content("Participant successfully removed from admin")
-      expect(page).to have_no_content(admin.name)
+      expect(page).not_to have_content(admin.name)
     end
   end
 end

--- a/decidim-core/spec/system/user_group_manage_members_spec.rb
+++ b/decidim-core/spec/system/user_group_manage_members_spec.rb
@@ -20,7 +20,7 @@ describe "User group manage members", type: :system do
     end
 
     it "does not show the link to edit" do
-      expect(page).to have_no_content("Manage members")
+      expect(page).not_to have_content("Manage members")
     end
 
     it "rejects the user that accesses manually" do
@@ -48,13 +48,13 @@ describe "User group manage members", type: :system do
     it "allows removing a user from the group" do
       accept_confirm { click_link "Remove participant" }
       expect(page).to have_content("Participant successfully removed from the group")
-      expect(page).to have_no_content(member.name)
+      expect(page).not_to have_content(member.name)
     end
 
     it "allows promoting a user" do
       accept_confirm { click_link "Make admin" }
       expect(page).to have_content("Participant promoted successfully")
-      expect(page).to have_no_content(member.name)
+      expect(page).not_to have_content(member.name)
     end
 
     context "with pending requests" do
@@ -71,7 +71,7 @@ describe "User group manage members", type: :system do
           click_link "Accept"
         end
 
-        expect(page).to have_no_css(".list-request")
+        expect(page).not_to have_css(".list-request")
         expect(page).to have_content("Join request successfully accepted")
         expect(page).to have_content(requested_user.name)
         expect(page).to have_content("Role: Member")
@@ -83,9 +83,9 @@ describe "User group manage members", type: :system do
           click_link "Reject"
         end
 
-        expect(page).to have_no_css(".list-request")
+        expect(page).not_to have_css(".list-request")
         expect(page).to have_content("Join request successfully rejected")
-        expect(page).to have_no_content(requested_user.name)
+        expect(page).not_to have_content(requested_user.name)
       end
     end
   end

--- a/decidim-core/spec/system/user_group_profile_edition_spec.rb
+++ b/decidim-core/spec/system/user_group_profile_edition_spec.rb
@@ -20,7 +20,7 @@ describe "User group profile edition", type: :system do
     end
 
     it "does not show the link to edit" do
-      expect(page).to have_no_content("Edit group profile")
+      expect(page).not_to have_content("Edit group profile")
     end
 
     it "rejects the user that accesses manually" do

--- a/decidim-core/spec/system/user_group_profile_spec.rb
+++ b/decidim-core/spec/system/user_group_profile_spec.rb
@@ -42,7 +42,7 @@ describe "User group profile", type: :system do
     end
 
     it "does not show verification stuff" do
-      expect(page).to have_no_content("This group is publicly verified")
+      expect(page).not_to have_content("This group is publicly verified")
     end
 
     context "and user group is verified" do
@@ -83,7 +83,7 @@ describe "User group profile", type: :system do
         click_link "Members"
 
         expect(page).to have_content(user.name)
-        expect(page).to have_no_content(pending_user.name)
+        expect(page).not_to have_content(pending_user.name)
       end
     end
   end

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -47,7 +47,7 @@ describe "Profile", type: :system do
     end
 
     it "does not show officialization stuff" do
-      expect(page).to have_no_content("This participant is publicly verified")
+      expect(page).not_to have_content("This participant is publicly verified")
     end
 
     context "and user officialized the standard way" do
@@ -208,14 +208,14 @@ describe "Profile", type: :system do
         click_link "Groups"
 
         expect(page).to have_content(accepted_user_group.name)
-        expect(page).to have_no_content(pending_user_group.name)
+        expect(page).not_to have_content(pending_user_group.name)
       end
 
       context "when user groups are disabled" do
         let(:organization) { create(:organization, user_groups_enabled: false) }
         let(:user) { create(:user, :confirmed, organization:) }
 
-        it { is_expected.to have_no_content("Groups") }
+        it { is_expected.not_to have_content("Groups") }
       end
     end
   end

--- a/decidim-core/spec/system/user_report_spec.rb
+++ b/decidim-core/spec/system/user_report_spec.rb
@@ -35,7 +35,7 @@ describe "Report User", type: :system do
     it "gives the option to sign in" do
       page.visit reportable_path
 
-      expect(page).to have_no_css("html.is-reveal-open")
+      expect(page).not_to have_css("html.is-reveal-open")
 
       click_button "Report"
 

--- a/decidim-core/spec/validators/password_validator_spec.rb
+++ b/decidim-core/spec/validators/password_validator_spec.rb
@@ -10,19 +10,19 @@ describe PasswordValidator do
     let(:errors) { ActiveModel::Errors.new(attribute.to_s => []) }
     let(:record) do
       double(
-        name: ::Faker::Name.name,
+        name: Faker::Name.name,
         email:,
-        nickname: ::Faker::Internet.username(specifier: 10..15),
+        nickname: Faker::Internet.username(specifier: 10..15),
         current_organization: organization,
         errors:,
         admin?: admin_record,
         previous_passwords:,
-        encrypted_password_was: ::Devise::Encryptor.digest(Decidim::User, "decidim123456"),
+        encrypted_password_was: Devise::Encryptor.digest(Decidim::User, "decidim123456"),
         encrypted_password_changed?: true
       )
     end
     let(:admin_record) { false }
-    let(:email) { ::Faker::Internet.email }
+    let(:email) { Faker::Internet.email }
     let(:previous_passwords) { [] }
     let(:attribute) { "password" }
     let(:options) do
@@ -91,7 +91,7 @@ describe PasswordValidator do
     end
 
     describe "short password" do
-      let(:value) { ::Faker::Internet.password(max_length: ::PasswordValidator::MINIMUM_LENGTH - 1) }
+      let(:value) { Faker::Internet.password(max_length: PasswordValidator::MINIMUM_LENGTH - 1) }
 
       it "is too short" do
         expect(validator).to be(false)
@@ -101,9 +101,9 @@ describe PasswordValidator do
       context "when the record is an admin" do
         let(:admin_record) { true }
         let(:value) do
-          ::Faker::Internet.password(
-            min_length: ::PasswordValidator::MINIMUM_LENGTH,
-            max_length: ::PasswordValidator::ADMIN_MINIMUM_LENGTH - 1
+          Faker::Internet.password(
+            min_length: PasswordValidator::MINIMUM_LENGTH,
+            max_length: PasswordValidator::ADMIN_MINIMUM_LENGTH - 1
           )
         end
 
@@ -115,7 +115,7 @@ describe PasswordValidator do
     end
 
     describe "long password" do
-      let(:value) { ::Faker::Internet.password(min_length: ::PasswordValidator::MAX_LENGTH + 1, max_length: ::PasswordValidator::MAX_LENGTH + 2) }
+      let(:value) { Faker::Internet.password(min_length: PasswordValidator::MAX_LENGTH + 1, max_length: PasswordValidator::MAX_LENGTH + 2) }
 
       it "is too long" do
         expect(validator).to be(false)
@@ -124,7 +124,7 @@ describe PasswordValidator do
     end
 
     describe "simple password" do
-      let(:value) { "ab" * ::PasswordValidator::MINIMUM_LENGTH }
+      let(:value) { "ab" * PasswordValidator::MINIMUM_LENGTH }
 
       it "does not have enough unique characters" do
         expect(validator).to be(false)
@@ -223,8 +223,8 @@ describe PasswordValidator do
 
     describe "repeated password" do
       let(:admin_record) { true }
-      let(:previous_passwords) { plain_passwords.map { |password| ::Devise::Encryptor.digest(Decidim::User, password) } }
-      let(:plain_passwords) { Array.new(6) { ::Faker::Internet.password(min_length: ::PasswordValidator::ADMIN_MINIMUM_LENGTH) } }
+      let(:previous_passwords) { plain_passwords.map { |password| Devise::Encryptor.digest(Decidim::User, password) } }
+      let(:plain_passwords) { Array.new(6) { Faker::Internet.password(min_length: PasswordValidator::ADMIN_MINIMUM_LENGTH) } }
 
       context "when password is last used" do
         let(:value) { plain_passwords[0] }

--- a/decidim-debates/app/events/decidim/debates/close_debate_event.rb
+++ b/decidim-debates/app/events/decidim/debates/close_debate_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Debates

--- a/decidim-debates/app/events/decidim/debates/create_debate_event.rb
+++ b/decidim-debates/app/events/decidim/debates/create_debate_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Debates

--- a/decidim-debates/spec/shared/manage_debates_examples.rb
+++ b/decidim-debates/spec/shared/manage_debates_examples.rb
@@ -56,7 +56,7 @@ RSpec.shared_examples "manage debates" do
 
       it "cannot edit the debate" do
         within find("tr", text: translated(debate.title)) do
-          expect(page).to have_no_selector(".action-icon--edit")
+          expect(page).not_to have_selector(".action-icon--edit")
         end
       end
     end
@@ -209,7 +209,7 @@ RSpec.shared_examples "manage debates" do
 
       it "cannot delete the debate" do
         within find("tr", text: translated(debate2.title)) do
-          expect(page).to have_no_selector(".action-icon--remove")
+          expect(page).not_to have_selector(".action-icon--remove")
         end
       end
     end
@@ -239,7 +239,7 @@ RSpec.shared_examples "manage debates" do
 
       within "table" do
         within find("tr", text: translated(debate.title)) do
-          expect(page).to have_no_selector(".action-icon--edit")
+          expect(page).not_to have_selector(".action-icon--edit")
           page.find(".action-icon--close").click
         end
       end
@@ -252,7 +252,7 @@ RSpec.shared_examples "manage debates" do
 
       it "cannot close the debate" do
         within find("tr", text: translated(debate.title)) do
-          expect(page).to have_no_selector(".action-icon--close")
+          expect(page).not_to have_selector(".action-icon--close")
         end
       end
     end

--- a/decidim-debates/spec/system/explore_debates_spec.rb
+++ b/decidim-debates/spec/system/explore_debates_spec.rb
@@ -224,7 +224,7 @@ describe "Explore debates", type: :system do
 
       it "does not list the hidden debates" do
         expect(page).to have_selector(".card--debate", count: debates_count - 1)
-        expect(page).to have_no_content(translated(debate.title))
+        expect(page).not_to have_content(translated(debate.title))
       end
     end
 

--- a/decidim-debates/spec/system/private_space_debate_spec.rb
+++ b/decidim-debates/spec/system/private_space_debate_spec.rb
@@ -33,7 +33,7 @@ describe "Private Space Debate", type: :system do
         visit_component
 
         within ".title-action" do
-          expect(page).to have_no_link("New debate")
+          expect(page).not_to have_link("New debate")
         end
       end
     end
@@ -60,7 +60,7 @@ describe "Private Space Debate", type: :system do
           visit_component
 
           within ".title-action" do
-            expect(page).to have_no_link("New debate")
+            expect(page).not_to have_link("New debate")
           end
         end
       end

--- a/decidim-debates/spec/system/user_closes_debate_spec.rb
+++ b/decidim-debates/spec/system/user_closes_debate_spec.rb
@@ -46,7 +46,7 @@ describe "User closes a debate", type: :system do
     end
 
     it "cannot be edited" do
-      expect(page).to have_no_content("Edit debate")
+      expect(page).not_to have_content("Edit debate")
     end
 
     it "is allowed to change the conclusions" do

--- a/decidim-debates/spec/system/user_creates_debate_spec.rb
+++ b/decidim-debates/spec/system/user_creates_debate_spec.rb
@@ -105,7 +105,7 @@ describe "User creates debate", type: :system do
       context "when creation is not enabled" do
         it "does not show the creation button" do
           visit_component
-          expect(page).to have_no_link("New debate")
+          expect(page).not_to have_link("New debate")
         end
       end
     end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -40,7 +40,7 @@ end
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  options = ::Selenium::WebDriver::Chrome::Options.new
+  options = Selenium::WebDriver::Chrome::Options.new
   options.args << "--explicitly-allowed-ports=#{Capybara.server_port}"
   options.args << "--headless"
   options.args << "--no-sandbox"
@@ -60,7 +60,7 @@ end
 # In order to work with PWA apps, Chrome cannot be run in headless mode, and requires
 # setting up special prefs and flags
 Capybara.register_driver :pwa_chrome do |app|
-  options = ::Selenium::WebDriver::Chrome::Options.new
+  options = Selenium::WebDriver::Chrome::Options.new
   options.args << "--explicitly-allowed-ports=#{Capybara.server_port}"
   options.args << "--no-sandbox"
   # Do not limit browser resources
@@ -87,7 +87,7 @@ Capybara.register_driver :pwa_chrome do |app|
 end
 
 Capybara.register_driver :iphone do |app|
-  options = ::Selenium::WebDriver::Chrome::Options.new
+  options = Selenium::WebDriver::Chrome::Options.new
   options.args << "--headless"
   options.args << "--no-sandbox"
   options.add_emulation(device_name: "iPhone 6")

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/cell_matchers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/cell_matchers.rb
@@ -4,7 +4,7 @@ module Decidim
   module CellMatchers
     RSpec::Matchers.define :render_nothing do |_expected_value|
       match do |actual_value|
-        expect(actual_value).to have_no_selector("html")
+        expect(actual_value).not_to have_selector("html")
       end
 
       diffable

--- a/decidim-dev/lib/tasks/lighthouse_report.rake
+++ b/decidim-dev/lib/tasks/lighthouse_report.rake
@@ -15,9 +15,9 @@ namespace :decidim do
 
       host = "http://localhost:3000"
       urls = ["/"]
-      urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::ParticipatoryProcess.published.first).path
-      urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::Meetings::Meeting.published.first).path
-      urls << ::Decidim::ResourceLocatorPresenter.new(Decidim::Proposals::Proposal.published.first).path
+      urls << Decidim::ResourceLocatorPresenter.new(Decidim::ParticipatoryProcess.published.first).path
+      urls << Decidim::ResourceLocatorPresenter.new(Decidim::Meetings::Meeting.published.first).path
+      urls << Decidim::ResourceLocatorPresenter.new(Decidim::Proposals::Proposal.published.first).path
 
       # Update lighthouse configuration with the urls
       lighthouse_rc_path = Rails.root.join("../.lighthouserc.json")

--- a/decidim-elections/app/events/decidim/elections/election_published_event.rb
+++ b/decidim-elections/app/events/decidim/elections/election_published_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Elections

--- a/decidim-elections/app/events/decidim/elections/trustees/notify_new_trustee_event.rb
+++ b/decidim-elections/app/events/decidim/elections/trustees/notify_new_trustee_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Elections

--- a/decidim-elections/app/events/decidim/elections/trustees/notify_trustee_new_election_event.rb
+++ b/decidim-elections/app/events/decidim/elections/trustees/notify_trustee_new_election_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Elections

--- a/decidim-elections/app/events/decidim/elections/votes/vote_accepted_event.rb
+++ b/decidim-elections/app/events/decidim/elections/votes/vote_accepted_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Elections

--- a/decidim-elections/app/events/decidim/votings/polling_officers/polling_station_assigned_event.rb
+++ b/decidim-elections/app/events/decidim/votings/polling_officers/polling_station_assigned_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Votings

--- a/decidim-elections/spec/commands/decidim/votings/admin/monitoring_committee_validate_polling_station_closure_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/admin/monitoring_committee_validate_polling_station_closure_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# frozen_string_literal: true
 
 require "spec_helper"
 

--- a/decidim-elections/spec/shared/manage_voting_components_examples.rb
+++ b/decidim-elections/spec/shared/manage_voting_components_examples.rb
@@ -158,7 +158,7 @@ shared_examples "manage voting components" do
         click_link "Delete"
       end
 
-      expect(page).to have_no_content("My component")
+      expect(page).not_to have_content("My component")
     end
   end
 

--- a/decidim-elections/spec/system/admin/admin_manages_answers_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_answers_spec.rb
@@ -85,7 +85,7 @@ describe "Admin manages answers", type: :system do
     let(:election) { create(:election, :created, component: current_component) }
 
     it "cannot add a new answer" do
-      expect(page).to have_no_content("New Answer")
+      expect(page).not_to have_content("New Answer")
     end
   end
 
@@ -129,7 +129,7 @@ describe "Admin manages answers", type: :system do
 
       it "cannot update the answer" do
         within find("tr", text: translated(answer.title)) do
-          expect(page).to have_no_selector(".action-icon--edit")
+          expect(page).not_to have_selector(".action-icon--edit")
         end
       end
     end
@@ -157,7 +157,7 @@ describe "Admin manages answers", type: :system do
 
       it "cannot delete the question" do
         within find("tr", text: translated(answer.title)) do
-          expect(page).to have_no_selector(".action-icon--remove")
+          expect(page).not_to have_selector(".action-icon--remove")
         end
       end
     end

--- a/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
@@ -124,7 +124,7 @@ describe "Admin manages elections", type: :system do
         end
 
         within find("tr", text: translated(election.title)) do
-          expect(page).to have_no_selector(".action-icon--publish")
+          expect(page).not_to have_selector(".action-icon--publish")
         end
       end
     end
@@ -143,7 +143,7 @@ describe "Admin manages elections", type: :system do
       end
 
       within find("tr", text: translated(election.title)) do
-        expect(page).to have_no_selector(".action-icon--unpublish")
+        expect(page).not_to have_selector(".action-icon--unpublish")
       end
     end
 
@@ -152,7 +152,7 @@ describe "Admin manages elections", type: :system do
 
       it "cannot unpublish the election" do
         within find("tr", text: translated(election.title)) do
-          expect(page).to have_no_selector(".action-icon--unpublish")
+          expect(page).not_to have_selector(".action-icon--unpublish")
         end
       end
     end
@@ -162,7 +162,7 @@ describe "Admin manages elections", type: :system do
 
       it "cannot unpublish the election" do
         within find("tr", text: translated(election.title)) do
-          expect(page).to have_no_selector(".action-icon--unpublish")
+          expect(page).not_to have_selector(".action-icon--unpublish")
         end
       end
     end
@@ -192,7 +192,7 @@ describe "Admin manages elections", type: :system do
 
       it "cannot delete the election" do
         within find("tr", text: translated(election.title)) do
-          expect(page).to have_no_selector(".action-icon--remove")
+          expect(page).not_to have_selector(".action-icon--remove")
         end
       end
     end

--- a/decidim-elections/spec/system/admin/admin_manages_questions_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_questions_spec.rb
@@ -76,7 +76,7 @@ describe "Admin manages questions", type: :system do
     let(:election) { create(:election, :created, component: current_component) }
 
     it "cannot add a new question" do
-      expect(page).to have_no_content("New Question")
+      expect(page).not_to have_content("New Question")
     end
   end
 
@@ -112,7 +112,7 @@ describe "Admin manages questions", type: :system do
 
       it "cannot update the question" do
         within find("tr", text: translated(question.title)) do
-          expect(page).to have_no_selector(".action-icon--edit")
+          expect(page).not_to have_selector(".action-icon--edit")
         end
       end
     end
@@ -140,7 +140,7 @@ describe "Admin manages questions", type: :system do
 
       it "cannot delete the question" do
         within find("tr", text: translated(question.title)) do
-          expect(page).to have_no_selector(".action-icon--remove")
+          expect(page).not_to have_selector(".action-icon--remove")
         end
       end
     end

--- a/decidim-elections/spec/system/admin/admin_manages_voting_ballot_styles_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_voting_ballot_styles_spec.rb
@@ -61,7 +61,7 @@ describe "Admin manages ballot styles", type: :system do
 
       expect(page).to have_admin_callout("successfully")
 
-      expect(page).to have_no_content(ballot_style.code)
+      expect(page).not_to have_content(ballot_style.code)
     end
 
     it "can update a ballot style" do

--- a/decidim-elections/spec/system/admin/admin_manages_voting_monitoring_committee_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_voting_monitoring_committee_spec.rb
@@ -70,7 +70,7 @@ describe "Admin manages the monitoring committee", type: :system do
       expect(page).to have_admin_callout("successfully")
 
       within "#monitoring_committee_members table" do
-        expect(page).to have_no_content(other_user.email)
+        expect(page).not_to have_content(other_user.email)
       end
     end
   end

--- a/decidim-elections/spec/system/admin/admin_manages_voting_polling_officers_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_voting_polling_officers_spec.rb
@@ -127,7 +127,7 @@ describe "Admin manages polling officers", type: :system do
       expect(page).to have_admin_callout("successfully")
 
       within "#polling_officers table" do
-        expect(page).to have_no_content(other_user.email)
+        expect(page).not_to have_content(other_user.email)
       end
     end
   end

--- a/decidim-elections/spec/system/admin/admin_manages_voting_polling_stations_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_voting_polling_stations_spec.rb
@@ -151,7 +151,7 @@ describe "Admin manages polling stations", type: :system, serves_geocoding_autoc
 
       expect(page).to have_admin_callout("successfully")
 
-      expect(page).to have_no_content(translated(polling_station.title, locale: :en))
+      expect(page).not_to have_content(translated(polling_station.title, locale: :en))
     end
 
     it "can update a polling_station" do

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -59,12 +59,12 @@ shared_examples_for "has questionnaire" do
         expect(page).to have_content("Step 1 of 2")
 
         within ".answer-questionnaire__submit", match: :first do
-          expect(page).to have_no_content("Back")
+          expect(page).not_to have_content("Back")
         end
 
         answer_first_questionnaire
 
-        expect(page).to have_no_selector(".success.flash")
+        expect(page).not_to have_selector(".success.flash")
       end
 
       it "allows revisiting previously-answered questionnaires with my answers" do
@@ -93,7 +93,7 @@ shared_examples_for "has questionnaire" do
 
       def answer_first_questionnaire
         within "div.answer-questionnaire__step", match: :first do
-          expect(page).to have_no_selector("#questionnaire_tos_agreement")
+          expect(page).not_to have_selector("#questionnaire_tos_agreement")
 
           fill_in question.body["en"], with: "My first answer"
           within ".answer-questionnaire__footer", match: :first do
@@ -142,7 +142,7 @@ shared_examples_for "has questionnaire" do
       it "does not leak defaults from other answers" do
         visit questionnaire_public_path
 
-        expect(page).to have_no_selector("input[type=radio]:checked")
+        expect(page).not_to have_selector("input[type=radio]:checked")
       end
     end
 
@@ -243,7 +243,7 @@ shared_examples_for "has questionnaire" do
       end
 
       it "shows errors without submitting the form" do
-        expect(page).to have_no_selector ".alert.flash"
+        expect(page).not_to have_selector ".alert.flash"
         different_error = I18n.t("decidim.forms.questionnaires.answer.max_choices_alert")
         expect(different_error).to eq("There are too many choices selected")
         expect(page).not_to have_content(different_error)
@@ -489,7 +489,7 @@ shared_examples_for "has questionnaire" do
 
         expect(page).to have_selector(".js-check-box-collection input[type=checkbox]", count: 3)
 
-        expect(page).to have_no_content("Max choices:")
+        expect(page).not_to have_content("Max choices:")
 
         check answer_options[0]["body"][:en]
         check answer_options[1]["body"][:en]

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires.rb
@@ -63,8 +63,8 @@ shared_examples_for "manage questionnaires" do
     it "cannot modify questionnaire questions" do
       visit questionnaire_edit_path
 
-      expect(page).to have_no_content("Add question")
-      expect(page).to have_no_content("Remove")
+      expect(page).not_to have_content("Add question")
+      expect(page).not_to have_content("Remove")
 
       expand_all_questions
 

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_display_conditions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_display_conditions.rb
@@ -21,7 +21,7 @@ shared_examples_for "add display conditions" do
       end
 
       it "does not display an add display condition button" do
-        expect(page).to have_no_button("Add display condition")
+        expect(page).not_to have_button("Add display condition")
       end
 
       context "when creating a new question" do
@@ -85,14 +85,14 @@ shared_examples_for "add display conditions" do
               select question_single_option.body["en"], from: "Question"
               select "Answered", from: "Condition"
 
-              expect(page).to have_no_select("Answer option")
-              expect(page).to have_no_css("[id$=condition_value_en]", visible: :visible)
+              expect(page).not_to have_select("Answer option")
+              expect(page).not_to have_css("[id$=condition_value_en]", visible: :visible)
 
               select question_single_option.body["en"], from: "Question"
               select "Equal", from: "Condition"
 
               expect(page).to have_select("Answer option")
-              expect(page).to have_no_css("[id$=condition_value_en]", visible: :visible)
+              expect(page).not_to have_css("[id$=condition_value_en]", visible: :visible)
             end
           end
         end
@@ -164,7 +164,7 @@ shared_examples_for "add display conditions" do
         it "loads a mandatory field with false value" do
           within_add_display_condition do
             expect(page).to have_selector("[id$=mandatory]")
-            expect(page).to have_no_selector("[id$=mandatory][checked]")
+            expect(page).not_to have_selector("[id$=mandatory][checked]")
           end
         end
 

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
@@ -119,7 +119,7 @@ shared_examples_for "add questions" do
         end
       end
 
-      expect(page).to have_no_content "Add answer option"
+      expect(page).not_to have_content "Add answer option"
 
       page.all(".questionnaire-question").each do |question|
         within question do
@@ -158,24 +158,24 @@ shared_examples_for "add questions" do
     expand_all_questions
 
     select "Long answer", from: "Type"
-    expect(page).to have_no_selector(".questionnaire-question-answer-option")
-    expect(page).to have_no_selector(".questionnaire-question-matrix-row")
+    expect(page).not_to have_selector(".questionnaire-question-answer-option")
+    expect(page).not_to have_selector(".questionnaire-question-matrix-row")
 
     select "Single option", from: "Type"
     expect(page).to have_selector(".questionnaire-question-answer-option", count: 2)
-    expect(page).to have_no_selector(".questionnaire-question-matrix-row")
+    expect(page).not_to have_selector(".questionnaire-question-matrix-row")
 
     select "Multiple option", from: "Type"
     expect(page).to have_selector(".questionnaire-question-answer-option", count: 2)
-    expect(page).to have_no_selector(".questionnaire-question-matrix-row")
+    expect(page).not_to have_selector(".questionnaire-question-matrix-row")
 
     select "Matrix (Multiple option)", from: "Type"
     expect(page).to have_selector(".questionnaire-question-answer-option", count: 2)
     expect(page).to have_selector(".questionnaire-question-matrix-row", count: 2)
 
     select "Short answer", from: "Type"
-    expect(page).to have_no_selector(".questionnaire-question-answer-option")
-    expect(page).to have_no_selector(".questionnaire-question-matrix-row")
+    expect(page).not_to have_selector(".questionnaire-question-answer-option")
+    expect(page).not_to have_selector(".questionnaire-question-matrix-row")
 
     select "Matrix (Single option)", from: "Type"
     expect(page).to have_selector(".questionnaire-question-answer-option", count: 2)
@@ -363,8 +363,8 @@ shared_examples_for "add questions" do
       click_link "English", match: :first
 
       expect(page).to have_nested_field("body_en", with: "Bye")
-      expect(page).to have_no_selector(nested_form_field_selector("body_ca"))
-      expect(page).to have_no_content("Adeu")
+      expect(page).not_to have_selector(nested_form_field_selector("body_ca"))
+      expect(page).not_to have_content("Adeu")
     end
   end
 
@@ -381,26 +381,26 @@ shared_examples_for "add questions" do
           fill_in find_nested_form_field_locator("body_en"), with: "This is the first question"
         end
 
-        expect(page).to have_no_content "Add answer option"
-        expect(page).to have_no_select("Maximum number of choices")
+        expect(page).not_to have_content "Add answer option"
+        expect(page).not_to have_select("Maximum number of choices")
       end
     end
 
     it "updates the free text option selector according to the selected question type" do
-      expect(page).to have_no_selector("input[type=checkbox][id$=_free_text]")
+      expect(page).not_to have_selector("input[type=checkbox][id$=_free_text]")
 
       select "Multiple option", from: "Type"
       expect(page).to have_selector("input[type=checkbox][id$=_free_text]")
 
       select "Short answer", from: "Type"
-      expect(page).to have_no_selector("input[type=checkbox][id$=_free_text]")
+      expect(page).not_to have_selector("input[type=checkbox][id$=_free_text]")
 
       select "Single option", from: "Type"
       expect(page).to have_selector("input[type=checkbox][id$=_free_text]")
     end
 
     it "updates the max choices selector according to the configured options" do
-      expect(page).to have_no_select("Maximum number of choices")
+      expect(page).not_to have_select("Maximum number of choices")
 
       select "Multiple option", from: "Type"
       expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
@@ -425,7 +425,7 @@ shared_examples_for "add questions" do
         expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
 
         select "Single option", from: "Type"
-        expect(page).to have_no_select("Maximum number of choices")
+        expect(page).not_to have_select("Maximum number of choices")
       end
     end
   end
@@ -442,27 +442,27 @@ shared_examples_for "add questions" do
           fill_in find_nested_form_field_locator("body_en"), with: "This is the first question"
         end
 
-        expect(page).to have_no_content "Add answer option"
-        expect(page).to have_no_content "Add row"
-        expect(page).to have_no_select("Maximum number of choices")
+        expect(page).not_to have_content "Add answer option"
+        expect(page).not_to have_content "Add row"
+        expect(page).not_to have_select("Maximum number of choices")
       end
     end
 
     it "updates the free text option selector according to the selected question type" do
-      expect(page).to have_no_selector("input[type=checkbox][id$=_free_text]")
+      expect(page).not_to have_selector("input[type=checkbox][id$=_free_text]")
 
       select "Matrix (Multiple option)", from: "Type"
       expect(page).to have_selector("input[type=checkbox][id$=_free_text]")
 
       select "Short answer", from: "Type"
-      expect(page).to have_no_selector("input[type=checkbox][id$=_free_text]")
+      expect(page).not_to have_selector("input[type=checkbox][id$=_free_text]")
 
       select "Matrix (Single option)", from: "Type"
       expect(page).to have_selector("input[type=checkbox][id$=_free_text]")
     end
 
     it "updates the max choices selector according to the configured options" do
-      expect(page).to have_no_select("Maximum number of choices")
+      expect(page).not_to have_select("Maximum number of choices")
 
       select "Matrix (Multiple option)", from: "Type"
       expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
@@ -487,7 +487,7 @@ shared_examples_for "add questions" do
         expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
 
         select "Matrix (Single option)", from: "Type"
-        expect(page).to have_no_select("Maximum number of choices")
+        expect(page).not_to have_select("Maximum number of choices")
       end
     end
   end

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/update_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/update_questions.rb
@@ -28,7 +28,7 @@ shared_examples_for "update questions" do
       visit_questionnaire_edit_path_and_expand_all
 
       expect(page).to have_selector("input[value='Modified question']")
-      expect(page).to have_no_selector("input[value='This is the first question']")
+      expect(page).not_to have_selector("input[value='This is the first question']")
       expect(page).to have_selector("input#questionnaire_questions_#{question.id}_mandatory[checked]")
       expect(page).to have_selector("input#questionnaire_questions_#{question.id}_max_characters[value='30']")
       expect(page).to have_selector("select#questionnaire_questions_#{question.id}_question_type option[value='long_answer'][selected]")
@@ -57,7 +57,7 @@ shared_examples_for "update questions" do
       expect(page).to have_content("must be greater than or equal to 0", count: 1)
 
       expect(page).to have_selector("input[value='']")
-      expect(page).to have_no_selector("input[value='This is the first question']")
+      expect(page).not_to have_selector("input[value='This is the first question']")
       expect(page).to have_selector("input#questionnaire_questions_#{question.id}_mandatory[checked]")
       expect(page).to have_selector("input#questionnaire_questions_#{question.id}_max_characters[value='-3']")
       expect(page).to have_select("Maximum number of choices", selected: "2")
@@ -79,7 +79,7 @@ shared_examples_for "update questions" do
 
       within ".questionnaire-question" do
         expect(page).to have_selector(".card-title", text: "#1")
-        expect(page).to have_no_button("Up")
+        expect(page).not_to have_button("Up")
       end
     end
 
@@ -104,7 +104,7 @@ shared_examples_for "update questions" do
     it "cannot be moved up" do
       within "form.edit_questionnaire" do
         within ".questionnaire-question" do
-          expect(page).to have_no_button("Up")
+          expect(page).not_to have_button("Up")
         end
       end
     end
@@ -112,7 +112,7 @@ shared_examples_for "update questions" do
     it "cannot be moved down" do
       within "form.edit_questionnaire" do
         within ".questionnaire-question" do
-          expect(page).to have_no_button("Down")
+          expect(page).not_to have_button("Down")
         end
       end
     end
@@ -140,7 +140,7 @@ shared_examples_for "update questions" do
       visit_questionnaire_edit_path_and_expand_all
 
       expect(page).to have_selector("input[value='Modified title and description']")
-      expect(page).to have_no_selector("input[value='This is the first title and description']")
+      expect(page).not_to have_selector("input[value='This is the first title and description']")
     end
 
     it "re-renders the form when the information is invalid and displays errors" do
@@ -159,7 +159,7 @@ shared_examples_for "update questions" do
       expect(page).to have_admin_callout("There was a problem saving")
       expect(page).to have_content("cannot be blank", count: 1)
       expect(page).to have_selector("input[value='']")
-      expect(page).to have_no_selector("input[value='This is the first title and description']")
+      expect(page).not_to have_selector("input[value='This is the first title and description']")
     end
 
     it "preserves deleted status across submission failures" do
@@ -177,7 +177,7 @@ shared_examples_for "update questions" do
 
       within ".questionnaire-question" do
         expect(page).to have_selector(".card-title", text: "#1")
-        expect(page).to have_no_button("Up")
+        expect(page).not_to have_button("Up")
       end
     end
 
@@ -202,7 +202,7 @@ shared_examples_for "update questions" do
     it "cannot be moved up" do
       within "form.edit_questionnaire" do
         within ".questionnaire-question" do
-          expect(page).to have_no_button("Up")
+          expect(page).not_to have_button("Up")
         end
       end
     end
@@ -210,7 +210,7 @@ shared_examples_for "update questions" do
     it "cannot be moved down" do
       within "form.edit_questionnaire" do
         within ".questionnaire-question" do
-          expect(page).to have_no_button("Down")
+          expect(page).not_to have_button("Down")
         end
       end
     end
@@ -521,7 +521,7 @@ shared_examples_for "update questions" do
         select "Single option", from: "Type"
 
         within ".questionnaire-question-answer-options-list" do
-          expect(page).to have_no_button("Remove")
+          expect(page).not_to have_button("Remove")
         end
 
         click_button "Add answer option"
@@ -533,7 +533,7 @@ shared_examples_for "update questions" do
         end
 
         within ".questionnaire-question-answer-options-list" do
-          expect(page).to have_no_button("Remove")
+          expect(page).not_to have_button("Remove")
         end
       end
 
@@ -542,7 +542,7 @@ shared_examples_for "update questions" do
 
       within ".questionnaire-question:last-of-type" do
         within ".questionnaire-question-answer-options-list" do
-          expect(page).to have_no_button("Remove")
+          expect(page).not_to have_button("Remove")
         end
       end
     end

--- a/decidim-forms/spec/cells/decidim/forms/question_readonly_cell_spec.rb
+++ b/decidim-forms/spec/cells/decidim/forms/question_readonly_cell_spec.rb
@@ -34,7 +34,7 @@ describe Decidim::Forms::QuestionReadonlyCell, type: :cell do
     end
 
     it "does not render the element with the answer idx attribute" do
-      expect(subject.call).to have_no_css("[data-answer-idx]")
+      expect(subject.call).not_to have_css("[data-answer-idx]")
     end
   end
 

--- a/decidim-initiatives/app/events/decidim/initiatives/admin/initiative_sent_to_technical_validation_event.rb
+++ b/decidim-initiatives/app/events/decidim/initiatives/admin/initiative_sent_to_technical_validation_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Initiatives

--- a/decidim-initiatives/app/events/decidim/initiatives/admin/support_threshold_reached_event.rb
+++ b/decidim-initiatives/app/events/decidim/initiatives/admin/support_threshold_reached_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Initiatives

--- a/decidim-initiatives/app/events/decidim/initiatives/approve_membership_request_event.rb
+++ b/decidim-initiatives/app/events/decidim/initiatives/approve_membership_request_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Initiatives

--- a/decidim-initiatives/app/events/decidim/initiatives/create_initiative_event.rb
+++ b/decidim-initiatives/app/events/decidim/initiatives/create_initiative_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Initiatives

--- a/decidim-initiatives/app/events/decidim/initiatives/endorse_initiative_event.rb
+++ b/decidim-initiatives/app/events/decidim/initiatives/endorse_initiative_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Initiatives

--- a/decidim-initiatives/app/events/decidim/initiatives/extend_initiative_event.rb
+++ b/decidim-initiatives/app/events/decidim/initiatives/extend_initiative_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Initiatives

--- a/decidim-initiatives/app/events/decidim/initiatives/initiative_sent_to_technical_validation_event.rb
+++ b/decidim-initiatives/app/events/decidim/initiatives/initiative_sent_to_technical_validation_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Initiatives

--- a/decidim-initiatives/app/events/decidim/initiatives/milestone_completed_event.rb
+++ b/decidim-initiatives/app/events/decidim/initiatives/milestone_completed_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Initiatives

--- a/decidim-initiatives/app/events/decidim/initiatives/revoke_membership_request_event.rb
+++ b/decidim-initiatives/app/events/decidim/initiatives/revoke_membership_request_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Initiatives

--- a/decidim-initiatives/app/events/decidim/initiatives/spawn_committee_request_event.rb
+++ b/decidim-initiatives/app/events/decidim/initiatives/spawn_committee_request_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Initiatives

--- a/decidim-initiatives/spec/cells/decidim/initiatives_votes/vote_cell_spec.rb
+++ b/decidim-initiatives/spec/cells/decidim/initiatives_votes/vote_cell_spec.rb
@@ -15,10 +15,10 @@ describe Decidim::InitiativesVotes::VoteCell, type: :cell do
 
   let(:personal_data_params) do
     {
-      name_and_surname: ::Faker::Name.name,
-      document_number: ::Faker::IDNumber.spanish_citizen_number,
-      date_of_birth: ::Faker::Date.birthday(min_age: 18, max_age: 40),
-      postal_code: ::Faker::Address.zip_code
+      name_and_surname: Faker::Name.name,
+      document_number: Faker::IDNumber.spanish_citizen_number,
+      date_of_birth: Faker::Date.birthday(min_age: 18, max_age: 40),
+      postal_code: Faker::Address.zip_code
     }
   end
 

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
@@ -173,7 +173,7 @@ describe "Admin manages initiative components", type: :system do
         page.find(".action-icon--remove").click
       end
 
-      expect(page).to have_no_content("My component")
+      expect(page).not_to have_content("My component")
     end
   end
 

--- a/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
@@ -97,8 +97,8 @@ describe "User answers the initiative", type: :system do
         page.find(".action-icon--answer").click
 
         within ".edit_initiative_answer" do
-          expect(page).to have_no_css("#initiative_signature_start_date")
-          expect(page).to have_no_css("#initiative_signature_end_date")
+          expect(page).not_to have_css("#initiative_signature_start_date")
+          expect(page).not_to have_css("#initiative_signature_end_date")
         end
       end
     end

--- a/decidim-initiatives/spec/system/authorized_comments_spec.rb
+++ b/decidim-initiatives/spec/system/authorized_comments_spec.rb
@@ -26,7 +26,7 @@ describe "Authorized comments", type: :system do
 
   shared_examples_for "allowed to comment" do
     it do
-      expect(page).to have_no_content("You need to be verified to comment at this moment")
+      expect(page).not_to have_content("You need to be verified to comment at this moment")
       expect(page).to have_selector("form.new_comment")
     end
   end

--- a/decidim-initiatives/spec/system/edit_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/edit_initiative_spec.rb
@@ -90,7 +90,7 @@ describe "Edit initiative", type: :system do
     it "renders an error" do
       visit decidim_initiatives.initiative_path(initiative)
 
-      expect(page).to have_no_content("Edit initiative")
+      expect(page).not_to have_content("Edit initiative")
 
       visit edit_initiative_path
 

--- a/decidim-initiatives/spec/system/initiative_signing_sms_verification_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_sms_verification_spec.rb
@@ -50,7 +50,7 @@ describe "Initiative signing", type: :system do
 
       click_button "Continue"
 
-      expect(page).to have_no_css("div.alert")
+      expect(page).not_to have_css("div.alert")
     end
   end
 

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -158,7 +158,7 @@ describe "Initiative", type: :system do
       it "shows the components" do
         within ".process-nav" do
           expect(page).to have_content(translated(meetings_component.name, locale: :en).upcase)
-          expect(page).to have_no_content(translated(proposals_component.name, locale: :en).upcase)
+          expect(page).not_to have_content(translated(proposals_component.name, locale: :en).upcase)
         end
       end
 

--- a/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/close_meeting_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Meetings

--- a/decidim-meetings/app/events/decidim/meetings/meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/meeting_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Meetings

--- a/decidim-meetings/app/events/decidim/meetings/meeting_registration_notification_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/meeting_registration_notification_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Meetings

--- a/decidim-meetings/app/events/decidim/meetings/meeting_registrations_enabled_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/meeting_registrations_enabled_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Meetings

--- a/decidim-meetings/app/events/decidim/meetings/meeting_registrations_over_percentage_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/meeting_registrations_over_percentage_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Meetings

--- a/decidim-meetings/app/events/decidim/meetings/registration_code_validated_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/registration_code_validated_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Meetings

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_meetings_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/upcoming_meetings_cell_spec.rb
@@ -86,7 +86,7 @@ module Decidim
 
         context "with no meetings" do
           it "renders nothing" do
-            expect(html).to have_no_css(".upcoming-meetings")
+            expect(html).not_to have_css(".upcoming-meetings")
           end
         end
       end

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_m_cell_spec.rb
@@ -24,8 +24,8 @@ module Decidim::Meetings
       end
 
       it "does not show creation date" do
-        expect(cell_html).to have_no_content("Created at")
-        expect(cell_html).to have_no_content(I18n.l(meeting.created_at.to_date, format: :decidim_short))
+        expect(cell_html).not_to have_content("Created at")
+        expect(cell_html).not_to have_content(I18n.l(meeting.created_at.to_date, format: :decidim_short))
       end
 
       context "when there are long descriptions" do

--- a/decidim-meetings/spec/lib/decidim/meetings/component_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/component_spec.rb
@@ -76,14 +76,12 @@ describe "Meetings component" do # rubocop:disable RSpec/DescribeClass
       let(:stats_name) { :followers_count }
 
       before do
-        # rubocop:disable RSpec/FactoryBot/CreateList
         2.times do
           create(:follow, followable: meeting, user: build(:user, organization:))
         end
         3.times do
           create(:follow, followable: hidden_meeting, user: build(:user, organization:))
         end
-        # rubocop:enable RSpec/FactoryBot/CreateList
       end
 
       it "counts the followers from visible meetings" do

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_polls_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_polls_spec.rb
@@ -100,11 +100,11 @@ describe "Admin manages meetings polls", type: :system do
 
       select "Single option", from: "Type"
       expect(page).to have_selector(".questionnaire-question-answer-option", count: 2)
-      expect(page).to have_no_selector(".questionnaire-question-matrix-row")
+      expect(page).not_to have_selector(".questionnaire-question-matrix-row")
 
       select "Multiple option", from: "Type"
       expect(page).to have_selector(".questionnaire-question-answer-option", count: 2)
-      expect(page).to have_no_selector(".questionnaire-question-matrix-row")
+      expect(page).not_to have_selector(".questionnaire-question-matrix-row")
     end
 
     it "does not incorrectly reorder when clicking answer options" do
@@ -193,22 +193,22 @@ describe "Admin manages meetings polls", type: :system do
             fill_in find_nested_form_field_locator("body_en"), with: "This is the first question"
           end
 
-          expect(page).to have_no_select("Maximum number of choices")
+          expect(page).not_to have_select("Maximum number of choices")
         end
       end
 
       it "updates the free text option selector according to the selected question type" do
-        expect(page).to have_no_selector("[id$=max_choices]")
+        expect(page).not_to have_selector("[id$=max_choices]")
 
         select "Multiple option", from: "Type"
         expect(page).to have_selector("[id$=max_choices]")
 
         select "Single option", from: "Type"
-        expect(page).to have_no_selector("[id$=max_choices]")
+        expect(page).not_to have_selector("[id$=max_choices]")
       end
 
       it "updates the max choices selector according to the configured options" do
-        expect(page).to have_no_select("Maximum number of choices")
+        expect(page).not_to have_select("Maximum number of choices")
 
         select "Multiple option", from: "Type"
         expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
@@ -233,7 +233,7 @@ describe "Admin manages meetings polls", type: :system do
           expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
 
           select "Single option", from: "Type"
-          expect(page).to have_no_select("Maximum number of choices")
+          expect(page).not_to have_select("Maximum number of choices")
         end
       end
     end
@@ -247,7 +247,7 @@ describe "Admin manages meetings polls", type: :system do
       visit questionnaire_edit_path
 
       expect(page).to have_content("Add question")
-      expect(page).to have_no_content("Remove")
+      expect(page).not_to have_content("Remove")
     end
   end
 

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -397,11 +397,11 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
       select "In person", from: :meeting_type_of_meeting
       expect(page).to have_field("Address")
       expect(page).to have_field(:meeting_location_en)
-      expect(page).to have_no_field("Online meeting URL")
+      expect(page).not_to have_field("Online meeting URL")
 
       select "Online", from: :meeting_type_of_meeting
-      expect(page).to have_no_field("Address")
-      expect(page).to have_no_field(:meeting_location_en)
+      expect(page).not_to have_field("Address")
+      expect(page).not_to have_field(:meeting_location_en)
       expect(page).to have_field("Online meeting URL")
 
       select "Hybrid", from: :meeting_type_of_meeting
@@ -416,13 +416,13 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
 
     within ".new_meeting" do
       select "Registration disabled", from: :meeting_registration_type
-      expect(page).to have_no_field("Registration URL")
+      expect(page).not_to have_field("Registration URL")
 
       select "On a different platform", from: :meeting_registration_type
       expect(page).to have_field("Registration URL")
 
       select "On this platform", from: :meeting_registration_type
-      expect(page).to have_no_field("Registration URL")
+      expect(page).not_to have_field("Registration URL")
     end
   end
 
@@ -441,7 +441,7 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
       expect(page).to have_admin_callout("successfully")
 
       within "table" do
-        expect(page).to have_no_content(Decidim::Meetings::MeetingPresenter.new(meeting2).title)
+        expect(page).not_to have_content(Decidim::Meetings::MeetingPresenter.new(meeting2).title)
       end
     end
   end
@@ -484,7 +484,7 @@ describe "Admin manages meetings", type: :system, serves_map: true, serves_geoco
       find(".card-title a.button").click
 
       within "label[for='meeting_registration_type']" do
-        expect(page).to have_no_content("There is an error in this field.")
+        expect(page).not_to have_content("There is an error in this field.")
       end
     end
 

--- a/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
+++ b/decidim-meetings/spec/system/explore_meeting_directory_spec.rb
@@ -329,7 +329,7 @@ describe "Explore meeting directory", type: :system do
         choose "Past"
       end
 
-      expect(page).to have_no_css(".card--meeting")
+      expect(page).not_to have_css(".card--meeting")
       within(all(".filters__section")[7]) do
         uncheck "All"
         check "Assemblies"

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -102,7 +102,7 @@ describe "Explore meetings", :slow, type: :system do
 
         expect(page).to have_selector(".card.card--meeting", count: meetings_count - 1)
 
-        expect(page).to have_no_content(translated(meeting.title))
+        expect(page).not_to have_content(translated(meeting.title))
       end
     end
 
@@ -163,7 +163,7 @@ describe "Explore meetings", :slow, type: :system do
               check "Official"
             end
 
-            expect(page).to have_no_content("6 MEETINGS")
+            expect(page).not_to have_content("6 MEETINGS")
             expect(page).to have_content("1 MEETING")
             expect(page).to have_css(".card--meeting", count: 1)
 
@@ -182,7 +182,7 @@ describe "Explore meetings", :slow, type: :system do
               check "Groups"
             end
 
-            expect(page).to have_no_content("6 MEETINGS")
+            expect(page).not_to have_content("6 MEETINGS")
             expect(page).to have_content("1 MEETING")
             expect(page).to have_css(".card--meeting", count: 1)
             within ".card--meeting" do
@@ -200,7 +200,7 @@ describe "Explore meetings", :slow, type: :system do
               check "Participants"
             end
 
-            expect(page).to have_no_content("6 MEETINGS")
+            expect(page).not_to have_content("6 MEETINGS")
             expect(page).to have_css(".card--meeting", count: meetings_count)
             expect(page).to have_content("#{meetings_count} MEETINGS")
           end
@@ -432,7 +432,7 @@ describe "Explore meetings", :slow, type: :system do
       it "hides map" do
         visit_component
 
-        expect(page).to have_no_css("div.map__help")
+        expect(page).not_to have_css("div.map__help")
       end
     end
   end
@@ -467,7 +467,7 @@ describe "Explore meetings", :slow, type: :system do
 
     context "without category or scope" do
       it "does not show any tag" do
-        expect(page).to have_no_selector("ul.tags.tag-container")
+        expect(page).not_to have_selector("ul.tags.tag-container")
       end
     end
 
@@ -585,7 +585,7 @@ describe "Explore meetings", :slow, type: :system do
 
       it "does not show contributions count" do
         within ".definition-data" do
-          expect(page).to have_no_content("CONTRIBUTIONS COUNT\n0")
+          expect(page).not_to have_content("CONTRIBUTIONS COUNT\n0")
         end
       end
     end

--- a/decidim-meetings/spec/system/live_meeting_access_spec.rb
+++ b/decidim-meetings/spec/system/live_meeting_access_spec.rb
@@ -54,12 +54,12 @@ describe "Meeting live event access", type: :system do
           it "does not show the meeting link embedded" do
             visit_meeting
 
-            expect(page).to have_no_content("This meeting is happening right now")
+            expect(page).not_to have_content("This meeting is happening right now")
             case embedding_type
             when :embedded
-              expect(page).to have_no_css("iframe")
+              expect(page).not_to have_css("iframe")
             else
-              expect(page).to have_no_content("JOIN MEETING")
+              expect(page).not_to have_content("JOIN MEETING")
             end
           end
         end
@@ -112,12 +112,12 @@ describe "Meeting live event access", type: :system do
           it "does not show the meeting link embedded" do
             visit_meeting
 
-            expect(page).to have_no_content("This meeting is happening right now")
+            expect(page).not_to have_content("This meeting is happening right now")
             case embedding_type
             when :embedded
-              expect(page).to have_no_css("iframe")
+              expect(page).not_to have_css("iframe")
             else
-              expect(page).to have_no_content("JOIN MEETING")
+              expect(page).not_to have_content("JOIN MEETING")
             end
           end
         end
@@ -130,12 +130,12 @@ describe "Meeting live event access", type: :system do
           it "does not show the meeting link embedded" do
             visit_meeting
 
-            expect(page).to have_no_content("This meeting is happening right now")
+            expect(page).not_to have_content("This meeting is happening right now")
             case embedding_type
             when :embedded
-              expect(page).to have_no_css("iframe")
+              expect(page).not_to have_css("iframe")
             else
-              expect(page).to have_no_content("JOIN MEETING")
+              expect(page).not_to have_content("JOIN MEETING")
             end
           end
         end
@@ -171,7 +171,7 @@ describe "Meeting live event access", type: :system do
         it "does not show the meeting link embedded" do
           visit_meeting
 
-          expect(page).to have_no_content("This meeting is happening right now")
+          expect(page).not_to have_content("This meeting is happening right now")
         end
       end
 
@@ -183,7 +183,7 @@ describe "Meeting live event access", type: :system do
         it "does not show the meeting link embedded" do
           visit_meeting
 
-          expect(page).to have_no_content("This meeting is happening right now")
+          expect(page).not_to have_content("This meeting is happening right now")
         end
       end
 
@@ -218,7 +218,7 @@ describe "Meeting live event access", type: :system do
       it "does not show the link to the live meeting streaming" do
         visit_meeting
 
-        expect(page).to have_no_content("This meeting is happening right now")
+        expect(page).not_to have_content("This meeting is happening right now")
       end
     end
 
@@ -309,7 +309,7 @@ describe "Meeting live event access", type: :system do
     it "does not show the link to the live meeting streaming" do
       visit_meeting
 
-      expect(page).to have_no_content("This meeting is happening right now")
+      expect(page).not_to have_content("This meeting is happening right now")
     end
   end
 
@@ -319,7 +319,7 @@ describe "Meeting live event access", type: :system do
     it "does not show the meeting link embedded" do
       visit_meeting
 
-      expect(page).to have_no_css("iframe")
+      expect(page).not_to have_css("iframe")
     end
   end
 
@@ -342,7 +342,7 @@ describe "Meeting live event access", type: :system do
       let(:current_time) { start_time - 20.minutes }
 
       it "is not live" do
-        expect(page).to have_no_content("This meeting is happening right now")
+        expect(page).not_to have_content("This meeting is happening right now")
       end
     end
 
@@ -366,7 +366,7 @@ describe "Meeting live event access", type: :system do
       let(:current_time) { end_time + 5.minutes }
 
       it "is not live" do
-        expect(page).to have_no_content("This meeting is happening right now")
+        expect(page).not_to have_content("This meeting is happening right now")
       end
     end
   end

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -192,8 +192,8 @@ describe "Meeting registrations", type: :system do
             expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
             expect(page).to have_text("19 slots remaining")
             expect(page).to have_text("Stop following")
-            expect(page).to have_no_text("ATTENDING PARTICIPANTS")
-            expect(page).to have_no_css("#list-of-public-participants")
+            expect(page).not_to have_text("ATTENDING PARTICIPANTS")
+            expect(page).not_to have_css("#list-of-public-participants")
           end
 
           it "they can join the meeting and configure their participation to be shown publicly" do
@@ -279,8 +279,8 @@ describe "Meeting registrations", type: :system do
 
             expect(page).to have_text("ATTENDING ORGANIZATIONS")
             expect(page).to have_text(user_group.name)
-            expect(page).to have_no_text("ATTENDING PARTICIPANTS")
-            expect(page).to have_no_css("#list-of-public-participants")
+            expect(page).not_to have_text("ATTENDING PARTICIPANTS")
+            expect(page).not_to have_css("#list-of-public-participants")
           end
         end
       end
@@ -415,8 +415,8 @@ describe "Meeting registrations", type: :system do
         it "does not show the registration code" do
           visit_meeting
 
-          expect(page).to have_no_css(".registration_code")
-          expect(page).to have_no_content(registration.code)
+          expect(page).not_to have_css(".registration_code")
+          expect(page).not_to have_content(registration.code)
         end
       end
 
@@ -442,7 +442,7 @@ describe "Meeting registrations", type: :system do
           visit_meeting
 
           expect(registration.validated_at).to be_nil
-          expect(page).to have_no_content("VALIDATION PENDING")
+          expect(page).not_to have_content("VALIDATION PENDING")
         end
       end
 
@@ -470,7 +470,7 @@ describe "Meeting registrations", type: :system do
           visit_meeting
 
           expect(registration.validated_at).not_to be_nil
-          expect(page).to have_no_content("VALIDATED")
+          expect(page).not_to have_content("VALIDATED")
         end
       end
 

--- a/decidim-meetings/spec/system/meeting_spec.rb
+++ b/decidim-meetings/spec/system/meeting_spec.rb
@@ -64,7 +64,7 @@ describe "Meeting", type: :system, download: true do
       it "hides the map section" do
         visit_meeting
 
-        expect(page).to have_no_css("div.address__map")
+        expect(page).not_to have_css("div.address__map")
       end
     end
 
@@ -106,7 +106,7 @@ describe "Meeting", type: :system, download: true do
       it "hides the map section" do
         visit_meeting
 
-        expect(page).to have_no_css("div.address__map")
+        expect(page).not_to have_css("div.address__map")
       end
     end
 
@@ -116,7 +116,7 @@ describe "Meeting", type: :system, download: true do
       it "hides the map section" do
         visit_meeting
 
-        expect(page).to have_no_css("div.address__map")
+        expect(page).not_to have_css("div.address__map")
       end
     end
   end
@@ -128,7 +128,7 @@ describe "Meeting", type: :system, download: true do
       visit_meeting
 
       within ".extra__date-container" do
-        expect(page).to have_no_content(meeting.start_time.year)
+        expect(page).not_to have_content(meeting.start_time.year)
       end
     end
   end

--- a/decidim-meetings/spec/system/private_meetings_spec.rb
+++ b/decidim-meetings/spec/system/private_meetings_spec.rb
@@ -70,7 +70,7 @@ describe "Private meetings", type: :system do
               expect(page).to have_content(translated(meeting.title, locale: :en))
               expect(page).to have_selector(".card", count: 1)
 
-              expect(page).to have_no_content(translated(private_meeting.title, locale: :en))
+              expect(page).not_to have_content(translated(private_meeting.title, locale: :en))
             end
           end
         end
@@ -87,7 +87,7 @@ describe "Private meetings", type: :system do
               expect(page).to have_content(translated(meeting.title, locale: :en))
               expect(page).to have_selector(".card", count: 1)
 
-              expect(page).to have_no_content(translated(private_meeting.title, locale: :en))
+              expect(page).not_to have_content(translated(private_meeting.title, locale: :en))
             end
           end
         end

--- a/decidim-meetings/spec/system/upcoming_meeting_for_card_view_hooks_spec.rb
+++ b/decidim-meetings/spec/system/upcoming_meeting_for_card_view_hooks_spec.rb
@@ -18,7 +18,7 @@ describe "Upcoming meeting for card view hook", type: :system do
       visit decidim_assemblies.assemblies_path
 
       within "#assembly_#{assembly.id}" do
-        expect(page).to have_no_selector(".card__icondata")
+        expect(page).not_to have_selector(".card__icondata")
       end
     end
   end

--- a/decidim-meetings/spec/system/user_close_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_close_meeting_spec.rb
@@ -125,7 +125,7 @@ describe "User edit meeting", type: :system do
       visit_component
 
       click_link translated(meeting.title)
-      expect(page).to have_no_content("Close meeting")
+      expect(page).not_to have_content("Close meeting")
     end
   end
 end

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -245,18 +245,18 @@ describe "User creates meeting", type: :system do
 
           within ".new_meeting" do
             select "Registration disabled", from: :meeting_registration_type
-            expect(page).to have_no_field("Registration URL")
-            expect(page).to have_no_field("Available slots")
-            expect(page).to have_no_field("Registration terms")
+            expect(page).not_to have_field("Registration URL")
+            expect(page).not_to have_field("Available slots")
+            expect(page).not_to have_field("Registration terms")
 
             select "On a different platform", from: :meeting_registration_type
             expect(page).to have_field("Registration URL")
-            expect(page).to have_no_field("Available slots")
-            expect(page).to have_no_field("Registration terms")
+            expect(page).not_to have_field("Available slots")
+            expect(page).not_to have_field("Registration terms")
 
             select "On this platform", from: :meeting_registration_type
             expect(page).to have_field("Available slots")
-            expect(page).to have_no_field("Registration URL")
+            expect(page).not_to have_field("Registration URL")
             expect(page).to have_field("Registration terms")
           end
         end
@@ -270,11 +270,11 @@ describe "User creates meeting", type: :system do
             select "In person", from: :meeting_type_of_meeting
             expect(page).to have_field("Address")
             expect(page).to have_field(:meeting_location)
-            expect(page).to have_no_field("Online meeting URL")
+            expect(page).not_to have_field("Online meeting URL")
 
             select "Online", from: :meeting_type_of_meeting
-            expect(page).to have_no_field("Address")
-            expect(page).to have_no_field(:meeting_location)
+            expect(page).not_to have_field("Address")
+            expect(page).not_to have_field(:meeting_location)
             expect(page).to have_field("Online meeting URL")
 
             select "Hybrid", from: :meeting_type_of_meeting
@@ -288,7 +288,7 @@ describe "User creates meeting", type: :system do
       context "when creation is not enabled" do
         it "does not show the creation button" do
           visit_component
-          expect(page).to have_no_link("New meeting")
+          expect(page).not_to have_link("New meeting")
         end
       end
     end

--- a/decidim-meetings/spec/system/user_edit_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_edit_meeting_spec.rb
@@ -100,12 +100,12 @@ describe "User edit meeting", type: :system do
         expect(page).to have_content "EDIT YOUR MEETING"
 
         within "form.edit_meeting" do
-          expect(page).to have_no_css("div.editor-input")
+          expect(page).not_to have_css("div.editor-input")
         end
 
         within "textarea#meeting_description" do
           expect(page).to have_content translated(meeting.description)
-          expect(page).to have_no_content '<div class="editor-input">'
+          expect(page).not_to have_content '<div class="editor-input">'
         end
       end
     end
@@ -120,7 +120,7 @@ describe "User edit meeting", type: :system do
       visit_component
 
       click_link translated(meeting.title)
-      expect(page).to have_no_content("Edit meeting")
+      expect(page).not_to have_content("Edit meeting")
       visit "#{current_path}/edit"
 
       expect(page).to have_content("not authorized")

--- a/decidim-participatory_processes/app/events/decidim/participatory_process_role_assigned_event.rb
+++ b/decidim-participatory_processes/app/events/decidim/participatory_process_role_assigned_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class ParticipatoryProcessRoleAssignedEvent < Decidim::Events::SimpleEvent

--- a/decidim-participatory_processes/app/events/decidim/participatory_process_step_activated_event.rb
+++ b/decidim-participatory_processes/app/events/decidim/participatory_process_step_activated_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class ParticipatoryProcessStepActivatedEvent < Decidim::Events::SimpleEvent

--- a/decidim-participatory_processes/app/events/decidim/participatory_process_step_changed_event.rb
+++ b/decidim-participatory_processes/app/events/decidim/participatory_process_step_changed_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   class ParticipatoryProcessStepChangedEvent < Decidim::Events::SimpleEvent

--- a/decidim-participatory_processes/spec/cells/decidim/participatory_process_groups/content_blocks/title_cell_spec.rb
+++ b/decidim-participatory_processes/spec/cells/decidim/participatory_process_groups/content_blocks/title_cell_spec.rb
@@ -64,9 +64,9 @@ describe Decidim::ParticipatoryProcessGroups::ContentBlocks::TitleCell, type: :c
       let(:meta_scope) { nil }
 
       it "hides meta attributes containers" do
-        expect(subject).to have_no_selector("svg.icon--twitter")
-        expect(subject).to have_no_selector("svg.icon--external-link")
-        expect(subject).to have_no_selector("svg.icon--globe")
+        expect(subject).not_to have_selector("svg.icon--twitter")
+        expect(subject).not_to have_selector("svg.icon--external-link")
+        expect(subject).not_to have_selector("svg.icon--globe")
       end
     end
 

--- a/decidim-participatory_processes/spec/shared/manage_participatory_process_private_users_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_participatory_process_private_users_examples.rb
@@ -63,7 +63,7 @@ shared_examples "manage participatory process private users examples" do
       expect(page).to have_admin_callout("successfully")
 
       within "#private_users table" do
-        expect(page).to have_no_content(other_user.email)
+        expect(page).not_to have_content(other_user.email)
       end
     end
 

--- a/decidim-participatory_processes/spec/shared/manage_process_admins_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_admins_examples.rb
@@ -76,7 +76,7 @@ shared_examples "manage process admins examples" do
       expect(page).to have_admin_callout("successfully")
 
       within "#process_admins table" do
-        expect(page).to have_no_content(other_user.email)
+        expect(page).not_to have_content(other_user.email)
       end
     end
 

--- a/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
@@ -24,7 +24,7 @@ shared_examples "manage process components" do
           find(".dummy").click
         end
 
-        expect(page).to have_no_content("Share tokens")
+        expect(page).not_to have_content("Share tokens")
 
         within ".new_component" do
           fill_in_i18n(
@@ -277,7 +277,7 @@ shared_examples "manage process components" do
         click_link "Delete"
       end
 
-      expect(page).to have_no_content("My component")
+      expect(page).not_to have_content("My component")
     end
   end
 
@@ -333,7 +333,7 @@ shared_examples "manage process components" do
           click_link "Configure"
         end
 
-        expect(page).to have_no_content("Share tokens")
+        expect(page).not_to have_content("Share tokens")
       end
 
       it "unpublishes the component" do

--- a/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
@@ -104,7 +104,7 @@ shared_examples "manage process steps examples" do
       expect(page).to have_admin_callout("successfully")
 
       within "#steps table" do
-        expect(page).to have_no_content(translated(process_step2.title))
+        expect(page).not_to have_content(translated(process_step2.title))
       end
     end
   end
@@ -116,7 +116,7 @@ shared_examples "manage process steps examples" do
       end
 
       within find("tr", text: translated(process_step.title)) do
-        expect(page).to have_no_content("Activate")
+        expect(page).not_to have_content("Activate")
       end
     end
   end

--- a/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
@@ -170,7 +170,7 @@ shared_examples "manage processes examples" do
 
     it "does not let the admin manage processes form other organizations" do
       within "table" do
-        expect(page).to have_no_content(external_participatory_process.title["en"])
+        expect(page).not_to have_content(external_participatory_process.title["en"])
       end
     end
   end

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_groups_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_groups_spec.rb
@@ -160,7 +160,7 @@ describe "Admin manages participatory process groups", type: :system do
 
       click_button "Update"
 
-      expect(page).to have_no_css("img")
+      expect(page).not_to have_css("img")
     end
 
     it "can delete them" do
@@ -171,7 +171,7 @@ describe "Admin manages participatory process groups", type: :system do
       expect(page).to have_admin_callout("successfully")
 
       within "table" do
-        expect(page).to have_no_content(participatory_process_group.title["en"])
+        expect(page).not_to have_content(participatory_process_group.title["en"])
       end
     end
 

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_types_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_types_spec.rb
@@ -79,7 +79,7 @@ describe "Admin manages participatory process types", type: :system do
         expect(page).to have_admin_callout("successfully")
 
         within ".card-section" do
-          expect(page).to have_no_content(translated(participatory_process_type.title))
+          expect(page).not_to have_content(translated(participatory_process_type.title))
         end
       end
     end

--- a/decidim-participatory_processes/spec/system/admin/participatory_process_admin_manages_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/participatory_process_admin_manages_participatory_processes_spec.rb
@@ -15,7 +15,7 @@ describe "Participatory process admin manages participatory processes", type: :s
   it_behaves_like "manage processes announcements"
 
   it "cannot create a new participatory_process" do
-    expect(page).to have_no_selector(".actions .new")
+    expect(page).not_to have_selector(".actions .new")
   end
 
   context "when deleting a participatory process" do
@@ -27,7 +27,7 @@ describe "Participatory process admin manages participatory processes", type: :s
 
     it "cannot delete a participatory_process" do
       within find("tr", text: translated(participatory_process2.title)) do
-        expect(page).to have_no_content("Delete")
+        expect(page).not_to have_content("Delete")
       end
     end
   end

--- a/decidim-participatory_processes/spec/system/admin/valuator_checks_components_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/valuator_checks_components_spec.rb
@@ -29,7 +29,7 @@ describe "Valuator checks components", type: :system do
     it "can only see the proposals component" do
       within ".layout-nav #components-list" do
         expect(page).to have_content(translated(current_component.name))
-        expect(page).to have_no_content(translated(another_component.name))
+        expect(page).not_to have_content(translated(another_component.name))
       end
     end
   end
@@ -42,7 +42,7 @@ describe "Valuator checks components", type: :system do
 
       within ".card" do
         expect(page).to have_content(translated(current_component.name))
-        expect(page).to have_no_content(translated(another_component.name))
+        expect(page).not_to have_content(translated(another_component.name))
       end
     end
   end

--- a/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
@@ -175,7 +175,7 @@ describe "Filter Participatory Processes", type: :system do
         end
 
         it "does not show the participatory process types filter" do
-          expect(page).to have_no_css("#process-type-filter")
+          expect(page).not_to have_css("#process-type-filter")
         end
       end
     end
@@ -239,9 +239,9 @@ describe "Filter Participatory Processes", type: :system do
               expect(page).to have_content("Awesome Type")
               expect(page).to have_content("The East Type")
               expect(page).to have_content("The West Type")
-              expect(page).to have_no_content("Old Type")
-              expect(page).to have_no_content("Empty Type")
-              expect(page).to have_no_content("Unpublished Type")
+              expect(page).not_to have_content("Old Type")
+              expect(page).not_to have_content("Empty Type")
+              expect(page).not_to have_content("Unpublished Type")
             end
           end
         end
@@ -263,12 +263,12 @@ describe "Filter Participatory Processes", type: :system do
           it "only shows process types with past processes" do
             within "#process-type-filter" do
               click_button "All types"
-              expect(page).to have_no_content("Awesome Type")
-              expect(page).to have_no_content("The East Type")
-              expect(page).to have_no_content("The West Type")
+              expect(page).not_to have_content("Awesome Type")
+              expect(page).not_to have_content("The East Type")
+              expect(page).not_to have_content("The West Type")
               expect(page).to have_content("Old Type")
-              expect(page).to have_no_content("Empty Type")
-              expect(page).to have_no_content("Unpublished Type")
+              expect(page).not_to have_content("Empty Type")
+              expect(page).not_to have_content("Unpublished Type")
             end
           end
         end
@@ -287,8 +287,8 @@ describe "Filter Participatory Processes", type: :system do
               expect(page).to have_content("3 ACTIVE PROCESSES")
             end
 
-            expect(page).to have_no_content("NW Rocks!")
-            expect(page).to have_no_content("SE Rocks!")
+            expect(page).not_to have_content("NW Rocks!")
+            expect(page).not_to have_content("SE Rocks!")
             group_2_process_type.processes.groupless.each do |group|
               expect(page).to have_content(translated(group.title))
             end
@@ -315,21 +315,21 @@ describe "Filter Participatory Processes", type: :system do
             end
 
             expect(page).to have_content("SE Rocks!")
-            expect(page).to have_no_content("NW Rocks!")
+            expect(page).not_to have_content("NW Rocks!")
             group_1_process_type.processes.groupless.each do |group|
-              expect(page).to have_no_content(translated(group.title))
+              expect(page).not_to have_content(translated(group.title))
             end
           end
 
           it "only shows process types with active processes in the group" do
             within "#process-type-filter" do
               click_button "All types"
-              expect(page).to have_no_content("Awesome Type")
+              expect(page).not_to have_content("Awesome Type")
               expect(page).to have_content("The East Type")
-              expect(page).to have_no_content("The West Type")
-              expect(page).to have_no_content("Old Type")
-              expect(page).to have_no_content("Empty Type")
-              expect(page).to have_no_content("Unpublished Type")
+              expect(page).not_to have_content("The West Type")
+              expect(page).not_to have_content("Old Type")
+              expect(page).not_to have_content("Empty Type")
+              expect(page).not_to have_content("Unpublished Type")
             end
           end
         end

--- a/decidim-participatory_processes/spec/system/participatory_process_all_metrics_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_all_metrics_spec.rb
@@ -86,15 +86,15 @@ describe "Participatory Processes", type: :system, download: true do
     it "does not render any metric chart" do
       # BIG CHART
       Decidim.metrics_registry.filtered(scope: "participatory_process", block: "big").each do |metric_manifest|
-        expect(page).to have_no_css(%(##{metric_manifest.metric_name}_chart))
+        expect(page).not_to have_css(%(##{metric_manifest.metric_name}_chart))
       end
       # MEDIUM CHARTS
       Decidim.metrics_registry.filtered(scope: "participatory_process", block: "medium").each do |metric_manifest|
-        expect(page).to have_no_css(%(##{metric_manifest.metric_name}_chart))
+        expect(page).not_to have_css(%(##{metric_manifest.metric_name}_chart))
       end
       # LITTLE CHARTS
       Decidim.metrics_registry.filtered(scope: "participatory_process", block: "small").each do |metric_manifest|
-        expect(page).to have_no_css(%(##{metric_manifest.metric_name}_chart))
+        expect(page).not_to have_css(%(##{metric_manifest.metric_name}_chart))
       end
     end
   end

--- a/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
@@ -42,7 +42,7 @@ describe "Participatory Process Groups", type: :system do
         expect(page).to have_content(translated(participatory_process_group.title, locale: :en))
         expect(page).to have_selector(".card", count: 1)
 
-        expect(page).to have_no_content(translated(other_group.title, locale: :en))
+        expect(page).not_to have_content(translated(other_group.title, locale: :en))
       end
     end
 
@@ -157,7 +157,7 @@ describe "Participatory Process Groups", type: :system do
         let(:cta_settings) { nil }
 
         it "does not show the block" do
-          expect(page).to have_no_selector("div.hero__container")
+          expect(page).not_to have_selector("div.hero__container")
         end
       end
     end
@@ -435,7 +435,7 @@ describe "Participatory Process Groups", type: :system do
     shared_examples "not showing processes belonging to other group" do
       it "does not list process of other group" do
         within("#processes-grid") do
-          expect(page).to have_no_content(translated(other_group_process.title, locale: :en))
+          expect(page).not_to have_content(translated(other_group_process.title, locale: :en))
         end
       end
     end

--- a/decidim-participatory_processes/spec/system/participatory_process_steps_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_steps_spec.rb
@@ -45,7 +45,7 @@ describe "Participatory Process Steps", type: :system do
       visit decidim_participatory_processes.participatory_process_participatory_process_steps_path(participatory_process)
 
       within ".process-header__phase" do
-        expect(page).to have_no_css(".process-header__button")
+        expect(page).not_to have_css(".process-header__button")
       end
     end
 

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -37,7 +37,7 @@ describe "Participatory Processes", type: :system do
       visit decidim.root_path
 
       within ".main-nav" do
-        expect(page).to have_no_content("Processes")
+        expect(page).not_to have_content("Processes")
       end
     end
   end
@@ -65,7 +65,7 @@ describe "Participatory Processes", type: :system do
         visit decidim.root_path
 
         within ".main-nav" do
-          expect(page).to have_no_content("Processes")
+          expect(page).not_to have_content("Processes")
         end
       end
     end
@@ -137,10 +137,10 @@ describe "Participatory Processes", type: :system do
           expect(page).to have_content(translated(group.title, locale: :en))
           expect(page).to have_selector(".card", count: 3)
 
-          expect(page).to have_no_content(translated(unpublished_process.title, locale: :en))
-          expect(page).to have_no_content(translated(past_process.title, locale: :en))
-          expect(page).to have_no_content(translated(upcoming_process.title, locale: :en))
-          expect(page).to have_no_content(translated(grouped_process.title, locale: :en))
+          expect(page).not_to have_content(translated(unpublished_process.title, locale: :en))
+          expect(page).not_to have_content(translated(past_process.title, locale: :en))
+          expect(page).not_to have_content(translated(upcoming_process.title, locale: :en))
+          expect(page).not_to have_content(translated(grouped_process.title, locale: :en))
         end
       end
 
@@ -368,7 +368,7 @@ describe "Participatory Processes", type: :system do
               )
             visit decidim_participatory_processes.participatory_process_path(participatory_process)
             expect(page).to have_content(translated(published_process.title))
-            expect(page).to have_no_content(translated(unpublished_process.title))
+            expect(page).not_to have_content(translated(unpublished_process.title))
           end
         end
 
@@ -376,7 +376,7 @@ describe "Participatory Processes", type: :system do
           it "shows the components" do
             within ".process-nav" do
               expect(page).to have_content(translated(proposals_component.name, locale: :en).upcase)
-              expect(page).to have_no_content(translated(meetings_component.name, locale: :en).upcase)
+              expect(page).not_to have_content(translated(meetings_component.name, locale: :en).upcase)
             end
           end
 
@@ -425,8 +425,8 @@ describe "Participatory Processes", type: :system do
                 expect(page).to have_css("h2.h2", text: "Statistics")
                 expect(page).to have_css(".statistic__title", text: "Proposals")
                 expect(page).to have_css(".statistic__number", text: "3")
-                expect(page).to have_no_css(".statistic__title", text: "Meetings")
-                expect(page).to have_no_css(".statistic__number", text: "0")
+                expect(page).not_to have_css(".statistic__title", text: "Meetings")
+                expect(page).not_to have_css(".statistic__number", text: "0")
               end
             end
           end
@@ -435,9 +435,9 @@ describe "Participatory Processes", type: :system do
             let(:show_statistics) { false }
 
             it "the stats for those components are not visible" do
-              expect(page).to have_no_css("h2.h2", text: "Statistics")
-              expect(page).to have_no_css(".statistic__title", text: "Proposals")
-              expect(page).to have_no_css(".statistic__number", text: "3")
+              expect(page).not_to have_css("h2.h2", text: "Statistics")
+              expect(page).not_to have_css(".statistic__title", text: "Proposals")
+              expect(page).not_to have_css(".statistic__number", text: "3")
             end
           end
 
@@ -445,11 +445,11 @@ describe "Participatory Processes", type: :system do
             let(:show_metrics) { false }
 
             it "the metrics for the participatory processes are not rendered" do
-              expect(page).to have_no_css("h4.section-heading", text: "METRICS")
+              expect(page).not_to have_css("h4.section-heading", text: "METRICS")
             end
 
             it "has no link to all metrics" do
-              expect(page).to have_no_link("Show all metrics")
+              expect(page).not_to have_link("Show all metrics")
             end
           end
 
@@ -457,7 +457,7 @@ describe "Participatory Processes", type: :system do
             let(:hashtag) { false }
 
             it "the hashtags for those components are not visible" do
-              expect(page).to have_no_content("#")
+              expect(page).not_to have_content("#")
             end
           end
         end
@@ -480,8 +480,8 @@ describe "Participatory Processes", type: :system do
             expect(page).to have_content("RELATED ASSEMBLIES")
             expect(page).to have_content(translated(published_assembly.title))
             expect(page).to have_content(translated(transparent_assembly.title))
-            expect(page).to have_no_content(translated(unpublished_assembly.title))
-            expect(page).to have_no_content(translated(private_assembly.title))
+            expect(page).not_to have_content(translated(unpublished_assembly.title))
+            expect(page).not_to have_content(translated(private_assembly.title))
           end
         end
 

--- a/decidim-participatory_processes/spec/system/private_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/private_participatory_processes_spec.rb
@@ -29,7 +29,7 @@ describe "Private Participatory Processes", type: :system do
           expect(page).to have_content(translated(participatory_process.title, locale: :en))
           expect(page).to have_selector(".card", count: 1)
 
-          expect(page).to have_no_content(translated(private_participatory_process.title, locale: :en))
+          expect(page).not_to have_content(translated(private_participatory_process.title, locale: :en))
         end
       end
     end
@@ -50,7 +50,7 @@ describe "Private Participatory Processes", type: :system do
           expect(page).to have_content(translated(participatory_process.title, locale: :en))
           expect(page).to have_selector(".card", count: 1)
 
-          expect(page).to have_no_content(translated(private_participatory_process.title, locale: :en))
+          expect(page).not_to have_content(translated(private_participatory_process.title, locale: :en))
         end
       end
 

--- a/decidim-proposals/app/events/decidim/proposals/accepted_proposal_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/accepted_proposal_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/admin/proposal_note_created_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/admin/proposal_note_created_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/admin/update_proposal_category_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/admin/update_proposal_category_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/admin/update_proposal_scope_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/admin/update_proposal_scope_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/collaborative_draft_access_accepted_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/collaborative_draft_access_accepted_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/collaborative_draft_access_rejected_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/collaborative_draft_access_rejected_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/collaborative_draft_access_request_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/collaborative_draft_access_request_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/collaborative_draft_access_requested_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/collaborative_draft_access_requested_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/collaborative_draft_access_requester_accepted_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/collaborative_draft_access_requester_accepted_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/collaborative_draft_access_requester_rejected_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/collaborative_draft_access_requester_rejected_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/collaborative_draft_withdrawn_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/collaborative_draft_withdrawn_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/evaluating_proposal_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/evaluating_proposal_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/proposal_endorsed_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/proposal_endorsed_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/proposal_mentioned_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/proposal_mentioned_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/publish_proposal_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/publish_proposal_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/app/events/decidim/proposals/rejected_proposal_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/rejected_proposal_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Proposals

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_activity_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_activity_cell_spec.rb
@@ -65,10 +65,10 @@ module Decidim
 
           it "correctly renders proposals with mentions" do
             html = cell("decidim/proposals/proposal_activity", action_log).call
-            expect(html).to have_no_content("gid://")
+            expect(html).not_to have_content("gid://")
             # REDESIGN_PENDING: The body is not displayed. Remove when redesign
             # is finished
-            expect(html).to have_no_content("#myhashtag")
+            expect(html).not_to have_content("#myhashtag")
           end
         end
       end

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_m_cell_spec.rb
@@ -70,7 +70,7 @@ module Decidim::Proposals
         it "renders the card with no status info" do
           expect(subject).to have_css(".card__header")
           expect(subject).to have_css(".card__text")
-          expect(subject).to have_no_css(".card-data__item")
+          expect(subject).not_to have_css(".card-data__item")
         end
       end
 

--- a/decidim-proposals/spec/events/decidim/proposals/admin/proposal_note_created_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/admin/proposal_note_created_event_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Decidim::Proposals::Admin::ProposalNoteCreatedEvent do
-  let(:resource) { create :proposal, title: ::Faker::Lorem.characters(number: 25) }
+  let(:resource) { create :proposal, title: Faker::Lorem.characters(number: 25) }
   let(:resource_title) { translated(resource.title) }
   let(:event_name) { "decidim.events.proposals.admin.proposal_note_created" }
   let(:component) { resource.component }
@@ -45,7 +45,7 @@ describe Decidim::Proposals::Admin::ProposalNoteCreatedEvent do
   context "when proposals component added to assemblies participatory space" do
     let(:assembly) { create(:assembly) }
     let(:proposal_component) { create :proposal_component, participatory_space: assembly }
-    let(:resource) { create :proposal, component: proposal_component, title: ::Faker::Lorem.characters(number: 25) }
+    let(:resource) { create :proposal, component: proposal_component, title: Faker::Lorem.characters(number: 25) }
     let(:admin_proposal_info_path) { "/admin/assemblies/#{participatory_space.slug}/components/#{component.id}/manage/proposals/#{resource.id}" }
     let(:admin_proposal_info_url) { "http://#{organization.host}/admin/assemblies/#{participatory_space.slug}/components/#{component.id}/manage/proposals/#{resource.id}" }
 

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -94,14 +94,12 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
       let(:stats_name) { :endorsements_count }
 
       before do
-        # rubocop:disable RSpec/FactoryBot/CreateList
         2.times do
           create(:endorsement, resource: proposal, author: build(:user, organization:))
         end
         3.times do
           create(:endorsement, resource: hidden_proposal, author: build(:user, organization:))
         end
-        # rubocop:enable RSpec/FactoryBot/CreateList
       end
 
       it "counts the endorsements from visible proposals" do

--- a/decidim-proposals/spec/lib/decidim/proposals/import/proposal_answer_creator_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/import/proposal_answer_creator_spec.rb
@@ -93,12 +93,12 @@ describe Decidim::Proposals::Import::ProposalAnswerCreator do
 
       context "and notifies followers" do
         before do
-          allow(::Decidim::Proposals::Admin::NotifyProposalAnswer).to receive(:call).with(proposal, "evaluating")
+          allow(Decidim::Proposals::Admin::NotifyProposalAnswer).to receive(:call).with(proposal, "evaluating")
         end
 
         it "notifies followers" do
           subject.finish!
-          expect(::Decidim::Proposals::Admin::NotifyProposalAnswer).to have_received(:call)
+          expect(Decidim::Proposals::Admin::NotifyProposalAnswer).to have_received(:call)
         end
       end
     end

--- a/decidim-proposals/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
@@ -49,7 +49,6 @@ describe Decidim::Proposals::Import::ProposalCreator do
 
   describe "#resource_attributes" do
     it "returns the attributes hash" do
-      # rubocop:disable Style/HashSyntax
       expect(subject.resource_attributes).to eq(
         :"title/en" => data[:"title/en"],
         :"body/en" => data[:"body/en"],

--- a/decidim-proposals/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
@@ -60,7 +60,6 @@ describe Decidim::Proposals::Import::ProposalCreator do
         component: data[:component],
         published_at: data[:published_at]
       )
-      # rubocop:enable Style/HashSyntax
     end
   end
 

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -109,7 +109,7 @@ shared_examples "manage proposals" do
             click_link "New proposal"
 
             within "form" do
-              expect(page).to have_no_content(/Scope/i)
+              expect(page).not_to have_content(/Scope/i)
             end
           end
 
@@ -289,12 +289,12 @@ shared_examples "manage proposals" do
 
         it "cannot create a new proposal from the main site" do
           visit_component
-          expect(page).to have_no_button("New Proposal")
+          expect(page).not_to have_button("New Proposal")
         end
 
         it "cannot create a new proposal from the admin site" do
           visit_component_admin
-          expect(page).to have_no_link(/New/)
+          expect(page).not_to have_link(/New/)
         end
       end
     end
@@ -306,12 +306,12 @@ shared_examples "manage proposals" do
 
       it "cannot create a new proposal from the main site" do
         visit_component
-        expect(page).to have_no_button("New Proposal")
+        expect(page).not_to have_button("New Proposal")
       end
 
       it "cannot create a new proposal from the admin site" do
         visit_component_admin
-        expect(page).to have_no_link(/New/)
+        expect(page).not_to have_link(/New/)
       end
     end
   end
@@ -471,7 +471,7 @@ shared_examples "manage proposals" do
         visit current_path
 
         within find("tr", text: proposal_title) do
-          expect(page).to have_no_link("Answer")
+          expect(page).not_to have_link("Answer")
         end
       end
     end
@@ -484,7 +484,7 @@ shared_examples "manage proposals" do
       it "cannot answer a proposal" do
         visit_component_admin
         within find("tr", text: I18n.t("decidim/amendment", scope: "activerecord.models", count: 1)) do
-          expect(page).to have_no_link("Answer")
+          expect(page).not_to have_link("Answer")
         end
       end
     end
@@ -498,7 +498,7 @@ shared_examples "manage proposals" do
     it "cannot answer a proposal" do
       go_to_admin_proposal_page(proposal)
 
-      expect(page).to have_no_selector(".edit_proposal_answer")
+      expect(page).not_to have_selector(".edit_proposal_answer")
     end
   end
 

--- a/decidim-proposals/spec/shared/manage_proposals_permissions_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_permissions_examples.rb
@@ -4,7 +4,7 @@ shared_examples "manage proposals permissions" do
   context "when authorization handler is Everyone" do
     before do
       component = proposal.component
-      visit ::Decidim::EngineRouter.admin_proxy(component.participatory_space).edit_component_permissions_path(component.id)
+      visit Decidim::EngineRouter.admin_proxy(component.participatory_space).edit_component_permissions_path(component.id)
     end
 
     it "is possible to select Example authorization handler" do

--- a/decidim-proposals/spec/shared/merge_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/merge_proposals_examples.rb
@@ -31,7 +31,7 @@ shared_examples "merge proposals" do
         it "does not show the merge action option" do
           click_button "Actions"
 
-          expect(page).to have_no_selector(:link_or_button, "Merge into a new one")
+          expect(page).not_to have_selector(:link_or_button, "Merge into a new one")
         end
       end
     end

--- a/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
@@ -52,7 +52,7 @@ describe "Admin edits proposals", type: :system do
         visit_component_admin
 
         expect(page).to have_content(translated(proposal.title))
-        expect(page).to have_no_css("a.action-icon--edit-proposal")
+        expect(page).not_to have_css("a.action-icon--edit-proposal")
         visit current_path + "proposals/#{proposal.id}/edit"
 
         expect(page).to have_content("not authorized")
@@ -88,7 +88,7 @@ describe "Admin edits proposals", type: :system do
 
         visit_component_admin
         find("a.action-icon--edit-proposal").click
-        expect(page).to have_no_content("Current file")
+        expect(page).not_to have_content("Current file")
       end
 
       it "can attach a file" do
@@ -118,7 +118,7 @@ describe "Admin edits proposals", type: :system do
       visit_component_admin
 
       expect(page).to have_content(translated(proposal.title))
-      expect(page).to have_no_css("a.action-icon--edit-proposal")
+      expect(page).not_to have_css("a.action-icon--edit-proposal")
       visit current_path + "proposals/#{proposal.id}/edit"
 
       expect(page).to have_content("not authorized")

--- a/decidim-proposals/spec/system/admin/admin_manages_proposal_valuators_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_manages_proposal_valuators_spec.rb
@@ -76,7 +76,7 @@ describe "Admin manages proposals valuators", type: :system do
       end
 
       expect(page).to have_content(translated(assigned_proposal.title))
-      expect(page).to have_no_content(translated(unassigned_proposal.title))
+      expect(page).not_to have_content(translated(unassigned_proposal.title))
     end
   end
 
@@ -145,7 +145,7 @@ describe "Admin manages proposals valuators", type: :system do
 
       expect(page).to have_content("Valuator unassigned from proposals successfully")
 
-      expect(page).to have_no_selector("#valuators")
+      expect(page).not_to have_selector("#valuators")
     end
   end
 end

--- a/decidim-proposals/spec/system/admin/valuator_manages_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin/valuator_manages_proposals_spec.rb
@@ -31,7 +31,7 @@ describe "Valuator manages proposals", type: :system do
   context "when listing the proposals" do
     it "can only see the assigned proposals" do
       expect(page).to have_content(translated(assigned_proposal.title))
-      expect(page).to have_no_content(translated(unassigned_proposal.title))
+      expect(page).not_to have_content(translated(unassigned_proposal.title))
     end
   end
 
@@ -77,7 +77,7 @@ describe "Valuator manages proposals", type: :system do
         expect(page).to have_content(another_user.name)
 
         within find("li", text: another_user.name) do
-          expect(page).to have_no_selector("a.red-icon")
+          expect(page).not_to have_selector("a.red-icon")
         end
 
         within find("li", text: user.name) do

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -67,7 +67,7 @@ describe "Admin views proposal details from admin", type: :system do
         go_to_admin_proposal_page(proposal)
 
         within "#proposal-authors-list" do
-          expect(page).to have_no_selector("a", text: "Official proposal")
+          expect(page).not_to have_selector("a", text: "Official proposal")
           expect(page).to have_content("Official proposal")
         end
       end

--- a/decidim-proposals/spec/system/collaborative_drafts_fields_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_fields_spec.rb
@@ -65,7 +65,7 @@ describe "Collaborative drafts", type: :system do
             visit new_collaborative_draft_path
 
             within "form.new_collaborative_draft" do
-              expect(page).to have_no_content("Scope")
+              expect(page).not_to have_content("Scope")
             end
           end
         end
@@ -351,7 +351,7 @@ describe "Collaborative drafts", type: :system do
         it "does not show the creation button" do
           visit_component
           click_link "Access collaborative drafts"
-          expect(page).to have_no_link("New collaborative draft")
+          expect(page).not_to have_link("New collaborative draft")
         end
       end
     end

--- a/decidim-proposals/spec/system/collaborative_drafts_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_spec.rb
@@ -382,7 +382,7 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
     end
 
     it "does not show the Collaborative drafts access button" do
-      expect(page).to have_no_content("Access collaborative drafts")
+      expect(page).not_to have_content("Access collaborative drafts")
     end
   end
 end

--- a/decidim-proposals/spec/system/edit_collaborative_draft_spec.rb
+++ b/decidim-proposals/spec/system/edit_collaborative_draft_spec.rb
@@ -135,7 +135,7 @@ describe "Edit collaborative_drafts", type: :system do
 
       click_link "Access collaborative drafts"
       click_link collaborative_draft.title
-      expect(page).to have_no_content("Edit collaborative draft")
+      expect(page).not_to have_content("Edit collaborative draft")
       visit "#{current_path}/edit"
 
       expect(page).to have_content("not authorized")
@@ -154,7 +154,7 @@ describe "Edit collaborative_drafts", type: :system do
 
       click_link "Access collaborative drafts"
       click_link collaborative_draft.title
-      expect(page).to have_no_content("Edit collaborative draft")
+      expect(page).not_to have_content("Edit collaborative draft")
       visit "#{current_path}/edit"
 
       expect(page).to have_content("not authorized")

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -84,8 +84,8 @@ describe "Edit proposals", type: :system do
 
           click_button "Send"
 
-          expect(page).to have_no_content("Related documents")
-          expect(page).to have_no_content("Related images")
+          expect(page).not_to have_content("Related documents")
+          expect(page).not_to have_content("Related images")
         end
 
         context "with attachment titles" do
@@ -292,7 +292,7 @@ describe "Edit proposals", type: :system do
       visit_component
 
       click_link proposal_title
-      expect(page).to have_no_content("Edit proposal")
+      expect(page).not_to have_content("Edit proposal")
       visit "#{current_path}/edit"
 
       expect(page).to have_content("not authorized")
@@ -310,7 +310,7 @@ describe "Edit proposals", type: :system do
       visit_component
 
       click_link proposal_title
-      expect(page).to have_no_content("Edit proposal")
+      expect(page).not_to have_content("Edit proposal")
       visit "#{current_path}/edit"
 
       expect(page).to have_content("not authorized")

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -89,8 +89,8 @@ describe "Edit proposals", type: :system do
         end
 
         context "with attachment titles" do
-          let(:attachment_file_title) { ::Faker::Lorem.sentence }
-          let(:attachment_image_title) { ::Faker::Lorem.sentence }
+          let(:attachment_file_title) { Faker::Lorem.sentence }
+          let(:attachment_image_title) { Faker::Lorem.sentence }
 
           it "can change attachment titles" do
             click_link "Edit proposal"

--- a/decidim-proposals/spec/system/filter_proposals_spec.rb
+++ b/decidim-proposals/spec/system/filter_proposals_spec.rb
@@ -106,7 +106,7 @@ describe "Filter Proposals", :slow, type: :system do
         visit_component
 
         within "form.new_filter" do
-          expect(page).to have_no_content(/Official/i)
+          expect(page).not_to have_content(/Official/i)
         end
       end
     end
@@ -188,7 +188,7 @@ describe "Filter Proposals", :slow, type: :system do
         visit_component
 
         within "form.new_filter" do
-          expect(page).to have_no_content(/Scope/i)
+          expect(page).not_to have_content(/Scope/i)
         end
       end
 
@@ -324,7 +324,7 @@ describe "Filter Proposals", :slow, type: :system do
           visit_component
 
           within "form.new_filter" do
-            expect(page).to have_no_content(/Status/i)
+            expect(page).not_to have_content(/Status/i)
           end
         end
       end
@@ -339,7 +339,7 @@ describe "Filter Proposals", :slow, type: :system do
         visit_component
 
         within "form.new_filter" do
-          expect(page).to have_no_content(/Status/i)
+          expect(page).not_to have_content(/Status/i)
         end
       end
     end
@@ -545,7 +545,7 @@ describe "Filter Proposals", :slow, type: :system do
                 expect(page).to have_content("1 PROPOSAL")
                 expect(page).to have_content("Amendment", count: 2)
                 expect(page).to have_content(translated(new_emendation.title))
-                expect(page).to have_no_content(translated(emendation.title))
+                expect(page).not_to have_content(translated(emendation.title))
               end
             end
 
@@ -558,7 +558,7 @@ describe "Filter Proposals", :slow, type: :system do
 
               it "cannot be filtered by type" do
                 within "form.new_filter" do
-                  expect(page).to have_no_content(/Type/i)
+                  expect(page).not_to have_content(/Type/i)
                 end
               end
             end
@@ -571,7 +571,7 @@ describe "Filter Proposals", :slow, type: :system do
 
             it "cannot be filtered by type" do
               within "form.new_filter" do
-                expect(page).to have_no_content(/Type/i)
+                expect(page).not_to have_content(/Type/i)
               end
             end
           end

--- a/decidim-proposals/spec/system/index_proposals_spec.rb
+++ b/decidim-proposals/spec/system/index_proposals_spec.rb
@@ -12,7 +12,7 @@ describe "Index proposals", type: :system do
     it "does not display empty message" do
       visit_component
 
-      expect(page).to have_no_content("There is no proposal yet")
+      expect(page).not_to have_content("There is no proposal yet")
     end
   end
 

--- a/decidim-proposals/spec/system/private_space_proposal_spec.rb
+++ b/decidim-proposals/spec/system/private_space_proposal_spec.rb
@@ -33,7 +33,7 @@ describe "Private Space Proposal", type: :system do
         visit_component
 
         within ".title-action" do
-          expect(page).to have_no_link("New proposal")
+          expect(page).not_to have_link("New proposal")
         end
       end
     end
@@ -60,7 +60,7 @@ describe "Private Space Proposal", type: :system do
           visit_component
 
           within ".title-action" do
-            expect(page).to have_no_link("New proposal")
+            expect(page).not_to have_link("New proposal")
           end
         end
       end

--- a/decidim-proposals/spec/system/proposals_fields_spec.rb
+++ b/decidim-proposals/spec/system/proposals_fields_spec.rb
@@ -63,7 +63,7 @@ describe "Proposals", type: :system do
             visit complete_proposal_path(component, proposal_draft)
 
             within "form.edit_proposal" do
-              expect(page).to have_no_content("Scope")
+              expect(page).not_to have_content("Scope")
             end
           end
         end
@@ -392,7 +392,7 @@ describe "Proposals", type: :system do
       context "when creation is not enabled" do
         it "does not show the creation button" do
           visit_component
-          expect(page).to have_no_link("New proposal")
+          expect(page).not_to have_link("New proposal")
         end
       end
 
@@ -420,7 +420,7 @@ describe "Proposals", type: :system do
             find("*[type=submit]").click
           end
 
-          expect(page).to have_no_content("successfully")
+          expect(page).not_to have_content("successfully")
           expect(page).to have_css("[data-alert-box].alert", text: "limit")
         end
       end

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -82,7 +82,7 @@ describe "Proposals", type: :system do
       it "does not show the scope name" do
         visit_component
         click_link proposal_title
-        expect(page).to have_no_content(translated(scope.name))
+        expect(page).not_to have_content(translated(scope.name))
       end
     end
 
@@ -486,7 +486,7 @@ describe "Proposals", type: :system do
 
       it "shows a disabled vote button for each proposal, but no links to full proposals" do
         expect(page).to have_button("Supports disabled", disabled: true, count: 2)
-        expect(page).to have_no_link("View proposal")
+        expect(page).not_to have_link("View proposal")
       end
     end
 
@@ -507,8 +507,8 @@ describe "Proposals", type: :system do
 
         visit_component
 
-        expect(page).to have_no_button("Supports disabled", disabled: true)
-        expect(page).to have_no_button("Vote")
+        expect(page).not_to have_button("Supports disabled", disabled: true)
+        expect(page).not_to have_button("Vote")
         expect(page).to have_link("View proposal", count: 2)
       end
     end

--- a/decidim-proposals/spec/system/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/system/vote_proposal_spec.rb
@@ -12,8 +12,8 @@ describe "Support Proposal", type: :system, slow: true do
   let!(:user) { create :user, :confirmed, organization: }
 
   def expect_page_not_to_include_votes
-    expect(page).to have_no_button("Support")
-    expect(page).to have_no_css(".card__support__data span", text: "0 Supports")
+    expect(page).not_to have_button("Support")
+    expect(page).not_to have_css(".card__support__data span", text: "0 Supports")
   end
 
   context "when votes are not enabled" do
@@ -107,7 +107,7 @@ describe "Support Proposal", type: :system, slow: true do
         it "is not able to vote it again" do
           within "#proposal-#{proposal.id}-vote-button" do
             expect(page).to have_button("Already supported")
-            expect(page).to have_no_button("Support")
+            expect(page).not_to have_button("Support")
           end
 
           within "#proposal-#{proposal.id}-votes-count" do
@@ -154,7 +154,7 @@ describe "Support Proposal", type: :system, slow: true do
               visit_component
 
               expect(page).to have_css(".voting-rules")
-              expect(page).to have_no_css(".remaining-votes-counter")
+              expect(page).not_to have_css(".remaining-votes-counter")
             end
           end
 
@@ -224,7 +224,7 @@ describe "Support Proposal", type: :system, slow: true do
           it "is not able to vote it again" do
             within "#proposal-#{proposal.id}-vote-button" do
               expect(page).to have_button("Already supported")
-              expect(page).to have_no_button("Support")
+              expect(page).not_to have_button("Support")
             end
           end
 
@@ -292,10 +292,10 @@ describe "Support Proposal", type: :system, slow: true do
         end
 
         page.find_link rejected_proposal_title
-        expect(page).to have_no_selector("#proposal-#{rejected_proposal.id}-vote-button")
+        expect(page).not_to have_selector("#proposal-#{rejected_proposal.id}-vote-button")
 
         click_link rejected_proposal_title
-        expect(page).to have_no_selector("#proposal-#{rejected_proposal.id}-vote-button")
+        expect(page).not_to have_selector("#proposal-#{rejected_proposal.id}-vote-button")
       end
     end
 

--- a/decidim-sortitions/spec/shared/manage_sortitions_examples.rb
+++ b/decidim-sortitions/spec/shared/manage_sortitions_examples.rb
@@ -53,8 +53,8 @@ shared_examples "manage sortitions" do
     end
 
     context "when creates a sortition" do
-      let(:sortition_dice) { ::Faker::Number.between(from: 1, to: 6) }
-      let(:sortition_target_items) { ::Faker::Number.between(from: 1, to: 10) }
+      let(:sortition_dice) { Faker::Number.between(from: 1, to: 6) }
+      let(:sortition_target_items) { Faker::Number.between(from: 1, to: 10) }
       let!(:proposal) { create :proposal, component: proposal_component }
 
       it_behaves_like "having a rich text editor for field", ".tabs-content[data-tabs-content='sortition-additional_info-tabs']", "full"

--- a/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
+++ b/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
@@ -54,7 +54,7 @@ describe "Admin manages surveys", type: :system do
         visit questionnaire_edit_path
         click_button "Expand all"
         expect(page).to have_selector("#questionnaire_questions_#{question.id}_body_en")
-        expect(page).to have_no_selector("#questionnaire_questions_#{question.id}_body_en[disabled]")
+        expect(page).not_to have_selector("#questionnaire_questions_#{question.id}_body_en[disabled]")
       end
 
       it "deletes answers after editing" do

--- a/decidim-system/spec/system/manage_admins_spec.rb
+++ b/decidim-system/spec/system/manage_admins_spec.rb
@@ -102,7 +102,7 @@ describe "Manage admins", type: :system do
     end
 
     within "table" do
-      expect(page).to have_no_content(admin2.email)
+      expect(page).not_to have_content(admin2.email)
     end
   end
 

--- a/decidim-system/spec/system/manage_oauth_applications_spec.rb
+++ b/decidim-system/spec/system/manage_oauth_applications_spec.rb
@@ -69,7 +69,7 @@ describe "Manage OAuth applications", type: :system do
       expect(page).to have_content("successfully")
 
       within "table" do
-        expect(page).to have_no_content(application.name)
+        expect(page).not_to have_content(application.name)
       end
     end
 

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -8,9 +8,9 @@ describe "Organizations", type: :system do
   shared_examples "form hiding advanced settings" do
     it "hides advanced settings" do
       expect(page).to have_content "Show advanced settings"
-      expect(page).to have_no_content "SMTP settings"
-      expect(page).to have_no_content "Omniauth settings"
-      expect(page).to have_no_content "File upload settings"
+      expect(page).not_to have_content "SMTP settings"
+      expect(page).not_to have_content "Omniauth settings"
+      expect(page).not_to have_content "File upload settings"
     end
   end
 

--- a/decidim-system/spec/system/sessions_spec.rb
+++ b/decidim-system/spec/system/sessions_spec.rb
@@ -33,7 +33,7 @@ describe "Sessions", type: :system do
         find("*[type=submit]").click
       end
 
-      expect(page).to have_no_content("Dashboard")
+      expect(page).not_to have_content("Dashboard")
     end
   end
 end

--- a/decidim-templates/lib/decidim/templates/test/shared_examples/uses_questionnaire_templates.rb
+++ b/decidim-templates/lib/decidim/templates/test/shared_examples/uses_questionnaire_templates.rb
@@ -15,7 +15,7 @@ shared_examples_for "uses questionnaire templates" do |_questionnaire_for|
       end
 
       it "does not show the template selection screen" do
-        expect(page).to have_no_content("Choose template")
+        expect(page).not_to have_content("Choose template")
       end
     end
 
@@ -33,7 +33,7 @@ shared_examples_for "uses questionnaire templates" do |_questionnaire_for|
         end
 
         it "does not show the template selection screen" do
-          expect(page).to have_no_content("Choose template")
+          expect(page).not_to have_content("Choose template")
         end
       end
 

--- a/decidim-verifications/app/events/decidim/verifications/managed_user_error_event.rb
+++ b/decidim-verifications/app/events/decidim/verifications/managed_user_error_event.rb
@@ -1,4 +1,4 @@
-# frozen-string_literal: true
+# frozen_string_literal: true
 
 module Decidim
   module Verifications

--- a/decidim-verifications/spec/cells/decidim/verifications/authorization_metadata_cell_spec.rb
+++ b/decidim-verifications/spec/cells/decidim/verifications/authorization_metadata_cell_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Decidim::Verifications::AuthorizationMetadataCell, type: :cell do
-  controller ::Decidim::ApplicationController
+  controller Decidim::ApplicationController
 
   subject { cell("decidim/verifications/authorization_metadata", model).call }
 

--- a/decidim-verifications/spec/system/authorizations_spec.rb
+++ b/decidim-verifications/spec/system/authorizations_spec.rb
@@ -162,7 +162,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
 
         within ".authorizations-list" do
           expect(page).to have_content("Example authorization")
-          expect(page).to have_no_link(text: /Example authorization/)
+          expect(page).not_to have_link(text: /Example authorization/)
         end
       end
 
@@ -207,8 +207,8 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
             visit_authorizations
 
             within ".authorizations-list" do
-              expect(page).to have_no_link(text: /Example authorization/)
-              expect(page).to have_no_css(".authorization-renewable")
+              expect(page).not_to have_link(text: /Example authorization/)
+              expect(page).not_to have_css(".authorization-renewable")
             end
           end
         end
@@ -262,7 +262,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
           visit_authorizations
 
           within ".authorizations-list" do
-            expect(page).to have_no_link(text: /Example authorization/)
+            expect(page).not_to have_link(text: /Example authorization/)
             expect(page).to have_content(I18n.l(authorization.granted_at, format: :long_with_particles))
           end
         end
@@ -298,7 +298,7 @@ describe "Authorizations", type: :system, with_authorization_workflows: ["dummy_
 
       it "does not list authorizations" do
         visit decidim_verifications.authorizations_path
-        expect(page).to have_no_link("Authorizations")
+        expect(page).not_to have_link("Authorizations")
       end
     end
   end

--- a/decidim-verifications/spec/system/id_documents/id_document_online_review_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_online_review_spec.rb
@@ -38,7 +38,7 @@ describe "Identity document online review", type: :system do
     submit_verification_form(doc_type: "DNI", doc_number: "XXXXXXXX")
 
     expect(page).to have_content("Participant successfully verified")
-    expect(page).to have_no_content("Verification #")
+    expect(page).not_to have_content("Verification #")
   end
 
   it "shows an error when information does not match" do
@@ -53,7 +53,7 @@ describe "Identity document online review", type: :system do
 
     it "dismisses the verification from the list" do
       expect(page).to have_content("Verification rejected. Participant will be prompted to amend their documents")
-      expect(page).to have_no_content("Verification #")
+      expect(page).not_to have_content("Verification #")
     end
 
     context "and the user logs back in" do

--- a/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
+++ b/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
@@ -38,7 +38,7 @@ module Decidim
       end
 
       it "renders the form without the partial" do
-        expect(render).to have_no_css("[data-partial-demo]")
+        expect(render).not_to have_css("[data-partial-demo]")
       end
     end
   end

--- a/decidim_app-design/config/environments/production.rb
+++ b/decidim_app-design/config/environments/production.rb
@@ -76,7 +76,7 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  config.log_formatter = Logger::Formatter.new
 
   # Use a different logger for distributed setups.
   # require 'syslog/logger'


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
While developing #10867, we have upgraded the rubocop, which added few rules that we were prepared for. Considering that This PR can have the potential of becoming very big, we have agreed to perform the library upgrades in a separate PR as per [comment](https://github.com/decidim/decidim/pull/10867#discussion_r1202293943), and fix the rubocop rules in other PR. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10867
- Fixes  #10899

#### Testing
Make sure the pipeline is green. 

#### Rules fixed 
- [x] Capybara/NegationMatcher
- [x] Style/RedundantConstantBase
- [x] Style/MagicCommentFormat
- [x] Lint/RedundantCopDisableDirective
- [x] Lint/DuplicateMagicComment
- [ ] Capybara/SpecificMatcher
- [ ] Capybara/SpecificFinders
- [ ] Capybara/SpecificActions
- [ ] Capybara/CurrentPathExpectation
- [ ] Style/RedundantStringEscape
- [ ] Style/MapToSet
- [ ] Style/HashSyntax
- [ ] Style/Semicolon
- [ ] Style/ConcatArrayLiterals
- [ ] Style/ClassEqualityComparison
- [ ] Style/RedundantParentheses
- [ ] Style/ArrayIntersect
- [ ] Style/MinMaxComparison
- [ ] Style/RedundantRegexpEscape
- [ ] RSpec/IndexedLet
- [ ] RSpec/Rails/InferredSpecType
- [ ] RSpec/ClassCheck
- [ ] RSpec/NoExpectationExample
- [ ] RSpec/SortMetadata
- [ ] RSpec/FactoryBot/ConsistentParenthesesStyle
- [ ] RSpec/MatchArray
- [ ] Rails/ActionControllerFlashBeforeRender
- [ ] RSpec/ContainExactly
- [ ] RSpec/Rails/TravelAround
- [ ] Style/EachForSimpleLoop
- [ ] RSpec/ContextWording
- [ ] RSpec/EmptyLineAfterExampleGroup
- [ ] Rails/ActiveSupportOnLoad
- [ ] RSpec/SkipBlockInsideExample
- [ ] RSpec/Rails/HaveHttpStatus
- [ ] Rails/HelperInstanceVariable
- [ ] RSpec/BeEmpty
- [ ] Rails/RootPathnameMethods

:hearts: Thank you!
