### PR TITLE
Redesign: labels' status color 

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_labels.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_labels.scss
@@ -1,16 +1,23 @@
 .label {
-  @apply bg-gray-2/20 text-gray-2 rounded inline-flex items-center gap-1 px-2 font-semibold text-sm;
+  --success: #16592e;
+  --bg-success: #c4ecd0;
+  --alert: #b9081b;
+  --bg-alert: #ffdee3;
+  --warning: #ad4910;
+  --bg-warning: #ffeebd;
+
+  @apply bg-background text-gray-2 rounded inline-flex items-center gap-1 px-2 font-semibold text-sm;
 
   &.success {
-    @apply bg-success/20 text-success;
+    @apply bg-[var(--bg-success)] text-[var(--success)];
   }
 
   &.alert {
-    @apply bg-alert/20 text-alert;
+    @apply bg-[var(--bg-alert)] text-[var(--alert)];
   }
 
   &.warning {
-    @apply bg-warning/20 text-warning;
+    @apply bg-[var(--bg-warning)] text-[var(--warning)];
   }
 
   &.reverse {


### PR DESCRIPTION
#### :tophat: What? Why?
In order to fulfill the WCAG color contrast requirements, text and background colors for labels are tuned.

#### :pushpin: Related Issues
- Fixes #11339 

#### 📷 Screenshots
https://decidim-redesign.populate.tools/search?term=

:hearts: Thank you!
