### PR TITLE
Fix debates admin issues

### DIFF
--- a/decidim-debates/app/views/decidim/debates/admin/debate_closes/edit.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debate_closes/edit.html.erb
@@ -4,11 +4,11 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, url: debate_debate_close_path(debate, @form), html: { class: "form form-defaults edit_close_debate" }) do |f| %>
       <div class="form__wrapper">
-        <div class="card">
+        <div class="card pt-4 pb-4">
 
           <div class="card-section">
             <div class="row column">

--- a/decidim-debates/app/views/decidim/debates/admin/debate_closes/edit.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debate_closes/edit.html.erb
@@ -4,7 +4,7 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div>
+<div class="item__edit item__edit-1col">
   <div class="item__edit-form">
     <%= decidim_form_for(@form, url: debate_debate_close_path(debate, @form), html: { class: "form form-defaults edit_close_debate" }) do |f| %>
       <div class="form__wrapper">

--- a/decidim-debates/app/views/decidim/debates/admin/debates/_form.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/_form.html.erb
@@ -1,9 +1,5 @@
 <div class="form__wrapper">
-  <div class="card">
-    <div class="card-divider">
-      <h2 class="card-title"><%= title %></h2>
-    </div>
-
+  <div class="card pt-4">
     <div class="card-section debate-fields">
        <div class="row column hashtags__container">
         <%= form.translated :text_field, :title, autofocus: true, class: "js-hashtags", hashtaggable: true, aria: { label: :title } %>

--- a/decidim-debates/app/views/decidim/debates/admin/debates/edit.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/edit.html.erb
@@ -4,7 +4,7 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div>
+<div class="item__edit item__edit-1col">
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form-defaults form edit_debate" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-debates/app/views/decidim/debates/admin/debates/edit.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/edit.html.erb
@@ -4,10 +4,10 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form-defaults form edit_debate" }) do |f| %>
-      <%= render partial: "form", object: f, locals: { title: t(".title") } %>
+      <%= render partial: "form", object: f %>
       <div class="item__edit-sticky">
         <div class="item__edit-sticky-container">
           <%= f.submit t(".update"), class: "button button__sm button__secondary" %>

--- a/decidim-debates/app/views/decidim/debates/admin/debates/new.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/new.html.erb
@@ -4,10 +4,10 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form-defaults form new_debate" }) do |f| %>
-      <%= render partial: "form", object: f, locals: { title: t(".title") } %>
+      <%= render partial: "form", object: f %>
       <div class="item__edit-sticky">
         <div class="item__edit-sticky-container">
           <%= f.submit t(".create"), class: "button button__sm button__secondary" %>

--- a/decidim-debates/app/views/decidim/debates/admin/debates/new.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/new.html.erb
@@ -4,7 +4,7 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div>
+<div class="item__edit item__edit-1col">
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form-defaults form new_debate" }) do |f| %>
       <%= render partial: "form", object: f %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR address the layout issues highlighted in #11605. 
- [x] padding around the form is not ok in `decidim-debates/app/views/decidim/debates/admin/debate_closes/edit.html.erb`
- [x] Missing `pt-4` on the card class in `decidim-debates/app/views/decidim/debates/admin/debate_closes/edit.html.erb`
-  [x] Title param is still passed to form and is not used in `decidim-debates/app/views/decidim/debates/admin/debates/edit.html.erb`
-  [x] Title param is still passed to form and is not used in `decidim-debates/app/views/decidim/debates/admin/debates/new.html.erb`
- [x] Old header  in `decidim-debates/app/views/decidim/debates/admin/debates/_form.html.erb`
- [x] Missing `pt-4` in `decidim-debates/app/views/decidim/debates/admin/debates/_form.html.erb`

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11605

#### Testing
1. Login as admin
2. Visit debates module pages and see there is a consistent layout

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
