### PR TITLE
Make organizations' colors seeds random

### DIFF
--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -20,6 +20,24 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
   smtp_label = ENV.fetch("SMTP_FROM_LABEL", Faker::Twitter.unique.screen_name)
   smtp_email = ENV.fetch("SMTP_FROM_EMAIL", Faker::Internet.email)
 
+  primary_color, secondary_color = [
+    ["#4CAF50", "#A0309E"],
+    ["#E91E63", "#1EE9A5"],
+    ["#009688", "#D12C26"],
+    ["#FF9800", "#00BCD4"]
+  ].sample
+
+  colors = {
+    "alert": "#ec5840",
+    "highlight": "#be6400",
+    "highlight-alternative": "#ff5731",
+    "primary": primary_color,
+    "secondary": secondary_color,
+    "success": "#57d685",
+    "theme": "#ef604d",
+    "warning": "#ffae00"
+  }
+
   organization = Decidim::Organization.first || Decidim::Organization.create!(
     name: Faker::Company.name,
     twitter_handler: Faker::Hipster.word,
@@ -50,7 +68,8 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
     badges_enabled: true,
     user_groups_enabled: true,
     send_welcome_notification: true,
-    file_upload_settings: Decidim::OrganizationSettings.default(:upload)
+    file_upload_settings: Decidim::OrganizationSettings.default(:upload),
+    colors: colors
   )
 
   if organization.top_scopes.none?

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -28,14 +28,14 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
   ].sample
 
   colors = {
-    "alert": "#ec5840",
-    "highlight": "#be6400",
+    alert: "#ec5840",
+    highlight: "#be6400",
     "highlight-alternative": "#ff5731",
-    "primary": primary_color,
-    "secondary": secondary_color,
-    "success": "#57d685",
-    "theme": "#ef604d",
-    "warning": "#ffae00"
+    primary: primary_color,
+    secondary: secondary_color,
+    success: "#57d685",
+    theme: "#ef604d",
+    warning: "#ffae00"
   }
 
   organization = Decidim::Organization.first || Decidim::Organization.create!(
@@ -69,7 +69,7 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
     user_groups_enabled: true,
     send_welcome_notification: true,
     file_upload_settings: Decidim::OrganizationSettings.default(:upload),
-    colors: colors
+    colors:
   )
 
   if organization.top_scopes.none?


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

Sometimes we style new things and we forget about using the CSS primary color. This PR makes this error more visible, by changing by default the organization primary and secondary colors to a random one. 

The color selection was made with the help of @carolromero 
#### :pushpin: Related Issues
 
- Related to #5870 and #10526

#### Testing

Regenerate the database with `bin/rails db:drop db:setup db:seed`

### :camera: Screenshots
![First screenshot of a process with some random colors](https://github.com/decidim/decidim/assets/717367/12c0ea95-8305-473a-8639-26d6c51341a7)
![Second screenshot of a process with some random colors](https://github.com/decidim/decidim/assets/717367/54540b82-3053-4288-8cdc-3f69e26fc958)
![Third screenshot of a process with some random colors](https://github.com/decidim/decidim/assets/717367/008d2c6f-44a1-4c87-81b7-ab5f700f3ffc)

:hearts: Thank you!
