### PR TITLE
Scroll down to show dropdown menu

### DIFF
--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -22,7 +22,7 @@ edit_link(
 
   <%= content_for :aside do %>
     <div class="conference__nav-container">
-      <button id="dropdown-trigger-conference" data-component="dropdown" data-target="dropdown-menu-conference" data-auto-close="true" data-disabled-md="true">
+      <button id="dropdown-trigger-conference" data-component="dropdown" data-target="dropdown-menu-conference" data-auto-close="true" data-disabled-md="true" data-scroll-to-menu="true">
         <span><%= t("decidim.searches.filters.jump_to") %></span>
         <%= icon "arrow-down-s-line" %>
         <%= icon "arrow-up-s-line" %>

--- a/decidim-core/app/cells/decidim/nav_links/show.erb
+++ b/decidim-core/app/cells/decidim/nav_links/show.erb
@@ -1,5 +1,5 @@
 <div class="participatory-space__nav-container">
-  <button id="dropdown-trigger-participatory-space" data-component="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-disabled-md="true">
+  <button id="dropdown-trigger-participatory-space" data-component="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-disabled-md="true" data-scroll-to-menu="true">
     <span><%= t("decidim.searches.filters.jump_to") %></span>
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>

--- a/decidim-core/app/packs/src/decidim/dropdown_scrollable.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_scrollable.js
@@ -1,0 +1,10 @@
+$(() => {
+  // Auto scroll to show the menu on the viewport
+  // @see: https://github.com/decidim/decidim/issues/11307
+  $(document).on("click", "[data-component='dropdown'][data-scroll-to-menu='true']", (ev) => {
+    const $target = $(ev.currentTarget);
+    if ($target.attr("aria-expanded") === "true") {
+      window.scrollTo({ top: $target.offset().top, behavior: "smooth" });
+    }
+  });
+});

--- a/decidim-core/app/packs/src/decidim/redesigned_index.js
+++ b/decidim-core/app/packs/src/decidim/redesigned_index.js
@@ -36,6 +36,7 @@ import "./append_elements"
 import "./user_registrations"
 import "./account_form"
 // import "./dropdowns_menus" -- deprecated
+import "./dropdown_scrollable"
 import "./append_redirect_url_to_modals"
 import "./form_attachments"
 import "./form_remote"


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Scroll down when clicking on the "Jump to" button of dropdown menus.

As I think it's not feasible to use this behavior as the default one, I included `data-scroll-to-menu` for the dropdown buttons where you want to use it.

#### :pushpin: Related Issues
- Fixes #11307 

#### Testing
From a mobile phone:
1. Go to a conference or participatory space.
2. Click on the "Jump to" button.
3. See the page scrolls down so the menu is shown.

### :camera: Screenshots
https://github.com/decidim/decidim/assets/6973564/f5c65ab3-b4c8-4e20-a111-8e5ac158d5bb

:hearts: Thank you!
