### PR TITLE
Don't show initiative state field instead of showing it disabled

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -81,10 +81,9 @@
           help_text: t("attachment_legend", scope: "decidim.initiatives.form") %>
     <% end %>
 
-    <%= f.select :state,
-                    Decidim::Initiative.states.keys.map { |state| [I18n.t(state, scope: "decidim.initiatives.admin_states"), state] },
-                    {},
-                    { disabled: !@form.state_updatable? } %>
+    <% if @form.state_updatable? %>
+      <%= f.select :state, Decidim::Initiative.states.keys.map { |state| [I18n.t(state, scope: "decidim.initiatives.admin_states"), state] }, {} %>
+    <% end %>
 
     <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
       <%= link_to :back, class: "button button__sm md:button__lg button__text-secondary" do %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Don't show initiative state field instead of showing it disabled.

#### :pushpin: Related Issues
- Fixes #11225 

#### Testing
1. Go to initiatives.
2. Click on "New initiative".
3. See no state field is shown.

### :camera: Screenshots
<img width="560" alt="Screenshot 2023-08-24 at 10 47 28" src="https://github.com/decidim/decidim/assets/6973564/6f85a7a9-6480-4f3e-9011-8c7cd83ce8dd">

:hearts: Thank you!
