### PR TITLE
Redesign: scopes picker

### DIFF
--- a/decidim-core/app/helpers/decidim/scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/scopes_helper.rb
@@ -40,6 +40,21 @@ module Decidim
     # Returns nothing.
     def scopes_picker_field(form, name, root: false, options: { checkboxes_on_top: true })
       root = try(:current_participatory_space)&.scope if root == false
+
+      form.scopes_picker name, options do |scope|
+        { url: decidim.scopes_picker_path(root:, current: scope&.id, field: form.label_for(name)),
+          text: scope_name_for_picker(scope, I18n.t("decidim.scopes.global")) }
+      end
+    end
+
+    # Renders a scopes select field in a form.
+    # form - FormBuilder object
+    # name - attribute name
+    # options       - An optional Hash with options:
+    #
+    # Returns nothing.
+    def scopes_select_field(form, name, root: false, options: {})
+      root = try(:current_participatory_space)&.scope if root == false
       ordered_descendants = if root.present?
                               root.descendants
                             else
@@ -51,11 +66,6 @@ module Decidim
         ordered_descendants.map { |scope| [" #{"-" * (scope.part_of.count - 1)} #{translated_attribute(scope.name)}", scope&.id] },
         options.merge(include_blank: I18n.t("decidim.scopes.prompt"))
       )
-
-      # form.scopes_picker name, options do |scope|
-      #   { url: decidim.scopes_picker_path(root:, current: scope&.id, field: form.label_for(name)),
-      #     text: scope_name_for_picker(scope, I18n.t("decidim.scopes.global")) }
-      # end
     end
 
     # Renders a scopes picker field in a form, not linked to a specific model.

--- a/decidim-core/app/helpers/decidim/scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/scopes_helper.rb
@@ -63,7 +63,7 @@ module Decidim
 
       form.select(
         name,
-        ordered_descendants.map { |scope| [" #{"-" * (scope.part_of.count - 1)} #{translated_attribute(scope.name)}", scope&.id] },
+        ordered_descendants.map { |scope| [" #{"&nbsp;" * 4 * (scope.part_of.count - 1)} #{translated_attribute(scope.name)}".html_safe, scope&.id] },
         options.merge(include_blank: I18n.t("decidim.scopes.prompt"))
       )
     end

--- a/decidim-core/app/helpers/decidim/scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/scopes_helper.rb
@@ -40,10 +40,22 @@ module Decidim
     # Returns nothing.
     def scopes_picker_field(form, name, root: false, options: { checkboxes_on_top: true })
       root = try(:current_participatory_space)&.scope if root == false
-      form.scopes_picker name, options do |scope|
-        { url: decidim.scopes_picker_path(root:, current: scope&.id, field: form.label_for(name)),
-          text: scope_name_for_picker(scope, I18n.t("decidim.scopes.global")) }
-      end
+      ordered_descendants = if root.present?
+                              root.descendants
+                            else
+                              current_organization.scopes
+                            end.sort { |a, b| a.part_of.reverse <=> b.part_of.reverse }
+
+      form.select(
+        name,
+        ordered_descendants.map { |scope| [" #{"-" * (scope.part_of.count - 1)} #{translated_attribute(scope.name)}", scope&.id] },
+        options.merge(include_blank: I18n.t("decidim.scopes.prompt"))
+      )
+
+      # form.scopes_picker name, options do |scope|
+      #   { url: decidim.scopes_picker_path(root:, current: scope&.id, field: form.label_for(name)),
+      #     text: scope_name_for_picker(scope, I18n.t("decidim.scopes.global")) }
+      # end
     end
 
     # Renders a scopes picker field in a form, not linked to a specific model.

--- a/decidim-debates/app/views/decidim/debates/debates/_form.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_form.html.erb
@@ -3,7 +3,7 @@
   <%= text_editor_for_debate_description(form) %>
 
   <% if current_component.has_subscopes? %>
-    <%= scopes_picker_field form, :scope_id, root: current_component.scope %>
+    <%= scopes_select_field form, :scope_id, root: current_component.scope %>
   <% end %>
 
   <% if current_participatory_space.categories&.any? %>

--- a/decidim-debates/spec/system/user_edits_debate_spec.rb
+++ b/decidim-debates/spec/system/user_edits_debate_spec.rb
@@ -41,6 +41,7 @@ describe "User edits a debate", type: :system do
         fill_in :debate_description, with: "Add your comments on whether Decidim is useful for every organization."
         # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
         # scope_pick scope_picker, scope
+        select translated(scope.name), from: :debate_scope_id
         select translated(category.name), from: :debate_category_id
 
         find("*[type=submit]").click
@@ -50,7 +51,7 @@ describe "User edits a debate", type: :system do
       expect(page).to have_content("Should every organization use Decidim?")
       expect(page).to have_content("Add your comments on whether Decidim is useful for every organization.")
       # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-      # expect(page).to have_content(translated(scope.name))
+      expect(page).to have_content(translated(scope.name))
       expect(page).to have_content(translated(category.name))
       expect(page).to have_selector("[data-author]", text: user.name)
     end
@@ -78,6 +79,7 @@ describe "User edits a debate", type: :system do
           fill_in :debate_description, with: "Add your comment on whether Decidim is useful for every organization."
           # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
           # scope_pick scope_picker, scope
+          select translated(scope.name), from: :debate_scope_id
           select translated(category.name), from: :debate_category_id
 
           find("*[type=submit]").click
@@ -87,7 +89,7 @@ describe "User edits a debate", type: :system do
         expect(page).to have_content("Should every organization use Decidim?")
         expect(page).to have_content("Add your comment on whether Decidim is useful for every organization.")
         # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-        # expect(page).to have_content(translated(scope.name))
+        expect(page).to have_content(translated(scope.name))
         expect(page).to have_content(translated(category.name))
         expect(page).to have_selector("[data-author]", text: user_group.name)
       end

--- a/decidim-debates/spec/system/user_edits_debate_spec.rb
+++ b/decidim-debates/spec/system/user_edits_debate_spec.rb
@@ -39,8 +39,6 @@ describe "User edits a debate", type: :system do
       within ".edit_debate" do
         fill_in :debate_title, with: "Should every organization use Decidim?"
         fill_in :debate_description, with: "Add your comments on whether Decidim is useful for every organization."
-        # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-        # scope_pick scope_picker, scope
         select translated(scope.name), from: :debate_scope_id
         select translated(category.name), from: :debate_category_id
 
@@ -50,7 +48,6 @@ describe "User edits a debate", type: :system do
       expect(page).to have_content("successfully")
       expect(page).to have_content("Should every organization use Decidim?")
       expect(page).to have_content("Add your comments on whether Decidim is useful for every organization.")
-      # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
       expect(page).to have_content(translated(scope.name))
       expect(page).to have_content(translated(category.name))
       expect(page).to have_selector("[data-author]", text: user.name)
@@ -77,8 +74,6 @@ describe "User edits a debate", type: :system do
         within ".edit_debate" do
           fill_in :debate_title, with: "Should every organization use Decidim?"
           fill_in :debate_description, with: "Add your comment on whether Decidim is useful for every organization."
-          # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-          # scope_pick scope_picker, scope
           select translated(scope.name), from: :debate_scope_id
           select translated(category.name), from: :debate_category_id
 
@@ -88,7 +83,6 @@ describe "User edits a debate", type: :system do
         expect(page).to have_content("successfully")
         expect(page).to have_content("Should every organization use Decidim?")
         expect(page).to have_content("Add your comment on whether Decidim is useful for every organization.")
-        # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
         expect(page).to have_content(translated(scope.name))
         expect(page).to have_content(translated(category.name))
         expect(page).to have_selector("[data-author]", text: user_group.name)

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_form.html.erb
@@ -59,7 +59,7 @@
 
 <% if current_participatory_space.has_subscopes? %>
   <div class="field">
-    <%= scopes_picker_field form, :decidim_scope_id %>
+    <%= scopes_select_field form, :decidim_scope_id %>
   </div>
 <% end %>
 

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -96,8 +96,6 @@ describe "User creates meeting", type: :system do
             fill_in :meeting_end_time, with: meeting_end_time.strftime(datetime_format)
             select "Registration disabled", from: :meeting_registration_type
             select translated(category.name), from: :meeting_decidim_category_id
-            # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-            # scope_pick select_data_picker(:meeting_decidim_scope_id), meeting_scope
             select translated(meeting_scope.name), from: :meeting_decidim_scope_id
 
             find("*[type=submit]").click
@@ -107,7 +105,6 @@ describe "User creates meeting", type: :system do
           expect(page).to have_content(meeting_title)
           expect(page).to have_content(meeting_description)
           expect(page).to have_content(translated(category.name))
-          # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
           expect(page).to have_content(translated(meeting_scope.name))
           expect(page).to have_content(meeting_address)
           expect(page).to have_content(meeting_start_time.strftime(time_format))
@@ -163,8 +160,6 @@ describe "User creates meeting", type: :system do
               fill_in :meeting_end_time, with: meeting_end_time.strftime(datetime_format)
               select "Registration disabled", from: :meeting_registration_type
               select translated(category.name), from: :meeting_decidim_category_id
-              # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-              # scope_pick select_data_picker(:meeting_decidim_scope_id), meeting_scope
               select translated(meeting_scope.name), from: :meeting_decidim_scope_id
               select user_group.name, from: :meeting_user_group_id
 
@@ -175,7 +170,6 @@ describe "User creates meeting", type: :system do
             expect(page).to have_content(meeting_title)
             expect(page).to have_content(meeting_description)
             expect(page).to have_content(translated(category.name))
-            # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
             expect(page).to have_content(translated(meeting_scope.name))
             expect(page).to have_content(meeting_address)
             expect(page).to have_content(meeting_start_time.strftime(time_format))
@@ -204,8 +198,6 @@ describe "User creates meeting", type: :system do
               fill_in :meeting_available_slots, with: meeting_available_slots
               fill_in :meeting_registration_terms, with: meeting_registration_terms
               select translated(category.name), from: :meeting_decidim_category_id
-              # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-              # scope_pick select_data_picker(:meeting_decidim_scope_id), meeting_scope
               select translated(meeting_scope.name), from: :meeting_decidim_scope_id
               select user_group.name, from: :meeting_user_group_id
 
@@ -216,7 +208,6 @@ describe "User creates meeting", type: :system do
             expect(page).to have_content(meeting_title)
             expect(page).to have_content(meeting_description)
             expect(page).to have_content(translated(category.name))
-            # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
             expect(page).to have_content(translated(meeting_scope.name))
             expect(page).to have_content(meeting_address)
             expect(page).to have_content(meeting_start_time.strftime(time_format))

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -96,9 +96,9 @@ describe "User creates meeting", type: :system do
             fill_in :meeting_end_time, with: meeting_end_time.strftime(datetime_format)
             select "Registration disabled", from: :meeting_registration_type
             select translated(category.name), from: :meeting_decidim_category_id
-            # REDESIGN_PENDING - Uncomment / adapt the next line after completing
-            # redesign of data picker of scope
+            # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
             # scope_pick select_data_picker(:meeting_decidim_scope_id), meeting_scope
+            select translated(meeting_scope.name), from: :meeting_decidim_scope_id
 
             find("*[type=submit]").click
           end
@@ -107,9 +107,8 @@ describe "User creates meeting", type: :system do
           expect(page).to have_content(meeting_title)
           expect(page).to have_content(meeting_description)
           expect(page).to have_content(translated(category.name))
-          # REDESIGN_PENDING - Uncomment / adapt the next line after completing
-          # redesign of data picker of scope
-          # expect(page).to have_content(translated(meeting_scope.name))
+          # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
+          expect(page).to have_content(translated(meeting_scope.name))
           expect(page).to have_content(meeting_address)
           expect(page).to have_content(meeting_start_time.strftime(time_format))
           expect(page).to have_content(meeting_end_time.strftime(time_format))
@@ -164,9 +163,9 @@ describe "User creates meeting", type: :system do
               fill_in :meeting_end_time, with: meeting_end_time.strftime(datetime_format)
               select "Registration disabled", from: :meeting_registration_type
               select translated(category.name), from: :meeting_decidim_category_id
-              # REDESIGN_PENDING - Uncomment / adapt the next line after completing
-              # redesign of data picker of scope
+              # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
               # scope_pick select_data_picker(:meeting_decidim_scope_id), meeting_scope
+              select translated(meeting_scope.name), from: :meeting_decidim_scope_id
               select user_group.name, from: :meeting_user_group_id
 
               find("*[type=submit]").click
@@ -176,9 +175,8 @@ describe "User creates meeting", type: :system do
             expect(page).to have_content(meeting_title)
             expect(page).to have_content(meeting_description)
             expect(page).to have_content(translated(category.name))
-            # REDESIGN_PENDING - Uncomment / adapt the next line after completing
-            # redesign of data picker of scope
-            # expect(page).to have_content(translated(meeting_scope.name))
+            # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
+            expect(page).to have_content(translated(meeting_scope.name))
             expect(page).to have_content(meeting_address)
             expect(page).to have_content(meeting_start_time.strftime(time_format))
             expect(page).to have_content(meeting_end_time.strftime(time_format))
@@ -206,9 +204,9 @@ describe "User creates meeting", type: :system do
               fill_in :meeting_available_slots, with: meeting_available_slots
               fill_in :meeting_registration_terms, with: meeting_registration_terms
               select translated(category.name), from: :meeting_decidim_category_id
-              # REDESIGN_PENDING - Uncomment / adapt the next line after completing
-              # redesign of data picker of scope
+              # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
               # scope_pick select_data_picker(:meeting_decidim_scope_id), meeting_scope
+              select translated(meeting_scope.name), from: :meeting_decidim_scope_id
               select user_group.name, from: :meeting_user_group_id
 
               find("*[type=submit]").click
@@ -218,9 +216,8 @@ describe "User creates meeting", type: :system do
             expect(page).to have_content(meeting_title)
             expect(page).to have_content(meeting_description)
             expect(page).to have_content(translated(category.name))
-            # REDESIGN_PENDING - Uncomment / adapt the next line after completing
-            # redesign of data picker of scope
-            # expect(page).to have_content(translated(meeting_scope.name))
+            # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
+            expect(page).to have_content(translated(meeting_scope.name))
             expect(page).to have_content(meeting_address)
             expect(page).to have_content(meeting_start_time.strftime(time_format))
             expect(page).to have_content(meeting_end_time.strftime(time_format))

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -60,7 +60,7 @@ describe "User creates meeting", type: :system do
         let(:meeting_available_slots) { 30 }
         let(:meeting_registration_terms) { "These are the registration terms for this meeting" }
         let(:online_meeting_url) { "http://decidim.org" }
-        let(:meeting_scope) { create :scope, organization: }
+        let!(:meeting_scope) { create :scope, organization: }
         let(:datetime_format) { I18n.t("time.formats.decidim_short") }
         let(:time_format) { I18n.t("time.formats.time_of_day") }
 

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_edit_form_fields.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_edit_form_fields.html.erb
@@ -29,7 +29,7 @@
 <% end %>
 
 <% if current_component.has_subscopes? %>
-  <%= scopes_picker_field form, :scope_id, root: current_component.scope %>
+  <%= scopes_select_field form, :scope_id, root: current_component.scope %>
 <% end %>
 
 <% if component_settings.attachments_allowed? %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -34,7 +34,7 @@
 <% end %>
 
 <% if current_component.has_subscopes? %>
-  <%= scopes_picker_field form, :scope_id, root: current_component.scope %>
+  <%= scopes_select_field form, :scope_id, root: current_component.scope %>
 <% end %>
 
 <% if component_settings.attachments_allowed? && @proposal %>

--- a/decidim-proposals/spec/system/collaborative_drafts_fields_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_fields_spec.rb
@@ -78,8 +78,6 @@ describe "Collaborative drafts", type: :system do
             fill_in :collaborative_draft_title, with: "More sidewalks and less roads"
             fill_in :collaborative_draft_body, with: "Cities need more people, not more cars"
             select translated(category.name), from: :collaborative_draft_category_id
-            # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-            # scope_pick scope_picker, scope
             select translated(scope.name), from: :collaborative_draft_scope_id
 
             find("*[type=submit]").click
@@ -89,7 +87,6 @@ describe "Collaborative drafts", type: :system do
           expect(page).to have_content("More sidewalks and less roads")
           expect(page).to have_content("Cities need more people, not more cars")
           expect(page).to have_content(translated(category.name))
-          # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
           expect(page).to have_content(translated(scope.name))
           expect(page).to have_author(user.name)
         end
@@ -144,8 +141,6 @@ describe "Collaborative drafts", type: :system do
               fill_in :collaborative_draft_body, with: "Cities need more people, not more cars"
               fill_in_geocoding :collaborative_draft_address, with: address
               select translated(category.name), from: :collaborative_draft_category_id
-              # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-              # scope_pick scope_picker, scope
               select translated(scope.name), from: :collaborative_draft_scope_id
 
               find("*[type=submit]").click
@@ -156,7 +151,6 @@ describe "Collaborative drafts", type: :system do
             expect(page).to have_content("Cities need more people, not more cars")
             expect(page).to have_content(address)
             expect(page).to have_content(translated(category.name))
-            # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
             expect(page).to have_content(translated(scope.name))
             expect(page).to have_author(user.name)
           end
@@ -238,8 +232,6 @@ describe "Collaborative drafts", type: :system do
               fill_in :collaborative_draft_title, with: "More sidewalks and less roads"
               fill_in :collaborative_draft_body, with: "Cities need more people, not more cars"
               select translated(category.name), from: :collaborative_draft_category_id
-              # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-              # scope_pick scope_picker, scope
               select translated(scope.name), from: :collaborative_draft_scope_id
               select user_group.name, from: :collaborative_draft_user_group_id
 
@@ -250,7 +242,6 @@ describe "Collaborative drafts", type: :system do
             expect(page).to have_content("More sidewalks and less roads")
             expect(page).to have_content("Cities need more people, not more cars")
             expect(page).to have_content(translated(category.name))
-            # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
             expect(page).to have_content(translated(scope.name))
             expect(page).to have_author(user_group.name)
           end
@@ -277,8 +268,6 @@ describe "Collaborative drafts", type: :system do
                 fill_in :collaborative_draft_body, with: "Cities need more people, not more cars"
                 fill_in :collaborative_draft_address, with: address
                 select translated(category.name), from: :collaborative_draft_category_id
-                # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-                # scope_pick scope_picker, scope
                 select translated(scope.name), from: :collaborative_draft_scope_id
                 select user_group.name, from: :collaborative_draft_user_group_id
 
@@ -290,7 +279,6 @@ describe "Collaborative drafts", type: :system do
               expect(page).to have_content("Cities need more people, not more cars")
               expect(page).to have_content(address)
               expect(page).to have_content(translated(category.name))
-              # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
               expect(page).to have_content(translated(scope.name))
               expect(page).to have_author(user_group.name)
             end

--- a/decidim-proposals/spec/system/collaborative_drafts_fields_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_fields_spec.rb
@@ -80,6 +80,7 @@ describe "Collaborative drafts", type: :system do
             select translated(category.name), from: :collaborative_draft_category_id
             # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
             # scope_pick scope_picker, scope
+            select translated(scope.name), from: :collaborative_draft_scope_id
 
             find("*[type=submit]").click
           end
@@ -89,7 +90,7 @@ describe "Collaborative drafts", type: :system do
           expect(page).to have_content("Cities need more people, not more cars")
           expect(page).to have_content(translated(category.name))
           # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-          # expect(page).to have_content(translated(scope.name))
+          expect(page).to have_content(translated(scope.name))
           expect(page).to have_author(user.name)
         end
 
@@ -145,6 +146,7 @@ describe "Collaborative drafts", type: :system do
               select translated(category.name), from: :collaborative_draft_category_id
               # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
               # scope_pick scope_picker, scope
+              select translated(scope.name), from: :collaborative_draft_scope_id
 
               find("*[type=submit]").click
             end
@@ -155,7 +157,7 @@ describe "Collaborative drafts", type: :system do
             expect(page).to have_content(address)
             expect(page).to have_content(translated(category.name))
             # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-            # expect(page).to have_content(translated(scope.name))
+            expect(page).to have_content(translated(scope.name))
             expect(page).to have_author(user.name)
           end
 
@@ -238,6 +240,7 @@ describe "Collaborative drafts", type: :system do
               select translated(category.name), from: :collaborative_draft_category_id
               # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
               # scope_pick scope_picker, scope
+              select translated(scope.name), from: :collaborative_draft_scope_id
               select user_group.name, from: :collaborative_draft_user_group_id
 
               find("*[type=submit]").click
@@ -248,7 +251,7 @@ describe "Collaborative drafts", type: :system do
             expect(page).to have_content("Cities need more people, not more cars")
             expect(page).to have_content(translated(category.name))
             # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-            # expect(page).to have_content(translated(scope.name))
+            expect(page).to have_content(translated(scope.name))
             expect(page).to have_author(user_group.name)
           end
 
@@ -276,6 +279,7 @@ describe "Collaborative drafts", type: :system do
                 select translated(category.name), from: :collaborative_draft_category_id
                 # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
                 # scope_pick scope_picker, scope
+                select translated(scope.name), from: :collaborative_draft_scope_id
                 select user_group.name, from: :collaborative_draft_user_group_id
 
                 find("*[type=submit]").click
@@ -287,7 +291,7 @@ describe "Collaborative drafts", type: :system do
               expect(page).to have_content(address)
               expect(page).to have_content(translated(category.name))
               # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-              # expect(page).to have_content(translated(scope.name))
+              expect(page).to have_content(translated(scope.name))
               expect(page).to have_author(user_group.name)
             end
           end

--- a/decidim-proposals/spec/system/proposals_fields_spec.rb
+++ b/decidim-proposals/spec/system/proposals_fields_spec.rb
@@ -75,8 +75,6 @@ describe "Proposals", type: :system do
             fill_in :proposal_title, with: "More sidewalks and less roads"
             fill_in :proposal_body, with: "Cities need more people, not more cars"
             select translated(category.name), from: :proposal_category_id
-            # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-            # scope_pick scope_picker, scope
             select translated(scope.name), from: :proposal_scope_id
 
             find("*[type=submit]").click
@@ -91,7 +89,6 @@ describe "Proposals", type: :system do
           expect(page).to have_content("More sidewalks and less roads")
           expect(page).to have_content("Cities need more people, not more cars")
           expect(page).to have_content(translated(category.name))
-          # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
           expect(page).to have_content(translated(scope.name))
           expect(page).to have_author(user.name)
         end
@@ -124,8 +121,6 @@ describe "Proposals", type: :system do
               expect(page).to have_content("You can move the point on the map.")
 
               select translated(category.name), from: :proposal_category_id
-              # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-              # scope_pick scope_picker, scope
               select translated(scope.name), from: :proposal_scope_id
 
               find("*[type=submit]").click
@@ -142,7 +137,6 @@ describe "Proposals", type: :system do
             expect(page).to have_content("Cities need more people, not more cars")
             expect(page).to have_content(address)
             expect(page).to have_content(translated(category.name))
-            # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
             expect(page).to have_content(translated(scope.name))
             expect(page).to have_author(user.name)
           end
@@ -215,8 +209,6 @@ describe "Proposals", type: :system do
               fill_in :proposal_title, with: "More sidewalks and less roads"
               fill_in :proposal_body, with: "Cities need more people, not more cars"
               select translated(category.name), from: :proposal_category_id
-              # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-              # scope_pick scope_picker, scope
               select translated(scope.name), from: :proposal_scope_id
               select user_group.name, from: :proposal_user_group_id
 
@@ -229,7 +221,6 @@ describe "Proposals", type: :system do
             expect(page).to have_content("More sidewalks and less roads")
             expect(page).to have_content("Cities need more people, not more cars")
             expect(page).to have_content(translated(category.name))
-            # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
             expect(page).to have_content(translated(scope.name))
             expect(page).to have_author(user_group.name)
           end
@@ -257,8 +248,6 @@ describe "Proposals", type: :system do
                 fill_in :proposal_body, with: "Cities need more people, not more cars"
                 fill_in :proposal_address, with: address
                 select translated(category.name), from: :proposal_category_id
-                # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-                # scope_pick scope_picker, scope
                 select translated(scope.name), from: :proposal_scope_id
                 select user_group.name, from: :proposal_user_group_id
 
@@ -272,7 +261,6 @@ describe "Proposals", type: :system do
               expect(page).to have_content("Cities need more people, not more cars")
               expect(page).to have_content(address)
               expect(page).to have_content(translated(category.name))
-              # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
               expect(page).to have_content(translated(scope.name))
               expect(page).to have_author(user_group.name)
             end

--- a/decidim-proposals/spec/system/proposals_fields_spec.rb
+++ b/decidim-proposals/spec/system/proposals_fields_spec.rb
@@ -77,6 +77,7 @@ describe "Proposals", type: :system do
             select translated(category.name), from: :proposal_category_id
             # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
             # scope_pick scope_picker, scope
+            select translated(scope.name), from: :proposal_scope_id
 
             find("*[type=submit]").click
           end
@@ -91,7 +92,7 @@ describe "Proposals", type: :system do
           expect(page).to have_content("Cities need more people, not more cars")
           expect(page).to have_content(translated(category.name))
           # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-          # expect(page).to have_content(translated(scope.name))
+          expect(page).to have_content(translated(scope.name))
           expect(page).to have_author(user.name)
         end
 
@@ -125,6 +126,7 @@ describe "Proposals", type: :system do
               select translated(category.name), from: :proposal_category_id
               # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
               # scope_pick scope_picker, scope
+              select translated(scope.name), from: :proposal_scope_id
 
               find("*[type=submit]").click
             end
@@ -141,7 +143,7 @@ describe "Proposals", type: :system do
             expect(page).to have_content(address)
             expect(page).to have_content(translated(category.name))
             # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-            # expect(page).to have_content(translated(scope.name))
+            expect(page).to have_content(translated(scope.name))
             expect(page).to have_author(user.name)
           end
 
@@ -215,6 +217,7 @@ describe "Proposals", type: :system do
               select translated(category.name), from: :proposal_category_id
               # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
               # scope_pick scope_picker, scope
+              select translated(scope.name), from: :proposal_scope_id
               select user_group.name, from: :proposal_user_group_id
 
               find("*[type=submit]").click
@@ -227,7 +230,7 @@ describe "Proposals", type: :system do
             expect(page).to have_content("Cities need more people, not more cars")
             expect(page).to have_content(translated(category.name))
             # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-            # expect(page).to have_content(translated(scope.name))
+            expect(page).to have_content(translated(scope.name))
             expect(page).to have_author(user_group.name)
           end
 
@@ -256,6 +259,7 @@ describe "Proposals", type: :system do
                 select translated(category.name), from: :proposal_category_id
                 # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
                 # scope_pick scope_picker, scope
+                select translated(scope.name), from: :proposal_scope_id
                 select user_group.name, from: :proposal_user_group_id
 
                 find("*[type=submit]").click
@@ -269,7 +273,7 @@ describe "Proposals", type: :system do
               expect(page).to have_content(address)
               expect(page).to have_content(translated(category.name))
               # REDESIGN_PENDING - scope picker is pending https://github.com/decidim/decidim/issues/10192
-              # expect(page).to have_content(translated(scope.name))
+              expect(page).to have_content(translated(scope.name))
               expect(page).to have_author(user_group.name)
             end
           end
@@ -289,7 +293,7 @@ describe "Proposals", type: :system do
           end
 
           it "shows a modal dialog" do
-            skip "REDESIGN_PENDING - The upload feature has to be simplified in redesign and multiple files upload fails"
+            # skip "REDESIGN_PENDING - The upload feature has to be simplified in redesign and multiple files upload fails"
 
             visit_component
             click_link "New proposal"
@@ -309,7 +313,7 @@ describe "Proposals", type: :system do
           let(:proposal_draft) { create(:proposal, :draft, users: [user], component:, title: "Proposal with attachments", body: "This is my proposal and I want to upload attachments.") }
 
           it "creates a new proposal with attachments" do
-            skip "REDESIGN_PENDING - The upload feature has to be simplified in redesign and multiple files upload fails"
+            # skip "REDESIGN_PENDING - The upload feature has to be simplified in redesign and multiple files upload fails"
 
             visit complete_proposal_path(component, proposal_draft)
 

--- a/decidim-verifications/app/views/dummy_authorization/_form.html.erb
+++ b/decidim-verifications/app/views/dummy_authorization/_form.html.erb
@@ -13,9 +13,10 @@
   <%= form.text_field :postal_code %>
   <%= form.date_field :birthday %>
 
-  <%# REDESIGN_PENDING: requires the modal implementation %>
-  <%= form.scopes_picker :scope_id, {} do |scope|
-      { url: decidim.scopes_picker_path(root: nil, current: form.object.scope_id, field: form.label_for(:scope_id)),
-        text: scope_name_for_picker(form.object.scope, I18n.t("decidim.scopes.global")) }
-    end %>
+  <%# REDESIGN_PENDING:  https://github.com/decidim/decidim/issues/10192 %>
+  <%= scopes_select_field(form, :scope_id) %>
+  <%# <%= form.scopes_picker :scope_id, {} do |scope| %>
+  <%#     { url: decidim.scopes_picker_path(root: nil, current: form.object.scope_id, field: form.label_for(:scope_id)), %>
+  <%#       text: scope_name_for_picker(form.object.scope, I18n.t("decidim.scopes.global")) } %>
+  <%#   end %1> %>
 </div>

--- a/decidim-verifications/app/views/dummy_authorization/_form.html.erb
+++ b/decidim-verifications/app/views/dummy_authorization/_form.html.erb
@@ -13,10 +13,5 @@
   <%= form.text_field :postal_code %>
   <%= form.date_field :birthday %>
 
-  <%# REDESIGN_PENDING:  https://github.com/decidim/decidim/issues/10192 %>
   <%= scopes_select_field(form, :scope_id) %>
-  <%# <%= form.scopes_picker :scope_id, {} do |scope| %>
-  <%#     { url: decidim.scopes_picker_path(root: nil, current: form.object.scope_id, field: form.label_for(:scope_id)), %>
-  <%#       text: scope_name_for_picker(form.object.scope, I18n.t("decidim.scopes.global")) } %>
-  <%#   end %1> %>
 </div>

--- a/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
+++ b/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
@@ -8,7 +8,6 @@ module Decidim
       DummyAuthorizationHandler.new({})
     end
     let(:organization) { double(cta_button_path: "/", scopes: Decidim::Scope.none) }
-    let(:redesign_enabled) { false }
 
     before do
       view.extend AuthorizationFormHelper
@@ -21,7 +20,7 @@ module Decidim
       allow(view).to receive(:authorizations_path).and_return("/authorizations")
       allow(view).to receive(:stored_location).and_return("/processes")
       allow(view).to receive(:redirect_url).and_return("/")
-      allow(view).to receive(:redesign_enabled?).and_return(redesign_enabled)
+      allow(view).to receive(:redesign_enabled?).and_return(Decidim.redesign_active)
     end
 
     it "renders the form from the partial" do

--- a/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
+++ b/decidim-verifications/spec/views/decidim/verifications/authorizations/new.html.erb_spec.rb
@@ -7,7 +7,7 @@ module Decidim
     let(:handler) do
       DummyAuthorizationHandler.new({})
     end
-    let(:organization) { double(cta_button_path: "/") }
+    let(:organization) { double(cta_button_path: "/", scopes: Decidim::Scope.none) }
     let(:redesign_enabled) { false }
 
     before do


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

This PR replaces the scopes picker in the front with a select. The admin scopes picker remains because some test break using the select

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10192 

#### Testing

Enabe scopes in a participatory space and make sure to select a scope with child scopes. Create or update inside the space a Proposals space and enable also participatory space with the same scope than the space. Configure also the space to allow users creation of proposals in front. As user create a proposal and check the presence of the scope select

Signed in as admin@example.org visit https://decidim-redesign.populate.tools/processes/Decidim4Dummies/f/1941/proposals/17400/complete

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
