### PR TITLE
Improve layout on endorsement list with extra padding

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/modules/_author-avatar.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/modules/_author-avatar.scss
@@ -29,6 +29,7 @@ $author-data-color: $muted;
 
 .author-data--small{
   padding-left: 25px;
+  padding-bottom: 10px;
 }
 
 .author-data--big{


### PR DESCRIPTION
Note: Recreating https://github.com/decidim/decidim/pull/11537 on requested branch.

#### :tophat: What? Why?
When a number of people have endorsed a proposal, I noticed that the layout is not great, with the avatars overlapping. I think that this is because there's no padding on the author list:

![screenshot-townhall mautic org-2023 08 29-09_31_13](https://github.com/decidim/decidim/assets/2930593/31f19d96-1134-4e2f-a08e-93fc2bc6dfdf)

I played about and I think that 10px should be sufficient, I'm not sure if this is used elsewhere, but if there's a vertical list I'm assuming that the same problem will be experienced there.

Here's what it looks like:

![screenshot-townhall mautic org-2023 08 29-09_31_57](https://github.com/decidim/decidim/assets/2930593/691ce3e9-cf81-4817-bdcb-2d289390ec3b)

![screenshot-townhall mautic org-2023 08 29-09_32_32](https://github.com/decidim/decidim/assets/2930593/4c0202b5-7cde-4361-8445-4638091295aa)

#### Testing
Have more than one person endorse something and check the list of endorsements.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
See above! 

:hearts: Thank you!
