### PR TITLE
 Backport 'Encode non-ASCII characters on external links' to v0.27 

### DIFF
--- a/decidim-core/app/controllers/decidim/links_controller.rb
+++ b/decidim-core/app/controllers/decidim/links_controller.rb
@@ -35,7 +35,7 @@ module Decidim
     end
 
     def external_url
-      @external_url ||= URI.parse(params[:external_url])
+      @external_url ||= URI.parse(URI::Parser.new.escape(params[:external_url]))
     end
   end
 end

--- a/decidim-core/spec/system/external_domain_warning_spec.rb
+++ b/decidim-core/spec/system/external_domain_warning_spec.rb
@@ -28,6 +28,17 @@ describe "ExternalDomainWarning", type: :system do
     expect(page).to have_link("Another link", href: "http://www.example.org")
   end
 
+  context "when url has special characters" do
+    let(:destination) { "https://example.org/test?foo=bàr" }
+    let(:url) { "http://#{organization.host}/link?external_url=#{destination}" }
+
+    it "does not show invalid url alert" do
+      visit url
+      expect(page).not_to have_content("Invalid URL")
+      expect(page).to have_content("b%C3%A0r")
+    end
+  end
+
   context "when url is invalid" do
     let(:invalid_url) { "http://#{organization.host}/link?external_url=foo" }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #11472 to v0.27

:hearts: Thank you!