### PR TITLE
Redesign: remove font-bold from breadcrumb

### DIFF
--- a/decidim-core/app/views/layouts/decidim/header/_redesigned_menu_breadcrumb_items.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_redesigned_menu_breadcrumb_items.html.erb
@@ -4,7 +4,7 @@
   <% if item[:dropdown_cell].present? %>
     <div class="relative">
       <div class="flex items-center" <%== 'aria-current="page"' if item[:active] %>>
-        <%= link_to item[:url], class: "menu-bar__breadcrumb-desktop__dropdown-trigger#{" font-bold" if item[:active]}" do %>
+        <%= link_to item[:url], class: "menu-bar__breadcrumb-desktop__dropdown-trigger" do %>
           <%= item_label %>
         <% end %>
         <button id="secondary-dropdown-summary"
@@ -21,9 +21,9 @@
       </div>
     </div>
   <% else %>
-    <%= link_to_if(item[:url].present? && !is_active_link?(item[:url], :exclusive), item_label, item[:url], class:"menu-bar__breadcrumb-desktop__dropdown-trigger#{' font-bold' if item[:active]}", "aria-current": (item[:active] ? "page" : nil)) do %>
+    <%= link_to_if(item[:url].present? && !is_active_link?(item[:url], :exclusive), item_label, item[:url], class:"menu-bar__breadcrumb-desktop__dropdown-trigger", "aria-current": (item[:active] ? "page" : nil)) do %>
       <%# alternative template %>
-      <%= content_tag :span, item_label, class:"menu-bar__breadcrumb-desktop__dropdown-trigger no-interactive#{' font-bold' if item[:active]}", tabindex: "0", "aria-current": "page" if item[:active] %>
+      <%= content_tag :span, item_label, class:"menu-bar__breadcrumb-desktop__dropdown-trigger no-interactive", tabindex: "0", "aria-current": "page" if item[:active] %>
     <% end %>
   <% end %>
 <% end %>

--- a/decidim-core/app/views/layouts/decidim/header/_redesigned_menu_breadcrumb_mobile_tablet.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_redesigned_menu_breadcrumb_mobile_tablet.html.erb
@@ -6,7 +6,7 @@
       <% if i.positive? %>
         <span>/</span>
       <% end %>
-      <span class="cursor-pointer <%= "truncate" if i.positive? %> <%= "font-bold" if item[:active] %>" <%== 'aria-current="page"' if item[:active] %>>
+      <span class="cursor-pointer <%= "truncate" if i.positive? %>" <%== 'aria-current="page"' if item[:active] %>>
         <% if item[:url].present? && !is_active_link?(item[:url], :exclusive) %>
           <%= link_to(item_label, item[:url]) %>
         <% else %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Don't highlight the elements of the breacrumb

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/10962

:hearts: Thank you!
