### PR TITLE
Add ESLint and Stylelint to component template

### DIFF
--- a/decidim-generators/lib/decidim/generators/component_templates/.eslintrc.json
+++ b/decidim-generators/lib/decidim/generators/component_templates/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@decidim"]
+}

--- a/decidim-generators/lib/decidim/generators/component_templates/.stylelintrc.json
+++ b/decidim-generators/lib/decidim/generators/component_templates/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@decidim/stylelint-config"]
+}

--- a/decidim-generators/lib/decidim/generators/component_templates/package.json.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/package.json.erb
@@ -2,6 +2,7 @@
   "name": "decidim-<%= component_name %>",
   "version": "0.0.1",
   "description": <%= JSON.generate(component_description || "") %>,
+  "private": true,
   "license": "AGPL-3.0",
   "scripts": {
     "lint": "eslint -c .eslintrc.json --no-error-on-unmatched-pattern --ignore-pattern app/packs/vendor --ext .js app/packs",

--- a/decidim-generators/lib/decidim/generators/component_templates/package.json.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/package.json.erb
@@ -1,0 +1,20 @@
+{
+  "name": "decidim-<%= component_name %>",
+  "version": "0.0.1",
+  "description": <%= JSON.generate(component_description || "") %>,
+  "license": "AGPL-3.0",
+  "scripts": {
+    "lint": "eslint -c .eslintrc.json --no-error-on-unmatched-pattern --ignore-pattern app/packs/vendor --ext .js app/packs",
+    "stylelint": "stylelint app/packs/**/*.scss"
+  },
+  "dependencies": {
+    "@decidim/browserslist-config": "<%= npm_package_version %>",
+    "@decidim/webpacker": "<%= npm_package_version %>"
+  },
+  "devDependencies": {
+    "@decidim/dev": "<%= npm_package_version %>",
+    "@decidim/eslint-config": "<%= npm_package_version %>",
+    "@decidim/stylelint-config": "<%= npm_package_version %>"
+  },
+  "browserslist": ["extends @decidim/browserslist-config"]
+}

--- a/decidim-generators/spec/runtime/config_flags_generator_spec.rb
+++ b/decidim-generators/spec/runtime/config_flags_generator_spec.rb
@@ -120,6 +120,7 @@ module Decidim
           "name" => "decidim-#{test_component}",
           "version" => "0.0.1",
           "description" => "",
+          "private" => true,
           "license" => "AGPL-3.0",
           "scripts" => {
             "lint" => "eslint -c .eslintrc.json --no-error-on-unmatched-pattern --ignore-pattern app/packs/vendor --ext .js app/packs",

--- a/decidim-generators/spec/runtime/config_flags_generator_spec.rb
+++ b/decidim-generators/spec/runtime/config_flags_generator_spec.rb
@@ -108,11 +108,34 @@ module Decidim
     context "with a component" do
       let(:test_component) { "dummy_component" }
       let(:command) { "decidim --component #{test_component}" }
+      let(:semver_friendly_version) { Decidim::GemManager.semver_friendly_version(Decidim.version) }
+      let(:npm_package_version) { "^#{semver_friendly_version}" }
 
       after { FileUtils.rm_rf("decidim-module-#{test_component}") }
 
-      it "suceeeds" do
+      it "succeeds" do
         expect(result[1]).to be_success, result[0]
+
+        expect(JSON.parse(File.read("decidim-module-#{test_component}/package.json"))).to eq(
+          "name" => "decidim-#{test_component}",
+          "version" => "0.0.1",
+          "description" => "",
+          "license" => "AGPL-3.0",
+          "scripts" => {
+            "lint" => "eslint -c .eslintrc.json --no-error-on-unmatched-pattern --ignore-pattern app/packs/vendor --ext .js app/packs",
+            "stylelint" => "stylelint app/packs/**/*.scss"
+          },
+          "dependencies" => {
+            "@decidim/browserslist-config" => npm_package_version,
+            "@decidim/webpacker" => npm_package_version
+          },
+          "devDependencies" => {
+            "@decidim/dev" => npm_package_version,
+            "@decidim/eslint-config" => npm_package_version,
+            "@decidim/stylelint-config" => npm_package_version
+          },
+          "browserslist" => ["extends @decidim/browserslist-config"]
+        )
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
We noticed that the ESLint and Stylelint are not automatically configured for the components generated with the decidim generators.

#### Testing
See that CI is green.

Or test it yourself by running the component generator and inspecting the generated component folder.