### PR TITLE
Fix the length of edit button in proposals

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_aside.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_aside.html.erb
@@ -10,7 +10,7 @@
 <% if (@proposal.amendable? && allowed_to?(:edit, :proposal, proposal: @proposal)) || (amendments_enabled? && @proposal.amendable? && current_component.current_settings.amendment_creation_enabled && can_participate_in_private_space?) || amendments_enabled? && can_react_to_emendation?(@proposal) || @proposal.withdrawable_by?(current_user) %>
 <section class="layout-aside__section layout-aside__buttons">
   <% if @proposal.amendable? && allowed_to?(:edit, :proposal, proposal: @proposal) %>
-    <%= link_to t("edit_proposal", scope: "decidim.proposals.proposals.show"), edit_proposal_path(@proposal), class: "button button__sm button__transparent-secondary" %>
+    <%= link_to t("edit_proposal", scope: "decidim.proposals.proposals.show"), edit_proposal_path(@proposal), class: "button button__sm button__transparent-secondary w-full" %>
   <% else %>
     <%= amend_button_for @proposal %>
   <% end %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR fixes the width of edit proposal button as seen in screenshots

#### :pushpin: Related Issues
- Fixes #11273

#### Testing
1. Create a proposal from frontend
2. See the edit link in aside toolbar 
3. Apply the patch 
4. See the edit link width in the aside toolbar

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
Before: 
![image](https://github.com/decidim/decidim/assets/105683/ac4ea93f-4baa-48c0-9757-8b562fdd4b97)

After:
![image](https://github.com/decidim/decidim/assets/105683/98f8e351-061f-402d-b106-3446a61cbe45)


:hearts: Thank you!
