### PR TITLE
Don't show map with only online meetings in Content Block

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component_cell.rb
@@ -62,7 +62,15 @@ module Decidim
       end
 
       def show_map?
+        maps_active? && !all_online_meetings?
+      end
+
+      def maps_active?
         Decidim::Map.available?(:geocoding, :dynamic)
+      end
+
+      def all_online_meetings?
+        collection.collect(&:type_of_meeting).all?("online")
       end
 
       def show_calendar?

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/highlighted_meetings_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/highlighted_meetings_cell_spec.rb
@@ -84,6 +84,42 @@ module Decidim
                 expect(meetings_ids).to include(item_id(meeting))
               end
             end
+
+            context "when the map is configured" do
+              before do
+                allow(Decidim::Map).to receive(:available?).and_return(true)
+              end
+
+              context "and there are in_person meetings" do
+                before do
+                  Decidim::Meetings::Meeting.update_all(type_of_meeting: "in_person") # rubocop:disable Rails/SkipsModelValidations
+                end
+
+                it "renders the map" do
+                  expect(html).to have_css(".meeting-list__block-map")
+                end
+              end
+
+              context "and there are hybrid meetings" do
+                before do
+                  Decidim::Meetings::Meeting.update_all(type_of_meeting: "hybrid") # rubocop:disable Rails/SkipsModelValidations
+                end
+
+                it "renders the map" do
+                  expect(html).to have_css(".meeting-list__block-map")
+                end
+              end
+
+              context "and there are online meetings" do
+                before do
+                  Decidim::Meetings::Meeting.update_all(type_of_meeting: "online") # rubocop:disable Rails/SkipsModelValidations
+                end
+
+                it "does not render the map" do
+                  expect(html).not_to have_css(".meeting-list__block-map")
+                end
+              end
+            end
           end
         end
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

In the meetings content block we show the Map even if all the meetings are online  

This PR fixes this bug. 

#### :pushpin: Related Issues
 
- Fixes #11265

#### Testing
 
0. Enable the Maps feature if it isn't enabled
1. Search for a Meetings content block
2. Edit all the meetings, changing them to "Type: Online"
3. See that you have the map
4. Apply this PR
3. See that you don't have the map anymore
  
### :camera: Screenshots 

#### Before 
![Screenshot of the meetings CB with only online meetings with the map enabled](https://github.com/decidim/decidim/assets/717367/d44f6a12-a197-49c2-981a-7c7ef5fd2035)

#### After

![Screenshot of the meetings CB with only online meetings without the map enabled](https://github.com/decidim/decidim/assets/717367/00362296-4e92-4e6a-9ae0-cace3808f076)

:hearts: Thank you!
