### PR TITLE
Redesign: make the actions buttons consistent

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
@@ -7,8 +7,6 @@
       <% end %>
       <%= t(".title") %>
 
-      <%= link_to t("actions.new_result", scope: "decidim.accountability"), new_result_path(parent_id: parent_result), class: "button button__sm button__secondary" if allowed_to? :create, :result %>
-      <%= render partial: "decidim/accountability/admin/shared/subnav" unless parent_result %>
       <%= export_dropdown %>
       <%= import_dropdown do %>
         <li class="imports--component imports--results">
@@ -18,6 +16,8 @@
           <%= link_to t("actions.import_csv", scope: "decidim.accountability"), import_results_path if allowed_to? :create, :result %>
         </li>
       <% end %>
+      <%= render partial: "decidim/accountability/admin/shared/subnav" unless parent_result %>
+      <%= link_to t("actions.new_result", scope: "decidim.accountability"), new_result_path(parent_id: parent_result), class: "button button__sm button__secondary" if allowed_to? :create, :result %>
     </h2>
   </div>
 

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
@@ -7,7 +7,7 @@
       <% end %>
       <%= t(".title") %>
 
-      <%= link_to t("actions.new", scope: "decidim.accountability", name: t("models.result.name", scope: "decidim.accountability.admin")), new_result_path(parent_id: parent_result), class: "button button__sm button__secondary" if allowed_to? :create, :result %>
+      <%= link_to t("actions.new_result", scope: "decidim.accountability"), new_result_path(parent_id: parent_result), class: "button button__sm button__secondary" if allowed_to? :create, :result %>
       <%= render partial: "decidim/accountability/admin/shared/subnav" unless parent_result %>
       <%= export_dropdown %>
       <%= import_dropdown do %>
@@ -89,7 +89,7 @@
               <% end %>
 
               <% if allowed_to? :create_children, :result, result: result %>
-                <%= icon_link_to "add-line", results_path(parent_id: result.id), t("actions.new", scope: "decidim.accountability", name: t("models.result.name", scope: "decidim.accountability.admin")), class: "action-icon--plus" %>
+                <%= icon_link_to "add-line", results_path(parent_id: result.id), t("actions.new_result", scope: "decidim.accountability"), class: "action-icon--plus" %>
               <% end %>
 
               <% if allowed_to? :update, :result, result: result %>

--- a/decidim-accountability/app/views/decidim/accountability/admin/statuses/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/statuses/index.html.erb
@@ -3,7 +3,7 @@
   <div class="item_show__header">
     <h2 class="item_show__header-title">
       <%= t(".title") %>
-      <%= link_to t("actions.new", scope: "decidim.accountability", name: t("models.status.name", scope: "decidim.accountability.admin")), new_status_path, class: "button button__sm button__secondary" if allowed_to? :create, :status %>
+      <%= link_to t("actions.new_status", scope: "decidim.accountability"), new_status_path, class: "button button__sm button__secondary" if allowed_to? :create, :status %>
     </h2>
   </div>
   <div class="table-scroll">

--- a/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/index.html.erb
@@ -5,7 +5,7 @@
         <%= link_to "#{translated_attribute(result.title)} > ", edit_result_path(result) %>
         <%= t(".title") %>
       </div>
-      <%= link_to t("actions.new", scope: "decidim.accountability", name: t("models.timeline_entry.name", scope: "decidim.accountability.admin")), new_result_timeline_entry_path(result), class: "button button__sm button__secondary button--title" if allowed_to? :create, :timeline_entry %>
+      <%= link_to t("actions.new_timeline_entry", scope: "decidim.accountability"), new_result_timeline_entry_path(result), class: "button button__sm button__secondary button--title" if allowed_to? :create, :timeline_entry %>
     </h2>
   </div>
   <div class="table-scroll">

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -87,8 +87,6 @@ en:
             name: Result
           status:
             name: Status
-          timeline_entry:
-            name: Timeline entry
         projects_import:
           create:
             invalid: There was a problem importing the projects into results, please follow the instructions carefully and make sure you have selected projects for implementation.

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -42,7 +42,9 @@ en:
         edit: Edit
         import: Import projects to results
         import_csv: Import CSV
-        new: New %{name}
+        new_result: New result
+        new_status: New status
+        new_timeline_entry: New timeline entry
         preview: Preview
         timeline_entries: Project evolution
         title: Actions

--- a/decidim-accountability/spec/shared/manage_child_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_child_results_examples.rb
@@ -39,7 +39,7 @@ RSpec.shared_examples "manage child results" do
   end
 
   it "creates a new child result" do
-    click_link "New Result", match: :first
+    click_link "New result", match: :first
 
     within ".new_result" do
       fill_in_i18n(
@@ -75,7 +75,7 @@ RSpec.shared_examples "manage child results" do
     before do
       visit current_path
       within ".table-list__actions" do
-        click_link "New Result"
+        click_link "New result"
       end
     end
 

--- a/decidim-accountability/spec/shared/manage_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_examples.rb
@@ -6,7 +6,7 @@ shared_examples "manage results" do
   include_context "when managing an accountability component as an admin"
 
   describe "admin form" do
-    before { click_on "New Result", match: :first }
+    before { click_on "New result", match: :first }
 
     it_behaves_like "having a rich text editor", "new_result", "full"
 
@@ -59,7 +59,7 @@ shared_examples "manage results" do
     end
 
     it "creates a new result", :slow do
-      click_link "New Result", match: :first
+      click_link "New result", match: :first
 
       within ".new_result" do
         fill_in_i18n(

--- a/decidim-accountability/spec/shared/manage_statuses_examples.rb
+++ b/decidim-accountability/spec/shared/manage_statuses_examples.rb
@@ -26,7 +26,7 @@ RSpec.shared_examples "manage statuses" do
   end
 
   it "creates a new status" do
-    click_link "New Status"
+    click_link "New status"
 
     within ".new_status" do
       fill_in :status_key, with: "status_key_1"

--- a/decidim-accountability/spec/system/admin/admin_manages_accountability_spec.rb
+++ b/decidim-accountability/spec/system/admin/admin_manages_accountability_spec.rb
@@ -21,7 +21,7 @@ describe "Admin manages accountability", type: :system do
   describe "child results" do
     before do
       within ".table-list__actions" do
-        click_link "New Result"
+        click_link "New result"
       end
     end
 

--- a/decidim-admin/app/views/decidim/admin/components/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/index.html.erb
@@ -12,7 +12,7 @@
           <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
         </button>
         <div class="dropdown-pane" id="add-component-dropdown" data-dropdown data-auto-focus="true" data-close-on-click="true">
-          <ul class="vertical menu add-components">
+          <ul class="vertical menu add-components font-normal">
             <% @manifests.each do |manifest| %>
               <li><%= link_to t("#{manifest.name}.name", scope: "decidim.components"), new_component_path(type: manifest.name), class: manifest.name %></li>
             <% end %>

--- a/decidim-admin/app/views/decidim/admin/components/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/index.html.erb
@@ -7,7 +7,10 @@
 
       <% if allowed_to?(:create, :component) %>
       <div class="relative">
-        <button class="button button__sm button__secondary button--title" data-toggle="add-component-dropdown"><%= t "components.index.add", scope: "decidim.admin" %></button>
+        <button class="button button__sm button__secondary button--title" data-toggle="add-component-dropdown">
+          <%= t "components.index.add", scope: "decidim.admin" %>
+          <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
+        </button>
         <div class="dropdown-pane" id="add-component-dropdown" data-dropdown data-auto-focus="true" data-close-on-click="true">
           <ul class="vertical menu add-components">
             <% @manifests.each do |manifest| %>

--- a/decidim-admin/app/views/decidim/admin/exports/_dropdown.html.erb
+++ b/decidim-admin/app/views/decidim/admin/exports/_dropdown.html.erb
@@ -1,4 +1,7 @@
-<span class="exports button button__sm button__secondary button--simple" data-toggle="export-dropdown"><%= t "actions.export", scope: "decidim.admin" %></span>
+<span class="exports button button__sm button__secondary button--simple" data-toggle="export-dropdown">
+  <%= t "actions.export", scope: "decidim.admin" %>
+  <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
+</span>
 <div class="dropdown-pane" id="export-dropdown" data-dropdown data-position=bottom data-alignment=right data-auto-focus="true" data-close-on-click="true">
   <ul class="vertical menu add-components">
     <% component.manifest.export_manifests.each do |manifest| %>

--- a/decidim-admin/app/views/decidim/admin/imports/_dropdown.html.erb
+++ b/decidim-admin/app/views/decidim/admin/imports/_dropdown.html.erb
@@ -1,4 +1,7 @@
-<span class="imports button button__sm button__secondary button--simple" data-toggle="import-dropdown"><%= t "actions.import", scope: "decidim.admin" %></span>
+<span class="imports button button__sm button__secondary button--simple" data-toggle="import-dropdown">
+  <%= t "actions.import", scope: "decidim.admin" %>
+  <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
+</span>
 <div class="dropdown-pane" id="import-dropdown" data-dropdown data-position=bottom data-alignment=right data-auto-focus="true" data-close-on-click="true">
   <ul class="vertical menu add-components">
     <% if custom %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -190,7 +190,6 @@ en:
         export: Export all
         export-selection: Export selection
         import: Import
-        new: New %{name}
         newsletter:
           new: New newsletter
         participatory_space_private_user:

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/index.html.erb
@@ -3,7 +3,7 @@
     <h2 class="item_show__header-title">
       <%= t("assembly_user_roles.index.assembly_admins_title", scope: "decidim.admin") %>
       <% if allowed_to? :create, :assembly_user_role %>
-         <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.assembly_user_role.name", scope: "decidim.admin")), new_assembly_user_role_path(current_assembly), class: "button button__sm button__secondary new" %>
+         <%= link_to t("actions.new_assembly_user_role", scope: "decidim.admin"), new_assembly_user_role_path(current_assembly), class: "button button__sm button__secondary new" %>
       <% end %>
     </h2>
   </div>

--- a/decidim-assemblies/app/views/layouts/decidim/admin/assembly_members.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/admin/assembly_members.html.erb
@@ -1,6 +1,6 @@
 <% content_for :breadcrumb_context_menu do %>
   <div class="process-title-content-breadcrumb-container-right">
-    <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.assembly_member.name", scope: "decidim.admin")), new_assembly_member_path(current_assembly), class: "button button__sm button__transparent process-title-content-breadcrumb-container-right-link" %>
+    <%= link_to t("actions.new_assembly_member", scope: "decidim.admin"), new_assembly_member_path(current_assembly), class: "button button__sm button__transparent process-title-content-breadcrumb-container-right-link" %>
     <div class="inline-block relative">
       <%= button_tag id: "assembly-menu-trigger", data: { component: "dropdown", target: "assembly-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
         <span>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -99,7 +99,9 @@ en:
       actions:
         import_assembly: Import
         new_assembly: New assembly
+        new_assembly_member: New assembly member
         new_assembly_type: New assembly type
+        new_assembly_user_role: New assembly admin
       assemblies:
         create:
           error: There was a problem creating a new assembly.

--- a/decidim-assemblies/spec/shared/manage_assembly_admins_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_admins_examples.rb
@@ -26,7 +26,7 @@ shared_examples "manage assembly admins examples" do
   end
 
   it "creates a new assembly admin" do
-    click_link "New Assembly admin"
+    click_link "New assembly admin"
 
     within ".new_assembly_user_role" do
       fill_in :assembly_user_role_email, with: other_user.email

--- a/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
@@ -15,7 +15,7 @@ shared_examples "manage assembly members examples" do
 
     it "creates a new assembly member" do
       within ".process-title-content" do
-        click_link "New Member"
+        click_link "New assembly member"
       end
 
       fill_in :assembly_member_designation_date, with: Time.current
@@ -51,7 +51,7 @@ shared_examples "manage assembly members examples" do
 
     it "creates a new assembly member" do
       within ".process-title-content" do
-        click_link "New Member"
+        click_link "New assembly member"
       end
 
       fill_in :assembly_member_designation_date, with: Time.current
@@ -79,7 +79,7 @@ shared_examples "manage assembly members examples" do
 
     it "creates a new assembly member" do
       within ".process-title-content" do
-        click_link "New Member"
+        click_link "New assembly member"
       end
 
       fill_in :assembly_member_designation_date, with: Time.current

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
@@ -3,7 +3,7 @@
   <div class="item_show__header">
     <h2 class="item_show__header-title">
       <%= t(".title") %>
-      <%= link_to t("actions.new", scope: "decidim.blogs", name: t("models.post.name", scope: "decidim.blogs.admin")), new_post_path, class: "button button__sm button__secondary ml-auto" if allowed_to? :create, :blogpost %>
+      <%= link_to t("actions.new", scope: "decidim.blogs"), new_post_path, class: "button button__sm button__secondary ml-auto" if allowed_to? :create, :blogpost %>
     </h2>
   </div>
   <div class="table-scroll">

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -24,9 +24,6 @@ en:
         new: New post
         title: Actions
       admin:
-        models:
-          post:
-            name: Post
         posts:
           create:
             invalid: There was a problem creating this post.

--- a/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
@@ -10,7 +10,7 @@
         <%= export_dropdown %>
       <% end %>
       <div id="js-other-actions-wrapper">
-        <%= link_to t("actions.new", scope: "decidim.budgets", name: t("models.budget.name", scope: "decidim.budgets.admin")), new_budget_path, class: "button button__sm button__secondary" if allowed_to? :create, :budget %>
+        <%= link_to t("actions.new_budget", scope: "decidim.budgets"), new_budget_path, class: "button button__sm button__secondary" if allowed_to? :create, :budget %>
       </div>
     </h2>
   </div>

--- a/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
@@ -3,11 +3,11 @@
   <div class="item_show__header">
     <h2 class="item_show__header-title">
       <%= t(".title") %>
-      <% if allowed_to? :remind, :order %>
-        <%= link_to t("actions.send_voting_reminders", scope: "decidim.budgets"), admin_reminders_path(current_component, name: "orders"), class: "button button__sm button__secondary" %>
-      <% end %>
       <% if allowed_to? :export, :budget %>
         <%= export_dropdown %>
+      <% end %>
+      <% if allowed_to? :remind, :order %>
+        <%= link_to t("actions.send_voting_reminders", scope: "decidim.budgets"), admin_reminders_path(current_component, name: "orders"), class: "button button__sm button__secondary" %>
       <% end %>
       <div id="js-other-actions-wrapper">
         <%= link_to t("actions.new_budget", scope: "decidim.budgets"), new_budget_path, class: "button button__sm button__secondary" if allowed_to? :create, :budget %>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/_bulk-actions.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/_bulk-actions.html.erb
@@ -6,9 +6,15 @@
     <%= render partial: "decidim/budgets/admin/projects/bulk_actions/scope-change" %>
     <%= render partial: "decidim/budgets/admin/projects/bulk_actions/change-selected" %>
 
-    <%= link_to t("actions.import", scope: "decidim.budgets", name: t("models.project.name", scope: "decidim.budgets.admin")), new_budget_proposals_import_path(budget), class: "button button__sm button__secondary" if allowed_to? :import_proposals, :project %>
     <% if allowed_to? :export, :budget %>
       <%= export_dropdown(current_component, budget.id) %>
+    <% end %>
+    <% if allowed_to? :import_proposals, :project %>
+      <%= import_dropdown do %>
+        <li class="imports--component">
+          <%= link_to t("actions.import", scope: "decidim.budgets", name: t("models.project.name", scope: "decidim.budgets.admin")), new_budget_proposals_import_path(budget) %>
+        </li>
+      <% end %>
     <% end %>
     <%= link_to t("actions.new_project", scope: "decidim.budgets"), new_budget_project_path, class: "button button__sm button__secondary new" if allowed_to? :create, :project %>
   </div>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/_bulk-actions.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/_bulk-actions.html.erb
@@ -10,6 +10,6 @@
     <% if allowed_to? :export, :budget %>
       <%= export_dropdown(current_component, budget.id) %>
     <% end %>
-    <%= link_to t("actions.new", scope: "decidim.budgets", name: t("models.project.name", scope: "decidim.budgets.admin")), new_budget_project_path, class: "button button__sm button__secondary new" if allowed_to? :create, :project %>
+    <%= link_to t("actions.new_project", scope: "decidim.budgets"), new_budget_project_path, class: "button button__sm button__secondary new" if allowed_to? :create, :project %>
   </div>
 </div>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/bulk_actions/_dropdown.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/bulk_actions/_dropdown.html.erb
@@ -1,7 +1,7 @@
 <div id="js-bulk-actions-wrapper">
   <button
     id="js-bulk-actions-button"
-    class="button button__sm button__transparent button__transparent-secondary dropdown"
+    class="button button__sm button__secondary"
     type="button"
     data-toggle="js-bulk-actions-dropdown">
     <%= t("decidim.budgets.admin.projects.index.actions") %>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/bulk_actions/_dropdown.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/bulk_actions/_dropdown.html.erb
@@ -5,6 +5,7 @@
     type="button"
     data-toggle="js-bulk-actions-dropdown">
     <%= t("decidim.budgets.admin.projects.index.actions") %>
+    <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
   </button>
 
   <div

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -46,7 +46,8 @@ en:
         edit: Edit
         edit_projects: Manage projects
         import: Import proposals to projects
-        new: New %{name}
+        new_budget: New budget
+        new_project: New project
         preview: Preview
         send_voting_reminders: Send voting reminders
         title: Actions

--- a/decidim-budgets/spec/shared/import_proposals_to_projects_examples.rb
+++ b/decidim-budgets/spec/shared/import_proposals_to_projects_examples.rb
@@ -8,6 +8,7 @@ shared_examples "import proposals to projects" do
   include Decidim::ComponentPathHelper
 
   it "imports proposals from one component to a budget component" do
+    page.find(".imports").click
     click_link "Import proposals to projects"
 
     within ".import_proposals" do

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -4,7 +4,7 @@ shared_examples "manage projects" do
   describe "admin form" do
     before do
       within ".process-content" do
-        click_link("New Project", class: "button")
+        click_link("New project", class: "button")
       end
     end
 
@@ -142,7 +142,7 @@ shared_examples "manage projects" do
 
   it "creates a new project", :slow do
     within ".bulk-actions-budgets" do
-      click_link "New Project"
+      click_link "New project"
     end
 
     within ".new_project" do
@@ -247,7 +247,7 @@ shared_examples "manage projects" do
 
     it "creates a new project" do
       within ".bulk-actions-budgets" do
-        click_link "New Project"
+        click_link "New project"
       end
 
       within ".new_project" do

--- a/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
@@ -15,13 +15,13 @@ describe "Admin manages budgets", type: :system do
   end
 
   describe "admin form" do
-    before { click_on "New Budget" }
+    before { click_on "New budget" }
 
     it_behaves_like "having a rich text editor", "new_budget", "content"
   end
 
   it "creates a new budget" do
-    click_link "New Budget"
+    click_link "New budget"
 
     within ".new_budget" do
       fill_in_i18n(

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_registrations/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_registrations/index.html.erb
@@ -4,7 +4,10 @@
     <h2 class="item_show__header-title">
       <%= t(".registrations") %>
       <% if allowed_to? :export_conference_registrations, :conference, conference: conference %>
-        <span class="exports button button__sm button__secondary button--simple button--title" data-toggle="export-dropdown"><%= t "actions.export", scope: "decidim.admin" %></span>
+        <span class="exports button button__sm button__secondary button--simple button--title" data-toggle="export-dropdown">
+          <%= t "actions.export", scope: "decidim.admin" %>
+          <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
+        </span>
         <div class="dropdown-pane" id="export-dropdown" data-dropdown data-auto-focus="true" data-close-on-click="true">
           <ul class="vertical menu add-components">
             <% %w(CSV JSON Excel).each do |format| %>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
@@ -19,7 +19,7 @@
     <h2 class="item_show__header-title">
       <%= t("conference_speakers.index.conference_speakers_title", scope: "decidim.admin") %>
       <% if allowed_to? :create, :conference_speaker %>
-         <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.conference_speaker.name", scope: "decidim.admin")), new_conference_speaker_path(current_conference), class: "button button__sm button__secondary new" %>
+         <%= link_to t("actions.new_speaker", scope: "decidim.admin"), new_conference_speaker_path(current_conference), class: "button button__sm button__secondary new" %>
       <% end %>
     </h2>
   </div>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/index.html.erb
@@ -4,7 +4,7 @@
     <h2 class="item_show__header-title">
       <%= t("conference_user_roles.index.conference_admins_title", scope: "decidim.admin") %>
       <% if allowed_to? :create, :conference_user_role %>
-         <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.conference_user_role.name", scope: "decidim.admin")), new_conference_user_role_path(current_conference), class: "button button__sm button__secondary new" %>
+         <%= link_to t("actions.new_conference_user_role", scope: "decidim.admin"), new_conference_user_role_path(current_conference), class: "button button__sm button__secondary new" %>
       <% end %>
     </h2>
   </div>

--- a/decidim-conferences/app/views/decidim/conferences/admin/media_links/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/media_links/index.html.erb
@@ -4,7 +4,7 @@
     <h2 class="item_show__header-title">
       <%= t("media_links.index.media_links_title", scope: "decidim.admin") %>
       <% if allowed_to? :create, :media_link %>
-         <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.media_link.name", scope: "decidim.admin")), new_conference_media_link_path(current_conference), class: "button button__sm button__secondary new" %>
+         <%= link_to t("actions.new_media_link", scope: "decidim.admin"), new_conference_media_link_path(current_conference), class: "button button__sm button__secondary new" %>
       <% end %>
     </h2>
   </div>

--- a/decidim-conferences/app/views/decidim/conferences/admin/partners/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/partners/index.html.erb
@@ -4,7 +4,7 @@
     <h2 class="item_show__header-title">
       <%= t(".title") %>
       <% if allowed_to? :create, :partner %>
-         <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.partner.name", scope: "decidim.admin")), new_conference_partner_path(current_conference), class: "button button__sm button__secondary new" %>
+         <%= link_to t("actions.new_partner", scope: "decidim.admin"), new_conference_partner_path(current_conference), class: "button button__sm button__secondary new" %>
       <% end %>
     </h2>
   </div>

--- a/decidim-conferences/app/views/decidim/conferences/admin/registration_types/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/registration_types/index.html.erb
@@ -4,7 +4,7 @@
     <h2 class="item_show__header-title">
       <%= t(".title") %>
       <% if allowed_to? :create, :registration_type %>
-         <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.registration_type.name", scope: "decidim.admin")), new_conference_registration_type_path(current_conference), class: "button button__sm button__secondary new" %>
+         <%= link_to t("actions.new_registration_type", scope: "decidim.admin"), new_conference_registration_type_path(current_conference), class: "button button__sm button__secondary new" %>
       <% end %>
     </h2>
   </div>

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -90,7 +90,12 @@ en:
     admin:
       actions:
         confirm: Confirm
-        new_conference: New Conference
+        new_conference: New conference
+        new_conference_user_role: New conference admin
+        new_media_link: New media link
+        new_partner: New partner
+        new_registration_type: New registration type
+        new_speaker: New speaker
         send_diplomas: Send certificates of attendance
       conference_copies:
         new:

--- a/decidim-conferences/spec/shared/manage_conference_admins_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_admins_examples.rb
@@ -26,7 +26,7 @@ shared_examples "manage conference admins examples" do
   end
 
   it "creates a new conference admin" do
-    click_link "New Conference Admin"
+    click_link "New conference admin"
 
     within ".new_conference_user_role" do
       fill_in :conference_user_role_email, with: other_user.email

--- a/decidim-conferences/spec/shared/manage_conference_speakers_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_speakers_examples.rb
@@ -20,7 +20,7 @@ shared_examples "manage conference speakers examples" do
 
   context "without existing user" do
     it "creates a new conference speaker" do
-      click_link "New Conference Speaker"
+      click_link "New speaker"
 
       within ".new_conference_speaker" do
         fill_in(
@@ -44,7 +44,7 @@ shared_examples "manage conference speakers examples" do
     let!(:speaker_user) { create(:user, organization: conference.organization) }
 
     it "creates a new conference speaker" do
-      click_link "New Conference Speaker"
+      click_link "New speaker"
 
       within ".new_conference_speaker" do
         select "Existing participant", from: :conference_speaker_existing_user

--- a/decidim-conferences/spec/shared/manage_conferences_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conferences_examples.rb
@@ -9,7 +9,7 @@ shared_examples "manage conferences" do
     let(:image2_path) { Decidim::Dev.asset(image2_filename) }
 
     before do
-      click_link "New Conference"
+      click_link "New conference"
     end
 
     %w(description short_description objectives).each do |field|

--- a/decidim-conferences/spec/shared/manage_media_links_examples.rb
+++ b/decidim-conferences/spec/shared/manage_media_links_examples.rb
@@ -12,7 +12,7 @@ shared_examples "manage media links examples" do
 
   describe "creating media link" do
     before do
-      click_link "New Media Link"
+      click_link "New media link"
     end
 
     it "creates a new media link" do

--- a/decidim-debates/app/views/decidim/debates/admin/debates/index.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/index.html.erb
@@ -5,7 +5,7 @@
       <%= t(".title") %>
       <div class="button--title">
         <%= export_dropdown if allowed_to? :export, :comments %>
-        <%= link_to t("actions.new", scope: "decidim.debates", name: t("models.debate.name", scope: "decidim.debates.admin")), new_debate_path, class: "button button__sm button__secondary" if allowed_to? :create, :debate %>
+        <%= link_to t("actions.new", scope: "decidim.debates"), new_debate_path, class: "button button__sm button__secondary" if allowed_to? :create, :debate %>
       </div>
     </h2>
   </div>

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -82,9 +82,6 @@ en:
             success: Debate successfully updated.
         exports:
           comments: Comments
-        models:
-          debate:
-            name: Debate
       admin_log:
         debate:
           close: "%{user_name} closed the %{resource_name} debate on the %{space_name} space"

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -52,7 +52,7 @@ en:
         confirm_destroy: Are you sure?
         destroy: Delete
         edit: Edit
-        new: New %{name}
+        new: New debate
         title: Actions
       admin:
         debate_closes:

--- a/decidim-debates/spec/shared/manage_debates_examples.rb
+++ b/decidim-debates/spec/shared/manage_debates_examples.rb
@@ -19,7 +19,7 @@ RSpec.shared_examples "manage debates" do
   end
 
   describe "admin form" do
-    before { click_on "New Debate" }
+    before { click_on "New debate" }
 
     it_behaves_like "having a rich text editor", "new_debate", "full"
   end
@@ -75,7 +75,7 @@ RSpec.shared_examples "manage debates" do
   end
 
   it "creates a new finite debate" do
-    click_link "New Debate"
+    click_link "New debate"
 
     within ".new_debate" do
       fill_in_i18n(
@@ -120,7 +120,7 @@ RSpec.shared_examples "manage debates" do
   end
 
   it "creates a new open debate" do
-    click_link "New Debate"
+    click_link "New debate"
 
     within ".new_debate" do
       fill_in_i18n(

--- a/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
@@ -1,9 +1,11 @@
 <div class="card">
   <div class="item_show__header">
     <h2 class="item_show__header-title">
-      <%= link_to translated_attribute(election.title), elections_path %> &gt;
-      <%= link_to translated_attribute(question.title), election_questions_path(election) %> &gt;
-      <%= t(".title") %>
+      <div>
+        <%= link_to translated_attribute(election.title), elections_path %> &gt;
+        <%= link_to translated_attribute(question.title), election_questions_path(election) %> &gt;
+        <%= t(".title") %>
+      </div>
 
       <div class="ml-auto">
         <% if allowed_to? :import_proposals, :answer, election: election, question: question %>

--- a/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
@@ -6,8 +6,14 @@
       <%= t(".title") %>
 
       <div class="ml-auto">
+        <% if allowed_to? :import_proposals, :answer, election: election, question: question %>
+          <%= import_dropdown do %>
+            <li class="imports--component">
+              <%= link_to t("actions.import", scope: "decidim.elections", name: t("models.answer.name", scope: "decidim.elections.admin")), new_election_question_proposals_import_path(election, question) %>
+            </li>
+          <% end %>
+        <% end %>
         <%= link_to t("actions.new_answer", scope: "decidim.elections"), new_election_question_answer_path(election, question), class: "button button__sm button__secondary" if allowed_to? :create, :answer, election: election, question: question %>
-        <%= link_to t("actions.import", scope: "decidim.elections", name: t("models.answer.name", scope: "decidim.elections.admin")), new_election_question_proposals_import_path(election, question), class: "button button__sm button__secondary" if allowed_to? :import_proposals, :answer, election: election, question: question %>
       </div>
     </h2>
   </div>

--- a/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
@@ -6,7 +6,7 @@
       <%= t(".title") %>
 
       <div class="ml-auto">
-        <%= link_to t("actions.new", scope: "decidim.elections", name: t("models.answer.name", scope: "decidim.elections.admin")), new_election_question_answer_path(election, question), class: "button button__sm button__secondary" if allowed_to? :create, :answer, election: election, question: question %>
+        <%= link_to t("actions.new_answer", scope: "decidim.elections"), new_election_question_answer_path(election, question), class: "button button__sm button__secondary" if allowed_to? :create, :answer, election: election, question: question %>
         <%= link_to t("actions.import", scope: "decidim.elections", name: t("models.answer.name", scope: "decidim.elections.admin")), new_election_question_proposals_import_path(election, question), class: "button button__sm button__secondary" if allowed_to? :import_proposals, :answer, election: election, question: question %>
       </div>
     </h2>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/index.html.erb
@@ -4,7 +4,7 @@
     <h2 class="item_show__header-title">
       <%= t(".title") %>
 
-      <%= link_to t("actions.new", scope: "decidim.elections", name: t("models.election.name", scope: "decidim.elections.admin")), new_election_path, class: "button button__sm button__secondary" if allowed_to? :create, :election %>
+      <%= link_to t("actions.new_election", scope: "decidim.elections"), new_election_path, class: "button button__sm button__secondary" if allowed_to? :create, :election %>
     </h2>
   </div>
   <div class="table-scroll">

--- a/decidim-elections/app/views/decidim/elections/admin/questions/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/index.html.erb
@@ -3,7 +3,7 @@
     <h2 class="item_show__header-title">
       <%= t(".title") %>
 
-      <%= link_to t("actions.new", scope: "decidim.elections", name: t("models.question.name", scope: "decidim.elections.admin")), new_election_question_path(election), class: "button button__sm button__secondary" if allowed_to? :create, :question, election: election %>
+      <%= link_to t("actions.new_question", scope: "decidim.elections"), new_election_question_path(election), class: "button button__sm button__secondary" if allowed_to? :create, :question, election: election %>
     </h2>
   </div>
   <div class="table-scroll">

--- a/decidim-elections/app/views/decidim/elections/admin/trustees_participatory_spaces/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/trustees_participatory_spaces/index.html.erb
@@ -3,7 +3,7 @@
   <div class="item_show__header">
     <h2 class="item_show__header-title">
       <%= t(".title") %>
-      <%= link_to t("actions.new", scope: "decidim.elections", name: t("models.trustee.name", scope: "decidim.elections.admin")), new_trustee_path, class: "button button__sm button__secondary new ml-auto" %>
+      <%= link_to t("actions.new_trustee", scope: "decidim.elections"), new_trustee_path, class: "button button__sm button__secondary new ml-auto" %>
     </h2>
   </div>
   <div class="table-scroll">

--- a/decidim-elections/app/views/decidim/votings/admin/ballot_styles/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/ballot_styles/index.html.erb
@@ -7,7 +7,7 @@
   <div class="item_show__header">
     <h2 class="item_show__header-title">
       <%= t(".title") %>
-      <%= link_to t("actions.new", scope: "decidim.votings.admin.ballot_styles.index", name: t("models.ballot_style.name", scope: "decidim.votings.admin")), new_voting_ballot_style_path(current_voting), class: "button button__sm button__secondary" if allowed_to? :create, :ballot_style, voting: current_voting %>
+      <%= link_to t("actions.new", scope: "decidim.votings.admin.ballot_styles.index"), new_voting_ballot_style_path(current_voting), class: "button button__sm button__secondary" if allowed_to? :create, :ballot_style, voting: current_voting %>
     </h2>
   </div>
   <div class="table-scroll">

--- a/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_members/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_members/index.html.erb
@@ -2,7 +2,7 @@
   <div class="item_show__header">
     <h2 class="item_show__header-title">
       <%= t(".title") %>
-      <%= link_to t("actions.new", scope: "decidim.votings.monitoring_committee_members", name: t("models.monitoring_committee_member.name", scope: "decidim.votings.admin")), new_voting_monitoring_committee_member_path(current_voting), class: "button button__sm button__secondary" if allowed_to? :create, :monitoring_committee_member, voting: current_voting %>
+      <%= link_to t("actions.new", scope: "decidim.votings.monitoring_committee_members"), new_voting_monitoring_committee_member_path(current_voting), class: "button button__sm button__secondary" if allowed_to? :create, :monitoring_committee_member, voting: current_voting %>
     </h2>
   </div>
   <div class="table-scroll">

--- a/decidim-elections/app/views/decidim/votings/admin/polling_officers/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_officers/index.html.erb
@@ -2,7 +2,7 @@
   <div class="item_show__header">
     <h2 class="item_show__header-title">
       <%= t(".title") %>
-      <%= link_to t("actions.new", scope: "decidim.votings.polling_officers", name: t("models.polling_officer.name", scope: "decidim.votings.admin")), new_voting_polling_officer_path(current_voting), class: "button button__sm button__secondary" if allowed_to? :create, :polling_officer, voting: current_voting %>
+      <%= link_to t("actions.new", scope: "decidim.votings.polling_officers"), new_voting_polling_officer_path(current_voting), class: "button button__sm button__secondary" if allowed_to? :create, :polling_officer, voting: current_voting %>
     </h2>
   </div>
 

--- a/decidim-elections/app/views/decidim/votings/admin/polling_stations/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_stations/index.html.erb
@@ -2,7 +2,7 @@
   <div class="item_show__header">
     <h2 class="item_show__header-title">
       <%= t(".title") %>
-      <%= link_to t("actions.new", scope: "decidim.votings.polling_stations", name: t("models.polling_station.name", scope: "decidim.votings.admin")), new_voting_polling_station_path(current_voting), class: "button button__sm button__secondary" if allowed_to? :create, :polling_station, voting: current_voting %>
+      <%= link_to t("actions.new", scope: "decidim.votings.polling_stations"), new_voting_polling_station_path(current_voting), class: "button button__sm button__secondary" if allowed_to? :create, :polling_station, voting: current_voting %>
     </h2>
   </div>
   <%= admin_filter_selector %>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -237,12 +237,6 @@ en:
         models:
           answer:
             name: Answer
-          election:
-            name: Election
-          question:
-            name: Question
-          trustee:
-            name: Trustee
         proposals_imports:
           create:
             invalid: There was a problem importing the proposals into answers.
@@ -883,25 +877,21 @@ en:
           ballot_style:
             fields:
               code: Code
-            name: Ballot Style
           monitoring_committee_member:
             fields:
               email: Email
               name: Name
-            name: Monitoring Committee Member
           polling_officer:
             fields:
               email: Email
               name: Name
               polling_station: Polling station (role)
-            name: Polling Officer
           polling_station:
             fields:
               address: Address
               polling_station_managers: Managers
               polling_station_president: President
               title: Title
-            name: Polling Station
           voting:
             fields:
               created_at: Created at

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -161,7 +161,10 @@ en:
         manage_answers: Manage answers
         manage_questions: Manage questions
         manage_steps: Manage steps
-        new: New %{name}
+        new_answer: New answer
+        new_election: New election
+        new_question: New question
+        new_trustee: New trustee
         preview: Preview
         publish: Publish
         title: Actions
@@ -802,7 +805,7 @@ en:
               confirm_destroy: Are you sure?
               destroy: Delete
               edit: Edit
-              new: New
+              new: New ballot style
               title: Actions
             associated_census_data: Associated census entries
             explanation_callout: A ballot style specifies what questions a voter will be presented in the booth. In a ballot style, you can choose what questions from this voting's election components belong to a ballot. The ballot style code is used to match a voter from the census with the ballot they will be presented in the booth. Do not create any ballot style if you always want to present all the questions.
@@ -1296,7 +1299,7 @@ en:
         actions:
           confirm_destroy: Are you sure?
           destroy: Delete
-          new: New
+          new: New polling officer
           title: Actions
         roles:
           manager: Manager
@@ -1317,7 +1320,7 @@ en:
           confirm_destroy: Are you sure?
           destroy: Delete
           edit: Edit
-          new: New
+          new: New polling station
           title: Actions
       votings:
         access_code_modal:

--- a/decidim-elections/spec/system/admin/admin_manages_answers_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_answers_spec.rb
@@ -29,6 +29,7 @@ describe "Admin manages answers", type: :system do
 
   describe "importing proposals" do
     it "imports proposals" do
+      page.find(".imports").click
       click_on "Import proposals to answers"
 
       within ".import_proposals" do
@@ -43,13 +44,13 @@ describe "Admin manages answers", type: :system do
   end
 
   describe "admin form" do
-    before { click_on "New Answer" }
+    before { click_link "New answer" }
 
     it_behaves_like "having a rich text editor", "new_answer", "full"
   end
 
   it "creates a new answer" do
-    click_on "New Answer"
+    click_link "New answer"
 
     within ".new_answer" do
       fill_in_i18n(
@@ -83,7 +84,7 @@ describe "Admin manages answers", type: :system do
     let(:election) { create(:election, :created, component: current_component) }
 
     it "cannot add a new answer" do
-      expect(page).not_to have_content("New Answer")
+      expect(page).not_to have_content("New answer")
     end
   end
 

--- a/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
@@ -23,14 +23,14 @@ describe "Admin manages elections", type: :system do
   end
 
   describe "admin form" do
-    before { click_on "New Election" }
+    before { click_on "New election" }
 
     it_behaves_like "having a rich text editor", "new_election", "full"
   end
 
   describe "creating an election" do
     it "creates a new election" do
-      click_link "New Election"
+      click_link "New election"
 
       within ".new_election" do
         fill_in_i18n(
@@ -70,7 +70,7 @@ describe "Admin manages elections", type: :system do
       let(:organization) { create(:organization, time_zone: "Madrid") }
 
       it "shows the correct time zone" do
-        click_link "New Election"
+        click_link "New election"
 
         expect(page).to have_content("Check that the organization time zone is correct")
         expect(page).to have_content("The current configuration is Madrid")

--- a/decidim-elections/spec/system/admin/admin_manages_questions_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_questions_spec.rb
@@ -21,7 +21,7 @@ describe "Admin manages questions", type: :system do
   end
 
   it "creates a new question" do
-    click_on "New Question"
+    click_on "New question"
 
     within ".new_question" do
       fill_in_i18n(

--- a/decidim-elections/spec/system/admin/admin_manages_trustees_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_trustees_spec.rb
@@ -18,7 +18,7 @@ describe "Admin manages trustees", type: :system do
 
   context "without existing trustee" do
     it "creates a new trustee" do
-      click_link "New Trustee"
+      click_link "New trustee"
 
       within ".new_trustee" do
         autocomplete_select "#{user.name} (@#{user.nickname})", from: :user_id
@@ -110,7 +110,7 @@ describe "Admin manages trustees", type: :system do
     let(:participatory_space) { create(:assembly, organization:) }
 
     it "shows the trustees page" do
-      expect(page).to have_content("New Trustee")
+      expect(page).to have_content("New trustee")
     end
   end
 
@@ -118,7 +118,7 @@ describe "Admin manages trustees", type: :system do
     let(:participatory_space) { create(:voting, organization:) }
 
     it "shows the trustees page" do
-      expect(page).to have_content("New Trustee")
+      expect(page).to have_content("New trustee")
     end
   end
 end

--- a/decidim-elections/spec/system/admin/admin_manages_voting_ballot_styles_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_voting_ballot_styles_spec.rb
@@ -38,7 +38,7 @@ describe "Admin manages ballot styles", type: :system do
     end
 
     it "can add a ballot style" do
-      click_link("New")
+      click_link("New ballot style")
 
       within ".new_ballot_style" do
         fill_in :ballot_style_code, with: "new code"

--- a/decidim-elections/spec/system/admin/admin_manages_voting_polling_officers_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_voting_polling_officers_spec.rb
@@ -84,7 +84,7 @@ describe "Admin manages polling officers", type: :system do
     let(:existing_user) { create(:user, organization: voting.organization) }
 
     before do
-      click_link("New")
+      click_link("New polling officer")
     end
 
     it "creates a new user" do

--- a/decidim-elections/spec/system/admin/admin_manages_voting_polling_stations_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_voting_polling_stations_spec.rb
@@ -99,7 +99,7 @@ describe "Admin manages polling stations", serves_geocoding_autocomplete: true, 
     end
 
     it "can add a polling station to a process", :serves_geocoding_autocomplete do
-      click_link("New")
+      click_link("New polling station")
 
       within ".new_polling_station" do
         fill_in_i18n(
@@ -209,7 +209,7 @@ describe "Admin manages polling stations", serves_geocoding_autocomplete: true, 
 
       before do
         # Prepare the view for submission (other than the address field)
-        click_link("New")
+        click_link("New polling station")
 
         fill_in_i18n(
           :polling_station_title,

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
@@ -1,9 +1,9 @@
 <span class="exports button button__sm button__secondary button--simple" data-toggle="<%= dropdown_id(collection_ids) %>">
   <% if collection_ids.present? %>
     <%= t("actions.export-selection", scope: "decidim.admin") %>
-    <% else %>
-        <%= t("actions.export", scope: "decidim.admin") %>
-    <% end %>
+  <% else %>
+    <%= t("actions.export", scope: "decidim.admin") %>
+  <% end %>
   <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
 </span>
 <div class="dropdown-pane"

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
@@ -4,6 +4,7 @@
     <% else %>
         <%= t("actions.export", scope: "decidim.admin") %>
     <% end %>
+  <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
 </span>
 <div class="dropdown-pane"
      id="<%= dropdown_id(collection_ids) %>"

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_initiative_type_scopes.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_initiative_type_scopes.html.erb
@@ -7,7 +7,7 @@
           <%= t("initiatives_types.initiative_type_scopes.title", scope: "decidim.initiatives.admin") %>
         </span>
       </button>
-      <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.initiatives_type_scope.name", scope: "decidim.admin")),
+      <%= link_to t("actions.new_initiative_type_scope", scope: "decidim.admin"),
                   new_initiatives_type_initiatives_type_scope_path(initiative_type),
                   class: "button button__sm button__secondary flex-none" if allowed_to? :create, :initiative_type_scope %>
     </h2>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
       actions:
         manage: Manage
         new_initiative_type: New initiative type
+        new_initiative_type_scope: New initiative type scope
       filters:
         initiatives:
           decidim_area_id_eq:

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_scopes_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_scopes_spec.rb
@@ -15,8 +15,8 @@ describe "Admin manages initiatives types scopes", type: :system do
   end
 
   context "when creating a new initiative type scope" do
-    it "creates a new initiative type scope" do
-      click_link "New Initiative type scope"
+    it "Creates a new initiative type scope" do
+      click_link "New initiative type scope"
       select translated(scope.name), from: :initiatives_type_scope_decidim_scopes_id
       fill_in :initiatives_type_scope_supports_required, with: 1000
       click_button "Create"
@@ -25,7 +25,7 @@ describe "Admin manages initiatives types scopes", type: :system do
     end
 
     it "allows creating initiative type scopes with a Global scope" do
-      click_link "New Initiative type scope"
+      click_link "New initiative type scope"
       fill_in :initiatives_type_scope_supports_required, with: 10
       click_button "Create"
 

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -5,7 +5,7 @@
       <%= t(".title") %>
       <div class="button--title">
         <%= export_dropdown %>
-        <%= link_to t("actions.new", scope: "decidim.meetings"), new_meeting_path, class: "button button__sm button__secondary" if allowed_to? :create, :meeting %>
+        <%= link_to t("actions.new_meeting", scope: "decidim.meetings"), new_meeting_path, class: "button button__sm button__secondary" if allowed_to? :create, :meeting %>
       </div>
     </h2>
   </div>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -4,7 +4,7 @@
     <h2 class="item_show__header-title">
       <%= t(".title") %>
       <div class="button--title">
-        <%= link_to t("actions.new", scope: "decidim.meetings", name: t("models.meeting.name", scope: "decidim.meetings.admin")), new_meeting_path, class: "button button__sm button__secondary" if allowed_to? :create, :meeting %>
+        <%= link_to t("actions.new", scope: "decidim.meetings"), new_meeting_path, class: "button button__sm button__secondary" if allowed_to? :create, :meeting %>
         <%= export_dropdown %>
       </div>
     </h2>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -4,8 +4,8 @@
     <h2 class="item_show__header-title">
       <%= t(".title") %>
       <div class="button--title">
-        <%= link_to t("actions.new", scope: "decidim.meetings"), new_meeting_path, class: "button button__sm button__secondary" if allowed_to? :create, :meeting %>
         <%= export_dropdown %>
+        <%= link_to t("actions.new", scope: "decidim.meetings"), new_meeting_path, class: "button button__sm button__secondary" if allowed_to? :create, :meeting %>
       </div>
     </h2>
   </div>

--- a/decidim-meetings/app/views/decidim/meetings/admin/registrations/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/registrations/_form.html.erb
@@ -6,7 +6,10 @@
         <div class="flex items-center gap-x-4 ml-auto">
           <%= link_to t(".invites"), meeting_registrations_invites_path(meeting), class: "button button__sm button__secondary #{"disabled" unless allowed_to? :read_invites, :meeting, meeting: meeting}" %>
           <% if allowed_to? :export_registrations, :meeting, meeting: meeting %>
-            <span class="exports dropdown tiny button button__sm button__secondary button--simple button--title" data-toggle="export-dropdown"><%= t "actions.export", scope: "decidim.admin" %></span>
+            <span class="exports dropdown tiny button button__sm button__secondary button--simple button--title" data-toggle="export-dropdown">
+              <%= t "actions.export", scope: "decidim.admin" %>
+              <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
+            </span>
             <div class="dropdown-pane" id="export-dropdown" data-dropdown data-auto-focus="true" data-close-on-click="true">
               <ul class="vertical menu add-components">
                 <% %w(CSV JSON Excel).each do |format| %>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -225,7 +225,7 @@ en:
             one: 'The meeting cannot be destroyed because it has %{count} proposal associated to it:'
             other: 'The meeting cannot be destroyed because it has %{count} proposals associated to it:'
         manage_poll: Manage poll
-        new: New meeting
+        new_meeting: New meeting
         preview: Preview
         registrations: Registrations
         title: Actions

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -352,9 +352,6 @@ en:
           update:
             invalid: There was a problem updating this meeting poll.
             success: Meeting poll successfully updated.
-        models:
-          meeting:
-            name: Meeting
         registrations:
           edit:
             save: Save

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
@@ -5,6 +5,7 @@
     type="button"
     data-toggle="js-bulk-actions-dropdown">
     <%= t("decidim.proposals.admin.proposals.index.actions") %>
+    <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
   </button>
 
   <div

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
@@ -1,7 +1,7 @@
 <div id="js-bulk-actions-wrapper">
   <button
     id="js-bulk-actions-button"
-    class="button button__sm button__transparent button__transparent-secondary dropdown"
+    class="button button__sm button__secondary"
     type="button"
     data-toggle="js-bulk-actions-dropdown">
     <%= t("decidim.proposals.admin.proposals.index.actions") %>

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
@@ -5,7 +5,7 @@
       <%= t(".title") %>
       <div class="button--title">
         <% if allowed_to? :create, :sortition %>
-          <%= link_to t("actions.new", scope: "decidim.sortitions.admin"), new_sortition_path, class: "button button__sm button__secondary" %>
+          <%= link_to t("actions.new_sortition", scope: "decidim.sortitions.admin"), new_sortition_path, class: "button button__sm button__secondary" %>
         <% end %>
       </div>
     </h2>

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
@@ -5,7 +5,7 @@
       <%= t(".title") %>
       <div class="button--title">
         <% if allowed_to? :create, :sortition %>
-          <%= link_to t("actions.new", scope: "decidim.sortitions.admin", name: t("models.sortition.name", scope: "decidim.sortitions.admin")), new_sortition_path, class: "button button__sm button__secondary" %>
+          <%= link_to t("actions.new", scope: "decidim.sortitions.admin"), new_sortition_path, class: "button button__sm button__secondary" %>
         <% end %>
       </div>
     </h2>

--- a/decidim-sortitions/config/locales/en.yml
+++ b/decidim-sortitions/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
         actions:
           destroy: Cancel the sortition
           edit: Edit
-          new: New sortition
+          new_sortition: New sortition
           show: Sortition details
         models:
           sortition:

--- a/decidim-sortitions/config/locales/en.yml
+++ b/decidim-sortitions/config/locales/en.yml
@@ -53,9 +53,6 @@ en:
               seed: Seed
               target_items: Items to select
               title: Title
-            name:
-              one: Sortition
-              other: Sortitions
         sortitions:
           confirm_destroy:
             confirm_destroy: Are you sure you want to cancel this sortition?

--- a/decidim-system/app/views/decidim/system/admins/index.html.erb
+++ b/decidim-system/app/views/decidim/system/admins/index.html.erb
@@ -2,7 +2,7 @@
   <h1 class="h1"><%= t ".title" %></h1>
 <% end %>
 
-<%= link_to t("actions.new", scope: "decidim.system", name: t("models.admin.name", scope: "decidim.system")), [:new, :admin], class: "button button__sm md:button__lg button__primary" %>
+<%= link_to t("actions.new_admin", scope: "decidim.system"), [:new, :admin], class: "button button__sm md:button__lg button__primary" %>
 
 <table>
   <thead>

--- a/decidim-system/app/views/decidim/system/oauth_applications/index.html.erb
+++ b/decidim-system/app/views/decidim/system/oauth_applications/index.html.erb
@@ -2,7 +2,7 @@
   <h1 class="h1"><%= t ".title" %></h1>
 <% end %>
 
-<%= link_to t("actions.new", scope: "decidim.system", name: t("models.oauth_application.name", scope: "decidim.system")), [:new, :oauth_application], class: "button button__sm md:button__lg button__primary" %>
+<%= link_to t("actions.new_oauth_application", scope: "decidim.system"), [:new, :oauth_application], class: "button button__sm md:button__lg button__primary" %>
 
 <table>
   <thead>

--- a/decidim-system/app/views/decidim/system/organizations/index.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/index.html.erb
@@ -2,6 +2,6 @@
   <h1 class="h1"><%= t ".title" %></h1>
 <% end %>
 
-<%= link_to t("actions.new", scope: "decidim.system", name: t("models.organization.name", scope: "decidim.system")), [:new, :organization], class: "button button__sm md:button__lg button__primary" %>
+<%= link_to t("actions.new_organization", scope: "decidim.system"), [:new, :organization], class: "button button__sm md:button__lg button__primary" %>
 
 <%= render partial: "decidim/system/shared/organizations_list", locals: { organizations: @organizations } %>

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -39,6 +39,9 @@ en:
         destroy: Delete
         edit: Edit
         new: New
+        new_admin: New admin
+        new_oauth_application: New OAUTH application
+        new_organization: New organization
         save: Save
         title: Actions
       admins:

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -38,7 +38,6 @@ en:
         confirm_destroy: Are you sure you want to delete this?
         destroy: Delete
         edit: Edit
-        new: New
         new_admin: New admin
         new_oauth_application: New OAUTH application
         new_organization: New organization
@@ -98,7 +97,6 @@ en:
           fields:
             created_at: Created at
             email: Email
-          name: Admin
           validations:
             email_uniqueness: another admin with the same email already exists
         oauth_application:
@@ -106,7 +104,6 @@ en:
             created_at: Created at
             name: OAuth application name
             organization_name: Organization
-          name: OAuth application
         organization:
           actions:
             save_and_invite: Create organization & invite admin
@@ -117,7 +114,6 @@ en:
             name: Name
             omniauth_settings: Omniauth settings
             smtp_settings: SMTP settings
-          name: Organization
       oauth_applications:
         create:
           error: There was a problem creating this application.

--- a/decidim-templates/app/views/decidim/templates/admin/block_user_templates/index.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/block_user_templates/index.html.erb
@@ -4,7 +4,7 @@
     <h2 class="item_show__header-title">
       <%= t ".title" %>
       <% if allowed_to?(:create, :template) %>
-        <%= link_to t("actions.new", scope: "decidim.admin.templates"), [:new, :block_user_template], class: "button button__sm button__secondary new" %>
+        <%= link_to t("actions.new_template", scope: "decidim.admin.templates"), [:new, :block_user_template], class: "button button__sm button__secondary new" %>
       <% end %>
     </h2>
   </div>

--- a/decidim-templates/app/views/decidim/templates/admin/block_user_templates/index.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/block_user_templates/index.html.erb
@@ -4,7 +4,7 @@
     <h2 class="item_show__header-title">
       <%= t ".title" %>
       <% if allowed_to?(:create, :template) %>
-        <%= link_to t("actions.new", scope: "decidim.admin", name: t("template.name", scope: "decidim.models").downcase), [:new, :block_user_template], class: "button button__sm button__secondary new" %>
+        <%= link_to t("actions.new", scope: "decidim.admin.templates"), [:new, :block_user_template], class: "button button__sm button__secondary new" %>
       <% end %>
     </h2>
   </div>

--- a/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/index.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/index.html.erb
@@ -4,7 +4,7 @@
     <h2 class="item_show__header-title">
       <%= t ".title" %>
       <% if allowed_to?(:create, :template) %>
-        <%= link_to t("actions.new", scope: "decidim.admin.templates"), [:new, :questionnaire_template], class: "button button__sm button__secondary new" %>
+        <%= link_to t("actions.new_template", scope: "decidim.admin.templates"), [:new, :questionnaire_template], class: "button button__sm button__secondary new" %>
       <% end %>
     </h2>
   </div>

--- a/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/index.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/index.html.erb
@@ -4,7 +4,7 @@
     <h2 class="item_show__header-title">
       <%= t ".title" %>
       <% if allowed_to?(:create, :template) %>
-        <%= link_to t("actions.new", scope: "decidim.admin", name: t("template.name", scope: "decidim.models").downcase), [:new, :questionnaire_template], class: "button button__sm button__secondary new" %>
+        <%= link_to t("actions.new", scope: "decidim.admin.templates"), [:new, :questionnaire_template], class: "button button__sm button__secondary new" %>
       <% end %>
     </h2>
   </div>

--- a/decidim-templates/config/locales/en.yml
+++ b/decidim-templates/config/locales/en.yml
@@ -13,6 +13,8 @@ en:
         manage: Manage
         templates: Templates
       templates:
+        actions:
+          new: New template
         apply:
           error: There was a problem applying this template.
           success: Template applied successfully.

--- a/decidim-templates/config/locales/en.yml
+++ b/decidim-templates/config/locales/en.yml
@@ -14,7 +14,7 @@ en:
         templates: Templates
       templates:
         actions:
-          new: New template
+          new_template: New template
         apply:
           error: There was a problem applying this template.
           success: Template applied successfully.


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

This PR tries to fix the consistency in the Actions buttons for the components. Most notably:

1. Makes the bulk "Action" button in the cases of Proposals and Budgets to behave as other dropdown buttons (same colors, with the chevron aka arrow in the right)
2. Adds the chevron arrow in other dropdowns (like Import and Export all) 
3. Fixes a problem with the translations and the different resources. 
4. Fixes a consistency order problem between the different buttons
 
##### About the translations and the different resources
 
Seems like it's overkill to not use the resource name, until you see  that having the generic brings too many bugs:

1. Some buttons say things like "New Project" instead of "New project"
2. For fixing that, on some buttons we were doing the equivalent to "New #{"Project".downcase}". This approach does not work on some languages where the subject needs to be capitalized (like German)
3. The generic approach meant that in some languages with gender, we had things like "Nuevo propuesta" (mixing genders) and leaving a bad impression on our translators when they didn't even have the fault :/

So, the fix is to actually separate the "New" button translation for each resource so translators can understand better and translate it in the correct gender and casing.
 
##### About the New Order of buttons

Right now we have the different bulk/actions buttons for the components without a consistent order. This commit tries to fix that.

The New Order (:D) is the following:

1. "Actions" (with dropdown) in the cases that there is one (like Proposals and Budgets)
2. "Export all" (with dropdown)
3. "Import" (with dropdown)
4. Other random actions (like "Send voting reminders" in Budgets)
5. New resource (like New budget). This one should be always the first, counting from the right side.

#### Testing

1. Sign in as admin
2. Go to the different components and see the different actions buttons in the components

### :camera: Screenshots

![Screenshot of the budgets component](https://github.com/decidim/decidim/assets/717367/1b0efc11-273f-4044-8f05-e3e96b4fcdc5)


:hearts: Thank you!
