### PR TITLE
force capital starting letter for PR titles

### DIFF
--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           disallowed_prefixes: "feat/,feature/,fix/,chore/,build/,ci/,refactor/,docs/,wip/,fix:"
           prefix_case_sensitive: false
-          regex: "[A-Z].+"
+          regex: "^[A-Z].+"
           min_length: 5
           max_length: 100

--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -18,5 +18,6 @@ jobs:
         with:
           disallowed_prefixes: "feat/,feature/,fix/,chore/,build/,ci/,refactor/,docs/,wip/,fix:"
           prefix_case_sensitive: false
+          regex: "[A-Z].+"
           min_length: 5
           max_length: 100


### PR DESCRIPTION
#### :tophat: What? Why?
Our "Lint PR format" is not ensuring that the PR title starts with a capital letter.

Therefore, PRs like #11432 will pass the check fine although the title is incorrectly formatted.

I think we should force starting capital letter to have a standard writing format for the titles.

#### :pushpin: Related Issues
- Related to #11432

#### Testing
Once this is merged, we could use #11432 as a test bench for this.

I am also testing it in this PR (on purpose).