### PR TITLE
Remove duplication for ParticipatorySpace User examples

### DIFF
--- a/decidim-admin/lib/decidim/admin/test/filters_participatory_space_user_roles_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/filters_participatory_space_user_roles_examples.rb
@@ -95,48 +95,28 @@ end
 shared_examples "filterable participatory space user roles" do
   context "when filtering by invite Accepted" do
     context "when filtering by null" do
-      it "returns participatory space users" do
-        apply_filter("Invite accepted", "Yes")
-
-        within ".stack tbody" do
-          expect(page).to have_content(invited_user2.name)
-          expect(page).to have_css("tr", count: 1)
-        end
+      include_examples "admin is filtering participatory space users", label: "Invite accepted", value: "Yes" do
+        let(:compare_with) { invited_user2.name }
       end
     end
 
     context "when filtering by not null" do
-      it "returns participatory space users" do
-        apply_filter("Invite accepted", "No")
-
-        within ".stack tbody" do
-          expect(page).to have_content(invited_user1.name)
-          expect(page).to have_css("tr", count: 1)
-        end
+      include_examples "admin is filtering participatory space users", label: "Invite accepted", value: "No" do
+        let(:compare_with) { invited_user1.name }
       end
     end
   end
 
   context "when filtering by logged in" do
     context "when filtering by null" do
-      it "returns participatory space users" do
-        apply_filter("Ever logged in", "Yes")
-
-        within ".stack tbody" do
-          expect(page).to have_content(invited_user2.name)
-          expect(page).to have_css("tr", count: 1)
-        end
+      include_examples "admin is filtering participatory space users", label: "Ever logged in", value: "Yes" do
+        let(:compare_with) { invited_user2.name }
       end
     end
 
     context "when filtering by not null" do
-      it "returns participatory space users" do
-        apply_filter("Ever logged in", "No")
-
-        within ".stack tbody" do
-          expect(page).to have_content(invited_user1.name)
-          expect(page).to have_css("tr", count: 1)
-        end
+      include_examples "admin is filtering participatory space users", label: "Ever logged in", value: "No" do
+        let(:compare_with) { invited_user1.name }
       end
     end
   end
@@ -144,22 +124,11 @@ end
 
 shared_examples "searchable participatory space user roles" do
   context "when searching by name or nickname or email" do
-    it "can be searched by name" do
-      search_by_text(name)
-
-      within ".stack tbody" do
-        expect(page).to have_content(name)
-        expect(page).to have_css("tr", count: 1)
-      end
+    include_examples "admin is searching participatory space users" do
+      let(:value) { name }
     end
-
-    it "can be searched by email" do
-      search_by_text(email)
-
-      within ".stack tbody" do
-        expect(page).to have_content(email)
-        expect(page).to have_css("tr", count: 1)
-      end
+    include_examples "admin is searching participatory space users" do
+      let(:value) { email }
     end
   end
 end

--- a/decidim-admin/lib/decidim/admin/test/filters_participatory_space_users_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/filters_participatory_space_users_examples.rb
@@ -1,50 +1,52 @@
 # frozen_string_literal: true
 
+shared_examples "admin is filtering participatory space users" do |label:, value:|
+  it "returns participatory space users" do
+    apply_filter(label, value)
+
+    within ".stack tbody" do
+      expect(page).to have_content(compare_with)
+      expect(page).to have_css("tr", count: 1)
+    end
+  end
+end
+
+shared_examples "admin is searching participatory space users" do
+  it "returns participatory space users" do
+    search_by_text(value)
+
+    within ".stack tbody" do
+      expect(page).to have_content(value)
+      expect(page).to have_css("tr", count: 1)
+    end
+  end
+end
+
 shared_examples "filterable participatory space users" do
   context "when filtering by invitation sent at" do
     context "when filtering by null" do
-      it "returns participatory space users" do
-        apply_filter("Invitation sent", "Not sent")
-
-        within ".stack tbody" do
-          expect(page).to have_content(invited_user2.name)
-          expect(page).to have_css("tr", count: 1)
-        end
+      include_examples "admin is filtering participatory space users", label: "Invitation sent", value: "Not sent" do
+        let(:compare_with) { invited_user2.name }
       end
     end
 
     context "when filtering by not null" do
-      it "returns participatory space users" do
-        apply_filter("Invitation sent", "Sent")
-
-        within ".stack tbody" do
-          expect(page).to have_content(invited_user1.name)
-          expect(page).to have_css("tr", count: 1)
-        end
+      include_examples "admin is filtering participatory space users", label: "Invitation sent", value: "Sent" do
+        let(:compare_with) { invited_user1.name }
       end
     end
   end
 
   context "when filtering by invitation accepted at" do
     context "when filtering by null" do
-      it "returns participatory space users" do
-        apply_filter("Invitation accepted", "Not accepted")
-
-        within ".stack tbody" do
-          expect(page).to have_content(invited_user2.name)
-          expect(page).to have_css("tr", count: 1)
-        end
+      include_examples "admin is filtering participatory space users", label: "Invitation accepted", value: "Not accepted" do
+        let(:compare_with) { invited_user2.name }
       end
     end
 
     context "when filtering by not null" do
-      it "returns participatory space users" do
-        apply_filter("Invitation accepted", "Accepted")
-
-        within ".stack tbody" do
-          expect(page).to have_content(invited_user1.name)
-          expect(page).to have_css("tr", count: 1)
-        end
+      include_examples "admin is filtering participatory space users", label: "Invitation accepted", value: "Accepted" do
+        let(:compare_with) { invited_user1.name }
       end
     end
   end
@@ -52,22 +54,11 @@ end
 
 shared_examples "searchable participatory space users" do
   context "when searching by name or nickname or email" do
-    it "can be searched by name" do
-      search_by_text(name)
-
-      within ".stack tbody" do
-        expect(page).to have_content(name)
-        expect(page).to have_css("tr", count: 1)
-      end
+    include_examples "admin is searching participatory space users" do
+      let(:value) { name }
     end
-
-    it "can be searched by email" do
-      search_by_text(email)
-
-      within ".stack tbody" do
-        expect(page).to have_content(email)
-        expect(page).to have_css("tr", count: 1)
-      end
+    include_examples "admin is searching participatory space users" do
+      let(:value) { email }
     end
   end
 end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
CodeClimate found that there was some duplication in the "filterable participatory space user roles" spec example. This PR refactors it so it's no longer duplicated.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10383

#### Testing
All the CI should be green

### :camera: Screenshots
![image](https://github.com/decidim/decidim/assets/105683/4685980b-a5b9-4931-8a63-6c7a8aeaf5cc)


:hearts: Thank you!
