### PR TITLE
Remove unused dependency: wicked

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,6 @@ PATH
       decidim-core (= 0.28.0.dev)
       decidim-verifications (= 0.28.0.dev)
       hexapdf (~> 0.32.0)
-      wicked (~> 1.3)
       wicked_pdf (~> 2.1)
       wkhtmltopdf-binary (~> 0.12)
     decidim-meetings (0.28.0.dev)
@@ -802,8 +801,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wicked (1.4.0)
-      railties (>= 3.0.7)
     wicked_pdf (2.6.3)
       activesupport
     wisper (2.0.1)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -157,7 +157,6 @@ PATH
       decidim-core (= 0.28.0.dev)
       decidim-verifications (= 0.28.0.dev)
       hexapdf (~> 0.32.0)
-      wicked (~> 1.3)
       wicked_pdf (~> 2.1)
       wkhtmltopdf-binary (~> 0.12)
     decidim-meetings (0.28.0.dev)
@@ -802,8 +801,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wicked (1.4.0)
-      railties (>= 3.0.7)
     wicked_pdf (2.1.0)
       activesupport
     wisper (2.0.1)

--- a/decidim-initiatives/decidim-initiatives.gemspec
+++ b/decidim-initiatives/decidim-initiatives.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-core", Decidim::Initiatives.version
   s.add_dependency "decidim-verifications", Decidim::Initiatives.version
   s.add_dependency "hexapdf", "~> 0.32.0"
-  s.add_dependency "wicked", "~> 1.3"
   s.add_dependency "wicked_pdf", "~> 2.1"
   s.add_dependency "wkhtmltopdf-binary", "~> 0.12"
 

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -157,7 +157,6 @@ PATH
       decidim-core (= 0.28.0.dev)
       decidim-verifications (= 0.28.0.dev)
       hexapdf (~> 0.32.0)
-      wicked (~> 1.3)
       wicked_pdf (~> 2.1)
       wkhtmltopdf-binary (~> 0.12)
     decidim-meetings (0.28.0.dev)
@@ -802,8 +801,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wicked (1.4.0)
-      railties (>= 3.0.7)
     wicked_pdf (2.6.3)
       activesupport
     wisper (2.0.1)


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
After #10727, and #10731 `wicked` gem is not being used anymore, therefore this PR removes the unused dependency. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10727
- Related to #10731
- Related to  #11545

#### Testing
1. Make sure the pipeline is green 
2. Make sure Initiative wizard still works 
3. Make sure the initiative signing wizard still works

:hearts: Thank you!
