### PR TITLE
Disabler for pointer events

### DIFF
--- a/decidim-core/app/cells/decidim/tab_panels/show.erb
+++ b/decidim-core/app/cells/decidim/tab_panels/show.erb
@@ -1,6 +1,6 @@
 <% if tabs.length > 0 %>
   <div class="layout-main__section" data-component="accordion" data-multiselectable="false" data-collapsible="false">
-    <ul class="tab-x-container">
+    <ul class="tab-x-container pointer-events-none">
       <% tabs.each_with_index do |tab, i| %>
         <li>
           <button id="trigger-<%= tab[:id] %>" class="tab-x" data-controls="panel-<%= tab[:id] %>" data-open="<%= "true" if i.zero? %>">


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
The cursor on some components within modules behaviour acted as if there were a link. This PR has added the ```pointer-events: none;``` property to disable this.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #11298 
- Fixes #11294 

#### Testing
*Describe the best way to test or validate your PR.*
1. Login 
2. Access any module (Assemblies for example) 
3. Head over to a meeting you can add yourself to or another profile
4. Reload the page 
5. See that the 'Organizations' link above your accepted attendance is not clickable.

### :camera: Screenshots

Highlighed in blue:
<img width="1358" alt="Screenshot 2023-08-07 at 11 45 11" src="https://github.com/decidim/decidim/assets/101816158/75853a36-9746-4b37-8ffc-24cd937651d3">


:hearts: Thank you!
