### PR TITLE
Fix missing attachments in initiatives

### DIFF
--- a/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
@@ -5,6 +5,8 @@ module Decidim
     # A command with all the business logic that creates a new initiative.
     class CreateInitiative < Decidim::Command
       include CurrentLocale
+      include ::Decidim::MultipleAttachmentsMethods
+      include ::Decidim::GalleryMethods
 
       # Public: Initializes the command.
       #
@@ -23,6 +25,16 @@ module Decidim
       # Returns nothing.
       def call
         return broadcast(:invalid) if form.invalid?
+
+        if process_attachments?
+          build_attachments
+          return broadcast(:invalid) if attachments_invalid?
+        end
+
+        if process_gallery?
+          build_gallery
+          return broadcast(:invalid) if gallery_invalid?
+        end
 
         initiative = create_initiative
 
@@ -44,6 +56,10 @@ module Decidim
 
         initiative.transaction do
           initiative.save!
+
+          @attached_to = initiative
+          create_attachments if process_attachments?
+          create_gallery if process_gallery?
 
           create_components_for(initiative)
           send_notification(initiative)

--- a/decidim-initiatives/app/commands/decidim/initiatives/update_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/update_initiative.rb
@@ -34,6 +34,11 @@ module Decidim
           return broadcast(:invalid) if attachments_invalid?
         end
 
+        if process_gallery?
+          build_gallery
+          return broadcast(:invalid) if gallery_invalid?
+        end
+
         @initiative = Decidim.traceability.update!(
           initiative,
           current_user,
@@ -43,6 +48,7 @@ module Decidim
         photo_cleanup!
         document_cleanup!
         create_attachments if process_attachments?
+        create_gallery if process_gallery?
 
         broadcast(:ok, initiative)
       rescue ActiveRecord::RecordInvalid

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -65,6 +65,13 @@
     <% end %>
 
     <% if initiative_type.attachments_enabled? %>
+      <%= f.attachment :documents,
+          multiple: true,
+          label: t("decidim.initiatives.form.add_documents"),
+          button_label: t("decidim.initiatives.form.add_documents"),
+          button_class: "button button__lg button__transparent-secondary w-full",
+          button_edit_label: t("decidim.initiatives.form.edit_documents"),
+          help_text: t("attachment_legend", scope: "decidim.initiatives.form") %>
       <%= f.attachment :photos,
           multiple: true,
           label: t("decidim.initiatives.form.add_image"),
@@ -72,13 +79,6 @@
           button_class: "button button__lg button__transparent-secondary w-full",
           button_edit_label: t("decidim.initiatives.form.edit_image"),
           help_text: t("image_legend", scope: "decidim.initiatives.form") %>
-      <%= f.attachment :add_documents,
-          multiple: true,
-          label: t("decidim.initiatives.form.add_documents"),
-          button_label: t("decidim.initiatives.form.add_documents"),
-          button_class: "button button__lg button__transparent-secondary w-full",
-          button_edit_label: t("decidim.initiatives.form.edit_documents"),
-          help_text: t("attachment_legend", scope: "decidim.initiatives.form") %>
     <% end %>
 
     <% if @form.state_updatable? %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
@@ -49,7 +49,7 @@
 <% end %>
 
 <% if current_initiative.type.attachments_enabled? %>
-  <%= form.attachment :add_documents,
+  <%= form.attachment :documents,
                       multiple: true,
                       label: t("decidim.initiatives.form.add_documents"),
                       button_label: t("decidim.initiatives.form.add_documents"),

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -13,7 +13,7 @@ describe "Initiative", type: :system do
   let(:signature_type) { "any" }
   let(:initiative_type_promoting_committee_enabled) { true }
   let(:initiative_type) do
-    create(:initiatives_type,
+    create(:initiatives_type, :attachments_enabled,
            organization:,
            minimum_committee_members: initiative_type_minimum_committee_members,
            promoting_committee_enabled: initiative_type_promoting_committee_enabled,
@@ -21,9 +21,9 @@ describe "Initiative", type: :system do
   end
   let!(:initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
   let!(:initiative_type_scope2) { create(:initiatives_type_scope, type: initiative_type) }
-  let!(:other_initiative_type) { create(:initiatives_type, organization:) }
+  let!(:other_initiative_type) { create(:initiatives_type, :attachments_enabled, organization:) }
   let!(:other_initiative_type_scope) { create(:initiatives_type_scope, type: other_initiative_type) }
-  let(:third_initiative_type) { create(:initiatives_type, organization:) }
+  let(:third_initiative_type) { create(:initiatives_type, :attachments_enabled, organization:) }
 
   shared_examples "initiatives path redirection" do
     it "redirects to initiatives path" do
@@ -746,8 +746,14 @@ describe "Initiative", type: :system do
           fill_in "initiative_description", with: translated(initiative.description, locale: :en)
           select("Online", from: "Signature collection type")
           select(translated(initiative_type_scope&.scope&.name, locale: :en), from: "Scope")
-          dynamically_attach_file(:initiative_add_documents, Decidim::Dev.asset("Exampledocument.pdf"))
+          dynamically_attach_file(:initiative_documents, Decidim::Dev.asset("Exampledocument.pdf"))
+          dynamically_attach_file(:initiative_photos, Decidim::Dev.asset("avatar.jpg"))
           find_button("Continue").click
+        end
+
+        it "saves the attachments" do
+          expect(Decidim::Initiative.last.documents.count).to eq(1)
+          expect(Decidim::Initiative.last.photos.count).to eq(1)
         end
 
         it "shows the page component" do

--- a/decidim-initiatives/spec/system/edit_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/edit_initiative_spec.rb
@@ -8,10 +8,10 @@ describe "Edit initiative", type: :system do
   let(:initiative_title) { translated(initiative.title) }
   let(:new_title) { "This is my initiative new title" }
 
-  let!(:initiative_type) { create(:initiatives_type, :online_signature_enabled, organization:) }
+  let!(:initiative_type) { create(:initiatives_type, :attachments_enabled, :online_signature_enabled, organization:) }
   let!(:scoped_type) { create(:initiatives_type_scope, type: initiative_type) }
 
-  let!(:other_initiative_type) { create(:initiatives_type, organization:) }
+  let!(:other_initiative_type) { create(:initiatives_type, :attachments_enabled, organization:) }
   let!(:other_scoped_type) { create(:initiatives_type_scope, type: initiative_type) }
 
   let(:initiative_path) { decidim_initiatives.initiative_path(initiative) }
@@ -54,6 +54,27 @@ describe "Edit initiative", type: :system do
 
     it "does not have status field" do
       expect(page).not_to have_xpath("//select[@id='initiative_state']")
+    end
+
+    it "allows adding attachments" do
+      visit initiative_path
+
+      click_link("Edit", href: edit_initiative_path)
+
+      expect(page).to have_content "Edit Initiative"
+
+      expect(initiative.reload.attachments.count).to eq(0)
+
+      dynamically_attach_file(:initiative_documents, Decidim::Dev.asset("Exampledocument.pdf"))
+      dynamically_attach_file(:initiative_photos, Decidim::Dev.asset("avatar.jpg"))
+
+      within "form.edit_initiative" do
+        click_button "Update"
+      end
+
+      expect(initiative.reload.documents.count).to eq(1)
+      expect(initiative.photos.count).to eq(1)
+      expect(initiative.attachments.count).to eq(2)
     end
 
     context "when initiative is published" do


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR restores support for attachments on initiatives.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11653

#### Testing
Prerequisites:
1. Login as admin
2.  visit the admin and enable file attachments for an initiative type
3. Make sure that participants can create initiatives 

Testing:
1. Visit the initiative space 
2. Click on New initiatives 
3. Select the initiative type that has the attachments enabled 
4. You should see the "add image" and "Add documents" ( click and attach test files) 
5. Go through entire creation process
6. View the initiative. You should have the Documents section present with 2 tabs ( docs and images ) 
7. Click edit , change / remove the files 
8. Click save , observe the changes in Initiative show page 

:hearts: Thank you!
