### PR TITLE
Fix title for "Active conferences" in content block

### DIFF
--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -507,7 +507,7 @@ en:
       pages:
         home:
           highlighted_conferences:
-            active_spaces: Active Conferences
+            active_spaces: Active conferences
             see_all_spaces: See all conferences
       registration_types:
         index:

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -507,7 +507,7 @@ en:
       pages:
         home:
           highlighted_conferences:
-            active_spaces: Conferences
+            active_spaces: Active Conferences
             see_all_spaces: See all conferences
       registration_types:
         index:


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR fixes the consistency issues with the active conferences reported in #11279

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes  #11279

#### Testing
1. Login as admin 
2. In organization homepage settings enable all content blocks ( Highlighted processes, assemblies, conferences, initiatives 
3. Visit application homepage ( ex: http://localhost:3000/) 
4. Check lables. They all should start with "Active ... "

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![image](https://github.com/decidim/decidim/assets/105683/5e7a3fbc-a47e-4010-982e-f2562af637bc)

:hearts: Thank you!
