### PR TITLE
Add title in arrows while navigating meetings

### DIFF
--- a/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
+++ b/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
@@ -8,16 +8,16 @@
     <% end %>
 
     <% if local_assigns.has_key?(:prev_path) %>
-      <%= link_to prev_path, class: "layout-item__arrow prev" do %>
+      <%= link_to prev_path, class: "layout-item__arrow prev", title: t(".prev") do %>
         <%= icon "arrow-left-s-line" %>
-        <span class="sr-only">prev item</span>
+        <span class="sr-only">%<%= t(".prev") %></span>
       <% end %>
     <% end %>
 
     <% if local_assigns.has_key?(:next_path) %>
-      <%= link_to next_path, class: "layout-item__arrow next" do %>
+      <%= link_to next_path, class: "layout-item__arrow next", title: t(".next") do %>
         <%= icon "arrow-right-s-line" %>
-        <span class="sr-only">next item</span>
+        <span class="sr-only"><%= t(".next") %></span>
       <% end %>
     <% end %>
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1928,8 +1928,8 @@ en:
         cache_version_page: Oooops! Your network is offline. This is a previously cached version of the page you are visiting, perhaps the content is not up to date.
       shared:
         layout_item:
-          next: "next item"
-          prev: "previous item"
+          next: Next item
+          prev: Previous item
       social_media_links:
         facebook: "%{organization} at Facebook"
         github: "%{organization} at GitHub"

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1926,6 +1926,10 @@ en:
         mark_as_read: Mark as read
       offline_banner:
         cache_version_page: Oooops! Your network is offline. This is a previously cached version of the page you are visiting, perhaps the content is not up to date.
+      shared:
+        layout_item:
+          next: "next item"
+          prev: "previous item"
       social_media_links:
         facebook: "%{organization} at Facebook"
         github: "%{organization} at GitHub"


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

Arrows navigation in Meetings don't have any kind of help. This PR adds a title for these icons so it's visible while hovering. 

#### :pushpin: Related Issues
 
- Fixes #11340

#### Testing

1. Go to a meeting
2. Hover in these arrows

### :camera: Screenshots
 

![Screenshot of the arrow hovered with the title "previous item"](https://github.com/decidim/decidim/assets/717367/4600e41b-0817-48a5-b70a-88d76f59756e)


:hearts: Thank you!
