### PR TITLE
Fix rubocop offense for RSpec/EmptyLineAfterExampleGroup

### DIFF
--- a/decidim-core/spec/queries/decidim/metrics/users_metric_manage_spec.rb
+++ b/decidim-core/spec/queries/decidim/metrics/users_metric_manage_spec.rb
@@ -46,6 +46,7 @@ describe Decidim::Metrics::UsersMetricManage do
 
         include_examples "computes the metric"
       end
+
       context "when the user is deleted before the end_time" do
         let!(:deleted_user) { create(:user, :confirmed, created_at: day, deleted_at: day, organization:) }
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

We have an error on our CI on develop after the last set of changes of the Rubocop rules. 

See https://github.com/decidim/decidim/actions/runs/5130899414/jobs/9230299549 


#### :pushpin: Related Issues
 
- Related to #10163 


#### Testing

CI should be green 

:hearts: Thank you!
