### PR TITLE
Add spec for checking that the Page inside of an Initiative works

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -152,6 +152,18 @@ bundle exec rake decidim:proposals:upgrade:remove_valuator_orphan_records
 
 You can see more details about this change on PR [\#10607](https://github.com/decidim/decidim/pull/10607)
 
+### 3.7. Initiatives pages exception fix
+
+We have addede a new tasks to fix a bug related to the pages component inside of the Initiatives module (`decidim-initiatives`).
+
+You can run the task with the following command:
+
+```console
+bundle exec rake decidim:initiatives:upgrade:fix_broken_pages
+```
+
+You can see more details about this change on PR [\#](https://github.com/decidim/decidim/pull/)
+
 ## 4. Scheduled tasks
 
 Implementers need to configure these changes it in your scheduler task system in the production server. We give the examples

--- a/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
@@ -106,7 +106,7 @@ module Decidim
             participatory_space: initiative
           )
 
-          initialize_pages(component) if component_name == :pages
+          initialize_pages(component) if component_name.in? ["pages", :pages]
         end
       end
 

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -128,7 +128,7 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
           participatory_space: initiative
         )
 
-        next unless component_name == :pages
+        next unless component_name.in? ["pages", :pages]
 
         Decidim::Pages::CreatePage.call(component) do
           on(:invalid) { raise "Cannot create page" }

--- a/decidim-initiatives/lib/tasks/upgrade/initiatives/decidim_initiatives_upgrade_tasks.rb
+++ b/decidim-initiatives/lib/tasks/upgrade/initiatives/decidim_initiatives_upgrade_tasks.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :initiatives do
+    namespace :upgrade do
+      desc "Fix the broken pages"
+      task fix_broken_pages: :environment do
+        Decidim::Initiative.find_each do |initiative|
+          initiative.components.where(manifest_name: "pages").each do |component|
+            if Decidim::Pages::Page.where(component: component).empty?
+              Decidim::Pages::CreatePage.call(component) do
+                on(:invalid) { raise "Cannot create page" }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -752,6 +752,17 @@ describe "Initiative", type: :system do
           find_button("Continue").click
         end
 
+        it "shows the page component" do
+          find_link("Continue").click
+          find_link("Edit my initiative").click
+
+          within ".process-nav__content" do
+            find_link("Page").click
+          end
+
+          expect(page).to have_content("Page")
+        end
+
         context "when minimum committee size is above zero" do
           before do
             find_link("Continue").click


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

There's a bug on the creation of Initiatives related to the Page functionality

##### Steps to reproduce

1. Create a new initiative (or use one initiative from the seeded database)
2. Go to the public page (aka `show.html.erb`)
3. Click on "Page"
4. See exception

##### Explanation 

This is related to the introduction of `Decidim::Env` with #8725: we're passing a string for the `Decidim::initiatives.default_components`, where we used to have a symbol. 

https://github.com/decidim/decidim/blob/b510d940404ce3492b00eba95e28647aa607b98c/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb#L78 

Mind that some installations didn't make the change to using the configuration with EnvVars, that's why its working there (for instance in https://try.decidim.org)

This PR fixes this bug in three different ways:

1. For existing installations, there's a new rake task: `bin/rails decidim:initiatives:upgrade:fix_broken_pages`
2. For new initiatives, we fix it on the command
3. For seeds (development and staging), we fix it on the seed

#### :pushpin: Related Issues

- Related to #8725 

#### Testing

##### Rake task

1. Check the bug by following the instructions on "Steps to reproduce"
2. Run  `bin/rails decidim:initiatives:upgrade:fix_broken_pages`
3. Check that the page is working

Note that it seems like the design is broken, but that's actually unrelated to the fix. It's because we have the redesign implemented on develop in `decidim-pages`

##### New initiatives

1. Sign in as a user
2. Go to Initiatives, create a new Initiative
3. Go to the initiative public page (aka show)
5. Click on "Page"
6. See that it works

##### Seeded initiatives

Regenerate the database and check that it is working by going to the "Page" of an Initiative

```console
bin/rails db:drop db:setup db:seed
``` 

### :camera: Screenshots

![Screenshot with the broken link](https://github.com/decidim/decidim/assets/717367/42938a42-0a9d-4af1-866b-bd0319f2f50f)

:hearts: Thank you!
