### PR TITLE
Redesign: make the flash alerts consistent (always above the navbar)

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -14,14 +14,13 @@ end
   <header>
     <%= render partial: "layouts/decidim/admin_links" if current_user&.admin %>
     <%= render partial: "layouts/decidim/header/main" %>
+    <% if display_flash_messages.present? %>
+      <div class="container">
+        <%= display_flash_messages %>
+      </div>
+    <% end %>
     <%= render partial: "layouts/decidim/header/menu" unless controller_name == "homepage" %>
   </header>
-
-  <% if display_flash_messages.present? %>
-    <div class="container">
-      <%= display_flash_messages %>
-    </div>
-  <% end %>
 
   <div id="content" data-content>
     <%= yield %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

The callouts were a bit weird between the homepage and the rest of the pages, as the navbar is not the same. There's more details and screenshots at #11326.

This PR fixes it by showing the callout messages always before the navbar. 

#### :pushpin: Related Issues
 
- Fixes #11326

#### Testing

1. Go to the homepage
2. Login 
3. See the callout
4. Go to another page (for instance, an assemblies#show page)
5. Logout
6. See the callout 

### :camera: Screenshots
 
![Screenshot of a flash alert in the homepage](https://github.com/decidim/decidim/assets/717367/079a237a-182a-4e4d-a98b-2a01cec28475)
![Screenshot of a flash alert in the assembly landing page](https://github.com/decidim/decidim/assets/717367/5de1123a-a810-4a5c-beb2-7c6b0e342691)

:hearts: Thank you!
