### PR TITLE
Hide notifications' "Mark all as read" button after click

### DIFF
--- a/decidim-core/app/packs/src/decidim/notifications.js
+++ b/decidim-core/app/packs/src/decidim/notifications.js
@@ -26,6 +26,9 @@ export default function(node = document) {
       emptyNotifications()
     }
   }
+  const hideReadAllButton = () => {
+    handleFadeOut(node.querySelector("[data-notification-read-all]"))
+  }
 
   const notifications = node.querySelectorAll("[data-notification]")
 
@@ -37,6 +40,7 @@ export default function(node = document) {
         "click", () => {
           notifications.forEach((notification) => handleFadeOut(notification))
           emptyNotifications()
+          hideReadAllButton()
         }
       )
   }

--- a/decidim-core/spec/system/notifications_spec.rb
+++ b/decidim-core/spec/system/notifications_spec.rb
@@ -103,6 +103,7 @@ describe "Notifications", type: :system do
       it "hides all notifications from the page" do
         click_link "Mark all as read"
         expect(page).not_to have_selector("[data-notification]")
+        expect(page).not_to have_content("Mark all as read")
         expect(page).to have_content("No notifications yet")
 
         within ".main-bar" do


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

When a user has pending notifications and they click the "Mark all as read" button, it stays there. With this PR we hide it after click.

This doesn't happen in v0.27 (I've just check it out in try.decidim.org) 

#### :pushpin: Related Issues
 
- Fixes #11280 

#### Testing

1. Sign in as admin@example.org
2. Follow a proposal 
3. In another browser, sign in as user@example.org
4. Leave a comment in that proposal
5. Go to the first browser (with the admin@example.org session) and visit the Notifications page
6. Click in the "Hide all as read" button and see that it's gone  

:hearts: Thank you!
