### PR TITLE
Redesign: use the redesigned flash messages on admin

### DIFF
--- a/decidim-accountability/spec/shared/export_results_examples.rb
+++ b/decidim-accountability/spec/shared/export_results_examples.rb
@@ -9,10 +9,7 @@ shared_examples "export results" do
     find(".exports").click
     perform_enqueued_jobs { click_link "Results as CSV" }
 
-    within ".callout.success" do
-      expect(page).to have_content("in progress")
-    end
-
+    expect(page).to have_admin_callout "Your export is currently in progress. You will receive an email when it is complete."
     expect(last_email.subject).to include("results", "csv")
     expect(last_email.attachments.length).to be_positive
     expect(last_email.attachments.first.filename).to match(/^results.*\.zip$/)
@@ -22,10 +19,7 @@ shared_examples "export results" do
     find(".exports").click
     perform_enqueued_jobs { click_link "Results as JSON" }
 
-    within ".callout.success" do
-      expect(page).to have_content("in progress")
-    end
-
+    expect(page).to have_admin_callout "Your export is currently in progress. You will receive an email when it is complete."
     expect(last_email.subject).to include("results", "json")
     expect(last_email.attachments.length).to be_positive
     expect(last_email.attachments.first.filename).to match(/^results.*\.zip$/)

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_redesigned_layout.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_redesigned_layout.scss
@@ -48,6 +48,10 @@ body {
   .callout {
     @apply mb-4;
   }
+
+  .flash {
+    @apply mb-0 mx-4;
+  }
 }
 
 .container {

--- a/decidim-admin/app/views/decidim/admin/shared/_js-callout.html.erb
+++ b/decidim-admin/app/views/decidim/admin/shared/_js-callout.html.erb
@@ -1,5 +1,7 @@
-<div class="callout callout--full <%= css %>" data-closable>
-  <%= text %>
+<div class="flash <%= css %>" data-closable>
+  <span class="flash__message">
+    <%= text %>
+  </span>
   <button class="close-button" type="button" data-close="">
     <span aria-hidden="true">×</span>
   </button>

--- a/decidim-admin/app/views/layouts/decidim/admin/_application.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_application.html.erb
@@ -44,8 +44,9 @@
             <%= yield :aside_menu_nav if content_for? :aside_menu_nav %>
 
             <%= render partial: "layouts/decidim/admin/breadcrumb" %>
+            <%= render partial: "layouts/decidim/admin/callouts_full" %>
+
             <div class="layout-content__container" data-content>
-              <%= render partial: "layouts/decidim/admin/callouts_full" %>
               <%= yield %>
             </div>
           </div>

--- a/decidim-admin/app/views/layouts/decidim/admin/_callouts_full.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_callouts_full.html.erb
@@ -1,14 +1,1 @@
-<div class="callout-wrapper">
-  <% flash.each do |key, value| %>
-    <% if /_html\Z/.match?(key)
-         key = key.gsub(/_html\Z/, "")
-         value = decidim_sanitize(value)
-       end %>
-    <div class="callout <%= FoundationRailsHelper::FlashHelper::DEFAULT_KEY_MATCHING[key.to_sym] %> callout--full" data-closable>
-      <%= value %>
-      <button class="close-button" aria-label="Dismiss alert" type="button" data-close>
-        <span aria-hidden="true">&times;</span>
-      </button>
-    </div>
-  <% end %>
-</div>
+<%= display_flash_messages %>

--- a/decidim-admin/app/views/layouts/decidim/admin/_callouts_full.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_callouts_full.html.erb
@@ -1,1 +1,3 @@
-<%= display_flash_messages %>
+<div class="callout-wrapper">
+  <%= display_flash_messages %>
+</div>

--- a/decidim-admin/spec/system/admin_invite_spec.rb
+++ b/decidim-admin/spec/system/admin_invite_spec.rb
@@ -47,11 +47,7 @@ describe "Admin invite", type: :system do
         find("*[type=submit]").click
       end
 
-      expect(page).to have_selector ".callout--full"
-
-      within ".callout--full" do
-        page.find(".close-button").click
-      end
+      expect(page).to have_admin_callout "Your password was set successfully. You are now signed in."
 
       expect(page).to have_current_path "/admin/admin_terms/show"
     end

--- a/decidim-admin/spec/system/admin_manages_help_sections_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_help_sections_spec.rb
@@ -20,9 +20,7 @@ describe "Admin manages help sections", type: :system do
 
       click_button "Save"
 
-      within ".callout.success" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout "Help sections updated successfully"
 
       within "#sections_participatory_processes_content-content-panel-0" do
         expect(page).to have_content("Well hello!")
@@ -37,9 +35,7 @@ describe "Admin manages help sections", type: :system do
 
       click_button "Save"
 
-      within ".callout.success" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout "Help sections updated successfully"
 
       within "#sections_participatory_processes_content-content-panel-0" do
         expect(page).to have_content("")

--- a/decidim-admin/spec/system/admin_passwords_spec.rb
+++ b/decidim-admin/spec/system/admin_passwords_spec.rb
@@ -49,7 +49,8 @@ describe "Admin passwords", type: :system do
         expect(page).to have_content("Password change")
         fill_in :password_user_password, with: new_password
         click_button "Change my password"
-        expect(page).to have_css(".callout.success")
+
+        expect(page).to have_admin_callout("Password successfully updated")
         expect(page).to have_current_path(decidim_admin.root_path)
       end
     end

--- a/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
@@ -45,9 +45,7 @@ describe "Admin manages budgets", type: :system do
 
     click_button "Create budget"
 
-    within ".callout-wrapper" do
-      expect(page).to have_content("successfully")
-    end
+    expect(page).to have_admin_callout("Budget successfully created.")
 
     within "table" do
       expect(page).to have_content("My Budget")
@@ -72,9 +70,7 @@ describe "Admin manages budgets", type: :system do
 
       click_button "Update budget"
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout("Budget successfully updated.")
 
       within "table" do
         expect(page).to have_content("My new title")
@@ -97,9 +93,7 @@ describe "Admin manages budgets", type: :system do
         end
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout("Budget successfully deleted.")
 
       within "table" do
         expect(page).not_to have_content(translated(budget.title))

--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -39,7 +39,8 @@ describe "Admin manages projects", type: :system do
       click_button "Change category"
       select translated(category.name), from: "category_id"
       click_button "Update"
-      expect(page).to have_css(".callout.success")
+
+      expect(page).to have_admin_callout "Projects successfully updated to the category"
       within "tr[data-id='#{project.id}']" do
         expect(page).to have_content(translated(category.name))
       end
@@ -53,7 +54,8 @@ describe "Admin manages projects", type: :system do
       click_button "Change scope"
       scope_pick select_data_picker(:scope_id), scope
       click_button "Update"
-      expect(page).to have_css(".callout.success")
+
+      expect(page).to have_admin_callout "Projects successfully updated to the scope"
       within "tr[data-id='#{project.id}']" do
         expect(page).to have_content(translated(scope.name))
       end
@@ -67,7 +69,8 @@ describe "Admin manages projects", type: :system do
       click_button "Change selected"
       select "Select", from: "selected_value"
       click_button "Update"
-      expect(page).to have_css(".callout.success")
+
+      expect(page).to have_admin_callout "These projects were successfully selected for implementation"
       within "tr[data-id='#{project.id}']" do
         expect(page).to have_content("Selected")
       end

--- a/decidim-debates/spec/shared/export_debate_comments_examples.rb
+++ b/decidim-debates/spec/shared/export_debate_comments_examples.rb
@@ -7,10 +7,7 @@ shared_examples "export debates comments" do
     find(".exports").click
     perform_enqueued_jobs { click_link "Comments as CSV" }
 
-    within ".callout.success" do
-      expect(page).to have_content("in progress")
-    end
-
+    expect(page).to have_admin_callout "Your export is currently in progress. You will receive an email when it is complete."
     expect(last_email.subject).to include("comments", "csv")
     expect(last_email.attachments.length).to be_positive
     expect(last_email.attachments.first.filename).to match(/^comments.*\.zip$/)
@@ -20,10 +17,7 @@ shared_examples "export debates comments" do
     find(".exports").click
     perform_enqueued_jobs { click_link "Comments as JSON" }
 
-    within ".callout.success" do
-      expect(page).to have_content("in progress")
-    end
-
+    expect(page).to have_admin_callout "Your export is currently in progress. You will receive an email when it is complete."
     expect(last_email.subject).to include("comments", "json")
     expect(last_email.attachments.length).to be_positive
     expect(last_email.attachments.first.filename).to match(/^comments.*\.zip$/)

--- a/decidim-debates/spec/shared/manage_debates_examples.rb
+++ b/decidim-debates/spec/shared/manage_debates_examples.rb
@@ -42,9 +42,7 @@ RSpec.shared_examples "manage debates" do
         find("*[type=submit]").click
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout "Debate successfully updated"
 
       within "table" do
         expect(page).to have_content("My new title")
@@ -114,9 +112,7 @@ RSpec.shared_examples "manage debates" do
       find("*[type=submit]").click
     end
 
-    within ".callout-wrapper" do
-      expect(page).to have_content("successfully")
-    end
+    expect(page).to have_admin_callout "Debate successfully created"
 
     within "table" do
       expect(page).to have_content("My debate")
@@ -161,9 +157,7 @@ RSpec.shared_examples "manage debates" do
       find("*[type=submit]").click
     end
 
-    within ".callout-wrapper" do
-      expect(page).to have_content("successfully")
-    end
+    expect(page).to have_admin_callout "Debate successfully created"
 
     within "table" do
       expect(page).to have_content("My debate")
@@ -184,9 +178,7 @@ RSpec.shared_examples "manage debates" do
         end
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout "Debate successfully deleted"
 
       within "table" do
         expect(page).not_to have_content(translated(debate2.title))
@@ -222,9 +214,7 @@ RSpec.shared_examples "manage debates" do
         find("*[type=submit]").click
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout "Debate successfully updated"
 
       within "table" do
         within find("tr", text: translated(debate.title)) do

--- a/decidim-debates/spec/shared/manage_debates_examples.rb
+++ b/decidim-debates/spec/shared/manage_debates_examples.rb
@@ -214,7 +214,7 @@ RSpec.shared_examples "manage debates" do
         find("*[type=submit]").click
       end
 
-      expect(page).to have_admin_callout "Debate successfully updated"
+      expect(page).to have_admin_callout "Debate successfully closed"
 
       within "table" do
         within find("tr", text: translated(debate.title)) do

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/helpers.rb
@@ -48,7 +48,9 @@ module Decidim
     end
 
     def have_admin_callout(text)
-      have_selector(".callout--full", text:)
+      within_flash_messages do
+        have_content text
+      end
     end
 
     def stub_get_request_with_format(rq_url, rs_format)

--- a/decidim-elections/spec/system/admin/admin_manages_answers_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_answers_spec.rb
@@ -38,7 +38,7 @@ describe "Admin manages answers", type: :system do
 
       click_button "Import proposals to answers"
 
-      expect(page).to have_content("3 proposals successfully imported")
+      expect(page).to have_admin_callout("3 proposals successfully imported")
     end
   end
 
@@ -72,9 +72,7 @@ describe "Admin manages answers", type: :system do
       find("*[type=submit]").click
     end
 
-    within ".callout-wrapper" do
-      expect(page).to have_content("successfully")
-    end
+    expect(page).to have_admin_callout("Answer successfully created.")
 
     within "table" do
       expect(page).to have_content("My answer")
@@ -115,9 +113,7 @@ describe "Admin manages answers", type: :system do
         find("*[type=submit]").click
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout("Answer successfully updated.")
 
       within "table" do
         expect(page).to have_content("My new answer")
@@ -143,9 +139,8 @@ describe "Admin manages answers", type: :system do
         end
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
+      # As there is more than one alert, we need to use have_content
+      expect(page).to have_content("Answer successfully deleted.")
 
       within "table" do
         expect(page).not_to have_content(translated(answer.title))
@@ -192,9 +187,7 @@ describe "Admin manages answers", type: :system do
         expect(page).to have_content("Selected")
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("Answer successfully selected")
-      end
+      expect(page).to have_admin_callout("Answer successfully selected")
     end
   end
 end

--- a/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
@@ -59,9 +59,7 @@ describe "Admin manages elections", type: :system do
         find("*[type=submit]").click
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout("Election successfully created")
 
       within "table" do
         expect(page).to have_content("My election")
@@ -103,9 +101,7 @@ describe "Admin manages elections", type: :system do
         find("*[type=submit]").click
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout("Election successfully updated")
 
       within "table" do
         expect(page).to have_content("My new title")
@@ -142,9 +138,7 @@ describe "Admin manages elections", type: :system do
           page.find(".action-icon--publish").click
         end
 
-        within ".callout-wrapper" do
-          expect(page).to have_content("successfully")
-        end
+        expect(page).to have_admin_callout("The election has been successfully published")
 
         within find("tr", text: translated(election.title)) do
           expect(page).not_to have_selector(".action-icon--publish")
@@ -161,9 +155,7 @@ describe "Admin manages elections", type: :system do
         page.find(".action-icon--unpublish").click
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout("The election has been successfully unpublished")
 
       within find("tr", text: translated(election.title)) do
         expect(page).not_to have_selector(".action-icon--unpublish")
@@ -201,9 +193,7 @@ describe "Admin manages elections", type: :system do
         end
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout("Election successfully deleted")
 
       within "table" do
         expect(page).not_to have_content(translated(election.title))

--- a/decidim-elections/spec/system/admin/admin_manages_questions_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_questions_spec.rb
@@ -37,9 +37,7 @@ describe "Admin manages questions", type: :system do
       find("*[type=submit]").click
     end
 
-    within ".callout-wrapper" do
-      expect(page).to have_content("successfully")
-    end
+    expect(page).to have_admin_callout("Question successfully created.")
 
     within "table" do
       expect(page).to have_content("My question")
@@ -52,9 +50,7 @@ describe "Admin manages questions", type: :system do
     it "does not create a new question" do
       visit Decidim::EngineRouter.admin_proxy(component).new_election_question_path(election)
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("You are not authorized to perform this action")
-      end
+      expect(page).to have_admin_callout("You are not authorized to perform this action")
     end
 
     it "cannot add a new question" do
@@ -80,9 +76,7 @@ describe "Admin manages questions", type: :system do
         find("*[type=submit]").click
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout("Question successfully updated.")
 
       within "table" do
         expect(page).to have_content("My new question")
@@ -108,9 +102,7 @@ describe "Admin manages questions", type: :system do
         end
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
+      expect(page).to have_admin_callout("Question successfully deleted.")
 
       within "table" do
         expect(page).not_to have_content(translated(question.title))

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
@@ -56,10 +56,7 @@ describe "Admin manages initiative components", type: :system do
     end
 
     it "is successfully created" do
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
-
+      expect(page).to have_admin_callout("Component created successfully.")
       expect(page).to have_content("My component")
     end
 
@@ -83,9 +80,7 @@ describe "Admin manages initiative components", type: :system do
       it "successfully edits it" do
         click_button "Update"
 
-        within ".callout-wrapper" do
-          expect(page).to have_content("successfully")
-        end
+        expect(page).to have_admin_callout("The component was updated successfully.")
       end
     end
   end
@@ -132,10 +127,7 @@ describe "Admin manages initiative components", type: :system do
         click_button "Update"
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("successfully")
-      end
-
+      expect(page).to have_admin_callout("The component was updated successfully.")
       expect(page).to have_content("My updated component")
 
       within find("tr", text: "My updated component") do

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_scopes_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_scopes_spec.rb
@@ -15,15 +15,13 @@ describe "Admin manages initiatives types scopes", type: :system do
   end
 
   context "when creating a new initiative type scope" do
-    it "Creates a new initiative type scope" do
+    it "creates a new initiative type scope" do
       click_link "New Initiative type scope"
       select translated(scope.name), from: :initiatives_type_scope_decidim_scopes_id
       fill_in :initiatives_type_scope_supports_required, with: 1000
       click_button "Create"
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("A new scope for the given initiative type has been created")
-      end
+      expect(page).to have_admin_callout("A new scope for the given initiative type has been created")
     end
 
     it "allows creating initiative type scopes with a Global scope" do
@@ -31,9 +29,7 @@ describe "Admin manages initiatives types scopes", type: :system do
       fill_in :initiatives_type_scope_supports_required, with: 10
       click_button "Create"
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("A new scope for the given initiative type has been created")
-      end
+      expect(page).to have_admin_callout("A new scope for the given initiative type has been created")
 
       within ".edit_initiative_type" do
         expect(page).to have_content("Global scope")
@@ -51,17 +47,15 @@ describe "Admin manages initiatives types scopes", type: :system do
     it "updates the initiative type scope" do
       click_link "Configure"
       click_button "Update"
-      within ".callout-wrapper" do
-        expect(page).to have_content("The scope has been successfully updated")
-      end
+
+      expect(page).to have_admin_callout("The scope has been successfully updated")
     end
 
     it "removes the initiative type scope" do
       click_link "Configure"
       accept_confirm { click_link "Delete" }
-      within ".callout-wrapper" do
-        expect(page).to have_content("The scope has been successfully removed")
-      end
+
+      expect(page).to have_admin_callout("The scope has been successfully removed")
     end
   end
 end

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_spec.rb
@@ -41,9 +41,7 @@ describe "Admin manages initiatives types", type: :system do
 
       click_button "Create"
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("A new initiative type has been successfully created")
-      end
+      expect(page).to have_admin_callout("A new initiative type has been successfully created")
     end
   end
 
@@ -68,9 +66,7 @@ describe "Admin manages initiatives types", type: :system do
 
       click_button "Update"
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("The initiative type has been successfully updated")
-      end
+      expect(page).to have_admin_callout("The initiative type has been successfully updated")
     end
   end
 
@@ -82,9 +78,7 @@ describe "Admin manages initiatives types", type: :system do
         end
       end
 
-      within ".callout-wrapper" do
-        expect(page).to have_content("The initiative type has been successfully removed")
-      end
+      expect(page).to have_admin_callout("The initiative type has been successfully removed")
     end
   end
 end

--- a/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
@@ -5,14 +5,12 @@ require "spec_helper"
 describe "User answers the initiative", type: :system do
   include_context "when admins initiative"
 
-  def submit_and_validate(message = "successfully")
+  def submit_and_validate(message)
     within "[data-content]" do
       find("*[type=submit]").click
     end
 
-    within ".callout-wrapper" do
-      expect(page).to have_content(message)
-    end
+    expect(page).to have_admin_callout(message)
   end
 
   context "when user is admin" do
@@ -36,7 +34,7 @@ describe "User answers the initiative", type: :system do
         )
       end
 
-      submit_and_validate
+      submit_and_validate("The initiative has been successfully updated")
     end
 
     context "when initiative is in published state" do
@@ -62,7 +60,7 @@ describe "User answers the initiative", type: :system do
             fill_in :initiative_signature_start_date, with: 1.day.ago
           end
 
-          submit_and_validate
+          submit_and_validate("The initiative has been successfully updated")
         end
 
         context "when dates are invalid" do
@@ -83,7 +81,7 @@ describe "User answers the initiative", type: :system do
               fill_in :initiative_signature_start_date, with: 1.month.since(initiative.signature_end_date)
             end
 
-            submit_and_validate("error")
+            submit_and_validate("An error has occurred")
             expect(page).to have_current_path decidim_admin_initiatives.edit_initiative_answer_path(initiative)
           end
         end

--- a/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
@@ -10,9 +10,7 @@ describe "User prints the initiative", type: :system do
       find("*[type=submit]").click
     end
 
-    within ".callout-wrapper" do
-      expect(page).to have_content("successfully")
-    end
+    expect(page).to have_admin_callout "The initiative has been successfully updated."
   end
 
   context "when initiative update" do

--- a/decidim-meetings/spec/shared/export_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/export_meetings_examples.rb
@@ -7,10 +7,7 @@ shared_examples "export meetings" do
     find(".exports").click
     perform_enqueued_jobs { click_link "Meetings as CSV" }
 
-    within ".callout.success" do
-      expect(page).to have_content("in progress")
-    end
-
+    expect(page).to have_admin_callout "Your export is currently in progress. You will receive an email when it is complete."
     expect(last_email.subject).to include("meetings", "csv")
     expect(last_email.attachments.length).to be_positive
     expect(last_email.attachments.first.filename).to match(/^meetings.*\.zip$/)
@@ -20,10 +17,7 @@ shared_examples "export meetings" do
     find(".exports").click
     perform_enqueued_jobs { click_link "Meetings as JSON" }
 
-    within ".callout.success" do
-      expect(page).to have_content("in progress")
-    end
-
+    expect(page).to have_admin_callout "Your export is currently in progress. You will receive an email when it is complete."
     expect(last_email.subject).to include("meetings", "json")
     expect(last_email.attachments.length).to be_positive
     expect(last_email.attachments.first.filename).to match(/^meetings.*\.zip$/)

--- a/decidim-proposals/spec/shared/export_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/export_proposals_examples.rb
@@ -7,10 +7,7 @@ shared_examples "export proposals" do
     find(".exports").click
     perform_enqueued_jobs { click_link "Proposals as CSV" }
 
-    within ".callout.success" do
-      expect(page).to have_content("in progress")
-    end
-
+    expect(page).to have_admin_callout "Your export is currently in progress. You will receive an email when it is complete."
     expect(last_email.subject).to include("proposals", "csv")
     expect(last_email.attachments.length).to be_positive
     expect(last_email.attachments.first.filename).to match(/^proposals.*\.zip$/)
@@ -20,10 +17,7 @@ shared_examples "export proposals" do
     find(".exports").click
     perform_enqueued_jobs { click_link "Proposals as JSON" }
 
-    within ".callout.success" do
-      expect(page).to have_content("in progress")
-    end
-
+    expect(page).to have_admin_callout "Your export is currently in progress. You will receive an email when it is complete."
     expect(last_email.subject).to include("proposals", "json")
     expect(last_email.attachments.length).to be_positive
     expect(last_email.attachments.first.filename).to match(/^proposals.*\.zip$/)

--- a/decidim-surveys/spec/shared/export_survey_user_answers_examples.rb
+++ b/decidim-surveys/spec/shared/export_survey_user_answers_examples.rb
@@ -15,10 +15,7 @@ shared_examples "export survey user answers" do
     find(".exports").click
     perform_enqueued_jobs { click_link "CSV" }
 
-    within ".callout.success" do
-      expect(page).to have_content("in progress")
-    end
-
+    expect(page).to have_admin_callout("Your export is currently in progress. You will receive an email when it is complete.")
     expect(last_email.subject).to include("survey_user_answers", "csv")
     expect(last_email.attachments.length).to be_positive
     expect(last_email.attachments.first.filename).to match(/^survey_user_answers.*\.zip$/)
@@ -30,10 +27,7 @@ shared_examples "export survey user answers" do
     find(".exports").click
     perform_enqueued_jobs { click_link "JSON" }
 
-    within ".callout.success" do
-      expect(page).to have_content("in progress")
-    end
-
+    expect(page).to have_admin_callout("Your export is currently in progress. You will receive an email when it is complete.")
     expect(last_email.subject).to include("survey_user_answers", "json")
     expect(last_email.attachments.length).to be_positive
     expect(last_email.attachments.first.filename).to match(/^survey_user_answers.*\.zip$/)
@@ -45,10 +39,7 @@ shared_examples "export survey user answers" do
     find(".exports").click
     perform_enqueued_jobs { click_link "PDF" }
 
-    within ".callout.success" do
-      expect(page).to have_content("in progress")
-    end
-
+    expect(page).to have_admin_callout("Your export is currently in progress. You will receive an email when it is complete.")
     expect(last_email.subject).to include("survey_user_answers", "pdf")
     expect(last_email.attachments.length).to be_positive
     expect(last_email.attachments.first.filename).to match(/^survey_user_answers.*\.zip$/)

--- a/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
+++ b/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
@@ -69,7 +69,7 @@ describe "Admin manages surveys", type: :system do
           click_button "Save"
         end
 
-        expect(page).to have_admin_callout("successfully")
+        expect(page).to have_admin_callout "Survey successfully saved"
         expect(questionnaire.answers).to be_empty
       end
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing the admin redesign, @carolromero has found a bug in the flash alerts/callouts, where they weren't using the new design. This PR fixes that. 

NOTE: it's out of the scope of the current PR to actually change the announcements/callouts that are mixed in some forms. The idea is to make a new PR after this one is merged with those changes, to keep them small. 

#### Testing

1. Sign in as admin 
2. Go to the Edit a process page
3. Click in the publish/unpublish  it to see the new callouts

### :camera: Screenshots

#### Before

![Screenshot of the old alert](https://github.com/decidim/decidim/assets/717367/b385cf12-271c-4caa-ac20-a6767ce3d248)


#### After 
![Screenshot of the new alert](https://github.com/decidim/decidim/assets/717367/c32a193c-0cc2-422d-be33-2f54cb4bad68)

:hearts: Thank you!
