### PR TITLE
Redesign: fix participatory process admin form 

### DIFF
--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -189,7 +189,7 @@
       <div class="row column">
         <%= form.check_box :private_space %>
       </div>
-          <div class="row column">
+      <div class="row column">
         <%= form.check_box :promoted %>
       </div>
     </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -158,7 +158,6 @@
                                     scope_type_depth_select_options,
                                     scope_type_depth_select_html_options %>
       </div>
-    </div>
 
       <div class="row column">
         <%= form.areas_select :area_id,


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing the admin, @carolromero found two bugs in the process form: 

1. The "area" selector was outside of the "Filters" accordion when it was closed
2. The cards and accordions where weird

That was because there was a bad div closing. This PR fixes it. 
 

#### Testing

1. Sign in as admin
2. Go to the processes new or edit forms, 
3. Close all the accordions
4. They should work well (specially the "Area" when collapsing "Filters"

### :camera: Screenshots


#### Before
![Screenshot of the processes admin form](https://github.com/decidim/decidim/assets/717367/a3d22813-34c2-4790-9ab4-97dfae2c067e)


#### After

![Screenshot of the processes admin form](https://github.com/decidim/decidim/assets/717367/374597b8-aa1d-48e7-b4e4-07b922c88195)


:hearts: Thank you!
