### PR TITLE
Redesign: list counters

### DIFF
--- a/decidim-blogs/app/views/decidim/blogs/posts/index.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/index.html.erb
@@ -10,6 +10,8 @@
   <%= render partial: "decidim/shared/component_announcement" %>
 
   <section id="blogs" class="layout-main__section layout-main__heading">
+    <h2 class="h5 md:h3 decorator"><%= t("count", scope: "decidim.blogs.posts.index", count: posts.length) %></h2>
+
     <% paginate_posts.each do |post| %>
       <%= card_for post, size: :l %>
     <% end %>

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -65,6 +65,11 @@ en:
             official_blog_post: Official post
             published_at: Publish time
             title: Title
+      posts:
+        index:
+          count:
+            one: "%{count} post"
+            other: "%{count} posts"
     components:
       blogs:
         actions:

--- a/decidim-budgets/app/cells/decidim/budgets/budgets_list/main_list.erb
+++ b/decidim-budgets/app/cells/decidim/budgets/budgets_list/main_list.erb
@@ -1,4 +1,4 @@
-<h2 class="h5 md:h3 decorator"><%= t(:my_budgets, scope: i18n_scope) %></h2>
+<h2 class="h5 md:h3 decorator"><%= t(:count, scope: i18n_scope, count: budgets.length) %></h2>
 
 <%= render partial: "decidim/shared/orders.html", locals: { orders: AVAILABLE_ORDERS, i18n_scope: "decidim.budgets.projects.orders" } %>
 

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -170,7 +170,9 @@ en:
         finished_message: You have finished the voting process. Thanks for participating!
         highlighted_cta: Vote on %{name}
         if_change_opinion: If you have changed your mind, you can
-        my_budgets: My budgets
+        count:
+          one: "%{count} budget"
+          other: "%{count} budgets"
         progress: Finish voting
         remove_vote: Remove vote
         show: See projects

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -167,12 +167,12 @@ en:
         cancel_order:
           more_than_one: delete your vote on %{name} and start over
           only_one: delete your vote and start over.
-        finished_message: You have finished the voting process. Thanks for participating!
-        highlighted_cta: Vote on %{name}
-        if_change_opinion: If you have changed your mind, you can
         count:
           one: "%{count} budget"
           other: "%{count} budgets"
+        finished_message: You have finished the voting process. Thanks for participating!
+        highlighted_cta: Vote on %{name}
+        if_change_opinion: If you have changed your mind, you can
         progress: Finish voting
         remove_vote: Remove vote
         show: See projects

--- a/decidim-meetings/app/views/decidim/meetings/shared/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/shared/_meetings.html.erb
@@ -11,6 +11,8 @@
 <% if meetings.length.zero? %>
   <%= cell("decidim/announcement", t("decidim.meetings.meetings.meetings.no_meetings_warning"), callout_class: "warning" ) %>
 <% else %>
+  <h2 class="h5 md:h3 decorator"><%= t("meetings_count", scope: "decidim.meetings.meetings.count", count: meetings.length) %></h2>
+
   <%= cell("decidim/announcement", t("decidim.meetings.meetings.meetings.upcoming_meetings_warning"), callout_class: "warning" ) if @forced_past_meetings %>
 
   <div class="card__list-list">

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_collaborative_drafts.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_collaborative_drafts.html.erb
@@ -1,6 +1,8 @@
 <% if @collaborative_drafts.empty? %>
   <%= cell("decidim/announcement", params[:filter].present? ? t("empty_filters", scope: "decidim.proposals.collaborative_drafts") : t("empty", scope: "decidim.proposals.collaborative_drafts")) %>
 <% else %>
+  <h2 class="h5 md:h3 decorator"><%= t("count", scope: "decidim.proposals.collaborative_drafts.index", count: @collaborative_drafts.length) %></h2>
+
   <%= order_selector available_orders, i18n_scope: "decidim.proposals.collaborative_drafts.orders" %>
 
   <div class="card__list-list">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
@@ -7,6 +7,8 @@
 <% if @proposals.empty? %>
   <%= cell("decidim/announcement", params[:filter].present? ? t(".empty_filters") : t(".empty")) %>
 <% else %>
+  <h2 class="h5 md:h3 decorator"><%= t("count", scope: "decidim.proposals.proposals.index", count: @proposals.length) %></h2>
+
   <%= order_selector available_orders, i18n_scope: "decidim.proposals.proposals.orders" %>
 
   <div class="card__list-list">

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -670,6 +670,10 @@ en:
           filter: Filter
           filter_by: Filter by
           unfold: Unfold
+        index:
+          count:
+            one: "%{count} collaborative draft"
+            other: "%{count} collaborative drafts"
         name: Collaborative drafts
         new:
           add_file: Add file
@@ -799,6 +803,9 @@ en:
         index:
           click_here: See all proposals
           collaborative_drafts_list: Access collaborative drafts
+          count:
+            one: "%{count} proposal"
+            other: "%{count} proposals"
           new_proposal: New proposal
           see_all: See all proposals
           see_all_withdrawn: See all withdrawn proposals


### PR DESCRIPTION
#### :tophat: What? Why?
In order to keep consistency throught the listings, there were a couple of them with no counter.

Related:

-Initiatives index, showing number of results where as on other pages such as proposals, budgets, debates, blogs, etc. we are not showing (WCAG 2.1: 2.4.6), [see guidance](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html)
Initiatives number of results
 Note that in the guidance it states "Consistent headings in different articles", meaning the convention should be the same across the application, currently we have such header e.g. at Initiatives which shows the number of results

### :camera: Screenshots
- https://decidim-redesign.populate.tools/processes/roadmap/f/122/proposals
- https://decidim-redesign.populate.tools/processes/roadmap/f/122/collaborative_drafts
- https://decidim-redesign.populate.tools/processes/Decidim4Dummies/f/392/posts

Previously implemented:
- https://decidim-redesign.populate.tools/processes/
- https://decidim-redesign.populate.tools/assemblies
- https://decidim-redesign.populate.tools/processes/Decidim4Dummies/f/1800/elections
- https://decidim-redesign.populate.tools/processes/Decidim4Dummies/f/169/debates
- https://decidim-redesign.populate.tools/processes/Decidim4Dummies/f/218/sortitions
- https://decidim-redesign.populate.tools/initiatives
- https://decidim-redesign.populate.tools/conferences

:hearts: Thank you!
