### PR TITLE
Deletion of leftovers ZIP files in tmp directory

### DIFF
--- a/decidim-core/app/jobs/decidim/download_your_data_export_job.rb
+++ b/decidim-core/app/jobs/decidim/download_your_data_export_job.rb
@@ -11,7 +11,8 @@ module Decidim
 
       generate_zip_file(user, path, password, export_format)
       save_or_upload_file(user, path)
-
+      #Deletes temporary file
+      File.delete(path)
       ExportMailer.download_your_data_export(user, filename, password).deliver_later
     end
 

--- a/decidim-core/app/jobs/decidim/download_your_data_export_job.rb
+++ b/decidim-core/app/jobs/decidim/download_your_data_export_job.rb
@@ -11,7 +11,7 @@ module Decidim
 
       generate_zip_file(user, path, password, export_format)
       save_or_upload_file(user, path)
-      #Deletes temporary file
+      # Deletes temporary file
       File.delete(path)
       ExportMailer.download_your_data_export(user, filename, password).deliver_later
     end

--- a/decidim-core/spec/jobs/decidim/download_your_data_export_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/download_your_data_export_job_spec.rb
@@ -16,5 +16,17 @@ module Decidim
       expect(email.subject).to include("export")
       expect(email.body.encoded).to match("Download")
     end
+
+    it "deletes the temporary file after finishing the job" do
+      user = create(:user)
+
+      expect(File).to receive(:delete) do |path|
+        expect(path.to_s).to match(%r{tmp\/[a-zA-Z0-9_-]+\.zip})
+      end
+
+      described_class.perform_now(user)
+
+      expect(user.download_your_data_file.attached?).to be(true)
+    end
   end
 end

--- a/decidim-core/spec/jobs/decidim/download_your_data_export_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/download_your_data_export_job_spec.rb
@@ -21,7 +21,7 @@ module Decidim
       user = create(:user)
 
       expect(File).to receive(:delete) do |path|
-        expect(path.to_s).to match(%r{tmp\/[a-zA-Z0-9_-]+\.zip})
+        expect(path.to_s).to match(%r{tmp/[a-zA-Z0-9_-]+\.zip})
       end
 
       described_class.perform_now(user)


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Added method along with path to allow ZIP files to be deleted after export job in the tmp directory. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11415

#### Testing
1. As user, ask for your data export
2. Check the ZIP filename in the received mail
3. See the remaining ZIP file in "tmp" folder has been deleted.

An Rspec test has been added to ```decidim-core/spec/jobs/decidim/download_your_data_export_job_spec.rb```to test this feature.

### :camera: Screenshots

:hearts: Thank you!
