### PR TITLE
Remove unused view hook for `:upcoming_meeting_for_card`

### DIFF
--- a/decidim-meetings/app/views/decidim/participatory_spaces/_upcoming_meeting_for_card.html.erb
+++ b/decidim-meetings/app/views/decidim/participatory_spaces/_upcoming_meeting_for_card.html.erb
@@ -1,3 +1,0 @@
-<span data-upcoming-meeting>
-  <%= format_date_range(upcoming_meeting.start_time, upcoming_meeting.end_time) %>
-</span>

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -65,22 +65,6 @@ module Decidim
           view_context.cell("decidim/meetings/highlighted_meetings", view_context.current_participatory_space)
         end
 
-        # This view hook is used in card cells. It renders the next upcoming
-        # meeting for the given participatory space.
-        Decidim.view_hooks.register(:upcoming_meeting_for_card, priority: Decidim::ViewHooks::LOW_PRIORITY) do |view_context|
-          published_components = Decidim::Component.where(participatory_space: view_context.current_participatory_space).published
-          upcoming_meeting = Decidim::Meetings::Meeting.where(component: published_components).published.upcoming.order(:start_time, :end_time).first
-
-          next unless upcoming_meeting
-
-          view_context.render(
-            partial: "decidim/participatory_spaces/upcoming_meeting_for_card.html",
-            locals: {
-              upcoming_meeting:
-            }
-          )
-        end
-
         Decidim.view_hooks.register(:conference_venues, priority: Decidim::ViewHooks::HIGH_PRIORITY) do |view_context|
           published_components = Decidim::Component.where(participatory_space: view_context.current_participatory_space).published
           meetings = Decidim::Meetings::Meeting.where(component: published_components).group_by(&:address)


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
While researching a fix for  #11541, i could not find any usages of the `upcoming_meeting_for_card` hook. Therefore this needs to go away. 

Investigating 0.26 branch, i could see that this hook is being used by: 
- decidim-assemblies/app/cells/decidim/assemblies/assembly_m/tags.erb
- decidim-conferences/app/cells/decidim/conferences/conference_m/tags.erb

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #11541

#### Testing
Make sure the pipeline is green

:hearts: Thank you!
