### PR TITLE
Fix decidim-templates routes in admin panel

### DIFF
--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -39,7 +39,7 @@ Decidim::Admin::Engine.routes.draw do
       mount manifest.admin_engine, at: "/#{manifest.name}", as: "decidim_admin_#{manifest.name}"
     end
 
-    mount Decidim::Templates::AdminEngine, at: "/templates", as: "decidim_admin_templates" if Decidim::Admin.enable_templates
+    mount Decidim::Templates::AdminEngine, at: "/templates", as: "decidim_admin_templates" if Decidim.module_installed?(:templates)
 
     resources :users, except: [:edit, :update], controller: "users" do
       member do


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
After #10968 was merged, we have broken the admin access in some installations. It was difficult to check as I could not reproduce it with a vanilla `development_app`.

Basically, we need to check the templates module as we already do for other modules. 

#### :pushpin: Related Issues

- Related to #10968 

#### Stacktrace

```
NameError:undefined local variable or method `decidim_admin_templates' for #<ActionView::Base:0x00000000066cd8> decidim_admin_templates.questionnaire_templates_path, ^^^^^^^^^^^^^^^^^^^^^^^ Did you mean? decidim_admin_assemblies
 from decidim (d2d390578050) decidim-templates/lib/decidim/templates/admin_engine.rb:64:in `block (2 levels) in <class:AdminEngine>'
 from decidim (d2d390578050) decidim-core/lib/decidim/menu.rb:20:in `instance_exec'
 from decidim (d2d390578050) decidim-core/lib/decidim/menu.rb:20:in `block in build_for'
 from decidim (d2d390578050) decidim-core/lib/decidim/menu.rb:19:in `each'
 from decidim (d2d390578050) decidim-core/lib/decidim/menu.rb:19:in `build_for'
 from decidim (d2d390578050) decidim-core/app/presenters/decidim/menu_presenter.rb:25:in `evaluated_menu'
 from decidim (d2d390578050) decidim-core/app/presenters/decidim/menu_presenter.rb:19:in `items'
 from decidim (d2d390578050) decidim-core/app/presenters/decidim/menu_presenter.rb:50:in `presented_items'
 from decidim (d2d390578050) decidim-core/app/presenters/decidim/menu_presenter.rb:56:in `menu_items'
 from decidim (d2d390578050) decidim-core/app/presenters/decidim/menu_presenter.rb:45:in `block in render_menu'
 from actionview (6.1.7.6) lib/action_view/helpers/capture_helper.rb:45:in `block in capture'
```

#### Testing

To reproduce the error:

1. In the development_app, change the Gemfile to pointing to develop. I could **not** reproduce this with the vanilla Gemfile (i.e. `path: "..."`). 

<details>
<summary>Gemfile (click to see)</summary>

```ruby
# frozen_string_literal: true

source "https://rubygems.org"

DECIDIM_VERSION = { github: "decidim/decidim", branch: "develop" }.freeze

ruby RUBY_VERSION

gem "decidim", DECIDIM_VERSION
gem "decidim-conferences", DECIDIM_VERSION
gem "decidim-elections", DECIDIM_VERSION
gem "decidim-initiatives", DECIDIM_VERSION
gem "decidim-templates", DECIDIM_VERSION

gem "bootsnap", "~> 1.4"

gem "puma", ">= 6.3.1"

group :development, :test do
  gem "byebug", "~> 11.0", platform: :mri

  gem "decidim-dev", DECIDIM_VERSION

  gem "brakeman", "~> 5.4"
  gem "net-imap", "~> 0.2.3"
  gem "net-pop", "~> 0.1.1"
  gem "net-smtp", "~> 0.3.1"
  gem "parallel_tests", "~> 4.2"
end

group :development do
  gem "letter_opener_web", "~> 2.0"
  gem "listen", "~> 3.1"
  gem "spring", "~> 2.0"
  gem "spring-watcher-listen", "~> 2.0"
  gem "web-console", "~> 4.2"
end

group :production do
end

group :development do
  # Profiling gems
  gem "bullet"
  gem "flamegraph"
  gem "memory_profiler"
  gem "rack-mini-profiler", require: false
  gem "stackprof"

```

</details>

2. Log in as admin
3. Go to /admin
4. See error
5. Stop the server
6. Change the Gemfile to this branch (`fix/templates-admin-routes`)

<details>
<summary>Gemfile (click to see)</summary>

```ruby
# frozen_string_literal: true

source "https://rubygems.org"

DECIDIM_VERSION = { github: "decidim/decidim", branch: "fix/templates-admin-routes" }.freeze

ruby RUBY_VERSION

gem "decidim", DECIDIM_VERSION
gem "decidim-conferences", DECIDIM_VERSION
gem "decidim-elections", DECIDIM_VERSION
gem "decidim-initiatives", DECIDIM_VERSION
gem "decidim-templates", DECIDIM_VERSION

gem "bootsnap", "~> 1.4"

gem "puma", ">= 6.3.1"

group :development, :test do
  gem "byebug", "~> 11.0", platform: :mri

  gem "decidim-dev", DECIDIM_VERSION

  gem "brakeman", "~> 5.4"
  gem "net-imap", "~> 0.2.3"
  gem "net-pop", "~> 0.1.1"
  gem "net-smtp", "~> 0.3.1"
  gem "parallel_tests", "~> 4.2"
end

group :development do
  gem "letter_opener_web", "~> 2.0"
  gem "listen", "~> 3.1"
  gem "spring", "~> 2.0"
  gem "spring-watcher-listen", "~> 2.0"
  gem "web-console", "~> 4.2"
end

group :production do
end

group :development do
  # Profiling gems
  gem "bullet"
  gem "flamegraph"
  gem "memory_profiler"
  gem "rack-mini-profiler", require: false
  gem "stackprof"

```
</details>

8. Start the server
9. Log in as admin
10. Go to /admin
11. See that its working


:hearts: Thank you!
