### PR TITLE
Redesign: add missing option for editing a process in the admin's index

### DIFF
--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
@@ -82,6 +82,12 @@
           </td>
           <td class="table-list__actions">
 
+            <% if allowed_to? :update, :process, process: process %>
+              <%= icon_link_to "pencil-line", edit_participatory_process_path(process), t("actions.configure", scope: "decidim.admin"), class: "action-icon--new" %>
+            <% else %>
+              <span class="action-space icon"></span>
+            <% end %>
+
             <% if allowed_to? :create, :process, process: process %>
               <%= icon_link_to "download-line", participatory_process_export_path(process), t("actions.export", scope: "decidim.admin"), method: :post, class: "action-icon--export" %>
             <% else %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing the redesign, @carolromero found a missing option in the processes index admin page, for editing a process. This PR adds it. 
 
#### Testing

1. Sign in as admin
2. Go to /admin/processes
3. See the edit button and click on it 

### :camera: Screenshots

![Screenshot of the processes admin page](https://github.com/decidim/decidim/assets/717367/d8d266b3-96ed-4fa0-a38f-32e0caae11e7)

:hearts: Thank you!
