### PR TITLE
Budgets component fix for Votings module

### DIFF
--- a/decidim-elections/app/controllers/decidim/votings/admin/reminders_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/admin/reminders_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    module Admin
+      # This controller allows to send reminders.
+      # It is targeted for customizations for reminder things that lives under
+      # votings.
+      class RemindersController < Decidim::Admin::RemindersController
+        include VotingAdmin
+      end
+    end
+  end
+end

--- a/decidim-elections/lib/decidim/votings/admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/admin_engine.rb
@@ -56,6 +56,7 @@ module Decidim
             resources :imports, only: [:new, :create] do
               get :example, on: :collection
             end
+            resources :reminders, only: [:new, :create]
           end
         end
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
The Budgets component under the module Votings (Elections) crashed when an Admin user tried to access it. This as been fixed by adding a new route ```resources :reminders, only: [:new, :create]``` within ```decidim-elections/lib/decidim/votings/admin_engine.rb```. 

Since this Voting module was inheriting the **RemindersController**  for proper functionality, this as also been added here: ```decidim-elections/app/controllers/decidim/votings/admin/reminders_controller.rb```. 

#### :pushpin: Related Issues
- Fixes #11110 

#### Testing
1. Login as an admin
2. head over to edit
3. head down to the Votings module (make sure you have **Budgets** activated). 
4. click on **Budgets** under components
5. notice the page doesn't give you a 404 error.
6. click on **Send Voting Reminders** in the same header next to export all
7. notice the solution working as normal.


### :camera: Screenshots

![image](https://github.com/decidim/decidim/assets/101816158/d454e45f-b696-4b4e-8047-aa33d10ed9cc)

After clicking on Send Voting Reminders:

![image](https://github.com/decidim/decidim/assets/101816158/dc4aef91-d24b-4d20-bffa-5e5c2d4fbe39)

:hearts: Thank you!
