### PR TITLE
Fix 'download your data' when there are comments on budgets

### DIFF
--- a/decidim-comments/lib/decidim/comments/comment_serializer.rb
+++ b/decidim-comments/lib/decidim/comments/comment_serializer.rb
@@ -33,7 +33,7 @@ module Decidim
 
       def root_commentable_url
         @root_commentable_url ||= if resource.root_commentable.respond_to?(:polymorphic_resource_url)
-                                    resource.root_commentable.polymorphic_resource_url
+                                    resource.root_commentable.polymorphic_resource_url({})
                                   else
                                     ResourceLocatorPresenter.new(resource.root_commentable).url
                                   end

--- a/decidim-comments/lib/decidim/comments/comment_vote_serializer.rb
+++ b/decidim-comments/lib/decidim/comments/comment_vote_serializer.rb
@@ -38,7 +38,7 @@ module Decidim
 
       def root_commentable_url
         @root_commentable_url ||= if resource.comment.root_commentable.respond_to?(:polymorphic_resource_url)
-                                    resource.comment.root_commentable.polymorphic_resource_url
+                                    resource.comment.root_commentable.polymorphic_resource_url({})
                                   else
                                     ResourceLocatorPresenter.new(resource.comment.root_commentable).url
                                   end

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -916,5 +916,29 @@ shared_examples "comments" do
         expect(page).to have_link "#decidim", href: "/search?term=%23decidim"
       end
     end
+
+    describe "export_serializer" do
+      let(:comment) { comments.first }
+
+      it "returns the serializer for the comment" do
+        expect(comment.class.export_serializer).to eq(Decidim::Comments::CommentSerializer)
+      end
+
+      context "with instance" do
+        subject { comment.class.export_serializer.new(comment).serialize }
+
+        it { is_expected.to have_key(:id) }
+        it { is_expected.to have_key(:created_at) }
+        it { is_expected.to have_key(:body) }
+        it { is_expected.to have_key(:locale) }
+        it { is_expected.to have_key(:author) }
+        it { is_expected.to have_key(:alignment) }
+        it { is_expected.to have_key(:depth) }
+        it { is_expected.to have_key(:user_group) }
+        it { is_expected.to have_key(:commentable_id) }
+        it { is_expected.to have_key(:commentable_type) }
+        it { is_expected.to have_key(:root_commentable_url) }
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
While reviewing #11527 i have noticed that the export class is actually raise an error.

```
2023-08-27T08:46:56.268Z pid=1088300 tid=omi0 WARN: ArgumentError: wrong number of arguments (given 0, expected 1)
2023-08-27T08:46:56.268Z pid=1088300 tid=omi0 WARN: /home/alecslupu/Sites/decidim/redesign/decidim-budgets/app/models/decidim/budgets/project.rb:73:in `polymorphic_resource_url'
/home/alecslupu/Sites/decidim/redesign/decidim-comments/lib/decidim/comments/comment_serializer.rb:36:in `root_commentable_url'
/home/alecslupu/Sites/decidim/redesign/decidim-comments/lib/decidim/comments/comment_serializer.rb:28:in `serialize'
/home/alecslupu/Sites/decidim/redesign/decidim-core/app/serializers/decidim/exporters/serializer.rb:24:in `run'
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #11527

#### Testing
1. Login with admin account 
2. From user profile, click request your data 
3. Process queues using sidekiq 
4. See error in sidekiq 
5. Apply patch, retry job
6. See there is no error in sidekiq 
7. Export archive is being delivered in letter opener

:hearts: Thank you!
