### PR TITLE
Add quotes to confirm your password error message

### DIFF
--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -41,7 +41,7 @@
 
       <%= f.password_field :password, password_field_options_for(:user) %>
 
-      <%= f.password_field "Confirm password", password_field_options_for(:user).except(:help_text) %>
+      <%= f.password_field :password_confirmation_form, password_field_options_for(:user).except(:help_text) %>
     </div>
 
     <div id="card__tos" class="form__wrapper-block">

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -41,7 +41,7 @@
 
       <%= f.password_field :password, password_field_options_for(:user) %>
 
-      <%= f.password_field :password_confirmation, password_field_options_for(:user).except(:help_text) %>
+      <%= f.password_field "Confirm password", password_field_options_for(:user).except(:help_text) %>
     </div>
 
     <div id="card__tos" class="form__wrapper-block">

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -41,7 +41,8 @@
 
       <%= f.password_field :password, password_field_options_for(:user) %>
 
-      <%= f.password_field :password_confirmation_form, password_field_options_for(:user).except(:help_text) %>
+      <%= f.password_field :password_confirmation, password_field_options_for(:user).except(:help_text).merge(label: t("password_confirmation", scope: "decidim.devise.registrations.new")) %>
+
     </div>
 
     <div id="card__tos" class="form__wrapper-block">

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -28,7 +28,6 @@ en:
         nickname: Nickname
         password: Password
         password_confirmation: '"Confirm your password"'
-        password_confirmation_form: Confirm your password
         personal_url: Personal URL
         remove_avatar: Remove avatar
         tos_agreement: Terms of service agreement

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
         nickname: Nickname
         password: Password
         password_confirmation: '"Confirm your password"'
+        password_confirmation_form: Confirm your password
         personal_url: Personal URL
         remove_avatar: Remove avatar
         tos_agreement: Terms of service agreement

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -27,7 +27,7 @@ en:
         name: Your name
         nickname: Nickname
         password: Password
-        password_confirmation: Confirm your password
+        password_confirmation: '"Confirm your password"'
         personal_url: Personal URL
         remove_avatar: Remove avatar
         tos_agreement: Terms of service agreement

--- a/decidim-core/spec/controllers/registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/registrations_controller_spec.rb
@@ -86,7 +86,7 @@ module Decidim
                 "Nickname cannot be blank",
                 "Nickname is invalid",
                 "Your email cannot be blank",
-                "Confirm your password does not match Password",
+                '"Confirm your password" does not match Password',
                 "Password is too short",
                 "Password does not have enough unique characters",
                 "Terms of service agreement must be accepted"


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Added quotation marks to password error to make the error message more clearer as per the request of issue #11284

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11284

#### Testing
*Describe the best way to test or validate your PR.*
1. Head over to Sign in/Log in
2. Click create an account
3. Fill the form
4. Purposely create different passwords in the confirmation field and hit enter 
5. See the the error output has quotes  

### :camera: Screenshots

<img width="704" alt="Screenshot 2023-08-28 at 11 22 43" src="https://github.com/decidim/decidim/assets/101816158/42d25a0b-f778-4283-9fd6-a57e14f37836">



:hearts: Thank you!
