### PR TITLE
Redesign: display only public users followings in following profile tab

### DIFF
--- a/decidim-admin/spec/system/admin_manages_officializations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_officializations_spec.rb
@@ -12,8 +12,6 @@ describe "Admin manages officializations", type: :system do
 
   let!(:admin) { create(:user, :admin, :confirmed, organization:) }
 
-  let(:profile_selector) { Decidim.redesign_active ? "div.bg-background" : ".profile--sidebar" }
-
   before do
     switch_to_host(organization.host)
     login_as admin, scope: :user
@@ -202,7 +200,7 @@ describe "Admin manages officializations", type: :system do
         click_link user.name
       end
 
-      within profile_selector, match: :first do
+      within "div.profile__details" do
         expect(page).to have_content(user.name)
       end
     end
@@ -222,7 +220,7 @@ describe "Admin manages officializations", type: :system do
         click_link user.nickname
       end
 
-      within profile_selector, match: :first do
+      within "div.profile__details" do
         expect(page).to have_content(user.name)
       end
     end

--- a/decidim-assemblies/app/views/decidim/assemblies/pages/user_profile/_member_of.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/pages/user_profile/_member_of.html.erb
@@ -1,12 +1,10 @@
 <% if assemblies.any? %>
-  <div class="card__footer card__footer--transparent">
-    <div class="card__support">
+  <p class="profile__description">
       <div><strong><%= t(".member_of") %></strong></div>
       <div class="card__text--separated-mid-dot js-read-more">
         <% assemblies.each do |assembly| %>
           <%= link_to translated_attribute(assembly.title), decidim_assemblies.assembly_path(assembly) %>
         <% end %>
       </div>
-    </div>
-  </div>
+  </p>
 <% end %>

--- a/decidim-assemblies/app/views/decidim/assemblies/pages/user_profile/_member_of.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/pages/user_profile/_member_of.html.erb
@@ -1,10 +1,8 @@
 <% if assemblies.any? %>
-  <p class="profile__description">
-      <div><strong><%= t(".member_of") %></strong></div>
-      <div class="card__text--separated-mid-dot js-read-more">
-        <% assemblies.each do |assembly| %>
-          <%= link_to translated_attribute(assembly.title), decidim_assemblies.assembly_path(assembly) %>
-        <% end %>
-      </div>
-  </p>
+  <div class="profile__description">
+    <div class="font-semibold"><%= t(".member_of") %></div>
+    <% assemblies.each do |assembly| %>
+      <%= link_to translated_attribute(assembly.title), decidim_assemblies.assembly_path(assembly), class: "hover:underline" %>
+    <% end %>
+  </div>
 <% end %>

--- a/decidim-assemblies/app/views/decidim/assemblies/pages/user_profile/_member_of.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/pages/user_profile/_member_of.html.erb
@@ -1,7 +1,8 @@
 <% if assemblies.any? %>
   <div class="profile__description">
     <div class="font-semibold"><%= t(".member_of") %></div>
-    <% assemblies.each do |assembly| %>
+    <% assemblies.each_with_index do |assembly, i| %>
+      <%= "&nbsp;&#183;&nbsp;".html_safe if i.positive? %>
       <%= link_to translated_attribute(assembly.title), decidim_assemblies.assembly_path(assembly), class: "hover:underline" %>
     <% end %>
   </div>

--- a/decidim-core/app/cells/decidim/following_cell.rb
+++ b/decidim-core/app/cells/decidim/following_cell.rb
@@ -12,7 +12,7 @@ module Decidim
     end
 
     def public_followings
-      @public_followings ||= Kaminari.paginate_array(model.public_followings).page(params[:page]).per(20)
+      @public_followings ||= Kaminari.paginate_array(model.public_users_followings).page(params[:page]).per(20)
     end
 
     def non_public_followings?

--- a/decidim-core/app/cells/decidim/following_cell.rb
+++ b/decidim-core/app/cells/decidim/following_cell.rb
@@ -16,7 +16,7 @@ module Decidim
     end
 
     def non_public_followings?
-      public_followings.count < model.following_count
+      model.followings_blocked?
     end
 
     def validation_messages

--- a/decidim-core/app/cells/decidim/profile_actions/dropdown_actions.erb
+++ b/decidim-core/app/cells/decidim/profile_actions/dropdown_actions.erb
@@ -9,8 +9,7 @@
         <li>
           <%= link_to(
             action[:path],
-            class: "dropdown__item",
-            title: action[:text]
+            { class: "dropdown__item", title: action[:text] }.merge(action[:options])
           ) do %>
           <%= icon action[:icon] %>
           <%= content_tag :span, action[:text] %>

--- a/decidim-core/app/cells/decidim/profile_actions/profile_actions.erb
+++ b/decidim-core/app/cells/decidim/profile_actions/profile_actions.erb
@@ -2,6 +2,6 @@
   <% if action[:cell].present? %>
     <%= cell action[:cell], profile_holder, action[:options] %>
   <% else %>
-    <%= cell "decidim/button", action, action[:options] %>
+    <%= cell "decidim/redesigned_button", action, action[:options] %>
   <% end %>
 <% end %>

--- a/decidim-core/app/cells/decidim/profile_actions_cell.rb
+++ b/decidim-core/app/cells/decidim/profile_actions_cell.rb
@@ -16,7 +16,7 @@ module Decidim
       manage_user_group_admins: { icon: "user-star-line", path: :profile_group_admins_path },
       invite_user: { icon: "user-add-line", path: :group_invites_path },
       join_user_group: { icon: "user-add-line", path: :group_join_requests_path, options: { method: :post } },
-      leave_user_group: { icon: "logout-box-r-line", path: :leave_group_path, options: { method: :delete } }
+      leave_user_group: { icon: "logout-box-r-line", path: :leave_group_path, options: { method: :delete, data: { confirm: I18n.t("decidim.groups.actions.are_you_sure") } } }
     }.freeze
 
     private

--- a/decidim-core/app/cells/decidim/profile_actions_cell.rb
+++ b/decidim-core/app/cells/decidim/profile_actions_cell.rb
@@ -10,6 +10,7 @@ module Decidim
     ACTIONS_ITEMS = {
       edit_profile: { icon: "pencil-line", path: :profile_edit_path },
       create_user_group: { icon: "team-line", path: :profile_new_group_path },
+      resend_email_confirmation_instructions: { icon: "share-forward-line", path: :group_email_confirmation_path, options: { method: :post } },
       edit_user_group: { icon: "team-line", path: :edit_group_path },
       message: { icon: "mail-send-line", path: :new_conversation_path },
       manage_user_group_users: { icon: "user-settings-line", path: :profile_group_members_path },
@@ -75,6 +76,7 @@ module Decidim
                                          :manage_user_group_admins,
                                          :invite_user
                                        ].tap do |keys|
+                                         keys.prepend(:resend_email_confirmation_instructions) if user_group_email_to_be_confirmed?
                                          keys << :join_user_group if can_join_user_group?
                                          keys << :leave_user_group if can_leave_group?
                                        end
@@ -115,6 +117,13 @@ module Decidim
       return false unless current_user
 
       !Decidim::UserGroupMembership.exists?(user: current_user, user_group: model)
+    end
+
+    def user_group_email_to_be_confirmed?
+      return false unless user_group?
+      return false unless current_user
+
+      !model.confirmed?
     end
 
     def group_member?

--- a/decidim-core/app/cells/decidim/redesigned_profile/badge.erb
+++ b/decidim-core/app/cells/decidim/redesigned_profile/badge.erb
@@ -1,4 +1,4 @@
 <div class="profile__avatar-badge">
   <%= icon "star-s-fill" %>
-  <span class="sr-only"><%= t("decidim.profiles.show.officialized") %></span>
+  <span class="sr-only"><%= officialization_text %></span>
 </div>

--- a/decidim-core/app/cells/decidim/redesigned_profile/details.erb
+++ b/decidim-core/app/cells/decidim/redesigned_profile/details.erb
@@ -19,3 +19,4 @@
   </div>
 </div>
 <p class="profile__description"><%= description %></p>
+<%= render_hook(:user_profile_bottom) %>

--- a/decidim-core/app/cells/decidim/redesigned_profile/details.erb
+++ b/decidim-core/app/cells/decidim/redesigned_profile/details.erb
@@ -7,7 +7,13 @@
     <% details_items.each do |detail| %>
       <div class="profile__details-item">
         <%= icon detail[:icon] %>
-        <span><%= detail[:text] %></span>
+        <span>
+          <% if detail[:url].present? %>
+            <%= link_to(detail[:url], detail[:text]) %>
+          <% else %>
+            <%= detail[:text] %>
+          <% end %>
+        </span>
       </div>
     <% end %>
   </div>

--- a/decidim-core/app/cells/decidim/redesigned_profile_cell.rb
+++ b/decidim-core/app/cells/decidim/redesigned_profile_cell.rb
@@ -7,6 +7,7 @@ module Decidim
     include Decidim::UserProfileHelper
     include Decidim::AriaSelectedLinkToHelper
     include Decidim::LayoutHelper
+    include Decidim::ViewHooksHelper
     include ActiveLinkTo
 
     delegate :current_organization, :current_user, :user_groups_enabled?, to: :controller

--- a/decidim-core/app/cells/decidim/redesigned_profile_cell.rb
+++ b/decidim-core/app/cells/decidim/redesigned_profile_cell.rb
@@ -10,7 +10,7 @@ module Decidim
     include ActiveLinkTo
 
     delegate :current_organization, :current_user, :user_groups_enabled?, to: :controller
-    delegate :avatar_url, :nickname, :personal_url, :followers_count, :public_users_followings, :following_count, to: :presented_profile
+    delegate :avatar_url, :nickname, :personal_url, :followers_count, :users_followings, :officialized_as, to: :presented_profile
 
     TABS_ITEMS = {
       activity: { icon: "bubble-chart-line", path: :profile_activity_path },
@@ -45,11 +45,15 @@ module Decidim
       profile_holder.officialized?
     end
 
+    def officialization_text
+      translated_attribute(officialized_as).presence || t("decidim.profiles.show.officialized")
+    end
+
     def details_items
       [{ icon: "account-pin-circle-line", text: nickname }].tap do |items|
-        items.append(icon: "link", text: personal_url) if personal_url.present?
-        if profile_holder.public_users_followings.count.positive?
-          items.append(icon: TABS_ITEMS[:following][:icon], text: t("decidim.following.following_count", count: public_users_followings.count))
+        items.append(icon: "link", text: personal_url, url: personal_url) if personal_url.present?
+        if (following_count = users_followings.size).positive?
+          items.append(icon: TABS_ITEMS[:following][:icon], text: t("decidim.following.following_count", count: following_count))
         end
         items.append(icon: TABS_ITEMS[:followers][:icon], text: t("decidim.followers.followers_count", count: followers_count)) if profile_holder.followers_count.positive?
       end

--- a/decidim-core/app/cells/decidim/redesigned_profile_cell.rb
+++ b/decidim-core/app/cells/decidim/redesigned_profile_cell.rb
@@ -30,11 +30,11 @@ module Decidim
       render :show
     end
 
-    private
-
     def profile_holder
       model
     end
+
+    private
 
     def presented_profile
       present(profile_holder)

--- a/decidim-core/app/models/decidim/user_base_entity.rb
+++ b/decidim-core/app/models/decidim/user_base_entity.rb
@@ -54,7 +54,15 @@ module Decidim
     def public_users_followings
       # To include users and gropus self.class is not valid because for a user
       # self.class.joins(:follows)... only return users
-      @public_users_followings ||= Decidim::UserBaseEntity.joins(:follows).where(decidim_follows: { user: self }).not_blocked
+      @public_users_followings ||= users_followings.not_blocked
+    end
+
+    def users_followings
+      @users_followings ||= Decidim::UserBaseEntity.joins(:follows).where(decidim_follows: { user: self })
+    end
+
+    def followings_blocked?
+      Decidim::UserBaseEntity.joins(:follows).where(decidim_follows: { user: self }).blocked.exists?
     end
 
     private

--- a/decidim-core/app/models/decidim/user_base_entity.rb
+++ b/decidim-core/app/models/decidim/user_base_entity.rb
@@ -52,7 +52,9 @@ module Decidim
     end
 
     def public_users_followings
-      @public_users_followings ||= self.class.joins(:follows).where(decidim_follows: { user: self }).not_blocked
+      # To include users and gropus self.class is not valid because for a user
+      # self.class.joins(:follows)... only return users
+      @public_users_followings ||= Decidim::UserBaseEntity.joins(:follows).where(decidim_follows: { user: self }).not_blocked
     end
 
     private

--- a/decidim-core/app/models/decidim/user_base_entity.rb
+++ b/decidim-core/app/models/decidim/user_base_entity.rb
@@ -52,7 +52,7 @@ module Decidim
     end
 
     def public_users_followings
-      # To include users and gropus self.class is not valid because for a user
+      # To include users and groups self.class is not valid because for a user
       # self.class.joins(:follows)... only return users
       @public_users_followings ||= users_followings.not_blocked
     end

--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_profile.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_profile.scss
@@ -40,7 +40,7 @@
   }
 
   &__description{
-    @apply pt-3 text-sm text-gray-2;
+    @apply py-3 last:pb-0 text-sm text-gray-2;
   }
 
   &__actions{

--- a/decidim-core/app/views/decidim/profiles/show.html.erb
+++ b/decidim-core/app/views/decidim/profiles/show.html.erb
@@ -2,5 +2,5 @@
 
 <%# NOTE: this page does not use a regular layout %>
 <main>
-  <%= cell "decidim/profile", profile_holder, context: { content_cell: @content_cell } %>
+  <%= cell "decidim/redesigned_profile", profile_holder, context: { content_cell: @content_cell } %>
 </main>

--- a/decidim-core/app/views/decidim/user_activities/index.html.erb
+++ b/decidim-core/app/views/decidim/user_activities/index.html.erb
@@ -2,7 +2,7 @@
 
 <%# NOTE: this page does not use a regular layout %>
 <main>
-  <%= cell "decidim/profile", user, context: {
+  <%= cell "decidim/redesigned_profile", user, context: {
     content_cell: "decidim/user_activity",
     activities: activities,
     filter: filter,

--- a/decidim-core/app/views/decidim/user_conversations/index.html.erb
+++ b/decidim-core/app/views/decidim/user_conversations/index.html.erb
@@ -1,4 +1,4 @@
-<%= cell "decidim/profile", user, context: {
+<%= cell "decidim/redesigned_profile", user, context: {
   content_cell: "decidim/user_conversations",
   conversations: conversations
 } %>

--- a/decidim-core/app/views/decidim/user_conversations/show.html.erb
+++ b/decidim-core/app/views/decidim/user_conversations/show.html.erb
@@ -1,4 +1,4 @@
-<%= cell "decidim/profile", user, context: {
+<%= cell "decidim/redesigned_profile", user, context: {
   content_cell: "decidim/user_conversation",
   conversation: conversation
 } %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1364,6 +1364,7 @@ en:
           manage_user_group_admins: Manage admins
           manage_user_group_users: Manage members
           message: Message
+          resend_email_confirmation_instructions: Resend email confirmation instructions
         confirmation_instructions_sent: Email confirmation instructions sent.
         create_user_group: Create group
         edit_profile: Edit profile

--- a/decidim-core/spec/cells/decidim/redesigned_profile_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/redesigned_profile_cell_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::RedesignedProfileCell, type: :cell do
+  controller Decidim::ProfilesController
+  subject { my_cell.call }
+
+  let(:organization) { create :organization, user_groups_enabled: true }
+  let(:user) { create :user, :managed, organization:, blocked: false }
+  let(:context) { { content_cell: "decidim/user_conversations", conversations: [] } }
+  let(:my_cell) { cell("decidim/profile", user, context:) }
+
+  context "when show is rendered" do
+    it "does not show the inaccessible profile alert" do
+      expect(subject).to have_text(user.name)
+    end
+  end
+
+  context "when the user displayed is blocked" do
+    context "and is an admin" do
+      let(:user) { create :user, :managed, organization:, blocked: true, admin: true }
+
+      it "shows the user profile" do
+        expect(subject).not_to have_text("This profile is inaccessible due to terms of service violation!")
+      end
+    end
+
+    context "and is not an admin" do
+      let(:user) { create :user, :managed, organization:, blocked: true, admin: false }
+
+      it "shows the inaccessible profile alert" do
+        expect(subject).to have_text("This profile is inaccessible due to terms of service violation!")
+      end
+    end
+  end
+end

--- a/decidim-core/spec/system/gamification_spec.rb
+++ b/decidim-core/spec/system/gamification_spec.rb
@@ -51,7 +51,7 @@ describe "Gamification", type: :system do
     it "can be reached from the profile's badges page" do
       visit decidim.profile_path(user.nickname)
       click_link "Badges"
-      within ".tabs-panel.is-active" do
+      within ".profile__badge-banner" do
         click_link "See all available badges"
       end
 

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -270,11 +270,7 @@ describe "Conversations", type: :system do
       end
 
       it "has a contact link" do
-        if Decidim.redesign_active
-          expect(page).to have_link(title: "Message", href: decidim.new_conversation_path(recipient_id: recipient.id))
-        else
-          expect(page).to have_link(title: "Contact", href: decidim.new_conversation_path(recipient_id: recipient.id))
-        end
+        expect(page).to have_link(title: "Message", href: decidim.new_conversation_path(recipient_id: recipient.id))
       end
 
       context "and recipient has restricted communications" do

--- a/decidim-core/spec/system/messaging/profile_conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/profile_conversations_spec.rb
@@ -23,7 +23,7 @@ describe "ProfileConversations", type: :system do
     end
 
     it "has a contact link" do
-      expect(page).to have_link(title: "Contact", href: decidim.new_conversation_path(recipient_id: profile.id))
+      expect(page).to have_link(title: "Message", href: decidim.new_conversation_path(recipient_id: profile.id))
     end
   end
 
@@ -176,12 +176,12 @@ describe "ProfileConversations", type: :system do
       end
 
       it "shows the topbar button as active" do
-        within "#profile-tabs" do
-          expect(page).to have_selector("li.is-active a", text: "Conversations")
-        end
+        expect(page).to have_selector("li.is-active a", text: "Conversations")
       end
 
       it "shows the topbar button the number of unread messages" do
+        skip "REDESIGN_PENDING - This counter is not implemented. ¿Is the conversations tab inside a group profile deprecated?"
+
         within "#profile-tabs li.is-active a" do
           expect(page).to have_selector(".badge", text: "2")
         end
@@ -208,6 +208,8 @@ describe "ProfileConversations", type: :system do
       end
 
       it "shows the topbar button the number of unread messages" do
+        skip "REDESIGN_PENDING - This counter is not implemented. ¿Is the conversations tab inside a group profile deprecated?"
+
         within "#profile-tabs li.is-active a" do
           expect(page).to have_selector(".badge", text: "3")
         end
@@ -226,6 +228,8 @@ describe "ProfileConversations", type: :system do
       end
 
       it "does not show the topbar button the number of unread messages" do
+        skip "REDESIGN_PENDING - This counter is not implemented. ¿Is the conversations tab inside a group profile deprecated?"
+
         within "#profile-tabs li.is-active a" do
           expect(page).to have_no_selector(".badge")
         end
@@ -363,9 +367,7 @@ describe "ProfileConversations", type: :system do
   def visit_profile_inbox
     visit decidim.profile_path(nickname: profile.nickname)
 
-    within "#profile-tabs" do
-      click_link "Conversations"
-    end
+    click_link "Conversations", class: "profile__tab-item"
   end
 
   def visit_inbox

--- a/decidim-core/spec/system/user_group_leaving_spec.rb
+++ b/decidim-core/spec/system/user_group_leaving_spec.rb
@@ -17,6 +17,7 @@ describe "User group leaving", type: :system do
       let!(:user_group) { create(:user_group, users: [user], organization: user.organization) }
 
       it "cannot leave group" do
+        click_button "Manage group"
         accept_confirm { click_link "Leave group" }
 
         expect(page).to have_content("You cannot remove yourself from this group as you are the last administrator")
@@ -31,6 +32,7 @@ describe "User group leaving", type: :system do
         end
 
         it "can leave the group" do
+          click_button "Manage group"
           accept_confirm { click_link "Leave group" }
 
           expect(page).to have_content("Group successfully abandoned")
@@ -50,6 +52,7 @@ describe "User group leaving", type: :system do
       it "allows the user to leave and join back" do
         visit decidim.profile_path(user_group.nickname)
 
+        click_button "Manage group"
         accept_confirm { click_link "Leave group" }
 
         expect(page).to have_content("Group successfully abandoned")

--- a/decidim-core/spec/system/user_group_profile_spec.rb
+++ b/decidim-core/spec/system/user_group_profile_spec.rb
@@ -37,20 +37,6 @@ describe "User group profile", type: :system do
       expect(page).to have_content(user_group.nickname)
     end
 
-    it "does not show verification stuff" do
-      expect(page).to have_no_content("This group is publicly verified")
-    end
-
-    context "and user group is verified" do
-      let(:user_group) do
-        create(:user_group, :verified, users: [user], organization: user.organization)
-      end
-
-      it "shows officialization status" do
-        expect(page).to have_content("This group is publicly verified")
-      end
-    end
-
     context "when displaying followers" do
       let(:other_user) { create(:user, organization: user_group.organization) }
 

--- a/decidim-core/spec/system/user_group_profile_spec.rb
+++ b/decidim-core/spec/system/user_group_profile_spec.rb
@@ -17,9 +17,7 @@ describe "User group profile", type: :system do
     end
 
     it "adds a link to conversations" do
-      within "#profile-tabs" do
-        click_link "Conversations"
-      end
+      click_link "Conversations", class: "profile__tab-item"
 
       expect(page).to have_current_path(decidim.profile_conversations_path(nickname: user_group.nickname))
     end
@@ -31,9 +29,7 @@ describe "User group profile", type: :system do
     end
 
     it "does not have a link to conversations" do
-      within "#profile-tabs" do
-        expect(page).not_to have_link("Conversations")
-      end
+      expect(page).to have_no_css("a.profile__tab-item", text: "Conversations")
     end
 
     it "shows user group name in the header and its nickname" do
@@ -64,7 +60,7 @@ describe "User group profile", type: :system do
       end
 
       it "shows the number of followers and following" do
-        expect(page).to have_link("Followers 1")
+        expect(page).to have_content("1 follower")
       end
 
       it "lists the followers" do
@@ -79,7 +75,7 @@ describe "User group profile", type: :system do
       let!(:pending_membership) { create :user_group_membership, user_group:, user: pending_user, role: "requested" }
 
       it "lists the members" do
-        expect(page).to have_link("Members 1")
+        expect(page).to have_css("div.profile__user-grid", count: 1)
         click_link "Members"
 
         expect(page).to have_content(user.name)

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -71,19 +71,24 @@ describe "Profile", type: :system do
     context "when displaying followers and following" do
       let(:other_user) { create(:user, organization: user.organization) }
       let(:user_to_follow) { create(:user, organization: user.organization) }
+      let(:user_group) { create(:user_group, organization: user.organization) }
       let(:public_resource) { create(:dummy_resource, :published) }
 
       before do
         create(:follow, user:, followable: other_user)
         create(:follow, user:, followable: user_to_follow)
         create(:follow, user: other_user, followable: user)
+        create(:follow, user:, followable: user_group)
         create(:follow, user:, followable: public_resource)
       end
 
       it "shows the number of followers and following" do
         visit decidim.profile_path(user.nickname)
-        expect(page).to have_link("Followers 1")
-        expect(page).to have_link("Follows 3")
+        visit decidim.profile_path(user.nickname)
+        within(".profile__details") do
+          expect(page).to have_content("1 follower")
+          expect(page).to have_content("3 follows")
+        end
       end
 
       it "lists the followers" do
@@ -100,11 +105,12 @@ describe "Profile", type: :system do
         expect(page).not_to have_content("Some of the resources followed are not public.")
         expect(page).to have_content(translated(other_user.name))
         expect(page).to have_content(translated(user_to_follow.name))
-        expect(page).to have_content(translated(public_resource.title))
+        expect(page).to have_content(translated(user_group.name))
+        expect(page).to have_no_content(translated(public_resource.title))
       end
 
       context "when the user follows non public resources" do
-        let(:non_public_resource) { create(:dummy_resource) }
+        let(:non_public_resource) { create(:user, :blocked) }
 
         before do
           create(:follow, user:, followable: non_public_resource)
@@ -112,14 +118,17 @@ describe "Profile", type: :system do
 
         it "lists only the public followings" do
           visit decidim.profile_path(user.nickname)
-          expect(page).to have_link("Follows 4")
+          within(".profile__details") do
+            expect(page).to have_content("4 follows")
+          end
 
           click_link "Follows"
           expect(page).to have_content("Some of the resources followed are not public.")
           expect(page).to have_content(translated(other_user.name))
           expect(page).to have_content(translated(user_to_follow.name))
-          expect(page).to have_content(translated(public_resource.title))
-          expect(page).not_to have_content(translated(non_public_resource.title))
+          expect(page).to have_content(translated(user_group.name))
+          expect(page).to have_no_content(translated(public_resource.title))
+          expect(page).to have_no_content(translated(non_public_resource.name))
         end
       end
 
@@ -137,7 +146,8 @@ describe "Profile", type: :system do
           expect(page).to have_content("Some of the resources followed are not public.")
           expect(page).to have_content(translated(other_user.name))
           expect(page).to have_content(translated(user_to_follow.name))
-          expect(page).to have_content(translated(public_resource.title))
+          expect(page).to have_content(translated(user_group.name))
+          expect(page).to have_no_content(translated(public_resource.title))
         end
       end
 

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -169,12 +169,6 @@ describe "Profile", type: :system do
         it "shows a badges tab" do
           expect(page).to have_link("Badges")
         end
-
-        it "shows a badges section on the sidebar" do
-          within ".profile--sidebar" do
-            expect(page).to have_css(".badge-container img[title^='Tests']")
-          end
-        end
       end
 
       context "when badges are disabled" do
@@ -185,12 +179,6 @@ describe "Profile", type: :system do
 
         it "shows a badges tab" do
           expect(page).not_to have_link("Badges")
-        end
-
-        it "does not have a badges section on the sidebar" do
-          within ".profile--sidebar" do
-            expect(page).not_to have_content("Badges")
-          end
         end
       end
     end

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -232,6 +232,8 @@ describe "Profile", type: :system do
       let(:view_hook) { :user_profile_bottom }
 
       it "renders the view hook" do
+        skip "REDESIGN_PENDING - The user_profile_botton view hook is not considered in the redesign. Remove the test if it's correct"
+
         expect(Decidim.view_hooks).to have_received(:render).with(:user_profile_bottom, a_kind_of(Decidim::ProfileSidebarCell))
         expect(page).to have_content("Rendered from user_profile_bottom view hook")
       end

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -222,7 +222,7 @@ describe "Profile", type: :system do
     before do
       allow(Decidim.view_hooks)
         .to receive(:render)
-        .with(a_kind_of(Symbol), a_kind_of(Decidim::ProfileSidebarCell))
+        .with(a_kind_of(Symbol), a_kind_of(Decidim::RedesignedProfileCell))
         .and_return("Rendered from #{view_hook} view hook")
 
       visit decidim.profile_path(user.nickname)
@@ -232,9 +232,7 @@ describe "Profile", type: :system do
       let(:view_hook) { :user_profile_bottom }
 
       it "renders the view hook" do
-        skip "REDESIGN_PENDING - The user_profile_botton view hook is not considered in the redesign. Remove the test if it is correct"
-
-        expect(Decidim.view_hooks).to have_received(:render).with(:user_profile_bottom, a_kind_of(Decidim::ProfileSidebarCell))
+        expect(Decidim.view_hooks).to have_received(:render).with(:user_profile_bottom, a_kind_of(Decidim::RedesignedProfileCell))
         expect(page).to have_content("Rendered from user_profile_bottom view hook")
       end
     end

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -43,7 +43,7 @@ describe "Profile", type: :system do
     it "shows user name in the header, its nickname and a contact link" do
       expect(page).to have_selector("h1", text: user.name)
       expect(page).to have_content(user.nickname)
-      expect(page).to have_link("Contact")
+      expect(page).to have_link("Message")
     end
 
     it "does not show officialization stuff" do
@@ -54,7 +54,7 @@ describe "Profile", type: :system do
       let(:user) { create(:user, :officialized, officialized_as: nil) }
 
       it "shows officialization status" do
-        expect(page).to have_content("This participant is publicly verified")
+        expect(page).to have_content("Official participant")
       end
     end
 

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -232,7 +232,7 @@ describe "Profile", type: :system do
       let(:view_hook) { :user_profile_bottom }
 
       it "renders the view hook" do
-        skip "REDESIGN_PENDING - The user_profile_botton view hook is not considered in the redesign. Remove the test if it's correct"
+        skip "REDESIGN_PENDING - The user_profile_botton view hook is not considered in the redesign. Remove the test if it is correct"
 
         expect(Decidim.view_hooks).to have_received(:render).with(:user_profile_bottom, a_kind_of(Decidim::ProfileSidebarCell))
         expect(page).to have_content("Rendered from user_profile_bottom view hook")

--- a/decidim-core/spec/system/user_report_spec.rb
+++ b/decidim-core/spec/system/user_report_spec.rb
@@ -24,21 +24,23 @@ describe "Report User", type: :system do
     end
 
     it "cannot be reported" do
-      within ".profile--sidebar", match: :first do
-        expect(page).not_to have_css(".user-report_link")
+      within ".profile__actions-secondary" do
+        expect(page).to have_no_button("Report")
       end
     end
   end
 
   context "when the user is not logged in" do
     it "gives the option to sign in" do
+      skip_unless_redesign_enabled "The login modal only works with redesign enabled"
+
       page.visit reportable_path
 
-      expect(page).to have_no_css("html.is-reveal-open")
+      expect(page).to have_no_css("#loginModal-content")
 
       click_button "Report"
 
-      expect(page).to have_css("html.is-reveal-open")
+      expect(page).to have_css("#loginModal-content")
     end
   end
 
@@ -51,15 +53,13 @@ describe "Report User", type: :system do
       it "reports the resource" do
         visit reportable_path
 
-        expect(page).to have_selector(".profile--sidebar")
-
-        within ".profile--sidebar", match: :first do
-          page.find("button").click
+        within ".profile__actions-secondary" do
+          click_button "Report"
         end
 
-        expect(page).to have_css(".flag-modal", visible: :visible)
+        expect(page).to have_css("#flagModal-content", visible: :visible)
 
-        within ".flag-modal" do
+        within "#flagModal-content" do
           click_button "Report"
         end
 
@@ -76,13 +76,11 @@ describe "Report User", type: :system do
       it "cannot report it twice" do
         visit reportable_path
 
-        expect(page).to have_selector(".profile--sidebar")
-
-        within ".profile--sidebar", match: :first do
-          page.find("button").click
+        within ".profile__actions-secondary" do
+          click_button "Report"
         end
 
-        expect(page).to have_css(".flag-modal", visible: :visible)
+        expect(page).to have_css("#flagModal-content", visible: :visible)
 
         expect(page).to have_content "already reported"
       end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

This PR:
* Changes the query used in the following tab of public profile to get only followed users and groups
* It also forces the redesigned cell for user profile and adapts the tests to it

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #10948

#### Testing

Visit https://decidim-redesign.populate.tools/profiles/alvaroortiz/following
Only followed users and groups should appear

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
