### PR TITLE
Redesign: dropdown on tablet devices

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_header.scss
@@ -319,10 +319,14 @@ header {
       /* overwrite default dropdown styles */
       [id*="dropdown-menu"] {
         @apply mx-0 py-0 border-0;
+
+        &[aria-hidden="true"] {
+          @apply md:hidden lg:flex;
+        }
       }
 
       [data-target*="dropdown"] {
-        @apply w-auto last-of-type:[&>svg]:block;
+        @apply md:block lg:hidden w-auto last-of-type:[&>svg]:block;
 
         > svg {
           @apply text-white;


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Hides the submenu for tablet sizes (+768px)

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/11454

### :camera: Screenshots
https://decidim-redesign.populate.tools/processes/Decidim4Dummies

:hearts: Thank you!
