### PR TITLE
Fix scope and category filtering links with ransack

### DIFF
--- a/decidim-budgets/app/cells/decidim/budgets/project_tags_cell.rb
+++ b/decidim-budgets/app/cells/decidim/budgets/project_tags_cell.rb
@@ -7,11 +7,11 @@ module Decidim
       private
 
       def category_path
-        resource_locator([model.budget, model]).index(filter: { category_id: [model.category.id.to_s] })
+        resource_locator([model.budget, model]).index(filter: { with_any_category: [model.category.id.to_s] })
       end
 
       def scope_path
-        resource_locator([model.budget, model]).index(filter: { scope_id: [model.scope.id] })
+        resource_locator([model.budget, model]).index(filter: { with_any_scope: [model.scope.id] })
       end
     end
   end

--- a/decidim-core/app/cells/decidim/tags_cell.rb
+++ b/decidim-core/app/cells/decidim/tags_cell.rb
@@ -74,7 +74,7 @@ module Decidim
     end
 
     def category_path
-      resource_locator(model).index(filter: { category_id: [model.category.id.to_s] })
+      resource_locator(model).index(filter: { filter_param(:category) => [model.category.id.to_s] })
     end
 
     def scope?
@@ -106,7 +106,18 @@ module Decidim
     end
 
     def scope_path
-      resource_locator(model).index(filter: { scope_id: [model.scope.id] })
+      resource_locator(model).index(filter: { filter_param(:scope) => [model.scope.id] })
+    end
+
+    def filter_param(name)
+      candidates = ["with_any_#{name}".to_sym, "with_#{name}".to_sym]
+      return candidates.first unless controller.respond_to?(:default_filter_params, true)
+
+      available_params = controller.send(:default_filter_params)
+      candidates.each do |candidate|
+        return candidate if available_params.has_key?(candidate)
+      end
+      candidates.first
     end
   end
 end

--- a/decidim-core/spec/cells/decidim/tags_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/tags_cell_spec.rb
@@ -54,6 +54,13 @@ describe Decidim::TagsCell, type: :cell do
       expect(html).to have_content(translated(scope.name))
     end
 
+    it "renders the correct filtering link" do
+      html = cell("decidim/tags", proposal_scoped, context: { extra_classes: ["tags--proposal"] }).call
+      path = Decidim::ResourceLocatorPresenter.new(proposal_scoped).index
+      query = { filter: { with_any_scope: [scope.id] } }.to_query
+      expect(html).to have_css(%(a[href="#{path}?#{query}"]))
+    end
+
     it "renders the subscope of a proposal" do
       html = cell("decidim/tags", proposal_subscoped, context: { extra_classes: ["tags--proposal"] }).call
       expect(html).to have_css(".tags.tags--proposal")
@@ -78,6 +85,13 @@ describe Decidim::TagsCell, type: :cell do
       html = cell("decidim/tags", proposal_categorized, context: { extra_classes: ["tags--proposal"] }).call
       expect(html).to have_css(".tags.tags--proposal")
       expect(html).to have_content(translated(category.name))
+    end
+
+    it "renders the correct filtering link" do
+      html = cell("decidim/tags", proposal_categorized, context: { extra_classes: ["tags--proposal"] }).call
+      path = Decidim::ResourceLocatorPresenter.new(proposal_categorized).index
+      query = { filter: { with_any_category: [category.id] } }.to_query
+      expect(html).to have_css(%(a[href="#{path}?#{query}"]))
     end
 
     it "renders the subcategory of a proposal" do

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -88,7 +88,7 @@ edit_link(
         </p>
         <span class="initiative__aside__element__data-text">
           <span class="text-sm font-normal text-gray-2 block">
-            <%= link_to translated_attribute(current_initiative.scope_name), initiatives_path(filter: { scope_id: [current_initiative.scope&.id] }) %>
+            <%= link_to translated_attribute(current_initiative.scope_name), initiatives_path(filter: { with_any_scope: [current_initiative.scope&.id] }) %>
           </span>
         </span>
       </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
@@ -22,6 +22,6 @@
   <% if params.dig("filter", "with_availability").present? && params["filter"]["with_availability"] == "withdrawn" %>
     <%= link_to t("decidim.proposals.proposals.index.see_all"), proposals_path("filter[with_availability]" => nil), class: "button button__sm button__text-secondary" %>
   <% else %>
-    <%= link_to t("decidim.proposals.proposals.index.see_all_withdrawn"), proposals_path(filter: { with_availability: "withdrawn", state: [""] }), class: "button button__sm button__text-secondary" %>
+    <%= link_to t("decidim.proposals.proposals.index.see_all_withdrawn"), proposals_path(filter: { with_availability: "withdrawn", with_any_state: [] }), class: "button button__sm button__text-secondary" %>
   <% end %>
 </div>

--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/_tags.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/_tags.html.erb
@@ -1,15 +1,15 @@
 <ul class="tags tags--sortition">
   <li>
     <%= link_to t("filters.active", scope: "decidim.sortitions.sortitions"),
-                sortitions_path(filter: { state: "active" }) unless sortition.cancelled? %>
+                sortitions_path(filter: { with_any_state: "active" }) unless sortition.cancelled? %>
 
     <%= link_to t("filters.cancelled", scope: "decidim.sortitions.sortitions"),
-                sortitions_path(filter: { state: "cancelled" }) if sortition.cancelled? %>
+                sortitions_path(filter: { with_any_state: "cancelled" }) if sortition.cancelled? %>
   </li>
 
   <% if sortition.category.present? %>
   <li>
-    <%= link_to translated_attribute(sortition.category.name), sortitions_path(filter: { category_id: [sortition.category.id] }) %>
+    <%= link_to translated_attribute(sortition.category.name), sortitions_path(filter: { with_category: sortition.category.id }) %>
   </li>
   <% end %>
 </ul>


### PR DESCRIPTION
#### :tophat: What? Why?
After the ransack filtering was introduced, the tag filtering links (category / scope) are not correctly formed.

There are also some other mistakes in the static filtering links that this PR is fixing.

#### :pushpin: Related Issues
- Related to #8748
- Fixes #11180

#### Testing
- Go to the proposals
- Open a proposal (considering you have enabled redesign)
- Click the category or scope filtering link
- See that the result page is filtering the results correctly