### PR TITLE
Redesign: button focus

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_buttons.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_buttons.scss
@@ -1,5 +1,5 @@
 .button {
-  @apply inline-flex items-center justify-center font-semibold text-center border border-transparent rounded transition cursor-pointer [&>svg]:flex-none [&>svg]:fill-current [&>span]:text-center [&>span]:break-words;
+  @apply inline-flex items-center justify-center font-semibold text-center border border-transparent rounded transition cursor-pointer [&>svg]:flex-none [&>svg]:fill-current [&>span]:text-center [&>span]:break-words focus:outline focus:outline-2 focus:outline-offset-2;
 
   &__xs {
     @apply text-sm [&:not([class*="button\\_\\_text"])]:px-3 [&:not([class*="button\\_\\_text"])]:py-1 gap-1;
@@ -18,30 +18,30 @@
   }
 
   &__primary {
-    @apply bg-primary text-white;
+    @apply bg-primary text-white focus:outline-primary;
   }
 
   &__secondary {
-    @apply bg-secondary text-white;
+    @apply bg-secondary text-white focus:outline-secondary;
   }
 
   &__tertiary {
-    @apply bg-tertiary text-white;
+    @apply bg-tertiary text-white focus:outline-tertiary;
   }
 
   &__transparent {
     @apply bg-transparent text-white border border-white;
 
     &-primary {
-      @apply border bg-white border-primary text-primary;
+      @apply border bg-white border-primary text-primary focus:outline-primary;
     }
 
     &-secondary {
-      @apply border bg-white border-secondary text-secondary;
+      @apply border bg-white border-secondary text-secondary focus:outline-secondary;
     }
 
     &-tertiary {
-      @apply border bg-white border-tertiary text-tertiary;
+      @apply border bg-white border-tertiary text-tertiary focus:outline-tertiary;
     }
   }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Include a focus status styles with a better contrast, for the _transparent_ and _regular_ versions

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/6168
- Button and link focus states are not visually distinguishable with a highlight border color (WCAG 2.1: 1.4.11, 2.4.7), [good reference for button implementation](https://www.wearecue.studio/insights/wcag-and-button-states)

### :camera: Screenshots
[Screencast from 22-08-23 16:40:41.webm](https://github.com/decidim/decidim/assets/817526/44d45789-90e9-4a29-a5e0-9e2123f46cd8)

:hearts: Thank you!
