### PR TITLE
Render partner without any link if it's not configured

### DIFF
--- a/decidim-conferences/app/cells/decidim/conferences/partner/image.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/partner/image.erb
@@ -1,0 +1,3 @@
+<div class="conference__grid-item-img">
+  <%= image_tag model.attached_uploader(:logo).path(variant: :medium), alt: "logo" %>
+</div>

--- a/decidim-conferences/app/cells/decidim/conferences/partner/show.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/partner/show.erb
@@ -1,6 +1,11 @@
-<%= link_to model.link || "", target: "_blank", class: "conference__grid-item", data: { "external-link": "false" } do %>
-  <div class="conference__grid-item-img">
-    <%= image_tag model.attached_uploader(:logo).path(variant: :medium), alt: "logo" %>
-  </div>
-  <h3 class="h5 conference__grid-item-text"><%= model.name %></h3>
+<% if model.link.present? %>
+  <%= link_to model.link, target: "_blank", class: "conference__grid-item", data: { "external-link": "false" } do %>
+    <%= render :image %>
+    <%= render :text %>
+  <% end %>
+<% else %>
+  <%= content_tag :div, nil, class: "conference__grid-item" do %>
+    <%= render :image %>
+    <%= render :text %>
+  <% end %>
 <% end %>

--- a/decidim-conferences/app/cells/decidim/conferences/partner/text.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/partner/text.erb
@@ -1,0 +1,1 @@
+<h3 class="h5 conference__grid-item-text"><%= model.name %></h3>

--- a/decidim-conferences/spec/cells/decidim/conferences/partner_cell_spec.rb
+++ b/decidim-conferences/spec/cells/decidim/conferences/partner_cell_spec.rb
@@ -23,5 +23,19 @@ module Decidim::Conferences
         expect(subject).to have_css(".conference__grid-item")
       end
     end
+
+    context "when rendering a partner with a link" do
+      it "renders a link" do
+        expect(subject).to have_css("a.conference__grid-item")
+      end
+    end
+
+    context "when rendering a partner without a link" do
+      let(:partner) { create(:partner, :collaborator, conference:, link: nil) }
+
+      it "renders a div instead of a link" do
+        expect(subject).to have_css("div.conference__grid-item")
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Render partner inside a `div` instead of an `a` when the link is not configured.

#### :pushpin: Related Issues
- Fixes #11286 

#### Testing
1. As an admin, configure a conference with a partner without a Link
2. Go to the Conference, find the Partner, and see there is no link for it

### :camera: Screenshots
https://github.com/decidim/decidim/assets/6973564/cb8c9eaa-10c8-4fba-a9f9-209a23cc6c41

:hearts: Thank you!
