### PR TITLE
Show only categories with items in data consent modal

### DIFF
--- a/decidim-core/app/cells/decidim/data_consent_cell.rb
+++ b/decidim-core/app/cells/decidim/data_consent_cell.rb
@@ -7,7 +7,9 @@ module Decidim
     end
 
     def categories
-      @categories ||= Decidim.consent_categories.map do |category|
+      @categories ||= Decidim.consent_categories
+                             .select { |category| category.has_key?(:items) }
+                             .map do |category|
         {
           slug: category[:slug],
           title: t("layouts.decidim.data_consent.modal.#{category[:slug]}.title"),

--- a/decidim-core/spec/cells/decidim/data_consent_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/data_consent_cell_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::DataConsentCell, type: :cell do
+  subject { my_cell.call }
+
+  controller Decidim::ApplicationController
+
+  let(:my_cell) { cell("decidim/data_consent") }
+
+  before do
+    allow(Decidim).to receive(:consent_categories).and_return(consent_categories)
+  end
+
+  context "when there are consent categories" do
+    let(:consent_categories) do
+      [
+        { slug: "essential", mandatory: true, items: [{ type: "cookie", name: "_session_id" }] }
+      ]
+    end
+
+    it "renders the cell" do
+      expect(subject).to have_css(".dc-categories")
+      expect(subject).to have_content "Essential"
+      expect(subject).to have_content "These cookies enable key functionality of the website and help to keep its users secured"
+      expect(subject).to have_content "_session_id"
+    end
+  end
+
+  context "when the consent categories do not have irems" do
+    let(:consent_categories) do
+      [
+        { slug: "essential", mandatory: true, items: [{ type: "cookie", name: "_session_id" }] },
+        { slug: "preferences", mandatory: false }
+      ]
+    end
+
+    it "renders the cell with the categories with items" do
+      expect(subject).to have_css(".dc-categories")
+      expect(subject).to have_content "Essential"
+      expect(subject).to have_content "These cookies enable key functionality of the website and help to keep its users secured"
+      expect(subject).to have_content "_session_id"
+
+      expect(subject).not_to have_content "Preferences"
+    end
+  end
+end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

On a default installation, we provide some categories for the Data consent modal. Sometimes you don't need to configure any of these, but even though there isn't any defined items on them, you still see them and can accept those categories. 

This PR changes this behavior and only shows the categories that actually have defined items on them. 

#### :pushpin: Related Issues
 
- Related to #9271 

#### Testing

1. Delete the "decidim-consent" cookie in your browser for the data consent acceptance
2. See the modal


### :camera: Screenshots

#### Before

![Screenshot of the cookie modal with categories without items](https://github.com/decidim/decidim/assets/717367/b403f239-c302-4a23-b35e-da567a0946ff)


#### After
![Screenshot of the cookie modal without categories without items](https://github.com/decidim/decidim/assets/717367/6c448e65-1b5e-4f3b-913c-4dbdbb12b5d1)



:hearts: Thank you!
