### PR TITLE
Redesign: fix assembly members sidebar menu

### DIFF
--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_members_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_members_controller.rb
@@ -7,7 +7,6 @@ module Decidim
       #
       class AssemblyMembersController < Decidim::Assemblies::Admin::ApplicationController
         include Concerns::AssemblyAdmin
-        layout "decidim/admin/assembly_members"
 
         def index
           enforce_permission_to :index, :assembly_member

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/index.html.erb
@@ -1,6 +1,9 @@
 <div class="item_show__header">
   <h2 class="item_show__header-title">
     <%= t("assembly_members_title", scope: "decidim.admin.assembly_members.index") %>
+    <% if allowed_to? :create, :assembly_member %>
+      <%= link_to t("actions.new_assembly_member", scope: "decidim.admin"), new_assembly_member_path(current_assembly), class: "button button__sm button__secondary new" %>
+    <% end %>
   </h2>
 </div>
 

--- a/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_members_examples.rb
@@ -14,9 +14,7 @@ shared_examples "manage assembly members examples" do
     let!(:assembly_member) { create(:assembly_member, assembly:) }
 
     it "creates a new assembly member" do
-      within ".process-title-content" do
-        click_link "New assembly member"
-      end
+      click_link "New assembly member"
 
       fill_in :assembly_member_designation_date, with: Time.current
 
@@ -50,9 +48,7 @@ shared_examples "manage assembly members examples" do
     let!(:member_user) { create(:user, organization: assembly.organization) }
 
     it "creates a new assembly member" do
-      within ".process-title-content" do
-        click_link "New assembly member"
-      end
+      click_link "New assembly member"
 
       fill_in :assembly_member_designation_date, with: Time.current
 
@@ -78,9 +74,7 @@ shared_examples "manage assembly members examples" do
     let!(:member_organization) { create(:user_group, :verified, organization: assembly.organization) }
 
     it "creates a new assembly member" do
-      within ".process-title-content" do
-        click_link "New assembly member"
-      end
+      click_link "New assembly member"
 
       fill_in :assembly_member_designation_date, with: Time.current
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR adds Assembly sidebar to the Assembly member page.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to  #11654

#### Testing
1. Login as admin and visit assembly member admin area 
2. Apply patch 
3. See there is a Sidebar menu

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
Before: 
![image](https://github.com/decidim/decidim/assets/105683/a2cc0ec7-928f-4042-b0cb-5ab05fe8cce0)

After:
![image](https://github.com/decidim/decidim/assets/105683/c251a992-c8d1-4996-a6e1-2d7441b29c8f)


:hearts: Thank you!
