### PR TITLE
Fix form width on all modules

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/admin/import_results/new.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/import_results/new.html.erb
@@ -4,7 +4,7 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= form_for(@form, url: import_results_path, html: { class: "form form-defaults import_projects" }) do |form| %>
       <div class="card py-4">

--- a/decidim-accountability/app/views/decidim/accountability/admin/projects_import/new.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/projects_import/new.html.erb
@@ -5,7 +5,7 @@
   </h2>
 </div>
 
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= form_for(@form, url: projects_import_index_path(@accountability), html: { class: "form form-defaults import_projects" }) do |f| %>
       <% if @form.origin_components.any? %>

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/edit.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/edit.html.erb
@@ -5,7 +5,7 @@
   </h2>
 </div>
 
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
      <%= decidim_form_for(@form, html: { class: "form form-defaults edit_result" }) do |f| %>
        <%= render partial: "form", object: f %>

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/new.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/new.html.erb
@@ -5,7 +5,7 @@
   </h2>
 </div>
 
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
      <%= decidim_form_for(@form, html: { class: "form form-defaults new_result" }) do |f| %>
        <%= render partial: "form", object: f %>

--- a/decidim-accountability/app/views/decidim/accountability/admin/statuses/edit.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/statuses/edit.html.erb
@@ -4,7 +4,7 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form-defaults form edit_status" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-accountability/app/views/decidim/accountability/admin/statuses/new.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/statuses/new.html.erb
@@ -4,7 +4,7 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form-defaults form new_status" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/edit.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/edit.html.erb
@@ -3,7 +3,7 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for([result, @form], html: { class: "form-defaults form edit_timeline_entry" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/new.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/new.html.erb
@@ -3,7 +3,7 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for([result, @form], html: { class: "form-defaults form new_timeline_entry" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_redesigned_item_edit.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_redesigned_item_edit.scss
@@ -98,7 +98,7 @@
   }
 
   &-sticky {
-    @apply w-full fixed left-0 bottom-0 bg-gray-2 border-t border-white;
+    @apply w-full fixed left-0 bottom-0 bg-gray-2 border-t border-white z-10;
 
     &-container {
       @apply px-8 py-4 flex gap-x-4 justify-end;

--- a/decidim-admin/app/views/decidim/admin/impersonations/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/impersonations/new.html.erb
@@ -12,7 +12,7 @@
     <% end %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, url: impersonatable_user_impersonations_path, html: { class: "form form-defaults new_impersonation" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-admin/app/views/decidim/admin/static_page_topics/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_page_topics/edit.html.erb
@@ -4,7 +4,7 @@
     <%= t ".title" %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <div class="form__wrapper">
       <%= decidim_form_for(@form, html: { class: "form form-defaults edit_static_page_topic" }) do |f| %>

--- a/decidim-admin/app/views/decidim/admin/static_page_topics/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_page_topics/new.html.erb
@@ -4,7 +4,7 @@
     <%= t ".title" %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <div class="form__wrapper">
       <%= decidim_form_for(@form, html: { class: "form form-defaults new_static_page_topic" }) do |f| %>

--- a/decidim-admin/app/views/decidim/admin/static_pages/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/edit.html.erb
@@ -4,7 +4,7 @@
     <%= t ".title" %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form form-defaults edit_static_page" }) do |f| %>
       <div class="card">

--- a/decidim-admin/app/views/decidim/admin/static_pages/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/new.html.erb
@@ -4,7 +4,7 @@
     <%= t ".title" %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form form-defaults new_static_page" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-admin/app/views/decidim/admin/user_groups_csv_verifications/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/user_groups_csv_verifications/new.html.erb
@@ -4,7 +4,7 @@
     <%= t ".title" %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <div class="form__wrapper">
       <%= decidim_form_for(@form, url: user_groups_csv_verification_path, html: { class: "form form-defaults" }) do |form| %>

--- a/decidim-admin/app/views/decidim/admin/users/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/new.html.erb
@@ -4,7 +4,7 @@
     <%= t ".title" %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form form-defaults new_user" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/edit.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/edit.html.erb
@@ -4,7 +4,7 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form-defaults form edit_post" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/new.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/new.html.erb
@@ -5,7 +5,7 @@
   </h2>
 </div>
 
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
      <%= decidim_form_for(@form, html: { class: "form-defaults form new_post" }) do |f| %>
        <%= render partial: "form", object: f %>

--- a/decidim-pages/app/views/decidim/pages/admin/pages/edit.html.erb
+++ b/decidim-pages/app/views/decidim/pages/admin/pages/edit.html.erb
@@ -5,7 +5,7 @@
   </h2>
 </div>
 
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, url: page_path, method: :post, html: { class: "form-defaults form edit_page" }) do |form| %>
       <%= render partial: "form", object: form %>

--- a/decidim-templates/app/views/decidim/templates/admin/block_user_templates/edit.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/block_user_templates/edit.html.erb
@@ -4,7 +4,7 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, url: block_user_template_path, html: { class: "form-defaults form edit_user_block_template" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-templates/app/views/decidim/templates/admin/block_user_templates/new.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/block_user_templates/new.html.erb
@@ -4,7 +4,7 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, url: block_user_templates_path, html: { class: "form-defaults form new_user_block_template" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/edit.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/edit.html.erb
@@ -4,7 +4,7 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, url: questionnaire_template_path, html: { class: "form form-defaults edit_questionnaire_template" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/new.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/new.html.erb
@@ -4,7 +4,7 @@
     <%= t(".title") %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, url: questionnaire_templates_path, html: { class: "form-defaults form new_questionnaire_template" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-verifications/app/views/decidim/verifications/csv_census/admin/census/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/csv_census/admin/census/index.html.erb
@@ -6,7 +6,7 @@
   </h2>
 </div>
 
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <div class="form__wrapper">
       <div class="card">
@@ -44,7 +44,12 @@
             <%= decidim_form_for @form, url: census_path, multipart: true do |form| %>
               <%= label_tag :file, t("admin.new.file", scope: "decidim.verifications.csv_census") %>
               <%= form.file_field :file %>
-              <%= submit_tag t("admin.new.submit", scope: "decidim.verifications.csv_census"), class: "button button__sm button__secondary" %>
+
+              <div class="item__edit-sticky">
+                <div class="item__edit-sticky-container">
+                  <%= submit_tag t("admin.new.submit", scope: "decidim.verifications.csv_census"), class: "button button__sm button__secondary" %>
+                </div>
+              </div>
             <% end %>
           </div>
         </div>

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/config/edit.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/config/edit.html.erb
@@ -6,12 +6,11 @@
   </h2>
 </div>
 
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, url: { action: :update }, html: { class: "form form-defaults" }) do |form| %>
       <div class="form__wrapper">
-        <div class="card">
-          <div class="card-divider"></div>
+        <div class="card pt-4">
           <div class="card-section">
             <div class="row column">
               <%= label_tag(:available_methods, t("activemodel.attributes.config.available_methods")) %>
@@ -26,8 +25,10 @@
         </div>
       </div>
 
-      <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
-        <%= form.submit t(".update"), class: "button button__sm button__secondary" %>
+      <div class="item__edit-sticky">
+        <div class="item__edit-sticky-container">
+          <%= form.submit t(".update"), class: "button button__sm button__secondary" %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/confirmations/new.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/confirmations/new.html.erb
@@ -7,7 +7,7 @@
   </h2>
 </div>
 
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, url: pending_authorization_confirmation_path(@pending_authorization),
                                 html: { class: "form form-defaults" }) do |form| %>

--- a/decidim-verifications/app/views/decidim/verifications/postal_letter/admin/pending_authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/postal_letter/admin/pending_authorizations/index.html.erb
@@ -5,7 +5,7 @@
   </h2>
 </div>
 
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <div class="card">
       <div class="card-section">


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
The admin forms have been designed having in mind that we will have a sidebar, which we are removing in #11681. This PR ensures that all all the forms are using the full width of the remaining area.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Relates to #11642
- Relates to #11640
- Relates to  #11643
- Relates to #11645

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
Before: 
![image](https://github.com/decidim/decidim/assets/105683/48a0da8d-0cc0-476c-a465-fb2742c22216)

After:
![image](https://github.com/decidim/decidim/assets/105683/bb1996b7-e649-4513-b8fb-5986c1c858ec)


:hearts: Thank you!
