### PR TITLE
Redesign: default gray

### DIFF
--- a/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
+++ b/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
@@ -34,7 +34,7 @@ module.exports = {
       warning: withOpacity("--warning-rgb"),
       black: "#020203",
       gray: {
-        DEFAULT: "#6B72804D", // 30% opacity
+        DEFAULT: "#6B7280CC", // 80% opacity
         2: "#3E4C5C",
         3: "#E1E5EF",
         4: "#242424",


### PR DESCRIPTION
#### :tophat: What? Why?
In order to deliver _WCAG 2.1: 1.4.11 Non-text contrast_, the default opacity rises to 80%.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/11484

#### Testing
Development app should be recreated, or, apply this change to the _development_app tailwind.config.js_

### :camera: Screenshots
https://decidim-redesign.populate.tools/users/sign_in

:hearts: Thank you!
