### PR TITLE
Don't show calendar with empty month in meetings' Content Block

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/meeting_month_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_month_cell.rb
@@ -7,6 +7,14 @@ module Decidim
 
       delegate :month, to: :start_date
 
+      def show
+        render if meetings_in_this_month?
+      end
+
+      def meetings_in_this_month?
+        meetings.collect(&:start_time).map { |date| date.strftime("%m").to_i }.any? month
+      end
+
       def month_days
         start_date.to_date.all_month
       end

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/highlighted_meetings_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/highlighted_meetings_cell_spec.rb
@@ -89,6 +89,24 @@ module Decidim
               end
             end
           end
+
+          context "with upcoming meetings in other month" do
+            context "when there are meetings in this month" do
+              context "and there are meetings in the next month" do
+                let!(:next_month_meeting) { create(:meeting, :published, component: meeting.component, start_time: meeting.start_time.advance(months: 1)) }
+
+                it "renders the two months" do
+                  expect(html).to have_css(".meeting-calendar__month time", count: 61)
+                end
+              end
+
+              context "and there are no meetings in the next month" do
+                it "renders only the current month" do
+                  expect(html).to have_css(".meeting-calendar__month time", count: 31)
+                end
+              end
+            end
+          end
         end
 
         context "with no meetings" do

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/highlighted_meetings_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/highlighted_meetings_cell_spec.rb
@@ -13,9 +13,13 @@ module Decidim
         let(:current_user) { create(:user, :confirmed, organization:) }
         let(:html) { cell("decidim/meetings/content_blocks/highlighted_meetings", content_block).call }
 
+        before do
+          travel_to(Time.zone.local(2021, 5, 15))
+        end
+
         context "with meetings" do
           let(:organization) { meeting.organization }
-          let(:meeting) { create(:meeting, :published, start_time: 1.week.from_now) }
+          let(:meeting) { create(:meeting, :published, start_time: Time.zone.local(2021, 5, 22)) }
 
           it "renders the meetings" do
             expect(html).to have_css(".card__list", count: 1)
@@ -24,7 +28,7 @@ module Decidim
           context "with upcoming meetings" do
             let(:meetings_ids) { html.find_all("a.card__list").map { |node| node[:id] } }
             let!(:past_meeting) do
-              create(:meeting, :published, start_time: 1.week.ago, component: meeting.component)
+              create(:meeting, :published, start_time: Time.zone.local(2021, 5, 7), component: meeting.component)
             end
             let!(:second_meeting) do
               create(:meeting, :published, start_time: meeting.start_time.advance(weeks: 1), component: meeting.component)
@@ -33,7 +37,7 @@ module Decidim
               create(:meeting, :moderated, :published, start_time: meeting.start_time.advance(weeks: 1), component: meeting.component)
             end
             let!(:unpublished_meeting) do
-              create(:meeting, start_time: 2.weeks.from_now, component: meeting.component)
+              create(:meeting, start_time: Time.zone.local(2021, 5, 30), component: meeting.component)
             end
 
             it { expect(html).to have_content("Upcoming meetings") }
@@ -52,7 +56,7 @@ module Decidim
 
             context "with upcoming private meetings" do
               let!(:meeting) do
-                create(:meeting, :published, start_time: 1.week.from_now, private_meeting: true, transparent: false)
+                create(:meeting, :published, start_time: Time.zone.local(2021, 5, 22), private_meeting: true, transparent: false)
               end
               let!(:second_meeting) do
                 create(:meeting, :published, start_time: meeting.start_time.advance(weeks: 1), component: meeting.component, private_meeting: true, transparent: false)
@@ -70,7 +74,7 @@ module Decidim
 
             context "with upcoming private meetings but invited user" do
               let!(:meeting) do
-                create(:meeting, :published, start_time: 1.week.from_now, private_meeting: true, transparent: false)
+                create(:meeting, :published, start_time: Time.zone.local(2021, 5, 22), private_meeting: true, transparent: false)
               end
               let!(:second_meeting) do
                 create(:meeting, :published, start_time: meeting.start_time.advance(weeks: 1), component: meeting.component, private_meeting: true, transparent: false)


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

In the meetings content block there's a problem where we show the monthly calendar even if there aren't any meetings for that month

This PR fixes this bug 

#### :pushpin: Related Issues
 
- Related to #11265

#### Testing

1. Search for a Meetings content block
2. Edit all the meetings, changing them to one this month (September)
3. See that you have the calendar for October empty 
4. Apply this PR
3. See that you don't have the calendar anymore for October 

### :camera: Screenshots

#### Before 
![Screenshot of the meetings content block with an empty month](https://github.com/decidim/decidim/assets/717367/51eed430-2e9c-4501-82de-9ce2cfd5f2ab)

#### After 
![Screenshot of the meetings content block without an empty month](https://github.com/decidim/decidim/assets/717367/dfefe32e-e4d5-4b4e-8ff7-ed51fc9ff8d0)

:hearts: Thank you!
