### PR TITLE
Fix rubocop linting issue

### DIFF
--- a/decidim-core/spec/queries/decidim/metrics/users_metric_manage_spec.rb
+++ b/decidim-core/spec/queries/decidim/metrics/users_metric_manage_spec.rb
@@ -46,6 +46,7 @@ describe Decidim::Metrics::UsersMetricManage do
 
         include_examples "computes the metric"
       end
+
       context "when the user is deleted before the end_time" do
         let!(:deleted_user) { create(:user, :confirmed, created_at: day, deleted_at: day, organization:) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
After #10693, there is a rubocop linting issue.

#### :pushpin: Related Issues
- Related to #10693

#### Testing
See that the lint CI workflow is green.