### PR TITLE
Redesign: maxlength warning

### DIFF
--- a/decidim-admin/app/views/layouts/decidim/admin/_js_configuration.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_js_configuration.html.erb
@@ -13,7 +13,8 @@ character_messages = {
   },
   "charactersLeft": {
     one: t("decidim.components.add_comment_form.remaining_characters_1", count: "%count%"),
-    other: t("decidim.components.add_comment_form.remaining_characters", count: "%count%")
+    other: t("decidim.components.add_comment_form.remaining_characters", count: "%count%"),
+    zero: t("decidim.components.add_comment_form.remaining_characters_0")
   }
 }
 %>

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -59,7 +59,7 @@ en:
           positive: Positive
           positive_selected: Your opinion about this topic is positive
         remaining_characters: "%{count} characters left"
-        remaining_characters_0: "you have reached the maximum of characters"
+        remaining_characters_0: you have reached the maximum of characters
         remaining_characters_1: "%{count} character left"
         title: Add your comment
       comment:

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -59,6 +59,7 @@ en:
           positive: Positive
           positive_selected: Your opinion about this topic is positive
         remaining_characters: "%{count} characters left"
+        remaining_characters_0: "you have reached the maximum of characters"
         remaining_characters_1: "%{count} character left"
         title: Add your comment
       comment:

--- a/decidim-core/app/packs/src/decidim/redesigned_input_character_counter.js
+++ b/decidim-core/app/packs/src/decidim/redesigned_input_character_counter.js
@@ -55,7 +55,7 @@ export default class InputCharacterCounter {
       if (this.$input.attr("id") && this.$input.attr("id").length > 0) {
         targetId = `${this.$input.attr("id")}_characters`;
       } else {
-        targetId = `characters_${Math.random().toString(36).substr(2, 9)}`;
+        targetId = `characters_${Math.random().toString(36).substring(2, 9)}`;
       }
     }
 
@@ -148,6 +148,11 @@ export default class InputCharacterCounter {
 
     this.$userInput.on("keyup", () => {
       this.updateStatus();
+
+      if (this.$userInput.val().length >= this.maxCharacters) {
+        this.$userInput.get(0).setCustomValidity(MESSAGES.limit)
+        this.$userInput.get(0).reportValidity()
+      }
     });
     this.$userInput.on("focus", () => {
       this.updateScreenReaderStatus();

--- a/decidim-core/app/packs/src/decidim/redesigned_input_character_counter.js
+++ b/decidim-core/app/packs/src/decidim/redesigned_input_character_counter.js
@@ -274,6 +274,9 @@ export default class InputCharacterCounter {
     if (this.maxCharacters > 0) {
       const remaining = this.maxCharacters - inputLength;
       let message = MESSAGES.charactersLeft.other;
+      if (remaining === 0) {
+        message = MESSAGES.charactersLeft.zero;
+      }
       if (remaining === 1) {
         message = MESSAGES.charactersLeft.one;
       }

--- a/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
@@ -20,7 +20,8 @@ character_messages = {
   },
   "charactersLeft": {
     one: t("decidim.components.add_comment_form.remaining_characters_1", count: "%count%"),
-    other: t("decidim.components.add_comment_form.remaining_characters", count: "%count%")
+    other: t("decidim.components.add_comment_form.remaining_characters", count: "%count%"),
+    zero: t("decidim.components.add_comment_form.remaining_characters_0")
   },
   "limit": t("activemodel.errors.models.answer.attributes.body.too_long")
 }

--- a/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
@@ -21,7 +21,8 @@ character_messages = {
   "charactersLeft": {
     one: t("decidim.components.add_comment_form.remaining_characters_1", count: "%count%"),
     other: t("decidim.components.add_comment_form.remaining_characters", count: "%count%")
-  }
+  },
+  "limit": t("activemodel.errors.models.answer.attributes.body.too_long")
 }
 external_link_messages = {
   "externalLink": t("decidim.accessibility.external_link")

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -285,7 +285,7 @@ shared_examples "comments" do
 
               field.native.send_keys "c"
               within ".remaining-character-count-sr" do
-                expect(page).to have_content("0 characters left")
+                expect(page).to have_content("you have reached the maximum of characters")
               end
 
               # Test that the SR counter will stick at the last announced
@@ -302,12 +302,12 @@ shared_examples "comments" do
                 expect(page).to have_content("150 characters left") # Normal
               end
               within ".remaining-character-count-sr" do
-                expect(page).to have_content("0 characters left") # Screen reader
+                expect(page).to have_content("you have reached the maximum of characters") # Screen reader
               end
 
               field.native.send_keys "d"
               within ".remaining-character-count-sr" do
-                expect(page).to have_content("0 characters left")
+                expect(page).to have_content("you have reached the maximum of characters")
               end
             end
           end
@@ -318,10 +318,10 @@ shared_examples "comments" do
             within ".add-comment form" do
               fill_in field_id, with: "a" * 2000
               within ".remaining-character-count" do
-                expect(page).to have_content("0 characters left") # Normal
+                expect(page).to have_content("you have reached the maximum of characters") # Normal
               end
               within ".remaining-character-count-sr" do
-                expect(page).to have_content("0 characters left") # Screen reader
+                expect(page).to have_content("you have reached the maximum of characters") # Screen reader
               end
 
               # Test that the SR counter updates correctly after hitting the

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -228,7 +228,7 @@ describe "Conversations", type: :system do
         expect(page).to have_content("Send")
         field = find_field("message_body")
         field.native.send_keys message_body
-        expect(page).to have_content("0 characters left")
+        expect(page).to have_content("you have reached the maximum of characters")
         click_button "Send"
         expect(page).to have_content(message)
         expect(page).not_to have_content(overflow)


### PR DESCRIPTION
#### :tophat: What? Why?
Display a custom validation to let the user know he has reached the character limit, when the HTMLElement includes `maxlength` attribute.

That was kinda tricky since the default browsers behaviour prevent you to add more characters than allowed, therefore, there is never an error. It requires to set a custom validation when the threshold is reached, but you can still submit the form. 

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/11220

### :camera: Screenshots
https://decidim-redesign.populate.tools/conversations/680

:hearts: Thank you!
