### PR TITLE
Display special characters in breadcrumb menu

### DIFF
--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_items.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_items.html.erb
@@ -1,5 +1,5 @@
 <% breadcrumb_items.each_with_index do |item, i| %>
-  <% item_label = decidim_html_escape(translated_attribute(item[:label])) %>
+  <% item_label = translated_attribute(item[:label]) %>
   <span>/</span>
   <% if item[:dropdown_cell].present? %>
     <div class="relative">
@@ -22,9 +22,9 @@
       </div>
     </div>
   <% else %>
-    <%= link_to_if(item[:url].present? && !is_active_link?(item[:url], :exclusive), item_label, item[:url], class:"menu-bar__breadcrumb-desktop__dropdown-wrapper menu-bar__breadcrumb-desktop__dropdown-trigger", "aria-current": (item[:active] ? "page" : nil)) do %>
+    <%= link_to_if(item[:url].present? && !is_active_link?(item[:url], :exclusive), item_label, item[:url], class: "menu-bar__breadcrumb-desktop__dropdown-wrapper menu-bar__breadcrumb-desktop__dropdown-trigger", "aria-current": (item[:active] ? "page" : nil)) do %>
       <%# alternative template %>
-      <%= content_tag :span, item_label, class:"menu-bar__breadcrumb-desktop__dropdown-trigger no-interactive", tabindex: "0", "aria-current": "page" if item[:active] %>
+      <%= content_tag :span, item_label, class: "menu-bar__breadcrumb-desktop__dropdown-trigger no-interactive", tabindex: "0", "aria-current": "page" if item[:active] %>
     <% end %>
   <% end %>
 <% end %>

--- a/decidim-core/spec/system/menu_spec.rb
+++ b/decidim-core/spec/system/menu_spec.rb
@@ -33,4 +33,20 @@ describe "Menu", type: :system do
       end
     end
   end
+
+  context "when rendering a component with special characters" do
+    let(:component_name) { "Collaborative Drafts & Amendments" }
+    let(:participatory_space) { create(:participatory_process, organization:) }
+    let(:proposal_component) { create(:proposal_component, name: { en: component_name }, participatory_space:) }
+    let(:proposal) { create(:proposal, component: proposal_component) }
+    let(:proposal_path) { Decidim::ResourceLocatorPresenter.new(proposal).path }
+
+    before do
+      visit proposal_path
+    end
+
+    it "renders the component name correctly" do
+      expect(page).to have_selector(".menu-bar__breadcrumb-desktop__dropdown-wrapper", text: component_name)
+    end
+  end
 end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Remove HTML escape from breadcrumb item label.

#### :pushpin: Related Issues
- Fixes #11342 

#### Testing
1. Change the name of a proposal components including an "&".
2. Go to a proposal of this component and see the name of the component correctly displayed in the breadcrumb menu.

### :camera: Screenshots
<img width="1428" alt="Screenshot 2023-08-23 at 12 30 11" src="https://github.com/decidim/decidim/assets/6973564/369cb4c2-dc51-4796-98c3-9c1d0a65af97">

:hearts: Thank you!
