### PR TITLE
Redesign: read more literal

### DIFF
--- a/decidim-core/app/cells/decidim/announcement/show.erb
+++ b/decidim-core/app/cells/decidim/announcement/show.erb
@@ -17,7 +17,7 @@
       </span>
       <%= icon "arrow-down-s-line" %>
       <span>
-        <%= t("close", scope: "layouts.decidim.announcements") %>
+        <%= t("view_less", scope: "layouts.decidim.announcements") %>
       </span>
       <%= icon "arrow-up-s-line" %>
     </button>

--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
@@ -21,7 +21,7 @@
         </span>
         <%= icon "arrow-down-s-line" %>
         <span>
-          <%= t("close", scope: "layouts.decidim.announcements") %>
+          <%= t("view_less", scope: "layouts.decidim.announcements") %>
         </span>
         <%= icon "arrow-up-s-line" %>
       </button>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1847,7 +1847,7 @@ en:
   layouts:
     decidim:
       announcements:
-        close: Close
+        view_less: Show less
         view_more: More information
       data_consent:
         details:


### PR DESCRIPTION
#### :tophat: What? Why?
Use a more accurate literal for the read more component

- A dynamic link named "Close" on the process page when the process description is expanded. Close what? Maybe "Show less" would be more appropriate term here (COGA 3.1.1)

### :camera: Screenshots
https://decidim-redesign.populate.tools/processes/Decidim4Dummies

:hearts: Thank you!
