### PR TITLE
Add form in accountability's import results controller

### DIFF
--- a/decidim-accountability/app/controllers/decidim/accountability/admin/import_results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/import_results_controller.rb
@@ -5,18 +5,30 @@ module Decidim
     module Admin
       # This controller allows an admin to import results from a csv file for the Accountability component
       class ImportResultsController < Admin::ApplicationController
+        before_action :ensure_permissions
+
         def new
-          @errors = []
+          @form = form(Admin::ImportResultsForm).instance
         end
 
         def create
-          @csv_file = params[:csv_file]
-          redirect_to(new_import_path) && return if @csv_file.blank?
+          @form = form(Admin::ImportResultsForm).from_params(params, current_component:)
 
-          Decidim::Accountability::Admin::ImportResultsCsvJob.perform_later(current_user, current_component, @csv_file.read.force_encoding("utf-8").encode("utf-8"))
+          if @form.valid?
+            Decidim::Accountability::Admin::ImportResultsCsvJob.perform_later(current_user, current_component, @form.local_file_path)
 
-          flash[:notice] = I18n.t("imports.create.success", scope: "decidim.accountability.admin")
-          redirect_to import_results_path(current_participatory_space, current_component)
+            flash[:notice] = I18n.t("imports.create.success", scope: "decidim.accountability.admin")
+            redirect_to import_results_path(current_participatory_space, current_component)
+          else
+            flash[:alert] = I18n.t("imports.create.invalid", scope: "decidim.accountability.admin")
+            render action: "new"
+          end
+        end
+
+        private
+
+        def ensure_permissions
+          enforce_permission_to :create, :result
         end
       end
     end

--- a/decidim-accountability/app/forms/decidim/accountability/admin/import_results_form.rb
+++ b/decidim-accountability/app/forms/decidim/accountability/admin/import_results_form.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Accountability
+    module Admin
+      class ImportResultsForm < Decidim::Form
+        include Decidim::HasUploadValidations
+        include Decidim::ProcessesFileLocally
+
+        attribute :file, Decidim::Attributes::Blob
+
+        validates :file, presence: true, file_content_type: { allow: ["text/csv"] }
+
+        def local_file_path
+          process_file_locally(file) do |file_path|
+            file_path
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-accountability/app/views/decidim/accountability/admin/import_results/new.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/import_results/new.html.erb
@@ -8,7 +8,7 @@
   <div class="item__edit-form">
     <%= form_for(@form, url: import_results_path, html: { class: "form form-defaults import_projects" }) do |form| %>
       <div class="card py-4">
-        <div class="card-section space-y-4">
+        <div class="card-section space-y-4 prose max-w-full">
           <div class="row column">
             <p><%= t(".info",
                      link_new_status: new_status_path,

--- a/decidim-accountability/app/views/decidim/accountability/admin/import_results/new.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/import_results/new.html.erb
@@ -6,7 +6,7 @@
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">
-    <%= form_tag(import_results_path, multipart: true, class: "form form-defaults new_import") do %>
+    <%= form_for(@form, url: import_results_path, html: { class: "form form-defaults import_projects" }) do |form| %>
       <div class="card py-4">
         <div class="card-section space-y-4">
           <div class="row column">
@@ -14,10 +14,10 @@
                      link_new_status: new_status_path,
                      link_new_result: new_result_path,
                      link_export_csv: link_to(t(".download_export"),exports_path(current_component, id: "results", format: "CSV"), method: :post)
-                    ).try("html_safe") %></p>
+                   ).try("html_safe") %></p>
           </div>
           <div class="row column">
-            <%= file_field_tag :csv_file %>
+            <%= form.upload :file, button_class: "button button__sm button__transparent-secondary" %>
           </div>
         </div>
       </div>

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -78,6 +78,7 @@ en:
             title: Import results from CSV
         imports:
           create:
+            invalid: There was a problem importing the results.
             success: The file has begun importing. You will receive an email in the next few minutes with the result of the import.
         models:
           result:


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR attempts to fix 2 issues: 

1. Import results permission check 
2. Admin redesign on import result page

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11641

#### Testing
1. Login to admin 
2. Visit accountability page
3. From  import menu chose "Import CSV"
4. Upload a results csv, and seee the email is successfully sent 
5. Apply Patch 
6. See how the attach button is being displayed
7. Repeat step 4 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

Before the PR: 
![image](https://github.com/decidim/decidim/assets/105683/3d4f940a-e87b-46f6-85be-77fd506a67e9)

After the pr: 

![image](https://github.com/decidim/decidim/assets/105683/3f5fd431-bddc-49e6-be85-bdf77912d439)


:hearts: Thank you!
