### PR TITLE
Add recognition to BrowserStack in the README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,5 @@
 :uri-blog: https://decidim.org/blog
+:uri-browserstack: https://www.browserstack.com
 :uri-chat: http://chat.decidim.org
 :uri-contributing: xref:CONTRIBUTING.adoc
 :uri-demo: https://try.decidim.org
@@ -72,6 +73,7 @@ All members of the Decidim community agree with {uri-social-contract}[Decidim So
 ** <<members,🧑 Members>>
 ** <<partners,💻 Partners>>
 * <<learn-more,📖 Learn More>>
+* <<credits,🎩 Credits>>
 
 '''
 
@@ -202,3 +204,7 @@ image::https://opencollective.com/decidim/tiers/partner.svg?avatarHeight=36&widt
 | How to contribute to the Decidim project and code base.
 
 |===
+
+== 🎩 Credits
+
+* This project is tested with {uri-browserstack}[BrowserStack].


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

We're opting for the BrowserStack Open Source Program, and they ask us to give them credit in our README. This PR does that. 

More information at https://www.browserstack.com/open-source 

#### Testing

* it should be [well formatted](https://github.com/decidim/decidim/blob/9ec1c6975401be180a6e3d9295533046409f7873/README.adoc#credits) 
* the anchor link should work 
* the external link should work

:hearts: Thank you!
