### PR TITLE
CSV & JSON export function fix

### DIFF
--- a/decidim-elections/app/controllers/decidim/votings/admin/exports_controller.rb
+++ b/decidim-elections/app/controllers/decidim/votings/admin/exports_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    module Admin
+      # This controller allows exporting things.
+      # It is targeted for customizations for exporting things that lives under
+      # a participatory process.
+      class ExportsController < Decidim::Admin::ExportsController
+        include VotingAdmin
+      end
+    end
+  end
+end

--- a/decidim-elections/app/permissions/decidim/votings/admin/permissions.rb
+++ b/decidim-elections/app/permissions/decidim/votings/admin/permissions.rb
@@ -120,7 +120,7 @@ module Decidim
               toggle_allow(user.admin? && (voting.dataset.blank? || voting.dataset.init_data?) && ballot_style.present?)
             end
           when :component_data
-            toggle_allow(user.admin?) if permission_action.action == :import
+            toggle_allow(user.admin?) if [:import, :export].member? permission_action.action
           end
         end
 

--- a/decidim-elections/spec/controllers/decidim/votings/exports_controller_spec.rb
+++ b/decidim-elections/spec/controllers/decidim/votings/exports_controller_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Votings
+    module Admin
+      describe ExportsController, type: :controller do
+        routes { Decidim::Votings::AdminEngine.routes }
+
+        let!(:organization) { create(:organization) }
+        let!(:voting) { create(:voting, organization:) }
+        let!(:user) { create(:user, :admin, :confirmed, organization:) }
+        let!(:component) { create(:component, participatory_space: voting, manifest_name: "dummy") }
+
+        let(:params) do
+          {
+            id: "dummies",
+            component_id: component.id,
+            voting_slug: voting.slug
+          }
+        end
+
+        before do
+          request.env["decidim.current_organization"] = organization
+          sign_in user, scope: :user
+        end
+
+        describe "POST create" do
+          context "when a format is provided" do
+            it "enqueues a job with the provided format" do
+              params[:format] = "csv"
+
+              expect(ExportJob).to receive(:perform_later)
+                .with(user, component, "dummies", "csv", nil)
+
+              post(:create, params:)
+            end
+          end
+
+          context "when a format is not provided" do
+            it "enqueues a job with the default format" do
+              expect(ExportJob).to receive(:perform_later)
+                .with(user, component, "dummies", "json", nil)
+
+              post(:create, params:)
+            end
+          end
+        end
+
+        it "traces the action", versioning: true do
+          expect(Decidim.traceability)
+            .to receive(:perform_action!)
+            .with("export_component", component, user, { name: "dummies", format: "json" })
+            .and_call_original
+
+          expect { post(:create, params:) }.to change(Decidim::ActionLog, :count)
+          action_log = Decidim::ActionLog.last
+          expect(action_log.action).to eq("export_component")
+          expect(action_log.version).to be_present
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/exports_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/exports_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    module Admin
+      # This controller allows exporting things.
+      # It is targeted for customizations for exporting things that lives under
+      # a participatory process.
+      class ExportsController < Decidim::Admin::ExportsController
+        include InitiativeAdmin
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/admin/permissions.rb
@@ -163,6 +163,7 @@ module Decidim
 
         def initiative_export_action?
           allow! if permission_action.subject == :initiatives && permission_action.action == :export
+          allow! if permission_action.action == :export && permission_action.subject == :component_data
         end
 
         def initiatives_settings_action?

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/admin/exports_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/admin/exports_controller_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    module Admin
+      describe ExportsController, type: :controller do
+        routes { Decidim::Initiatives::AdminEngine.routes }
+
+        let!(:organization) { create(:organization) }
+        let!(:initiative) { create(:initiative, organization:) }
+        let!(:user) { create(:user, :admin, :confirmed, organization:) }
+        let!(:component) { create(:component, participatory_space: initiative, manifest_name: "dummy") }
+
+        let(:params) do
+          {
+            id: "dummies",
+            component_id: component.id,
+            initiative_slug: initiative.slug
+          }
+        end
+
+        before do
+          request.env["decidim.current_organization"] = organization
+          sign_in user, scope: :user
+        end
+
+        describe "POST create" do
+          context "when a format is provided" do
+            it "enqueues a job with the provided format" do
+              params[:format] = "csv"
+
+              expect(ExportJob).to receive(:perform_later)
+                .with(user, component, "dummies", "csv", nil)
+
+              post(:create, params:)
+            end
+          end
+
+          context "when a format is not provided" do
+            it "enqueues a job with the default format" do
+              expect(ExportJob).to receive(:perform_later)
+                .with(user, component, "dummies", "json", nil)
+
+              post(:create, params:)
+            end
+          end
+        end
+
+        it "traces the action", versioning: true do
+          expect(Decidim.traceability)
+            .to receive(:perform_action!)
+            .with("export_component", component, user, { name: "dummies", format: "json" })
+            .and_call_original
+
+          expect { post(:create, params:) }.to change(Decidim::ActionLog, :count)
+          action_log = Decidim::ActionLog.last
+          expect(action_log.action).to eq("export_component")
+          expect(action_log.version).to be_present
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
The modules in Initiatuves, Consultations and Votings export function in specific components did not work and upon an attempted export, created a 404 error. This fix creates an ``` exports_controller.rb ``` file in the coorispionding modules and updates the ``` permissions.rb ``` file, to allow an admin user to export correctly. 
 
#### :pushpin: Related Issues
*Link your PR to an issue*

- Fixes #11107 #11115 

#### Testing
1. Login as an admin and head over to edit 
2. Head down to the Votings module 
3. Click a component like Accountability
4. Click a created file 
5. Attempt to export via "CSV" or "JSON"
6. Notice the export working correctly and green.

The ```exports_controller.rb``` for elections/votings and initiatives have a rspec testing file you can call: 

1. ```decidim-elections/spec/controllers/decidim/votings/exports_controller_spec.rb```
2. ```decidim-initiatives/spec/controllers/decidim/initiatives/admin/exports_controller_spec.rb``` 

### :camera: Screenshots
![image](https://github.com/decidim/decidim/assets/101816158/a7ce8c29-bb11-4ebe-bfc9-e5bb97331bd9)


:hearts: Thank you!
