### PR TITLE
Fix Permissions screen on budgets throw errors

### DIFF
--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -66,12 +66,16 @@ module Decidim
         Decidim::Budgets::AdminLog::ProjectPresenter
       end
 
+      def resource_locator
+        ::Decidim::ResourceLocatorPresenter.new([budget, self])
+      end
+
       def polymorphic_resource_path(url_params)
-        ::Decidim::ResourceLocatorPresenter.new([budget, self]).path(url_params)
+        resource_locator.path(url_params)
       end
 
       def polymorphic_resource_url(url_params)
-        ::Decidim::ResourceLocatorPresenter.new([budget, self]).url(url_params)
+        resource_locator.url(url_params)
       end
 
       # Public: Overrides the `comments_have_votes?` Commentable concern method.

--- a/decidim-budgets/spec/system/admin_manages_project_permissions_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_project_permissions_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages project permissions", type: :system do
+  let(:manifest_name) { "budgets" }
+  let(:budget) { create(:budget, component: current_component) }
+  let!(:project) { create(:project, budget:) }
+
+  include_context "when managing a component as an admin"
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit_component_admin
+    within find("tr", text: translated(budget.title)) do
+      page.find(".action-icon--edit-projects").click
+    end
+    within find("tr", text: translated(project.title)) do
+      page.find(".action-icon--permissions").click
+    end
+  end
+
+  it "Saves the permissions" do
+    expect(page).to have_content("Edit permissions")
+
+    within find("fieldset", text: "Vote") do
+      page.check("Example authorization (Direct)")
+    end
+    click_button "Submit"
+    expect(page).to have_content("Permissions updated successfully")
+    within find("tr", text: translated(budget.title)) do
+      page.find(".action-icon--edit-projects").click
+    end
+    within find("tr", text: translated(project.title)) do
+      expect(page).to have_css(".action-icon--highlighted")
+      page.find(".action-icon--permissions").click
+    end
+    within find("fieldset", text: "Vote") do
+      expect(page).to have_checked_field("Example authorization (Direct)")
+    end
+  end
+end

--- a/decidim-core/app/helpers/decidim/resource_helper.rb
+++ b/decidim-core/app/helpers/decidim/resource_helper.rb
@@ -75,6 +75,8 @@ module Decidim
 
     # Returns an instance of ResourceLocatorPresenter with the given resource
     def resource_locator(resource)
+      return resource.resource_locator if resource.respond_to?(:resource_locator)
+
       ::Decidim::ResourceLocatorPresenter.new(resource)
     end
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR fixes the admin permission on budget's project 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11292

#### Testing
1. Login as admin, and navigate to admin interface 
2. Navigate to a participatory process, budget component
3. Select a Budget, then on Projects visit the permission screen 
4. See error 
5. Apply patch 
6. See there is no error, and the data can be seen

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
