### PR TITLE
Add performance configuration for Lighthouse testing

### DIFF
--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -21,6 +21,7 @@ env:
   RUBY_VERSION: 3.1.1
   NODE_VERSION: 16.13.0
   RAILS_ENV: development
+  RAILS_BOOST_PERFORMANCE: "true"
   WEBPACKER_RUNTIME_COMPILE: "false"
 
 concurrency:
@@ -83,6 +84,9 @@ jobs:
         working-directory: ./development_app/
       - run: bundle exec rails server -b localhost -d
         name: Run Rails server
+        working-directory: ./development_app/
+      - run: bundle exec rails decidim:lighthouse:warmup
+        name: Warmup the cache at the configured lighthouse urls
         working-directory: ./development_app/
       - name: Audit URLs using Lighthouse
         uses: treosh/lighthouse-ci-action@v10

--- a/decidim-dev/lib/decidim/dev/engine.rb
+++ b/decidim-dev/lib/decidim/dev/engine.rb
@@ -8,6 +8,9 @@ module Decidim
       engine_name "decidim_dev"
 
       initializer "decidim_dev.tools" do
+        # Disable if the boost performance mode is enabled
+        next if Rails.application.config.try(:boost_performance)
+
         ActiveSupport.on_load(:action_controller) { include Decidim::Dev::NeedsDevelopmentTools }
       end
 

--- a/decidim-dev/lib/tasks/lighthouse_report.rake
+++ b/decidim-dev/lib/tasks/lighthouse_report.rake
@@ -13,17 +13,39 @@ namespace :decidim do
       # Because seeds make urls dynamic, this task updates the lighthouse configuration
       # to add dynamically the urls to check.
 
-      host = "http://localhost:3000"
-      urls = ["/"]
-      urls << Decidim::ResourceLocatorPresenter.new(Decidim::ParticipatoryProcess.published.first).path
-      urls << Decidim::ResourceLocatorPresenter.new(Decidim::Meetings::Meeting.published.first).path
-      urls << Decidim::ResourceLocatorPresenter.new(Decidim::Proposals::Proposal.published.first).path
-
       # Update lighthouse configuration with the urls
       lighthouse_rc_path = Rails.root.join("../.lighthouserc.json")
       lighthouserc = JSON.parse(File.read(lighthouse_rc_path))
-      lighthouserc["ci"]["collect"]["url"] = urls.map { |url| "#{host}#{url}" }
+      lighthouserc["ci"]["collect"]["url"] = lighthouse_urls
       File.write(lighthouse_rc_path, lighthouserc.to_json)
+    end
+
+    desc "Warms up the URLs to be requested"
+    task warmup: :environment do
+      lighthouse_urls.each do |url|
+        uri = URI.parse(url)
+        connection = Net::HTTP.new(uri.host, uri.port)
+        connection.start do |http|
+          puts "Warming up #{uri.path}"
+          response = http.get(uri.path)
+          puts "--HTTP STATUS: #{response.code}"
+        end
+      end
+    end
+
+    private
+
+    def lighthouse_urls
+      host = "http://localhost:3000"
+      lighthouse_paths.map { |path| "#{host}#{path}" }
+    end
+
+    def lighthouse_paths
+      ["/"].tap do |urls|
+        urls << Decidim::ResourceLocatorPresenter.new(Decidim::ParticipatoryProcess.published.first).path
+        urls << Decidim::ResourceLocatorPresenter.new(Decidim::Meetings::Meeting.published.first).path
+        urls << Decidim::ResourceLocatorPresenter.new(Decidim::Proposals::Proposal.published.first).path
+      end
     end
   end
 end

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -333,6 +333,26 @@ module Decidim
                   "# config.available_locales = Rails.application.secrets.decidim[:available_locales].presence || [:en]"
       end
 
+      def dev_performance_config
+        gsub_file "config/environments/development.rb", /^end\n$/, <<~CONFIG
+
+            # Performance configs for local testing
+            if ENV.fetch("RAILS_BOOST_PERFORMANCE", false).to_s == "true"
+              # Indicate boost performance mode
+              config.boost_performance = true
+              # Enable caching and eager load
+              config.eager_load = true
+              config.cache_classes = true
+              # Logging
+              config.log_level = :info
+              config.action_view.logger = nil
+              # Compress the HTML responses with gzip
+              config.middleware.use Rack::Deflater
+            end
+          end
+        CONFIG
+      end
+
       def authorization_handler
         return unless options[:demo]
 

--- a/decidim-generators/lib/decidim/generators/app_templates/bullet_initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/bullet_initializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if defined?(Bullet)
+if defined?(Bullet) && !Rails.application.config.try(:boost_performance)
   Rails.application.config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true

--- a/decidim-generators/lib/decidim/generators/app_templates/rack_profiler_initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/rack_profiler_initializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if Rails.env.development?
+if Rails.env.development? && !Rails.application.config.try(:boost_performance)
   require "rack-mini-profiler"
 
   # initialization is skipped so trigger it


### PR DESCRIPTION
#### :tophat: What? Why?
Implements a new environment variable configuration for the development environment to support performance improvements at the development environment for performance testing.

This is achieved using the `RAILS_BOOST_PERFORMANCE=true` environment configuration when starting the development server. This will apply the following configurations:
- Enables code eager loading through `config.eager_load = true`
- Enables code caching through `config.cache_classes = true`
- Sets log level to `:info` to avoid unnecessary logging
- Disables ActionView logging
- Compresses the HTML responses with gzip through `Rack::Deflater`
- Disables the following development features to avoid adding unnecessary delay to the server response time and page rendering time:
  * Bullet
  * Rack profiler
  * The front-end a11y tool (through the `decidim-dev` gem)

Note that there is also a related PR (#11181) which enables serving the gzip or br compressed versions of the static assets transpiled through webpack. By default, the JS and CSS files (and other text files) are already served as compressed when the compressed version exists at the `public/decidim-packs` directory. But it does not work for the compiled images, such as the remixicon set or default avatar which have a different mime type (`image/*`).

Additionally, this adds a "warmup" rake task for the performance metrics in order to fill up the cache on those pages that are tested through Lighthouse.

#### :pushpin: Related Issues
- Related to #11181

#### Testing
- Re-generate the development_app (`bundle exec rake development_app`) because there are new configurations added by the app generator
- Using this branch, start the development server using `RAILS_BOOST_PERFORMANCE=true bundle exec rails s --no-log-to-stdout`
  * Note that the `--no-log-to-stdout` flag disables unnecessary logging during development, this is not required when the server is started in the daemonized mode as in the Lighthouse workflow (using the `-d` flag)
- Request the front page two times
- Notice that there is no rack profiler or the a11y tool visible on the page
- Notice the page load is faster when you request the page for the second time (after it is cached)
- Inspect the "Network" tab of the development console and see the first request to the page you are making should be now served with the header `Content-Encoding: gzip`

You can also test the warmup action using the following command within the `development_app`:
```bash
$ bundle exec rails decidim:lighthouse:warmup
```

You will see some messages in the console indicating which pages were requested to warmup their caches.