### PR TITLE
Check for supported locale in Emoji picker

### DIFF
--- a/decidim-core/app/packs/src/decidim/input_emoji.js
+++ b/decidim-core/app/packs/src/decidim/input_emoji.js
@@ -34,7 +34,7 @@ export class EmojiButton {
     let emojiLocale = document.documentElement.getAttribute("lang");
 
     if (!SUPPORTED_LOCALES.includes(emojiLocale)) {
-      const secondaryLocale = emojiLocale.split("-")[0];
+      const secondaryLocale = emojiLocale?.split("-")[0];
       if (SUPPORTED_LOCALES.includes(secondaryLocale)) {
         emojiLocale = secondaryLocale;
       } else {

--- a/decidim-core/app/packs/src/decidim/input_emoji.js
+++ b/decidim-core/app/packs/src/decidim/input_emoji.js
@@ -29,7 +29,7 @@ export class EmojiButton {
 
   // Get the current locale used for the emoji database
   //
-  // @returns {string} the current locale if it's supported by emoji base, or english as the fallback locale
+  // @returns {string} the current locale if it is supported by emoji base, or english as the fallback locale
   static locale() {
     let emojiLocale = document.documentElement.getAttribute("lang");
 

--- a/decidim-core/app/packs/src/decidim/input_emoji.js
+++ b/decidim-core/app/packs/src/decidim/input_emoji.js
@@ -26,6 +26,23 @@ export class EmojiButton {
     return I18N_CONFIG;
   }
 
+  // Get the current locale used for the emoji database
+  //
+  // @see {@link https://emojibase.dev/docs/datasets/#supported-locales|Supported locales in the Emojibase documentation site}
+  // @see {@link https://github.com/milesj/emojibase/blob/master/packages/core/src/constants.ts}|the SUPPORTED_LOCALES constant}
+  //
+  // @returns {string} the current locale if it's supported by emoji base, or english as the fallback locale
+  static locale() {
+    const emojibaseSupportedLocales = ["da", "de", "en", "en-gb", "es", "es-mx", "et", "fi", "fr", "hu", "it", "ja", "ko", "lt", "ms", "nb", "nl", "pl", "pt", "ru", "sv", "th", "uk", "zh", "zh-hant"];
+    const currentLocale = document.documentElement.getAttribute("lang");
+
+    if (emojibaseSupportedLocales.includes(currentLocale)) {
+      return currentLocale;
+    }
+
+    return "en";
+  }
+
   constructor(elem) {
     const i18nConfig = EmojiButton.i18n();
     const i18nDictionary = i18nConfig.dictionary;
@@ -66,7 +83,7 @@ export class EmojiButton {
 
     const picker = createPopup({
       autoFocus: "search",
-      locale: document.documentElement.getAttribute("lang"),
+      locale: EmojiButton.locale(),
       i18n: i18nDictionary
     }, {
       position: "bottom-end",

--- a/decidim-core/app/packs/src/decidim/input_emoji.js
+++ b/decidim-core/app/packs/src/decidim/input_emoji.js
@@ -1,4 +1,5 @@
 import { createPopup } from "@picmo/popup-picker";
+import { SUPPORTED_LOCALES } from "emojibase";
 
 import * as i18n from "src/decidim/i18n";
 
@@ -28,19 +29,20 @@ export class EmojiButton {
 
   // Get the current locale used for the emoji database
   //
-  // @see {@link https://emojibase.dev/docs/datasets/#supported-locales|Supported locales in the Emojibase documentation site}
-  // @see {@link https://github.com/milesj/emojibase/blob/master/packages/core/src/constants.ts}|the SUPPORTED_LOCALES constant}
-  //
   // @returns {string} the current locale if it's supported by emoji base, or english as the fallback locale
   static locale() {
-    const emojibaseSupportedLocales = ["da", "de", "en", "en-gb", "es", "es-mx", "et", "fi", "fr", "hu", "it", "ja", "ko", "lt", "ms", "nb", "nl", "pl", "pt", "ru", "sv", "th", "uk", "zh", "zh-hant"];
-    const currentLocale = document.documentElement.getAttribute("lang");
+    let emojiLocale = document.documentElement.getAttribute("lang");
 
-    if (emojibaseSupportedLocales.includes(currentLocale)) {
-      return currentLocale;
+    if (!SUPPORTED_LOCALES.includes(emojiLocale)) {
+      const secondaryLocale = emojiLocale.split("-")[0];
+      if (SUPPORTED_LOCALES.includes(secondaryLocale)) {
+        emojiLocale = secondaryLocale;
+      } else {
+        emojiLocale = "en";
+      }
     }
 
-    return "en";
+    return emojiLocale;
   }
 
   constructor(elem) {

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -104,6 +104,48 @@ shared_examples "comments" do
       expect(page).to have_selector(".add-comment form")
     end
 
+    describe "when using emojis" do
+      shared_examples_for "allowing to select emojis" do
+        it "allows selecting emojis" do
+          within_language_menu do
+            click_link locale
+          end
+
+          within ".add-comment form" do
+            expect(page).to have_selector(".emoji__container")
+            expect(page).to have_selector(".emoji__trigger .emoji__button")
+            find(".emoji__trigger .emoji__button").click
+          end
+
+          within ".picmo__popupContainer .picmo__picker .picmo__content" do
+            expect(page).to have_content(phrase)
+            categories = page.all(".picmo__emojiCategory")
+            within categories[1] do
+              click_button "😀"
+            end
+          end
+
+          within ".add-comment form" do
+            expect(find("textarea").value.strip).to have_content("😀")
+          end
+        end
+      end
+
+      context "when the locale is supported" do
+        let(:locale) { "English" }
+        let(:phrase) { "SMILEYS & EMOTION" }
+
+        it_behaves_like "allowing to select emojis"
+      end
+
+      context "when the locale is not supported" do
+        let(:locale) { "Català" }
+        let(:phrase) { "SOMRIURES I EMOCIONS" }
+
+        it_behaves_like "allowing to select emojis"
+      end
+    end
+
     context "when no default comments length specified" do
       it "displays the numbers of characters left" do
         within ".add-comment form" do


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
While working in Emojis, I found that we added i18n supported (yay!) but it fails if the locale isn't supported by our library providers (`@picmo/popup-picker` and `emojibase`). 

The solution is to check if it's supported by them and if not fallback to English (as it used to work until now).

Sadly I couldn't find any API to get this list, so we're hardcoding the supported locales :/ 

#### :pushpin: Related Issues
 
- Related to #9667
 

#### Testing

1. Log in as an user
2. Change your current locale to "catalan"
3. Go to a comment textarea
4. Click on the emoji button

### :camera: Screenshots
 
#### Before

![Error in emoji picker in catalan](https://github.com/decidim/decidim/assets/717367/1e5ece07-084b-4f33-9fbf-de135e13a831)

#### After

![Fixed emoji picker in catalan](https://github.com/decidim/decidim/assets/717367/ffa097af-3fb7-4ca5-aac2-241cdc8f23eb)

Mind that in this case emojipicker getting the correct locale but the problem is in emojibase that doesn't support catalan. 

:hearts: Thank you!
