### PR TITLE
Redesign: lock sass embedded to 1.62

### DIFF
--- a/decidim_app-design/packages/webpacker/package-lock.json
+++ b/decidim_app-design/packages/webpacker/package-lock.json
@@ -21,7 +21,7 @@
         "@tailwindcss/typography": "^0.5.2",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.0.0",
-        "compression-webpack-plugin": "^9.0.0 || ^10.0.0",
+        "compression-webpack-plugin": "^10.0.0",
         "css-loader": "^6.7.3",
         "expose-loader": "^4.1.0",
         "glob": "^9.3.2",
@@ -35,7 +35,7 @@
         "postcss-loader": "^7.1.0",
         "postcss-preset-env": "^8.2.0",
         "postcss-scss": "^4.0.6",
-        "sass-embedded": "^1.60.0",
+        "sass-embedded": "~1.62.0",
         "shakapacker": "~6.6.0",
         "source-map-loader": "^4.0.1",
         "style-loader": "^3.3.2",
@@ -3552,15 +3552,15 @@
       }
     },
     "node_modules/compression-webpack-plugin": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-9.2.0.tgz",
-      "integrity": "sha512-R/Oi+2+UHotGfu72fJiRoVpuRifZT0tTC6UqFD/DUo+mv8dbOow9rVOuTvDv5nPPm3GZhHL/fKkwxwIHnJ8Nyw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-10.0.0.tgz",
+      "integrity": "sha512-wLXLIBwpul/ALcm7Aj+69X0pYT3BYt6DdPn3qrgBIh9YejV9Bju9ShhlAsjujLyWMo6SAweFIWaUoFmXZNuNrg==",
       "dependencies": {
         "schema-utils": "^4.0.0",
         "serialize-javascript": "^6.0.0"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 14.15.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7823,9 +7823,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass-embedded": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.60.0.tgz",
-      "integrity": "sha512-pTCcbAaymfRX0Zkc17fGAVRBX3PPnj0vmWg93oGpeP/IMncxa58s+OPgDNIjSTDJ5wZGjTc95L1QY/zlubjC0g==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.62.0.tgz",
+      "integrity": "sha512-SwTIG6UmrMiT94/v8G+2pPf6i+XwY4hOQxm8HZl0ld0st2KdGDj/SBXDznFl7+sJ6tFq6hvVvrB9rW5Nj7EhuQ==",
       "dependencies": {
         "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
@@ -7837,20 +7837,20 @@
         "node": ">=14.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-darwin-arm64": "1.60.0",
-        "sass-embedded-darwin-x64": "1.60.0",
-        "sass-embedded-linux-arm": "1.60.0",
-        "sass-embedded-linux-arm64": "1.60.0",
-        "sass-embedded-linux-ia32": "1.60.0",
-        "sass-embedded-linux-x64": "1.60.0",
-        "sass-embedded-win32-ia32": "1.60.0",
-        "sass-embedded-win32-x64": "1.60.0"
+        "sass-embedded-darwin-arm64": "1.62.0",
+        "sass-embedded-darwin-x64": "1.62.0",
+        "sass-embedded-linux-arm": "1.62.0",
+        "sass-embedded-linux-arm64": "1.62.0",
+        "sass-embedded-linux-ia32": "1.62.0",
+        "sass-embedded-linux-x64": "1.62.0",
+        "sass-embedded-win32-ia32": "1.62.0",
+        "sass-embedded-win32-x64": "1.62.0"
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.60.0.tgz",
-      "integrity": "sha512-vgHLlLo+HggvmDT60fwMDJjjSUBRp65yZBbaXNEigUjHCAt4ghQ0fsWmcyWRXX8yFAOVH3Ya8qtbUlkvE1e3qw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.62.0.tgz",
+      "integrity": "sha512-bYEM6DY7kteOd/aJXUisiavm8B1acRhpIn+rhzKZeTn87kUW5RzZv2nKaSmb1vUd4ZptDGaJ144qz/d20rnogQ==",
       "cpu": [
         "arm64"
       ],
@@ -7863,9 +7863,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.60.0.tgz",
-      "integrity": "sha512-K7uFEzL5CnzPh7uNscstd2v4NooTJoQyjd64z6y3MWb3ArCl57w4ig/QAzwnydJ2YgaJD2YYVQrokCHyu4tjOw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.62.0.tgz",
+      "integrity": "sha512-2sBQ4uWjZbf8TKXF8Aq7N0p5V2tKUr4zX9gQAiKvm1NBYwsW22+m8D34heOWu50ikpIxebvt7i/z7hafH5kzKg==",
       "cpu": [
         "x64"
       ],
@@ -7878,9 +7878,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.60.0.tgz",
-      "integrity": "sha512-bLefkjt6kaHI9XqxRd+xHPSiKd/Klx7aVOV7K68F4O4YQSIs1pvdryrj6XeHtAyuNckkBStyRruD+bRPwJ7LmQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.62.0.tgz",
+      "integrity": "sha512-0lz9Ids/OzKiOK+fd5wo/fHBGJ5lCHbcRsjDnU0CIMWkUmMt7yhcFABWB/TUofS5XvrohYbGqs+yKP3X0oGX3g==",
       "cpu": [
         "arm"
       ],
@@ -7893,9 +7893,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.60.0.tgz",
-      "integrity": "sha512-VoN/aLHWnSNZbRR0eifsylrPBWzqQsG++J2qPbzvnuakRspaIRDCirw2QGFhksmyty5bn/syekKAIUUaCamBJQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.62.0.tgz",
+      "integrity": "sha512-FexUt8aE7I7fJub3N6+NsDdbPRP/O8o400qpbEbY7BWgiWEdpr81OBulQZY/2LzZUnz9keUhfpmltNY3SNg3kg==",
       "cpu": [
         "arm64"
       ],
@@ -7908,9 +7908,9 @@
       }
     },
     "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.60.0.tgz",
-      "integrity": "sha512-2XkIOT+7rNkjuDMugFASnbvwh9Fg48hZZh8kW4ZPGj1QxHtZNlGLXt0C/i0jAZUdjhhyjd9l+xUIxZj5/JClPg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.62.0.tgz",
+      "integrity": "sha512-VpDHtMIwcoWqDsiskjhDYAle0SJV4mUiZJTXg5RkMzoX1ZyNiVz+uNaZ88kDqcGXsWpe2i0sIlljD4ryaiMAhA==",
       "cpu": [
         "ia32"
       ],
@@ -7923,9 +7923,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.60.0.tgz",
-      "integrity": "sha512-V0ZooknRIkS3lqn+3Yh2xrpfgd82A4n9PvzV/1KJWs4p5eJsapRIx/yGXHPFHfooHagN57kDWaFFdQYUfuYHrw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.62.0.tgz",
+      "integrity": "sha512-dntYMsu0QonlerFB8VDlzxoJcpMEtN9lPHstKOQ6rk6hbSFPvcI8MqqUomlOjmpakKeVrpyZ04nm9jHrzlFmYg==",
       "cpu": [
         "x64"
       ],
@@ -7938,9 +7938,9 @@
       }
     },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.60.0.tgz",
-      "integrity": "sha512-pMNKxcysEVK4Dh27yLFNBAMqAKAJoVsl67lQ79LNrlZIVlIIwo/s1ajvImbf2srhWzizDJ1irxH2oBpF0kvxEA==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.62.0.tgz",
+      "integrity": "sha512-rTCZCVkQa6XcreyQ8gYqnsEG13HCzqKoN2mCvIuGwJro8IjyT2PzWauouO0M06T0FLH0pc3EvKdKaLdtijf9AQ==",
       "cpu": [
         "ia32"
       ],
@@ -7953,9 +7953,9 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.60.0.tgz",
-      "integrity": "sha512-vGPeil9FzxJhPnWZ0zMLrY+GTT/fAUDVrKWQoXTxPfc7EugngbrqZ1qwVIVVCOC5zXDULB6LixCLFS8ut9R3KA==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.62.0.tgz",
+      "integrity": "sha512-g6DZBPGfIDKLBarvYRVKJ+7rJAHJXkOQQVrYSWm22klA9ZNZ0CaVyqLqejttZPKGreD8h/xh2uz/s6w/P900Sw==",
       "cpu": [
         "x64"
       ],
@@ -12170,9 +12170,9 @@
       }
     },
     "compression-webpack-plugin": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-9.2.0.tgz",
-      "integrity": "sha512-R/Oi+2+UHotGfu72fJiRoVpuRifZT0tTC6UqFD/DUo+mv8dbOow9rVOuTvDv5nPPm3GZhHL/fKkwxwIHnJ8Nyw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-10.0.0.tgz",
+      "integrity": "sha512-wLXLIBwpul/ALcm7Aj+69X0pYT3BYt6DdPn3qrgBIh9YejV9Bju9ShhlAsjujLyWMo6SAweFIWaUoFmXZNuNrg==",
       "requires": {
         "schema-utils": "^4.0.0",
         "serialize-javascript": "^6.0.0"
@@ -15049,22 +15049,22 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass-embedded": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.60.0.tgz",
-      "integrity": "sha512-pTCcbAaymfRX0Zkc17fGAVRBX3PPnj0vmWg93oGpeP/IMncxa58s+OPgDNIjSTDJ5wZGjTc95L1QY/zlubjC0g==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.62.0.tgz",
+      "integrity": "sha512-SwTIG6UmrMiT94/v8G+2pPf6i+XwY4hOQxm8HZl0ld0st2KdGDj/SBXDznFl7+sJ6tFq6hvVvrB9rW5Nj7EhuQ==",
       "requires": {
         "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
         "immutable": "^4.0.0",
         "rxjs": "^7.4.0",
-        "sass-embedded-darwin-arm64": "1.60.0",
-        "sass-embedded-darwin-x64": "1.60.0",
-        "sass-embedded-linux-arm": "1.60.0",
-        "sass-embedded-linux-arm64": "1.60.0",
-        "sass-embedded-linux-ia32": "1.60.0",
-        "sass-embedded-linux-x64": "1.60.0",
-        "sass-embedded-win32-ia32": "1.60.0",
-        "sass-embedded-win32-x64": "1.60.0",
+        "sass-embedded-darwin-arm64": "1.62.0",
+        "sass-embedded-darwin-x64": "1.62.0",
+        "sass-embedded-linux-arm": "1.62.0",
+        "sass-embedded-linux-arm64": "1.62.0",
+        "sass-embedded-linux-ia32": "1.62.0",
+        "sass-embedded-linux-x64": "1.62.0",
+        "sass-embedded-win32-ia32": "1.62.0",
+        "sass-embedded-win32-x64": "1.62.0",
         "supports-color": "^8.1.1"
       },
       "dependencies": {
@@ -15084,51 +15084,51 @@
       }
     },
     "sass-embedded-darwin-arm64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.60.0.tgz",
-      "integrity": "sha512-vgHLlLo+HggvmDT60fwMDJjjSUBRp65yZBbaXNEigUjHCAt4ghQ0fsWmcyWRXX8yFAOVH3Ya8qtbUlkvE1e3qw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.62.0.tgz",
+      "integrity": "sha512-bYEM6DY7kteOd/aJXUisiavm8B1acRhpIn+rhzKZeTn87kUW5RzZv2nKaSmb1vUd4ZptDGaJ144qz/d20rnogQ==",
       "optional": true
     },
     "sass-embedded-darwin-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.60.0.tgz",
-      "integrity": "sha512-K7uFEzL5CnzPh7uNscstd2v4NooTJoQyjd64z6y3MWb3ArCl57w4ig/QAzwnydJ2YgaJD2YYVQrokCHyu4tjOw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.62.0.tgz",
+      "integrity": "sha512-2sBQ4uWjZbf8TKXF8Aq7N0p5V2tKUr4zX9gQAiKvm1NBYwsW22+m8D34heOWu50ikpIxebvt7i/z7hafH5kzKg==",
       "optional": true
     },
     "sass-embedded-linux-arm": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.60.0.tgz",
-      "integrity": "sha512-bLefkjt6kaHI9XqxRd+xHPSiKd/Klx7aVOV7K68F4O4YQSIs1pvdryrj6XeHtAyuNckkBStyRruD+bRPwJ7LmQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.62.0.tgz",
+      "integrity": "sha512-0lz9Ids/OzKiOK+fd5wo/fHBGJ5lCHbcRsjDnU0CIMWkUmMt7yhcFABWB/TUofS5XvrohYbGqs+yKP3X0oGX3g==",
       "optional": true
     },
     "sass-embedded-linux-arm64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.60.0.tgz",
-      "integrity": "sha512-VoN/aLHWnSNZbRR0eifsylrPBWzqQsG++J2qPbzvnuakRspaIRDCirw2QGFhksmyty5bn/syekKAIUUaCamBJQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.62.0.tgz",
+      "integrity": "sha512-FexUt8aE7I7fJub3N6+NsDdbPRP/O8o400qpbEbY7BWgiWEdpr81OBulQZY/2LzZUnz9keUhfpmltNY3SNg3kg==",
       "optional": true
     },
     "sass-embedded-linux-ia32": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.60.0.tgz",
-      "integrity": "sha512-2XkIOT+7rNkjuDMugFASnbvwh9Fg48hZZh8kW4ZPGj1QxHtZNlGLXt0C/i0jAZUdjhhyjd9l+xUIxZj5/JClPg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.62.0.tgz",
+      "integrity": "sha512-VpDHtMIwcoWqDsiskjhDYAle0SJV4mUiZJTXg5RkMzoX1ZyNiVz+uNaZ88kDqcGXsWpe2i0sIlljD4ryaiMAhA==",
       "optional": true
     },
     "sass-embedded-linux-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.60.0.tgz",
-      "integrity": "sha512-V0ZooknRIkS3lqn+3Yh2xrpfgd82A4n9PvzV/1KJWs4p5eJsapRIx/yGXHPFHfooHagN57kDWaFFdQYUfuYHrw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.62.0.tgz",
+      "integrity": "sha512-dntYMsu0QonlerFB8VDlzxoJcpMEtN9lPHstKOQ6rk6hbSFPvcI8MqqUomlOjmpakKeVrpyZ04nm9jHrzlFmYg==",
       "optional": true
     },
     "sass-embedded-win32-ia32": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.60.0.tgz",
-      "integrity": "sha512-pMNKxcysEVK4Dh27yLFNBAMqAKAJoVsl67lQ79LNrlZIVlIIwo/s1ajvImbf2srhWzizDJ1irxH2oBpF0kvxEA==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.62.0.tgz",
+      "integrity": "sha512-rTCZCVkQa6XcreyQ8gYqnsEG13HCzqKoN2mCvIuGwJro8IjyT2PzWauouO0M06T0FLH0pc3EvKdKaLdtijf9AQ==",
       "optional": true
     },
     "sass-embedded-win32-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.60.0.tgz",
-      "integrity": "sha512-vGPeil9FzxJhPnWZ0zMLrY+GTT/fAUDVrKWQoXTxPfc7EugngbrqZ1qwVIVVCOC5zXDULB6LixCLFS8ut9R3KA==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.62.0.tgz",
+      "integrity": "sha512-g6DZBPGfIDKLBarvYRVKJ+7rJAHJXkOQQVrYSWm22klA9ZNZ0CaVyqLqejttZPKGreD8h/xh2uz/s6w/P900Sw==",
       "optional": true
     },
     "schema-utils": {

--- a/decidim_app-design/packages/webpacker/package.json
+++ b/decidim_app-design/packages/webpacker/package.json
@@ -37,7 +37,7 @@
     "postcss-loader": "^7.1.0",
     "postcss-preset-env": "^8.2.0",
     "postcss-scss": "^4.0.6",
-    "sass-embedded": "^1.60.0",
+    "sass-embedded": "~1.62.0",
     "shakapacker": "~6.6.0",
     "source-map-loader": "^4.0.1",
     "style-loader": "^3.3.2",

--- a/packages/webpacker/package-lock.json
+++ b/packages/webpacker/package-lock.json
@@ -21,7 +21,7 @@
         "@tailwindcss/typography": "^0.5.2",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.0.0",
-        "compression-webpack-plugin": "^9.0.0 || ^10.0.0",
+        "compression-webpack-plugin": "^10.0.0",
         "css-loader": "^6.7.3",
         "expose-loader": "^4.1.0",
         "glob": "^9.3.2",
@@ -35,7 +35,7 @@
         "postcss-loader": "^7.1.0",
         "postcss-preset-env": "^8.2.0",
         "postcss-scss": "^4.0.6",
-        "sass-embedded": "^1.60.0",
+        "sass-embedded": "~1.62.0",
         "shakapacker": "~6.6.0",
         "source-map-loader": "^4.0.1",
         "style-loader": "^3.3.2",
@@ -3552,15 +3552,15 @@
       }
     },
     "node_modules/compression-webpack-plugin": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-9.2.0.tgz",
-      "integrity": "sha512-R/Oi+2+UHotGfu72fJiRoVpuRifZT0tTC6UqFD/DUo+mv8dbOow9rVOuTvDv5nPPm3GZhHL/fKkwxwIHnJ8Nyw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-10.0.0.tgz",
+      "integrity": "sha512-wLXLIBwpul/ALcm7Aj+69X0pYT3BYt6DdPn3qrgBIh9YejV9Bju9ShhlAsjujLyWMo6SAweFIWaUoFmXZNuNrg==",
       "dependencies": {
         "schema-utils": "^4.0.0",
         "serialize-javascript": "^6.0.0"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 14.15.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7823,9 +7823,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass-embedded": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.60.0.tgz",
-      "integrity": "sha512-pTCcbAaymfRX0Zkc17fGAVRBX3PPnj0vmWg93oGpeP/IMncxa58s+OPgDNIjSTDJ5wZGjTc95L1QY/zlubjC0g==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.62.0.tgz",
+      "integrity": "sha512-SwTIG6UmrMiT94/v8G+2pPf6i+XwY4hOQxm8HZl0ld0st2KdGDj/SBXDznFl7+sJ6tFq6hvVvrB9rW5Nj7EhuQ==",
       "dependencies": {
         "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
@@ -7837,20 +7837,20 @@
         "node": ">=14.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-darwin-arm64": "1.60.0",
-        "sass-embedded-darwin-x64": "1.60.0",
-        "sass-embedded-linux-arm": "1.60.0",
-        "sass-embedded-linux-arm64": "1.60.0",
-        "sass-embedded-linux-ia32": "1.60.0",
-        "sass-embedded-linux-x64": "1.60.0",
-        "sass-embedded-win32-ia32": "1.60.0",
-        "sass-embedded-win32-x64": "1.60.0"
+        "sass-embedded-darwin-arm64": "1.62.0",
+        "sass-embedded-darwin-x64": "1.62.0",
+        "sass-embedded-linux-arm": "1.62.0",
+        "sass-embedded-linux-arm64": "1.62.0",
+        "sass-embedded-linux-ia32": "1.62.0",
+        "sass-embedded-linux-x64": "1.62.0",
+        "sass-embedded-win32-ia32": "1.62.0",
+        "sass-embedded-win32-x64": "1.62.0"
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.60.0.tgz",
-      "integrity": "sha512-vgHLlLo+HggvmDT60fwMDJjjSUBRp65yZBbaXNEigUjHCAt4ghQ0fsWmcyWRXX8yFAOVH3Ya8qtbUlkvE1e3qw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.62.0.tgz",
+      "integrity": "sha512-bYEM6DY7kteOd/aJXUisiavm8B1acRhpIn+rhzKZeTn87kUW5RzZv2nKaSmb1vUd4ZptDGaJ144qz/d20rnogQ==",
       "cpu": [
         "arm64"
       ],
@@ -7863,9 +7863,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.60.0.tgz",
-      "integrity": "sha512-K7uFEzL5CnzPh7uNscstd2v4NooTJoQyjd64z6y3MWb3ArCl57w4ig/QAzwnydJ2YgaJD2YYVQrokCHyu4tjOw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.62.0.tgz",
+      "integrity": "sha512-2sBQ4uWjZbf8TKXF8Aq7N0p5V2tKUr4zX9gQAiKvm1NBYwsW22+m8D34heOWu50ikpIxebvt7i/z7hafH5kzKg==",
       "cpu": [
         "x64"
       ],
@@ -7878,9 +7878,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.60.0.tgz",
-      "integrity": "sha512-bLefkjt6kaHI9XqxRd+xHPSiKd/Klx7aVOV7K68F4O4YQSIs1pvdryrj6XeHtAyuNckkBStyRruD+bRPwJ7LmQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.62.0.tgz",
+      "integrity": "sha512-0lz9Ids/OzKiOK+fd5wo/fHBGJ5lCHbcRsjDnU0CIMWkUmMt7yhcFABWB/TUofS5XvrohYbGqs+yKP3X0oGX3g==",
       "cpu": [
         "arm"
       ],
@@ -7893,9 +7893,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.60.0.tgz",
-      "integrity": "sha512-VoN/aLHWnSNZbRR0eifsylrPBWzqQsG++J2qPbzvnuakRspaIRDCirw2QGFhksmyty5bn/syekKAIUUaCamBJQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.62.0.tgz",
+      "integrity": "sha512-FexUt8aE7I7fJub3N6+NsDdbPRP/O8o400qpbEbY7BWgiWEdpr81OBulQZY/2LzZUnz9keUhfpmltNY3SNg3kg==",
       "cpu": [
         "arm64"
       ],
@@ -7908,9 +7908,9 @@
       }
     },
     "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.60.0.tgz",
-      "integrity": "sha512-2XkIOT+7rNkjuDMugFASnbvwh9Fg48hZZh8kW4ZPGj1QxHtZNlGLXt0C/i0jAZUdjhhyjd9l+xUIxZj5/JClPg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.62.0.tgz",
+      "integrity": "sha512-VpDHtMIwcoWqDsiskjhDYAle0SJV4mUiZJTXg5RkMzoX1ZyNiVz+uNaZ88kDqcGXsWpe2i0sIlljD4ryaiMAhA==",
       "cpu": [
         "ia32"
       ],
@@ -7923,9 +7923,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.60.0.tgz",
-      "integrity": "sha512-V0ZooknRIkS3lqn+3Yh2xrpfgd82A4n9PvzV/1KJWs4p5eJsapRIx/yGXHPFHfooHagN57kDWaFFdQYUfuYHrw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.62.0.tgz",
+      "integrity": "sha512-dntYMsu0QonlerFB8VDlzxoJcpMEtN9lPHstKOQ6rk6hbSFPvcI8MqqUomlOjmpakKeVrpyZ04nm9jHrzlFmYg==",
       "cpu": [
         "x64"
       ],
@@ -7938,9 +7938,9 @@
       }
     },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.60.0.tgz",
-      "integrity": "sha512-pMNKxcysEVK4Dh27yLFNBAMqAKAJoVsl67lQ79LNrlZIVlIIwo/s1ajvImbf2srhWzizDJ1irxH2oBpF0kvxEA==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.62.0.tgz",
+      "integrity": "sha512-rTCZCVkQa6XcreyQ8gYqnsEG13HCzqKoN2mCvIuGwJro8IjyT2PzWauouO0M06T0FLH0pc3EvKdKaLdtijf9AQ==",
       "cpu": [
         "ia32"
       ],
@@ -7953,9 +7953,9 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.60.0.tgz",
-      "integrity": "sha512-vGPeil9FzxJhPnWZ0zMLrY+GTT/fAUDVrKWQoXTxPfc7EugngbrqZ1qwVIVVCOC5zXDULB6LixCLFS8ut9R3KA==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.62.0.tgz",
+      "integrity": "sha512-g6DZBPGfIDKLBarvYRVKJ+7rJAHJXkOQQVrYSWm22klA9ZNZ0CaVyqLqejttZPKGreD8h/xh2uz/s6w/P900Sw==",
       "cpu": [
         "x64"
       ],
@@ -12170,9 +12170,9 @@
       }
     },
     "compression-webpack-plugin": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-9.2.0.tgz",
-      "integrity": "sha512-R/Oi+2+UHotGfu72fJiRoVpuRifZT0tTC6UqFD/DUo+mv8dbOow9rVOuTvDv5nPPm3GZhHL/fKkwxwIHnJ8Nyw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-10.0.0.tgz",
+      "integrity": "sha512-wLXLIBwpul/ALcm7Aj+69X0pYT3BYt6DdPn3qrgBIh9YejV9Bju9ShhlAsjujLyWMo6SAweFIWaUoFmXZNuNrg==",
       "requires": {
         "schema-utils": "^4.0.0",
         "serialize-javascript": "^6.0.0"
@@ -15049,22 +15049,22 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass-embedded": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.60.0.tgz",
-      "integrity": "sha512-pTCcbAaymfRX0Zkc17fGAVRBX3PPnj0vmWg93oGpeP/IMncxa58s+OPgDNIjSTDJ5wZGjTc95L1QY/zlubjC0g==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.62.0.tgz",
+      "integrity": "sha512-SwTIG6UmrMiT94/v8G+2pPf6i+XwY4hOQxm8HZl0ld0st2KdGDj/SBXDznFl7+sJ6tFq6hvVvrB9rW5Nj7EhuQ==",
       "requires": {
         "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
         "immutable": "^4.0.0",
         "rxjs": "^7.4.0",
-        "sass-embedded-darwin-arm64": "1.60.0",
-        "sass-embedded-darwin-x64": "1.60.0",
-        "sass-embedded-linux-arm": "1.60.0",
-        "sass-embedded-linux-arm64": "1.60.0",
-        "sass-embedded-linux-ia32": "1.60.0",
-        "sass-embedded-linux-x64": "1.60.0",
-        "sass-embedded-win32-ia32": "1.60.0",
-        "sass-embedded-win32-x64": "1.60.0",
+        "sass-embedded-darwin-arm64": "1.62.0",
+        "sass-embedded-darwin-x64": "1.62.0",
+        "sass-embedded-linux-arm": "1.62.0",
+        "sass-embedded-linux-arm64": "1.62.0",
+        "sass-embedded-linux-ia32": "1.62.0",
+        "sass-embedded-linux-x64": "1.62.0",
+        "sass-embedded-win32-ia32": "1.62.0",
+        "sass-embedded-win32-x64": "1.62.0",
         "supports-color": "^8.1.1"
       },
       "dependencies": {
@@ -15084,51 +15084,51 @@
       }
     },
     "sass-embedded-darwin-arm64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.60.0.tgz",
-      "integrity": "sha512-vgHLlLo+HggvmDT60fwMDJjjSUBRp65yZBbaXNEigUjHCAt4ghQ0fsWmcyWRXX8yFAOVH3Ya8qtbUlkvE1e3qw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.62.0.tgz",
+      "integrity": "sha512-bYEM6DY7kteOd/aJXUisiavm8B1acRhpIn+rhzKZeTn87kUW5RzZv2nKaSmb1vUd4ZptDGaJ144qz/d20rnogQ==",
       "optional": true
     },
     "sass-embedded-darwin-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.60.0.tgz",
-      "integrity": "sha512-K7uFEzL5CnzPh7uNscstd2v4NooTJoQyjd64z6y3MWb3ArCl57w4ig/QAzwnydJ2YgaJD2YYVQrokCHyu4tjOw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.62.0.tgz",
+      "integrity": "sha512-2sBQ4uWjZbf8TKXF8Aq7N0p5V2tKUr4zX9gQAiKvm1NBYwsW22+m8D34heOWu50ikpIxebvt7i/z7hafH5kzKg==",
       "optional": true
     },
     "sass-embedded-linux-arm": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.60.0.tgz",
-      "integrity": "sha512-bLefkjt6kaHI9XqxRd+xHPSiKd/Klx7aVOV7K68F4O4YQSIs1pvdryrj6XeHtAyuNckkBStyRruD+bRPwJ7LmQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.62.0.tgz",
+      "integrity": "sha512-0lz9Ids/OzKiOK+fd5wo/fHBGJ5lCHbcRsjDnU0CIMWkUmMt7yhcFABWB/TUofS5XvrohYbGqs+yKP3X0oGX3g==",
       "optional": true
     },
     "sass-embedded-linux-arm64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.60.0.tgz",
-      "integrity": "sha512-VoN/aLHWnSNZbRR0eifsylrPBWzqQsG++J2qPbzvnuakRspaIRDCirw2QGFhksmyty5bn/syekKAIUUaCamBJQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.62.0.tgz",
+      "integrity": "sha512-FexUt8aE7I7fJub3N6+NsDdbPRP/O8o400qpbEbY7BWgiWEdpr81OBulQZY/2LzZUnz9keUhfpmltNY3SNg3kg==",
       "optional": true
     },
     "sass-embedded-linux-ia32": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.60.0.tgz",
-      "integrity": "sha512-2XkIOT+7rNkjuDMugFASnbvwh9Fg48hZZh8kW4ZPGj1QxHtZNlGLXt0C/i0jAZUdjhhyjd9l+xUIxZj5/JClPg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.62.0.tgz",
+      "integrity": "sha512-VpDHtMIwcoWqDsiskjhDYAle0SJV4mUiZJTXg5RkMzoX1ZyNiVz+uNaZ88kDqcGXsWpe2i0sIlljD4ryaiMAhA==",
       "optional": true
     },
     "sass-embedded-linux-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.60.0.tgz",
-      "integrity": "sha512-V0ZooknRIkS3lqn+3Yh2xrpfgd82A4n9PvzV/1KJWs4p5eJsapRIx/yGXHPFHfooHagN57kDWaFFdQYUfuYHrw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.62.0.tgz",
+      "integrity": "sha512-dntYMsu0QonlerFB8VDlzxoJcpMEtN9lPHstKOQ6rk6hbSFPvcI8MqqUomlOjmpakKeVrpyZ04nm9jHrzlFmYg==",
       "optional": true
     },
     "sass-embedded-win32-ia32": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.60.0.tgz",
-      "integrity": "sha512-pMNKxcysEVK4Dh27yLFNBAMqAKAJoVsl67lQ79LNrlZIVlIIwo/s1ajvImbf2srhWzizDJ1irxH2oBpF0kvxEA==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.62.0.tgz",
+      "integrity": "sha512-rTCZCVkQa6XcreyQ8gYqnsEG13HCzqKoN2mCvIuGwJro8IjyT2PzWauouO0M06T0FLH0pc3EvKdKaLdtijf9AQ==",
       "optional": true
     },
     "sass-embedded-win32-x64": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.60.0.tgz",
-      "integrity": "sha512-vGPeil9FzxJhPnWZ0zMLrY+GTT/fAUDVrKWQoXTxPfc7EugngbrqZ1qwVIVVCOC5zXDULB6LixCLFS8ut9R3KA==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.62.0.tgz",
+      "integrity": "sha512-g6DZBPGfIDKLBarvYRVKJ+7rJAHJXkOQQVrYSWm22klA9ZNZ0CaVyqLqejttZPKGreD8h/xh2uz/s6w/P900Sw==",
       "optional": true
     },
     "schema-utils": {

--- a/packages/webpacker/package.json
+++ b/packages/webpacker/package.json
@@ -37,7 +37,7 @@
     "postcss-loader": "^7.1.0",
     "postcss-preset-env": "^8.2.0",
     "postcss-scss": "^4.0.6",
-    "sass-embedded": "^1.60.0",
+    "sass-embedded": "~1.62.0",
     "shakapacker": "~6.6.0",
     "source-map-loader": "^4.0.1",
     "style-loader": "^3.3.2",


### PR DESCRIPTION
This PR locks the sass-embedded package to 1.62.

Related to https://github.com/decidim/decidim/pull/11074