### PR TITLE
Add follow button to the participatory spaces menu bar

### DIFF
--- a/decidim-assemblies/app/views/layouts/decidim/assembly.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/assembly.html.erb
@@ -8,6 +8,10 @@
 <%= append_javascript_pack_tag "decidim_assemblies" %>
 <%= append_stylesheet_pack_tag "decidim_assemblies", media: "all" %>
 
+<%= content_for :participatory_space_actions do %>
+  <%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
+<% end %>
+
 <%= render "layouts/decidim/application" do %>
   <main>
     <%= yield %>

--- a/decidim-assemblies/app/views/layouts/decidim/assembly.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/assembly.html.erb
@@ -8,9 +8,7 @@
 <%= append_javascript_pack_tag "decidim_assemblies" %>
 <%= append_stylesheet_pack_tag "decidim_assemblies", media: "all" %>
 
-<%= content_for :participatory_space_actions do %>
-  <%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
-<% end %>
+<%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
 
 <%= render "layouts/decidim/application" do %>
   <main>

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -166,6 +166,14 @@ describe "Assemblies", type: :system do
         visit decidim_assemblies.assembly_path(assembly)
       end
 
+      describe "follow button" do
+        let!(:user) { create(:user, :confirmed, organization:) }
+        let(:followable) { assembly }
+        let(:followable_path) { decidim_assemblies.assembly_path(assembly) }
+
+        include_examples "follows"
+      end
+
       context "when hero, main_data extra_data, metadata and dates_metadata blocks are enabled" do
         let(:blocks_manifests) { [:hero, :main_data, :extra_data, :metadata, :dates_metadata] }
 
@@ -218,15 +226,6 @@ describe "Assemblies", type: :system do
         it_behaves_like "has attachments content blocks" do
           let(:attached_to) { assembly }
         end
-      end
-
-      context "when last activities block enabled" do
-        let!(:user) { create(:user, :confirmed, organization:) }
-        let(:blocks_manifests) { [:last_activity] }
-        let(:followable) { assembly }
-        let(:followable_path) { decidim_assemblies.assembly_path(assembly) }
-
-        include_examples "follows"
       end
 
       context "when having rich content" do

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -220,6 +220,15 @@ describe "Assemblies", type: :system do
         end
       end
 
+      context "when last activities block enabled" do
+        let!(:user) { create(:user, :confirmed, organization:) }
+        let(:blocks_manifests) { [:last_activity] }
+        let(:followable) { assembly }
+        let(:followable_path) { decidim_assemblies.assembly_path(assembly) }
+
+        include_examples "follows"
+      end
+
       context "when having rich content" do
         let(:blocks_manifests) { [:hero, :main_data, :metadata] }
 

--- a/decidim-budgets/spec/system/follow_projects_spec.rb
+++ b/decidim-budgets/spec/system/follow_projects_spec.rb
@@ -12,5 +12,5 @@ describe "Follow projects", type: :system do
 
   let(:followable_path) { resource_locator([budget, followable]).path }
 
-  include_examples "follows"
+  include_examples "follows with a component"
 end

--- a/decidim-conferences/app/views/layouts/decidim/conference.html.erb
+++ b/decidim-conferences/app/views/layouts/decidim/conference.html.erb
@@ -8,6 +8,10 @@
 <%= append_javascript_pack_tag "decidim_conferences" %>
 <%= append_stylesheet_pack_tag "decidim_conferences" %>
 
+<%= content_for :participatory_space_actions do %>
+  <%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
+<% end %>
+
 <%= render "layouts/decidim/application" do %>
   <%= yield %>
 <% end %>

--- a/decidim-conferences/app/views/layouts/decidim/conference.html.erb
+++ b/decidim-conferences/app/views/layouts/decidim/conference.html.erb
@@ -8,9 +8,7 @@
 <%= append_javascript_pack_tag "decidim_conferences" %>
 <%= append_stylesheet_pack_tag "decidim_conferences" %>
 
-<%= content_for :participatory_space_actions do %>
-  <%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
-<% end %>
+<%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
 
 <%= render "layouts/decidim/application" do %>
   <%= yield %>

--- a/decidim-conferences/spec/system/conferences_spec.rb
+++ b/decidim-conferences/spec/system/conferences_spec.rb
@@ -141,6 +141,14 @@ describe "Conferences", type: :system do
       visit decidim_conferences.conference_path(conference)
     end
 
+    describe "follow button" do
+      let!(:user) { create(:user, :confirmed, organization:) }
+      let(:followable) { conference }
+      let(:followable_path) { decidim_conferences.conference_path(conference) }
+
+      include_examples "follows"
+    end
+
     describe "conference venues" do
       before do
         meetings.empty?

--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_last_activity/content.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_last_activity/content.erb
@@ -4,9 +4,6 @@
     <%= render_recent_avatars %>
   </div>
   <div class="label text-lg"><%= participants_count %></div>
-  <div class="ml-auto">
-    <%= cell("decidim/follow_button", resource) %>
-  </div>
 </div>
 
 <div class="space-y-4">

--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_last_activity/content.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_last_activity/content.erb
@@ -4,6 +4,9 @@
     <%= render_recent_avatars %>
   </div>
   <div class="label text-lg"><%= participants_count %></div>
+  <div class="ml-auto">
+    <%= cell("decidim/follow_button", resource) %>
+  </div>
 </div>
 
 <div class="space-y-4">

--- a/decidim-core/app/cells/decidim/follow_button/show.erb
+++ b/decidim-core/app/cells/decidim/follow_button/show.erb
@@ -5,7 +5,7 @@
         title: text,
         method:,
         remote:,
-        id: dom_id(model, :follow)
+        id: dom_id(model, id_option)
       ) do %>
     <%= render :content %>
   <% end %>
@@ -18,7 +18,7 @@
         title: t("decidim.shared.follow_button.log_in_before_follow"),
         params: req_params,
         'aria-haspopup': true,
-        id: dom_id(model, :follow)
+        id: dom_id(model, id_option)
       ) do %>
     <%= render :content %>
   <% end %>

--- a/decidim-core/app/cells/decidim/follow_button_cell.rb
+++ b/decidim-core/app/cells/decidim/follow_button_cell.rb
@@ -17,6 +17,10 @@ module Decidim
       end
     end
 
+    def id_option
+      @id_option ||= options[:mobile] ? "follow-mobile" : "follow"
+    end
+
     private
 
     def button_classes

--- a/decidim-core/app/controllers/decidim/follows_controller.rb
+++ b/decidim-core/app/controllers/decidim/follows_controller.rb
@@ -4,7 +4,7 @@ module Decidim
   class FollowsController < Decidim::ApplicationController
     include FormFactory
     before_action :authenticate_user!
-    helper_method :resource, :button_cell
+    helper_method :resource, :button_cell, :button_cell_mobile
 
     def destroy
       @form = form(Decidim::FollowForm).from_params(params)
@@ -46,6 +46,10 @@ module Decidim
       # REDESIGN_PENDING - After removing the old follow button the inline
       # param should also be removed
       params.require(:follow).permit(:button_classes, :inline).to_h.symbolize_keys
+    end
+
+    def button_cell_mobile
+      @button_cell_mobile ||= cell("decidim/follow_button", resource, **button_options.merge(mobile: true))
     end
 
     def button_cell

--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_header.scss
@@ -326,7 +326,7 @@ header {
       }
 
       [data-target*="dropdown"] {
-        @apply md:block lg:hidden w-auto last-of-type:[&>svg]:block;
+        @apply md:block lg:hidden w-auto last-of-type:[&>svg]:block ml-auto;
 
         > svg {
           @apply text-white;
@@ -336,6 +336,10 @@ header {
 
     &__actions {
       @apply hidden lg:flex justify-between items-center gap-6;
+
+      &-mobile {
+        @apply [&_svg]:w-4 [&_svg]:h-4 [&_span]:sr-only;
+      }
     }
 
     &__main-dropdown {

--- a/decidim-core/app/views/decidim/follows/update_button.js.erb
+++ b/decidim-core/app/views/decidim/follows/update_button.js.erb
@@ -1,7 +1,9 @@
 var $followResource = $("#<%= dom_id(resource, :follow) %>");
+var $followResourceMobile = $("#<%= dom_id(resource, "follow-mobile") %>");
 var $followersCount = $("#<%= dom_id(resource, :followers_count) %>");
 
 morphdom($followResource[0], "<%= j(button_cell.to_s.strip.html_safe) %>");
+morphdom($followResourceMobile[0], "<%= j(button_cell_mobile.to_s.strip.html_safe) %>");
 
 if ($followersCount.length > 0) {
   $followersCount[0].innerText = <%= button_cell.followers_count %>

--- a/decidim-core/app/views/layouts/decidim/header/_follow_space_menu_bar_button.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_follow_space_menu_bar_button.html.erb
@@ -1,1 +1,7 @@
-<%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent") %>
+<%= content_for :participatory_space_actions do %>
+  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent") %>
+<% end %>
+
+<%= content_for :participatory_space_mobile_actions do %>
+  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent", mobile: true) %>
+<% end %>

--- a/decidim-core/app/views/layouts/decidim/header/_follow_space_menu_bar_button.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_follow_space_menu_bar_button.html.erb
@@ -1,0 +1,1 @@
+<%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent") %>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
@@ -21,7 +21,7 @@
     </button>
   <% end %>
   <% if content_for?(:participatory_space_mobile_actions) %>
-    <div>
+    <div class="menu-bar__actions-mobile">
       <%= content_for :participatory_space_mobile_actions %>
     </div>
   <% end %>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
@@ -20,6 +20,11 @@
       <%= icon "arrow-down-s-line", class: "flex-none w-6 h-6 fill-current" %>
     </button>
   <% end %>
+  <% if content_for?(:participatory_space_mobile_actions) %>
+    <div>
+      <%= content_for :participatory_space_mobile_actions %>
+    </div>
+  <% end %>
 </div>
 <% if dropdown_item.present? %>
   <div id="secondary-dropdown-menu-mobile" aria-hidden="true">

--- a/decidim-core/lib/decidim/core/test/shared_examples/follows_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/follows_examples.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 shared_examples "follows" do
-  include_context "with a component"
-
   before do
     login_as user, scope: :user
   end
@@ -34,6 +32,11 @@ shared_examples "follows" do
       end
     end
   end
+end
+
+shared_examples "follows with a component" do
+  include_context "with a component"
+  include_examples "follows"
 
   context "when the user is following the followable's participatory space" do
     before do

--- a/decidim-debates/spec/system/follow_debate_spec.rb
+++ b/decidim-debates/spec/system/follow_debate_spec.rb
@@ -11,5 +11,5 @@ describe "Follow debates", type: :system do
 
   let(:followable_path) { resource_locator(followable).path }
 
-  include_examples "follows"
+  include_examples "follows with a component"
 end

--- a/decidim-elections/app/views/layouts/decidim/votings.html.erb
+++ b/decidim-elections/app/views/layouts/decidim/votings.html.erb
@@ -1,9 +1,7 @@
 <%= append_javascript_pack_tag "decidim_votings" %>
 <%= append_stylesheet_pack_tag "decidim_votings" %>
 
-<%= content_for :participatory_space_actions do %>
-  <%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
-<% end %>
+<%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
 
 <%= render "layouts/decidim/application" do %>
   <%= cell "decidim/translation_bar", current_organization %>

--- a/decidim-elections/app/views/layouts/decidim/votings.html.erb
+++ b/decidim-elections/app/views/layouts/decidim/votings.html.erb
@@ -1,6 +1,10 @@
 <%= append_javascript_pack_tag "decidim_votings" %>
 <%= append_stylesheet_pack_tag "decidim_votings" %>
 
+<%= content_for :participatory_space_actions do %>
+  <%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
+<% end %>
+
 <%= render "layouts/decidim/application" do %>
   <%= cell "decidim/translation_bar", current_organization %>
 

--- a/decidim-elections/spec/system/voting_spec.rb
+++ b/decidim-elections/spec/system/voting_spec.rb
@@ -25,6 +25,13 @@ describe "Voting", type: :system do
       expect(page).to have_i18n_content(voting.description)
     end
 
+    describe "follow button" do
+      let(:followable) { voting }
+      let(:followable_path) { decidim_votings.voting_path(voting) }
+
+      include_examples "follows"
+    end
+
     it_behaves_like "has embedded video in description", :description do
       before do
         voting.update!(description:)

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -205,9 +205,6 @@ edit_link(
   <% end %>
   <div class="ml-auto">
     <%= cell "decidim/share_button", nil %>
-    <% if current_user %>
-      <%= render partial: "decidim/shared/follow_button", class: "text-center", locals: { followable: current_participatory_space, large: true } %>
-    <% end %>
   </div>
 </section>
 

--- a/decidim-initiatives/app/views/layouts/decidim/initiative_head.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/initiative_head.html.erb
@@ -3,6 +3,10 @@
 
 <% provide :meta_image_url, current_initiative.type.attached_uploader(:banner_image).path %>
 
+<%= content_for :participatory_space_actions do %>
+  <%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
+<% end %>
+
 <%= render "layouts/decidim/application" do %>
   <%= render partial: "decidim/initiatives/initiatives/initiative_hero" %>
   <%= render layout:"layouts/decidim/shared/layout_two_col", locals: { reverse: true, main_enabled: false } do %>

--- a/decidim-initiatives/app/views/layouts/decidim/initiative_head.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/initiative_head.html.erb
@@ -3,9 +3,7 @@
 
 <% provide :meta_image_url, current_initiative.type.attached_uploader(:banner_image).path %>
 
-<%= content_for :participatory_space_actions do %>
-  <%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
-<% end %>
+<%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
 
 <%= render "layouts/decidim/application" do %>
   <%= render partial: "decidim/initiatives/initiatives/initiative_hero" %>

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -56,6 +56,14 @@ describe "Initiative", type: :system do
         end
       end
 
+      describe "follow button" do
+        let!(:user) { create(:user, :confirmed, organization:) }
+        let(:followable) { initiative }
+        let(:followable_path) { decidim_initiatives.initiative_path(initiative) }
+
+        include_examples "follows"
+      end
+
       context "when signature interval is defined" do
         let(:base_initiative) do
           create(:initiative,

--- a/decidim-meetings/spec/system/follow_meetings_spec.rb
+++ b/decidim-meetings/spec/system/follow_meetings_spec.rb
@@ -11,5 +11,5 @@ describe "Follow meetings", type: :system do
 
   let(:followable_path) { resource_locator(followable).path }
 
-  include_examples "follows"
+  include_examples "follows with a component"
 end

--- a/decidim-participatory_processes/app/views/layouts/decidim/participatory_process.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/participatory_process.html.erb
@@ -8,6 +8,10 @@
 <%= append_javascript_pack_tag "decidim_participatory_processes" %>
 <%= append_stylesheet_pack_tag "decidim_participatory_processes", media: "all" %>
 
+<%= content_for :participatory_space_actions do %>
+  <%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
+<% end %>
+
 <%= render "layouts/decidim/application" do %>
   <main>
     <%= yield %>

--- a/decidim-participatory_processes/app/views/layouts/decidim/participatory_process.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/participatory_process.html.erb
@@ -8,9 +8,7 @@
 <%= append_javascript_pack_tag "decidim_participatory_processes" %>
 <%= append_stylesheet_pack_tag "decidim_participatory_processes", media: "all" %>
 
-<%= content_for :participatory_space_actions do %>
-  <%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
-<% end %>
+<%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
 
 <%= render "layouts/decidim/application" do %>
   <main>

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -230,6 +230,14 @@ describe "Participatory Processes", type: :system do
         visit decidim_participatory_processes.participatory_process_path(participatory_process)
       end
 
+      describe "follow button" do
+        let!(:user) { create(:user, :confirmed, organization:) }
+        let(:followable) { participatory_process }
+        let(:followable_path) { decidim_participatory_processes.participatory_process_path(participatory_process) }
+
+        include_examples "follows"
+      end
+
       context "when requesting the process path" do
         context "when hero, main_data and phase and duration blocks are enabled" do
           let(:blocks_manifests) { [:process_hero, :main_data, :extra_data, :metadata] }
@@ -268,15 +276,6 @@ describe "Participatory Processes", type: :system do
             let(:attached_to) { participatory_process }
             let(:collection_for) { participatory_process }
           end
-        end
-
-        context "when last activities block enabled" do
-          let!(:user) { create(:user, :confirmed, organization:) }
-          let(:blocks_manifests) { [:last_activity] }
-          let(:followable) { participatory_process }
-          let(:followable_path) { decidim_participatory_processes.participatory_process_path(participatory_process) }
-
-          include_examples "follows"
         end
 
         context "and it belongs to a group" do

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -270,6 +270,15 @@ describe "Participatory Processes", type: :system do
           end
         end
 
+        context "when last activities block enabled" do
+          let!(:user) { create(:user, :confirmed, organization:) }
+          let(:blocks_manifests) { [:last_activity] }
+          let(:followable) { participatory_process }
+          let(:followable_path) { decidim_participatory_processes.participatory_process_path(participatory_process) }
+
+          include_examples "follows"
+        end
+
         context "and it belongs to a group" do
           let!(:group) { create(:participatory_process_group, participatory_processes: [participatory_process], organization:) }
           let(:blocks_manifests) { [:extra_data] }

--- a/decidim-proposals/spec/system/follow_proposals_spec.rb
+++ b/decidim-proposals/spec/system/follow_proposals_spec.rb
@@ -11,5 +11,5 @@ describe "Follow proposals", type: :system do
 
   let(:followable_path) { resource_locator(followable).path }
 
-  include_examples "follows"
+  include_examples "follows with a component"
 end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

This PR:
* Includes a follow button in the participatory spaces menu bar using a desktop and a mobile version.
* Adds some test

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11204

#### Testing

Visit the landing page of the participatory space, see the menu bar, click on the button

### :camera: Screenshots

![Screenshot from 2023-09-25 21-26-37](https://github.com/decidim/decidim/assets/446459/9f90c9c6-d1ab-44c9-a6cd-8e9371611a72)

:hearts: Thank you!
