### PR TITLE
Backport 'Avoid password change to be requested when user registration mode is disabled' to v0.27

### DIFF
--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -261,6 +261,7 @@ module Decidim
     end
 
     def needs_password_update?
+      return false if organization.users_registration_mode == "disabled"
       return false unless admin?
       return false unless Decidim.config.admin_password_strong
       return true if password_updated_at.blank?

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -599,6 +599,20 @@ describe "Authentication", type: :system do
           expect(page).to have_content("Successfully")
           expect(page).to have_content(user.name)
         end
+
+        context "when admin password is expired" do
+          let(:user) { create(:user, :confirmed, :admin, password_updated_at: 91.days.ago, organization:) }
+
+          before do
+            allow(Decidim.config).to receive(:admin_password_expiration_days).and_return(90)
+          end
+
+          it "can log in without being prompted to change the password" do
+            find(".sign-in-link").click
+            click_link "Sign in with Facebook"
+            expect(page).to have_content("Successfully")
+          end
+        end
       end
     end
   end

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -601,7 +601,7 @@ describe "Authentication", type: :system do
         end
 
         context "when admin password is expired" do
-          let(:user) { create(:user, :confirmed, :admin, password_updated_at: 91.days.ago, organization:) }
+          let(:user) { create(:user, :confirmed, :admin, password_updated_at: 91.days.ago, organization: organization) }
 
           before do
             allow(Decidim.config).to receive(:admin_password_expiration_days).and_return(90)


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #11070 to v0.27

:hearts: Thank you!