### PR TITLE
Redesign: fix 'Add content block' button and list

### DIFF
--- a/decidim-admin/app/views/decidim/admin/shared/landing_page/_content_blocks.html.erb
+++ b/decidim-admin/app/views/decidim/admin/shared/landing_page/_content_blocks.html.erb
@@ -10,7 +10,7 @@
           <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
         </button>
         <div class="dropdown-pane" id="add-content-block-dropdown" data-dropdown data-auto-focus="true" data-close-on-click="true">
-          <ul class="vertical menu add-components">
+          <ul class="vertical menu add-components font-normal">
             <% available_manifests.each do |manifest| %>
               <li><%= link_to t(manifest.public_name_key), resource_create_url(manifest.name), method: :post %></li>
             <% end %>

--- a/decidim-admin/app/views/decidim/admin/shared/landing_page/_content_blocks.html.erb
+++ b/decidim-admin/app/views/decidim/admin/shared/landing_page/_content_blocks.html.erb
@@ -5,7 +5,10 @@
       <%= content_blocks_title %>
 
       <div>
-        <button class="button button__sm button__secondary button--title" data-toggle="add-content-block-dropdown"><%= add_content_block_text %></button>
+        <button class="button button__sm button__secondary button--title" data-toggle="add-content-block-dropdown">
+          <%= add_content_block_text %>
+          <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
+        </button>
         <div class="dropdown-pane" id="add-content-block-dropdown" data-dropdown data-auto-focus="true" data-close-on-click="true">
           <ul class="vertical menu add-components">
             <% available_manifests.each do |manifest| %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing the redesign, @carolromero has found a couple errors in the 'Add content block' button: 

1. There was a missing icon with the arrow (aka chevron)
2. The options in the menu were with a bold

This PR fixes both of these issues
 

#### Testing

1. Sign in as admin
2. Go to http://localhost:3000/admin/organization/homepage/edit 
3. See and click the "Add content block" button

### :camera: Screenshots

#### Before
![Screenshot of the button](https://github.com/decidim/decidim/assets/717367/6ea38803-8170-4a0a-aaf4-dca50cdc622d)


#### After
![Screenshot of the button](https://github.com/decidim/decidim/assets/717367/b5b7a107-b8e7-4163-a754-f3f3e1950560)


:hearts: Thank you!
