### PR TITLE
Redesign: organization colors

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
@@ -98,12 +98,10 @@ module Decidim
           colors: {
             primary: form.primary_color,
             secondary: form.secondary_color,
+            tertiary: form.tertiaryy_color,
             success: form.success_color,
             warning: form.warning_color,
-            alert: form.alert_color,
-            highlight: form.highlight_color,
-            "highlight-alternative": form.highlight_alternative_color,
-            theme: form.theme_color
+            alert: form.alert_color
           }
         }
       end

--- a/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
@@ -98,7 +98,7 @@ module Decidim
           colors: {
             primary: form.primary_color,
             secondary: form.secondary_color,
-            tertiary: form.tertiaryy_color,
+            tertiary: form.tertiary_color,
             success: form.success_color,
             warning: form.warning_color,
             alert: form.alert_color

--- a/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
@@ -29,14 +29,12 @@ module Decidim
       attribute :enable_omnipresent_banner, Boolean, default: false
       attribute :omnipresent_banner_url, String
 
-      attribute :primary_color, String, default: "#ef604d"
-      attribute :secondary_color, String, default: "#599aa6"
-      attribute :success_color, String, default: "#57d685"
-      attribute :warning_color, String, default: "#ffae00"
-      attribute :alert_color, String, default: "#ec5840"
-      attribute :highlight_color, String, default: "#be6400"
-      attribute :highlight_alternative_color, String, default: "#ff5731"
-      attribute :theme_color, String, default: "#ef604d"
+      attribute :primary_color, String
+      attribute :secondary_color, String
+      attribute :tertiary_color, String
+      attribute :success_color, String
+      attribute :warning_color, String
+      attribute :alert_color, String
 
       translatable_attribute :cta_button_text, String
       translatable_attribute :description, String

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/form/_colors.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/form/_colors.html.erb
@@ -61,12 +61,10 @@
     <div class="organization-colors">
       <%= form.color_field :primary_color, value: current_organization.colors["primary"] %>
       <%= form.color_field :secondary_color, value: current_organization.colors["secondary"] %>
+      <%= form.color_field :tertiary_color, value: current_organization.colors["tertiary"] %>
       <%= form.color_field :success_color, value: current_organization.colors["success"] %>
       <%= form.color_field :warning_color, value: current_organization.colors["warning"] %>
       <%= form.color_field :alert_color, value: current_organization.colors["alert"] %>
-      <%= form.color_field :highlight_color, value: current_organization.colors["highlight"] %>
-      <%= form.color_field :highlight_alternative_color, value: current_organization.colors["highlight-alternative"] %>
-      <%= form.color_field :theme_color, value: current_organization.colors["theme"] %>
     </div>
 
     <% if Decidim.enable_html_header_snippets %>

--- a/decidim-admin/spec/system/admin_manages_organization_appearance_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_appearance_spec.rb
@@ -72,8 +72,6 @@ describe "Admin manages organization", type: :system do
       dynamically_attach_file(:organization_official_img_header, Decidim::Dev.asset("city2.jpeg"), remove_before: true)
       dynamically_attach_file(:organization_official_img_footer, Decidim::Dev.asset("city3.jpeg"), remove_before: true)
 
-      fill_in :organization_theme_color, with: "#a0a0a0"
-
       click_button "Update"
 
       expect(page).to have_content("updated successfully")
@@ -81,19 +79,6 @@ describe "Admin manages organization", type: :system do
       within "#minimap" do
         expect(page.all("img").count).to eq(4)
       end
-    end
-
-    it "updates the value of the theme-color meta tag" do
-      color = "#a0a0a0"
-
-      visit decidim_admin.edit_organization_appearance_path
-
-      fill_in :organization_theme_color, with: color
-      click_button "Update"
-      visit decidim.root_path
-      meta_tag = page.find 'meta[name="theme-color"]', visible: false
-
-      expect(meta_tag[:content]).to eq(color)
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -173,7 +173,7 @@ module Decidim
     # Example:
     #
     # --primary: #ff0000;
-    # --primary-rgb: 255,0,0
+    # --primary-rgb: 255 0 0
     #
     # Hexadecimal variables can be used as a normal CSS color:
     #

--- a/decidim-core/app/packs/src/decidim/map/controller.js
+++ b/decidim-core/app/packs/src/decidim/map/controller.js
@@ -11,7 +11,7 @@ export default class MapController {
     this.mapId = mapId;
     this.config = $.extend({
       popupTemplateId: "marker-popup",
-      markerColor: "#ef604d"
+      markerColor: "#e02d2d"
     }, config);
 
     this.map = null;

--- a/decidim-core/app/packs/src/decidim/map/legacy.js
+++ b/decidim-core/app/packs/src/decidim/map/legacy.js
@@ -33,7 +33,7 @@ const legacyMapSupport = ($map) => {
 
   let markerColor = getComputedStyle(document.documentElement).getPropertyValue("--primary");
   if (!markerColor || markerColor.length < 1) {
-    markerColor = "#ef604d";
+    markerColor = "#e02d2d";
   }
 
   // Configure the map element with the new style

--- a/decidim-core/app/packs/stylesheets/decidim/redesigned_application.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/redesigned_application.scss
@@ -2,21 +2,6 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
-:root {
-  --primary: #e02d2d;
-  --primary-rgb: 224 45 45;
-  --secondary: #155abf;
-  --secondary-rgb: 21 90 191;
-  --tertiary: #ebc34b;
-  --tertiary-rgb: 235 195 75;
-  --success: #28a745;
-  --success-rgb: 40 167 69;
-  --warning: #ffb703;
-  --warning-rgb: 255 183 3;
-  --alert: #e7131a;
-  --alert-rgb: 231 19 26;
-}
-
 @layer base {
   @import "stylesheets/decidim/redesigned_fonts.scss";
   @import "stylesheets/decidim/redesigned_typography.scss";

--- a/decidim-core/app/views/decidim/manifests/show.json.erb
+++ b/decidim-core/app/views/decidim/manifests/show.json.erb
@@ -4,8 +4,8 @@
   "description": "<%= organization_params.translated_description %>",
   "display": "<%= organization_params.pwa_display %>",
   "start_url": "<%= organization_params.start_url %>",
-  "theme_color": "<%= organization_params.colors["theme"] %>",
-  "background_color": "<%= organization_params.colors["theme"] %>",
+  "theme_color": "<%= organization_params.colors["primary"] %>",
+  "background_color": "<%= organization_params.colors["primary"] %>",
   "icons": [
     {
       "src": "<%= current_organization.attached_uploader(:favicon).variant_path :small %>",

--- a/decidim-core/app/views/layouts/decidim/_head.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_head.html.erb
@@ -18,7 +18,7 @@
 <meta property="og:image" content="<%= decidim_meta_image_url %>">
 
 <% if current_organization.colors.present? %>
-  <meta name="theme-color" content="<%= current_organization.colors["theme"] %>">
+  <meta name="theme-color" content="<%= current_organization.colors["primary"] %>">
 <% end %>
 
 <%= legacy_favicon %>

--- a/decidim-core/app/views/layouts/decidim/_organization_colors.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_organization_colors.html.erb
@@ -1,6 +1,5 @@
-<% unless css.blank? %>
 <style media="all">
 :root{
   <%= css %>
-}</style>
-<% end %>
+}
+</style>

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -20,22 +20,20 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
   smtp_label = ENV.fetch("SMTP_FROM_LABEL", Faker::Twitter.unique.screen_name)
   smtp_email = ENV.fetch("SMTP_FROM_EMAIL", Faker::Internet.email)
 
-  primary_color, secondary_color = [
-    ["#4CAF50", "#A0309E"],
-    ["#E91E63", "#1EE9A5"],
-    ["#009688", "#D12C26"],
-    ["#FF9800", "#00BCD4"]
+  primary_color, secondary_color, tertiary_color = [
+    ["#4caf50", "#a0309e", "#a8753e"],
+    ["#e91e63", "#1ee9a5", "#e9b61e"],
+    ["#009688", "#d12c26", "#b4a110"],
+    ["#ff9800", "#00bcd4", "#ea0094"]
   ].sample
 
   colors = {
-    alert: "#ec5840",
-    highlight: "#be6400",
-    "highlight-alternative": "#ff5731",
+    alert: "#e7131a",
     primary: primary_color,
     secondary: secondary_color,
-    success: "#57d685",
-    theme: "#ef604d",
-    warning: "#ffae00"
+    tertiary: tertiary_color,
+    success: "#28a745",
+    warning: "#ffb703"
   }
 
   organization = Decidim::Organization.first || Decidim::Organization.create!(

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -21,6 +21,7 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
   smtp_email = ENV.fetch("SMTP_FROM_EMAIL", Faker::Internet.email)
 
   primary_color, secondary_color, tertiary_color = [
+    ["#e02d2d", "#155abf", "#ebc34b"],
     ["#4caf50", "#a0309e", "#a8753e"],
     ["#e91e63", "#1ee9a5", "#e9b61e"],
     ["#009688", "#d12c26", "#b4a110"],

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -113,7 +113,7 @@ FactoryBot.define do
     content_security_policy { {} }
     colors do
       {
-        primary: "#f0f0f0"
+        primary: "#ef604d"
       }
     end
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -113,7 +113,9 @@ FactoryBot.define do
     content_security_policy { {} }
     colors do
       {
-        primary: "#ef604d"
+        primary: "#e02d2d",
+        secondary: "#155abf",
+        tertiary: "#ebc34b"
       }
     end
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -111,6 +111,11 @@ FactoryBot.define do
     file_upload_settings { Decidim::OrganizationSettings.default(:upload) }
     enable_participatory_space_filters { true }
     content_security_policy { {} }
+    colors do
+      {
+        primary: "#f0f0f0"
+      }
+    end
 
     trait :secure_context do
       host { "localhost" }

--- a/decidim-core/lib/decidim/map/dynamic_map.rb
+++ b/decidim-core/lib/decidim/map/dynamic_map.rb
@@ -29,7 +29,7 @@ module Decidim
       # @return [Hash] The default options for the map builder.
       def builder_options
         {
-          marker_color: organization.colors.fetch("primary", "#ef604d"),
+          marker_color: organization.colors.fetch("primary", "#e02d2d"),
           tile_layer: tile_layer_configuration
         }
       end

--- a/decidim-core/spec/controllers/manifests_controller_spec.rb
+++ b/decidim-core/spec/controllers/manifests_controller_spec.rb
@@ -25,8 +25,8 @@ module Decidim
         expect(manifest["name"]).to eq(organization.name)
         expect(manifest["lang"]).to eq(organization.default_locale)
         expect(manifest["description"]).to eq(ActionView::Base.full_sanitizer.sanitize(organization.description["en"]))
-        expect(manifest["background_color"]).to eq("#f0f0f0")
-        expect(manifest["theme_color"]).to eq("#f0f0f0")
+        expect(manifest["background_color"]).to eq("#e02d2d")
+        expect(manifest["theme_color"]).to eq("#e02d2d")
         expect(manifest["display"]).to eq("standalone")
         expect(manifest["start_url"]).to eq("/")
         expect(manifest["icons"]).to match(

--- a/decidim-core/spec/controllers/manifests_controller_spec.rb
+++ b/decidim-core/spec/controllers/manifests_controller_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   describe ManifestsController, type: :controller do
     routes { Decidim::Core::Engine.routes }
 
-    let(:organization) { create(:organization, name: "Organization's name", colors: { "theme" => "#f0f0f0" }) }
+    let(:organization) { create(:organization, name: "Organization's name") }
 
     before do
       Decidim::Organization.destroy_all

--- a/decidim-core/spec/lib/map/dynamic_map_spec.rb
+++ b/decidim-core/spec/lib/map/dynamic_map_spec.rb
@@ -16,7 +16,7 @@ module Decidim
         it "creates a new builder instance" do
           expect(Decidim::Map::DynamicMap::Builder).to receive(:new).with(
             template,
-            { marker_color: "#ef604d",
+            { marker_color: "#e02d2d",
               tile_layer: { url: nil, options: {} } }
           ).and_call_original
 
@@ -34,7 +34,7 @@ module Decidim
       describe "#builder_options" do
         it "prepares and returns the correct builder options" do
           expect(utility.builder_options).to eq(
-            marker_color: "#ef604d",
+            marker_color: "#e02d2d",
             tile_layer: { url: nil, options: {} }
           )
         end

--- a/decidim-core/spec/lib/map/provider/dynamic_map/here_spec.rb
+++ b/decidim-core/spec/lib/map/provider/dynamic_map/here_spec.rb
@@ -29,7 +29,7 @@ module Decidim
 
             it "returns the correct builder options" do
               expect(subject.builder_options).to eq(
-                marker_color: "#ef604d",
+                marker_color: "#e02d2d",
                 tile_layer: {
                   api_key: "key1234", foo: "bar", language: "eng"
                 }
@@ -48,7 +48,7 @@ module Decidim
               it "returns the correct builder options for CA" do
                 I18n.locale = "ca"
                 expect(subject.builder_options).to eq(
-                  marker_color: "#ef604d",
+                  marker_color: "#e02d2d",
                   tile_layer: {
                     api_key: "key1234", foo: "bar", language: "cat"
                   }
@@ -58,7 +58,7 @@ module Decidim
               it "returns the correct builder options for ES" do
                 I18n.locale = "es"
                 expect(subject.builder_options).to eq(
-                  marker_color: "#ef604d",
+                  marker_color: "#e02d2d",
                   tile_layer: {
                     api_key: "key1234", foo: "bar", language: "spa"
                   }
@@ -77,7 +77,7 @@ module Decidim
               it "returns the correct builder options" do
                 expect(ActiveSupport::Deprecation).to receive(:warn)
                 expect(subject.builder_options).to eq(
-                  marker_color: "#ef604d",
+                  marker_color: "#e02d2d",
                   tile_layer: {
                     app_id: "appid123",
                     app_code: "secret456",

--- a/decidim-core/spec/lib/map/provider/dynamic_map/osm_spec.rb
+++ b/decidim-core/spec/lib/map/provider/dynamic_map/osm_spec.rb
@@ -30,7 +30,7 @@ module Decidim
 
             it "prepares and returns the correct builder options" do
               expect(utility.builder_options).to eq(
-                marker_color: "#ef604d",
+                marker_color: "#e02d2d",
                 tile_layer: {
                   url: "https://tiles.example.org",
                   options: {}
@@ -51,7 +51,7 @@ module Decidim
 
               it "prepares and returns the correct builder options" do
                 expect(utility.builder_options).to eq(
-                  marker_color: "#ef604d",
+                  marker_color: "#e02d2d",
                   tile_layer: {
                     url: "https://tiles.example.org",
                     options: { foo: "bar", baz: "foobar" }
@@ -75,7 +75,7 @@ module Decidim
 
               it "prepares and returns the correct builder options" do
                 expect(utility.builder_options).to eq(
-                  marker_color: "#ef604d",
+                  marker_color: "#e02d2d",
                   tile_layer: {
                     url: "https://tiles.example.org",
                     options: { api_key: "key1234", foo: "bar", baz: "foobar" }

--- a/decidim-core/spec/services/decidim/notifications_subscriptions_persistor_spec.rb
+++ b/decidim-core/spec/services/decidim/notifications_subscriptions_persistor_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   describe NotificationsSubscriptionsPersistor, type: :service do
     subject { described_class.new(user) }
 
-    let(:organization) { create(:organization, colors: { "theme" => "#f0f0f0" }) }
+    let(:organization) { create(:organization) }
     let(:params) { { endpoint: "https://example.es", keys: { auth: "auth_code_121", p256dh: "a_p256dh" } } }
 
     describe "#add_subscription" do


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Since #10974, decidim application always sets the variable `current_organization.colors`. Therefore, we can establish one single point to configure all the application colors, in order to avoid including duplicate or useless colors along the code.

The tertiary sample colors chosen has been generated through the triadic algorythm from the previous primary-secondary tuple (https://www.sessions.edu/color-calculator/)

Included also:
- Using of the default browser outline color for the card links (card-L)
- Allowing the setup of the redesigned colors from the admin panel
- Removal the outdated variables

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/11404

### :camera: Screenshots
https://decidim-redesign.populate.tools/admin/organization/appearance/edit

:hearts: Thank you!
