### PR TITLE
Fix flaky spec for mobile version of the search form

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_cookies.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_cookies.scss
@@ -5,7 +5,7 @@
     @apply fixed bottom-0 z-50 bg-white w-full shadow-[0_-4px_6px_rgba(211,211,211,0.25)];
 
     animation-name: slideInUp;
-    animation-duration: 500ms;
+    animation-duration: 50ms;
 
     @keyframes slideInUp {
       from {


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

This past week I saw a couple of times a flaky spec related to the mobile search. 

See [example in CI](https://github.com/decidim/decidim/actions/runs/6034245108/job/16372407595?pr=11551). As this will expire in a couple days, here's the relevant output:

> Failures:
> 
>   1) Search when the device is a mobile shows the mobile version of the search form
>      Failure/Error: click_button(id: "dropdown-trigger-links-mobile-search")
> 
>      Selenium::WebDriver::Error::ElementClickInterceptedError:
>        element click intercepted: Element <button id="dropdown-trigger-links-mobile-search" class="main-bar__links-mobile__item" data-component="dropdown" data-target="dropdown-menu-search-mobile" data-autofocus="input-search-mobile" aria-haspopup="true" aria-controls="dropdown-menu-search-mobile">...</button> is not clickable at point (144, 630). Other element would receive the click: <button id="dc-modal-accept" class="button button__sm md:button__lg button__transparent-secondary" data-dialog-close="dc-modal">...</button>
>          (Session info: headless chrome=116.0.5845.96)
> 
>      [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_search_when_the_device_is_a_mobile_shows_the_mobile_version_of_the_search_form_844.png
> 
>      [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_search_when_the_device_is_a_mobile_shows_the_mobile_version_of_the_search_form_844.html
> 
> 
> 
> Failed examples:
> 
> rspec ./spec/system/search_spec.rb:43 # Search when the device is a mobile shows the mobile version of the search form
> 

And this is what the screenshot is giving us:

![failures_r_spec_example_groups_search_when_the_device_is_a_mobile_shows_the_mobile_version_of_the_search_form_844](https://github.com/decidim/decidim/assets/717367/bbd23bce-6622-4473-99d5-30036f510f2d)

Seeing the relevant lines of the spec itself:

https://github.com/decidim/decidim/blob/8449f4157a244493512457395d873303706c6424/decidim-core/spec/system/search_spec.rb#L39-L40

My hypothesis on what's happening is the following:

1. The page is loading
2. Sometimes the browser is slow and the animation for the cookie banner takes a bit more than usual
3. Due to the animation, Capybara clicks wrongly on the "Settings" button instead of "Accept all", so instead of closing the cookie banner it opens the the modal.

#### Testing

As this is a flaky, it's difficult to test. I found two strategies for now. In both strategies you should check the failure first in `develop` and then you should apply this PR and run it again to see that it doesn't fail anymore. 

#### Slow strategy

In a bash shell:
```bash
for i in $(seq 1 500); do bin/rspec decidim-core/spec/system/search_spec.rb   || break; done
```

#### Fast strategy

I'm still working on refining a bit this one, but it's using the same sequential approach with also a parallel one 🚀. 

Steps to follow:

1. With a [working parallel_tests set-up](https://docs.decidim.org/en/develop/develop/testing#_running_specs_in_parallel), so:
```bash
cd spec/decidim_dummy_app/
bundle exec rake parallel:create
bundle exec rake parallel:prepare
cd -
```
2. Apply the following patch
```diff
diff --git a/decidim-core/spec/system/search_spec.rb b/decidim-core/spec/system/search_spec.rb
index abde92a5ba..ec587f8562 100644
--- a/decidim-core/spec/system/search_spec.rb
+++ b/decidim-core/spec/system/search_spec.rb
@@ -40,8 +40,10 @@ describe "Search", type: :system do
       click_button(id: "dropdown-trigger-links-mobile-search")
     end
 
-    it "shows the mobile version of the search form" do
-      expect(page).to have_css("#input-search-mobile")
+    1000.times do
+      it "shows the mobile version of the search form" do
+        expect(page).to have_css("#input-search-mobile")
+      end
     end
   end
 end

```
3. Run the spec with parallel_spec. It's important to do it with the --exec option, as if we don't do it like this it will try to run it in 1 process. 
```bash
cd decidim-core
RAILS_ENV=test bundle exec parallel_test --exec "bundle exec rspec spec/system/search_spec.rb"
```
What I could not find the way (for now) is to stop in a failing spec, so you need to check out the output to see if there's a FAILED spec manually 😞 

:hearts: Thank you!
