### PR TITLE
Update elections dependencies to 0.24.2

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
       bulletin_board:
-        image: decidim/decidim-bulletin-board:0.24.1
+        image: decidim/decidim-bulletin-board:0.24.2
         ports: ["8000:8000"]
         env:
           DATABASE_URL: postgresql://postgres:postgres@postgres/bb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ PATH
       devise_invitable (~> 2.0)
     decidim-api (0.28.0.dev)
       commonmarker (~> 0.23.0, >= 0.23.9)
-      graphql (~> 2.0)
+      graphql (~> 2.0.0)
       graphql-docs (~> 3.0.1)
       rack-cors (~> 1.0)
     decidim-assemblies (0.28.0.dev)

--- a/decidim-api/decidim-api.gemspec
+++ b/decidim-api/decidim-api.gemspec
@@ -28,7 +28,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor,docs}/**/*", "Rakefile", "README.md"]
 
   s.add_dependency "commonmarker", "~> 0.23.0", ">= 0.23.9"
-  s.add_dependency "graphql", "~> 2.0"
+  # Looks like version 2.1 breaks graphql-clien See https://github.com/github/graphql-client/pull/311
+  s.add_dependency "graphql", "~> 2.0.0"
   s.add_dependency "graphql-docs", "~> 3.0.1"
   s.add_dependency "rack-cors", "~> 1.0"
   s.add_development_dependency "decidim-comments", Decidim::Api.version

--- a/decidim-elections/docs/docker/bulletin_board/docker-compose.yml
+++ b/decidim-elections/docs/docker/bulletin_board/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - pg-data:/var/lib/postgresql/data
   app:
-    image: decidim/decidim-bulletin-board:0.24.1
+    image: decidim/decidim-bulletin-board:0.24.2
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db/decidim_bulletin_board_test
       - RAILS_ENV=test

--- a/decidim-elections/docs/docker/bulletin_board_test/docker-compose.yml
+++ b/decidim-elections/docs/docker/bulletin_board_test/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - pg-data:/var/lib/postgresql/data
   app:
-    image: decidim/decidim-bulletin-board:0.24.1
+    image: decidim/decidim-bulletin-board:0.24.2
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db/decidim_bulletin_board_test
       - RAILS_ENV=test

--- a/decidim_app-design/package-lock.json
+++ b/decidim_app-design/package-lock.json
@@ -2741,8 +2741,9 @@
       "link": true
     },
     "node_modules/@decidim/decidim-bulletin_board": {
-      "version": "0.24.1",
-      "license": "ISC",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@decidim/decidim-bulletin_board/-/decidim-bulletin_board-0.24.2.tgz",
+      "integrity": "sha512-x+xG/nAOAFPd1gz/WZRfbglGjLGM015lW4voXM2aMdRMbp8s4I8st8QXNW4+hiipnpwoxB+xZ50tBDdJzJbHCg==",
       "dependencies": {
         "@apollo/client": "^3.2.7",
         "core-js": "^3.8.3",
@@ -2904,12 +2905,14 @@
       "link": true
     },
     "node_modules/@decidim/voting_schemes-dummy": {
-      "version": "0.24.1",
-      "license": "ISC"
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-dummy/-/voting_schemes-dummy-0.24.2.tgz",
+      "integrity": "sha512-akwIv9cFYN57m7vxIMNnUJYqk/B8HBGXjzcK4keBBuyiLgcPxq1rOtYB8HqVAAN9fRdC8mqxLZfcvryz4zjlCA=="
     },
     "node_modules/@decidim/voting_schemes-electionguard": {
-      "version": "0.24.1",
-      "license": "ISC"
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-electionguard/-/voting_schemes-electionguard-0.24.2.tgz",
+      "integrity": "sha512-moXU4SkGd8HoshDBnvxzrVA4eDmYd/CXhSL9JOMhCQ2FVajEHmstWGo04/c286vItE3meMviQ7PB8EvgN5dErQ=="
     },
     "node_modules/@decidim/webpacker": {
       "resolved": "packages/webpacker",
@@ -19557,9 +19560,9 @@
       "version": "0.28.0-dev",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@decidim/decidim-bulletin_board": "0.24.1",
-        "@decidim/voting_schemes-dummy": "0.24.1",
-        "@decidim/voting_schemes-electionguard": "0.24.1"
+        "@decidim/decidim-bulletin_board": "0.24.2",
+        "@decidim/voting_schemes-dummy": "0.24.2",
+        "@decidim/voting_schemes-electionguard": "0.24.2"
       }
     },
     "packages/eslint-config": {
@@ -21309,7 +21312,9 @@
       }
     },
     "@decidim/decidim-bulletin_board": {
-      "version": "0.24.1",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@decidim/decidim-bulletin_board/-/decidim-bulletin_board-0.24.2.tgz",
+      "integrity": "sha512-x+xG/nAOAFPd1gz/WZRfbglGjLGM015lW4voXM2aMdRMbp8s4I8st8QXNW4+hiipnpwoxB+xZ50tBDdJzJbHCg==",
       "requires": {
         "@apollo/client": "^3.2.7",
         "core-js": "^3.8.3",
@@ -21391,9 +21396,9 @@
     "@decidim/elections": {
       "version": "file:packages/elections",
       "requires": {
-        "@decidim/decidim-bulletin_board": "0.24.1",
-        "@decidim/voting_schemes-dummy": "0.24.1",
-        "@decidim/voting_schemes-electionguard": "0.24.1"
+        "@decidim/decidim-bulletin_board": "0.24.2",
+        "@decidim/voting_schemes-dummy": "0.24.2",
+        "@decidim/voting_schemes-electionguard": "0.24.2"
       }
     },
     "@decidim/eslint-config": {
@@ -21409,10 +21414,14 @@
       "requires": {}
     },
     "@decidim/voting_schemes-dummy": {
-      "version": "0.24.1"
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-dummy/-/voting_schemes-dummy-0.24.2.tgz",
+      "integrity": "sha512-akwIv9cFYN57m7vxIMNnUJYqk/B8HBGXjzcK4keBBuyiLgcPxq1rOtYB8HqVAAN9fRdC8mqxLZfcvryz4zjlCA=="
     },
     "@decidim/voting_schemes-electionguard": {
-      "version": "0.24.1"
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-electionguard/-/voting_schemes-electionguard-0.24.2.tgz",
+      "integrity": "sha512-moXU4SkGd8HoshDBnvxzrVA4eDmYd/CXhSL9JOMhCQ2FVajEHmstWGo04/c286vItE3meMviQ7PB8EvgN5dErQ=="
     },
     "@decidim/webpacker": {
       "version": "file:packages/webpacker",

--- a/decidim_app-design/packages/elections/package.json
+++ b/decidim_app-design/packages/elections/package.json
@@ -10,8 +10,8 @@
   "author": "Decidim Contributors",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@decidim/decidim-bulletin_board": "0.24.1",
-    "@decidim/voting_schemes-dummy": "0.24.1",
-    "@decidim/voting_schemes-electionguard": "0.24.1"
+    "@decidim/decidim-bulletin_board": "0.24.2",
+    "@decidim/voting_schemes-dummy": "0.24.2",
+    "@decidim/voting_schemes-electionguard": "0.24.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2741,8 +2741,9 @@
       "link": true
     },
     "node_modules/@decidim/decidim-bulletin_board": {
-      "version": "0.24.1",
-      "license": "ISC",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@decidim/decidim-bulletin_board/-/decidim-bulletin_board-0.24.2.tgz",
+      "integrity": "sha512-x+xG/nAOAFPd1gz/WZRfbglGjLGM015lW4voXM2aMdRMbp8s4I8st8QXNW4+hiipnpwoxB+xZ50tBDdJzJbHCg==",
       "dependencies": {
         "@apollo/client": "^3.2.7",
         "core-js": "^3.8.3",
@@ -2904,12 +2905,14 @@
       "link": true
     },
     "node_modules/@decidim/voting_schemes-dummy": {
-      "version": "0.24.1",
-      "license": "ISC"
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-dummy/-/voting_schemes-dummy-0.24.2.tgz",
+      "integrity": "sha512-akwIv9cFYN57m7vxIMNnUJYqk/B8HBGXjzcK4keBBuyiLgcPxq1rOtYB8HqVAAN9fRdC8mqxLZfcvryz4zjlCA=="
     },
     "node_modules/@decidim/voting_schemes-electionguard": {
-      "version": "0.24.1",
-      "license": "ISC"
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-electionguard/-/voting_schemes-electionguard-0.24.2.tgz",
+      "integrity": "sha512-moXU4SkGd8HoshDBnvxzrVA4eDmYd/CXhSL9JOMhCQ2FVajEHmstWGo04/c286vItE3meMviQ7PB8EvgN5dErQ=="
     },
     "node_modules/@decidim/webpacker": {
       "resolved": "packages/webpacker",
@@ -19557,9 +19560,9 @@
       "version": "0.28.0-dev",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@decidim/decidim-bulletin_board": "0.24.1",
-        "@decidim/voting_schemes-dummy": "0.24.1",
-        "@decidim/voting_schemes-electionguard": "0.24.1"
+        "@decidim/decidim-bulletin_board": "0.24.2",
+        "@decidim/voting_schemes-dummy": "0.24.2",
+        "@decidim/voting_schemes-electionguard": "0.24.2"
       }
     },
     "packages/eslint-config": {
@@ -21309,7 +21312,9 @@
       }
     },
     "@decidim/decidim-bulletin_board": {
-      "version": "0.24.1",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@decidim/decidim-bulletin_board/-/decidim-bulletin_board-0.24.2.tgz",
+      "integrity": "sha512-x+xG/nAOAFPd1gz/WZRfbglGjLGM015lW4voXM2aMdRMbp8s4I8st8QXNW4+hiipnpwoxB+xZ50tBDdJzJbHCg==",
       "requires": {
         "@apollo/client": "^3.2.7",
         "core-js": "^3.8.3",
@@ -21391,9 +21396,9 @@
     "@decidim/elections": {
       "version": "file:packages/elections",
       "requires": {
-        "@decidim/decidim-bulletin_board": "0.24.1",
-        "@decidim/voting_schemes-dummy": "0.24.1",
-        "@decidim/voting_schemes-electionguard": "0.24.1"
+        "@decidim/decidim-bulletin_board": "0.24.2",
+        "@decidim/voting_schemes-dummy": "0.24.2",
+        "@decidim/voting_schemes-electionguard": "0.24.2"
       }
     },
     "@decidim/eslint-config": {
@@ -21409,10 +21414,14 @@
       "requires": {}
     },
     "@decidim/voting_schemes-dummy": {
-      "version": "0.24.1"
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-dummy/-/voting_schemes-dummy-0.24.2.tgz",
+      "integrity": "sha512-akwIv9cFYN57m7vxIMNnUJYqk/B8HBGXjzcK4keBBuyiLgcPxq1rOtYB8HqVAAN9fRdC8mqxLZfcvryz4zjlCA=="
     },
     "@decidim/voting_schemes-electionguard": {
-      "version": "0.24.1"
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@decidim/voting_schemes-electionguard/-/voting_schemes-electionguard-0.24.2.tgz",
+      "integrity": "sha512-moXU4SkGd8HoshDBnvxzrVA4eDmYd/CXhSL9JOMhCQ2FVajEHmstWGo04/c286vItE3meMviQ7PB8EvgN5dErQ=="
     },
     "@decidim/webpacker": {
       "version": "file:packages/webpacker",

--- a/packages/elections/package.json
+++ b/packages/elections/package.json
@@ -10,8 +10,8 @@
   "author": "Decidim Contributors",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@decidim/decidim-bulletin_board": "0.24.1",
-    "@decidim/voting_schemes-dummy": "0.24.1",
-    "@decidim/voting_schemes-electionguard": "0.24.1"
+    "@decidim/decidim-bulletin_board": "0.24.2",
+    "@decidim/voting_schemes-dummy": "0.24.2",
+    "@decidim/voting_schemes-electionguard": "0.24.2"
   }
 }


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

The bulletin board gem and all the related npm packages has been updated to version 0.24.2.
This is required in order for elections to work.

Also, this bug is affecting the elections module: https://github.com/github/graphql-client/issues/310 and https://github.com/github/graphql-client/pull/311 It seems that GraphQL 2.1 changes some apis affecting the GraphQL::Client lib.

So I've locked the GraphQL library to `~> 2.0.0`

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
