### PR TITLE
Raise an error if the export format is unknown

### DIFF
--- a/decidim-core/lib/decidim/exporters.rb
+++ b/decidim-core/lib/decidim/exporters.rb
@@ -10,7 +10,7 @@ module Decidim
     autoload :ExportData, "decidim/exporters/export_data"
 
     # Lock the export formats to one of the available exporters
-    EXPORT_FORMATS = [:JSON, :CSV, :Excel, :PDF].freeze
+    EXPORT_FORMATS = [:JSON, :CSV, :Excel, :PDF, :FormPDF].freeze
 
     class UnknownFormatError < StandardError; end
 
@@ -26,6 +26,7 @@ module Decidim
     def self.find_exporter(format)
       raise UnknownFormatError unless format.respond_to?(:to_sym)
       raise UnknownFormatError unless EXPORT_FORMATS.include?(format.to_sym)
+      raise UnknownFormatError unless const_defined?(format.to_sym)
 
       const_get(format.to_sym)
     end

--- a/decidim-core/lib/decidim/exporters.rb
+++ b/decidim-core/lib/decidim/exporters.rb
@@ -9,6 +9,11 @@ module Decidim
     autoload :PDF, "decidim/exporters/pdf"
     autoload :ExportData, "decidim/exporters/export_data"
 
+    # Lock the export formats to one of the available exporters
+    EXPORT_FORMATS = [:JSON, :CSV, :Excel, :PDF].freeze
+
+    class UnknownFormatError < StandardError; end
+
     # Necessary for the i18n normalizer to locate strings not directly invoked in views:
 
     # i18n-tasks-use t('decidim.admin.exports.formats.JSON')
@@ -19,7 +24,10 @@ module Decidim
     #
     # format - The exporter format as a string. i.e "CSV"
     def self.find_exporter(format)
-      const_get(format)
+      raise UnknownFormatError unless format.respond_to?(:to_sym)
+      raise UnknownFormatError unless EXPORT_FORMATS.include?(format.to_sym)
+
+      const_get(format.to_sym)
     end
   end
 end

--- a/decidim-core/spec/lib/exporters_spec.rb
+++ b/decidim-core/spec/lib/exporters_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Exporters do
+    describe ".find_exporter" do
+      subject { described_class.find_exporter(format) }
+
+      described_class::EXPORT_FORMATS.each do |format|
+        let(:format) { format }
+
+        context "with the #{format} format" do
+          subject { described_class.find_exporter(format) }
+
+          it "returns the correct exporter" do
+            expect(subject).to eq(described_class.const_get(format))
+          end
+        end
+      end
+
+      context "with an unknown format" do
+        let(:format) { "XYZ" }
+
+        it "raises an UnknownFormatError" do
+          expect { subject }.to raise_error(described_class::UnknownFormatError)
+        end
+      end
+
+      context "with nil format" do
+        let(:format) { nil }
+
+        it "raises an UnknownFormatError" do
+          expect { subject }.to raise_error(described_class::UnknownFormatError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
If the export format is unexpected, raise an error instead of letting the underlying code evaluate.

Potentially we could also catch these errors and show an error message but this is just to prevent users adding an arbitrary parameter to the request, although these requests are typically controlled by admin users.

#### Testing
- Go to any view where you have export links
- Copy one of the export links
- Change the `format` param to something else
- See that the correct error is raised (`Decidim::Exporters::UnknownFormatError`)