### PR TITLE
Redesign: content blocks tasks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -128,9 +128,9 @@ bundle exec rake decidim:content_blocks:initialize_default_content_blocks
 
 The task has some optional arguments:
 
-* The first to specify the manifest name and generate the default content blocks only on the spaces or resources with the manifest name (`participatory_processes`, `participatory_process_group` or `assemblies`).
-* The second can be the id of a resource o space to apply only on the space or resource with the id. This argument is considered only if the manifest name argument is present.
-* The last argument only works on participatory spaces (assemblies and participatory processes) and when set as true the task also creates a content block for each published component on the space unless a block already exists for that component or the block exists for the component type and configured to display resources from all components of the same type.
+- The first to specify the manifest name and generate the default content blocks only on the spaces or resources with the manifest name (`participatory_processes`, `participatory_process_group` or `assemblies`).
+- The second can be the id of a resource o space to apply only on the space or resource with the id. This argument is considered only if the manifest name argument is present.
+- The last argument only works on participatory spaces (assemblies and participatory processes) and when set as true the task also creates a content block for each published component on the space unless a block already exists for that component or the block exists for the component type and configured to display resources from all components of the same type.
 
 For example, to generate the default content blocks and also the components blocks on participatory spaces run the command with arguments:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -118,6 +118,26 @@ bundle exec rake decidim:webpacker:install
 
 This will make the necessary changes in the `config/webpacker.yml`, but also in the `config/webpack/` folder.
 
+### 3.5. Initialize content blocks on spaces or resources with landing page
+
+The processes and assemblies participatory spaces have changed the show page and now is composed using content blocks. For the new spaces created in this version a callback is executed creating the content blocks marked as `default!` in the engine for the corresponding homepage scope. To have the same initialization in the existing spaces there is a task to generate those blocks if not present already. Run the below command to generate default content blocks when not present for all spaces and resources with content blocks homepage (participatory processes, participatory process groups and assemblies):
+
+```console
+bundle exec rake decidim:content_blocks:initialize_default_content_blocks
+```
+
+The task has some optional arguments:
+
+* The first to specify the manifest name and generate the default content blocks only on the spaces or resources with the manifest name (`participatory_processes`, `participatory_process_group` or `assemblies`).
+* The second can be the id of a resource o space to apply only on the space or resource with the id. This argument is considered only if the manifest name argument is present.
+* The last argument only works on participatory spaces (assemblies and participatory processes) and when set as true the task also creates a content block for each published component on the space unless a block already exists for that component or the block exists for the component type and configured to display resources from all components of the same type.
+
+For example, to generate the default content blocks and also the components blocks on participatory spaces run the command with arguments:
+
+```console
+bundle exec rake decidim:content_blocks:initialize_default_content_blocks[,,true]
+```
+
 #### Note for development
 
 If you are using the `Procfile.dev` file, you will need to make sure that you have the following line in your configuration. If you have not altered the `Procfile.dev` file, you will not need to do anything, as we covered that part:

--- a/decidim-admin/app/controllers/decidim/admin/components_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/components_controller.rb
@@ -35,7 +35,12 @@ module Decidim
 
         CreateComponent.call(@form) do
           on(:ok) do
-            flash[:notice] = I18n.t("components.create.success", scope: "decidim.admin")
+            if (landing_page_path = participatory_space_landing_page_path(@component)).present?
+              flash[:notice_html] = I18n.t("components.create.success_landing_page", landing_page_path:, scope: "decidim.admin").html_safe
+            else
+              flash[:notice] = I18n.t("components.create.success", scope: "decidim.admin")
+            end
+
             redirect_to action: :index
           end
 
@@ -167,6 +172,13 @@ module Decidim
           previous_settings["default_step"] || {},
           current_settings["default_step"] || {}
         )
+      end
+
+      def participatory_space_landing_page_path(component)
+        participatory_space = component.participatory_space
+        return if participatory_space.manifest.content_blocks_scope_name.blank?
+
+        Decidim::EngineRouter.admin_proxy(participatory_space).send("edit_#{participatory_space.manifest.route_name}_landing_page_path")
       end
     end
   end

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -321,6 +321,7 @@ en:
         create:
           error: There was a problem creating this component.
           success: Component created successfully.
+          success_landing_page: Component created successfully. You can add a content block for this component in the home of the space. Go to <a href="%{landing_page_path}">Landing page</a> to configure it.
         destroy:
           error: There was a problem destroying this component.
           success: Component deleted successfully.

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly.rb
@@ -25,6 +25,7 @@ module Decidim
           if assembly.persisted?
             add_admins_as_followers(assembly)
             link_participatory_processes(assembly)
+            Decidim::ContentBlocksCreator.new(assembly).create_default!
 
             broadcast(:ok, assembly)
           else

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -110,19 +110,16 @@ module Decidim
           content_block.settings do |settings|
             settings.attribute :html_content, type: :text, translated: true
           end
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:assembly_homepage, :hero) do |content_block|
           content_block.cell = "decidim/content_blocks/participatory_space_hero"
           content_block.public_name_key = "decidim.content_blocks.hero.name"
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:assembly_homepage, :announcement) do |content_block|
           content_block.cell = "decidim/content_blocks/participatory_space_announcement"
           content_block.public_name_key = "decidim.content_blocks.announcement.name"
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:assembly_homepage, :main_data) do |content_block|
@@ -134,7 +131,6 @@ module Decidim
         Decidim.content_blocks.register(:assembly_homepage, :extra_data) do |content_block|
           content_block.cell = "decidim/assemblies/content_blocks/extra_data"
           content_block.public_name_key = "decidim.assemblies.content_blocks.extra_data.name"
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:assembly_homepage, :metadata) do |content_block|
@@ -146,13 +142,11 @@ module Decidim
         Decidim.content_blocks.register(:assembly_homepage, :dates_metadata) do |content_block|
           content_block.cell = "decidim/assemblies/content_blocks/dates_metadata"
           content_block.public_name_key = "decidim.assemblies.content_blocks.dates_metadata.name"
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:assembly_homepage, :social_networks_metadata) do |content_block|
           content_block.cell = "decidim/content_blocks/participatory_space_social_networks"
           content_block.public_name_key = "decidim.content_blocks.social_networks_metadata.name"
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:assembly_homepage, :last_activity) do |content_block|
@@ -162,13 +156,11 @@ module Decidim
           content_block.settings do |settings|
             settings.attribute :max_last_activity_users, type: :integer, default: Decidim::ContentBlocks::ParticipatorySpaceLastActivityCell::DEFAULT_MAX_LAST_ACTIVITY_USERS
           end
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:assembly_homepage, :stats) do |content_block|
           content_block.cell = "decidim/assemblies/content_blocks/stats"
           content_block.public_name_key = "decidim.content_blocks.participatory_space_stats.name"
-          content_block.default!
         end
 
         if Decidim.module_installed?(:accountability)

--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -271,6 +271,8 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
         Decidim.component_manifests.each do |manifest|
           manifest.seed!(current_assembly.reload)
         end
+
+        Decidim::ContentBlocksCreator.new(current_assembly).create_default!
       end
     end
   end

--- a/decidim-core/app/services/decidim/content_blocks_creator.rb
+++ b/decidim-core/app/services/decidim/content_blocks_creator.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Service to generate content blocks on spaces o resources which have content
+  # blocks registered for them on their engines.
+  #
+  # This class is initialized passing an space which can be an organization, a
+  # participatory space with content blocks like processes or assemblies or a
+  # participatory process group.
+  class ContentBlocksCreator
+    attr_reader :space, :scope_name, :scoped_resource_id, :is_organization, :organization, :default_content_blocks, :component_content_blocks
+
+    def initialize(space)
+      @space = space
+      @is_organization = space.is_a? Decidim::Organization
+      @organization = is_organization ? space : space.organization
+      @scoped_resource_id = is_organization ? nil : space.id
+      manifest = manifest_for(space)
+      @scope_name = is_organization ? :homepage : manifest.content_blocks_scope_name
+      raise ArgumentError, "[ERROR] The #{manifest.name} spaces do not define a content blocks scope" if scope_name.blank?
+
+      @default_content_blocks = Decidim.content_blocks.for(scope_name).select(&:default)
+      @component_content_blocks = Decidim.content_blocks.for(scope_name).select(&:component_manifest_name)
+    end
+
+    # Creates all content blocks registered as default for the space or
+    # resource unless one created with the same manifest already exists in
+    # the same space.
+    def create_default!
+      default_content_blocks.each_with_index do |manifest, index|
+        next if Decidim::ContentBlock.exists?(decidim_organization_id: organization.id, scope_name:, manifest_name: manifest.name, scoped_resource_id:)
+
+        weight = (index + 1) * 10
+
+        Decidim::ContentBlock.create(
+          decidim_organization_id: organization.id,
+          weight:,
+          scope_name:,
+          scoped_resource_id:,
+          manifest_name: manifest.name,
+          published_at: Time.current
+        )
+      end
+    end
+
+    # This method only works in participatory spaces. For all the components
+    # published in the space creates an associated content block if registered
+    # for the sope and component and is not created configured for the
+    # component or globally to cover all components of the same type.
+    def create_components_blocks!
+      return unless space.is_a? Decidim::Participable
+
+      space.components.published.each_with_index do |component, index|
+        block_manifest = component_content_blocks.find { |manifest| manifest.component_manifest_name == component.manifest_name }
+
+        next unless block_manifest
+
+        content_blocks = Decidim::ContentBlock.where(decidim_organization_id: organization.id, scope_name:, manifest_name: block_manifest.name, scoped_resource_id:)
+
+        # Ignore creation if there is already a content block for the same
+        # component or a general content block for all the components of the
+        # same type in the space
+        next if content_blocks.any? do |block|
+          component_id = block.settings.component_id
+          component_id.blank? || component_id.to_i == component.id
+        end
+
+        weight = ((index + 1) * 10) + 1000
+
+        Decidim::ContentBlock.create(
+          decidim_organization_id: organization.id,
+          weight:,
+          scope_name:,
+          scoped_resource_id:,
+          manifest_name: block_manifest.name,
+          settings: { component_id: component.id.to_s },
+          published_at: Time.current
+        )
+      end
+    end
+
+    private
+
+    def manifest_for(resource)
+      return resource.manifest if resource.is_a? Decidim::Participable
+      return resource.resource_manifest if resource.is_a? Decidim::Resourceable
+    end
+  end
+end

--- a/decidim-core/lib/tasks/decidim_content_blocks_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_content_blocks_tasks.rake
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :content_blocks do
+    desc "Initializes a default set of content blocks for each space whose landing page uses content blocks"
+    task :initialize_default_content_blocks, [:manifest_name, :space_id, :include_components] => :environment do |_task, args|
+      manifest_name = args[:manifest_name]
+      space_id = args[:space_id]&.to_i
+
+      raise "Please, provide a valid manifest name to find the space by id" if space_id.present? && manifest_name.blank?
+
+      include_components = args[:include_components] == "true"
+
+      valid_manifests = manifests_with_content_blocks
+      valid_manifests = valid_manifests.select { |manifest| manifest.name.to_s == manifest_name.to_s } if manifest_name.present?
+
+      raise "The #{manifest_name} spaces do not exist or have content blocks" if manifest_name.present? && valid_manifests.blank?
+
+      valid_manifests.each do |manifest|
+        spaces = resources_for(manifest)
+        spaces = spaces.select { |space| space.id == space_id } if space_id.present?
+
+        spaces.each do |space|
+          content_blocks_creator = Decidim::ContentBlocksCreator.new(space)
+          content_blocks_creator.create_default!
+
+          content_blocks_creator.create_components_blocks! if include_components
+        end
+      end
+    end
+
+    def manifests_with_content_blocks
+      [
+        Decidim.participatory_space_manifests,
+        Decidim.resource_manifests
+      ].map do |manifests|
+        manifests.select { |manifest| manifest.content_blocks_scope_name.present? }
+      end.flatten
+    end
+
+    def resources_for(manifest)
+      return manifest.participatory_spaces.call(Decidim::Organization.all) if manifest.respond_to?(:participatory_spaces)
+      return manifest.model_class.all if manifest.respond_to?(:model_class)
+
+      []
+    end
+  end
+end

--- a/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/extra_data_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/extra_data_cell.rb
@@ -11,7 +11,7 @@ module Decidim
         private
 
         def extra_data_items
-          [developer_group_item, target_item, participatory_scope_item, participatory_structure_item]
+          [developer_group_item, target_item, participatory_scope_item, participatory_structure_item].compact
         end
 
         def developer_group_item

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
@@ -27,6 +27,8 @@ module Decidim
           if process.persisted?
             add_admins_as_followers(process)
             link_related_processes
+            Decidim::ContentBlocksCreator.new(process).create_default!
+
             broadcast(:ok, process)
           else
             form.errors.add(:hero_image, process.errors[:hero_image]) if process.errors.include? :hero_image

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process_group.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process_group.rb
@@ -25,6 +25,8 @@ module Decidim
           group = create_participatory_process_group
 
           if group.persisted?
+            Decidim::ContentBlocksCreator.new(group).create_default!
+
             broadcast(:ok, group)
           else
             form.errors.add(:hero_image, group.errors[:hero_image]) if group.errors.include? :hero_image

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -91,6 +91,33 @@ module Decidim
           content_block.default!
         end
 
+        Decidim.content_blocks.register(:participatory_process_group_homepage, :extra_data) do |content_block|
+          content_block.cell = "decidim/participatory_process_groups/content_blocks/extra_data"
+          content_block.public_name_key = "decidim.participatory_process_groups.content_blocks.extra_data.name"
+          content_block.default!
+        end
+
+        Decidim.content_blocks.register(:participatory_process_group_homepage, :cta) do |content_block|
+          content_block.cell = "decidim/content_blocks/cta"
+          content_block.settings_form_cell = "decidim/content_blocks/cta_settings_form"
+          content_block.public_name_key = "decidim.content_blocks.cta.name"
+
+          content_block.images = [
+            {
+              name: :background_image,
+              uploader: "Decidim::HomepageImageUploader"
+            }
+          ]
+
+          content_block.settings do |settings|
+            settings.attribute :button_text, type: :text, translated: true
+            settings.attribute :button_url, type: :string, required: true
+            settings.attribute :description, type: :string, translated: true, editor: true
+          end
+
+          content_block.default!
+        end
+
         (1..3).each do |index|
           Decidim.content_blocks.register(:participatory_process_group_homepage, :"html_#{index}") do |content_block|
             content_block.cell = "decidim/content_blocks/html"
@@ -100,7 +127,6 @@ module Decidim
             content_block.settings do |settings|
               settings.attribute :html_content, type: :text, translated: true
             end
-            content_block.default!
           end
         end
 
@@ -185,6 +211,7 @@ module Decidim
             content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_settings_form"
             content_block.public_name_key = "decidim.accountability.content_blocks.highlighted_results.results"
             content_block.component_manifest_name = "accountability"
+            content_block.default!
 
             content_block.settings do |settings|
               settings.attribute :order, type: :enum, default: "random", choices: %w(random recent)
@@ -288,33 +315,6 @@ module Decidim
               settings.attribute :component_id, type: :select, default: nil
             end
           end
-        end
-
-        Decidim.content_blocks.register(:participatory_process_group_homepage, :extra_data) do |content_block|
-          content_block.cell = "decidim/participatory_process_groups/content_blocks/extra_data"
-          content_block.public_name_key = "decidim.participatory_process_groups.content_blocks.extra_data.name"
-          content_block.default!
-        end
-
-        Decidim.content_blocks.register(:participatory_process_group_homepage, :cta) do |content_block|
-          content_block.cell = "decidim/content_blocks/cta"
-          content_block.settings_form_cell = "decidim/content_blocks/cta_settings_form"
-          content_block.public_name_key = "decidim.content_blocks.cta.name"
-
-          content_block.images = [
-            {
-              name: :background_image,
-              uploader: "Decidim::HomepageImageUploader"
-            }
-          ]
-
-          content_block.settings do |settings|
-            settings.attribute :button_text, type: :text, translated: true
-            settings.attribute :button_url, type: :string, required: true
-            settings.attribute :description, type: :string, translated: true, editor: true
-          end
-
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:participatory_process_group_homepage, :stats) do |content_block|

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -138,19 +138,16 @@ module Decidim
           content_block.settings do |settings|
             settings.attribute :html_content, type: :text, translated: true
           end
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:participatory_process_homepage, :process_hero) do |content_block|
           content_block.cell = "decidim/participatory_processes/content_blocks/hero"
           content_block.public_name_key = "decidim.participatory_processes.content_blocks.hero.name"
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:participatory_process_homepage, :announcement) do |content_block|
           content_block.cell = "decidim/content_blocks/participatory_space_announcement"
           content_block.public_name_key = "decidim.content_blocks.announcement.name"
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:participatory_process_homepage, :main_data) do |content_block|
@@ -162,7 +159,6 @@ module Decidim
         Decidim.content_blocks.register(:participatory_process_homepage, :extra_data) do |content_block|
           content_block.cell = "decidim/participatory_processes/content_blocks/extra_data"
           content_block.public_name_key = "decidim.participatory_processes.content_blocks.extra_data.name"
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:participatory_process_homepage, :metadata) do |content_block|
@@ -178,19 +174,16 @@ module Decidim
           content_block.settings do |settings|
             settings.attribute :max_last_activity_users, type: :integer, default: Decidim::ContentBlocks::ParticipatorySpaceLastActivityCell::DEFAULT_MAX_LAST_ACTIVITY_USERS
           end
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:participatory_process_homepage, :stats) do |content_block|
           content_block.cell = "decidim/participatory_processes/content_blocks/stats"
           content_block.public_name_key = "decidim.content_blocks.participatory_space_stats.name"
-          content_block.default!
         end
 
         Decidim.content_blocks.register(:participatory_process_homepage, :metrics) do |content_block|
           content_block.cell = "decidim/participatory_processes/content_blocks/metrics"
           content_block.public_name_key = "decidim.content_blocks.participatory_space_metrics.name"
-          content_block.default!
         end
 
         if Decidim.module_installed?(:accountability)

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -93,19 +93,8 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
       )
     end
 
-    landing_page_content_blocks = [:title, :extra_data, :cta, :highlighted_proposals, :highlighted_results, :highlighted_meetings, :stats, :participatory_processes]
-
     process_groups.each do |process_group|
-      landing_page_content_blocks.each.with_index(1) do |manifest_name, index|
-        Decidim::ContentBlock.create(
-          organization:,
-          scope_name: :participatory_process_group_homepage,
-          manifest_name:,
-          weight: index,
-          scoped_resource_id: process_group.id,
-          published_at: Time.current
-        )
-      end
+      Decidim::ContentBlocksCreator.new(process_group).create_default!
     end
 
     process_types = []
@@ -199,6 +188,8 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
           participatory_process: process,
           role:
         )
+
+        Decidim::ContentBlocksCreator.new(process).create_default!
       end
 
       attachment_collection = Decidim::AttachmentCollection.create!(

--- a/decidim-system/app/commands/decidim/system/create_default_content_blocks.rb
+++ b/decidim-system/app/commands/decidim/system/create_default_content_blocks.rb
@@ -19,23 +19,10 @@ module Decidim
       #
       # Returns nothing.
       def call
-        content_blocks.each_with_index do |manifest, index|
-          weight = (index + 1) * 10
-          Decidim::ContentBlock.create(
-            decidim_organization_id: organization.id,
-            weight:,
-            scope_name: :homepage,
-            manifest_name: manifest.name,
-            published_at: Time.current
-          )
-        end
+        Decidim::ContentBlocksCreator.new(organization).create_default!
       end
 
       private
-
-      def content_blocks
-        Decidim.content_blocks.for(:homepage).select(&:default)
-      end
 
       attr_reader :organization
     end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

This PR:
* Defines a service to generate content blocks for landing pages of organizations, processes, assemblies or groups of processes
* Uses the service in the create_default_content_blocks command called in the organization creation
* Uses the service in the creation commands of processes, assemblies or groups of processes
* Defines a task to create default content blocks on existing processes, assemblies and groups of processes and optionally create content blocks associated to published components (this option only applies to processes and assemblies). The task can be called for a specific type of space using its space or resource manifest name (`participatory_processes`, `assemblies` or `participatory_process_group`) and also the id of an instance of their models can be specified
* Fixes a bug on extra_data participatory process group content block that occurs when the associated data is empty

NOTE

This PR depends on #10931 which implements association between participatory process group and content blocks via resource manifest. Once merged this PR the failing tests should pass

#### :pushpin: Related Issues
*Link your PR to an issue*

- Fixes #10747 
- Fixes #10412

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
