### PR TITLE
Redesign: fix spacing in Devise forms

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_layout.scss
@@ -11,7 +11,7 @@
 }
 
 .layout-1col {
-  @apply container grid grid-rows-[max-content] grid-cols-12 auto-rows-max mb-12 md:mb-32 grow;
+  @apply container grid grid-rows-[max-content] grid-cols-12 auto-rows-max mb-12 grow;
 
   &.cols-6 > * {
     @apply col-span-12 md:col-start-3 md:col-span-8 lg:col-start-4 lg:col-span-6 self-start;

--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_login.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_login.scss
@@ -8,11 +8,11 @@
   }
 
   &__info-separator {
-    @apply mb-10 border border-background;
+    @apply border border-background;
   }
 
   &__omniauth {
-    @apply flex flex-col items-center gap-8 text-gray-2 font-semibold w-fit mx-auto;
+    @apply flex flex-col items-center gap-8 text-gray-2 font-semibold w-fit mx-auto mt-10;
 
     &-button {
       @apply button button__xl border border-gray shadow-[0_4px_6px_rgba(211,211,211,0.25)] justify-start gap-8 text-lg w-full;

--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_login.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_login.scss
@@ -7,6 +7,10 @@
     @apply mb-10 text-gray-2 text-sm;
   }
 
+  &__info-separator {
+    @apply mb-10 border border-background;
+  }
+
   &__omniauth {
     @apply flex flex-col items-center gap-8 text-gray-2 font-semibold w-fit mx-auto;
 

--- a/decidim-core/app/packs/stylesheets/decidim/_redesigned_login.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_redesigned_login.scss
@@ -10,10 +10,6 @@
   &__omniauth {
     @apply flex flex-col items-center gap-8 text-gray-2 font-semibold w-fit mx-auto;
 
-    &-container {
-      @apply border-t-2 border-background pt-10;
-    }
-
     &-button {
       @apply button button__xl border border-gray shadow-[0_4px_6px_rgba(211,211,211,0.25)] justify-start gap-8 text-lg w-full;
 

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -23,11 +23,9 @@
     <%= form_required_explanation %>
   </div>
 
-  <div class="login__omniauth-container">
-    <% cache current_organization do %>
-      <%= render "decidim/devise/shared/omniauth_buttons" %>
-    <% end %>
-  </div>
+  <% cache current_organization do %>
+    <%= render "decidim/devise/shared/omniauth_buttons" %>
+  <% end %>
 
   <%= decidim_form_for(@form, namespace: "registration", as: resource_name, url: registration_path(resource_name), html: { id: "register-form" }) do |f| %>
     <%= invisible_captcha %>

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -23,6 +23,8 @@
     <%= form_required_explanation %>
   </div>
 
+  <span class="login__info-separator"></span>
+
   <% cache current_organization do %>
     <%= render "decidim/devise/shared/omniauth_buttons" %>
   <% end %>

--- a/decidim-core/app/views/decidim/devise/sessions/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/sessions/new.html.erb
@@ -30,7 +30,7 @@
   <% end %>
 
   <% if current_organization.sign_in_enabled? %>
-    <%= decidim_form_for(resource, namespace: "session", as: resource_name, url: session_path(resource_name) ) do |f| %>
+    <%= decidim_form_for(resource, namespace: "session", as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="form__wrapper">
         <%= f.email_field :email, autocomplete: "email", placeholder: t("placeholder_email", scope: "decidim.devise.shared"), required: true %>
 

--- a/decidim-core/app/views/decidim/devise/sessions/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/sessions/new.html.erb
@@ -23,6 +23,8 @@
     <% end %>
   </div>
 
+  <span class="login__info-separator"></span>
+
   <% cache current_organization do %>
     <%= render "decidim/devise/shared/omniauth_buttons" %>
   <% end %>

--- a/decidim-core/app/views/decidim/devise/sessions/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/sessions/new.html.erb
@@ -23,11 +23,9 @@
     <% end %>
   </div>
 
-  <div class="login__omniauth-container">
-    <% cache current_organization do %>
-      <%= render "decidim/devise/shared/omniauth_buttons" %>
-    <% end %>
-  </div>
+  <% cache current_organization do %>
+    <%= render "decidim/devise/shared/omniauth_buttons" %>
+  <% end %>
 
   <% if current_organization.sign_in_enabled? %>
     <%= decidim_form_for(resource, namespace: "session", as: resource_name, url: session_path(resource_name) ) do |f| %>


### PR DESCRIPTION
#### :tophat: What? Why?

When the Ominauth provider is disabled, there's too much spacing in the first fields of the Devise forms where this is, basically http://localhost:3000/users/sign_in?locale=en and http://localhost:3000/users/sign_up?locale=en 

This PR fixes that.

It also fixes a too much spacing problem that we have in the middle viewport (tablets). 

Regarding the other spacings (i.e. margins/paddings) from the issues, I can't see them anymore. I think that they're respecting the `.form__wrapper` top and bottom margins correctly.

#### :pushpin: Related Issues

- Fixes #11281 
- Fixes #11345

#### Testing

1. Disable the developer omniauth provider, by going to `development_app/config/secrets.yml` and changing the `development.omniauth.developer.enabled` key to false (line 169 in the default generated secrets.yml)
2. Restart the development server
3. Visit these pages and see the spacing (before and after this PR) 
4. Change the viewport with the webdev tools. See that the footer isn't that far as it was before. 

### :camera: Screenshots

#### Before
![Screenshot of the "Sign up" form (with too much spacing)](https://github.com/decidim/decidim/assets/717367/db52515c-9418-4fbf-a37a-99ffd89bc16a)
![Screenshot of the "Log in" form (with too much spacing)](https://github.com/decidim/decidim/assets/717367/b77d15c6-6b3e-42ca-ae64-c05cb4c7a09c)

#### After 

![Screenshot of the "Sign up" form (with the correct spacing)](https://github.com/decidim/decidim/assets/717367/8af7f3e9-3a77-4add-885f-e9a01659bf2e)

![Screenshot of the "Log in" form (with the correct spacing)](https://github.com/decidim/decidim/assets/717367/304cc1d3-2a7e-4d47-97f0-218f30bdbc78)

:hearts: Thank you!
