### PR TITLE
Backport "Lock ChromeDriver to the latest working version" to v0.27

### DIFF
--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -52,6 +52,10 @@ runs:
       name: Create the screenshots folder
       shell: "bash"
     - uses: nanasess/setup-chromedriver@v1.0.1
+      with:
+        # TODO: Unpin when nanasess/setup-chromedriver#190 is fixed:
+        #       https://github.com/nanasess/setup-chromedriver/issues/190
+        chromedriver-version: 114.0.5735.90
     - run: RAILS_ENV=test bundle exec rails assets:precompile
       name: Precompile assets
       working-directory: ./spec/decidim_dummy_app/


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

Currently the pipelines are failing due to a nev version of chromedriver being shipped.  This PR locks the chromedriver to the last known working version, so that we can avoid being blocked by issue. 

```
##setup chromedriver
/home/runner/work/_actions/nanasess/setup-chromedriver/v2/lib/setup-chromedriver.sh  linux64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0   193    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
Error: The process '/home/runner/work/_actions/nanasess/setup-chromedriver/v2/lib/setup-chromedriver.sh' failed with exit code 22
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/nanasess/setup-chromedriver/issues/190
- Related to https://github.com/decidim/decidim/pull/11391

#### Testing
Make sure the pipeline is green

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
