### PR TITLE
Fix wrong 'no activity' text on last activities page

### DIFF
--- a/decidim-core/app/views/decidim/last_activities/_activities.html.erb
+++ b/decidim-core/app/views/decidim/last_activities/_activities.html.erb
@@ -2,5 +2,5 @@
   <%= cell "decidim/activities", activities %>
   <%= decidim_paginate activities, resource_type: params[:with_resource_type] %>
 <% else %>
-  <%= cell "decidim/announcement", t("decidim.user_activity.index.no_activities_warning") %>
+  <%= cell "decidim/announcement", t("decidim.last_activities.no_activities_warning") %>
 <% end %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1041,6 +1041,7 @@ en:
       index:
         last_activity: Last activity
       name: Last activities
+      no_activities_warning: There are no entries to show for this activity type.
     linked_resource_from:
       included_in: Included in
     links:

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -148,7 +148,7 @@ describe "Last activity", type: :system do
 
         it "does not show the activities" do
           expect(page).to have_css("[data-activity]", count: 0)
-          expect(page).to have_content "This participant does not have any activity yet."
+          expect(page).to have_content "There are no entries to show for this activity type."
         end
       end
     end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR changes the text from "This participant does not have any activity yet." to "There are no entries to show for this activity type."

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #11283

#### Testing
1. Visit the last activities page 
2. Select any of the activity types from the left until you get one with no entries
3. See message 
4. Apply patch 
5. See the message changed

### :camera: Screenshots
![image](https://github.com/decidim/decidim/assets/105683/33075789-c378-41fc-b8d5-1a30aaa3bc72)

:hearts: Thank you!
