### PR TITLE
Redesign: don't submit forms on modal's cancel

### DIFF
--- a/decidim-core/app/cells/decidim/report_button/flag_modal.erb
+++ b/decidim-core/app/cells/decidim/report_button/flag_modal.erb
@@ -55,7 +55,7 @@
     </div>
 
     <div data-dialog-actions>
-      <button class="button button__lg button__transparent-secondary" data-dialog-close="flagModal">
+      <button type="button" class="button button__lg button__transparent-secondary" data-dialog-close="flagModal">
         <%= t("decidim.shared.confirm_modal.cancel") %>
       </button>
 

--- a/decidim-core/app/views/decidim/shared/_login_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_login_modal.html.erb
@@ -40,7 +40,7 @@
 
     <% if current_organization.sign_in_enabled? %>
       <div data-dialog-actions>
-        <button class="button button__lg button__transparent-secondary" data-dialog-close="loginModal">
+        <button type="button" class="button button__lg button__transparent-secondary" data-dialog-close="loginModal">
           <%= t("cancel", scope: "decidim.admin.actions") %>
         </button>
         <button type="submit" class="button button__lg button__secondary">

--- a/decidim-debates/app/views/decidim/debates/debates/_close_debate_modal.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_close_debate_modal.html.erb
@@ -13,10 +13,10 @@
       </div>
     </div>
     <div data-dialog-actions>
-      <button data-dialog-close="close-debate" class="button button__sm md:button__lg button__secondary">
+      <button type="button" data-dialog-close="close-debate" class="button button__sm md:button__lg button__transparent-secondary">
         <%= t("cancel", scope: "decidim.debates.debates.close_debate_modal") %>
       </button>
-      <button class="button button__sm md:button__lg button__secondary">
+      <button type="submit" class="button button__sm md:button__lg button__secondary">
         <%= t("send", scope: "decidim.debates.debates.close_debate_modal") %>
       </button>
     </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Avoid submitting the form clicking on the modal's cancel action

#### :pushpin: Related Issues
- Fixes #11434

:hearts: Thank you!
