### PR TITLE
Remove duplication for add questions specs examples

### DIFF
--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
@@ -4,32 +4,34 @@ require "spec_helper"
 
 shared_examples_for "add questions" do
   shared_examples_for "updating the max choices selector according to the configured options" do
-    expect(page).not_to have_select("Maximum number of choices")
+    it "updates them" do
+      expect(page).not_to have_select("Maximum number of choices")
 
-    select "Multiple option", from: "Type"
-    expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
-
-    click_button "Add answer option"
-    expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3))
-
-    click_button "Add answer option"
-    expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3 4))
-
-    within(".questionnaire-question-answer-option:last-of-type") { click_button "Remove" }
-    expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3))
-
-    within(".questionnaire-question-answer-option:last-of-type") { click_button "Remove" }
-    expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
-
-    click_button "Add question"
-    expand_all_questions
-
-    within(".questionnaire-question:last-of-type") do
-      select multiple_option_string, from: "Type"
+      select "Multiple option", from: "Type"
       expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
 
-      select single_option_string, from: "Type"
-      expect(page).not_to have_select("Maximum number of choices")
+      click_button "Add answer option"
+      expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3))
+
+      click_button "Add answer option"
+      expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3 4))
+
+      within(".questionnaire-question-answer-option:last-of-type") { click_button "Remove" }
+      expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3))
+
+      within(".questionnaire-question-answer-option:last-of-type") { click_button "Remove" }
+      expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
+
+      click_button "Add question"
+      expand_all_questions
+
+      within(".questionnaire-question:last-of-type") do
+        select multiple_option_string, from: "Type"
+        expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
+
+        select single_option_string, from: "Type"
+        expect(page).not_to have_select("Maximum number of choices")
+      end
     end
   end
 

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 shared_examples_for "add questions" do
-  shared_example_for "updating the max choices selector according to the configured options" do
+  shared_examples_for "updating the max choices selector according to the configured options" do
     expect(page).not_to have_select("Maximum number of choices")
 
     select "Multiple option", from: "Type"

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
@@ -3,6 +3,36 @@
 require "spec_helper"
 
 shared_examples_for "add questions" do
+  shared_example_for "updating the max choices selector according to the configured options" do
+    expect(page).not_to have_select("Maximum number of choices")
+
+    select "Multiple option", from: "Type"
+    expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
+
+    click_button "Add answer option"
+    expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3))
+
+    click_button "Add answer option"
+    expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3 4))
+
+    within(".questionnaire-question-answer-option:last-of-type") { click_button "Remove" }
+    expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3))
+
+    within(".questionnaire-question-answer-option:last-of-type") { click_button "Remove" }
+    expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
+
+    click_button "Add question"
+    expand_all_questions
+
+    within(".questionnaire-question:last-of-type") do
+      select multiple_option_string, from: "Type"
+      expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
+
+      select single_option_string, from: "Type"
+      expect(page).not_to have_select("Maximum number of choices")
+    end
+  end
+
   it "adds a few questions and separators to the questionnaire" do
     fields_body = ["This is the first question", "This is the second question", "This is the first title and description"]
 
@@ -369,6 +399,9 @@ shared_examples_for "add questions" do
   end
 
   context "when adding a multiple option question" do
+    let(:multiple_option_string) { "Multiple option" }
+    let(:single_option_string) { "Single option" }
+
     before do
       visit questionnaire_edit_path
 
@@ -399,38 +432,13 @@ shared_examples_for "add questions" do
       expect(page).to have_selector("input[type=checkbox][id$=_free_text]")
     end
 
-    it "updates the max choices selector according to the configured options" do
-      expect(page).not_to have_select("Maximum number of choices")
-
-      select "Multiple option", from: "Type"
-      expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
-
-      click_button "Add answer option"
-      expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3))
-
-      click_button "Add answer option"
-      expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3 4))
-
-      within(".questionnaire-question-answer-option:last-of-type") { click_button "Remove" }
-      expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3))
-
-      within(".questionnaire-question-answer-option:last-of-type") { click_button "Remove" }
-      expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
-
-      click_button "Add question"
-      expand_all_questions
-
-      within(".questionnaire-question:last-of-type") do
-        select "Multiple option", from: "Type"
-        expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
-
-        select "Single option", from: "Type"
-        expect(page).not_to have_select("Maximum number of choices")
-      end
-    end
+    it_behaves_like "updating the max choices selector according to the configured options"
   end
 
   context "when adding a matrix question" do
+    let(:multiple_option_string) { "Matrix (Multiple option)" }
+    let(:single_option_string) { "Matrix (Single option)" }
+
     before do
       visit questionnaire_edit_path
 
@@ -461,34 +469,6 @@ shared_examples_for "add questions" do
       expect(page).to have_selector("input[type=checkbox][id$=_free_text]")
     end
 
-    it "updates the max choices selector according to the configured options" do
-      expect(page).not_to have_select("Maximum number of choices")
-
-      select "Matrix (Multiple option)", from: "Type"
-      expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
-
-      click_button "Add answer option"
-      expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3))
-
-      click_button "Add answer option"
-      expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3 4))
-
-      within(".questionnaire-question-answer-option:last-of-type") { click_button "Remove" }
-      expect(page).to have_select("Maximum number of choices", options: %w(Any 2 3))
-
-      within(".questionnaire-question-answer-option:last-of-type") { click_button "Remove" }
-      expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
-
-      click_button "Add question"
-      expand_all_questions
-
-      within(".questionnaire-question:last-of-type") do
-        select "Matrix (Multiple option)", from: "Type"
-        expect(page).to have_select("Maximum number of choices", options: %w(Any 2))
-
-        select "Matrix (Single option)", from: "Type"
-        expect(page).not_to have_select("Maximum number of choices")
-      end
-    end
+    it_behaves_like "updating the max choices selector according to the configured options"
   end
 end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

CodeClimate found that there was some duplication in the "add questions" spec example. This PR refactors it so it's no longer duplicated. 
 
#### :pushpin: Related Issues
 
- Related to #10383

#### Testing

All the CI should be green 

### :camera: Screenshots

From [Codeclimate](https://codeclimate.com/github/decidim/decidim/pull/10383): 

![Screenshot of Codeclimate alert](https://github.com/decidim/decidim/assets/717367/57ef8fd6-a34f-4768-94a7-0568d514d503)


Mind that the link will expire in a couple of weeks. 

:hearts: Thank you!
