### PR TITLE
Fix Admin dashboard disappear if you are in Trustee Zone

### DIFF
--- a/decidim-elections/app/controllers/decidim/elections/trustee_zone/application_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/trustee_zone/application_controller.rb
@@ -14,6 +14,11 @@ module Decidim
 
         before_action :ensure_configured_bulletin_board!
 
+        register_permissions(::Decidim::Elections::TrusteeZone::ApplicationController,
+                             ::Decidim::Admin::Permissions,
+                             ::Decidim::Elections::Permissions,
+                             ::Decidim::Permissions)
+
         private
 
         def ensure_configured_bulletin_board!
@@ -35,10 +40,7 @@ module Decidim
         end
 
         def permission_class_chain
-          [
-            Decidim::Elections::Permissions,
-            Decidim::Permissions
-          ]
+          ::Decidim.permissions_registry.chain_for(::Decidim::Elections::TrusteeZone::ApplicationController)
         end
       end
     end

--- a/decidim-elections/app/controllers/decidim/elections/trustee_zone/application_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/trustee_zone/application_controller.rb
@@ -15,8 +15,8 @@ module Decidim
         before_action :ensure_configured_bulletin_board!
 
         register_permissions(::Decidim::Elections::TrusteeZone::ApplicationController,
-                             ::Decidim::Admin::Permissions,
                              ::Decidim::Elections::Permissions,
+                             ::Decidim::Admin::Permissions,
                              ::Decidim::Permissions)
 
         private


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
While reviewing #10870 i came across the need of switching between Trustee zone in profile and Admin Dashboard. I saw that Admin menu disappeared in that particular page, and i have remembered about #9586
.
#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #9586

#### Testing
1. Login as admin using the latest develop branch 
2. Visit Trustee zone in user profile
3. Hover the user profile menu
4. See there **IS NO** entry for Admin Dashboard menu 
5. Apply patch 
6. repeat 2 + 3
7. See there **IS** a entry for Admin Dashboard menu 

![no_tauler_configuració_trustee](https://user-images.githubusercontent.com/40388743/179236390-191f8ad2-67ac-4bda-bfa9-ac6e98f09bef.gif)

:hearts: Thank you!
