### PR TITLE
Allow disabling password expiration

### DIFF
--- a/decidim-admin/spec/system/admin_passwords_spec.rb
+++ b/decidim-admin/spec/system/admin_passwords_spec.rb
@@ -54,6 +54,21 @@ describe "Admin passwords", type: :system do
         expect(page).to have_current_path(decidim_admin.root_path)
       end
     end
+
+    context "when password expiry is disabled" do
+      around(:example) do |ex|
+        original = Decidim.config.admin_password_expiration_days
+        Decidim.config.admin_password_expiration_days = 0
+        ex.run
+        Decidim.config.admin_password_expiration_days = original
+      end
+
+      it "does not prompt to change password" do
+        manual_login(user.email, password)
+        expect(page).not_to have_content("Admin users need to change their password every")
+        expect(page).not_to have_content("Password change")
+      end
+    end
   end
 
   context "when users password is expired" do

--- a/decidim-admin/spec/system/admin_passwords_spec.rb
+++ b/decidim-admin/spec/system/admin_passwords_spec.rb
@@ -56,7 +56,7 @@ describe "Admin passwords", type: :system do
     end
 
     context "when password expiry is disabled" do
-      around(:example) do |ex|
+      around do |ex|
         original = Decidim.config.admin_password_expiration_days
         Decidim.config.admin_password_expiration_days = 0
         ex.run

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -264,6 +264,7 @@ module Decidim
       return false if organization.users_registration_mode == "disabled"
       return false unless admin?
       return false unless Decidim.config.admin_password_strong
+      return false if Decidim.config.admin_password_expiration_days == 0
       return identities.none? if password_updated_at.blank?
 
       password_updated_at < Decidim.config.admin_password_expiration_days.days.ago

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -264,7 +264,7 @@ module Decidim
       return false if organization.users_registration_mode == "disabled"
       return false unless admin?
       return false unless Decidim.config.admin_password_strong
-      return false if Decidim.config.admin_password_expiration_days == 0
+      return false if Decidim.config.admin_password_expiration_days.zero?
       return identities.none? if password_updated_at.blank?
 
       password_updated_at < Decidim.config.admin_password_expiration_days.days.ago

--- a/docs/modules/configure/pages/environment_variables.adoc
+++ b/docs/modules/configure/pages/environment_variables.adoc
@@ -669,7 +669,7 @@ Additional context: This has been revealed as an issue during a security audit o
 |No
 
 |DECIDIM_ADMIN_PASSWORD_EXPIRATION_DAYS
-|Defines how many days admin passwords are valid before they need to be reset.
+|Defines how many days admin passwords are valid before they need to be reset. If you want to disable password expiration, you can set this value to `0`.
 |90
 |No
 


### PR DESCRIPTION
#### :tophat: What? Why?
In #9347, strong password policies for admins were introduced. These include minimum password length constraints, password reuse constraints and password expiration (by default every 90 days).
While [minimum password length](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls) and [password reuse prevention](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/07-Testing_for_Weak_Password_Policy#how-to-test) are officially recommended, password expiration, i.e. forcing users to change their passwords on a regular basis, is explicitly [advised against](https://pages.nist.gov/800-63-FAQ/#q-b05) (along with [password complexity rules](https://pages.nist.gov/800-63-FAQ/#q-b06)).

This PR does not attempt to change the default 90 days password expiration (let me know in case you would prefer that). Instead, it allows decidim instances, to disable password expiration, without disabling the other strong admin password policies.

Note: Setting the password expiration period to a very high value (such as 36500 days = 100 years) does not work as expected, because due to #10492, the `password_updated_at` column can sometimes be reset to `nil`, in which case the forced password change still triggers, with a confusing flash message.

#### :pushpin: Related Issues
- #9347
- #10492

#### Testing
- In an initializer: `Decidim.configure { |config|config.admin_password_expiration_days = 0 }`
- Restart server
- `Decidim::User.find(1).update(password_updated_at: nil)`
- Login with user with id 1 (admin@example.org)
- Don't see "Change your password" view

### :camera: Screenshots
N/A

:hearts: Thank you!
