### PR TITLE
Fix configuration param and documentation links in CSP

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -186,7 +186,7 @@ In order to customize the CSP we are providing, have 2 options, either by using 
 
 Please read more in the docs:
 
-- [Customize Content Security Policy](https://docs.decidim.org/develop/en/customize/content_security_policy)
+- [Customize Content Security Policy](https://docs.decidim.org/en/develop/customize/content_security_policy)
 - [Using Content Security Policy initializer](https://docs.decidim.org/en/develop/configure/initializer#_content_security_policy)
 
 You can check more about the implementation in the [\#10700](https://github.com/decidim/decidim/pull/10700) pull request.

--- a/decidim-core/lib/decidim/content_security_policy.rb
+++ b/decidim-core/lib/decidim/content_security_policy.rb
@@ -38,7 +38,7 @@ module Decidim
     def initialize(organization = nil, additional_policies = {})
       @organization = organization
       @policy = default_policy
-      @additional_policies = additional_policies
+      @additional_policies = additional_policies.stringify_keys
     end
 
     def output_policy

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -526,7 +526,7 @@ module Decidim
 
   # List of additional content security policies to be appended to the default ones
   # This is useful for adding custom CSPs for external services like Here Maps, YouTube, etc.
-  # Read more: https://docs.decidim.org/en/develop/configure/initializer/#_content-security-policy
+  # Read more: https://docs.decidim.org/en/develop/configure/initializer#_content_security_policy
   config_accessor :content_security_policies_extra do
     {}
   end

--- a/decidim-core/spec/lib/content_security_policy_spec.rb
+++ b/decidim-core/spec/lib/content_security_policy_spec.rb
@@ -27,6 +27,22 @@ module Decidim
       it { expect(subject.append_csp_directive("default-src", "https://example.org")).to be_a(Array) }
       it { expect(subject.append_csp_directive("default-src", "https://example.org")).to include("https://example.org") }
 
+      context "when policies as passed as hash" do
+        let(:additional_content_security_policies) { { "img-src": %w('self') } } # rubocop:disable Lint/PercentStringArray
+
+        it "does not raise any errors" do
+          expect { subject.output_policy }.not_to raise_error(RuntimeError)
+        end
+      end
+
+      context "when policies as passed as string" do
+        let(:additional_content_security_policies) { { "img-src" => %w('self') } } # rubocop:disable Lint/PercentStringArray
+
+        it "does not raise any errors" do
+          expect { subject.output_policy }.not_to raise_error(RuntimeError)
+        end
+      end
+
       context "when append to existing directives" do
         before do
           subject.append_csp_directive("default-src", "https://example.org")

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -378,7 +378,7 @@ Decidim.configure do |config|
   # ]
 
   # Defines additional content security policies following the structure
-  # Read more: https://docs.decidim.org/en/develop/configure/initializer/#_content-security-policy
+  # Read more: https://docs.decidim.org/en/develop/configure/initializer#_content_security_policy
   config.content_security_policies_extra = {}
 
   # Admin admin password configurations


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
After #10700 has been merged, the following documentation links have been published: 
- https://docs.decidim.org/en/develop/configure/initializer#_content_security_policy
- https://docs.decidim.org/en/develop/customize/content_security_policy 

This PR attempt to fix all the places where the code pointed to newly published pages. 
In the same time, attempts to fix a configuration issue: the system was developed to support stringified keys, yet, after the latest changes were implemented, this did not worked as expected: 

```
# works 

    Decidim.content_security_policies_extra = {
      "img-src" => %w(https://via.placeholder.com),
    }

# does not work ( raises a RuntimeError ) 

    Decidim.content_security_policies_extra = {
      "img-src": %w(https://via.placeholder.com),
    }
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10700

#### Testing
1. Test the links and see they point to right locations 

For the configuration: 
1. On the develop branch test the code snippets from above
2. Pass keys as symbols to configuration
3.  See it fails 
4. Apply patch 
5. Repeat step 2
6. See the error is gone


:hearts: Thank you!
