### PR TITLE
Refactor Decidim jobs to inherit from Decidim::ApplicationJob

### DIFF
--- a/decidim-admin/app/jobs/decidim/admin/application_job.rb
+++ b/decidim-admin/app/jobs/decidim/admin/application_job.rb
@@ -4,7 +4,7 @@ module Decidim
   module Admin
     # Custom ApplicationJob scoped to the admin panel.
     #
-    class ApplicationJob < ActiveJob::Base
+    class ApplicationJob < Decidim::ApplicationJob
     end
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/bullet.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/bullet.rb
@@ -3,12 +3,7 @@
 require "bullet"
 
 RSpec.configure do |config|
-  if defined?(Bullet::ActiveJob)
-    Decidim::ApplicationJob.include(Bullet::ActiveJob)
-    Decidim::Admin::ApplicationJob.include(Bullet::ActiveJob)
-    Decidim::System::ApplicationJob.include(Bullet::ActiveJob)
-    Decidim::Verifications::CsvCensus::ApplicationJob.include(Bullet::ActiveJob)
-  end
+  Decidim::ApplicationJob.include(Bullet::ActiveJob) if defined?(Bullet::ActiveJob)
 
   Rails.application.config.after_initialize do
     Bullet.enable = Decidim::Env.new("DECIDIM_BULLET_ENABLED", "false").present?

--- a/decidim-system/app/jobs/decidim/system/application_job.rb
+++ b/decidim-system/app/jobs/decidim/system/application_job.rb
@@ -4,7 +4,7 @@ module Decidim
   module System
     # Custom ApplicationJob scoped to the system panel.
     #
-    class ApplicationJob < ActiveJob::Base
+    class ApplicationJob < Decidim::ApplicationJob
     end
   end
 end

--- a/decidim-verifications/app/jobs/decidim/verifications/csv_census/application_job.rb
+++ b/decidim-verifications/app/jobs/decidim/verifications/csv_census/application_job.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Verifications
     module CsvCensus
-      class ApplicationJob < ActiveJob::Base
+      class ApplicationJob < Decidim::ApplicationJob
       end
     end
   end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While working on https://github.com/decidim/decidim/pull/11416, i have noticed that not all of the jobs are inherited from the same Decidim job (Decidim::ApplicationJob). We need to refactor and add the Decidim::ApplicationJob as a single point of inheritance.

#### :pushpin: Related Issues
*Link your PR to an issue*

- Fixes #11462 

#### Testing
Make sure the pipeline is green

:hearts: Thank you!
