### PR TITLE
Revert "Lock ChromeDriver to the latest working version (#11391)"

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -64,10 +64,6 @@ jobs:
           ruby-version: ${{ inputs.ruby_version }}
           bundler-cache: true
       - uses: nanasess/setup-chromedriver@v2
-        with:
-          # TODO: Unpin when nanasess/setup-chromedriver#190 is fixed:
-          #       https://github.com/nanasess/setup-chromedriver/issues/190
-          chromedriver-version: 114.0.5735.90
       - uses: actions/cache@v3
         id: app-cache
         with:


### PR DESCRIPTION
#### :tophat: What? Why?
This reverts commit 2450714dee4df4281c52e1c9979f8d2de22453cd from PR #11391.

This is no longer required, see the related issues (it has been fixed upstream).

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to
  * #11391
  * nanasess/setup-chromedriver#201
  * nanasess/setup-chromedriver#200
  * nanasess/setup-chromedriver#190

#### Testing
See that the CI is green and system specs are running normally.