### PR TITLE
Fix bug with sanitize_branch method on `bin/backports` script

### DIFF
--- a/lib/decidim/git_backport_manager.rb
+++ b/lib/decidim/git_backport_manager.rb
@@ -150,9 +150,9 @@ module Decidim
     # Replace all the characters from the user supplied input that are uncontrolled
     # and could generate a command line injection
     #
-    # @return [String] the sanitized backport_branch
-    def sanitize_branch(backport_branch)
-      Shellwords.escape(backport_branch.gsub(%r{[^0-9a-z/-]}i, ""))
+    # @return [String] the sanitized branch name
+    def sanitize_branch(branch_name)
+      Shellwords.escape(branch_name.gsub("`", ""))
     end
 
     # Exit the script execution if there are any unstaged changes

--- a/spec/lib/decidim/git_backport_manager_spec.rb
+++ b/spec/lib/decidim/git_backport_manager_spec.rb
@@ -40,6 +40,14 @@ describe Decidim::GitBackportManager do
     it "sets the backport_branch as expected" do
       expect(subject.send(:backport_branch)).to eq("backport/fix-topsomething-9876")
     end
+
+    context "when the branch name has a dot" do
+      let(:backport_branch) { "backport/0.26/fix-something-9876" }
+
+      it "sets the backport_branch as expected" do
+        expect(subject.send(:backport_branch)).to eq("backport/0.26/fix-something-9876")
+      end
+    end
   end
 
   describe "#checkout_develop" do


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While doing a new set of backports, and after we merged #11065, I noticed that I've broken the `bin/backports` script, as we were doing too much sanitization and this produced that the branch that was pushed and the one that was created with the PR didn't match. As an example:

* the branch pushed was `backport/0.26/fix-html-titles-in-admin-panel-11116`
* the branch created with the PR (aka the `head` branch) was `backport/026/fix-html-titles-in-admin-panel-11116`

Note that there's a missing dot. This PR fixes it by allowing the dot (and also escaping the shellwords)

#### :pushpin: Related Issues
 
- Related to #11065 

#### Testing
It should work by manually using the script (I tested this on #11331, #11332, #11333, #11334, #11335 and #11336)

We shouldn't see any warning from CodeQL 

:hearts: Thank you!
