### PR TITLE
Show different text for the Register CTA when the user is already registered

### DIFF
--- a/decidim-conferences/app/views/decidim/conferences/conferences/_conference_hero.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/_conference_hero.html.erb
@@ -17,12 +17,16 @@
         <%= " @ " + current_participatory_space.location.to_s if current_participatory_space.location %>
       </p>
       <% if current_participatory_space.registrations_enabled? %>
-        <%= link_to t("layouts.decidim.conference_hero.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class:"button button__lg button__secondary" %>
+        <% if current_participatory_space.has_registration_for?(current_user) %>
+          <%= link_to t("layouts.decidim.conference_hero.manage_registration"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__primary" %>
+        <% else %>
+          <%= link_to t("layouts.decidim.conference_hero.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__secondary" %>
+        <% end %>
       <% end %>
 
       <% component_meeting = current_participatory_space.components.where(manifest_name: "meetings").published.first || self.try(:current_component) %>
       <% if component_meeting.present? %>
-        <%= link_to translated_attribute(component_meeting.name), decidim_conferences.conference_conference_program_path(current_participatory_space, id: component_meeting.id), class:"button button__lg button__transparent" %>
+        <%= link_to translated_attribute(component_meeting.name), decidim_conferences.conference_conference_program_path(current_participatory_space, id: component_meeting.id), class: "button button__lg button__transparent" %>
       <% end %>
     </div>
   </div>

--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -54,7 +54,11 @@ edit_link(
 
       <div>
         <% if current_participatory_space.registrations_enabled? %>
-          <%= link_to t("decidim.conferences.conferences.show.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__secondary" %>
+          <% if current_participatory_space.has_registration_for?(current_user) %>
+            <%= link_to t("decidim.conferences.conferences.show.manage_registration"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__primary" %>
+          <% else %>
+            <%= link_to t("decidim.conferences.conferences.show.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__secondary" %>
+          <% end %>
         <% end %>
         <% current_participatory_space.components.where(manifest_name: "meetings").each do |component_meeting| %>
           <% if component_meeting.published? || component_meeting == self.try(:current_component) %>

--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -35,7 +35,7 @@ edit_link(
 
   <%= render partial: "conference_hero" %>
 
-  <%= render layout:"layouts/decidim/shared/layout_two_col", locals: { reverse: true, main_enabled: false } do %>
+  <%= render layout: "layouts/decidim/shared/layout_two_col", locals: { reverse: true, main_enabled: false } do %>
 
     <%= participatory_space_floating_help %>
 
@@ -54,11 +54,11 @@ edit_link(
 
       <div>
         <% if current_participatory_space.registrations_enabled? %>
-          <%= link_to t("decidim.conferences.conferences.show.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class:"button button__lg button__secondary" %>
+          <%= link_to t("decidim.conferences.conferences.show.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__secondary" %>
         <% end %>
         <% current_participatory_space.components.where(manifest_name: "meetings").each do |component_meeting| %>
           <% if component_meeting.published? || component_meeting == self.try(:current_component) %>
-            <%= link_to translated_attribute(component_meeting.name), decidim_conferences.conference_conference_program_path(current_participatory_space, id: component_meeting.id), class:"button button__lg button__transparent-secondary" %>
+            <%= link_to translated_attribute(component_meeting.name), decidim_conferences.conference_conference_program_path(current_participatory_space, id: component_meeting.id), class: "button button__lg button__transparent-secondary" %>
           <% end %>
         <% end %>
       </div>
@@ -88,7 +88,11 @@ edit_link(
               <p class="conference__box-description"><%= t("decidim.conferences.conferences.show.login_as", name: current_user.name, email: current_user.email ) %></p>
             </div>
             <div>
-              <%= link_to t("decidim.conferences.conferences.show.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class:"button button__lg button__secondary" %>
+              <% if current_participatory_space.has_registration_for?(current_user) %>
+                <%= link_to t("decidim.conferences.conferences.show.manage_registration"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__primary" %>
+              <% else %>
+                <%= link_to t("decidim.conferences.conferences.show.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__secondary" %>
+              <% end %>
             </div>
           </div>
         <% else %>

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -569,8 +569,8 @@ en:
   layouts:
     decidim:
       conference_hero:
-        register: Register
         manage_registration: Manage registration
+        register: Register
       conferences:
         conference:
           more_info: More info

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -456,6 +456,7 @@ en:
         show:
           login_as: You are logged in as %{name} <%{email}>
           make_conference_registration: Register for the conference
+          manage_registration: Manage registration
           register: Register
       content_blocks:
         highlighted_conferences:

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -570,6 +570,7 @@ en:
     decidim:
       conference_hero:
         register: Register
+        manage_registration: Manage registration
       conferences:
         conference:
           more_info: More info

--- a/decidim-conferences/spec/system/conference_registrations_spec.rb
+++ b/decidim-conferences/spec/system/conference_registrations_spec.rb
@@ -93,8 +93,16 @@ describe "Conference registrations", type: :system do
         login_as user, scope: :user
       end
 
-      it "shows register button" do
+      it "shows register buttons" do
         visit_conference
+
+        within ".conference__hero" do
+          expect(page).to have_content "Register"
+        end
+
+        within ".conference__content-block" do
+          expect(page).to have_content "Register"
+        end
 
         within ".conference__box" do
           expect(page).to have_content "Register"
@@ -127,8 +135,16 @@ describe "Conference registrations", type: :system do
       login_as user, scope: :user
     end
 
-    it "shows manage registration button" do
+    it "shows manage registration buttons" do
       visit_conference
+
+      within ".conference__hero" do
+        expect(page).to have_content "Manage registration"
+      end
+
+      within ".conference__content-block" do
+        expect(page).to have_content "Manage registration"
+      end
 
       within ".conference__box" do
         expect(page).to have_content "Manage registration"

--- a/decidim-conferences/spec/system/conference_registrations_spec.rb
+++ b/decidim-conferences/spec/system/conference_registrations_spec.rb
@@ -93,6 +93,14 @@ describe "Conference registrations", type: :system do
         login_as user, scope: :user
       end
 
+      it "shows register button" do
+        visit_conference
+
+        within ".conference__box" do
+          expect(page).to have_content "Register"
+        end
+      end
+
       it "they can join the conference" do
         visit_conference_registration_types
 
@@ -117,6 +125,14 @@ describe "Conference registrations", type: :system do
     before do
       create(:conference_registration, conference:, user:, registration_type:)
       login_as user, scope: :user
+    end
+
+    it "shows manage registration button" do
+      visit_conference
+
+      within ".conference__box" do
+        expect(page).to have_content "Manage registration"
+      end
     end
 
     it "they can leave the conference" do


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Show different text and button appearance for the Register CTA when the user is registered.

#### :pushpin: Related Issues
- Fixes #11341

#### Testing
1. Go to the main conference page
2. Scroll down to Register
3. See the text "Register for the conference"
4. Click "register"
5. Select registration type (and make sure the button states "Attending" )
6. Go back to the previous page and refresh
7. See the Button states "Manage registration" instead of "Register" and the appearance has changed too

### :camera: Screenshots
Conference Hero:
<img width="752" alt="Screenshot 2023-08-24 at 08 50 45" src="https://github.com/decidim/decidim/assets/6973564/f0eab096-ddaa-42a2-908a-9af1d03ae535">
<img width="750" alt="Screenshot 2023-08-24 at 08 50 24" src="https://github.com/decidim/decidim/assets/6973564/808a7aac-47c2-4297-ad27-13a4e644fa26">

Details:
<img width="1007" alt="Screenshot 2023-08-24 at 08 50 54" src="https://github.com/decidim/decidim/assets/6973564/9465ab31-4e81-4fdd-a394-2e8d48e5d723">
<img width="1008" alt="Screenshot 2023-08-24 at 08 50 03" src="https://github.com/decidim/decidim/assets/6973564/064aae33-449d-4dd7-b2b3-0b3d86444f5f">

Register:
<img width="1036" alt="Screenshot 2023-08-23 at 09 38 54" src="https://github.com/decidim/decidim/assets/6973564/07c404ea-bd42-411e-ab9f-74433b69a6db">
<img width="1022" alt="Screenshot 2023-08-23 at 09 39 01" src="https://github.com/decidim/decidim/assets/6973564/a20eb380-4531-4449-b5aa-b94397b6cf7c">


:hearts: Thank you!
