### PR TITLE
Fix JS exception on Votings admin

### DIFF
--- a/decidim-elections/app/packs/src/decidim/votings/admin/polling_stations_form.js
+++ b/decidim-elections/app/packs/src/decidim/votings/admin/polling_stations_form.js
@@ -2,5 +2,8 @@ import attachGeocoding from "src/decidim/geocoding/attach_input"
 
 $(() => {
   const $form = $(".edit_polling_station, .new_polling_station");
-  attachGeocoding($form.find("#polling_station_address"));
+
+  if ($form.length > 0) {
+    attachGeocoding($form.find("#polling_station_address"));
+  }
 })


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While working on #11548, I found out an exception in the Votings space admin. This PR fixes it. 

It's related to the change in the webpack entrypoints and the redesign so it doesn't need to be backported. 

The exception is:


> Uncaught TypeError: e.attr(...) is undefined
>     l attach_input.js:63
>     <anonymous> polling_stations_form.js:4
>     jQuery 13
>     Webpack 9

#### :pushpin: Related Issues
 
- Related to #11548

#### Testing


1. Sign in as admin
2. Go to the admin dashboard -> Votings -> Select a voting of type "Hybrid" 
3. Go to Monitoring Committee - Members section in the sidebar
4. See exception in the JS console of the web development tools 

### :camera: Screenshots

![Screenshot of the web development tools console](https://github.com/decidim/decidim/assets/717367/47df7a41-3cfd-4006-ba05-405ce5b885b1)

:hearts: Thank you!
