### PR TITLE
Fix title for Spaces in edit admin page

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/edit.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/edit.html.erb
@@ -1,4 +1,5 @@
 <% add_decidim_page_title(t("info", scope: "decidim.admin.menu.assemblies_submenu")) %>
+<% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
 
 <div class="item_show__header">
   <h2 class="item_show__header-title">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/edit.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="item_show__header">
   <h2 class="item_show__header-title">
-    <%= t("info", scope: "decidim.admin.menu.participatory_processes_submenu") %>
+    <%= t("info", scope: "decidim.admin.menu.assemblies_submenu") %>
   </h2>
 </div>
 <div class="item__edit">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/edit.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/edit.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(t("info", scope: "decidim.admin.menu.assemblies_submenu")) %>
+
 <div class="item_show__header">
   <h2 class="item_show__header-title">
     <%= t("info", scope: "decidim.admin.menu.assemblies_submenu") %>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -205,7 +205,7 @@ en:
           attachments: Attachments
           categories: Categories
           components: Components
-          info: Info
+          info: About this assembly
           landing_page: Landing page
           moderations: Moderations
           private_users: Private users

--- a/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
@@ -52,7 +52,7 @@ shared_examples "manage assemblies" do
 
     it "update an assembly without images does not delete them" do
       within_admin_menu do
-        click_link "Info"
+        click_link "About this assembly"
       end
       click_button "Update"
 

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/edit.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/edit.html.erb
@@ -1,5 +1,5 @@
 <% add_decidim_page_title(t("info", scope: "decidim.admin.menu.conferences_submenu")) %>
-<% add_decidim_page_title(translated_attribute(current_conference.title)) %>
+<% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
 
 <div class="item_show__header">
   <h2 class="item_show__header-title">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/edit.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/edit.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_page_title(translated_attribute(current_conference.title)) %>
 <div class="item_show__header">
   <h2 class="item_show__header-title">
-    <%= t("info", scope: "decidim.admin.menu.participatory_processes_submenu") %>
+    <%= t("info", scope: "decidim.admin.menu.conferences_submenu") %>
   </h2>
 </div>
 

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/edit.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/edit.html.erb
@@ -1,4 +1,6 @@
+<% add_decidim_page_title(t("info", scope: "decidim.admin.menu.conferences_submenu")) %>
 <% add_decidim_page_title(translated_attribute(current_conference.title)) %>
+
 <div class="item_show__header">
   <h2 class="item_show__header-title">
     <%= t("info", scope: "decidim.admin.menu.conferences_submenu") %>

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -195,7 +195,7 @@ en:
           conference_invites: Invites
           conference_speakers: Speakers
           diploma: Certificate of Attendance
-          info: Info
+          info: About this conference
           media_links: Media Links
           moderations: Moderations
           partners: Partners

--- a/decidim-conferences/spec/shared/manage_conferences_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conferences_examples.rb
@@ -119,7 +119,7 @@ shared_examples "manage conferences" do
 
     it "update an conference without images does not delete them" do
       within_admin_menu do
-        click_link "Info"
+        click_link "About this conference"
       end
       click_button "Update"
 

--- a/decidim-elections/app/views/decidim/votings/admin/votings/edit.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/votings/edit.html.erb
@@ -1,4 +1,6 @@
-<% add_decidim_page_title(t("votings.edit.update", scope: "decidim.votings.admin")) %>
+<% add_decidim_page_title(t("info", scope: "decidim.votings.admin.menu.votings_submenu")) %>
+<% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
+
 <div class="item_show__header">
     <h2 class="item_show__header-title">
     <%= t("info", scope: "decidim.votings.admin.menu.votings_submenu") %>

--- a/decidim-elections/app/views/decidim/votings/admin/votings/edit.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/votings/edit.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_page_title(t("votings.edit.update", scope: "decidim.votings.admin")) %>
 <div class="item_show__header">
     <h2 class="item_show__header-title">
-    <%= t("info", scope: "decidim.admin.menu.participatory_processes_submenu") %>
+    <%= t("info", scope: "decidim.votings.admin.menu.votings_submenu") %>
   </h2>
 </div>
 <div class="item__edit">

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -866,7 +866,7 @@ en:
             ballot_styles: Ballot Styles
             census: Census
             components: Components
-            info: Information
+            info: About this voting
             landing_page: Landing Page
             monitoring_committee: Monitoring Committee
             monitoring_committee_election_results: Validate Results

--- a/decidim-elections/spec/system/admin/admin_manages_votings_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_votings_spec.rb
@@ -297,13 +297,13 @@ describe "Admin manages votings", type: :system do
     end
 
     within_admin_menu do
-      expect(page).to have_content("Information")
+      expect(page).to have_content("About this voting")
       expect(page).to have_content("Landing Page")
       expect(page).to have_content("Components")
       expect(page).to have_content("Attachments")
       expect(page).to have_content("Polling Stations")
       expect(page).to have_content("Polling Officers")
-      expect(page).to have_css(".is-active", text: "Information")
+      expect(page).to have_css(".is-active", text: "About this voting")
     end
   end
 end

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/edit.html.erb
@@ -1,4 +1,6 @@
+<% add_decidim_page_title(t("info", scope: "decidim.admin.menu.initiatives_submenu")) %>
 <% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
+
 <div class="item_show__header">
   <h2 class="item_show__header-title">
     <%= t("info", scope: "decidim.admin.menu.initiatives_submenu") %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/edit.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
 <div class="item_show__header">
   <h2 class="item_show__header-title">
-    <%= t("info", scope: "decidim.admin.menu.participatory_processes_submenu") %>
+    <%= t("info", scope: "decidim.admin.menu.initiatives_submenu") %>
   </h2>
 </div>
 <div class="item__edit">

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -111,6 +111,8 @@ en:
         initiative_type_scopes: Initiative type scopes
         initiatives: Initiatives
         initiatives_settings: Settings
+        initiatives_submenu:
+          info: About this initiative
         initiatives_types: Initiative types
         moderations: Moderations
       models:

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/edit.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/edit.html.erb
@@ -1,3 +1,6 @@
+<% add_decidim_page_title(t("info", scope: "decidim.admin.menu.participatory_processes_submenu")) %>
+<% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
+
 <div class="item_show__header">
   <h2 class="item_show__header-title">
     <%= t("info", scope: "decidim.admin.menu.participatory_processes_submenu") %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/show.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
+
 <div class="item_show__header">
   <% if current_participatory_space.private_space? %>
     <%= icon "lock-line" %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/show.html.erb
@@ -1,3 +1,4 @@
+<% add_decidim_page_title(t("info", scope: "decidim.admin.menu.participatory_processes_submenu")) %>
 <% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
 
 <div class="item_show__header">


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

After the redesign, @carolromero has detected some wrong titles in the spaces edit pages. 

Basically, they were wrong in most of the cases (Assemblies, Votings, Conferences, etc).

This PR fixes it. It also fixes the HTML meta title in these pages. 


#### Testing

1. Sign in as admin
2. Visit every of the admin pages with this bug. Most notably:
- [x] Assembly
- [x] Votings
- [x] Conferences
- [x] Initiatives

### :camera: Screenshots

![Screenshot of the assembly's edit page in the admin panel](https://github.com/decidim/decidim/assets/717367/e394acfc-c4b2-445d-86d0-def53522bb58)


:hearts: Thank you!
