### PR TITLE
Redesign: remove foundation references from comments

### DIFF
--- a/decidim-comments/app/views/decidim/comments/comments/reload.js.erb
+++ b/decidim-comments/app/views/decidim/comments/comments/reload.js.erb
@@ -10,7 +10,6 @@
   $comments.replaceWith(commentsHtml);
 
   $comments = $("#" + rootCommentableId);
-  $comments.foundation();
 
   // Re-create the component
   component = new Decidim.CommentsComponent($comments, $comments.data("decidim-comments"));

--- a/decidim-comments/app/views/decidim/comments/comments/update.js.erb
+++ b/decidim-comments/app/views/decidim/comments/comments/update.js.erb
@@ -12,8 +12,6 @@ $(() => {
 
   $comment.replaceWith(commentHtml);
 
-  $comments.foundation();
-
   // Re-create the component
   component = new Decidim.CommentsComponent($comments, $comments.data("decidim-comments"));
   component.mountComponent();


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Avoid foundation errors from comments when some actions trigger ajax calls

### :camera: Screenshots
![imagen](https://github.com/decidim/decidim/assets/817526/b8877e4f-1fe3-4688-9c98-c1f6b9cf6c38)

:hearts: Thank you!
