### PR TITLE
Backport 'Fix error when SVG icon is not available in the file system' to v0.27

### DIFF
--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -105,7 +105,10 @@ module Decidim
       # non-nil because otherwise it will be set to the asset host at
       # ActionView::Helpers::AssetUrlHelper#compute_asset_host.
       img_path = asset_pack_path(path, host: "", protocol: :relative)
-      Rails.public_path.join(img_path.sub(%r{^/}, ""))
+      path = Rails.public_path.join(img_path.sub(%r{^/}, ""))
+      return unless File.exist?(path)
+
+      path
     rescue ::Webpacker::Manifest::MissingEntryError
       nil
     end

--- a/decidim-core/spec/helpers/decidim/layout_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/layout_helper_spec.rb
@@ -23,6 +23,18 @@ module Decidim
         end
       end
 
+      context "when the icon exists in the manifest but not in the file system" do
+        let(:path) { "media/images/google.svg" }
+
+        before do
+          allow(helper).to receive(:asset_pack_path).and_return("/unexisting/path.svg")
+        end
+
+        it "returns nil" do
+          expect(subject).to be_nil
+        end
+      end
+
       context "when using a custom host" do
         let(:path) { "media/images/google.svg" }
 
@@ -57,6 +69,18 @@ module Decidim
 
       context "when the icon does not exist" do
         let(:path) { "media/images/hooli.svg" }
+
+        it "returns nil" do
+          expect(subject).to be_nil
+        end
+      end
+
+      context "when the icon exists in the manifest but not in the file system" do
+        let(:path) { "media/images/google.svg" }
+
+        before do
+          allow(helper).to receive(:asset_pack_path).and_return("/unexisting/path.svg")
+        end
 
         it "returns nil" do
           expect(subject).to be_nil


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #10988 to v0.27

:hearts: Thank you!