### PR TITLE
Apply br/gzip to development and test environments

### DIFF
--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -45,6 +45,7 @@ require "decidim/webpacker"
 
 require "decidim/api"
 require "decidim/middleware/strip_x_forwarded_host"
+require "decidim/middleware/static_dispatcher"
 require "decidim/middleware/current_organization"
 
 module Decidim
@@ -71,6 +72,18 @@ module Decidim
       end
 
       initializer "decidim_core.middleware" do |app|
+        if app.config.public_file_server.enabled
+          headers = app.config.public_file_server.headers || {}
+
+          app.config.middleware.swap(
+            ActionDispatch::Static,
+            Decidim::Middleware::StaticDispatcher,
+            app.paths["public"].first,
+            index: app.config.public_file_server.index_name,
+            headers:
+          )
+        end
+
         app.config.middleware.insert_before Warden::Manager, Decidim::Middleware::CurrentOrganization
         app.config.middleware.insert_before Warden::Manager, Decidim::Middleware::StripXForwardedHost
         app.config.middleware.use BatchLoader::Middleware

--- a/decidim-core/lib/decidim/middleware/static_dispatcher.rb
+++ b/decidim-core/lib/decidim/middleware/static_dispatcher.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Middleware
+    # A middleware that handles static assets serving. This extends from
+    # ActionDispatch::Static and adds the ability to serve compressed images
+    # also when running under the puma server solely.
+    #
+    # On production environments, the static files should be served directly
+    # from the HTTP server in front of the application. This mainly used for
+    # development and testing environments but also serves as a backup option
+    # to ensure these assets are transferred using proper compression.
+    class StaticDispatcher < ActionDispatch::Static
+      # Initializes the Rack Middleware.
+      #
+      # app - The Rack application
+      # path - The root path for the static files
+      # index - The index file route for folders
+      # headers - Additional response headers
+      def initialize(app, path, index: "index", headers: {})
+        @app = app
+        @file_handler = ActionDispatch::FileHandler.new(
+          path,
+          index:,
+          headers:,
+          compressible_content_types: %r{\A(?:(text|image)/|application/javascript)}
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
During some assets weight analysis on the alpha site, it was noticed that some assets (such as SVG images) are transferred without compression.

On production environments this can be fixed by applying a compression algorithm at the HTTP server configuration but this does not apply for development / testing.

Fortunately webpack is compiling the gzipped/brotli compressed versions of the assets and `ActionDispatch::Static` supports serving these files if we modify the compressible content types configuration here:
https://github.com/rails/rails/blob/b22439ed6412fef74afc86ff3f87ca57eafa94e7/actionpack/lib/action_dispatch/middleware/static.rb#L53

Unfortunately there was no direct configuration option to change this value, so I had to override the whole middleware.

#### Testing
- Precompile the production versions of the assets using `RAILS_ENV=production bundle exec rails assets:precompile` at the development app
- Within the `public/decidim-packs/media/images` folder, check that every image has a `.br` and `.gz` version (should happen when the assets are built for production or test environments)
- Start the development server
- Open the browser's developer console's "network" tab
- Request the front page of the service
- From the network requests, search for `remixicon.symbol`, see that the content encoding of that request is either `br` or `gzip` in the response headers
- See that the transferred asset size is about ~200kb (original asset size > 900kb)