### PR TITLE
Fix open-ended dependency on doorkeeper

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ PATH
       devise (~> 4.7)
       devise-i18n (~> 1.2)
       diffy (~> 3.3)
-      doorkeeper (>= 5.6.6)
+      doorkeeper (~> 5.6, >= 5.6.6)
       doorkeeper-i18n (~> 4.0)
       file_validators (~> 3.0)
       fog-local (~> 0.6)

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency "devise", "~> 4.7"
   s.add_dependency "devise-i18n", "~> 1.2"
   s.add_dependency "diffy", "~> 3.3"
-  s.add_dependency "doorkeeper", ">= 5.6.6"
+  s.add_dependency "doorkeeper", "~> 5.6", ">= 5.6.6"
   s.add_dependency "doorkeeper-i18n", "~> 4.0"
   s.add_dependency "file_validators", "~> 3.0"
   s.add_dependency "fog-local", "~> 0.6"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -71,7 +71,7 @@ PATH
       devise (~> 4.7)
       devise-i18n (~> 1.2)
       diffy (~> 3.3)
-      doorkeeper (>= 5.6.6)
+      doorkeeper (~> 5.6, >= 5.6.6)
       doorkeeper-i18n (~> 4.0)
       file_validators (~> 3.0)
       fog-local (~> 0.6)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -71,7 +71,7 @@ PATH
       devise (~> 4.7)
       devise-i18n (~> 1.2)
       diffy (~> 3.3)
-      doorkeeper (>= 5.6.6)
+      doorkeeper (~> 5.6, >= 5.6.6)
       doorkeeper-i18n (~> 4.0)
       file_validators (~> 3.0)
       fog-local (~> 0.6)


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
While running in pipeline (generators), the following warning is being displayed: 

```
WARNING:  open-ended dependency on doorkeeper (>= 5.6.6) is not recommended
  if doorkeeper is semantically versioned, use:
    add_runtime_dependency 'doorkeeper', '~> 5.6', '>= 5.6.6'
```

:hearts: Thank you!
