### PR TITLE
Redesign: skip map

### DIFF
--- a/decidim-core/app/helpers/decidim/map_helper.rb
+++ b/decidim-core/app/helpers/decidim/map_helper.rb
@@ -68,9 +68,9 @@ module Decidim
       map_html_options = { id: "map" }.merge(html_options)
       bottom_id = "#{map_html_options[:id]}_bottom"
 
-      help = content_tag(:div, class: "sr-only") do
-        sr_content = content_tag(:p, t("screen_reader_explanation", scope: "decidim.map.dynamic"))
-        link = link_to(t("skip_button", scope: "decidim.map.dynamic"), "##{bottom_id}")
+      help = content_tag(:div, class: "map__skip-container") do
+        sr_content = content_tag(:p, t("screen_reader_explanation", scope: "decidim.map.dynamic"), class: "sr-only")
+        link = link_to(t("skip_button", scope: "decidim.map.dynamic"), "##{bottom_id}", class: "map__skip")
 
         sr_content + link
       end

--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_map.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_map.scss
@@ -2,6 +2,14 @@
   @apply h-full bg-background z-0;
 }
 
+.map__skip {
+  @apply absolute z-10 top-1 left-1 -translate-y-full py-1 px-4 bg-primary rounded-br-lg text-white cursor-pointer transition focus:translate-y-0;
+
+  &-container {
+    @apply relative overflow-hidden focus-within:overflow-visible;
+  }
+}
+
 .static-map {
   @apply cursor-pointer overflow-hidden [&_img]:w-full [&_img]:h-full [&_img]:object-cover;
 


### PR DESCRIPTION
#### :tophat: What? Why?
Make visible the skip map option

- Skip map link is not visible for visual users as it used to be in previous versions (WCAG 2.1: 1.4.13)

### :camera: Screenshots
https://decidim-redesign.populate.tools/meetings

:hearts: Thank you!
