### PR TITLE
Fix spec related to the change of 'Log in'/'Log out'

### DIFF
--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -265,7 +265,7 @@ describe "Authentication", type: :system do
 
       within_user_menu do
         expect(page).to have_content("My account")
-        expect(page).to have_content("Sign out")
+        expect(page).to have_content("Log out")
       end
     end
   end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

After the change of the wording of  "Log in"/"Log out" from #11460, we have failing spec in `develop`. This PR fixes it.

#### :pushpin: Related Issues

- Related to #11460


#### Testing

Everything should be green 

:hearts: Thank you!
