### PR TITLE
Remove duplication from stats presenters

### DIFF
--- a/decidim-assemblies/app/presenters/decidim/assemblies/assembly_stats_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/assembly_stats_presenter.rb
@@ -10,45 +10,14 @@ module Decidim
         __getobj__.fetch(:assembly)
       end
 
-      # Public: returns a collection of stats (Hash) for the Assembly Home.
-      def collection
-        highlighted_stats = assembly_participants_stats
-        highlighted_stats.concat(assembly_followers_stats(priority: StatsRegistry::HIGH_PRIORITY))
-        highlighted_stats.concat(component_stats(priority: StatsRegistry::HIGH_PRIORITY))
-        highlighted_stats.concat(component_stats(priority: StatsRegistry::MEDIUM_PRIORITY))
-        highlighted_stats.concat(comments_stats(:assemblies))
-        highlighted_stats = highlighted_stats.reject(&:empty?)
-        highlighted_stats = highlighted_stats.reject { |_stat_manifest, _stat_title, stat_number| stat_number.zero? }
-        grouped_highlighted_stats = highlighted_stats.group_by(&:first)
-
-        statistics(grouped_highlighted_stats)
-      end
-
       private
 
-      def assembly_participants_stats
-        Decidim.stats.only([:participants_count]).with_context(assembly)
-               .map { |stat_title, stat_number| [assembly.manifest.name, stat_title, stat_number] }
+      def participatory_space
+        assembly
       end
 
-      def component_stats(conditions)
-        Decidim.component_manifests.map do |component_manifest|
-          component_manifest.stats.except([:proposals_accepted])
-                            .filter(conditions)
-                            .with_context(published_components)
-                            .map { |stat_title, stat_number| [component_manifest.name, stat_title, stat_number] }.flatten
-        end
-      end
-
-      def assembly_followers_stats(conditions)
-        Decidim.stats.only([:followers_count])
-               .filter(conditions)
-               .with_context(assembly)
-               .map { |stat_title, stat_number| [assembly.manifest.name, stat_title, stat_number] }
-      end
-
-      def published_components
-        @published_components ||= Component.where(participatory_space: assembly).published
+      def participatory_space_sym
+        :assemblies
       end
     end
   end

--- a/decidim-assemblies/app/presenters/decidim/assemblies/assembly_stats_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/assembly_stats_presenter.rb
@@ -6,19 +6,11 @@ module Decidim
     class AssemblyStatsPresenter < Decidim::StatsPresenter
       include Decidim::IconHelper
 
-      def assembly
-        __getobj__.fetch(:assembly)
-      end
-
       private
 
-      def participatory_space
-        assembly
-      end
+      def participatory_space = __getobj__.fetch(:assembly)
 
-      def participatory_space_sym
-        :assemblies
-      end
+      def participatory_space_sym = :assemblies
     end
   end
 end

--- a/decidim-conferences/app/presenters/decidim/conferences/conference_stats_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/conference_stats_presenter.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Conferences
-    # A presenter to render statistics in the homepage.
+    # A presenter to render statistics in a Conference.
     class ConferenceStatsPresenter < Decidim::StatsPresenter
       include IconHelper
 
@@ -10,31 +10,12 @@ module Decidim
         __getobj__.fetch(:conference)
       end
 
-      # Public: Render a collection of primary stats.
-      def highlighted
-        highlighted_stats = component_stats(priority: StatsRegistry::HIGH_PRIORITY)
-        highlighted_stats.concat(component_stats(priority: StatsRegistry::MEDIUM_PRIORITY))
-        highlighted_stats.concat(comments_stats(:conferences))
-        highlighted_stats = highlighted_stats.reject(&:empty?)
-        highlighted_stats = highlighted_stats.reject { |_manifest, _name, data| data.zero? }
-        grouped_highlighted_stats = highlighted_stats.group_by(&:first)
-
-        statistics(grouped_highlighted_stats)
+      def participatory_space
+        conference
       end
 
-      private
-
-      def component_stats(conditions)
-        Decidim.component_manifests.map do |component_manifest|
-          component_manifest.stats
-                            .filter(conditions)
-                            .with_context(published_components)
-                            .map { |name, data| [component_manifest.name, name, data] }.flatten
-        end
-      end
-
-      def published_components
-        @published_components ||= Component.where(participatory_space: conference).published
+      def participatory_space_sym
+        :conferences
       end
     end
   end

--- a/decidim-conferences/app/presenters/decidim/conferences/conference_stats_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/conference_stats_presenter.rb
@@ -6,17 +6,11 @@ module Decidim
     class ConferenceStatsPresenter < Decidim::StatsPresenter
       include IconHelper
 
-      def conference
-        __getobj__.fetch(:conference)
-      end
+      private
 
-      def participatory_space
-        conference
-      end
+      def participatory_space = __getobj__.fetch(:conference)
 
-      def participatory_space_sym
-        :conferences
-      end
+      def participatory_space_sym = :conferences
     end
   end
 end

--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -110,7 +110,7 @@ edit_link(
     <% if current_participatory_space.show_statistics? %>
       <section class="content-block" data-statistics>
         <h2 class="h2 decorator"><%= t("decidim.statistics.headline") %></h2>
-        <%= cell("decidim/statistics", stats.highlighted) %>
+        <%= cell("decidim/statistics", stats.collection) %>
       </section>
     <% end %>
 

--- a/decidim-conferences/spec/presenters/decidim/conferences/conference_stats_presenter_spec.rb
+++ b/decidim-conferences/spec/presenters/decidim/conferences/conference_stats_presenter_spec.rb
@@ -11,7 +11,7 @@ module Decidim
     let!(:conference) { create(:conference, organization:) }
     let!(:component) { create(:component, participatory_space: conference) }
 
-    describe "#highlighted" do
+    describe "#collection" do
       let(:manifest) do
         Decidim::ComponentManifest.new.tap do |manifest|
           manifest.name = "Test"
@@ -36,7 +36,7 @@ module Decidim
       end
 
       it "renders a collection of stats including users and proceses" do
-        expect(subject.highlighted).to include({ stat_number: 10, stat_title: :foo })
+        expect(subject.collection).to include({ stat_number: 10, stat_title: :foo })
       end
     end
 
@@ -79,14 +79,14 @@ module Decidim
       end
 
       it "return the sum of all the comments from debates, meetings and budgets" do
-        data = subject.highlighted.first
+        data = subject.collection.first
         expect(data).not_to be_nil
         expect(data[:stat_title]).to eq :comments_count
         expect(data[:stat_number]).to eq 18
       end
 
       it "contains only one stat" do
-        data = subject.highlighted.second
+        data = subject.collection.second
         expect(data).to be_nil
       end
     end

--- a/decidim-core/app/presenters/decidim/stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/stats_presenter.rb
@@ -27,5 +27,63 @@ module Decidim
       end
       statistics.map { |key, number| { stat_title: key, stat_number: number } }
     end
+
+    # Public: returns a collection of stats (Hash) for the Participatory Space Home.
+    def collection
+      highlighted_stats = participatory_space_participants_stats
+      highlighted_stats.concat(participatory_space_followers_stats(priority: StatsRegistry::HIGH_PRIORITY))
+      highlighted_stats.concat(component_stats(priority: StatsRegistry::HIGH_PRIORITY))
+      highlighted_stats.concat(component_stats(priority: StatsRegistry::MEDIUM_PRIORITY))
+      highlighted_stats.concat(comments_stats(participatory_space_sym))
+      highlighted_stats = highlighted_stats.reject(&:empty?)
+      highlighted_stats = highlighted_stats.reject { |_stat_manifest, _stat_title, stat_number| stat_number.zero? }
+      grouped_highlighted_stats = highlighted_stats.group_by(&:first)
+
+      statistics(grouped_highlighted_stats)
+    end
+
+    def card_collection
+      card_stats = Decidim.stats.only([:followers_count, :votings_count])
+                          .filter(priority: StatsRegistry::HIGH_PRIORITY)
+                          .with_context(participatory_space)
+                          .map { |stat_title, stat_number| [participatory_space.manifest.name, stat_title, stat_number] }
+
+      statistics(card_stats.group_by(&:first))
+    end
+
+    private
+
+    def participatory_space = raise "Not implemented"
+
+    def participatory_space_sym = raise "Not implemented"
+
+    def participatory_space_for_components = participatory_space
+
+    def participatory_space_participants_stats
+      Decidim.stats.only([:participants_count]).with_context(participatory_space)
+             .map { |stat_title, stat_number| [participatory_space.manifest.name, stat_title, stat_number] }
+    end
+
+    def component_stats(conditions)
+      Decidim.component_manifests.map do |component_manifest|
+        component_manifest.stats.except([:proposals_accepted])
+                          .filter(conditions)
+                          .with_context(published_components)
+                          .map { |stat_title, stat_number| [component_manifest.name, stat_title, stat_number] }.flatten
+      end
+    end
+
+    def participatory_space_followers_stats(conditions)
+      Decidim.stats.only([:followers_count])
+             .filter(conditions)
+             .with_context(participatory_space)
+             .map { |stat_title, stat_number| [participatory_space.manifest.name, stat_title, stat_number] }
+    end
+
+    # We use participatory_space_for_components instead of participatory_space as in ParticipatoryProcessGroupStatsPresenter
+    # needs to be different
+    def published_components
+      @published_components ||= Component.where(participatory_space: participatory_space_for_components).published
+    end
   end
 end

--- a/decidim-core/app/presenters/decidim/stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/stats_presenter.rb
@@ -46,7 +46,7 @@ module Decidim
       card_stats = Decidim.stats.only([:followers_count, :votings_count])
                           .filter(priority: StatsRegistry::HIGH_PRIORITY)
                           .with_context(participatory_space)
-                          .map { |stat_title, stat_number| [participatory_space.manifest.name, stat_title, stat_number] }
+                          .map { |stat_title, stat_number| [participatory_space_sym, stat_title, stat_number] }
 
       statistics(card_stats.group_by(&:first))
     end
@@ -59,7 +59,7 @@ module Decidim
 
     def participatory_space_participants_stats
       Decidim.stats.only([:participants_count]).with_context(participatory_space)
-             .map { |stat_title, stat_number| [participatory_space.manifest.name, stat_title, stat_number] }
+             .map { |stat_title, stat_number| [participatory_space_sym, stat_title, stat_number] }
     end
 
     def component_stats(conditions)
@@ -75,7 +75,7 @@ module Decidim
       Decidim.stats.only([:followers_count])
              .filter(conditions)
              .with_context(participatory_space)
-             .map { |stat_title, stat_number| [participatory_space.manifest.name, stat_title, stat_number] }
+             .map { |stat_title, stat_number| [participatory_space_sym, stat_title, stat_number] }
     end
 
     def published_components

--- a/decidim-core/app/presenters/decidim/stats_presenter.rb
+++ b/decidim-core/app/presenters/decidim/stats_presenter.rb
@@ -57,8 +57,6 @@ module Decidim
 
     def participatory_space_sym = raise "Not implemented"
 
-    def participatory_space_for_components = participatory_space
-
     def participatory_space_participants_stats
       Decidim.stats.only([:participants_count]).with_context(participatory_space)
              .map { |stat_title, stat_number| [participatory_space.manifest.name, stat_title, stat_number] }
@@ -80,10 +78,8 @@ module Decidim
              .map { |stat_title, stat_number| [participatory_space.manifest.name, stat_title, stat_number] }
     end
 
-    # We use participatory_space_for_components instead of participatory_space as in ParticipatoryProcessGroupStatsPresenter
-    # needs to be different
     def published_components
-      @published_components ||= Component.where(participatory_space: participatory_space_for_components).published
+      @published_components ||= Component.where(participatory_space:).published
     end
   end
 end

--- a/decidim-elections/app/presenters/decidim/votings/voting_stats_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/votings/voting_stats_presenter.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Votings
-    # A presenter to render statistics in the homepage.
+    # A presenter to render statistics in a Voting.
     class VotingStatsPresenter < Decidim::StatsPresenter
       include Decidim::IconHelper
 
@@ -10,45 +10,12 @@ module Decidim
         __getobj__.fetch(:voting)
       end
 
-      # Public: returns a collection of stats (Hash) for the Voting Landing.
-      def collection
-        highlighted_stats = voting_participants_stats
-        highlighted_stats.concat(voting_followers_stats(priority: StatsRegistry::HIGH_PRIORITY))
-        highlighted_stats.concat(component_stats(priority: StatsRegistry::HIGH_PRIORITY))
-        highlighted_stats.concat(component_stats(priority: StatsRegistry::MEDIUM_PRIORITY))
-        highlighted_stats.concat(comments_stats(:votings))
-        highlighted_stats = highlighted_stats.reject(&:empty?)
-        highlighted_stats = highlighted_stats.reject { |_stat_manifest, _stat_title, stat_number| stat_number.zero? }
-        grouped_highlighted_stats = highlighted_stats.group_by(&:first)
-
-        statistics(grouped_highlighted_stats)
+      def participatory_space
+        voting
       end
 
-      private
-
-      def voting_participants_stats
-        Decidim.stats.only([:participants_count]).with_context(voting)
-               .map { |stat_title, stat_number| [voting.manifest.name, stat_title, stat_number] }
-      end
-
-      def component_stats(conditions)
-        Decidim.component_manifests.map do |component_manifest|
-          component_manifest.stats.except([:proposals_accepted])
-                            .filter(conditions)
-                            .with_context(published_components)
-                            .map { |stat_title, stat_number| [component_manifest.name, stat_title, stat_number] }.flatten
-        end
-      end
-
-      def voting_followers_stats(conditions)
-        Decidim.stats.only([:followers_count])
-               .filter(conditions)
-               .with_context(voting)
-               .map { |stat_title, stat_number| [voting.manifest.name, stat_title, stat_number] }
-      end
-
-      def published_components
-        @published_components ||= Component.where(participatory_space: voting).published
+      def participatory_space_sym
+        :votings
       end
     end
   end

--- a/decidim-elections/app/presenters/decidim/votings/voting_stats_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/votings/voting_stats_presenter.rb
@@ -6,17 +6,11 @@ module Decidim
     class VotingStatsPresenter < Decidim::StatsPresenter
       include Decidim::IconHelper
 
-      def voting
-        __getobj__.fetch(:voting)
-      end
+      private
 
-      def participatory_space
-        voting
-      end
+      def participatory_space = __getobj__.fetch(:voting)
 
-      def participatory_space_sym
-        :votings
-      end
+      def participatory_space_sym = :votings
     end
   end
 end

--- a/decidim-elections/spec/presenters/decidim/votings/voting_stats_presenter_spec.rb
+++ b/decidim-elections/spec/presenters/decidim/votings/voting_stats_presenter_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Votings::VotingStatsPresenter do
+    subject { described_class.new(voting:) }
+
+    let!(:organization) { create(:organization) }
+    let!(:user) { create(:user, :confirmed, organization:) }
+    let!(:voting) { create(:voting, organization:) }
+    let!(:component) { create(:component, participatory_space: voting) }
+
+    describe "#collection" do
+      let(:manifest) do
+        Decidim::ComponentManifest.new.tap do |manifest|
+          manifest.name = "Test"
+        end
+      end
+
+      before do
+        manifest.stats.register :foo, priority: StatsRegistry::HIGH_PRIORITY, &proc { 10 }
+        manifest.stats.register :bar, priority: StatsRegistry::HIGH_PRIORITY, &proc { 0 }
+
+        I18n.backend.store_translations(
+          :en,
+          decidim: {
+            votings: {
+              statistics: {
+                foo: "Foo",
+                bar: "Bar"
+              }
+            }
+          }
+        )
+
+        allow(Decidim).to receive(:component_manifests).and_return([manifest])
+      end
+
+      it "return a collection of stats including stats title and value" do
+        data = subject.collection.first
+        expect(data).not_to be_nil
+        expect(data).to have_key(:stat_title)
+        expect(data).to have_key(:stat_number)
+        expect(data[:stat_title]).to eq :foo
+        expect(data[:stat_number]).to eq 10
+      end
+
+      it "does not return 0 values" do
+        data = subject.collection.second
+        expect(data).to be_nil
+      end
+    end
+
+    describe "comments count stat" do
+      let(:manifest_proposals) do
+        Decidim::ComponentManifest.new.tap do |manifest|
+          manifest.name = "proposals"
+        end
+      end
+
+      let(:manifest_meetings) do
+        Decidim::ComponentManifest.new.tap do |manifest|
+          manifest.name = "meetings"
+        end
+      end
+
+      let(:manifest_budgets) do
+        Decidim::ComponentManifest.new.tap do |manifest|
+          manifest.name = "budgets"
+        end
+      end
+
+      before do
+        manifest_meetings.stats.register :comments_count, tag: :comments, &proc { 10 }
+        manifest_proposals.stats.register :comments_count, tag: :comments, &proc { 5 }
+        manifest_budgets.stats.register :comments_count, tag: :comments, &proc { 3 }
+
+        I18n.backend.store_translations(
+          :en,
+          decidim: {
+            participatory_processes: {
+              statistics: {
+                comments_count: "Comments"
+              }
+            }
+          }
+        )
+
+        allow(Decidim).to receive(:component_manifests).and_return([manifest_meetings, manifest_proposals, manifest_budgets])
+      end
+
+      it "return the sum of all the comments from proposals, meetings and budgets" do
+        data = subject.collection.first
+        expect(data).not_to be_nil
+        expect(data[:stat_title]).to eq :comments_count
+        expect(data[:stat_number]).to eq 18
+      end
+
+      it "contains only one stat" do
+        data = subject.collection.second
+        expect(data).to be_nil
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_group_stats_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_group_stats_presenter.rb
@@ -13,7 +13,7 @@ module Decidim
       def participatory_space_sym = :participatory_process_group
 
       def participatory_processes
-        @participatory_processes ||= participatory_process_group.participatory_processes
+        @participatory_processes ||= participatory_space.participatory_processes
       end
 
       def published_components

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_group_stats_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_group_stats_presenter.rb
@@ -2,51 +2,15 @@
 
 module Decidim
   module ParticipatoryProcesses
-    # A presenter to render statistics in the homepage.
+    # A presenter to render statistics in a Participatory Process Group
     class ParticipatoryProcessGroupStatsPresenter < Decidim::StatsPresenter
       include Decidim::IconHelper
 
-      def participatory_process_group
-        __getobj__.fetch(:participatory_process_group)
-      end
-
-      # Public: returns a collection of stats (Hash) for the participatory
-      # process group landing page.
-      def collection
-        highlighted_stats = process_participants_stats
-        highlighted_stats.concat(process_followers_stats(priority: StatsRegistry::HIGH_PRIORITY))
-        highlighted_stats.concat(component_stats(priority: StatsRegistry::HIGH_PRIORITY))
-        highlighted_stats.concat(component_stats(priority: StatsRegistry::MEDIUM_PRIORITY))
-        highlighted_stats.concat(comments_stats(:participatory_processes))
-        highlighted_stats = highlighted_stats.reject(&:empty?)
-        highlighted_stats = highlighted_stats.reject { |_stat_manifest, _stat_title, stat_number| stat_number.zero? }
-        grouped_highlighted_stats = highlighted_stats.group_by(&:first)
-
-        statistics(grouped_highlighted_stats)
-      end
-
       private
 
-      def process_participants_stats
-        Decidim.stats.only([:participants_count]).with_context(participatory_process_group)
-               .map { |stat_title, stat_number| [:participatory_process_group, stat_title, stat_number] }
-      end
+      def participatory_space = __getobj__.fetch(:participatory_process_group)
 
-      def component_stats(conditions)
-        Decidim.component_manifests.map do |component_manifest|
-          component_manifest.stats.except([:proposals_accepted])
-                            .filter(conditions)
-                            .with_context(published_components)
-                            .map { |stat_title, stat_number| [component_manifest.name, stat_title, stat_number] }.flatten
-        end
-      end
-
-      def process_followers_stats(conditions)
-        Decidim.stats.only([:followers_count])
-               .filter(conditions)
-               .with_context(participatory_process_group)
-               .map { |stat_title, stat_number| [:participatory_process_group, stat_title, stat_number] }
-      end
+      def participatory_space_sym = :participatory_process_group
 
       def participatory_processes
         @participatory_processes ||= participatory_process_group.participatory_processes

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_stats_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_stats_presenter.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module ParticipatoryProcesses
-    # A presenter to render statistics in the homepage.
+    # A presenter to render statistics in a Participatory Process.
     class ParticipatoryProcessStatsPresenter < Decidim::StatsPresenter
       include Decidim::IconHelper
 
@@ -10,54 +10,12 @@ module Decidim
         __getobj__.fetch(:participatory_process)
       end
 
-      # Public: returns a collection of stats (Hash) for the Process Home.
-      def collection
-        highlighted_stats = process_participants_stats
-        highlighted_stats.concat(process_followers_stats(priority: StatsRegistry::HIGH_PRIORITY))
-        highlighted_stats.concat(component_stats(priority: StatsRegistry::HIGH_PRIORITY))
-        highlighted_stats.concat(component_stats(priority: StatsRegistry::MEDIUM_PRIORITY))
-        highlighted_stats.concat(comments_stats(:participatory_processes))
-        highlighted_stats = highlighted_stats.reject(&:empty?)
-        highlighted_stats = highlighted_stats.reject { |_stat_manifest, _stat_title, stat_number| stat_number.zero? }
-        grouped_highlighted_stats = highlighted_stats.group_by(&:first)
-
-        statistics(grouped_highlighted_stats)
+      def participatory_space
+        participatory_process
       end
 
-      def card_collection
-        card_stats = Decidim.stats.only([:followers_count, :votings_count])
-                            .filter(priority: StatsRegistry::HIGH_PRIORITY)
-                            .with_context(participatory_process)
-                            .map { |stat_title, stat_number| [participatory_process.manifest.name, stat_title, stat_number] }
-
-        statistics(card_stats.group_by(&:first))
-      end
-
-      private
-
-      def process_participants_stats
-        Decidim.stats.only([:participants_count]).with_context(participatory_process)
-               .map { |stat_title, stat_number| [participatory_process.manifest.name, stat_title, stat_number] }
-      end
-
-      def component_stats(conditions)
-        Decidim.component_manifests.map do |component_manifest|
-          component_manifest.stats.except([:proposals_accepted])
-                            .filter(conditions)
-                            .with_context(published_components)
-                            .map { |stat_title, stat_number| [component_manifest.name, stat_title, stat_number] }.flatten
-        end
-      end
-
-      def process_followers_stats(conditions)
-        Decidim.stats.only([:followers_count])
-               .filter(conditions)
-               .with_context(participatory_process)
-               .map { |stat_title, stat_number| [participatory_process.manifest.name, stat_title, stat_number] }
-      end
-
-      def published_components
-        @published_components ||= Component.where(participatory_space: participatory_process).published
+      def participatory_space_sym
+        :participatory_processes
       end
     end
   end

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_stats_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_stats_presenter.rb
@@ -6,17 +6,11 @@ module Decidim
     class ParticipatoryProcessStatsPresenter < Decidim::StatsPresenter
       include Decidim::IconHelper
 
-      def participatory_process
-        __getobj__.fetch(:participatory_process)
-      end
+      private
 
-      def participatory_space
-        participatory_process
-      end
+      def participatory_space = __getobj__.fetch(:participatory_process)
 
-      def participatory_space_sym
-        :participatory_processes
-      end
+      def participatory_space_sym = :participatory_processes
     end
   end
 end

--- a/decidim-participatory_processes/spec/presenters/decidim/participatory_processes/participatory_process_group_stats_presenter_spec.rb
+++ b/decidim-participatory_processes/spec/presenters/decidim/participatory_processes/participatory_process_group_stats_presenter_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ParticipatoryProcesses::ParticipatoryProcessGroupStatsPresenter do
+    subject { described_class.new(participatory_process_group:) }
+
+    let!(:organization) { create(:organization) }
+    let!(:user) { create(:user, :confirmed, organization:) }
+    let(:participatory_process_group) { create(:participatory_process_group, organization:) }
+
+    describe "#collection" do
+      let(:manifest) do
+        Decidim::ComponentManifest.new.tap do |manifest|
+          manifest.name = "Test"
+        end
+      end
+
+      before do
+        manifest.stats.register :foo, priority: StatsRegistry::HIGH_PRIORITY, &proc { 10 }
+        manifest.stats.register :bar, priority: StatsRegistry::HIGH_PRIORITY, &proc { 0 }
+
+        I18n.backend.store_translations(
+          :en,
+          decidim: {
+            participatory_processes: {
+              statistics: {
+                foo: "Foo",
+                bar: "Bar"
+              }
+            }
+          }
+        )
+
+        allow(Decidim).to receive(:component_manifests).and_return([manifest])
+      end
+
+      it "return a collection of stats including stats title and value" do
+        data = subject.collection.first
+        expect(data).not_to be_nil
+        expect(data).to have_key(:stat_title)
+        expect(data).to have_key(:stat_number)
+        expect(data[:stat_title]).to eq :foo
+        expect(data[:stat_number]).to eq 10
+      end
+
+      it "does not return 0 values" do
+        data = subject.collection.second
+        expect(data).to be_nil
+      end
+    end
+
+    describe "count stats from multiple components" do
+      let(:manifest_proposals) do
+        Decidim::ComponentManifest.new.tap do |manifest|
+          manifest.name = "proposals"
+        end
+      end
+
+      let(:manifest_meetings) do
+        Decidim::ComponentManifest.new.tap do |manifest|
+          manifest.name = "meetings"
+        end
+      end
+
+      before do
+        manifest_meetings.stats.register :comments_count, tag: :comments, &proc { 10 }
+        manifest_meetings.stats.register :endorsements_count, tag: :endorsements, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY, &proc { 5 }
+        manifest_proposals.stats.register :comments_count, tag: :comments, &proc { 5 }
+        manifest_proposals.stats.register :endorsements_count, tag: :endorsements, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY, &proc { 3 }
+
+        I18n.backend.store_translations(
+          :en,
+          decidim: {
+            participatory_processes: {
+              statistics: {
+                comments_count: "Comments",
+                endorsements_count: "Endorsements"
+              }
+            }
+          }
+        )
+
+        allow(Decidim).to receive(:component_manifests).and_return([manifest_meetings, manifest_proposals])
+      end
+
+      it "returns the sum of all the comments from proposals and meetings" do
+        data = subject.collection.find { |stat| stat[:stat_title] == :comments_count }
+        expect(data).not_to be_nil
+        expect(data[:stat_number]).to eq 15
+      end
+
+      it "returns the sum of all the endorsements from proposals and meetings" do
+        data = subject.collection.find { |stat| stat[:stat_title] == :endorsements_count }
+        expect(data).not_to be_nil
+        expect(data[:stat_number]).to eq 8
+      end
+
+      it "contains only two stats" do
+        expect(subject.collection.count).to be(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

CodeClimate found that the stats presenters were duplicated. This PR refactors them so they're no longer duplicated. 
 

#### :pushpin: Related Issues
 
- Related to #10383

#### Testing

All the CI should be green 

### :camera: Screenshots

From [Codeclimate](https://codeclimate.com/github/decidim/decidim/pull/10383): 

![Screenshot of Codeclimate alert](https://github.com/decidim/decidim/assets/717367/7f548c55-ce22-47ab-8447-c101c17263c9)

Mind that the link will expire in a couple of weeks. 

Also it's mentioning two locations but I found a couple more locations. 

:hearts: Thank you!
