### PR TITLE
Add spec for fixed empty pagination on Activities' moderated resources

### DIFF
--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -151,6 +151,21 @@ describe "Last activity", type: :system do
           expect(page).to have_content "There are no entries to show for this activity type."
         end
       end
+
+      context "when there are lots of moderated resources" do
+        before do
+          100.times.each do
+            comment = create(:comment)
+            create(:action_log, action: "create", visibility: "all", resource: comment, organization:)
+            create(:moderation, reportable: comment, hidden_at: 1.day.ago)
+          end
+          visit current_path
+        end
+
+        it "works without an empty pagination" do
+          expect(page).to have_css("[data-activity]", count: 3)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

Basically, on #10385 we have fixed the last activities pagination when there are lots of moderated resources in the same page.

This PR adds a spec for this case.

#### :pushpin: Related Issues
 
- Fixes #11146
- Related to #10385

#### Testing

As @alecslupu mentioned, this was fixed in v0.27 and it's (for now) pending to be backported to v0.26. So, the best way of checking this out is to manually backport this to v0.26 and see the failing spec. 


1. Checkout 0.26 branch and recreate `test_app`:
```bash
git checkout release/0.26-stable
bin/rake test_app
```
2. Manually add this block (equivalent code from this PR but for this older version of decidim):
```diff
diff --git a/decidim-core/spec/system/last_activity_spec.rb b/decidim-core/spec/system/last_activity_spec.rb
index 0a38deb74e..61b87164cd 100644
--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -150,6 +150,21 @@ describe "Last activity", type: :system do
           expect(page).to have_css(".card--activity", count: 0)
         end
       end
+
+      context "when there are lots of moderated resources" do
+        before do
+          100.times.each do
+            comment = create(:comment)
+            create(:action_log, action: "create", visibility: "all", resource: comment, organization: organization)
+            create(:moderation, reportable: comment, hidden_at: 1.day.ago)
+          end
+          visit current_path
+        end
+
+        it "works without an empty pagination" do
+          expect(page).to have_css(".card--activity", count: 3)
+        end
+      end
     end
   end
 end
```
3. Run the specs
```
bin/rspec decidim-core/spec/system/last_activity_spec.rb
```

See that this fails (screenshot below). 
And also you can check these same steps but on release/0.27-stable to see that this was indeed solved

### :camera: Screenshots

This is the screenshot from the failing spec on v0.26: 

![Screenshot from failing spec](https://github.com/decidim/decidim/assets/717367/34fb23bb-2c94-4f24-bed7-833de06ef01a)

:hearts: Thank you!
