### PR TITLE
Fix flaky collaborative drafts spec

### DIFF
--- a/decidim-proposals/spec/system/collaborative_drafts_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_spec.rb
@@ -281,6 +281,9 @@ describe "Explore Collaborative Drafts", type: :system, versioning: true do
 
           context "when the author receives the request" do
             before do
+              within ".header .title-bar .topbar__user__logged" do
+                expect(page).to have_content(user.name)
+              end
               relogin_as author, scope: :user
               visit current_path
               within ".header .title-bar .topbar__user__logged" do


### PR DESCRIPTION
#### :tophat: What? Why?
Flaky run on collaborative drafts system spec:
https://github.com/decidim/decidim/actions/runs/5202182450/jobs/9383425448

The relogin part of this spec is not working as after `visit current_path` the user is still the same as it was before. Trying to avoid this by expecting the previous user before performing the relogin and reloading of the page.

```
Failures:

  1) Explore Collaborative Drafts with collaborative drafts enabled renders collaborative draft details when visits an non author user when the user requests access when the author receives the request shows the button to accept the request
     Failure/Error:
       within ".header .title-bar .topbar__user__logged" do
         expect(page).to have_content(user.name)
       end

     Capybara::ElementNotFound:
       Unable to find css ".header .title-bar .topbar__user__logged"

     # ./spec/system/collaborative_drafts_spec.rb:241:in `block (5 levels) in <top (required)>'
```

#### Testing
Run the spec for several times to try to hit one flaky run:
```bash
$ cd decidim-proposals
$ for i in {1..100}; do bundle exec rspec spec/system/collaborative_drafts_spec.rb -e "with collaborative drafts enabled renders collaborative draft details when visits an non author user when the user requests access when the author receives the request shows the button to accept the request" || break; done
```