### PR TITLE
Add "Tile usage" notice at the top of doc page for OSM maps and geocoding

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -47,6 +47,9 @@ Decidim.configure do |config|
 
   # Map and Geocoder configuration
   #
+  # See Decidim docs at https://docs.decidim.org/en/develop/services/maps.html
+  # for more information about how it works and how to set it up.
+  #
   # == HERE Maps ==
   # config.maps = {
   #   provider: :here,

--- a/docs/modules/services/pages/maps.adoc
+++ b/docs/modules/services/pages/maps.adoc
@@ -1,6 +1,14 @@
 = Maps and geocoding
 
 Decidim has the ability to geocode proposals and meetings and display them on a map.
+
+[CAUTION]
+====
+It is important to notice that you can not use the OpenStreetMap service from openstreetmap.org. As they mention in their https://operations.osmfoundation.org/policies/tiles/[tile usage policy]:
+
+> OpenStreetMap data is free for everyone to use. Our tile servers are not.
+====
+
 Decidim has built-in support for the following map service providers:
 
 * http://here.com[HERE Maps] (Recommended)

--- a/docs/modules/services/pages/maps.adoc
+++ b/docs/modules/services/pages/maps.adoc
@@ -4,7 +4,7 @@ Decidim has the ability to geocode proposals and meetings and display them on a 
 
 [CAUTION]
 ====
-It is important to notice that you can not use the OpenStreetMap service from openstreetmap.org. As they mention in their https://operations.osmfoundation.org/policies/tiles/[tile usage policy]:
+It is important to notice that you cannot use the OpenStreetMap service from openstreetmap.org. As they mention in their https://operations.osmfoundation.org/policies/tiles/[tile usage policy]:
 
 > OpenStreetMap data is free for everyone to use. Our tile servers are not.
 ====


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

With the introduction of CSP (#10700), we don't allow using OSM as a map provider. As the documentation isn't 100% clear that you are not allowed to use it, this PR clarifies it better.

Note that we already had this phrase 

> ** We cannot use the OSM's own services by their https://operations.osmfoundation.org/policies/tiles/[tile usage policy].

But with a callout we reinforce that. 

#### :pushpin: Related Issues
 
- Fixes #11153

#### Testing

Read the documentation and comment

### :camera: Screenshots

![Screenshot of the documentation page](https://github.com/decidim/decidim/assets/717367/63aa4e5e-34b1-412e-8c11-904f93f9b446)

:hearts: Thank you!
