### PR TITLE
Fix issues with overriding maps and loading Leaflet

### DIFF
--- a/decidim-core/app/packs/src/decidim/map/controller.js
+++ b/decidim-core/app/packs/src/decidim/map/controller.js
@@ -1,5 +1,3 @@
-import * as L from "leaflet";
-import "src/decidim/map/icon"
 import MapControllerRegistry from "src/decidim/map/controller_registry"
 
 export default class MapController {

--- a/decidim-core/app/packs/src/decidim/map/controller/drag_marker.js
+++ b/decidim-core/app/packs/src/decidim/map/controller/drag_marker.js
@@ -1,6 +1,4 @@
-import * as L from "leaflet";
 import MapController from "src/decidim/map/controller"
-import "src/decidim/vendor/leaflet-tilelayer-here"
 
 export default class MapDragMarkerController extends MapController {
   start() {

--- a/decidim-core/app/packs/src/decidim/map/controller/markers.js
+++ b/decidim-core/app/packs/src/decidim/map/controller/markers.js
@@ -1,5 +1,4 @@
 import "src/decidim/vendor/jquery-tmpl"
-import * as L from "leaflet";
 import MapController from "src/decidim/map/controller"
 import "leaflet.markercluster";
 

--- a/decidim-core/app/packs/src/decidim/map/controller/static.js
+++ b/decidim-core/app/packs/src/decidim/map/controller/static.js
@@ -1,4 +1,3 @@
-import * as L from "leaflet";
 import MapController from "src/decidim/map/controller"
 
 const openLink = window.open;

--- a/decidim-core/app/packs/src/decidim/map/factory.js
+++ b/decidim-core/app/packs/src/decidim/map/factory.js
@@ -1,3 +1,5 @@
+import "src/decidim/map/icon"
+
 import MapMarkersController from "src/decidim/map/controller/markers"
 import MapStaticController from "src/decidim/map/controller/static"
 import MapDragMarkerController from "src/decidim/map/controller/drag_marker"

--- a/decidim-core/app/packs/src/decidim/map/factory.js
+++ b/decidim-core/app/packs/src/decidim/map/factory.js
@@ -24,7 +24,8 @@ import MapDragMarkerController from "src/decidim/map/controller/drag_marker"
  *   window.Decidim.createMapController = (mapId, config) => {
  *     if (config.type === "custom") {
  *       // Obviously you need to implement CustomMapController for this to
- *       // work.
+ *       // work. You can find an example at:
+ *       // decidim-dev/app/packs/src/decidim/dev/test/custom_map_factory.js
  *       return new window.Decidim.CustomMapController(mapId, config);
  *     }
  *

--- a/decidim-core/app/packs/src/decidim/map/icon.js
+++ b/decidim-core/app/packs/src/decidim/map/icon.js
@@ -1,4 +1,3 @@
-import * as L from "leaflet";
 import { SVGIcon } from "src/decidim/map/svg-icon";
 
 L.DivIcon.SVGIcon = SVGIcon;

--- a/decidim-core/app/packs/src/decidim/map/legacy.js
+++ b/decidim-core/app/packs/src/decidim/map/legacy.js
@@ -1,6 +1,5 @@
 /* eslint-disable require-jsdoc */
 
-import * as L from "leaflet";
 import "src/decidim/map/factory"
 
 /**

--- a/decidim-core/app/packs/src/decidim/map/provider/default.js
+++ b/decidim-core/app/packs/src/decidim/map/provider/default.js
@@ -1,3 +1,5 @@
+import "leaflet"
+
 /**
  * NOTE:
  * This has to load before decidim/map in order for it to apply correctly when

--- a/decidim-core/app/packs/src/decidim/map/provider/here.js
+++ b/decidim-core/app/packs/src/decidim/map/provider/here.js
@@ -1,4 +1,5 @@
-import * as L from "leaflet"
+import "leaflet"
+import "src/decidim/vendor/leaflet-tilelayer-here"
 
 /**
  * NOTE:

--- a/decidim-core/lib/decidim/core/test/shared_examples/map_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/map_examples.rb
@@ -99,7 +99,7 @@ shared_context "with frontend map elements" do
     # context.
     final_html = html_document
     Rails.application.routes.draw do
-      get "maptiles/:x/:y/:z.png", to: ->(_) { [200, {}, [final_html]] }
+      get "maptiles/:z/:x/:y.png", to: ->(_) { [200, {}, [final_html]] }
       get "test_dynamic_map", to: ->(_) { [200, {}, [final_html]] }
       get "offline", to: ->(_) { [200, {}, [""]] }
     end

--- a/decidim-core/lib/decidim/core/test/shared_examples/map_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/map_examples.rb
@@ -99,6 +99,7 @@ shared_context "with frontend map elements" do
     # context.
     final_html = html_document
     Rails.application.routes.draw do
+      get "maptiles/:x/:y/:z.png", to: ->(_) { [200, {}, [final_html]] }
       get "test_dynamic_map", to: ->(_) { [200, {}, [final_html]] }
       get "offline", to: ->(_) { [200, {}, [""]] }
     end

--- a/decidim-core/lib/decidim/map/dynamic_map.rb
+++ b/decidim-core/lib/decidim/map/dynamic_map.rb
@@ -67,9 +67,9 @@ module Decidim
             "data-markers-data" => options.fetch(:markers, []).to_json
           }.merge(html_options)
 
+          append_assets
           content = template.capture { yield }.html_safe if block_given?
 
-          append_assets
           template.content_tag(:div, map_html_options) do
             (content || "")
           end

--- a/decidim-dev/app/packs/entrypoints/decidim_dev_test_custom_map.js
+++ b/decidim-dev/app/packs/entrypoints/decidim_dev_test_custom_map.js
@@ -1,0 +1,1 @@
+import "src/decidim/dev/test/custom_map_factory";

--- a/decidim-dev/app/packs/src/decidim/dev/test/custom_map_factory.js
+++ b/decidim-dev/app/packs/src/decidim/dev/test/custom_map_factory.js
@@ -1,0 +1,35 @@
+import MapMarkersController from "src/decidim/map/controller/markers";
+
+const appendToBody = (content) => {
+  const p = document.createElement("p");
+  p.innerHTML = content;
+  document.body.appendChild(p);
+}
+
+class CustomMapController extends MapMarkersController {
+  start() {
+    this.markerClusters = null;
+    this.addMarkers(this.config.markers);
+
+    appendToBody("Custom map started");
+  }
+}
+
+const origCreateMapController = window.Decidim.createMapController;
+
+const createMapController = (mapId, config) => {
+  if (config.type === "custom") {
+    return new CustomMapController(mapId, config);
+  }
+
+  return origCreateMapController(mapId, config);
+}
+
+window.Decidim.createMapController = createMapController;
+
+// Test that the map events are working correctly
+$("[data-decidim-map]").on("ready.decidim", (ev, _map, mapConfig) => {
+  appendToBody("Custom map ready");
+});
+
+appendToBody("LOADED");

--- a/decidim-dev/app/packs/src/decidim/dev/test/custom_map_factory.js
+++ b/decidim-dev/app/packs/src/decidim/dev/test/custom_map_factory.js
@@ -1,3 +1,18 @@
+/**
+ * Example of a custom map controller and how to override the
+ * `createMapController` factory method. To use it in the ERB view, add the
+ * following snippet to any view:
+ *
+ * <%= dynamic_map_for type: "custom", markers: [{ title: "Test 1", latitude: 41.385063, longitude: 2.173404 }], popup_template_id: "custom-popup" do %>
+ *  <% append_javascript_pack_tag("decidim_dev_test_custom_map") %>
+ *  <template id="custom-popup">
+ *    <div>
+ *      <h3>${title}</h3>
+ *    </div>
+ *  </template>
+ * <% end %>
+ */
+
 import MapMarkersController from "src/decidim/map/controller/markers";
 
 const appendToBody = (content) => {

--- a/decidim-dev/app/packs/src/decidim/dev/test/custom_map_factory.js
+++ b/decidim-dev/app/packs/src/decidim/dev/test/custom_map_factory.js
@@ -27,6 +27,11 @@ const createMapController = (mapId, config) => {
 
 window.Decidim.createMapController = createMapController;
 
+// Prevent external requests to the Here URLs during tests
+if (L.TileLayer.HERE) {
+  L.TileLayer.HERE.prototype.onAdd = function(map) {};
+}
+
 // Test that the map events are working correctly
 $("[data-decidim-map]").on("ready.decidim", (ev, _map, mapConfig) => {
   appendToBody("Custom map ready");

--- a/decidim-dev/config/assets.rb
+++ b/decidim-dev/config/assets.rb
@@ -4,5 +4,6 @@ base_path = File.expand_path("..", __dir__)
 
 Decidim::Webpacker.register_path("#{base_path}/app/packs")
 Decidim::Webpacker.register_entrypoints(
-  decidim_dev: "#{base_path}/app/packs/entrypoints/decidim_dev.js"
+  decidim_dev: "#{base_path}/app/packs/entrypoints/decidim_dev.js",
+  decidim_dev_test_custom_map: "#{base_path}/app/packs/entrypoints/decidim_dev_test_custom_map.js"
 )

--- a/decidim-dev/spec/system/custom_map_spec.rb
+++ b/decidim-dev/spec/system/custom_map_spec.rb
@@ -69,7 +69,6 @@ describe "Custom map", type: :system do
     let(:map_config) do
       {
         provider: :here
-        # dynamic: { api_key: "12345" }
       }
     end
 

--- a/decidim-dev/spec/system/custom_map_spec.rb
+++ b/decidim-dev/spec/system/custom_map_spec.rb
@@ -46,6 +46,12 @@ describe "Custom map", type: :system do
       expect(page).to have_content("Custom map started")
       expect(page).to have_content("Custom map ready")
     end
+
+    it "shows the map marker" do
+      within "[data-decidim-map]" do
+        expect(page).to have_css(".leaflet-marker-icon", count: marker_data.length)
+      end
+    end
   end
 
   let(:marker_data) do

--- a/decidim-dev/spec/system/custom_map_spec.rb
+++ b/decidim-dev/spec/system/custom_map_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Custom map", type: :system do
+  include_context "with frontend map builder" do
+    let(:template_class) do
+      Class.new(ActionView::Base) do
+        include Decidim::MapHelper
+
+        def protect_against_forgery?
+          false
+        end
+
+        def snippets
+          @snippets ||= Decidim::Snippets.new
+        end
+      end
+    end
+  end
+
+  include_context "with frontend map elements" do
+    let(:html_body) do
+      Decidim.maps = map_config
+      Decidim::Map.reset_utility_configuration!
+
+      markers = marker_data
+      template.instance_eval do
+        dynamic_map_for type: "custom", markers:, popup_template_id: "custom-popup" do
+          append_javascript_pack_tag("decidim_dev_test_custom_map")
+
+          <<~HTML.html_safe
+            <template id="custom-popup">
+              <div>
+                <h3>${title}</h3>
+              </div>
+            </template>
+          HTML
+        end
+      end
+    end
+  end
+
+  shared_examples "working custom map" do
+    it "allows overriding the map controller" do
+      expect(page).to have_content("Custom map started")
+      expect(page).to have_content("Custom map ready")
+    end
+  end
+
+  let(:marker_data) do
+    [
+      { title: "Test 1", latitude: 41.385063, longitude: 2.173404 }
+    ]
+  end
+
+  context "with OSM" do
+    let(:map_config) do
+      {
+        provider: :osm,
+        dynamic: { tile_layer: { url: "/maptiles/{z}/{x}/{y}.png" } }
+      }
+    end
+
+    it_behaves_like "working custom map"
+  end
+
+  context "with Here" do
+    let(:map_config) do
+      {
+        provider: :here
+        # dynamic: { api_key: "12345" }
+      }
+    end
+
+    it_behaves_like "working custom map"
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
There are several problems when trying to override the maps currently:

- The core map assets are loaded **after** the map element has been created but this is problematic because additional map assets can be added during that block as per the map customization documentation.
- The Leaflet package is loaded several times causing issues with the Here provider with the map customizations. Every time the Leaflet package is loaded, it adds a local version of that library to the file where it is loaded to causing the Here tile layer not to be available in the global `L` constant.
- The Here tile layer package is not loaded within the Here provider but within the `drag_markers.js` map controller which is incorrect as we do not want this file to be included for non-Here providers.

This PR fixes the problems by fixing the map assets and the order of inclusion when the map element is created.

In this PR I am also adding a custom map factory within the `decidim-dev` gem because this file does not need to be bundled to the production applications, this is why I added it to `decidim-dev`. This is only used to test that the map factory can be customized and is working correctly. This has to be tested end-to-end why it needs its own asset pack.

This fix should be also backported but it is not straight forward as the map inclusion strategy has changed due to Shakapacker. I can work on the backports once this is merged.

#### :pushpin: Related Issues
- Related to
  * #7464
  * #9425
  * #10389

#### Testing
To see the loading error:
- Checkout `develop` and make sure your development app is up to date
- Within the `decidim-dev` gem add the following files from this PR:
  * `decidim-dev/app/packs/entrypoints/decidim_dev_test_custom_map.js`
  * `decidim-dev/app/packs/src/decidim/dev/test/custom_map_factory.js`
- Register this new pack within the `assets.rb` configuration of the `decidim-dev` gem (as in this PR)
- Configure your application to use Here maps
  * `config.maps = { provider: :here, api_key: "12345" }` within the Decidim initializer
- Add the following snippet (see below) to the index page of proposals and visit that page
- See errors in the developer console

The snippet to use the custom map within the proposals index page (for instance):
```ruby
<%= dynamic_map_for type: "custom", markers: [{ title: "Test 1", latitude: 41.385063, longitude: 2.173404 }], popup_template_id: "custom-popup" do %>
  <% append_javascript_pack_tag("decidim_dev_test_custom_map") %>
  <template id="custom-popup">
    <div>
      <h3>${title}</h3>
    </div>
  </template>
<% end %>
```

After this error is solved as per this PR, reload that page and see the map working correctly without errors. Note that you may have to adjust the content security policy depending on your map configuration.

Also after this PR is applied, you should see a couple of paragraphs of text added to the bottom of the page where the map is added to indicate that the map customization is working correctly. There is a spec added in this PR to test that for both OSM and Here.

The added system spec to the `decidim-dev` gem is testing this exact case for both OSM and Here.

### :camera: Screenshots
This is a screenshot of the developer console when trying to load the custom map:
![Here tilelayer problems](https://github.com/decidim/decidim/assets/864340/f2e51a6e-d36a-4f96-891e-9098b986b45f)

In text format for easier searching:
```
jquery.js:3783 Uncaught TypeError: L.TileLayer.HERE is not a constructor
    at push.../decidim-core/app/packs/src/decidim/vendor/leaflet-tilelayer-here.js.L.tileLayer.here (leaflet-tilelayer-here.js:211:1)
    at HTMLDivElement.<anonymous> (here.js:13:1)
    at HTMLDivElement.dispatch (jquery.js:5135:1)
    at elemData.handle (jquery.js:4939:1)
    at Object.trigger (jquery.js:8619:1)
    at HTMLDivElement.<anonymous> (jquery.js:8697:1)
    at Function.each (jquery.js:383:1)
    at jQuery.fn.init.each (jquery.js:205:1)
    at jQuery.fn.init.trigger (jquery.js:8696:1)
    at HTMLDivElement.<anonymous> (map.js:29:1)
```