### PR TITLE
Redesign: semantic datetimes

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -117,6 +117,7 @@ ignore_missing:
   - decidim.budgets.projects_helper.current_rule_call_for_action_text.*
   - decidim.debates.debate_m.footer.commented_time_ago
   - date.abbr_day_names
+  - date.day_names
   - date.month_names
   - explanation
 

--- a/decidim-meetings/app/cells/decidim/meetings/dates_and_map/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/dates_and_map/show.erb
@@ -11,9 +11,9 @@
       <span><%= l(end_time, format: "%d") if !same_day? || !same_month? %></span>
     </div>
     <div class="meeting__calendar-time">
-      <span><%= l(start_time, format: "%H:%M") %></span>
+      <time datetime="<%= start_time.iso8601 %>"><%= l(start_time, format: "%H:%M") %></time>
       <span class="meeting__calendar-separator"><%= "-" %></span>
-      <span><%= l(end_time, format: "%H:%M") %></span>
+      <time datetime="<%= end_time.iso8601 %>"><%= l(end_time, format: "%H:%M") %></time>
     </div>
   </div>
 

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_l/image.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_l/image.erb
@@ -1,5 +1,5 @@
-<div class="card__calendar">
+<time class="card__calendar" datetime="<%= meeting.start_time.iso8601 %>">
   <div class="card__calendar-month"><%= l(meeting.start_time, format: "%b") %></div>
   <div class="card__calendar-day"><%= l(meeting.start_time, format: "%d") %></div>
   <div class="card__calendar-time"><%= l(meeting.start_time, format: "%H:%M") %></div>
-</div>
+</time>

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_month/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_month/show.erb
@@ -1,8 +1,8 @@
 <table class="meeting-calendar__month">
   <caption><%= month_name %></caption>
   <thead>
-    <% abbr_day_names.each do |day| %>
-      <th><%= day %></th>
+    <% abbr_day_names.each_with_index do |day, i| %>
+      <th><abbr title="<%= day_names[i] %>"><%= day %></abbr></th>
     <% end %>
   </thead>
   <tbody>
@@ -17,7 +17,9 @@
         <% end %>
 
         <% days.each do |day| %>
-          <%= content_tag :td, l(day, format: "%d"), class: day_class(day) %>
+          <%= content_tag :td, class: day_class(day) do %>
+            <time datetime="<%= day %>"><%= l(day, format: "%d") %></time>
+          <% end %>
         <% end %>
 
         <% if !is_first_day %>

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_month_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_month_cell.rb
@@ -25,6 +25,10 @@ module Decidim
         @abbr_day_names ||= I18n.t("date.abbr_day_names").rotate(first_week_date_rotation)
       end
 
+      def day_names
+        @day_names ||= I18n.t("date.day_names").rotate(first_week_date_rotation)
+      end
+
       def first_day_of_month?(date)
         date.day == 1
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Datetimes are shown semantically

- The calendar elements representing a date and time next to events are not represented semantically correctly using the <time> HTML element (WCAG 2.1: 1.3.6)
- The sidebar calendars on the meetings pages have incorrect sematincs (WCAG 2.1: 1.3.6), [see reference article](https://css-tricks.com/making-calendars-with-accessibility-and-internationalization-in-mind/)
   - Weekday names should be indicated with the <abbr> element (WCAG 2.1: 3.1.4)
   - The individual dates should be indicated with the <time> element (WCAG 2.1: 1.3.6)

### :camera: Screenshots
https://decidim-redesign.populate.tools/meetings

:hearts: Thank you!
