### PR TITLE
Redesign: display a disabled message button in public profile if user blocks th…

### DIFF
--- a/decidim-core/app/cells/decidim/profile_actions_cell.rb
+++ b/decidim-core/app/cells/decidim/profile_actions_cell.rb
@@ -12,6 +12,7 @@ module Decidim
       create_user_group: { icon: "team-line", path: :profile_new_group_path },
       edit_user_group: { icon: "team-line", path: :edit_group_path },
       message: { icon: "mail-send-line", path: :new_conversation_path },
+      disabled_message: { icon: "mail-send-line", options: { html_options: { disabled: true, title: I18n.t("decidim.user_contact_disabled") } } },
       manage_user_group_users: { icon: "user-settings-line", path: :profile_group_members_path },
       manage_user_group_admins: { icon: "user-star-line", path: :profile_group_admins_path },
       invite_user: { icon: "user-add-line", path: :group_invites_path },
@@ -61,7 +62,7 @@ module Decidim
       @actions_keys ||= [].tap do |keys|
         keys << :edit_profile if own_profile?
         keys << :create_user_group if own_profile? && user_groups_enabled?
-        keys << :message if can_contact_user?
+        keys << message_key if can_contact_user?
         keys << :join_user_group if can_join_user_group?
         keys << :leave_user_group if can_leave_group?
       end
@@ -81,6 +82,12 @@ module Decidim
                                      else
                                        []
                                      end
+    end
+
+    def message_key
+      return :message if current_or_new_conversation_path_with(presented_profile).present?
+
+      :disabled_message
     end
 
     def profile_actions
@@ -122,7 +129,7 @@ module Decidim
     end
 
     def can_contact_user?
-      !own_profile? && presented_profile.can_be_contacted? && current_or_new_conversation_path_with(presented_profile).present?
+      !current_user || (current_user && current_user != model && presented_profile.can_be_contacted?)
     end
   end
 end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1355,6 +1355,7 @@ en:
       user:
         actions:
           create_user_group: Create group
+          disabled_message: Message
           edit_profile: Edit profile
           edit_user_group: Edit group profile
           invite_user: Invite participant


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR changes the public profile of a user which blocks direct messages to display a disabled message button instead of hidding it

> There is a test in the legacy design which expects a disabled message link with a muted envelop icon and a text on the profile of users who have muted their direct messages. After the redesign the profile hides the "Message" button. Is this OK or we should add a "muted conversations" indicator in the profile?

#### :pushpin: Related Issues

- Related to #9674

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
