### PR TITLE
Fix for sending welcome emails for new participants

### DIFF
--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -293,7 +293,8 @@ module Decidim
         event: "decidim.events.core.welcome_notification",
         event_class: WelcomeNotificationEvent,
         resource: self,
-        affected_users: [self]
+        affected_users: [self],
+        extra: { force_email: true }
       )
     end
 

--- a/decidim-core/app/services/decidim/email_notification_generator.rb
+++ b/decidim-core/app/services/decidim/email_notification_generator.rb
@@ -63,7 +63,7 @@ module Decidim
     # Returns nothing.
     def send_email_to(recipient, user_role:)
       return unless recipient
-      return unless recipient.notifications_sending_frequency == "real_time"
+      return unless should_send_email?(recipient)
       return if resource.respond_to?(:can_participate?) && !resource.can_participate?(recipient)
 
       wait_time = 0
@@ -79,6 +79,12 @@ module Decidim
           extra
         )
         .deliver_later(wait: wait_time)
+    end
+
+    def should_send_email?(recipient)
+      return extra[:force_email] if extra.has_key?(:force_email)
+
+      recipient.notifications_sending_frequency == "real_time"
     end
 
     def component


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

Reviewing old PRs, I found that the welcome email feature wasn't working with the introduction of digest emails (see #8486). @arusa explained it really well in #10470:

> 10 Months ago there was a check added, that only allows notification mails to be sent to users with notifications_sending_frequency == "real_time"
> 
> The problem with that is, that in decidim 0.27 new users don't get any welcome notification mails anymore, because new users by default have notifications_sending_frequency set as "daily".
> 
> I just commented out the line that breaks welcome mails for my decidim installation.
> 
> A better fix would probably be to make an exception for the event "decidim.events.core.welcome_notification".

Then @ahukkanen explained how to approach this exception change in a [comment](https://github.com/decidim/decidim/pull/10470#issuecomment-1457829899), and as its a PR that's without much movement, it's an ongoing bug on the last release, and we already have the code, I went ahead and do it 😄  

Thanks both of you for detecting and telling how to fix this! 👏🏽 👏🏽 

#### :pushpin: Related Issues

- Related to #10470

#### Testing

1. Create a new user
2. Confirm their account on /letter_opener
3. See the welcome email 

### :camera: Screenshots
 
![Screenshot of the welcome email in letter opener](https://github.com/decidim/decidim/assets/717367/c927d3e5-bea0-4e35-85ca-09b7dcd501f2)

:hearts: Thank you!
