### PR TITLE
Redesign: fix conference speaker filter position

### DIFF
--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
@@ -1,18 +1,4 @@
 <% add_decidim_page_title(t("conference_speakers.index.conference_speakers_title", scope: "decidim.admin")) %>
-<div class="filters__section">
-  <div class="fcell search">
-    <%= form_tag "", method: :get do %>
-      <div class="input-group">
-        <%= search_field_tag :q, @query,label: false, class: "input-group-field", placeholder: t(".search") %>
-        <div class="input-group-button">
-         <button type="submit" class="text-secondary" aria-label="<%= t("decidim.search.term_input_placeholder") %>">
-          <%= icon "search-line", class: "fill-secondary w-4 h-4" %>
-        </button>
-        </div>
-      </div>
-    <% end %>
-  </div>
-</div>
 
 <div class="card" id="conference_speakers">
   <div class="item_show__header">
@@ -23,6 +9,22 @@
       <% end %>
     </h2>
   </div>
+
+  <div class="filters__section">
+    <div class="fcell search">
+      <%= form_tag "", method: :get do %>
+        <div class="input-group">
+          <%= search_field_tag :q, @query,label: false, class: "input-group-field", placeholder: t(".search") %>
+          <div class="input-group-button">
+            <button type="submit" class="text-secondary" aria-label="<%= t("decidim.search.term_input_placeholder") %>">
+              <%= icon "search-line", class: "fill-secondary w-4 h-4" %>
+            </button>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
   <div class="table-scroll">
     <table class="table-list">
       <thead>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR fixes the position of the Conference Speaker filter, by placing it under the page title. 

#### Testing
*Describe the best way to test or validate your PR.*
1. Login as admin  and visit Conference admin area 
2. Visit Conference speaker and see the filter 
3. Apply patch 
4. See changes 

### :camera: Screenshots
Before: 
![image](https://github.com/decidim/decidim/assets/105683/c304246f-e4a7-4546-8597-145fd87f55ba)

After: 
![image](https://github.com/decidim/decidim/assets/105683/4e047ecb-93f2-4fa9-8986-8cc5d7f6649d)


:hearts: Thank you!
