### PR TITLE
Change to display initiatives after creation

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
@@ -28,7 +28,7 @@
                         data: { confirm: t(".confirm") } %>
           <% end %>
           <%= link_to t(".edit_my_initiative"), edit_initiative_path(current_initiative), class: "button expanded light secondary" %>
-          <%= link_to t(".go_to_my_initiatives"), decidim_initiatives.initiatives_path(filter: { author: "myself", state: "" }), class: "button expanded" %>
+          <%= link_to t(".go_to_my_initiatives"), decidim_initiatives.initiatives_path(filter: { author: "myself", with_any_state: "" }), class: "button expanded" %>
           <%= link_to t(".back_to_initiatives"), initiatives_path, class: "button white-button expanded" %>
         </div>
       </div>

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -772,6 +772,15 @@ describe "Initiative", type: :system do
               expect(page).to have_link("Edit my initiative")
             end
           end
+
+          it "displays a link to take the user to their initiatives" do
+            within ".actions" do
+              expect(page).to have_link("Go to my initiatives")
+              find_link("Go to my initiatives").click
+            end
+
+            expect(page).to have_content(translated(initiative.title, locale: :en))
+          end
         end
 
         context "when minimum committee size is zero" do


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Initiatives were not displayed upon clicking "Go to my initiatives", once a user finished using the form. 

With a change to the ```filter:``` hash, by allowing to display all created initiatives via ```with_any_state```, these are now displayed to the user under their author via "myself".   

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #10897

#### Testing
1. User goes to initiatives.
2. Clicks top left "New Initiative". 
3. Fills outs form.
4. At finish, user clicks "Go to my initiatives".
5. Initiatives are displayed to the user.

An Rspec test is available by calling ```decidim-initiatives/spec/system/create_initiative_spec.rb``` 

### :camera: Screenshots

Before: 

![image](https://github.com/decidim/decidim/assets/101816158/0143c975-7649-4657-893d-1390e2ffaff1)

After: 

![image](https://github.com/decidim/decidim/assets/101816158/a19b6ab8-9d3d-47a7-b106-e5ff6fca0e01)

:hearts: Thank you!
