### PR TITLE
Redesign: tab navigation on mobile

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -12,7 +12,7 @@ end
 
 <div class="layout-container">
   <header>
-    <%= link_to t("skip_button", scope: "decidim.accessibility"), url_for(anchor: "content"), class: "layout-container__skip" %>
+    <%= link_to t("skip_button", scope: "decidim.accessibility"), "#content", class: "layout-container__skip" %>
     <%= render partial: "layouts/decidim/admin_links" if current_user&.admin %>
     <%= render partial: "layouts/decidim/header/main" %>
     <%= render partial: "layouts/decidim/header/menu" unless controller_name == "homepage" %>

--- a/decidim-core/app/views/layouts/decidim/header/_main.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main.html.erb
@@ -11,20 +11,20 @@
     </div>
 
     <div class="lg:hidden">
-      <%# Sticky menu mobile %>
-      <div class="main-bar__links-mobile">
-        <%= render partial: "layouts/decidim/header/main_links_mobile" %>
-      </div>
-
       <%# Main dropdown mobile %>
-      <div id="main-dropdown-summary-mobile" class="main-bar__links-mobile__trigger"
+      <button id="main-dropdown-summary-mobile" class="main-bar__links-mobile__trigger"
         data-component="dropdown"
         data-target="dropdown-menu-main-mobile">
         <%= icon "menu-line" %><span class="sr-only"><%= t("main_menu", scope: "layouts.decidim.header") %></span>
-      </div>
+      </button>
 
       <div id="dropdown-menu-main-mobile" class="main-bar__links-mobile__dropdown" aria-hidden="true">
         <%= render partial: "layouts/decidim/header/menu_breadcrumb_main_dropdown", locals: { id: "breadcrumb-main-dropdown-mobile" } %>
+      </div>
+
+      <%# Sticky menu mobile %>
+      <div class="main-bar__links-mobile">
+        <%= render partial: "layouts/decidim/header/main_links_mobile" %>
       </div>
 
       <%# Overlay menus mobile %>


### PR DESCRIPTION
#### :tophat: What? Why?
Allow the navigation on mobile devices. Includes also from #11195:

- Skip to main content link contains the URL path of the page which can cause a change of context instead of skipping the content (WCAG 2.1: 2.4.1), note that change of context != bypass blocks

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/11351

### :camera: Screenshots
https://decidim-redesign.populate.tools/

:hearts: Thank you!
