### PR TITLE
Backport 'Fix the unused keyword arguments for the budgets workflows' to v0.26

### DIFF
--- a/decidim-budgets/lib/decidim/budgets/workflows/all.rb
+++ b/decidim-budgets/lib/decidim/budgets/workflows/all.rb
@@ -11,7 +11,7 @@ module Decidim
         end
 
         # Users can vote in all budgets with this workflow.
-        def vote_allowed?(resource, _consider_progress: true)
+        def vote_allowed?(resource, consider_progress: true) # rubocop:disable Lint/UnusedMethodArgument
           !voted?(resource)
         end
       end

--- a/decidim-budgets/lib/decidim/budgets/workflows/base.rb
+++ b/decidim-budgets/lib/decidim/budgets/workflows/base.rb
@@ -40,7 +40,7 @@ module Decidim
         #                      Using `false` allow UI to offer users to discard votes in progress to start voting in another resource.
         #
         # Returns Boolean.
-        def vote_allowed?(_resource, _consider_progress: true)
+        def vote_allowed?(_resource, consider_progress: true) # rubocop:disable Lint/UnusedMethodArgument
           raise StandardError, "Not implemented"
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #11174 to v0.26

:hearts: Thank you!