### PR TITLE
Redesign: highlight links on hover

### DIFF
--- a/decidim-core/app/cells/decidim/author/name.erb
+++ b/decidim-core/app/cells/decidim/author/name.erb
@@ -1,5 +1,5 @@
 <% if profile_path? %>
-  <%= link_to display_name, profile_path, class: "author__name" %>
+  <%= link_to display_name, profile_path, class: "author__name hover:underline" %>
 <% else %>
   <%= content_tag :span, display_name, class: "author__name" %>
 <% end %>

--- a/decidim-core/app/cells/decidim/footer_pages/topics.erb
+++ b/decidim-core/app/cells/decidim/footer_pages/topics.erb
@@ -4,7 +4,7 @@
       <h2 class="h5 mb-4"><%= topic[:title] %></h2>
       <ul class="space-y-4 break-inside-avoid">
         <% topic[:pages].each do |page| %>
-          <%= page_item(page, class: "font-semibold") %>
+          <%= page_item(page, class: "font-semibold hover:underline") %>
         <% end %>
       </ul>
     </nav>

--- a/decidim-core/app/helpers/decidim/menu_helper.rb
+++ b/decidim-core/app/helpers/decidim/menu_helper.rb
@@ -37,7 +37,7 @@ module Decidim
       @footer_menu ||= ::Decidim::FooterMenuPresenter.new(
         :menu,
         self,
-        element_class: "font-semibold",
+        element_class: "font-semibold hover:underline",
         active_class: "is-active",
         container_options: { class: "space-y-4 break-inside-avoid" },
         label: t("layouts.decidim.footer.decidim_title")

--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_activity.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_activity.scss
@@ -36,6 +36,10 @@
       svg {
         @apply w-3.5 h-3.5 text-gray fill-current;
       }
+
+      a {
+        @apply hover:underline;
+      }
     }
   }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_omnipresent_banner.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_omnipresent_banner.scss
@@ -1,5 +1,5 @@
 .omnipresent-banner {
-  @apply flex items-center justify-center gap-4 bg-gray-4 text-white text-center px-4 py-2 text-md transition first:[&>*]:font-bold focus:outline-none hover:bg-black focus:bg-black;
+  @apply flex items-center justify-center gap-4 bg-gray-4 text-white text-center px-4 py-2 text-md transition first:[&>*]:font-bold focus:outline-none hover:bg-black hover:underline focus:bg-black;
 
   svg {
     @apply flex-none text-white fill-current;

--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_tags.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_tags.scss
@@ -1,5 +1,5 @@
 .tag {
-  @apply flex items-center gap-1;
+  @apply flex items-center gap-1 hover:underline;
 
   &-container {
     @apply flex items-center gap-2 text-sm text-gray-2;

--- a/decidim-core/app/views/layouts/decidim/_application.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_application.html.erb
@@ -8,6 +8,7 @@
 
   <body class="text-black text-md form-defaults">
     <!--noindex--><!--googleoff: all-->
+    <%= link_to t("skip_button", scope: "decidim.accessibility"), "#content", class: "layout-container__skip" %>
     <%= cell("decidim/data_consent", current_organization) %>
     <%= render partial: "layouts/decidim/impersonation_warning" %>
     <%= render partial: "layouts/decidim/omnipresent_banner" %>

--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -12,7 +12,6 @@ end
 
 <div class="layout-container">
   <header>
-    <%= link_to t("skip_button", scope: "decidim.accessibility"), "#content", class: "layout-container__skip" %>
     <%= render partial: "layouts/decidim/admin_links" if current_user&.admin %>
     <%= render partial: "layouts/decidim/header/main" %>
     <%= render partial: "layouts/decidim/header/menu" unless controller_name == "homepage" %>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_legal.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_legal.html.erb
@@ -1,4 +1,4 @@
-<ul class="flex flex-col md:flex-row gap-10 text-sm text-white">
+<ul class="flex flex-col md:flex-row gap-10 text-sm text-white hover:[&_a]:underline">
   <%= cell("decidim/footer_pages", :pages) %>
   <li>
     <%= link_to t("layouts.decidim.footer.terms_and_conditions"), decidim.page_path("terms-and-conditions") %>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
@@ -3,9 +3,9 @@
 <nav role="navigation" aria-label="<%= t("layouts.decidim.footer.resources") %>">
   <h2 class="h5 mb-4"><%= t("layouts.decidim.footer.resources") %></h2>
   <ul class="space-y-4 break-inside-avoid">
-    <li class="font-semibold"><%= link_to t("decidim.profiles.show.activity"), decidim.last_activities_path %></li>
-    <li class="font-semibold"><%= link_to t("decidim.pages.home.extended.meetings"), Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path %></li>
-    <li class="font-semibold"><%= link_to t("layouts.decidim.footer.download_open_data"), decidim.open_data_download_path %></li>
+    <li class="font-semibold hover:underline"><%= link_to t("decidim.profiles.show.activity"), decidim.last_activities_path %></li>
+    <li class="font-semibold hover:underline"><%= link_to t("decidim.pages.home.extended.meetings"), Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path %></li>
+    <li class="font-semibold hover:underline"><%= link_to t("layouts.decidim.footer.download_open_data"), decidim.open_data_download_path %></li>
   </ul>
 </nav>
 
@@ -13,15 +13,15 @@
   <h2 class="h5 mb-4"><%= t("layouts.decidim.user_menu.profile") %></h2>
   <ul class="space-y-4 break-inside-avoid">
     <% if current_user %>
-      <li class="font-semibold"><%= link_to t("layouts.decidim.user_menu.configuration"), decidim.account_path %></li>
-      <li class="font-semibold"><%= link_to t("layouts.decidim.user_menu.public_profile"), decidim.profile_path(current_user.nickname) %></li>
-      <li class="font-semibold"><%= link_to t("layouts.decidim.user_menu.notifications"), decidim.notifications_path %></li>
-      <li class="font-semibold"><%= link_to t("layouts.decidim.user_menu.conversations"), decidim.conversations_path %></li>
+      <li class="font-semibold hover:underline"><%= link_to t("layouts.decidim.user_menu.configuration"), decidim.account_path %></li>
+      <li class="font-semibold hover:underline"><%= link_to t("layouts.decidim.user_menu.public_profile"), decidim.profile_path(current_user.nickname) %></li>
+      <li class="font-semibold hover:underline"><%= link_to t("layouts.decidim.user_menu.notifications"), decidim.notifications_path %></li>
+      <li class="font-semibold hover:underline"><%= link_to t("layouts.decidim.user_menu.conversations"), decidim.conversations_path %></li>
     <% else %>
       <% if current_organization.sign_up_enabled? %>
-        <li class="font-semibold"><%= link_to t("layouts.decidim.footer.sign_up"), decidim.new_user_registration_path %></li>
+        <li class="font-semibold hover:underline"><%= link_to t("layouts.decidim.footer.sign_up"), decidim.new_user_registration_path %></li>
       <% end %>
-      <li class="font-semibold"><%= link_to t("layouts.decidim.footer.sign_in"), decidim.new_user_session_path %></li>
+      <li class="font-semibold hover:underline"><%= link_to t("layouts.decidim.footer.sign_in"), decidim.new_user_session_path %></li>
     <% end %>
   </ul>
 </nav>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_social_media_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_social_media_links.html.erb
@@ -1,4 +1,4 @@
-<ul class="flex justify-between md:justify-start gap-6 text-sm text-white">
+<ul class="flex justify-between md:justify-start gap-6 text-sm text-white hover:[&_a]:opacity-50">
   <% if current_organization.twitter_handler.present? %>
     <li>
       <a target="_blank" data-external-link="false" rel="noopener noreferrer" href="https://twitter.com/<%= current_organization.twitter_handler %>">

--- a/decidim-core/app/views/layouts/decidim/footer/_mini.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_mini.html.erb
@@ -4,11 +4,11 @@
       <a rel="decidim noopener noreferrer" href="https://decidim.org/" target="_blank" data-external-link="false">
         <%= image_pack_tag("media/images/decidim-logo.svg", alt: t("layouts.decidim.footer.decidim_logo"), class: "max-h-8 block") %>
       </a>
-      <div class="text-xs mt-2">
+      <div class="text-xs mt-2 hover:[&_a]:underline">
         <%= t("layouts.decidim.footer.made_with_open_source").html_safe %>
       </div>
     </div>
-    <a class="flex gap-1" rel="license noopener noreferrer" href="http://creativecommons.org/licenses/by-sa/4.0/" target="_blank" data-external-link="false">
+    <a class="flex gap-1 hover:opacity-50" rel="license noopener noreferrer" href="http://creativecommons.org/licenses/by-sa/4.0/" target="_blank" data-external-link="false">
       <span class="sr-only"><%= t("layouts.decidim.footer.cc_by_license") %></span>
       <%= icon "creative-commons-line", class: "w-6 h-6 fill-current" %>
       <%= icon "creative-commons-by-line", class: "w-6 h-6 fill-current" %>


### PR DESCRIPTION
#### :tophat: What? Why?
Mark links in some way (usually underline) to distinguish from plain texts. From https://github.com/decidim/decidim/issues/6170#issuecomment-1653810668

Includes also:
- Links are not visually distinguishable from other text in the footer (use either underline or a color with a 3:1 color contrast against the "surrounding" non-link text, i.e. the headings and footer body text, WCAG 2.1: 1.4.1 / [best practices](https://brand.wwu.edu/accessibility/guide/give-links-distinguishable-visual-cues), [further reading](https://theadminbar.com/accessibility-weekly/underline-your-links/))
- Link in the omnipresent banner is not visually identifiable from the surrounding content (WCAG 2.1: 1.4.1, see above) and is missing a non-color designator for the hover/focus states (WCAG 2.1: 1.4.11)
- When omnipresent banner is enabled, the skip to content link comes after that in the DOM element order, although the skip link should be above all content that is repeated on multiple pages (WCAG 2.1: 2.4.1)

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/6170

:hearts: Thank you!
