### PR TITLE
Show all projects if none is selected when the voting has finished

### DIFF
--- a/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
@@ -54,7 +54,11 @@ module Decidim
       end
 
       def default_filter_status_params
-        voting_finished? && budget.projects.selected.any? ? %w(selected) : %w(all)
+        show_selected_budgets? ? %w(selected) : %w(all)
+      end
+
+      def show_selected_budgets?
+        voting_finished? && budget.projects.selected.any?
       end
     end
   end

--- a/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
@@ -54,7 +54,7 @@ module Decidim
       end
 
       def default_filter_status_params
-        voting_finished? ? %w(selected) : %w(all)
+        voting_finished? && budget.projects.selected.any? ? %w(selected) : %w(all)
       end
     end
   end

--- a/decidim-budgets/spec/system/explore_projects_spec.rb
+++ b/decidim-budgets/spec/system/explore_projects_spec.rb
@@ -147,11 +147,43 @@ describe "Explore projects", :slow, type: :system do
           visit_budget
 
           within ".with_any_status_check_boxes_tree_filter" do
-            uncheck "Selected"
+            expect(all("input[type=checkbox]")[0]).to be_checked
+            expect(all("input[type=checkbox]")[2]).not_to be_checked
           end
 
           within "#projects" do
             expect(page).to have_css(".budget-list__item", count: 1)
+            expect(page).to have_content(translated(project.title))
+          end
+
+          within ".with_any_status_check_boxes_tree_filter" do
+            uncheck "Selected"
+          end
+
+          within "#projects" do
+            expect(page).to have_css(".budget-list__item", count: 5)
+            expect(page).to have_content(translated(project.title))
+          end
+
+          within ".with_any_status_check_boxes_tree_filter" do
+            check "Not selected"
+          end
+
+          within "#projects" do
+            expect(page).to have_css(".budget-list__item", count: 4)
+            expect(page).not_to have_content(translated(project.title))
+          end
+        end
+
+        it "does not filter selected by default" do
+          visit_budget
+          within ".with_any_status_check_boxes_tree_filter" do
+            expect(all("input[type=checkbox]")[0]).not_to be_checked
+            expect(all("input[type=checkbox]")[1]).not_to be_checked
+          end
+
+          within "#projects" do
+            expect(page).to have_css(".budget-list__item", count: 5)
             expect(page).to have_content(translated(project.title))
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?
As long as no project has been given a "selected/unselected" status, all projects should be displayed.

#### :pushpin: Related Issues
- Fixes #10636 

#### Testing
 1. Allows filtering by status.
 2. Does not filter selected by default.

### :camera: Screenshots
Voting enabled:
![image](https://github.com/decidim/decidim/assets/116598037/154d6f77-4203-4dc6-9ca7-44bbb04cf79e)

Voting finish (not status yet)
![image](https://github.com/decidim/decidim/assets/116598037/8ac76496-1412-4de5-ac33-203dbd1bf8e8)


:hearts: Thank you!
