### PR TITLE
Freeze devise-i18n to 1.11.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ PATH
       date_validator (~> 0.12.0)
       decidim-api (= 0.28.0.dev)
       devise (~> 4.7)
-      devise-i18n (~> 1.2)
+      devise-i18n (~> 1.2, < 1.11.1)
       diffy (~> 3.3)
       doorkeeper (~> 5.6, >= 5.6.6)
       doorkeeper-i18n (~> 4.0)
@@ -264,7 +264,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     batch-loader (1.5.0)
-    bcrypt (3.1.18)
+    bcrypt (3.1.19)
     better_html (2.0.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -337,8 +337,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-i18n (1.10.2)
-      devise (>= 4.8.0)
+    devise-i18n (1.11.0)
+      devise (>= 4.9.0)
     devise_invitable (2.0.8)
       actionmailer (>= 5.0)
       devise (>= 4.6)
@@ -512,7 +512,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
-    minitest (5.19.0)
+    minitest (5.20.0)
     msgpack (1.4.5)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -808,7 +808,7 @@ GEM
     wkhtmltopdf-binary (0.12.6.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.11)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   ruby

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "charlock_holmes", "~> 0.7"
   s.add_dependency "date_validator", "~> 0.12.0"
   s.add_dependency "devise", "~> 4.7"
-  s.add_dependency "devise-i18n", "~> 1.2"
+  s.add_dependency "devise-i18n", "~> 1.2", "< 1.11.1"
   s.add_dependency "diffy", "~> 3.3"
   s.add_dependency "doorkeeper", "~> 5.6", ">= 5.6.6"
   s.add_dependency "doorkeeper-i18n", "~> 4.0"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -65,7 +65,7 @@ PATH
       date_validator (~> 0.12.0)
       decidim-api (= 0.28.0.dev)
       devise (~> 4.7)
-      devise-i18n (~> 1.2)
+      devise-i18n (~> 1.2, < 1.11.1)
       diffy (~> 3.3)
       doorkeeper (~> 5.6, >= 5.6.6)
       doorkeeper-i18n (~> 4.0)
@@ -264,7 +264,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     batch-loader (1.5.0)
-    bcrypt (3.1.18)
+    bcrypt (3.1.19)
     better_html (2.0.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -337,8 +337,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-i18n (1.10.2)
-      devise (>= 4.8.0)
+    devise-i18n (1.11.0)
+      devise (>= 4.9.0)
     devise_invitable (2.0.8)
       actionmailer (>= 5.0)
       devise (>= 4.6)
@@ -512,7 +512,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
-    minitest (5.19.0)
+    minitest (5.20.0)
     msgpack (1.4.5)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -808,7 +808,7 @@ GEM
     wkhtmltopdf-binary (0.12.6.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.11)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   ruby

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -65,7 +65,7 @@ PATH
       date_validator (~> 0.12.0)
       decidim-api (= 0.28.0.dev)
       devise (~> 4.7)
-      devise-i18n (~> 1.2)
+      devise-i18n (~> 1.2, < 1.11.1)
       diffy (~> 3.3)
       doorkeeper (~> 5.6, >= 5.6.6)
       doorkeeper-i18n (~> 4.0)
@@ -264,7 +264,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     batch-loader (1.5.0)
-    bcrypt (3.1.18)
+    bcrypt (3.1.19)
     better_html (2.0.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -337,8 +337,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-i18n (1.10.2)
-      devise (>= 4.8.0)
+    devise-i18n (1.11.0)
+      devise (>= 4.9.0)
     devise_invitable (2.0.8)
       actionmailer (>= 5.0)
       devise (>= 4.6)
@@ -512,7 +512,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
-    minitest (5.19.0)
+    minitest (5.20.0)
     msgpack (1.4.5)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -808,7 +808,7 @@ GEM
     wkhtmltopdf-binary (0.12.6.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.11)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Lock devise-i18n to 1.11.0 to avoid helper loading issue. When running performance metrics pipeline usin devise-i18n v 1.11.1, we will get the error from below screenshot. It was first revealed in  #11707 , while running pipeline https://github.com/decidim/decidim/actions/runs/6388830214/job/17339831244

![image](https://github.com/decidim/decidim/assets/105683/81f7c125-4e35-4040-b4e8-9cd69d837548)


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/tigrish/devise-i18n/pull/347

#### Testing
Make sure the pipeline is green.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
