### PR TITLE
Fix conference venues meetings visibility

### DIFF
--- a/decidim-conferences/spec/system/conferences_spec.rb
+++ b/decidim-conferences/spec/system/conferences_spec.rb
@@ -132,13 +132,75 @@ describe "Conferences", type: :system do
   describe "when going to the conference page" do
     let!(:conference) { base_conference }
     let!(:proposals_component) { create(:component, :published, participatory_space: conference, manifest_name: :proposals) }
-    let!(:meetings_component) { create(:component, :unpublished, participatory_space: conference, manifest_name: :meetings) }
+    let!(:meetings_component) { create(:meeting_component, :unpublished, participatory_space: conference) }
 
     before do
       create_list(:proposal, 3, component: proposals_component)
       allow(Decidim).to receive(:component_manifests).and_return([proposals_component.manifest, meetings_component.manifest])
 
       visit decidim_conferences.conference_path(conference)
+    end
+
+    describe "conference venues" do
+      before do
+        meetings.empty?
+        allow(Decidim).to receive(:address).and_return("foo bar")
+
+        visit decidim_conferences.conference_path(conference)
+      end
+
+      context "when the meeting component is not published" do
+        let!(:meetings_component) { create(:meeting_component, :unpublished, participatory_space: conference) }
+        let!(:meetings) { create_list(:meeting, 3, :published, component: meetings_component) }
+
+        it "does not show the venues" do
+          expect(page).not_to have_content("Conference Venues")
+        end
+      end
+
+      context "when the meeting component is published" do
+        let!(:meetings_component) { create(:meeting_component, :published, participatory_space: conference) }
+
+        context "when there are published meetings" do
+          let!(:meetings) { create_list(:meeting, 3, :published, component: meetings_component) }
+
+          it "does show the venues" do
+            expect(page).to have_content("Conference Venues")
+          end
+        end
+
+        context "when there are moderated meetings" do
+          let!(:meetings) { create_list(:meeting, 3, :moderated, :published, component: meetings_component) }
+
+          it "does not show the venues" do
+            expect(page).not_to have_content("Conference Venues")
+          end
+        end
+
+        context "when there are no published meetings" do
+          let!(:meetings) { create_list(:meeting, 3, published_at: nil, component: meetings_component) }
+
+          it "does not show the venues" do
+            expect(page).not_to have_content("Conference Venues")
+          end
+        end
+
+        context "when there are no visible meetings" do
+          let!(:meetings) { create_list(:meeting, 3, :published, private_meeting: true, transparent: false, component: meetings_component) }
+
+          it "does not show the venues" do
+            expect(page).not_to have_content("Conference Venues")
+          end
+        end
+
+        context "when there are visible meetings" do
+          let!(:meetings) { create_list(:meeting, 3, :published, private_meeting: true, transparent: true, component: meetings_component) }
+
+          it "does not show the venues" do
+            expect(page).to have_content("Conference Venues")
+          end
+        end
+      end
     end
 
     it "shows the details of the given conference" do

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -83,8 +83,9 @@ module Decidim
 
         Decidim.view_hooks.register(:conference_venues, priority: Decidim::ViewHooks::HIGH_PRIORITY) do |view_context|
           published_components = Decidim::Component.where(participatory_space: view_context.current_participatory_space).published
-          meetings = Decidim::Meetings::Meeting.where(component: published_components).group_by(&:address)
-          meetings_geocoded = Decidim::Meetings::Meeting.where(component: published_components).geocoded
+          meetings = Decidim::Meetings::Meeting.visible.not_hidden.published.where(component: published_components).group_by(&:address)
+          meetings_geocoded = Decidim::Meetings::Meeting.visible.not_hidden.published.where(component: published_components).geocoded
+
           next unless meetings.any?
 
           view_context.render(


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR attempts to fix meeting visibility in conference venues, where all addresses for meetings published, unpublished, transparent are being displayed.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11540

#### Testing
1. Visit a Conference, and check the venues section
2. Go to admin section, in the meetings component listing
3. Unpublish all the meetings
4. Go to frontend and refresh the page
5. See the Conference Venues and see that addresses are still visible.
6. Apply patch 
7. See the Conference venues are not being visible
8. 
:hearts: Thank you!
