### PR TITLE
Use organization's time zone in user answers serializer

### DIFF
--- a/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
+++ b/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
@@ -30,9 +30,11 @@ module Decidim
       alias resource answers
 
       def hash_for(answer)
+        timezone = answer&.organization&.time_zone || "UTC"
+
         {
           answer_translated_attribute_name(:id) => answer&.session_token,
-          answer_translated_attribute_name(:created_at) => answer&.created_at&.to_s(:db),
+          answer_translated_attribute_name(:created_at) => answer&.created_at&.in_time_zone(timezone)&.strftime("%Y-%m-%d %H:%M:%S"),
           answer_translated_attribute_name(:ip_hash) => answer&.ip_hash,
           answer_translated_attribute_name(:user_status) => answer_translated_attribute_name(answer&.decidim_user_id.present? ? "registered" : "unregistered")
         }

--- a/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -147,6 +147,36 @@ module Decidim
           end
         end
 
+        context "when time zone is UTC" do
+          let(:time_zone) { "UTC" }
+          let(:created_at) { Time.new(2000, 1, 2, 3, 4, 5, 0) }
+
+          before do
+            questionable.organization.update!(time_zone:)
+            answers.first.update!(created_at:)
+          end
+
+          it "Time uses configured time zone in exported data" do
+            key = I18n.t(:created_at, scope: "decidim.forms.user_answers_serializer")
+            expect(serialized[key]).to eq "2000-01-02 03:04:05"
+          end
+        end
+
+        context "when time zone is non-UTC" do
+          let(:time_zone) { "Hawaii" }
+          let(:created_at) { Time.new(2000, 1, 2, 3, 4, 5, 0) }
+
+          before do
+            questionable.organization.update!(time_zone:)
+            answers.first.update!(created_at:)
+          end
+
+          it "Time uses configured time zone in exported data" do
+            key = I18n.t(:created_at, scope: "decidim.forms.user_answers_serializer")
+            expect(serialized[key]).to eq "2000-01-01 17:04:05"
+          end
+        end
+
         context "when the questionnaire body is very long" do
           let!(:questionnaire) { create(:questionnaire, questionnaire_for: questionable, description: questionnaire_description) }
           let(:questionnaire_description) do


### PR DESCRIPTION
#### :tophat: What? Why?

Fix `Decidim::Forms::UserAnswersSerializer` to use organization's time zone.

Note: `to_s(:db)` always use UTC, so I use `strftime()`.

#### :pushpin: Related Issues
- Fixes #11200

#### Testing

Same as #11200 :

1. Go to admin -> settings
2. Set Time Zone to `(GMT+0900) Tokyo`
3. Answer Survey
4. Go to admin -> the participatory processes -> survey
5. Click `Export all` and select Excel
6. Open exported file and See `Answered on` column


### :camera: Screenshots

Before:

<img width="1100" alt="before" src="https://github.com/decidim/decidim/assets/10401/fd775716-f0ac-4af6-9176-0e89cd672781">

After:

<img width="1100" alt="after" src="https://github.com/decidim/decidim/assets/10401/ac4653b1-9b46-4a6d-b791-6ea9874be2fa">
