### PR TITLE
Fix the a11y tool icons with redesign

### DIFF
--- a/decidim-dev/app/packs/src/decidim/dev/accessibility.js
+++ b/decidim-dev/app/packs/src/decidim/dev/accessibility.js
@@ -1,5 +1,5 @@
 import axe from "axe-core"
-import icon from "src/decidim/icon"
+import icon from "src/decidim/redesigned_icon"
 
 const positionIndicators = () => {
   $(".decidim-accessibility-indicator").each((_i, el) => {
@@ -66,7 +66,7 @@ $(() => {
 
     if (results.violations.length < 1) {
       $badge.addClass("decidim-accessibility-success");
-      $(".decidim-accessibility-info", $badge).append(icon("check", { class: "w-4 h-4 fill-current" }));
+      $(".decidim-accessibility-info", $badge).append(icon("check-fill", { class: "w-4 h-4 fill-current" }));
       $report.append(`
         <div class="decidim-accessibility-report-item">
           <div class="decidim-accessibility-report-item-title">
@@ -78,7 +78,7 @@ $(() => {
     }
 
     $badge.addClass("decidim-accessibility-violation");
-    $(".decidim-accessibility-info", $badge).append(icon("warning", { class: "w-4 h-4 fill-current" })).append(`
+    $(".decidim-accessibility-info", $badge).append(icon("error-warning-fill", { class: "w-4 h-4 mr-1 fill-current" })).append(`
       <span class="decidim-accessibility-info-amount">
         ${results.violations.length}
       </span>
@@ -113,7 +113,7 @@ $(() => {
           const selector = target.replace(/#\\3([0-9]) /g, "#$1")
           const $target = $(selector);
           const $indicator = $(`
-            <div class="decidim-accessibility-indicator" aria-hidden="true">${icon("warning", { class: "w-4 h-4 fill-current" })}</div>
+            <div class="decidim-accessibility-indicator" aria-hidden="true">${icon("error-warning-fill", { class: "w-4 h-4 fill-current" })}</div>
           `);
           $indicator.data("accessibility-target", $target);
           $target.data("accessibility-indicator", $indicator);

--- a/decidim-dev/spec/system/accessibility_tool_spec.rb
+++ b/decidim-dev/spec/system/accessibility_tool_spec.rb
@@ -17,7 +17,7 @@ describe "Accessibility tool", type: :system do
   let(:html_document) do
     document_inner = html_body
     template.instance_eval do
-      js_config = { icons_path: asset_pack_path("media/images/icons.svg") }
+      js_config = { icons_path: asset_pack_path("media/images/remixicon.symbol.svg") }
 
       <<~HTML.strip
         <!doctype html>
@@ -116,7 +116,7 @@ describe "Accessibility tool", type: :system do
     it "runs the accessibility tool and reports violations" do
       expect(page).to have_selector(".decidim-accessibility-badge")
       within ".decidim-accessibility-badge .decidim-accessibility-info" do
-        expect(page).to have_selector(".icon--check")
+        expect(page).to have_selector("svg use[href$='#ri-check-fill']")
       end
       expect(page).not_to have_selector(".decidim-accessibility-report")
 


### PR DESCRIPTION
#### :tophat: What? Why?
Now that the redesign is merged to develop, we can switch the a11y tool to use the redesigned icons for it to display correctly under redesign.

After this, the icons will be displayed correctly with the tool. There is some further work to do to fix it completely, e.g. displaying the clickable sections with link colors, etc. i.e. to apply the correct Tailwind classes to the tool.

#### :pushpin: Related Issues
- Related to #11122

#### Testing
Check the top left corner of the development app, you should see the a11y tool icons displayed correctly.

Open the a11y sidebar after which you should also see the violation icons on the page where violations are indicated.