### PR TITLE
Redesign: remove the item itself from nav menu

### DIFF
--- a/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
+++ b/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
@@ -43,11 +43,6 @@ module Decidim
         components = participatory_space.components.published.or(Decidim::Component.where(id: try(:current_component)))
 
         [
-          {
-            name: t("assembly_menu_item", scope: "layouts.decidim.assembly_navigation"),
-            url: decidim_assemblies.assembly_path(participatory_space),
-            active: is_active_link?(decidim_assemblies.assembly_path(participatory_space), :exclusive)
-          },
           *(if participatory_space.members.not_ceased.any?
               [{
                 name: t("assembly_member_menu_item", scope: "layouts.decidim.assembly_navigation"),

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -472,4 +472,3 @@ en:
             other: "%{count} assemblies"
       assembly_navigation:
         assembly_member_menu_item: Members
-        assembly_menu_item: The assembly

--- a/decidim-assemblies/spec/system/assembly_members_spec.rb
+++ b/decidim-assemblies/spec/system/assembly_members_spec.rb
@@ -32,9 +32,7 @@ describe "Assembly members", type: :system do
       it "the menu link is not shown" do
         visit decidim_assemblies.assembly_path(assembly)
 
-        within ".participatory-space__nav-container" do
-          expect(page).not_to have_content("Members")
-        end
+        expect(page).not_to have_content("Members")
       end
     end
   end

--- a/decidim-assemblies/spec/system/assembly_members_spec.rb
+++ b/decidim-assemblies/spec/system/assembly_members_spec.rb
@@ -72,9 +72,7 @@ describe "Assembly members", type: :system do
         it "the menu link is not shown" do
           visit decidim_assemblies.assembly_path(assembly)
 
-          within ".participatory-space__nav-container" do
-            expect(page).not_to have_content("Members")
-          end
+          expect(page).not_to have_content("Members")
         end
       end
     end

--- a/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
+++ b/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
@@ -17,12 +17,7 @@ module Decidim
       # Items to display in the navigation of a conference
       #
       def conference_nav_items(participatory_space)
-        [
-          {
-            name: t("layouts.decidim.conferences_nav.conference_menu_item"),
-            url: decidim_conferences.conference_path(participatory_space)
-          }
-        ].tap do |items|
+        [].tap do |items|
           if participatory_space.speakers.exists?
             items << {
               name: t("layouts.decidim.conferences_nav.conference_speaker_menu_item"),

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -580,7 +580,6 @@ en:
             one: "%{count} conference"
             other: "%{count} conferences"
       conferences_nav:
-        conference_menu_item: Information
         conference_partners_menu_item: Partners
         conference_speaker_menu_item: Speakers
         media: Media

--- a/decidim-elections/app/helpers/decidim/votings/votings_helper.rb
+++ b/decidim-elections/app/helpers/decidim/votings/votings_helper.rb
@@ -25,11 +25,6 @@ module Decidim
 
         (
           [
-            {
-              name: t("layouts.decidim.voting_navigation.voting_menu_item"),
-              url: decidim_votings.voting_path(participatory_space),
-              active: is_active_link?(decidim_votings.voting_path(participatory_space), :exclusive)
-            },
             if participatory_space.check_census_enabled?
               {
                 name: t("layouts.decidim.voting_navigation.check_census"),

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -1407,7 +1407,6 @@ en:
       voting_navigation:
         check_census: Can I vote?
         election_log: Election log
-        voting_menu_item: The voting
       votings:
         index:
           promoted_votings: Highlighted votings

--- a/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
@@ -23,14 +23,7 @@ module Decidim
       def initiative_nav_items(participatory_space)
         components = participatory_space.components.published.or(Decidim::Component.where(id: try(:current_component)))
 
-        [
-          {
-            name: t("initiative_menu_item", scope: "layouts.decidim.initiative_header"),
-            url: decidim_initiatives.initiative_path(participatory_space),
-            active: is_active_link?(decidim_initiatives.initiative_path(participatory_space), :exclusive) ||
-              is_active_link?(decidim_initiatives.initiative_version_path(participatory_space, participatory_space.versions.count), :inclusive)
-          }
-        ] + components.map do |component|
+        components.map do |component|
           {
             name: translated_attribute(component.name),
             url: main_component_path(component),

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -615,8 +615,6 @@ en:
         finish: Finish
         promotal_committee: Promoter committee
         select_initiative_type: Choose
-      initiative_header:
-        initiative_menu_item: Initiative
       initiative_signature_creation_header:
         fill_personal_data: Complete your data
         finish: Finish

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -61,14 +61,7 @@ module Decidim
       def process_nav_items(participatory_space)
         components = participatory_space.components.published.or(Decidim::Component.where(id: try(:current_component)))
 
-        [
-          {
-            name: t("process_menu_item", scope: "layouts.decidim.process_navigation"),
-            url: decidim_participatory_processes.participatory_process_path(participatory_space),
-            active: is_active_link?(decidim_participatory_processes.participatory_process_path(participatory_space), :exclusive) ||
-              is_active_link?(decidim_participatory_processes.all_metrics_participatory_process_path(participatory_space), :exclusive)
-          }
-        ] + components.map do |component|
+        components.map do |component|
           {
             name: translated_attribute(component.name),
             url: main_component_path(component),

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -533,5 +533,3 @@ en:
           more_info_about: More info about process %{resource_name}
           take_part: Take part
           take_part_in: Take part in process %{resource_name}
-      process_navigation:
-        process_menu_item: The process


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Remove the resource link to itself from the navigation menu

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/11213

### :camera: Screenshots
https://decidim-redesign.populate.tools/assemblies/eix-comunitat
https://decidim-redesign.populate.tools/votings/voting
https://decidim-redesign.populate.tools/initiatives/i-181
https://decidim-redesign.populate.tools/conferences/DecidimFest22
https://decidim-redesign.populate.tools/processes/Decidim4Dummies

:hearts: Thank you!
