### PR TITLE
Raise exception in `UserTimelineController` if no user with the nickname provided

### DIFF
--- a/decidim-core/app/controllers/decidim/user_timeline_controller.rb
+++ b/decidim-core/app/controllers/decidim/user_timeline_controller.rb
@@ -12,7 +12,7 @@ module Decidim
     helper_method :activities, :resource_types, :user
 
     def index
-      raise ActionController::RoutingError, "Not Found" if current_user != user
+      raise ActionController::RoutingError, "Not Found" if !user || current_user != user
     end
 
     private

--- a/decidim-core/app/controllers/decidim/user_timeline_controller.rb
+++ b/decidim-core/app/controllers/decidim/user_timeline_controller.rb
@@ -12,7 +12,7 @@ module Decidim
     helper_method :activities, :resource_types, :user
 
     def index
-      raise ActionController::RoutingError, "Not Found" if !user || current_user != user
+      raise ActionController::RoutingError, "Not Found" unless user && current_user == user
     end
 
     private

--- a/decidim-core/spec/controllers/decidim/user_timeline_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/user_timeline_controller_spec.rb
@@ -4,29 +4,54 @@ require "spec_helper"
 
 module Decidim
   describe UserTimelineController, type: :controller do
+    subject { get :index, params: { nickname: nickname } }
+
     routes { Decidim::Core::Engine.routes }
 
     let(:organization) { create(:organization) }
     let!(:user) { create(:user, :confirmed, nickname: "Nick", organization: organization) }
+    let(:nickname) { "foobar" }
 
     before do
       request.env["decidim.current_organization"] = organization
-      sign_in user
+    end
+
+    shared_examples_for "a not found page" do
+      it "raises an ActionController::RoutingError" do
+        expect { subject }.to raise_error(ActionController::RoutingError, "Not Found")
+      end
     end
 
     describe "#index" do
-      context "with a different user than me" do
-        it "raises an ActionController::RoutingError" do
-          expect do
-            get :index, params: { nickname: "foobar" }
-          end.to raise_error(ActionController::RoutingError, "Not Found")
+      context "with the user logged in" do
+        before do
+          sign_in user
+        end
+
+        context "with a different user than me" do
+          it_behaves_like "a not found page"
+        end
+
+        context "with my user with uppercase" do
+          let(:nickname) { user.nickname.upcase }
+
+          it "returns the lowercased user" do
+            subject
+
+            expect(response).to render_template(:index)
+          end
         end
       end
 
-      context "with my user with uppercase" do
-        it "returns the lowercased user" do
-          get :index, params: { nickname: "NICK" }
-          expect(response).to render_template(:index)
+      context "without the user logged in" do
+        context "with a non existing user" do
+          it_behaves_like "a not found page"
+        end
+
+        context "with my user with uppercase" do
+          let(:nickname) { user.nickname.upcase }
+
+          it_behaves_like "a not found page"
         end
       end
     end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Raise `ActionController::RoutingError` exception in `UserTimelineController` if no user with the nickname provided

#### :pushpin: Related Issues
- Fixes #11464

#### Testing
1. Without login into the system, go to `/profiles/non_existing_user_nickname/timeline` and see a 404 Not Found page shown.

:hearts: Thank you!
