### PR TITLE
Fix Bootsnap configuration

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -223,22 +223,6 @@ module Decidim
         end
       end
 
-      def tweak_bootsnap
-        gsub_file "config/boot.rb", %r{require 'bootsnap/setup'.*$}, <<~RUBY.rstrip
-          require "bootsnap"
-
-          env = ENV["RAILS_ENV"] || "development"
-
-          Bootsnap.setup(
-            cache_dir: File.expand_path(File.join("..", "tmp", "cache"), __dir__),
-            development_mode: env == "development",
-            load_path_cache: true,
-            compile_cache_iseq: !ENV["SIMPLECOV"],
-            compile_cache_yaml: true
-          )
-        RUBY
-      end
-
       def tweak_spring
         return unless File.exist?("config/spring.rb")
 

--- a/decidim-generators/lib/decidim/generators/app_templates/config/boot.rb.tt
+++ b/decidim-generators/lib/decidim/generators/app_templates/config/boot.rb.tt
@@ -1,0 +1,16 @@
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+
+require "bundler/setup" # Set up gems listed in the Gemfile.
+<% if depend_on_bootsnap? -%>
+require "bootsnap"
+
+env = ENV["RAILS_ENV"] || "development"
+
+Bootsnap.setup(
+  cache_dir: File.expand_path(File.join("..", "tmp", "cache"), __dir__),
+  development_mode: env == "development",
+  load_path_cache: true,
+  compile_cache_iseq: !ENV["SIMPLECOV"],
+  compile_cache_yaml: true
+)
+<%- end -%>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
On a closer look on the initialization process, i have noticed that our bootsnap config is not working properly. 

As per rails [bootsnap.rb](https://github.com/rails/rails/blob/6-1-stable/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt) template, we can see that we have 
```
require "bootsnap/setup" # Speed up boot time by caching expensive operations.
```

Whereas, in our generator we have 
```
gsub_file "config/boot.rb", %r{require 'bootsnap/setup'.*$}, <<~RUBY.rstrip
```

As we can see rails official version is using double quotes whereas we are just using single quotes. 

#### Testing
1. On a development application open "config/bootsnap.rb"
2. See the decidim related config is not present 
3. Apply the patch 
4. Regenerate application 
5. Open the new  "config/bootsnap.rb"
6. See decidim related config there. 
7. Repeat 1 to 6 for the test application. 

:hearts: Thank you!
