### PR TITLE
Fix error when SVG icon is not available in the file system

### DIFF
--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -139,7 +139,10 @@ module Decidim
       # non-nil because otherwise it will be set to the asset host at
       # ActionView::Helpers::AssetUrlHelper#compute_asset_host.
       img_path = asset_pack_path(path, host: "", protocol: :relative)
-      Rails.public_path.join(img_path.sub(%r{^/}, ""))
+      path = Rails.public_path.join(img_path.sub(%r{^/}, ""))
+      return unless File.exist?(path)
+
+      path
     rescue ::Webpacker::Manifest::MissingEntryError
       nil
     end

--- a/decidim-core/spec/helpers/decidim/layout_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/layout_helper_spec.rb
@@ -23,6 +23,18 @@ module Decidim
         end
       end
 
+      context "when the icon exists in the manifest but not in the file system" do
+        let(:path) { "media/images/google.svg" }
+
+        before do
+          allow(helper).to receive(:asset_pack_path).and_return("/unexisting/path.svg")
+        end
+
+        it "returns nil" do
+          expect(subject).to be_nil
+        end
+      end
+
       context "when using a custom host" do
         let(:path) { "media/images/google.svg" }
 
@@ -57,6 +69,18 @@ module Decidim
 
       context "when the icon does not exist" do
         let(:path) { "media/images/hooli.svg" }
+
+        it "returns nil" do
+          expect(subject).to be_nil
+        end
+      end
+
+      context "when the icon exists in the manifest but not in the file system" do
+        let(:path) { "media/images/google.svg" }
+
+        before do
+          allow(helper).to receive(:asset_pack_path).and_return("/unexisting/path.svg")
+        end
 
         it "returns nil" do
           expect(subject).to be_nil


### PR DESCRIPTION
#### :tophat: What? Why?
Bumped into this error while trying out the redesign sync branch without regenerating the application (i.e. updating the build configurations).

The error was caused by this line trying to read an unexisting path:
https://github.com/decidim/decidim/blob/21bf844a88e2856e6dc9e242884ecc5ede88b69f/decidim-core/app/helpers/decidim/layout_helper.rb#L129

The error is of the following type:
```
ActionView::Template::Error (No such file or directory @ rb_sysopen - /.../decidim/development_app/public/decidim-packs/media/images/decidim-symbol-477ad97e983ccadb2e18.svg):
     8: 
     9:   <body class="text-black text-md form-defaults">
    10:     <!--noindex--><!--googleoff: all-->
    11:     <%= cell("decidim/data_consent", current_organization) %>
    12:     <%= render partial: "layouts/decidim/impersonation_warning" %>
    13:     <%= render partial: "layouts/decidim/omnipresent_banner" %>
    14:     <%= render partial: "layouts/decidim/redesigned_timeout_modal" %>

/.../decidim/decidim-core/app/helpers/decidim/layout_helper.rb:121:in `read'
/.../decidim/decidim-core/app/helpers/decidim/layout_helper.rb:121:in `external_icon'
/.../decidim/decidim-core/app/cells/decidim/data_consent/dialog.erb:4:in `__tilt_123380'
```

#### Testing
Try running the added specs by commenting out the added lines in the layout helper and it should replicate this error.