### PR TITLE
Fix unpublished label between Components and Space

### DIFF
--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -160,7 +160,7 @@ module Decidim
             caption += content_tag(
               :span,
               t(component.published_at? ? "published" : "unpublished", scope: "decidim.admin.participatory_processes.index"),
-              class: component.published_at? ? "label success !text-sm" : "label reverse !text-sm"
+              class: component.published_at? ? "label success !text-sm" : "label alert !text-sm"
             )
 
             menu.add_item [component.manifest_name, component.id].join("_"),


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing the redesign @carolromero found a minor inconsistency between the labels when a Component and an Space are unpublished. This PR fixes it  

#### Testing

1. Sign in as admin
2. Unpublish a participatory process
3. Unpublish a component in this process
4. Go to the admin' process page
5. Check the labels

### :camera: Screenshots

#### Before
![Screenshot of the labels](https://github.com/decidim/decidim/assets/717367/1dbc5d71-1019-4fae-aa53-5c0ef3e1f0bd)

#### After
![Screenshot of the labels](https://github.com/decidim/decidim/assets/717367/c341414d-34f9-4eab-a87a-6ba7b9965258)



:hearts: Thank you!
