### PR TITLE
Redesign: toggle contrast & focus form validation

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_forms.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_forms.scss
@@ -25,7 +25,7 @@
         @apply pr-1 pl-6 py-0.5 text-sm;
       }
 
-      &.is-invalid-input {
+      &.is-invalid-input:not(:focus) {
         @apply outline-2 outline-alert;
       }
     }

--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_toggle_switch.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_toggle_switch.scss
@@ -47,7 +47,11 @@
     }
 
     input:focus ~ &-content {
-      @apply outline outline-tertiary outline-offset-2 outline-1 transition-none;
+      @apply outline outline-alert outline-offset-2 transition-none;
+    }
+
+    input:focus:checked ~ &-content {
+      @apply outline-success;
     }
 
     input:checked ~ &-content {


### PR DESCRIPTION
#### :tophat: What? Why?
Increase the outline for the toggle buttons. Avoid showing an outline when field is focused

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/9288
- Fixes https://github.com/decidim/decidim/issues/11485

### :camera: Screenshots
https://decidim-redesign.populate.tools/notifications_settings
https://decidim-redesign.populate.tools/users/sign_in

:hearts: Thank you!
