### PR TITLE
Redesign: confirm modal Foundation-free

### DIFF
--- a/decidim-core/app/packs/src/decidim/confirm.js
+++ b/decidim-core/app/packs/src/decidim/confirm.js
@@ -7,25 +7,15 @@
 
 import Rails from "@rails/ujs"
 
-let TEMPLATE_HTML = null;
-
 class ConfirmDialog {
   constructor(sourceElement) {
-    this.$modal = $(TEMPLATE_HTML);
+    this.$modal = $("#confirm-modal");
     this.$source = sourceElement;
-    this.$content = $(".confirm-modal-content", this.$modal);
+    this.$content = $("[data-confirm-modal-content]", this.$modal);
     this.$buttonConfirm = $("[data-confirm-ok]", this.$modal);
     this.$buttonCancel = $("[data-confirm-cancel]", this.$modal);
 
-    // Avoid duplicate IDs and append the new modal to the body
-    const titleId = `confirm-modal-title-${Math.random().toString(36).substring(7)}`;
-
-    this.$modal.removeAttr("id");
-    $("#confirm-modal-title", this.$modal).attr("id", titleId);
-    this.$modal.attr("aria-labelledby", titleId);
-
-    $("body").append(this.$modal);
-    this.$modal.foundation();
+    window.Decidim.currentDialogs["confirm-modal"].open()
   }
 
   confirm(message) {
@@ -35,23 +25,21 @@ class ConfirmDialog {
     this.$buttonCancel.off("click");
 
     return new Promise((resolve) => {
+
       this.$buttonConfirm.on("click", (ev) => {
         ev.preventDefault();
 
-        this.$modal.foundation("close");
+        window.Decidim.currentDialogs["confirm-modal"].close()
         resolve(true);
         this.$source.focus();
       });
+
       this.$buttonCancel.on("click", (ev) => {
         ev.preventDefault();
 
-        this.$modal.foundation("close");
+        window.Decidim.currentDialogs["confirm-modal"].close()
         resolve(false);
         this.$source.focus();
-      });
-
-      this.$modal.foundation("open").on("closed.zf.reveal", () => {
-        this.$modal.remove();
       });
     });
   }
@@ -74,11 +62,6 @@ const allowAction = (ev, element) => {
 
   if (!Rails.fire(element, "confirm")) {
     return false;
-  }
-
-  if (TEMPLATE_HTML === null) {
-    TEMPLATE_HTML = $("#confirm-modal")[0].outerHTML;
-    $("#confirm-modal").remove();
   }
 
   const dialog = new ConfirmDialog(

--- a/decidim-core/app/packs/src/decidim/redesigned_confirm.js
+++ b/decidim-core/app/packs/src/decidim/redesigned_confirm.js
@@ -7,25 +7,15 @@
 
 import Rails from "@rails/ujs"
 
-let TEMPLATE_HTML = null;
-
 class ConfirmDialog {
   constructor(sourceElement) {
-    this.$modal = $(TEMPLATE_HTML);
+    this.$modal = $("#confirm-modal");
     this.$source = sourceElement;
-    this.$content = $(".confirm-modal-content", this.$modal);
+    this.$content = $("[data-confirm-modal-content]", this.$modal);
     this.$buttonConfirm = $("[data-confirm-ok]", this.$modal);
     this.$buttonCancel = $("[data-confirm-cancel]", this.$modal);
 
-    // Avoid duplicate IDs and append the new modal to the body
-    const titleId = `confirm-modal-title-${Math.random().toString(36).substring(7)}`;
-
-    this.$modal.removeAttr("id");
-    $("#confirm-modal-title", this.$modal).attr("id", titleId);
-    this.$modal.attr("aria-labelledby", titleId);
-
-    $("body").append(this.$modal);
-    this.$modal.foundation();
+    window.Decidim.currentDialogs["confirm-modal"].open()
   }
 
   confirm(message) {
@@ -35,23 +25,21 @@ class ConfirmDialog {
     this.$buttonCancel.off("click");
 
     return new Promise((resolve) => {
+
       this.$buttonConfirm.on("click", (ev) => {
         ev.preventDefault();
 
-        this.$modal.foundation("close");
+        window.Decidim.currentDialogs["confirm-modal"].close()
         resolve(true);
         this.$source.focus();
       });
+
       this.$buttonCancel.on("click", (ev) => {
         ev.preventDefault();
 
-        this.$modal.foundation("close");
+        window.Decidim.currentDialogs["confirm-modal"].close()
         resolve(false);
         this.$source.focus();
-      });
-
-      this.$modal.foundation("open").on("closed.zf.reveal", () => {
-        this.$modal.remove();
       });
     });
   }
@@ -74,11 +62,6 @@ const allowAction = (ev, element) => {
 
   if (!Rails.fire(element, "confirm")) {
     return false;
-  }
-
-  if (TEMPLATE_HTML === null) {
-    TEMPLATE_HTML = $("#confirm-modal")[0].outerHTML;
-    $("#confirm-modal").remove();
   }
 
   const dialog = new ConfirmDialog(

--- a/decidim-core/app/packs/src/decidim/redesigned_index.js
+++ b/decidim-core/app/packs/src/decidim/redesigned_index.js
@@ -49,7 +49,7 @@ import "./responsive_horizontal_tabs"
 import "./security/selfxss_warning"
 // import "./floating_help" --deprecated
 import "./redesigned_session_timeouter"
-import "./confirm"
+import "./redesigned_confirm"
 import "./results_listing"
 // import "./represent_user_group" -- deprecated
 import "./impersonation"

--- a/decidim-core/app/views/decidim/shared/_redesigned_confirm_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_redesigned_confirm_modal.html.erb
@@ -1,21 +1,17 @@
-<div id="confirm-modal" data-dialog="confirm-modal" aria-hidden="true" role="dialog" aria-labelledby="confirm-modal-title" aria-modal="true" data-reveal>
-  <div id="confirm-modal-content">
-    <button type="button" data-dialog-close="confirm-modal" data-dialog-closable="" aria-label="<%= t("close_modal", scope: "decidim.shared.confirm_modal") %>">×</button>
+<%= decidim_modal id: "confirm-modal" do %>
+  <div data-dialog-container>
+    <%= icon "delete-bin-line" %>
+    <h2 class="h2" data-dialog-title id="dialog-title-confirm-modal"><%= t("title", scope: "decidim.shared.confirm_modal") %></h2>
 
-    <div data-dialog-container>
-      <%= icon "delete-bin-line" %>
-      <h2 class="h2" data-dialog-title id="dialog-title-confirm-modal"><%= t("title", scope: "decidim.shared.confirm_modal") %></h2>
-
-      <div class="confirm-modal-content"></div>
-    </div>
-
-    <div data-dialog-actions>
-      <a class="button button__lg button__transparent-secondary" role="button" href="#" data-confirm-cancel aria-label="<%= t("cancel", scope: "decidim.shared.confirm_modal") %>">
-        <%= t("cancel", scope: "decidim.shared.confirm_modal") %>
-      </a>
-      <a class="button button__lg button__secondary" role="button" href="#" data-confirm-ok aria-label="<%= t("ok", scope: "decidim.shared.confirm_modal") %>">
-        <%= t("ok", scope: "decidim.shared.confirm_modal") %>
-      </a>
-    </div>
+    <div data-confirm-modal-content></div>
   </div>
-</div>
+
+  <div data-dialog-actions>
+    <button class="button button__lg button__transparent-secondary" data-confirm-cancel data-dialog-close="confirm-modal">
+      <span><%= t("cancel", scope: "decidim.shared.confirm_modal") %></span>
+    </button>
+    <button class="button button__lg button__secondary" data-confirm-ok>
+      <span><%= t("ok", scope: "decidim.shared.confirm_modal") %></span>
+    </button>
+  </div>
+<% end %>

--- a/decidim-core/app/views/layouts/decidim/_redesigned_application.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_redesigned_application.html.erb
@@ -19,7 +19,7 @@
       <%= yield %>
     <% end %>
 
-    <%= render partial: "decidim/shared/redesigned_confirm_modal" %>
+    <%= render partial: redesign_enabled? ? "decidim/shared/redesigned_confirm_modal" : "decidim/shared/confirm_modal" %>
     <%= render partial: "decidim/shared/redesigned_login_modal" unless current_user %>
     <%= render partial: "decidim/shared/redesigned_authorization_modal" %>
     <%= render partial: "decidim/shared/redesigned_share_modal" %>

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/confirmation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/confirmation_helpers.rb
@@ -10,8 +10,6 @@ module ConfirmationHelpers
   def accept_confirm(_text = nil, **options)
     yield if block_given?
 
-    # The test can already be "within", so find the body using xpath
-    message = nil
     confirm_selector = options.fetch(:admin, !Decidim.redesign_active) ? ".confirm-modal-content" : "[data-confirm-modal-content]"
     message = find(confirm_selector).text
     find("[data-confirm-ok]").click
@@ -27,8 +25,6 @@ module ConfirmationHelpers
   def dismiss_confirm(_text = nil, **_options)
     yield if block_given?
 
-    # The test can already be "within", so find the body using xpath
-    message = nil
     confirm_selector = options.fetch(:admin, !Decidim.redesign_active) ? ".confirm-modal-content" : "[data-confirm-modal-content]"
     message = find(confirm_selector).text
     find("[data-confirm-cancel]").click

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/confirmation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/confirmation_helpers.rb
@@ -28,7 +28,7 @@ module ConfirmationHelpers
   #
   # See:
   # https://github.com/teamcapybara/capybara/blob/44621209496fe4dd352709799a0061a80d97d562/lib/capybara/session.rb#L657
-  def dismiss_confirm(_text = nil, **_options)
+  def dismiss_confirm(_text = nil, **options)
     yield if block_given?
 
     # The test can already be "within", so find the body using xpath

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/confirmation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/confirmation_helpers.rb
@@ -10,9 +10,13 @@ module ConfirmationHelpers
   def accept_confirm(_text = nil, **options)
     yield if block_given?
 
+    body = find(:xpath, "/html/body")
     confirm_selector = options.fetch(:admin, !Decidim.redesign_active) ? ".confirm-modal-content" : "[data-confirm-modal-content]"
-    message = find(confirm_selector).text
-    find("[data-confirm-ok]").click
+
+    within body do
+      message = find(confirm_selector).text
+      find("[data-confirm-ok]").click
+    end
 
     message
   end
@@ -25,9 +29,13 @@ module ConfirmationHelpers
   def dismiss_confirm(_text = nil, **_options)
     yield if block_given?
 
+    body = find(:xpath, "/html/body")
     confirm_selector = options.fetch(:admin, !Decidim.redesign_active) ? ".confirm-modal-content" : "[data-confirm-modal-content]"
-    message = find(confirm_selector).text
-    find("[data-confirm-cancel]").click
+
+    within body do
+      message = find(confirm_selector).text
+      find("[data-confirm-cancel]").click
+    end
 
     message
   end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/confirmation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/confirmation_helpers.rb
@@ -10,8 +10,10 @@ module ConfirmationHelpers
   def accept_confirm(_text = nil, **options)
     yield if block_given?
 
+    # The test can already be "within", so find the body using xpath
     body = find(:xpath, "/html/body")
     confirm_selector = options.fetch(:admin, !Decidim.redesign_active) ? ".confirm-modal-content" : "[data-confirm-modal-content]"
+    message = nil
 
     within body do
       message = find(confirm_selector).text
@@ -29,8 +31,10 @@ module ConfirmationHelpers
   def dismiss_confirm(_text = nil, **_options)
     yield if block_given?
 
+    # The test can already be "within", so find the body using xpath
     body = find(:xpath, "/html/body")
     confirm_selector = options.fetch(:admin, !Decidim.redesign_active) ? ".confirm-modal-content" : "[data-confirm-modal-content]"
+    message = nil
 
     within body do
       message = find(confirm_selector).text

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/confirmation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/confirmation_helpers.rb
@@ -12,13 +12,9 @@ module ConfirmationHelpers
 
     # The test can already be "within", so find the body using xpath
     message = nil
-    body = find(:xpath, "/html/body")
-    confirm_selector = options.fetch(:admin, !Decidim.redesign_active) ? ".confirm-reveal" : "[data-dialog='confirm-modal']"
-
-    within(body.find(confirm_selector)) do
-      message = find(".confirm-modal-content").text
-      find("a.button[data-confirm-ok]").click
-    end
+    confirm_selector = options.fetch(:admin, !Decidim.redesign_active) ? ".confirm-modal-content" : "[data-confirm-modal-content]"
+    message = find(confirm_selector).text
+    find("[data-confirm-ok]").click
 
     message
   end
@@ -33,11 +29,9 @@ module ConfirmationHelpers
 
     # The test can already be "within", so find the body using xpath
     message = nil
-    body = find(:xpath, "/html/body")
-    within(body.find(".confirm-reveal")) do
-      message = find(".confirm-modal-content").text
-      find("a.button[data-confirm-cancel]").click
-    end
+    confirm_selector = options.fetch(:admin, !Decidim.redesign_active) ? ".confirm-modal-content" : "[data-confirm-modal-content]"
+    message = find(confirm_selector).text
+    find("[data-confirm-cancel]").click
 
     message
   end

--- a/decidim-verifications/spec/system/revocation_auths_spec.rb
+++ b/decidim-verifications/spec/system/revocation_auths_spec.rb
@@ -107,7 +107,7 @@ describe "Authorizations revocation flow", type: :system do
     context "when clicking Revoke All authorizations option" do
       it "appears revoke all confirmation dialog" do
         within ".container" do
-          message = dismiss_confirm do
+          message = dismiss_confirm admin: true do
             click_link(t("decidim.admin.menu.authorization_revocation.button"))
           end
           expect(message).to eq(t("decidim.admin.menu.authorization_revocation.destroy.confirm_all"))
@@ -116,7 +116,7 @@ describe "Authorizations revocation flow", type: :system do
 
       it "does not appear revoke before confirmation dialog" do
         within ".container" do
-          message = dismiss_confirm do
+          message = dismiss_confirm admin: true do
             click_link(t("decidim.admin.menu.authorization_revocation.button"))
           end
           expect(message).not_to eq(t("decidim.admin.menu.authorization_revocation.destroy.confirm"))
@@ -127,7 +127,7 @@ describe "Authorizations revocation flow", type: :system do
     context "when clicking Revoke Before Date authorizations option" do
       it "appears revoke before confirmation dialog" do
         within ".container" do
-          message = dismiss_confirm do
+          message = dismiss_confirm admin: true do
             click_button(t("decidim.admin.menu.authorization_revocation.button_before"))
           end
           expect(message).to eq(t("decidim.admin.menu.authorization_revocation.destroy.confirm"))
@@ -136,7 +136,7 @@ describe "Authorizations revocation flow", type: :system do
 
       it "does not appear revoke all confirmation dialog" do
         within ".container" do
-          message = dismiss_confirm do
+          message = dismiss_confirm admin: true do
             click_button(t("decidim.admin.menu.authorization_revocation.button_before"))
           end
           expect(message).not_to eq(t("decidim.admin.menu.authorization_revocation.destroy.confirm_all"))


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Refactor the confirm modal according to the rest of modals, and remove the Foundation dependency, simplifying the logic just a bit.
This is a technical refactor.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/10871

#### :camera: Screenshots
You can create comments and then remove 'em: https://decidim-redesign.populate.tools/processes/Decidim4Dummies/f/170/proposals/15838

:hearts: Thank you!
