### PR TITLE
Fix persistance of the area in initiative creation

### DIFF
--- a/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
@@ -63,6 +63,7 @@ module Decidim
           scoped_type:,
           signature_type: form.type.signature_type,
           decidim_user_group_id: form.decidim_user_group_id,
+          decidim_area_id: form.area_id,
           state: "created"
         )
       end

--- a/decidim-initiatives/spec/commands/decidim/initiatives/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/create_initiative_spec.rb
@@ -37,6 +37,7 @@ module Decidim
           described_class.new(form, author)
         end
 
+        let(:area) { create(:area, organization:) }
         let(:scoped_type) { create(:initiatives_type_scope) }
         let(:organization) { scoped_type.type.organization }
         let(:author) { create(:user, organization:) }
@@ -55,11 +56,17 @@ module Decidim
             type_id: scoped_type.type.id,
             signature_type: "online",
             scope_id: scoped_type.scope.id,
-            decidim_user_group_id: nil
+            decidim_user_group_id: nil,
+            area_id: area.id
           }
         end
         let(:follower) { create(:user, organization:) }
         let!(:follow) { create(:follow, followable: author, user: follower) }
+
+        it "sets the area" do
+          subject.call
+          expect(Decidim::Initiative.last.area).to eq(area)
+        end
 
         it "does not notify author about committee request" do
           expect(Decidim::EventsManager)


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
When creating an initiative that has area enabled, currently, that information is not being persisted to DB. This PR fixes it

#### Testing
1. Go to Initiative type admin and check "Enable authors to choose the area for their initiative"
2. Go to public interface and create an initiative. Make sure you select area. 
3. Continue the creation flow,  then visit Created initiative. 
4. See there is no area displayed in the sidebar
5. Apply the patch 
6. Repeat 2+ 3 
7. See there is area displayed in the sidebar

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![image](https://github.com/decidim/decidim/assets/105683/f6e9fa7e-d957-4330-b1b7-12927228239e)

:hearts: Thank you!
