### PR TITLE
Update GitHub Action of Lighthouse to v10

### DIFF
--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -85,7 +85,7 @@ jobs:
         name: Run Rails server
         working-directory: ./development_app/
       - name: Audit URLs using Lighthouse
-        uses: treosh/lighthouse-ci-action@v8
+        uses: treosh/lighthouse-ci-action@v10
         with:
           runs: 3 # run more than once to warm up the application
           uploadArtifacts: true


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
SInce we have merged #11122, we can see that Performance Monitoring pipeline is constantly failing due to poor metrics in proposals.
While investigating, i have noticed there are some github actions deprecations: 

![image](https://github.com/decidim/decidim/assets/105683/94529288-e2c1-4e3a-ac92-879124693a2f)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #11122

#### Testing
Check the pipeline and see is green.

:hearts: Thank you!
