### PR TITLE
Do not display accessibility in initiative print

### DIFF
--- a/decidim-initiatives/app/packs/stylesheets/decidim/initiatives/print-initiative.scss
+++ b/decidim-initiatives/app/packs/stylesheets/decidim/initiatives/print-initiative.scss
@@ -110,6 +110,18 @@
 }
 
 @media print {
+  .decidim-accessibility-indicator {
+    display: none;
+  }
+
+  .decidim-accessibility-badge {
+    display: none;
+  }
+
+  .decidim-accessibility-report {
+    display: none;
+  }
+
   .process-header {
     display: none;
   }


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR prevents accessibility violations to be printed in initiatives. 

Further details in my comment from: https://github.com/decidim/decidim/pull/11577#pullrequestreview-1618079462

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to  #11577

#### Testing
1. Login as admin  and visit initiatives admin area 
2. Click on Print on any initiatives 
3. See the that accessibility elements are being printed 
4. Apply the patch 
5. Click on Print on any initiatives 
6. See there are no accessibility elements within PDF. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
