### PR TITLE
Use `with_any_scope` instead of `with_scope` for assemblies and processes

### DIFF
--- a/decidim-assemblies/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -54,7 +54,7 @@ module Decidim
 
       def default_filter_params
         {
-          with_scope: nil,
+          with_any_scope: nil,
           with_area: nil,
           type_id_eq: nil
         }

--- a/decidim-assemblies/app/helpers/decidim/assemblies/filter_assemblies_helper.rb
+++ b/decidim-assemblies/app/helpers/decidim/assemblies/filter_assemblies_helper.rb
@@ -18,7 +18,7 @@ module Decidim
           .url_helpers
           .assemblies_path(
             filter: {
-              with_scope: filter.with_scope,
+              with_any_scope: filter.with_any_scope,
               with_area: filter.with_area,
               type_id_eq: type_id
             }

--- a/decidim-assemblies/app/models/decidim/assembly.rb
+++ b/decidim-assemblies/app/models/decidim/assembly.rb
@@ -159,7 +159,7 @@ module Decidim
     end
 
     def self.ransackable_scopes(_auth_object = nil)
-      [:with_area, :with_scope]
+      [:with_area, :with_any_scope]
     end
 
     private

--- a/decidim-assemblies/spec/requests/assembly_search_spec.rb
+++ b/decidim-assemblies/spec/requests/assembly_search_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Assembly search", type: :request do
   end
 
   context "when filtering by scope" do
-    let(:filter_params) { { with_scope: assembly1.scope.id } }
+    let(:filter_params) { { with_any_scope: [assembly1.scope.id] } }
 
     it "displays matching assemblies" do
       expect(subject).to include(translated(assembly1.title))

--- a/decidim-assemblies/spec/system/filter_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/filter_assemblies_spec.rb
@@ -54,7 +54,7 @@ describe "Filter Assemblies", type: :system do
 
     context "and choosing a scope" do
       before do
-        visit decidim_assemblies.assemblies_path(filter: { with_scope: scope.id })
+        visit decidim_assemblies.assemblies_path(filter: { with_any_scope: [scope.id] })
       end
 
       it "lists all processes belonging to that scope" do

--- a/decidim-core/app/helpers/decidim/decidim_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/decidim_form_helper.rb
@@ -84,6 +84,7 @@ module Decidim
 
       template = ""
       template += render("decidim/scopes/scopes_picker_input",
+                         values_options: { delete_button: false },
                          picker_options: picker_options,
                          prompt_params: prompt_params,
                          scopes: scopes,

--- a/decidim-core/app/packs/src/decidim/data_picker.js
+++ b/decidim-core/app/packs/src/decidim/data_picker.js
@@ -243,6 +243,7 @@ export default class DataPicker {
         fadeoutTime = 0;
       }
       this.current.target.fadeOut(fadeoutTime, () => {
+        this.current.target.find("input")?.trigger("change");
         this.current.target.remove();
         this.current.target = null;
       });

--- a/decidim-core/app/views/decidim/scopes/_scopes_picker_input.html.erb
+++ b/decidim-core/app/views/decidim/scopes/_scopes_picker_input.html.erb
@@ -4,7 +4,7 @@
 
 <%- @scope_picker_values = capture do %>
   <div class="picker-values"><%- scopes.each do |scope, params| %>
-    <div><a class="<%= values_options[:class] %>" href="<%= params[:url] %>" data-picker-value="<%= scope.id %>"><%=  "× " if values_options[:delete_button] %><%= params[:text] %></a></div>
+    <div><a class="<%= values_options[:class] %>" href="<%= params[:url] %>" data-picker-value="<%= scope.id %>"><%= "× " if values_options[:delete_button] %><%= params[:text] %></a></div>
   <% end %></div>
 <% end %>
 

--- a/decidim-core/app/views/decidim/scopes/_scopes_picker_input.html.erb
+++ b/decidim-core/app/views/decidim/scopes/_scopes_picker_input.html.erb
@@ -4,7 +4,7 @@
 
 <%- @scope_picker_values = capture do %>
   <div class="picker-values"><%- scopes.each do |scope, params| %>
-    <div><a class="<%= values_options[:delete_button] ? "label primary" : "" %>" href="<%= params[:url] %>" data-picker-value="<%= scope.id %>"><%= values_options[:delete_button] ? "× " : "" %><%= params[:text] %></a></div>
+    <div><a class="<%= values_options[:class] %>" href="<%= params[:url] %>" data-picker-value="<%= scope.id %>"><%=  "× " if values_options[:delete_button] %><%= params[:text] %></a></div>
   <% end %></div>
 <% end %>
 

--- a/decidim-core/app/views/decidim/scopes/_scopes_picker_input.html.erb
+++ b/decidim-core/app/views/decidim/scopes/_scopes_picker_input.html.erb
@@ -4,7 +4,7 @@
 
 <%- @scope_picker_values = capture do %>
   <div class="picker-values"><%- scopes.each do |scope, params| %>
-    <div><a href="<%= params[:url] %>" data-picker-value="<%= scope.id %>"><%= params[:text] %></a></div>
+    <div><a class="<%= values_options[:delete_button] ? "label primary" : "" %>" href="<%= params[:url] %>" data-picker-value="<%= scope.id %>"><%= values_options[:delete_button] ? "× " : "" %><%= params[:text] %></a></div>
   <% end %></div>
 <% end %>
 

--- a/decidim-core/app/views/decidim/shared/participatory_space_filters/_filters.html.erb
+++ b/decidim-core/app/views/decidim/shared/participatory_space_filters/_filters.html.erb
@@ -1,6 +1,6 @@
 <%= filter_form_for filter do |form| %>
   <div class="columns mediumlarge-6 large-5">
-    <%= scopes_picker_filter form, :with_scope, checkboxes_on_top: checkboxes_on_top %>
+    <%= scopes_picker_filter form, :with_any_scope, checkboxes_on_top: checkboxes_on_top %>
   </div>
   <div class="columns mediumlarge-6 large-5">
     <%= form.areas_select :with_area,

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -317,6 +317,7 @@ module Decidim
       template = ""
       template += "<label>#{label_for(attribute) + required_for_attribute(attribute)}</label>" unless options[:label] == false
       template += @template.render("decidim/scopes/scopes_picker_input",
+                                   values_options: { delete_button: true },
                                    picker_options: picker_options,
                                    prompt_params: prompt_params,
                                    scopes: scopes,

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -317,7 +317,7 @@ module Decidim
       template = ""
       template += "<label>#{label_for(attribute) + required_for_attribute(attribute)}</label>" unless options[:label] == false
       template += @template.render("decidim/scopes/scopes_picker_input",
-                                   values_options: { delete_button: true },
+                                   values_options: { delete_button: true, class: "label primary" },
                                    picker_options: picker_options,
                                    prompt_params: prompt_params,
                                    scopes: scopes,

--- a/decidim-core/spec/helpers/decidim/decidim_form_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/decidim_form_helper_spec.rb
@@ -76,7 +76,7 @@ module Decidim
         expected = <<~HTML
           <div id="my_thing_decidim_scope_id" class="data-picker picker-single" data-picker-name="my_thing[decidim_scope_id]">
             <div class="picker-values">
-              <div><a href="/my/url" data-picker-value="#{scope.id}">My text</a></div>
+              <div><a class="" href="/my/url" data-picker-value="#{scope.id}">My text</a></div>
             </div>
 
             <div class="picker-prompt"><a href="/my/url" role="button" aria-label="Select a scope (currently: My text)">My text</a></div>

--- a/decidim-core/spec/helpers/decidim/scopes_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/scopes_helper_spec.rb
@@ -14,7 +14,7 @@ module Decidim
           <div id="my_scope_input" class="data-picker picker-single" data-picker-name="my_scope_input">
             <div class="picker-values">
               <div>
-                <a href="/scopes/picker?current=#{scope.id}&amp;field=my_scope_input" data-picker-value="#{scope.id}">
+                <a class="" href="/scopes/picker?current=#{scope.id}&amp;field=my_scope_input" data-picker-value="#{scope.id}">
                   #{scope.name["en"]} (#{scope.scope_type.name["en"]})
                 </a>
               </div>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/highlighted_participatory_processes/filters.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/highlighted_participatory_processes/filters.erb
@@ -3,7 +3,7 @@
     <%= cell(
       "decidim/scopes_picker",
       form,
-      attribute: :with_scope,
+      attribute: :with_any_scope,
       multiple: true,
       legend_title: I18n.t("decidim.scopes.scopes"),
       label: false,

--- a/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/highlighted_participatory_processes_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/highlighted_participatory_processes_cell.rb
@@ -42,7 +42,7 @@ module Decidim
 
         def default_filter_params
           {
-            with_scope: nil,
+            with_any_scope: nil,
             with_area: nil,
             with_type: nil
           }

--- a/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/process_filters_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/process_filters_cell.rb
@@ -56,7 +56,7 @@ module Decidim
         query = base_relation.ransack(
           {
             with_date: date_filter,
-            with_scope: get_filter(:with_scope),
+            with_any_scope: get_filter(:with_any_scope),
             with_area: get_filter(:with_area),
             with_type: filter_with_type ? get_filter(:with_type) : nil
           },

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_filters_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_filters_cell.rb
@@ -34,7 +34,7 @@ module Decidim
         {
           filter: {
             with_date: date_filter,
-            with_scope: get_filter(:with_scope),
+            with_any_scope: get_filter(:with_any_scope),
             with_area: get_filter(:with_area),
             with_type: type_filter || get_filter(:with_type)
           }
@@ -45,7 +45,7 @@ module Decidim
         query = ParticipatoryProcess.where(organization: current_organization).ransack(
           {
             with_date: date_filter,
-            with_scope: get_filter(:with_scope),
+            with_any_scope: get_filter(:with_any_scope),
             with_area: get_filter(:with_area),
             with_type: filter_with_type ? get_filter(:with_type) : nil
           },

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
@@ -46,7 +46,7 @@ module Decidim
 
       def default_filter_params
         {
-          with_scope: nil,
+          with_any_scope: nil,
           with_area: nil,
           with_type: nil,
           with_date: default_date_filter

--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -207,7 +207,7 @@ module Decidim
     ransacker_i18n :title
 
     def self.ransackable_scopes(_auth_object = nil)
-      [:with_date, :with_area, :with_scope, :with_type]
+      [:with_date, :with_area, :with_any_scope, :with_type]
     end
   end
 end

--- a/decidim-participatory_processes/spec/requests/participatory_process_search_spec.rb
+++ b/decidim-participatory_processes/spec/requests/participatory_process_search_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Participatory process search", type: :request do
   end
 
   context "when filtering by scope" do
-    let(:filter_params) { { with_scope: process1.scope.id } }
+    let(:filter_params) { { with_any_scope: [process1.scope.id] } }
 
     it "displays matching assemblies" do
       expect(subject).to include(translated(process1.title))

--- a/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
@@ -119,7 +119,7 @@ describe "Filter Participatory Processes", type: :system do
 
     context "and choosing a scope" do
       before do
-        visit decidim_participatory_processes.participatory_processes_path(filter: { with_scope: scope.id })
+        visit decidim_participatory_processes.participatory_processes_path(filter: { with_any_scope: [scope.id] })
       end
 
       it "lists all processes belonging to that scope" do

--- a/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
@@ -126,6 +126,19 @@ describe "Filter Participatory Processes", type: :system do
         expect(page).to have_content(translated(process_with_scope.title))
         expect(page).not_to have_content(translated(process_without_scope.title))
       end
+
+      context "and unselecting the scope again" do
+        before do
+          within "#participatory-space-filters" do
+            click_link translated(scope.name)
+          end
+        end
+
+        it "lists all processes" do
+          expect(page).to have_content(translated(process_with_scope.title))
+          expect(page).to have_content(translated(process_without_scope.title))
+        end
+      end
     end
   end
 

--- a/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
@@ -535,7 +535,7 @@ describe "Participatory Process Groups", type: :system do
     context "when filtering processes by scope" do
       context "and choosing a scope" do
         before do
-          visit decidim_participatory_processes.participatory_process_group_path(participatory_process_group, filter: { with_scope: scope.id })
+          visit decidim_participatory_processes.participatory_process_group_path(participatory_process_group, filter: { with_any_scope: [scope.id] })
         end
 
         it "lists active process belonging to that scope" do


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Use `with_any_scope` instead of `with_scope` for assemblies and processes.

#### :pushpin: Related Issues
- Fixes #11413 

#### Testing
1. Go to processes or assemblies
2. Filter by scope
3. Filter by another scope
4. Check the page loads successfully
5. Access again the page reloading with the URL with the two filters and see the page loads successfully

:hearts: Thank you!
