### PR TITLE
Load the editor JS only when needed with redesign

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_redesigned_decidim_javascript.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_redesigned_decidim_javascript.html.erb
@@ -1,9 +1,9 @@
 <%#REDESIGN PENDING: for performance reasons defer this javacript call would be good, although there are references to jquery that need to be reviewed %>
 
 <% if Decidim.service_worker_enabled %>
-  <%= javascript_pack_tag "redesigned_decidim_core", "decidim_editor", "decidim_sw", defer: false %>
+  <%= javascript_pack_tag "redesigned_decidim_core", "decidim_sw", defer: false %>
 <% else %>
-  <%= javascript_pack_tag "redesigned_decidim_core", "decidim_editor", defer: false %>
+  <%= javascript_pack_tag "redesigned_decidim_core", defer: false %>
 <% end %>
 
 <%= render partial: "layouts/decidim/redesigned_js_configuration" %>


### PR DESCRIPTION
#### :tophat: What? Why?
While investigating the Lighthouse report on the alpha site, I noticed that the change done at #10973 was reverted by the redesign merge (#11122).

This re-applies the change to the redesigned layout from #10973.

#### :pushpin: Related Issues
- Related to
  * #10973
  * #11122
  * #11178

#### Testing
See that the editor assets (JS/CSS) is not loaded when there is no editor on the page.

### :camera: Screenshots
![Lighthouse report relevant parts](https://github.com/decidim/decidim/assets/864340/e6c72ec9-1ee7-41b0-af19-52bdbc06e834)

And on the page source (a proposal page):
![Editor JS in the page source](https://github.com/decidim/decidim/assets/864340/f1faa065-d111-4149-be63-d9ddad0b3862)