### PR TITLE
Add 127.0.0.1 and 0.0.0.0 as secondary hosts in the Organization's seeds

### DIFF
--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -54,7 +54,7 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
       port: ENV.fetch("SMTP_PORT", nil) || ENV.fetch("DECIDIM_SMTP_PORT", "25")
     },
     host: ENV.fetch("DECIDIM_HOST", "localhost"),
-    secondary_hosts: ENV.fetch("DECIDIM_HOST", "localhost") == "localhost" ? ["0.0.0.0", "127.0.0.1"] : nil,
+    secondary_hosts: ENV.fetch("DECIDIM_HOST", nil) == "localhost" ? ["0.0.0.0", "127.0.0.1"] : nil,
     external_domain_whitelist: ["decidim.org", "github.com"],
     description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
       Decidim::Faker::Localized.sentence(word_count: 15)

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -54,6 +54,7 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
       port: ENV.fetch("SMTP_PORT", nil) || ENV.fetch("DECIDIM_SMTP_PORT", "25")
     },
     host: ENV.fetch("DECIDIM_HOST", "localhost"),
+    secondary_hosts: ENV.fetch("DECIDIM_HOST", "localhost") == "localhost" ? ["0.0.0.0", "127.0.0.1"] : nil,
     external_domain_whitelist: ["decidim.org", "github.com"],
     description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
       Decidim::Faker::Localized.sentence(word_count: 15)

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -54,7 +54,7 @@ if !Rails.env.production? || ENV.fetch("SEED", nil)
       port: ENV.fetch("SMTP_PORT", nil) || ENV.fetch("DECIDIM_SMTP_PORT", "25")
     },
     host: ENV.fetch("DECIDIM_HOST", "localhost"),
-    secondary_hosts: ENV.fetch("DECIDIM_HOST", nil) == "localhost" ? ["0.0.0.0", "127.0.0.1"] : nil,
+    secondary_hosts: ENV.fetch("DECIDIM_HOST", "localhost") == "localhost" ? ["0.0.0.0", "127.0.0.1"] : nil,
     external_domain_whitelist: ["decidim.org", "github.com"],
     description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
       Decidim::Faker::Localized.sentence(word_count: 15)


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

This is something that appeared when introducing new developers to Decidim.

Basically, that when you start the Rails server, you see the following line in the output: 

> 14:47:19 web.1       | Puma starting in single mode...                                          
> 14:47:19 web.1       | * Puma version: 6.3.1 (ruby 3.1.1-p18) ("Mugi No Toki Itaru")            
> 14:47:19 web.1       | *  Min threads: 5                                                        
> 14:47:19 web.1       | *  Max threads: 5                                                        
> 14:47:19 web.1       | *  Environment: development                                              
> 14:47:19 web.1       | *          PID: 723172                                                   
> 14:47:19 web.1       | * Listening on http://0.0.0.0:3000                                       
> 14:47:19 web.1       | Use Ctrl-C to stop          

If you open that URL, you'll have the /system panel, and that's something that you're not expecting after several minutes/hours of trying to get working the development environment.

So, this PR fixes that by adding "0.0.0.0" as a secondary host if the host is localhost. Just in case we also add 127.0.0.1 too. 
 

#### Testing

1. Open http://0.0.0.0:3000 see that's the /system login 
2. Create a new development_app with `bin/rake development_app`
3. Open http://0.0.0.0:3000 see you're redirected 

:hearts: Thank you!
