### PR TITLE
Redesign: fix wrong copy in Conference registration

### DIFF
--- a/decidim-conferences/app/controllers/decidim/conferences/conferences_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conferences_controller.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# i18n-tasks-use t('decidim.conferences.conferences.show.already_have_an_account?')
+# i18n-tasks-use t('decidim.conferences.conferences.show.are_you_new?')
+# i18n-tasks-use t('decidim.conferences.conferences.show.sign_in_description')
+# i18n-tasks-use t('decidim.conferences.conferences.show.sign_up_description')
 module Decidim
   module Conferences
     # A controller that holds the logic to show Conferences in a

--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -100,7 +100,7 @@ edit_link(
             </div>
           </div>
         <% else %>
-          <%= render partial: "decidim/devise/shared/login_boxes" %>
+          <%= render partial: "decidim/devise/shared/login_boxes", locals: { scope: "decidim.conferences.conferences.show" } %>
         <% end %>
       </section>
     <% end %>

--- a/decidim-conferences/app/views/decidim/conferences/registration_types/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/registration_types/index.html.erb
@@ -21,7 +21,7 @@ edit_link(
       <span class="sr-only"><%= t("registration_types.index.register", scope: "decidim.conferences") %> (<%= translated_attribute current_participatory_space.title %>)</span>
     </h1>
 
-    <%= render partial: "decidim/devise/shared/login_boxes" unless current_user %>
+    <%= render partial: "decidim/devise/shared/login_boxes", locals: { scope: "decidim.conferences.conferences.show" } unless current_user %>
 
     <% if collection.any? %>
       <p class="conference__registration-container-title"><%= t(".choose_an_option") %></p>

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -195,7 +195,7 @@ en:
           conference_invites: Invites
           conference_speakers: Speakers
           diploma: Certificate of Attendance
-          info: Info
+          info: About this conference
           media_links: Media Links
           moderations: Moderations
           partners: Partners

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -195,7 +195,7 @@ en:
           conference_invites: Invites
           conference_speakers: Speakers
           diploma: Certificate of Attendance
-          info: About this conference
+          info: Info
           media_links: Media Links
           moderations: Moderations
           partners: Partners
@@ -454,10 +454,14 @@ en:
           collaborators: Partners
           main_promotors: Organizers
         show:
+          already_have_an_account?: Already have an account?
+          are_you_new?: New participant?
           login_as: You are logged in as %{name} <%{email}>
           make_conference_registration: Register for the conference
           manage_registration: Manage registration
           register: Register
+          sign_in_description: Log in to register to the conference
+          sign_up_description: Create an account to register to the conference
       content_blocks:
         highlighted_conferences:
           name: Highlighted conferences

--- a/decidim-core/app/views/decidim/devise/shared/_login_boxes.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_login_boxes.html.erb
@@ -2,10 +2,10 @@
   <button type="button" class="login__box" data-dialog-open="loginModal">
     <%= icon "login-box-line", class: "login__box-icon" %>
     <p class="login__box-title">
-      <%= t("decidim.forms.questionnaires.show.answer_questionnaire.already_have_an_account?") %>
+      <%= t("already_have_an_account?", scope: ) %>
     </p>
     <p class="login__box-description">
-      <%= t("decidim.forms.questionnaires.show.answer_questionnaire.sign_in_description") %>
+      <%= t("sign_in_description", scope: ) %>
     </p>
     <div class="login__box-link">
       <%= t("decidim.devise.registrations.new.log_in") %>
@@ -15,10 +15,10 @@
   <%= link_to(decidim.new_user_registration_path, class: "login__box") do %>
     <%= icon "user-add-line", class: "login__box-icon" %>
     <p class="login__box-title">
-      <%= t("decidim.forms.questionnaires.show.answer_questionnaire.are_you_new?") %>
+      <%= t("are_you_new?", scope: ) %>
     </p>
     <p class="login__box-description">
-      <%= t("decidim.forms.questionnaires.show.answer_questionnaire.sign_up_description") %>
+      <%= t("sign_up_description", scope: ) %>
     </p>
     <div class="login__box-link">
       <%= t("decidim.devise.registrations.new.sign_up") %>

--- a/decidim-forms/app/views/decidim/forms/questionnaires/_questionnaire_readonly.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/_questionnaire_readonly.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: "decidim/devise/shared/login_boxes" %>
+<%= render partial: "decidim/devise/shared/login_boxes", locals: { scope: "decidim.forms.questionnaires.show.answer_questionnaire" } %>
 
 <div class="answer-questionnaire mt-12">
   <ol class="answer-questionnaire__step">


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR fixes the register conference copy on login boxes. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes  #11277

#### Testing
1. As guest check the show conference action 
2. See login boxes doe not refer to Surveys 
3. Check surveys ( that can be answered) and see the copy

:hearts: Thank you!
