### PR TITLE
Fix initiative page static ransack filter links

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/_finish_help.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/_finish_help.html.erb
@@ -3,6 +3,6 @@
     <%== t ".publish_helper_text" %>
   </p>
   <p>
-    <%== t ".access_reminder", link: link_to(t("myself", scope: "decidim.initiatives.initiatives.filters"), decidim_initiatives.initiatives_path(filter: { author: "myself", state: "" })) %>
+    <%== t ".access_reminder", link: link_to(t("myself", scope: "decidim.initiatives.initiatives.filters"), decidim_initiatives.initiatives_path(filter: { author: "myself", with_any_state: "" })) %>
   </p>
 </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_tags_type.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_tags_type.html.erb
@@ -1,1 +1,1 @@
-<span class="text-sm font-normal block"><%= link_to translated_attribute(resource.type.title), initiatives_path(filter: { type: [resource.type.id] }) %></span>
+<span class="text-sm font-normal block"><%= link_to translated_attribute(resource.type.title), initiatives_path(filter: { with_any_type: [resource.type.id] }) %></span>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -109,7 +109,7 @@ edit_link(
           </p>
           <span class="initiative__aside__element__data-text">
             <span class="text-sm font-normal text-gray-2 block">
-              <%= link_to translated_attribute(current_initiative.area_name), initiatives_path(filter: { area_id: [current_initiative.area.id] }) %>
+              <%= link_to translated_attribute(current_initiative.area_name), initiatives_path(filter: { with_any_area: [current_initiative.area.id] }) %>
             </span>
           </span>
         </div>


### PR DESCRIPTION
#### :tophat: What? Why?
After backporting #11182, I noticed a couple of places where we still have incorrect filter parameters after the ransack change.

This does not need to be backported because the templates have changed and the related templates were already fixed by the backport PR #11248.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to
  * #11182
  * #8748

#### Testing
- Make sure at least one initiative type has areas enabled
- Make sure you have open initiatives with areas
- Go to the initiative page (which has an area)
- Test that the area filter link in the sidebar works
- Test that the type filter in the sidebar works