### PR TITLE
Redesign: differentiate titles and links in the footer

### DIFF
--- a/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
@@ -1,7 +1,7 @@
 <%= footer_menu.render %>
 
 <nav role="navigation" aria-label="<%= t("layouts.decidim.footer.resources") %>">
-  <h2 class="h5 mb-4"><%= t("layouts.decidim.footer.resources") %></h2>
+  <h2 class="h4 mb-4"><%= t("layouts.decidim.footer.resources") %></h2>
   <ul class="space-y-4 break-inside-avoid">
     <li class="font-semibold underline"><%= link_to t("decidim.profiles.show.activity"), decidim.last_activities_path %></li>
     <li class="font-semibold underline"><%= link_to t("decidim.pages.home.extended.meetings"), Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path %></li>
@@ -10,7 +10,7 @@
 </nav>
 
 <nav role="navigation" aria-label="<%= t("layouts.decidim.user_menu.profile") %>">
-  <h2 class="h5 mb-4"><%= t("layouts.decidim.user_menu.profile") %></h2>
+  <h2 class="h4 mb-4"><%= t("layouts.decidim.user_menu.profile") %></h2>
   <ul class="space-y-4 break-inside-avoid">
     <% if current_user %>
       <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.configuration"), decidim.account_path %></li>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

It's not easy to see the difference between the footer's sections links and titles.

This PR fixes it. 


#### :pushpin: Related Issues
 
- Fixes #11344

#### Testing

1. See the footer 

### :camera: Screenshots

#### Before
![Screenshot of the footer (before)](https://github.com/decidim/decidim/assets/717367/7e43190c-c150-490b-ab57-89c27f587b14)

#### After 
![Screenshot of the footer (after)](https://github.com/decidim/decidim/assets/717367/7006c49b-621c-4375-b426-c503b9091b50)


:hearts: Thank you!
