### PR TITLE
Redesign: fix accordions in edit Process form

### DIFF
--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -21,11 +21,11 @@
         <%= form.number_field :weight %>
       </div>
 
-    <div class="row">
-      <div class="columns xlarge-6 slug">
-        <%= form.text_field :slug, help_text: t(".slug_help_html", url: decidim_form_slug_url(:processes, form.object.slug)) %>
-        </p>
-      </div>
+      <div class="row">
+        <div class="columns xlarge-6 slug">
+          <%= form.text_field :slug, help_text: t(".slug_help_html", url: decidim_form_slug_url(:processes, form.object.slug)) %>
+          </p>
+        </div>
 
         <div class="columns xlarge-6">
           <%= form.text_field :hashtag %>
@@ -40,22 +40,22 @@
         <%= form.translated :editor, :description, aria: { label: :description } %>
       </div>
 
-    <div class="row column">
-      <%= form.translated :editor, :announcement, help_text: t(".announcement_help") %>
+      <div class="row column">
+        <%= form.translated :editor, :announcement, help_text: t(".announcement_help") %>
+      </div>
     </div>
-  </div>
   </div>
 
   <div class="card" data-component="accordion" id="accordion-duration">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-duration" type="button">
-          <svg viewBox="0 0 24 24" id="ri-arrow-right-s-line">
-            <path fill="none" d="M0 0h24v24H0z" />
-            <path d="M13.172 12l-4.95-4.95 1.414-1.414L16 12l-6.364 6.364-1.414-1.414z" />
-          </svg>
-          <h2 class="card-title" id="duration">
-           <%= t("duration", scope: "decidim.participatory_processes.admin.participatory_processes.form") %>
-          </h2>
+        <svg viewBox="0 0 24 24" id="ri-arrow-right-s-line">
+          <path fill="none" d="M0 0h24v24H0z" />
+          <path d="M13.172 12l-4.95-4.95 1.414-1.414L16 12l-6.364 6.364-1.414-1.414z" />
+        </svg>
+        <h2 class="card-title" id="duration">
+          <%= t("duration", scope: "decidim.participatory_processes.admin.participatory_processes.form") %>
+        </h2>
       </button>
     </div>
 

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -44,6 +44,7 @@
       <%= form.translated :editor, :announcement, help_text: t(".announcement_help") %>
     </div>
   </div>
+  </div>
 
   <div class="card" data-component="accordion" id="accordion-duration">
     <div class="card-divider">


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

After seeing how this form works after merging #11660, @carolromero has noticed that the accordions are too close, and they should be more separated, as others forms (such as Assemblies or Conferences).

This PR fixes that.

I've also fixed the indentation, as the problem was probably related to a bad HTML indentantion. 

#### :pushpin: Related Issues
 
- Related to #11660 
 

#### Testing

1. Sign in as admin 
2. Edit a process
3. Close all the accordions

### :camera: Screenshots
 
![Edit process accordions](https://github.com/decidim/decidim/assets/717367/1f79962d-dea5-4487-8649-138b070b2936)

:hearts: Thank you!
