### PR TITLE
Redesign: fix behavior with the send to technical validation button

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_buttons.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_buttons.scss
@@ -63,6 +63,7 @@
 
   &[disabled],
   &.disabled {
+    cursor: not-allowed;
     @apply text-gray-2 bg-background-3 border border-gray-2;
   }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_buttons.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_buttons.scss
@@ -63,8 +63,9 @@
 
   &[disabled],
   &.disabled {
-    cursor: not-allowed;
     @apply text-gray-2 bg-background-3 border border-gray-2;
+
+    cursor: not-allowed;
   }
 
   &.is-hover,

--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_buttons.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_buttons.scss
@@ -63,9 +63,7 @@
 
   &[disabled],
   &.disabled {
-    @apply text-gray-2 bg-background-3 border border-gray-2;
-
-    cursor: not-allowed;
+    @apply text-gray-2 bg-background-3 border border-gray-2 cursor-not-allowed;
   }
 
   &.is-hover,

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -437,6 +437,10 @@ module Decidim
       committee_members.approved.count >= minimum_committee_members
     end
 
+    def missing_committee_members
+      minimum_committee_members - committee_members.approved.count
+    end
+
     def component
       nil
     end

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_send_to_technical_validation.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_send_to_technical_validation.html.erb
@@ -4,5 +4,5 @@
               class: "button button__xl w-full button__secondary mt-4",
               data: { confirm: } %>
 <% else %>
-  <%= link_to title, "#", class: "button button__xl w-full button__secondary mt-4 disabled" %>
+  <%= link_to title, "#", class: "button button__xl w-full button__secondary mt-4 disabled", disabled: true %>
 <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -146,6 +146,17 @@ edit_link(
 
 <%= participatory_space_floating_help %>
 
+<% if current_initiative.created? %>
+  <% if allowed_to? :send_to_technical_validation, :initiative, initiative: current_initiative %>
+    <%= cell("decidim/announcement", t(".send_to_technical_validation_announcement"), callout_class: "success") %>
+  <% else %>
+    <%= cell("decidim/announcement", t(".before_send_to_technical_validation_announcement",
+                                       count: current_initiative.missing_committee_members,
+                                       href: link_to(new_initiative_committee_request_url(current_initiative),
+                                                     new_initiative_committee_request_path(current_initiative))), callout_class: "warning") %>
+  <% end %>
+<% end %>
+
 <% add_decidim_page_title(translated_attribute(current_initiative.title)) %>
 
 <section class="layout-main__section layout-main__heading">

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -528,11 +528,14 @@ en:
           initiative_rejected_reason: This initiative has been rejected due to its lack of signatures.
         show:
           area: Area
+          before_send_to_technical_validation_announcement: "Before sending your initiative for technical validation, you need to add %{count} more members to the promoter
+            committee.<br/><br/>Share this link with the people you want to be part of your committee: %{href}"
           confirm: You are going to send the initiative for an admin to review it and publish it. Once published you will not be able to edit it. Are you sure?
           edit: Edit
           initiative_data: Initiative data
           scope: Scope
           send_to_technical_validation: Send to technical validation
+          send_to_technical_validation_announcement: If everything looks ok, click on "Send to technical validation" for an administrator to review and publish your initiative
           signature_collection: Signature collection
           state: State
           type: Type

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -528,8 +528,7 @@ en:
           initiative_rejected_reason: This initiative has been rejected due to its lack of signatures.
         show:
           area: Area
-          before_send_to_technical_validation_announcement: "Before sending your initiative for technical validation, you need to add %{count} more members to the promoter
-            committee.<br/><br/>Share this link with the people you want to be part of your committee: %{href}"
+          before_send_to_technical_validation_announcement: 'Before sending your initiative for technical validation, you need to add %{count} more members to the promoter committee.<br/><br/>Share this link with the people you want to be part of your committee: %{href}'
           confirm: You are going to send the initiative for an admin to review it and publish it. Once published you will not be able to edit it. Are you sure?
           edit: Edit
           initiative_data: Initiative data

--- a/decidim-initiatives/spec/models/decidim/initiative_spec.rb
+++ b/decidim-initiatives/spec/models/decidim/initiative_spec.rb
@@ -264,6 +264,31 @@ module Decidim
       end
     end
 
+    describe "#missing_committee_members" do
+      subject { initiative.missing_committee_members }
+
+      let(:initiatives_type_minimum_committee_members) { 2 }
+      let(:initiative) { create(:initiative, organization:, scoped_type:) }
+
+      before { initiative.committee_members.destroy_all }
+
+      context "when all missing members" do
+        it { is_expected.to be 2 }
+      end
+
+      context "when one missing member" do
+        before { create(:initiatives_committee_member, initiative:) }
+
+        it { is_expected.to be 1 }
+      end
+
+      context "when no missing members" do
+        before { create_list(:initiatives_committee_member, initiatives_type_minimum_committee_members, initiative:) }
+
+        it { is_expected.to be 0 }
+      end
+    end
+
     describe "sorting" do
       subject(:sorter) { described_class.ransack("s" => "supports_count desc") }
 

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -130,6 +130,70 @@ describe "Initiative", type: :system do
           expect(page).not_to have_content("0 comments")
         end
       end
+
+      context "when I am the author of the initiative" do
+        before do
+          sign_in initiative.author
+          visit decidim_initiatives.initiative_path(initiative)
+        end
+
+        shared_examples_for "initiative does not show send to technical validation" do
+          it { expect(page).not_to have_link("Send to technical validation") }
+        end
+
+        shared_examples_for "initiative shows send to technical validation disabled" do
+          it { expect(page).to have_link("Send to technical validation", href: "#") }
+        end
+
+        context "when initiative state is created" do
+          let(:state) { :created }
+
+          context "when the user cannot send the initiative to technical validation" do
+            before do
+              initiative.committee_members.destroy_all
+              visit decidim_initiatives.initiative_path(initiative)
+            end
+
+            it_behaves_like "initiative shows send to technical validation disabled"
+            it { expect(page).to have_content("Before sending your initiative for technical validation") }
+          end
+
+          context "when the user can send the initiative to technical validation" do
+            it { expect(page).to have_link("Send to technical validation", href: decidim_initiatives.send_to_technical_validation_initiative_path(initiative)) }
+            it { expect(page).to have_content('If everything looks ok, click on "Send to technical validation" for an administrator to review and publish your initiative') }
+          end
+        end
+
+        context "when initiative state is validating" do
+          let(:state) { :validating }
+
+          it_behaves_like "initiative shows send to technical validation disabled"
+        end
+
+        context "when initiative state is discarded" do
+          let(:state) { :discarded }
+
+          it_behaves_like "initiative does not show send to technical validation"
+        end
+
+        context "when initiative state is published" do
+          let(:state) { :published }
+
+          it_behaves_like "initiative does not show send to technical validation"
+        end
+
+        context "when initiative state is rejected" do
+          let(:state) { :rejected }
+
+          it_behaves_like "initiative does not show send to technical validation"
+        end
+
+        context "when initiative state is accepted" do
+          let(:state) { :accepted }
+
+          it_behaves_like "initiative does not show send to technical validation"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
- Show the "Send to technical validation" button disabled if the action cannot be performed.
- Include an announcement when the state of the initiative is "created". If you can send it to technical validation, the announcement is green and says you can perform the action. Otherwise, the announcement is yellow and explains the next steps you should follow.

#### :pushpin: Related Issues
- Fixes #11350 

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
<img width="1332" alt="Screenshot 2023-08-30 at 17 44 35" src="https://github.com/decidim/decidim/assets/6973564/d273b25d-6e0a-40f1-b051-1cc262c3faf8">

<img width="1333" alt="Screenshot 2023-08-30 at 17 49 07" src="https://github.com/decidim/decidim/assets/6973564/d1e3a07e-fbe7-4b32-9e8a-7d9c052d716a">

:hearts: Thank you!
