### PR TITLE
Redesign: display alert when no projects

### DIFF
--- a/decidim-accountability/app/cells/decidim/accountability/results/show.erb
+++ b/decidim-accountability/app/cells/decidim/accountability/results/show.erb
@@ -1,3 +1,7 @@
-<% results.each do |result| %>
-  <%= card_for result, render_extra_data: true %>
+<% if results.any? %>
+  <% results.each do |result| %>
+    <%= card_for result, render_extra_data: true %>
+  <% end %>
+<% else %>
+  <%= cell("decidim/announcement", t("no_results", scope: "decidim.accountability.results")) %>
 <% end %>

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -248,6 +248,7 @@ en:
             votes: Supports
         timeline:
           title: Project evolution
+        no_results: There are no projects
     admin:
       filters:
         results:

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -233,6 +233,7 @@ en:
           global_status: Global execution status
         nav_breadcrumb:
           global: Global execution
+        no_results: There are no projects
         search:
           search: Search for actions
         show:
@@ -248,7 +249,6 @@ en:
             votes: Supports
         timeline:
           title: Project evolution
-        no_results: There are no projects
     admin:
       filters:
         results:


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Show some information in case there are no projects for the seleted category

#### :pushpin: Related Issues
- Fixes #11223

### :camera: Screenshots
https://decidim-redesign.populate.tools/processes/Decidim4Dummies/f/171/results?filter%5Bwith_category%5D=210&filter%5Bwith_scope%5D=69

:hearts: Thank you!
