### PR TITLE
Spelling of i18n value in participatory texts

### DIFF
--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -458,7 +458,7 @@ en:
               md: Markdown
               odt: ODT
             bottom_hint: "(You will be able to preview and sort document sections)"
-            document_legend: 'Add a document lesser than 2MB, each section until 3 levels deep will be parsed into proposals. Suported formats are: %{valid_mime_types}'
+            document_legend: 'Add a document lesser than 2MB, each section until 3 levels deep will be parsed into proposals. Supported formats are: %{valid_mime_types}'
             title: Add document
             upload_document: Upload document
           publish:


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Fixes a wrongly spelt i18n value in participatory-texts in proposals. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11671

#### Testing
1. Login as an admin.
2. Go to processes and choose one.
3. Make a new proposal and click participatory texts make sure that's active.
4. Click participatory texts on your newly created proposal.
5. Attempt to import one and see the small print has correctly been spelt.


### :camera: Screenshots

![Screenshot 2023-09-28 at 13 19 22](https://github.com/decidim/decidim/assets/101816158/358f9833-16fb-4c38-8ff7-c0a992273665)


:hearts: Thank you!
