### PR TITLE
Deletion of ZIP file in tmp folder OpenData export job

### DIFF
--- a/decidim-core/app/jobs/decidim/open_data_job.rb
+++ b/decidim-core/app/jobs/decidim/open_data_job.rb
@@ -11,6 +11,8 @@ module Decidim
       raise "Could not generate Open Data export" unless exporter.export.positive?
 
       organization.open_data_file.attach(io: File.open(path, "rb"), filename: organization.open_data_file_path)
+      # Deletes the temporary file file
+      File.delete(path)
     end
   end
 end

--- a/decidim-core/spec/jobs/decidim/open_data_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/open_data_job_spec.rb
@@ -16,4 +16,15 @@ describe Decidim::OpenDataJob do
       expect { subject.perform_now(organization) }.to change { organization.open_data_file.attached? }.from(false).to(true)
     end
   end
+
+  it "deletes the temporary file after finishing the job" do
+    organization = create(:organization)
+
+    expect(File).to receive(:delete) do |path|
+      expect(path.to_s).to match(%r{tmp\/.*})
+    end
+
+    described_class.perform_now(organization)
+
+  end
 end

--- a/decidim-core/spec/jobs/decidim/open_data_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/open_data_job_spec.rb
@@ -21,10 +21,8 @@ describe Decidim::OpenDataJob do
     organization = create(:organization)
 
     expect(File).to receive(:delete) do |path|
-      expect(path.to_s).to match(%r{tmp\/.*})
+      expect(path.to_s).to match(%r{tmp/.*})
     end
-
     described_class.perform_now(organization)
-
   end
 end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
A solution that allows ZIP files that were not being deleted in the tmp folder in OpenData job. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11505

#### Testing
1. Run the decidim:open_data:export task
2. Download the opendata ZIP file from link in footer
3. See the same ZIP file has been removed in "tmp" folder

an Rspec test has been added to ```decidim-core/spec/jobs/decidim/open_data_job_spec.rb``` to test this deletion method. 

### :camera: Screenshots

:hearts: Thank you!
