### PR TITLE
Fix password confirm validation error message

### DIFF
--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -39,7 +39,7 @@ module Decidim
           end
 
           on(:invalid) do
-            flash.now[:alert] = @form.errors.full_messages.join(", ") if @form.errors.full_messages.any?
+            flash.now[:alert] = t("error", scope: "decidim.devise.registrations.create")
             render :new
           end
         end

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -24,7 +24,7 @@ module Decidim
     validates :nickname, presence: true, format: { with: Decidim::User::REGEXP_NICKNAME }
 
     validates :nickname, length: { maximum: Decidim::User.nickname_max_length, allow_blank: true }
-    validates :password, confirmation: true
+    validates :password, confirmation: { message: '"Confirm your password" does not match Password' }
     validates :password, password: { name: :name, email: :email, username: :nickname }, if: -> { password.present? }
     validates :password_confirmation, presence: true, if: :password_present
     validates :avatar, passthru: { to: Decidim::User }

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -24,7 +24,7 @@ module Decidim
     validates :nickname, presence: true, format: { with: Decidim::User::REGEXP_NICKNAME }
 
     validates :nickname, length: { maximum: Decidim::User.nickname_max_length, allow_blank: true }
-    validates :password, confirmation: { message: "#{t(".password_confirmation")} does not match Password" }
+    validates :password, confirmation: { message: t("password_confirmation_message") }
     validates :password, password: { name: :name, email: :email, username: :nickname }, if: -> { password.present? }
     validates :password_confirmation, presence: true, if: :password_present
     validates :avatar, passthru: { to: Decidim::User }

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -24,7 +24,7 @@ module Decidim
     validates :nickname, presence: true, format: { with: Decidim::User::REGEXP_NICKNAME }
 
     validates :nickname, length: { maximum: Decidim::User.nickname_max_length, allow_blank: true }
-    validates :password, confirmation: { message: '"Confirm your password" does not match Password' }
+    validates :password, confirmation: { message: "#{t(".password_confirmation")} does not match Password" }
     validates :password, password: { name: :name, email: :email, username: :nickname }, if: -> { password.present? }
     validates :password_confirmation, presence: true, if: :password_present
     validates :avatar, passthru: { to: Decidim::User }

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -24,7 +24,7 @@ module Decidim
     validates :nickname, presence: true, format: { with: Decidim::User::REGEXP_NICKNAME }
 
     validates :nickname, length: { maximum: Decidim::User.nickname_max_length, allow_blank: true }
-    validates :password, confirmation: { message: t("password_confirmation_message") }
+    validates :password, confirmation: { message: I18n.t("errors.messages.password_confirmation_message") }
     validates :password, password: { name: :name, email: :email, username: :nickname }, if: -> { password.present? }
     validates :password_confirmation, presence: true, if: :password_present
     validates :avatar, passthru: { to: Decidim::User }

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -17,7 +17,7 @@ module Decidim
     validates :name, presence: true, format: { with: Decidim::User::REGEXP_NAME }
     validates :nickname, presence: true, format: { with: Decidim::User::REGEXP_NICKNAME }, length: { maximum: Decidim::User.nickname_max_length }
     validates :email, presence: true, "valid_email_2/email": { disposable: true }
-    validates :password, confirmation: true
+    validates :password, confirmation: { message: I18n.t("errors.messages.password_confirmation_message") }
     validates :password, password: { name: :name, email: :email, username: :nickname }
     validates :password_confirmation, presence: true
     validates :tos_agreement, allow_nil: false, acceptance: true

--- a/decidim-core/config/locales/ca.yml
+++ b/decidim-core/config/locales/ca.yml
@@ -1667,7 +1667,7 @@ ca:
         didn_t_receive_confirmation_instructions: No has rebut instruccions de confirmació?
         didn_t_receive_unlock_instructions: No has rebut instruccions de desbloqueig?
         forgot_your_password: Has oblidat la teva contrasenya?
-        sign_in: Entra
+        sign_in: Iniciar sessió
         sign_in_with_provider: Inicia sessió amb %{provider}
         sign_up: Registra't
       minimum_password_length:

--- a/decidim-core/config/locales/ca.yml
+++ b/decidim-core/config/locales/ca.yml
@@ -1658,7 +1658,7 @@ ca:
     sessions:
       already_signed_out: Sessió finalitzada correctament.
       new:
-        sign_in: Iniciar sessió
+        sign_in: Entra
       signed_in: Sessió iniciada correctament.
       signed_out: S'ha iniciat la sessió correctament.
     shared:
@@ -1667,7 +1667,7 @@ ca:
         didn_t_receive_confirmation_instructions: No has rebut instruccions de confirmació?
         didn_t_receive_unlock_instructions: No has rebut instruccions de desbloqueig?
         forgot_your_password: Has oblidat la teva contrasenya?
-        sign_in: Iniciar sessió
+        sign_in: Entra
         sign_in_with_provider: Inicia sessió amb %{provider}
         sign_up: Registra't
       minimum_password_length:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1692,7 +1692,6 @@ en:
       public: Your public information.
   errors:
     messages:
-      password_confirmation_message: '"Confirm your password" does not match Password'
       allowed_file_content_types: 'only files with the following extensions are allowed: %{types}'
       already_confirmed: was already confirmed, please try signing in
       confirmation_period_expired: needs to be confirmed within %{period}, please request a new one
@@ -1709,6 +1708,7 @@ en:
       not_saved:
         one: 'There''s been an error processing your request:'
         other: 'There were multiple errors when processing your request:'
+      password_confirmation_message: '"Confirm your password" does not match Password'
       too_many_marks: is using too many consecutive punctuation marks (e.g. ! and ?)
       too_much_caps: is using too many capital letters (over 25% of the text)
       too_short: is too short (under %{count} characters)

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -534,6 +534,8 @@ en:
           subtitle: Please fill in the following form in order to complete the sign up
           username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
       registrations:
+        create:
+          error: There was a problem creating your account.
         new:
           already_have_an_account?: Already have an account?
           newsletter: Receive an occasional newsletter with relevant information

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -28,7 +28,6 @@ en:
         nickname: Nickname
         password: Password
         password_confirmation: Confirm your password
-        password_confirmation_message: '"Confirm your password" does not match Password'
         personal_url: Personal URL
         remove_avatar: Remove avatar
         tos_agreement: Terms and conditions of use agreement
@@ -1693,6 +1692,7 @@ en:
       public: Your public information.
   errors:
     messages:
+      password_confirmation_message: '"Confirm your password" does not match Password'
       allowed_file_content_types: 'only files with the following extensions are allowed: %{types}'
       already_confirmed: was already confirmed, please try signing in
       confirmation_period_expired: needs to be confirmed within %{period}, please request a new one

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -27,7 +27,8 @@ en:
         name: Your name
         nickname: Nickname
         password: Password
-        password_confirmation: 'Confirm your password'
+        password_confirmation: Confirm your password
+        password_confirmation_message: '"Confirm your password" does not match Password'
         personal_url: Personal URL
         remove_avatar: Remove avatar
         tos_agreement: Terms and conditions of use agreement

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -27,7 +27,7 @@ en:
         name: Your name
         nickname: Nickname
         password: Password
-        password_confirmation: Confirm your password
+        password_confirmation: 'Confirm your password'
         personal_url: Personal URL
         remove_avatar: Remove avatar
         tos_agreement: Terms and conditions of use agreement

--- a/decidim-core/spec/controllers/registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/registrations_controller_spec.rb
@@ -59,7 +59,7 @@ module Decidim
 
         it "adds the flash message" do
           post :create, params: params
-          expect(controller.flash.now[:alert]).to have_content("Your email can't be blank")
+          expect(controller.flash.now[:alert]).to have_content("There was a problem creating your account.")
         end
 
         context "when all params are invalid" do
@@ -80,18 +80,7 @@ module Decidim
 
           it "adds the flash message" do
             post :create, params: params
-            expect(controller.flash.now[:alert]).to have_content(
-              [
-                "Your name can't be blank",
-                "Nickname can't be blank",
-                "Nickname is invalid",
-                "Your email can't be blank",
-                "Confirm your password doesn't match Password",
-                "Password is too short",
-                "Password does not have enough unique characters",
-                "Terms and conditions of use agreement must be accepted"
-              ].join(", ")
-            )
+            expect(controller.flash.now[:alert]).to have_content("There was a problem creating your account.")
           end
         end
       end
@@ -105,7 +94,7 @@ module Decidim
 
         it "informs the user she must accept the pending invitation" do
           send_form_and_expect_rendering_the_new_template_again
-          expect(controller.flash.now[:alert]).to have_content("You have a pending invitation, accept it to finish creating your account")
+          expect(controller.flash.now[:alert]).to have_content("There was a problem creating your account.")
         end
       end
     end

--- a/decidim-core/spec/forms/account_form_spec.rb
+++ b/decidim-core/spec/forms/account_form_spec.rb
@@ -11,6 +11,7 @@ module Decidim
         nickname: nickname,
         password: password,
         password_confirmation: password_confirmation,
+        password_confirmation_message: password_confirmation_message,
         avatar: avatar,
         remove_avatar: remove_avatar,
         personal_url: personal_url,

--- a/decidim-core/spec/forms/account_form_spec.rb
+++ b/decidim-core/spec/forms/account_form_spec.rb
@@ -11,7 +11,6 @@ module Decidim
         nickname: nickname,
         password: password,
         password_confirmation: password_confirmation,
-        password_confirmation_message: password_confirmation_message,
         avatar: avatar,
         remove_avatar: remove_avatar,
         personal_url: personal_url,

--- a/decidim-core/spec/forms/account_form_spec.rb
+++ b/decidim-core/spec/forms/account_form_spec.rb
@@ -155,11 +155,11 @@ module Decidim
       end
     end
 
-    describe "password_confirmation" do
+    describe "password_confirmation_message" do
       context "when the password confirmaiton does not match" do
         let(:password_confirmation) { "aaaabbbbcccc" }
 
-        it { is_expected.to be_invalid }
+        it { is_expected.not_to be_valid }
 
         it "adds the correct error" do
           subject.valid?

--- a/decidim-core/spec/forms/account_form_spec.rb
+++ b/decidim-core/spec/forms/account_form_spec.rb
@@ -155,6 +155,19 @@ module Decidim
       end
     end
 
+    describe "password_confirmation" do
+      context "when the password confirmaiton does not match" do
+        let(:password_confirmation) { "aaaabbbbcccc" }
+
+        it { is_expected.to be_invalid }
+
+        it "adds the correct error" do
+          subject.valid?
+          expect(subject.errors[:password_confirmation]).to include('"Confirm your password" does not match Password')
+        end
+      end
+    end
+
     describe "personal_url" do
       context "when it doesn't start with http" do
         let(:personal_url) { "example.org" }

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -153,4 +153,18 @@ module Decidim
       it { is_expected.to be_invalid }
     end
   end
+
+  describe "password_confirmation" do
+    context "when the password confirmaiton does not match" do
+      let(:password_confirmation) { "aaaabbbbcccc" }
+
+      it { is_expected.to be_invalid }
+
+      it "adds the correct error" do
+        subject.valid?
+        expect(subject.errors[:password_confirmation]).to include('"Confirm your password" does not match Password')
+      end
+    end
+  end
+
 end

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -37,12 +37,6 @@ module Decidim
       }
     end
 
-    context "with correct data" do
-      it "is valid" do
-        expect(subject).to be_valid
-      end
-    end
-
     context "when everything is OK" do
       it { is_expected.to be_valid }
     end
@@ -158,17 +152,17 @@ module Decidim
 
       it { is_expected.to be_invalid }
     end
-  end
 
-  describe "password_confirmation" do
-    context "when the password confirmaiton does not match" do
-      let(:password_confirmation) { "aaaabbbbcccc" }
+    describe "password_confirmation" do
+      context "when the password confirmaiton does not match" do
+        let(:password_confirmation) { "aaaabbbbcccc" }
 
-      it { is_expected.not_to be_valid }
+        it { is_expected.to be_invalid }
 
-      it "adds the correct error" do
-        subject.valid?
-        expect(subject.errors[:password_confirmation]).to include('"Confirm your password" does not match Password')
+        it "adds the correct error" do
+          subject.valid?
+          expect(subject.errors[:password_confirmation]).to include('"Confirm your password" does not match Password')
+        end
       end
     end
   end

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -37,6 +37,12 @@ module Decidim
       }
     end
 
+    context "with correct data" do
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+
     context "when everything is OK" do
       it { is_expected.to be_valid }
     end
@@ -158,7 +164,7 @@ module Decidim
     context "when the password confirmaiton does not match" do
       let(:password_confirmation) { "aaaabbbbcccc" }
 
-      it { is_expected.to be_invalid }
+      it { is_expected.not_to be_valid }
 
       it "adds the correct error" do
         subject.valid?

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -166,5 +166,4 @@ module Decidim
       end
     end
   end
-
 end

--- a/decidim-core/spec/system/locales_spec.rb
+++ b/decidim-core/spec/system/locales_spec.rb
@@ -57,7 +57,7 @@ describe "Locales", type: :system do
       fill_in "session_user_email", with: "toto@example.org"
       fill_in "session_user_password", with: "toto"
 
-      click_button "Iniciar sessió"
+      click_button "Entra"
 
       expect(page).to have_content("Email o la contrasenya no són vàlids.")
     end

--- a/decidim-core/spec/system/locales_spec.rb
+++ b/decidim-core/spec/system/locales_spec.rb
@@ -48,7 +48,7 @@ describe "Locales", type: :system do
     end
 
     it "displays devise messages with the right locale when authentication fails" do
-      click_link "Log In"
+      click_link "Sign In"
 
       within_language_menu do
         click_link "Català"

--- a/decidim-core/spec/system/locales_spec.rb
+++ b/decidim-core/spec/system/locales_spec.rb
@@ -57,6 +57,7 @@ describe "Locales", type: :system do
       fill_in "session_user_email", with: "toto@example.org"
       fill_in "session_user_password", with: "toto"
 
+
       click_button "Iniciar sessió"
 
       expect(page).to have_content("Email o la contrasenya no són vàlids.")

--- a/decidim-core/spec/system/locales_spec.rb
+++ b/decidim-core/spec/system/locales_spec.rb
@@ -57,7 +57,6 @@ describe "Locales", type: :system do
       fill_in "session_user_email", with: "toto@example.org"
       fill_in "session_user_password", with: "toto"
 
-
       click_button "Iniciar sessió"
 
       expect(page).to have_content("Email o la contrasenya no són vàlids.")

--- a/decidim-core/spec/system/locales_spec.rb
+++ b/decidim-core/spec/system/locales_spec.rb
@@ -48,7 +48,7 @@ describe "Locales", type: :system do
     end
 
     it "displays devise messages with the right locale when authentication fails" do
-      click_link "Sign In"
+      click_link "Log In"
 
       within_language_menu do
         click_link "Català"


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This is a password confirmation alert message change to allow the alert to be more clearer according to the original issuer #11283. 

An original PR to this issue was moved from 0.28 to 0.27: https://github.com/decidim/decidim/pull/11534  

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11284

#### Testing
1. Head over to Sign in/Log in
2. Click create an account
3. Fill the form
4. Purposely create different passwords in the confirmation field and hit enter
5. See the the error output has quotes

### :camera: Screenshots

:hearts: Thank you!
