### PR TITLE
Redesign: update default static map size to 300px

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_map.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_map.scss
@@ -3,7 +3,7 @@
 }
 
 .static-map{
-  @apply cursor-pointer overflow-hidden [&_img]:w-full [&_img]:object-cover;
+  @apply cursor-pointer overflow-hidden [&_img]:w-full [&_img]:h-full [&_img]:object-cover;
 
   &__container{
     @apply flex gap-4 [&>*]:w-1/2 first:[&>*]:self-center;

--- a/decidim-core/app/services/decidim/static_map_generator.rb
+++ b/decidim-core/app/services/decidim/static_map_generator.rb
@@ -7,9 +7,9 @@ module Decidim
       @resource = resource
       @options = options
 
-      @options[:zoom] ||= 15
-      @options[:width] ||= 120
-      @options[:height] ||= 120
+      @options[:zoom] ||= Decidim::Map::StaticMap::DEFAULT_ZOOM
+      @options[:width] ||= Decidim::Map::StaticMap::DEFAULT_SIZE
+      @options[:height] ||= Decidim::Map::StaticMap::DEFAULT_SIZE
     end
 
     def data

--- a/decidim-core/lib/decidim/map/provider/static_map/here.rb
+++ b/decidim-core/lib/decidim/map/provider/static_map/here.rb
@@ -10,9 +10,9 @@ module Decidim
           def url_params(latitude:, longitude:, options: {})
             params = {
               c: "#{latitude}, #{longitude}",
-              z: options[:zoom] || 15,
-              w: options[:width] || 120,
-              h: options[:height] || 120,
+              z: options[:zoom] || Decidim::Map::StaticMap::DEFAULT_ZOOM,
+              w: options[:width] || Decidim::Map::StaticMap::DEFAULT_SIZE,
+              h: options[:height] || Decidim::Map::StaticMap::DEFAULT_SIZE,
               f: 1
             }
 

--- a/decidim-core/lib/decidim/map/provider/static_map/osm.rb
+++ b/decidim-core/lib/decidim/map/provider/static_map/osm.rb
@@ -17,9 +17,9 @@ module Decidim
                 type: "Point",
                 coordinates: [longitude, latitude]
               }.to_json,
-              zoom: options[:zoom] || 15,
-              width: options[:width] || 300,
-              height: options[:height] || 300
+              zoom: options[:zoom] || Decidim::Map::StaticMap::DEFAULT_ZOOM,
+              width: options[:width] || Decidim::Map::StaticMap::DEFAULT_SIZE,
+              height: options[:height] || Decidim::Map::StaticMap::DEFAULT_SIZE
             }
           end
         end

--- a/decidim-core/lib/decidim/map/provider/static_map/osm.rb
+++ b/decidim-core/lib/decidim/map/provider/static_map/osm.rb
@@ -18,8 +18,8 @@ module Decidim
                 coordinates: [longitude, latitude]
               }.to_json,
               zoom: options[:zoom] || 15,
-              width: options[:width] || 120,
-              height: options[:height] || 120
+              width: options[:width] || 300,
+              height: options[:height] || 300
             }
           end
         end

--- a/decidim-core/lib/decidim/map/static_map.rb
+++ b/decidim-core/lib/decidim/map/static_map.rb
@@ -5,6 +5,9 @@ module Decidim
     # A base class for static mapping functionality, common to all static map
     # services.
     class StaticMap < Map::Utility
+      DEFAULT_SIZE = 300
+      DEFAULT_ZOOM = 15
+
       # Creates a link for the static maps. This will point to an external map
       # service where the user can further explore the given location.
       #
@@ -103,9 +106,9 @@ module Decidim
         {
           latitude:,
           longitude:,
-          zoom: options.fetch(:zoom, 15),
-          width: options.fetch(:width, 120),
-          height: options.fetch(:height, 120)
+          zoom: options.fetch(:zoom, DEFAULT_ZOOM),
+          width: options.fetch(:width, DEFAULT_SIZE),
+          height: options.fetch(:height, DEFAULT_SIZE)
         }
       end
 

--- a/decidim-core/lib/decidim/map/static_map.rb
+++ b/decidim-core/lib/decidim/map/static_map.rb
@@ -51,9 +51,9 @@ module Decidim
       #   * zoom: A number to represent the zoom value of the map image (default
       #     15)
       #   * width: A number to represent the pixel width of the map image
-      #     (default 120)
+      #     (default 300)
       #   * height: A number to represent the pixel height of the map image
-      #     (default 120)
+      #     (default 300)
       #
       # @return [String] The URL to request for the static map image.
       def url(latitude:, longitude:, options: {})

--- a/decidim-core/spec/lib/map/provider/static_map/here_spec.rb
+++ b/decidim-core/spec/lib/map/provider/static_map/here_spec.rb
@@ -27,9 +27,9 @@ module Decidim
               ).to eq(
                 apiKey: "key1234",
                 c: "#{latitude}, #{longitude}",
-                z: 15,
-                w: 120,
-                h: 120,
+                z: Decidim::Map::StaticMap::DEFAULT_ZOOM,
+                w: Decidim::Map::StaticMap::DEFAULT_SIZE,
+                h: Decidim::Map::StaticMap::DEFAULT_SIZE,
                 f: 1
               )
             end
@@ -71,9 +71,9 @@ module Decidim
                   app_id: "appid123",
                   app_code: "secret456",
                   c: "#{latitude}, #{longitude}",
-                  z: 15,
-                  w: 120,
-                  h: 120,
+                  z: Decidim::Map::StaticMap::DEFAULT_ZOOM,
+                  w: Decidim::Map::StaticMap::DEFAULT_SIZE,
+                  h: Decidim::Map::StaticMap::DEFAULT_SIZE,
                   f: 1
                 )
               end

--- a/decidim-core/spec/lib/map/provider/static_map/osm_spec.rb
+++ b/decidim-core/spec/lib/map/provider/static_map/osm_spec.rb
@@ -26,9 +26,9 @@ module Decidim
                   type: "Point",
                   coordinates: [longitude, latitude]
                 }.to_json,
-                zoom: 15,
-                width: 120,
-                height: 120
+                zoom: Decidim::Map::StaticMap::DEFAULT_ZOOM,
+                width: Decidim::Map::StaticMap::DEFAULT_SIZE,
+                height: Decidim::Map::StaticMap::DEFAULT_SIZE
               )
             end
 

--- a/decidim-core/spec/lib/map/static_map_spec.rb
+++ b/decidim-core/spec/lib/map/static_map_spec.rb
@@ -59,7 +59,7 @@ module Decidim
 
           it "returns the correct URL" do
             expect(subject.url(latitude:, longitude:)).to eq(
-              "https://staticmaps.example.org/?latitude=#{latitude}&longitude=#{longitude}&zoom=15&width=120&height=120"
+              "https://staticmaps.example.org/?latitude=#{latitude}&longitude=#{longitude}&zoom=#{Decidim::Map::StaticMap::DEFAULT_ZOOM}&width=#{Decidim::Map::StaticMap::DEFAULT_SIZE}&height=#{DECIDIM::MAP::STATICMAP::DEFAULT_SIZE}"
             )
           end
 
@@ -68,7 +68,7 @@ module Decidim
 
             it "returns the correct URL" do
               expect(subject.url(latitude:, longitude:)).to eq(
-                "https://staticmaps.example.org/?key=123&msg=foo&latitude=#{latitude}&longitude=#{longitude}&zoom=15&width=120&height=120"
+                "https://staticmaps.example.org/?key=123&msg=foo&latitude=#{latitude}&longitude=#{longitude}&zoom=#{Decidim::Map::StaticMap::DEFAULT_ZOOM}&width=#{Decidim::Map::StaticMap::DEFAULT_SIZE}&height=#{DECIDIM::MAP::STATICMAP::DEFAULT_SIZE}"
               )
             end
           end
@@ -130,9 +130,9 @@ module Decidim
           ).to eq(
             latitude:,
             longitude:,
-            zoom: 15,
-            width: 120,
-            height: 120
+            zoom: Decidim::Map::StaticMap::DEFAULT_ZOOM,
+            width: Decidim::Map::StaticMap::DEFAULT_SIZE,
+            height: Decidim::Map::StaticMap::DEFAULT_SIZE
           )
         end
 
@@ -176,7 +176,7 @@ module Decidim
 
         context "when the URL is configured" do
           let(:config) { { url: "https://staticmaps.example.org/" } }
-          let(:image_url) { "https://staticmaps.example.org/?latitude=#{latitude}&longitude=#{longitude}&zoom=15&width=120&height=120" }
+          let(:image_url) { "https://staticmaps.example.org/?latitude=#{latitude}&longitude=#{longitude}&zoom=#{Decidim::Map::StaticMap::DEFAULT_ZOOM}&width=#{Decidim::Map::StaticMap::DEFAULT_SIZE}&height=#{DECIDIM::MAP::STATICMAP::DEFAULT_SIZE}" }
           let(:body) { "imagedata" }
 
           before do

--- a/decidim-core/spec/lib/map/static_map_spec.rb
+++ b/decidim-core/spec/lib/map/static_map_spec.rb
@@ -59,7 +59,7 @@ module Decidim
 
           it "returns the correct URL" do
             expect(subject.url(latitude:, longitude:)).to eq(
-              "https://staticmaps.example.org/?latitude=#{latitude}&longitude=#{longitude}&zoom=#{Decidim::Map::StaticMap::DEFAULT_ZOOM}&width=#{Decidim::Map::StaticMap::DEFAULT_SIZE}&height=#{DECIDIM::MAP::STATICMAP::DEFAULT_SIZE}"
+              "https://staticmaps.example.org/?latitude=#{latitude}&longitude=#{longitude}&zoom=#{Decidim::Map::StaticMap::DEFAULT_ZOOM}&width=#{Decidim::Map::StaticMap::DEFAULT_SIZE}&height=#{Decidim::Map::StaticMap::DEFAULT_SIZE}"
             )
           end
 
@@ -68,7 +68,7 @@ module Decidim
 
             it "returns the correct URL" do
               expect(subject.url(latitude:, longitude:)).to eq(
-                "https://staticmaps.example.org/?key=123&msg=foo&latitude=#{latitude}&longitude=#{longitude}&zoom=#{Decidim::Map::StaticMap::DEFAULT_ZOOM}&width=#{Decidim::Map::StaticMap::DEFAULT_SIZE}&height=#{DECIDIM::MAP::STATICMAP::DEFAULT_SIZE}"
+                "https://staticmaps.example.org/?key=123&msg=foo&latitude=#{latitude}&longitude=#{longitude}&zoom=#{Decidim::Map::StaticMap::DEFAULT_ZOOM}&width=#{Decidim::Map::StaticMap::DEFAULT_SIZE}&height=#{Decidim::Map::StaticMap::DEFAULT_SIZE}"
               )
             end
           end
@@ -176,7 +176,7 @@ module Decidim
 
         context "when the URL is configured" do
           let(:config) { { url: "https://staticmaps.example.org/" } }
-          let(:image_url) { "https://staticmaps.example.org/?latitude=#{latitude}&longitude=#{longitude}&zoom=#{Decidim::Map::StaticMap::DEFAULT_ZOOM}&width=#{Decidim::Map::StaticMap::DEFAULT_SIZE}&height=#{DECIDIM::MAP::STATICMAP::DEFAULT_SIZE}" }
+          let(:image_url) { "https://staticmaps.example.org/?latitude=#{latitude}&longitude=#{longitude}&zoom=#{Decidim::Map::StaticMap::DEFAULT_ZOOM}&width=#{Decidim::Map::StaticMap::DEFAULT_SIZE}&height=#{Decidim::Map::StaticMap::DEFAULT_SIZE}" }
           let(:body) { "imagedata" }
 
           before do

--- a/docs/modules/develop/pages/maps.adoc
+++ b/docs/modules/develop/pages/maps.adoc
@@ -434,8 +434,8 @@ By default, this will return a link to the configured static map URL with the fo
  ** `latitude` - The value for the `latitude` option provided for the method.
  ** `longitude` - The value for the `longitude` option provided for the method.
  ** `zoom` - The value for key `:zoom` in the options hash (default: 15).
- ** `width` - The value for key `:width` in the options hash (default: 120).
- ** `height` - The value for key `:height` in the options hash (default: 120).
+ ** `width` - The value for key `:width` in the options hash (default: 300).
+ ** `height` - The value for key `:height` in the options hash (default: 300).
 * `url_params(latitude:, longitude:, options: {})` - Returns a hash of prepared URL parameters for the `url` method.
 For the default parameters, see the explanations above for the `url` method.
 * `image_data(latitude:, longitude:, options: {})` - Does a request to the URL defined by the `url` method and returns the raw binary data in the response body of that request.
@@ -475,7 +475,7 @@ When calling the `url` method with the latitude of `1.123` and longitude of `2.4
 
 [source,bash]
 ----
-https://staticmap.example.org/?latitude=1.123&longitude=2.456&zoom=15&width=120&height=120&style=bright&foo=bar
+https://staticmap.example.org/?latitude=1.123&longitude=2.456&zoom=15&width=300&height=300&style=bright&foo=bar
 ----
 
 If you want to use the dynamic map replacements for the static map images, do not configure `static` section for your maps:


### PR DESCRIPTION
#### :tophat: What? Why?

This PR:

- updates static maps default size to 300px, to adapt to the new design
- refactors the default size and default zoom, extracting them to constants, so future updates will be easier

#### :pushpin: Related Issues

- Fixes https://github.com/decidim/decidim/issues/10145#event-9430137588

#### Testing

- Create a meeting with an address
- Check the map is big enough to don't display pixelated
- Here's an example: https://decidim-redesign.populate.tools/processes/Decidim4Dummies/f/168/meetings/1810

### :camera: Screenshots

![Screenshot 2023-06-06 at 06 48 23](https://github.com/decidim/decidim/assets/17616/a4d83474-4633-4c2f-8249-b482c0e92e33)

:hearts: Thank you!
