### PR TITLE
Fix the unused keyword arguments for the budgets workflows

### DIFF
--- a/decidim-budgets/lib/decidim/budgets/workflows/all.rb
+++ b/decidim-budgets/lib/decidim/budgets/workflows/all.rb
@@ -11,7 +11,7 @@ module Decidim
         end
 
         # Users can vote in all budgets with this workflow.
-        def vote_allowed?(resource, _consider_progress: true)
+        def vote_allowed?(resource, consider_progress: true) # rubocop:disable Lint/UnusedMethodArgument
           !voted?(resource)
         end
       end

--- a/decidim-budgets/lib/decidim/budgets/workflows/base.rb
+++ b/decidim-budgets/lib/decidim/budgets/workflows/base.rb
@@ -40,7 +40,7 @@ module Decidim
         #                      Using `false` allow UI to offer users to discard votes in progress to start voting in another resource.
         #
         # Returns Boolean.
-        def vote_allowed?(_resource, _consider_progress: true)
+        def vote_allowed?(_resource, consider_progress: true) # rubocop:disable Lint/UnusedMethodArgument
           raise StandardError, "Not implemented"
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
These keyword arguments have been marked with the starting underscore character because they are unused.

But for keyword arguments this is incorrect because it changes the method signature. The keyword arguments should maintain the same name as the original signature indicates. Otherwise it will cause issues if these methods are called with the originally named keyword argument. You would see the following error in the logs (and the application would break):

```
`vote_allowed?': unknown keyword: :consider_progress (ArgumentError)
```

#### Testing
Try calling one of the workflow methods by passing the `consider_progress` keyword argument to it.