### PR TITLE
Don't ask for overwriting .ruby-version on app generation

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -132,7 +132,7 @@ module Decidim
       end
 
       def ruby_version
-        copy_file ".ruby-version", ".ruby-version"
+        copy_file ".ruby-version", ".ruby-version", force: true
       end
 
       def node_version


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

When we're generating the application, we have some interactivity during the process, as we have to answer if we agree to overwrite the `.ruby-version` file of the generated app. This PR fixes that. 

#### :pushpin: Related Issues
 
- Related to #10574

#### Testing

Run `bin/rake development_app` and see that it doesn't ask you overriding this file anymore. 

### :camera: Screenshots
![Screenshot of the app generation process](https://github.com/decidim/decidim/assets/717367/4285544e-8190-46e6-8dc8-eb0becdd8783)


:hearts: Thank you!
