### PR TITLE
Fix admin redesign in sortitions module

### DIFF
--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/_form.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/_form.html.erb
@@ -1,9 +1,5 @@
 <div class="form__wrapper">
-  <div class="card">
-    <div class="card-divider">
-      <h2 class="card-title"><%= t ".title" %></h2>
-    </div>
-
+  <div class="card pt-4">
     <div class="card-section">
       <div class="row">
         <div class="columns xlarge-12">

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/confirm_destroy.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/confirm_destroy.html.erb
@@ -6,7 +6,7 @@
   </h2>
 </div>
 
-<div>
+<div class="item__edit item__edit-1col">
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form form-defaults confirm_destroy_sortition" }, method: :delete) do |form| %>
       <div class="form__wrapper">

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/confirm_destroy.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/confirm_destroy.html.erb
@@ -6,15 +6,11 @@
   </h2>
 </div>
 
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form form-defaults confirm_destroy_sortition" }, method: :delete) do |form| %>
       <div class="form__wrapper">
-        <div class="card">
-          <div class="card-divider">
-            <h2 class="card-title"><%= decidim_html_escape(translated_attribute(sortition.title)) %></h2>
-          </div>
-
+        <div class="card pt-4">
           <div class="card-section">
             <div class="row">
               <div class="columns xlarge-12">
@@ -25,8 +21,10 @@
         </div>
       </div>
 
-      <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
-        <%= form.submit t(".destroy"), data: { confirm: t(".confirm_destroy") }, class: "button button__sm button__secondary" %>
+      <div class="item__edit-sticky">
+        <div class="item__edit-sticky-container">
+          <%= form.submit t(".destroy"), data: { confirm: t(".confirm_destroy") }, class: "button button__sm button__secondary" %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/edit.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/edit.html.erb
@@ -1,32 +1,30 @@
 <% add_decidim_page_title(translated_attribute(sortition.title)) %>
 <div class="item_show__header">
   <h2 class="item_show__header-title">
-    <%= decidim_html_escape(translated_attribute(sortition.title)) %>
+    <%= t ".title" %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form-defaults form edit_sortition" }) do |form| %>
-      <div class="card">
-        <div class="card-divider">
-          <h2 class="card-title"><%= t ".title" %></h2>
-        </div>
+      <div class="form__wrapper">
+        <div class="card pt-4">
+          <div class="card-section">
+            <div class="row">
+              <div class="columns xlarge-12">
+                <%= form.translated :text_field, :title, autofocus: true, aria: { label: :title } %>
+              </div>
 
-        <div class="card-section">
-          <div class="row">
-            <div class="columns xlarge-12">
-              <%= form.translated :text_field, :title, autofocus: true, aria: { label: :title } %>
-            </div>
-
-            <div class="columns xlarge-12">
-              <%= form.translated :editor, :additional_info, lines: 10, aria: { label: :additional_info } %>
+              <div class="columns xlarge-12">
+                <%= form.translated :editor, :additional_info, lines: 10, aria: { label: :additional_info } %>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div class="item__edit-sticky">
-        <div class="item__edit-sticky-container">
-          <%= form.submit t(".update"), class: "button button__sm button__secondary" %>
+        <div class="item__edit-sticky">
+          <div class="item__edit-sticky-container">
+            <%= form.submit t(".update"), class: "button button__sm button__secondary" %>
+          </div>
         </div>
       </div>
     <% end %>

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/edit.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/edit.html.erb
@@ -4,7 +4,7 @@
     <%= t ".title" %>
   </h2>
 </div>
-<div>
+<div class="item__edit item__edit-1col">
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form-defaults form edit_sortition" }) do |form| %>
       <div class="form__wrapper">

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/new.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/new.html.erb
@@ -4,7 +4,7 @@
     <%= t ".title" %>
   </h2>
 </div>
-<div class="item__edit item__edit-1col">
+<div>
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form-defaults form new_sortition" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/new.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/new.html.erb
@@ -4,7 +4,7 @@
     <%= t ".title" %>
   </h2>
 </div>
-<div>
+<div class="item__edit item__edit-1col">
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form-defaults form new_sortition" }) do |f| %>
       <%= render partial: "form", object: f %>

--- a/decidim-sortitions/config/locales/en.yml
+++ b/decidim-sortitions/config/locales/en.yml
@@ -73,7 +73,6 @@ en:
           form:
             all_categories: All categories
             select_proposal_component: Select the proposals set
-            title: New sortition for proposals
           index:
             title: Sortitions
           new:


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR fixes some of the template issues highlighted in #11607. Please see below the list of adressed issues. 
- [x] Old title is present in `decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/_form.html.erb`
- [x] Old title is present in `decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/edit.html.erb`
- [x] Text input is not styled in `decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/edit.html.erb`
- [x] NO sticky button in `decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/confirm_destroy.html.erb`
- [x] Extra pagination param in `decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb`

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11607 

#### Testing
1. Login as admin 
2. Visit sortitions module pages and see there is a consistent layout

:hearts: Thank you!
