### PR TITLE
Fix ambiguous id column on projects query

### DIFF
--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -59,7 +59,7 @@ module Decidim
         # array. This is why we search for match ",2," instead to get the actual
         # position for ID 2.
         concat_ids = connection.quote(",#{ids.join(",")},")
-        order(Arel.sql("position(concat(',', id::text, ',') in #{concat_ids})"))
+        order(Arel.sql("position(concat(',', decidim_budgets_projects.id::text, ',') in #{concat_ids})"))
       end
 
       def self.log_presenter_class_for(_log)


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Fix the ambiguous id column on the `ordered_ids` method from the `Decidim::Budgets::Project` model.

#### :pushpin: Related Issues
- Fixes #11469 

#### Testing
1. Go to a participatory space with a budget component.
2. Go to the budget component (enable "show votes" from the admin panel if not enabled).
3. Filter by category.
4. Order by most voted.

:hearts: Thank you!
