### PR TITLE
Redesign: special markup for single step

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_participatory_spaces.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_participatory_spaces.scss
@@ -148,7 +148,6 @@
           @apply text-white bg-secondary;
         }
 
-        &:hover &-title,
         &[aria-expanded="true"] &-title {
           @apply font-semibold;
         }

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_step/show.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_step/show.erb
@@ -8,16 +8,30 @@
           <% steps.each_with_index do |step, i| %>
             <% active = step == active_step %>
             <li>
-              <button id="trigger-process-steps-<%= i %>" class="participatory-space__metadata-modal__step<%= " is-active" if active %>" data-controls="panel-process-steps-<%= i %>" data-open="<%= "true" if active %>">
-                <span><%= step.position + 1 %></span>
-                <span>
-                  <span class="participatory-space__metadata-modal__step-title">
-                    <span class="participatory-space__metadata-modal__step-current"><%= t("active_step", scope: "layouts.decidim.participatory_processes.participatory_process") %></span>
-                    <%= translated_attribute(step.title) %>
+              <%# NOTE: The following markup is duplicated to fulfill a11y requirements %>
+              <% if steps.length == 1 %>
+                <div id="trigger-process-steps-<%= i %>" class="participatory-space__metadata-modal__step<%= " is-active" if active %>" aria-expanded="true">
+                  <span><%= step.position + 1 %></span>
+                  <span>
+                    <span class="participatory-space__metadata-modal__step-title">
+                      <span class="participatory-space__metadata-modal__step-current"><%= t("active_step", scope: "layouts.decidim.participatory_processes.participatory_process") %></span>
+                      <%= translated_attribute(step.title) %>
+                    </span>
+                    <span class="participatory-space__metadata-modal__step-dates"><%= step_dates(step) %></span>
                   </span>
-                  <span class="participatory-space__metadata-modal__step-dates"><%= step_dates(step) %></span>
-                </span>
-              </button>
+                </div>
+              <% else %>
+                <button id="trigger-process-steps-<%= i %>" class="participatory-space__metadata-modal__step<%= " is-active" if active %>" data-controls="panel-process-steps-<%= i %>" data-open="<%= "true" if active %>">
+                  <span><%= step.position + 1 %></span>
+                  <span>
+                    <span class="participatory-space__metadata-modal__step-title">
+                      <span class="participatory-space__metadata-modal__step-current"><%= t("active_step", scope: "layouts.decidim.participatory_processes.participatory_process") %></span>
+                      <%= translated_attribute(step.title) %>
+                    </span>
+                    <span class="participatory-space__metadata-modal__step-dates"><%= step_dates(step) %></span>
+                  </span>
+                </button>
+              <% end %>
             </li>
           <% end %>
         </ol>


### PR DESCRIPTION
#### :tophat: What? Why?
Duplicate the markup to remove the button when there only one phase and no need to use an accordion.

- When there is only a single step in a process, the process step is focusable without any actual functionality attached to the button (WCAG 2.1: 1.3.6, COGA 3.1.1)

### :camera: Screenshots
https://decidim-redesign.populate.tools/processes/Welcome

:hearts: Thank you!
