### PR TITLE
Fix user and group related migrations calling the actual record classes

### DIFF
--- a/decidim-core/db/migrate/20181030090144_destroy_deleted_users_follows.rb
+++ b/decidim-core/db/migrate/20181030090144_destroy_deleted_users_follows.rb
@@ -10,7 +10,7 @@ class DestroyDeletedUsersFollows < ActiveRecord::Migration[5.2]
   end
 
   def change
-    deleted_users = Decidim::User.where.not(deleted_at: nil).pluck(:id)
+    deleted_users = User.where.not(deleted_at: nil).pluck(:id)
     Follow.where(decidim_followable_type: "Decidim::UserBaseEntity", decidim_followable_id: deleted_users).destroy_all
     Follow.where(decidim_user_id: deleted_users).destroy_all
   end

--- a/decidim-core/db/migrate/20181204110723_remove_following_users_count_from_users.rb
+++ b/decidim-core/db/migrate/20181204110723_remove_following_users_count_from_users.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class RemoveFollowingUsersCountFromUsers < ActiveRecord::Migration[5.2]
+  class UserBaseEntity < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+
+  class Follow < ApplicationRecord
+    self.table_name = :decidim_follows
+  end
+
   def up
     remove_column :decidim_users, :following_users_count
   end
@@ -8,8 +16,8 @@ class RemoveFollowingUsersCountFromUsers < ActiveRecord::Migration[5.2]
   def down
     add_column :decidim_users, :following_users_count, :integer, null: false, default: 0
 
-    Decidim::UserBaseEntity.find_each do |entity|
-      following_users_count = Decidim::Follow.where(decidim_user_id: entity.id, decidim_followable_type: ["Decidim::UserBaseEntity", "Decidim::User", "Decidim::UserGroup"]).count
+    UserBaseEntity.find_each do |entity|
+      following_users_count = Follow.where(decidim_user_id: entity.id, decidim_followable_type: ["Decidim::UserBaseEntity", "Decidim::User", "Decidim::UserGroup"]).count
       entity.following_users_count = following_users_count
       entity.save
     end

--- a/decidim-core/db/migrate/20181204110723_remove_following_users_count_from_users.rb
+++ b/decidim-core/db/migrate/20181204110723_remove_following_users_count_from_users.rb
@@ -3,6 +3,7 @@
 class RemoveFollowingUsersCountFromUsers < ActiveRecord::Migration[5.2]
   class UserBaseEntity < ApplicationRecord
     self.table_name = :decidim_users
+    self.inheritance_column = nil # disable the default inheritance
   end
 
   class Follow < ApplicationRecord

--- a/decidim-core/db/migrate/20181214101250_add_notification_types_to_users.rb
+++ b/decidim-core/db/migrate/20181214101250_add_notification_types_to_users.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class AddNotificationTypesToUsers < ActiveRecord::Migration[5.2]
+  class UserBaseEntity < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+
   def change
     add_column :decidim_users, :notification_types, :string, default: "all"
     # rubocop:disable Rails/SkipsModelValidations
-    Decidim::UserBaseEntity.update_all(notification_types: "all")
+    UserBaseEntity.update_all(notification_types: "all")
     # rubocop:enable Rails/SkipsModelValidations
 
     change_column_null :decidim_users, :notification_types, false

--- a/decidim-core/db/migrate/20181214101250_add_notification_types_to_users.rb
+++ b/decidim-core/db/migrate/20181214101250_add_notification_types_to_users.rb
@@ -3,6 +3,7 @@
 class AddNotificationTypesToUsers < ActiveRecord::Migration[5.2]
   class UserBaseEntity < ApplicationRecord
     self.table_name = :decidim_users
+    self.inheritance_column = nil # disable the default inheritance
   end
 
   def change

--- a/decidim-core/db/migrate/20190412131728_fix_user_names.rb
+++ b/decidim-core/db/migrate/20190412131728_fix_user_names.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class FixUserNames < ActiveRecord::Migration[5.2]
+  class UserBaseEntity < ApplicationRecord
+    include Decidim::Nicknamizable
+
+    self.table_name = :decidim_users
+  end
+
   def change
     # Comes from Decidim::User specs
     weird_characters =
@@ -8,7 +14,7 @@ class FixUserNames < ActiveRecord::Migration[5.2]
     characters_to_remove = "<>?%&^*\#@()[]=+:;\"{}\\|/"
 
     weird_characters.each do |character|
-      Decidim::UserBaseEntity.where(deleted_at: nil).where("name like '%#{character}%' escape '\' OR nickname like '%#{character}%' escape '\'").find_each do |entity|
+      UserBaseEntity.where(deleted_at: nil).where("name like '%#{character}%' escape '\' OR nickname like '%#{character}%' escape '\'").find_each do |entity|
         Rails.logger.debug { "detected character: #{character}" }
         Rails.logger.debug { "UserBaseEntity ID: #{entity.id}" }
         Rails.logger.debug { "#{entity.name} => #{entity.name.delete(characters_to_remove).strip}" }
@@ -16,7 +22,7 @@ class FixUserNames < ActiveRecord::Migration[5.2]
 
         entity.name = entity.name.delete(characters_to_remove).strip
         sanitized_nickname = entity.nickname.delete(characters_to_remove).strip
-        entity.nickname = Decidim::UserBaseEntity.nicknamize(sanitized_nickname, organization: entity.organization)
+        entity.nickname = UserBaseEntity.nicknamize(sanitized_nickname, organization: entity.organization)
         entity.save(validate: false)
       end
     end

--- a/decidim-core/db/migrate/20190412131728_fix_user_names.rb
+++ b/decidim-core/db/migrate/20190412131728_fix_user_names.rb
@@ -5,6 +5,7 @@ class FixUserNames < ActiveRecord::Migration[5.2]
     include Decidim::Nicknamizable
 
     self.table_name = :decidim_users
+    self.inheritance_column = nil # disable the default inheritance
   end
 
   def change

--- a/decidim-core/db/migrate/20200211173227_add_direct_message_types_to_users.rb
+++ b/decidim-core/db/migrate/20200211173227_add_direct_message_types_to_users.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class AddDirectMessageTypesToUsers < ActiveRecord::Migration[5.2]
+  class UserBaseEntity < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+
   def change
     add_column :decidim_users, :direct_message_types, :string, default: "all"
     # rubocop:disable Rails/SkipsModelValidations
-    Decidim::UserBaseEntity.update_all(direct_message_types: "all")
+    UserBaseEntity.update_all(direct_message_types: "all")
     # rubocop:enable Rails/SkipsModelValidations
 
     change_column_null :decidim_users, :direct_message_types, false

--- a/decidim-core/db/migrate/20200211173227_add_direct_message_types_to_users.rb
+++ b/decidim-core/db/migrate/20200211173227_add_direct_message_types_to_users.rb
@@ -3,6 +3,7 @@
 class AddDirectMessageTypesToUsers < ActiveRecord::Migration[5.2]
   class UserBaseEntity < ApplicationRecord
     self.table_name = :decidim_users
+    self.inheritance_column = nil # disable the default inheritance
   end
 
   def change

--- a/decidim-core/db/migrate/20210302150803_invalidate_all_sessions_for_deleted_users.rb
+++ b/decidim-core/db/migrate/20210302150803_invalidate_all_sessions_for_deleted_users.rb
@@ -3,6 +3,9 @@
 class InvalidateAllSessionsForDeletedUsers < ActiveRecord::Migration[5.2]
   class User < ApplicationRecord
     self.table_name = "decidim_users"
+    self.inheritance_column = nil # disable the default inheritance
+
+    default_scope { where(type: "Decidim::User") }
   end
 
   def up

--- a/decidim-core/db/migrate/20210302150803_invalidate_all_sessions_for_deleted_users.rb
+++ b/decidim-core/db/migrate/20210302150803_invalidate_all_sessions_for_deleted_users.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class InvalidateAllSessionsForDeletedUsers < ActiveRecord::Migration[5.2]
-  def up
-    Decidim::User.reset_column_information
+  class User < ApplicationRecord
+    self.table_name = "decidim_users"
+  end
 
-    Decidim::User.where.not(deleted_at: nil).find_each(&:invalidate_all_sessions!)
+  def up
+    User.where.not(deleted_at: nil).find_each do |user|
+      user.update!(session_token: SecureRandom.hex)
+    end
   end
 
   def down; end

--- a/decidim-core/db/migrate/20210310120640_add_followable_counter_cache_to_users.rb
+++ b/decidim-core/db/migrate/20210310120640_add_followable_counter_cache_to_users.rb
@@ -1,14 +1,21 @@
 # frozen_string_literal: true
 
 class AddFollowableCounterCacheToUsers < ActiveRecord::Migration[5.2]
+  class Follow < ApplicationRecord
+    self.table_name = "decidim_follows"
+  end
+
+  class User < ApplicationRecord
+    self.table_name = "decidim_users"
+  end
+
   def change
     add_column :decidim_users, :follows_count, :integer, null: false, default: 0, index: true
 
     reversible do |dir|
       dir.up do
-        Decidim::User.reset_column_information
-        Decidim::User.find_each do |record|
-          record.class.reset_counters(record.id, :follows)
+        User.find_each do |record|
+          record.update!(follows_count: Follow.where(decidim_user_id: record.id).count)
         end
       end
     end

--- a/decidim-core/db/migrate/20210310120640_add_followable_counter_cache_to_users.rb
+++ b/decidim-core/db/migrate/20210310120640_add_followable_counter_cache_to_users.rb
@@ -7,6 +7,9 @@ class AddFollowableCounterCacheToUsers < ActiveRecord::Migration[5.2]
 
   class User < ApplicationRecord
     self.table_name = "decidim_users"
+    self.inheritance_column = nil # disable the default inheritance
+
+    default_scope { where(type: "Decidim::User") }
   end
 
   def change

--- a/decidim-debates/db/migrate/20181003081235_fix_user_groups_ids_on_debates.rb
+++ b/decidim-debates/db/migrate/20181003081235_fix_user_groups_ids_on_debates.rb
@@ -3,6 +3,7 @@
 class FixUserGroupsIdsOnDebates < ActiveRecord::Migration[5.2]
   class UserGroup < ApplicationRecord
     self.table_name = :decidim_users
+    self.inheritance_column = nil # disable the default inheritance
 
     default_scope { where(type: "Decidim::UserGroup") }
   end

--- a/decidim-debates/db/migrate/20181003081235_fix_user_groups_ids_on_debates.rb
+++ b/decidim-debates/db/migrate/20181003081235_fix_user_groups_ids_on_debates.rb
@@ -1,13 +1,23 @@
 # frozen_string_literal: true
 
 class FixUserGroupsIdsOnDebates < ActiveRecord::Migration[5.2]
+  class UserGroup < ApplicationRecord
+    self.table_name = :decidim_users
+
+    default_scope { where(type: "Decidim::UserGroup") }
+  end
+
+  class Debate < ApplicationRecord
+    self.table_name = :decidim_debates_debates
+  end
+
   # rubocop:disable Rails/SkipsModelValidations
   def change
-    Decidim::UserGroup.find_each do |group|
+    UserGroup.find_each do |group|
       old_id = group.extended_data["old_user_group_id"]
       next unless old_id
 
-      Decidim::Debates::Debate
+      Debate
         .where(decidim_user_group_id: old_id)
         .update_all(decidim_user_group_id: group.id)
     end

--- a/decidim-debates/db/migrate/20181016132850_add_organization_as_author_to_debates.rb
+++ b/decidim-debates/db/migrate/20181016132850_add_organization_as_author_to_debates.rb
@@ -13,7 +13,6 @@ class AddOrganizationAsAuthorToDebates < ActiveRecord::Migration[5.2]
   def change
     add_column :decidim_debates_debates, :decidim_author_type, :string
 
-    Debate.reset_column_information
     Debate.find_each do |debate|
       if debate.decidim_author_id.present?
         debate.decidim_author_type = "Decidim::UserBaseEntity"

--- a/decidim-initiatives/db/migrate/20181003082010_fix_user_groups_ids_on_initiatives.rb
+++ b/decidim-initiatives/db/migrate/20181003082010_fix_user_groups_ids_on_initiatives.rb
@@ -3,6 +3,7 @@
 class FixUserGroupsIdsOnInitiatives < ActiveRecord::Migration[5.2]
   class UserGroup < ApplicationRecord
     self.table_name = :decidim_users
+    self.inheritance_column = nil # disable the default inheritance
 
     default_scope { where(type: "Decidim::UserGroup") }
   end

--- a/decidim-initiatives/db/migrate/20181003082010_fix_user_groups_ids_on_initiatives.rb
+++ b/decidim-initiatives/db/migrate/20181003082010_fix_user_groups_ids_on_initiatives.rb
@@ -1,16 +1,30 @@
 # frozen_string_literal: true
 
 class FixUserGroupsIdsOnInitiatives < ActiveRecord::Migration[5.2]
+  class UserGroup < ApplicationRecord
+    self.table_name = :decidim_users
+
+    default_scope { where(type: "Decidim::UserGroup") }
+  end
+
+  class Initiative < ApplicationRecord
+    self.table_name = :decidim_initiatives
+  end
+
+  class InitiativesVote < ApplicationRecord
+    self.table_name = :decidim_initiatives_votes
+  end
+
   # rubocop:disable Rails/SkipsModelValidations
   def change
-    Decidim::UserGroup.find_each do |group|
+    UserGroup.find_each do |group|
       old_id = group.extended_data["old_user_group_id"]
       next unless old_id
 
-      Decidim::Initiative
+      Initiative
         .where(decidim_user_group_id: old_id)
         .update_all(decidim_user_group_id: group.id)
-      Decidim::InitiativesVote
+      InitiativesVote
         .where(decidim_user_group_id: old_id)
         .update_all(decidim_user_group_id: group.id)
     end

--- a/decidim-proposals/db/migrate/20181003074440_fix_user_groups_ids_in_proposals_endorsements.rb
+++ b/decidim-proposals/db/migrate/20181003074440_fix_user_groups_ids_in_proposals_endorsements.rb
@@ -5,13 +5,19 @@ class FixUserGroupsIdsInProposalsEndorsements < ActiveRecord::Migration[5.2]
     self.table_name = :decidim_proposals_proposal_endorsements
   end
 
+  class UserGroup < ApplicationRecord
+    self.table_name = :decidim_users
+
+    default_scope { where(type: "Decidim::UserGroup") }
+  end
+
   # rubocop:disable Rails/SkipsModelValidations
   def change
-    Decidim::UserGroup.find_each do |group|
+    UserGroup.find_each do |group|
       old_id = group.extended_data["old_user_group_id"]
       next unless old_id
 
-      Decidim::Proposals::ProposalEndorsement
+      ProposalEndorsement
         .where(decidim_user_group_id: old_id)
         .update_all(decidim_user_group_id: group.id)
     end

--- a/decidim-proposals/db/migrate/20181003074440_fix_user_groups_ids_in_proposals_endorsements.rb
+++ b/decidim-proposals/db/migrate/20181003074440_fix_user_groups_ids_in_proposals_endorsements.rb
@@ -7,6 +7,7 @@ class FixUserGroupsIdsInProposalsEndorsements < ActiveRecord::Migration[5.2]
 
   class UserGroup < ApplicationRecord
     self.table_name = :decidim_users
+    self.inheritance_column = nil # disable the default inheritance
 
     default_scope { where(type: "Decidim::UserGroup") }
   end

--- a/decidim-proposals/db/migrate/20200708091228_move_proposals_fields_to_i18n.rb
+++ b/decidim-proposals/db/migrate/20200708091228_move_proposals_fields_to_i18n.rb
@@ -1,15 +1,37 @@
 # frozen_string_literal: true
 
 class MoveProposalsFieldsToI18n < ActiveRecord::Migration[5.2]
+  class Proposal < ApplicationRecord
+    include Decidim::HasComponent
+
+    self.table_name = :decidim_proposals_proposals
+  end
+
+  class Coauthorship < ApplicationRecord
+    self.table_name = :decidim_coauthorships
+  end
+
+  class UserBaseEntity < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+  end
+
   def up
     add_column :decidim_proposals_proposals, :new_title, :jsonb
     add_column :decidim_proposals_proposals, :new_body, :jsonb
 
-    reset_column_information
-
     PaperTrail.request(enabled: false) do
-      Decidim::Proposals::Proposal.find_each do |proposal|
-        author = proposal.coauthorships.first.author
+      Proposal.find_each do |proposal|
+        coauthorship = Coauthorship.order(:id).find_by(coauthorable_type: "Decidim::Proposals::Proposal", coauthorable_id: proposal.id)
+        author =
+          if coauthorship.decidim_author_type == "Decidim::Organization"
+            Organization.find_by(id: coauthorship.decidim_author_id)
+          else
+            UserBaseEntity.find_by(id: coauthorship.decidim_author_id)
+          end
 
         locale = if author
                    author.try(:locale).presence || author.try(:default_locale).presence || author.try(:organization).try(:default_locale).presence
@@ -38,17 +60,13 @@ class MoveProposalsFieldsToI18n < ActiveRecord::Migration[5.2]
     rename_column :decidim_proposals_proposals, :new_body, :body
 
     create_indexs
-
-    reset_column_information
   end
 
   def down
     add_column :decidim_proposals_proposals, :new_title, :string
     add_column :decidim_proposals_proposals, :new_body, :string
 
-    reset_column_information
-
-    Decidim::Proposals::Proposal.find_each do |proposal|
+    Proposal.find_each do |proposal|
       proposal.new_title = proposal.title.values.first
       proposal.new_body = proposal.body.values.first
 
@@ -63,15 +81,6 @@ class MoveProposalsFieldsToI18n < ActiveRecord::Migration[5.2]
     rename_column :decidim_proposals_proposals, :new_body, :body
 
     create_indexs
-
-    reset_column_information
-  end
-
-  def reset_column_information
-    Decidim::User.reset_column_information
-    Decidim::Coauthorship.reset_column_information
-    Decidim::Proposals::Proposal.reset_column_information
-    Decidim::Organization.reset_column_information
   end
 
   def remove_indexs

--- a/decidim-proposals/db/migrate/20200708091228_move_proposals_fields_to_i18n.rb
+++ b/decidim-proposals/db/migrate/20200708091228_move_proposals_fields_to_i18n.rb
@@ -13,6 +13,7 @@ class MoveProposalsFieldsToI18n < ActiveRecord::Migration[5.2]
 
   class UserBaseEntity < ApplicationRecord
     self.table_name = :decidim_users
+    self.inheritance_column = nil # disable the default inheritance
   end
 
   class Organization < ApplicationRecord

--- a/decidim-proposals/db/migrate/20201002085508_fix_proposals_data.rb
+++ b/decidim-proposals/db/migrate/20201002085508_fix_proposals_data.rb
@@ -1,14 +1,34 @@
 # frozen_string_literal: true
 
 class FixProposalsData < ActiveRecord::Migration[5.2]
-  def up
-    reset_column_information
+  class Proposal < ApplicationRecord
+    self.table_name = :decidim_proposals_proposals
+  end
 
+  class Coauthorship < ApplicationRecord
+    self.table_name = :decidim_coauthorships
+  end
+
+  class UserBaseEntity < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+
+  class Organization < ApplicationRecord
+    self.table_name = :decidim_organizations
+  end
+
+  def up
     PaperTrail.request(enabled: false) do
-      Decidim::Proposals::Proposal.find_each do |proposal|
+      Proposal.find_each do |proposal|
         next if proposal.title.is_a?(Hash) && proposal.body.is_a?(Hash)
 
-        author = proposal.coauthorships.first.author
+        coauthorship = Coauthorship.order(:id).find_by(coauthorable_type: "Decidim::Proposals::Proposal", coauthorable_id: proposal.id)
+        author =
+          if coauthorship.decidim_author_type == "Decidim::Organization"
+            Organization.find_by(id: coauthorship.decidim_author_id)
+          else
+            UserBaseEntity.find_by(id: coauthorship.decidim_author_id)
+          end
 
         locale = author.try(:locale).presence || author.try(:default_locale).presence || author.try(:organization).try(:default_locale).presence
 
@@ -21,16 +41,7 @@ class FixProposalsData < ActiveRecord::Migration[5.2]
         # rubocop:enable Rails/SkipsModelValidations
       end
     end
-
-    reset_column_information
   end
 
   def down; end
-
-  def reset_column_information
-    Decidim::User.reset_column_information
-    Decidim::Coauthorship.reset_column_information
-    Decidim::Proposals::Proposal.reset_column_information
-    Decidim::Organization.reset_column_information
-  end
 end

--- a/decidim-proposals/db/migrate/20201002085508_fix_proposals_data.rb
+++ b/decidim-proposals/db/migrate/20201002085508_fix_proposals_data.rb
@@ -11,6 +11,7 @@ class FixProposalsData < ActiveRecord::Migration[5.2]
 
   class UserBaseEntity < ApplicationRecord
     self.table_name = :decidim_users
+    self.inheritance_column = nil # disable the default inheritance
   end
 
   class Organization < ApplicationRecord

--- a/decidim-sortitions/db/migrate/20181017110803_make_sortitions_authors_polymorphic.rb
+++ b/decidim-sortitions/db/migrate/20181017110803_make_sortitions_authors_polymorphic.rb
@@ -3,6 +3,9 @@
 class MakeSortitionsAuthorsPolymorphic < ActiveRecord::Migration[5.2]
   class User < ApplicationRecord
     self.table_name = :decidim_users
+    self.inheritance_column = nil # disable the default inheritance
+
+    default_scope { where(type: "Decidim::User") }
   end
 
   class Sortition < ApplicationRecord

--- a/decidim-sortitions/db/migrate/20181017110803_make_sortitions_authors_polymorphic.rb
+++ b/decidim-sortitions/db/migrate/20181017110803_make_sortitions_authors_polymorphic.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 class MakeSortitionsAuthorsPolymorphic < ActiveRecord::Migration[5.2]
+  class User < ApplicationRecord
+    self.table_name = :decidim_users
+  end
+
   def change
     add_column :decidim_sortitions_sortitions, :decidim_author_type, :string
 
     Decidim::Sortitions::Sortition.reset_column_information
     Decidim::Sortitions::Sortition.includes(:author).find_each do |sortition|
       author = if sortition.decidim_author_id.present?
-                 Decidim::User.find(sortition.decidim_author_id)
+                 User.find_by(id: sortition.decidim_author_id) || sortition.organization
                else
                  sortition.organization
                end


### PR DESCRIPTION
#### :tophat: What? Why?
We are currently working on a privacy module where we want to apply a default scope to the `Decidim::User` record to ensure we are publicly only displaying public users.

This brings a problem during the initial migrations because the `published_at` column is added to the user record after our module's migrations are run at the very end of all the migrations.

The core migrations are trying to use this new column already when it is not available because we are referring to the actual `Decidim::User` class at the migrations. And also the core migrations should eventually work without the default scope that we are applying in the external module.

#### Testing
See that the migration process completes successfully when creating a new development or test app and check that CI is green.