### PR TITLE
Refactor: inline method `Decidim::Admin.enable_templates`

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/application_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/application_controller.rb
@@ -33,7 +33,7 @@ module Decidim
       helper Decidim::LanguageChooserHelper
       helper Decidim::ComponentPathHelper
       helper Decidim::SanitizeHelper
-      helper Decidim::Templates::Admin::ApplicationHelper if Decidim::Admin.enable_templates
+      helper Decidim::Templates::Admin::ApplicationHelper if Decidim.module_installed?(:templates)
 
       default_form_builder Decidim::Admin::FormBuilder
 

--- a/decidim-admin/lib/decidim/admin.rb
+++ b/decidim-admin/lib/decidim/admin.rb
@@ -27,10 +27,6 @@ module Decidim
       [15, 50, 100]
     end
 
-    config_accessor :enable_templates do
-      Decidim.const_defined?("Templates")
-    end
-
     Kaminari.configure do |config|
       config.default_per_page = Decidim::Admin.per_page_range.first
       config.max_per_page = Decidim::Admin.per_page_range.last


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the front end.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

In #11613, @alecslupu mentioned that we should change the implementation of the `Decidim::Admin.enable_templates` method. As it's being used in only one place, I preferred just to inline the method and change the implementation there. 

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/pull/11613#pullrequestreview-1633145733 

#### Testing

Everything should be green. 


:hearts: Thank you!
