### PR TITLE
Log in users automatically after confirmation

### DIFF
--- a/decidim-core/app/controllers/decidim/devise/confirmations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/confirmations_controller.rb
@@ -31,6 +31,8 @@ module Decidim
       def after_confirmation_path_for(resource_name, resource)
         return profile_path(resource.nickname) if resource_name == :user_group
 
+        sign_in(resource)
+
         super
       end
     end

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -262,13 +262,18 @@ describe "Authentication", type: :system do
   end
 
   describe "Confirm email" do
-    it "confirms the user" do
+    it "confirms and logs in the user" do
       perform_enqueued_jobs { create(:user, organization:) }
 
       visit last_email_link
 
       expect(page).to have_content("successfully confirmed")
       expect(last_user).to be_confirmed
+
+      within_user_menu do
+        expect(page).to have_content("My account")
+        expect(page).to have_content("Sign out")
+      end
     end
   end
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While working in the Bug Squash Party, I detected that we could improve the user registration flow a bit by automatically logging in to participants once they have confirmed.

#### :pushpin: Related Issues
 
- Closes  #11278

#### Testing

1. Register a new account
2. Confirm the email

### :camera: Screenshots

![Screenshot of the notification after the confirmation with the participant already logged in](https://github.com/decidim/decidim/assets/717367/c4323358-90ee-4af8-b693-6021732813f5)



:hearts: Thank you!
