### PR TITLE
Fix/Incorrect component link generation in a space

### DIFF
--- a/decidim-blogs/lib/decidim/blogs/engine.rb
+++ b/decidim-blogs/lib/decidim/blogs/engine.rb
@@ -15,7 +15,10 @@ module Decidim
 
       routes do
         resources :posts, only: [:index, :show]
-        root to: "posts#index"
+        scope "/posts" do
+          root to: "posts#index"
+        end
+        get "/", to: redirect("posts", status: 301)
       end
 
       initializer "decidim_blogs.add_cells_view_paths" do

--- a/decidim-budgets/lib/decidim/budgets/engine.rb
+++ b/decidim-budgets/lib/decidim/budgets/engine.rb
@@ -20,8 +20,10 @@ module Decidim
             resource :line_item, only: [:create, :destroy]
           end
         end
-
-        root to: "budgets#index"
+        scope "/budgets" do
+          root to: "budgets#index"
+        end
+        get "/", to: redirect("budgets", status: 301)
       end
 
       initializer "decidim_budgets.add_cells_view_paths" do

--- a/decidim-budgets/spec/requests/project_search_spec.rb
+++ b/decidim-budgets/spec/requests/project_search_spec.rb
@@ -99,4 +99,25 @@ RSpec.describe "Project search", type: :request do
       end
     end
   end
+
+  describe "#index" do
+    let(:url) { "http://#{component.organization.host + request_path}" }
+
+    it "redirects to the index page" do
+      get(
+        url_to_root(request_path),
+        params: {},
+        headers: { "HOST" => component.organization.host }
+      )
+      expect(response["Location"]).to eq(url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  private
+
+  def url_to_root(url)
+    parts = url.split("/")
+    parts[0..-2].join("/")
+  end
 end

--- a/decidim-debates/lib/decidim/debates/engine.rb
+++ b/decidim-debates/lib/decidim/debates/engine.rb
@@ -15,7 +15,10 @@ module Decidim
           end
           resources :versions, only: [:show]
         end
-        root to: "debates#index"
+        scope "/debates" do
+          root to: "debates#index"
+        end
+        get "/", to: redirect("debates", status: 301)
       end
 
       initializer "decidim_debates.settings_changes" do

--- a/decidim-debates/spec/requests/debate_search_spec.rb
+++ b/decidim-debates/spec/requests/debate_search_spec.rb
@@ -171,4 +171,25 @@ RSpec.describe "Debate search", type: :request do
       end
     end
   end
+
+  describe "#index" do
+    let(:url) { "http://#{component.organization.host + request_path}" }
+
+    it "redirects to the index page" do
+      get(
+        url_to_root(request_path),
+        params: {},
+        headers: { "HOST" => component.organization.host }
+      )
+      expect(response["Location"]).to eq(url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  private
+
+  def url_to_root(url)
+    parts = url.split("/")
+    parts[0..-2].join("/")
+  end
 end

--- a/decidim-elections/lib/decidim/elections/engine.rb
+++ b/decidim-elections/lib/decidim/elections/engine.rb
@@ -22,8 +22,10 @@ module Decidim
 
           get :election_log, on: :member
         end
-
-        root to: "elections#index"
+        scope "/elections" do
+          root to: "elections#index"
+        end
+        get "/", to: redirect("elections", status: 301)
       end
 
       initializer "decidim_elections.add_cells_view_paths" do

--- a/decidim-elections/spec/requests/election_search_spec.rb
+++ b/decidim-elections/spec/requests/election_search_spec.rb
@@ -143,4 +143,24 @@ RSpec.describe "Election search", type: :request do
       end
     end
   end
+
+  describe "#index" do
+    let(:url) { "http://#{component.organization.host + request_path}" }
+
+    it "redirects to the index page" do
+      get(
+        url_to_root(request_path),
+        params: {},
+        headers: { "HOST" => component.organization.host }
+      )
+      expect(response["Location"]).to eq(url)
+    end
+  end
+
+  private
+
+  def url_to_root(url)
+    parts = url.split("/")
+    parts[0..-2].join("/")
+  end
 end

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -38,7 +38,11 @@ module Decidim
             resources :answers, only: [:index, :create]
           end
         end
-        root to: "meetings#index"
+        scope "/meetings" do
+          root to: "meetings#index"
+        end
+        get "/", to: redirect("meetings", status: 301)
+
         resource :calendar, only: [:show], format: :text do
           resources :meetings, only: [:show], controller: :calendars, action: :meeting_calendar
         end

--- a/decidim-meetings/spec/requests/meeting_search_spec.rb
+++ b/decidim-meetings/spec/requests/meeting_search_spec.rb
@@ -223,4 +223,25 @@ RSpec.describe "Meeting search", type: :request do
       end
     end
   end
+
+  describe "#index" do
+    let(:url) { "http://#{component.organization.host + request_path}" }
+
+    it "redirects to the index page" do
+      get(
+        url_to_root(request_path),
+        params: {},
+        headers: { "HOST" => component.organization.host }
+      )
+      expect(response["Location"]).to eq(url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  private
+
+  def url_to_root(url)
+    parts = url.split("/")
+    parts[0..-2].join("/")
+  end
 end

--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -35,7 +35,10 @@ module Decidim
           end
           resources :versions, only: [:show]
         end
-        root to: "proposals#index"
+        scope "/proposals" do
+          root to: "proposals#index"
+        end
+        get "/", to: redirect("proposals", status: 301)
       end
 
       initializer "decidim_proposals.content_processors" do |_app|

--- a/decidim-proposals/spec/requests/proposal_search_spec.rb
+++ b/decidim-proposals/spec/requests/proposal_search_spec.rb
@@ -220,4 +220,25 @@ RSpec.describe "Proposal search", type: :request do
       end
     end
   end
+
+  describe "#index" do
+    let(:url) { "http://#{component.organization.host + request_path}" }
+
+    it "redirects to the index page" do
+      get(
+        url_to_root(request_path),
+        params: {},
+        headers: { "HOST" => component.organization.host }
+      )
+      expect(response["Location"]).to eq(url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  private
+
+  def url_to_root(url)
+    parts = url.split("/")
+    parts[0..-2].join("/")
+  end
 end

--- a/decidim-sortitions/lib/decidim/sortitions/engine.rb
+++ b/decidim-sortitions/lib/decidim/sortitions/engine.rb
@@ -13,7 +13,10 @@ module Decidim
 
       routes do
         resources :sortitions, only: [:index, :show]
-        root to: "sortitions#index"
+        scope "/sortitions" do
+          root to: "sortitions#index"
+        end
+        get "/", to: redirect("sortitions", status: 301)
       end
 
       initializer "decidim_sortitions.add_cells_view_paths" do

--- a/decidim-sortitions/spec/requests/sortition_search_spec.rb
+++ b/decidim-sortitions/spec/requests/sortition_search_spec.rb
@@ -90,4 +90,25 @@ RSpec.describe "Sortition search", type: :request do
       end
     end
   end
+
+  describe "#index" do
+    let(:url) { "http://#{component.organization.host + request_path}" }
+
+    it "redirects to the index page" do
+      get(
+        url_to_root(request_path),
+        params: {},
+        headers: { "HOST" => component.organization.host }
+      )
+      expect(response["Location"]).to eq(url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  private
+
+  def url_to_root(url)
+    parts = url.split("/")
+    parts[0..-2].join("/")
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently the menu of components in a space produces a link to a component that does not include the last bit of the slug. This PR solves this issue

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #[10876](https://github.com/decidim/decidim/issues/10876)

#### Testing
Just run the tests normally.

:hearts: Thank you!
