### PR TITLE
Fix seeded trustees

### DIFF
--- a/decidim-elections/lib/decidim/elections/component.rb
+++ b/decidim-elections/lib/decidim/elections/component.rb
@@ -518,7 +518,7 @@ Decidim.register_component(:elections) do |component|
     end
 
     %w(admin@example.org user@example.org user2@example.org).each do |email|
-      trustee = Decidim::Elections::Trustee.create!(
+      trustee = Decidim::Elections::Trustee.find_or_create_by(
         user: Decidim::User.find_by(email:),
         organization: participatory_space.organization
       )


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

On #10901, I made a mistake where the Trustees could not actually be used for the Key Generation ceremony. That's the whole point for them :/ 

This PR fixes it

#### :pushpin: Related Issues
 
- Related to #10901
 

#### Testing


(Before the patch) 

1. Having a Bulletin Board working (like the one from #10870) 
2. Run the seeds 
3. Sign in as admin@example.org
4. Go to http://localhost:3000/trustee/ 
5. Generate the identification key. See that you still can generate it
6. Apply the patch
7. Rerun the seeds
8. Sign in as admin@example.org
9. Go to http://localhost:3000/trustee/ 
10. Generate the identification key. See that you can not generate it again

:hearts: Thank you!
