### PR TITLE
Backport 'Fix flaky collaborative drafts spec' to v0.27

### DIFF
--- a/decidim-proposals/spec/system/collaborative_drafts_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_spec.rb
@@ -281,6 +281,9 @@ describe "Explore Collaborative Drafts", versioning: true, type: :system do
 
           context "when the author receives the request" do
             before do
+              within ".header .title-bar .topbar__user__logged" do
+                expect(page).to have_content(user.name)
+              end
               relogin_as author, scope: :user
               visit current_path
               within ".header .title-bar .topbar__user__logged" do


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #10970 to v0.27

:hearts: Thank you!