### PR TITLE
Remove xlarge-* references from admin forms

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -19,6 +19,15 @@ linters:
       - text/javascript
       - text/template
 
+  DeprecatedClasses:
+    enabled: true
+    exclude:
+      - 'decidim_app-design/**/*.erb'
+    addendum: "Please remove it from code."
+    rule_set:
+      - deprecated: ['xlarge-[\w]*']
+        suggestion: "Foundation classes are deprecated."
+
   Rubocop:
     enabled: true
 

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/_form.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/_form.html.erb
@@ -31,21 +31,21 @@
       <% end %>
 
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.date_field :start_date %>
         </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.date_field :end_date %>
         </div>
       </div>
 
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.select :decidim_accountability_status_id, statuses.map { |status| [translated_attribute(status.name), status.id, { "data-progress" => status.progress }] }, include_blank: true %>
         </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.number_field :progress %>
         </div>
       </div>

--- a/decidim-admin/app/views/decidim/admin/areas/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/areas/_form.html.erb
@@ -5,7 +5,7 @@
         <%= form.translated :text_field, :name, aria: { label: :name } %>
       </div>
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.collection_select :area_type_id, organization_area_types, :id, :name %>
         </div>
       </div>

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -2,11 +2,11 @@
   <div class="card pt-4">
     <div class="card-section">
       <div class="row column">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.text_field :name %>
         </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <div class="label--tabs">
             <label for="organization_social_handlers">
               <%= t(".social_handlers") %>

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
@@ -14,11 +14,11 @@
       </div>
 
     <div class="row">
-      <div class="columns xlarge-6 slug">
+      <div class="columns slug">
         <%= form.text_field :cta_button_path, help_text: t(".cta_button_path_help_html", url: decidim_form_slug_url("", form.object.cta_button_path)) %>
       </div>
 
-      <div class="columns xlarge-6">
+      <div class="columns">
         <%= form.translated :text_field, :cta_button_text, help_text: t(".cta_button_text_help") %>
       </div>
     </div>
@@ -60,7 +60,7 @@
       </div>
 
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.upload :highlighted_content_banner_image, button_class: "button button__sm button__transparent-secondary" %>
         </div>
       </div>

--- a/decidim-admin/app/views/decidim/admin/participatory_space_private_users/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_space_private_users/_form.html.erb
@@ -2,10 +2,10 @@
   <div class="card pt-4">
     <div id="panel-title" class="card-section">
       <div class="row">
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.text_field :name, readonly: @form.persisted? %>
         </div>
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.email_field :email, readonly: @form.persisted? %>
         </div>
       </div>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -23,11 +23,11 @@
       </div>
 
     <div class="row">
-      <div class="columns xlarge-6 slug">
+      <div class="columns slug">
         <%= form.text_field :slug, help_text: t(".slug_help_html", url: decidim_form_slug_url(:assemblies, form.object.slug)) %>
       </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.text_field :hashtag %>
         </div>
       </div>
@@ -102,11 +102,11 @@
 
     <div id="panel-images" class="card-section">
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.upload :hero_image, button_class: "button button__sm button__transparent-secondary" %>
         </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.upload :banner_image, button_class: "button button__sm button__transparent-secondary" %>
         </div>
       </div>
@@ -160,17 +160,17 @@
         <%= form.translated :text_field, :participatory_structure, aria: { label: :participatory_structure } %>
       </div>
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.translated :text_field, :meta_scope, aria: { label: :meta_scope } %>
         </div>
       </div>
 
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.translated :text_field, :developer_group, aria: { label: :developer_group } %>
         </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.translated :text_field, :local_area, aria: { label: :local_area } %>
         </div>
       </div>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_imports/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_imports/_form.html.erb
@@ -19,13 +19,13 @@
           </div>
           <div class="card-section">
             <div class="row">
-              <div class="columns xlarge-3">
+              <div class="columns">
                 <%= form.check_box :import_categories %>
               </div>
-              <div class="columns xlarge-3">
+              <div class="columns">
                 <%= form.check_box :import_attachments %>
               </div>
-              <div class="columns xlarge-6">
+              <div class="columns">
                 <%= form.check_box :import_components %>
               </div>
             </div>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/_form.html.erb
@@ -2,13 +2,13 @@
   <div class="card pt-4">
     <div class="card-section">
       <div class="row">
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.text_field :name, readonly: @form.persisted? %>
         </div>
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.email_field :email, readonly: @form.persisted? %>
         </div>
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.label :role %>
           <%= select :assembly_user_role, :role, @form.roles, include_blank: false %>
         </div>

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/_form.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/_form.html.erb
@@ -14,7 +14,7 @@
         <%= form.translated :editor, :body, lines: 30, aria: { label: :body } %>
       </div>
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.datetime_field :published_at %>
         </div>
       </div>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/_form.html.erb
@@ -2,13 +2,13 @@
   <div class="card pt-4">
     <div class="card-section">
       <div class="row">
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.text_field :name, readonly: @form.persisted? %>
         </div>
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.email_field :email, readonly: @form.persisted? %>
         </div>
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.label :role %>
           <%= select :conference_user_role, :role, @form.roles, include_blank: false %>
         </div>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
@@ -23,11 +23,11 @@
       </div>
 
     <div class="row">
-      <div class="columns xlarge-6 slug">
+      <div class="columns slug">
         <%= form.text_field :slug, help_text: t(".slug_help_html", url: decidim_form_slug_url(:conferences, form.object.slug)) %>
       </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.text_field :hashtag %>
         </div>
       </div>
@@ -53,11 +53,11 @@
       </div>
 
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.upload :hero_image, button_class: "button button__sm button__transparent-secondary" %>
         </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.upload :banner_image, button_class: "button button__sm button__transparent-secondary" %>
         </div>
       </div>

--- a/decidim-conferences/app/views/decidim/conferences/admin/diplomas/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/diplomas/_form.html.erb
@@ -3,13 +3,13 @@
     <div class="card-divider"></div>
     <div class="card-section">
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.upload :main_logo, button_class: "button button__sm button__transparent-secondary" %>
         </div>
       </div>
 
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.upload :signature, button_class: "button button__sm button__transparent-secondary" %>
         </div>
       </div>

--- a/decidim-debates/app/views/decidim/debates/admin/debates/_form.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/_form.html.erb
@@ -26,10 +26,10 @@
       </div>
 
       <div class="row column debate-fields--finite">
-        <div class="column xlarge-6">
+        <div class="column">
           <%= form.datetime_field :start_time %>
         </div>
-        <div class="column xlarge-6">
+        <div class="column">
           <%= form.datetime_field :end_time %>
         </div>
       </div>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/_form.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/_form.html.erb
@@ -13,10 +13,10 @@
         <% announcement_message = t(".organization_time_zone", time_zone: current_organization.time_zone, time: Time.zone.now) %>
         <%= cell("decidim/announcement", announcement_message, callout_class: "warning" ) %>
 
-        <div class="column xlarge-6">
+        <div class="column">
           <%= form.datetime_field :start_time %>
         </div>
-        <div class="column xlarge-6">
+        <div class="column">
           <%= form.datetime_field :end_time %>
         </div>
       </div>

--- a/decidim-elections/app/views/decidim/votings/admin/votings/_form.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/votings/_form.html.erb
@@ -19,11 +19,11 @@
       </div>
 
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.datetime_field :start_time %>
         </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.datetime_field :end_time %>
         </div>
       </div>
@@ -40,19 +40,19 @@
       </div>
 
     <div class="row">
-      <div class="columns xlarge-6 slug">
+      <div class="columns slug">
         <%= form.text_field :slug, label: t(".slug"), help_text: t(".slug_help_html", url: decidim_form_slug_url(:votings, form.object.slug)) %>
       </div>
     </div>
 
     <div class="row">
-      <div class="columns xlarge-6 show_check_census">
+      <div class="columns show_check_census">
         <%= form.check_box :show_check_census, help_text: t(".show_check_census_help") %>
       </div>
     </div>
 
     <div class="row">
-      <div class="columns xlarge-6 census_contact_information">
+      <div class="columns census_contact_information">
         <%= form.text_field :census_contact_information, label: t(".census_contact_information"), help_text: t(".census_contact_information_help") %>
       </div>
     </div>
@@ -62,11 +62,11 @@
       </div>
 
       <div class="row">
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.upload :banner_image, label: t(".banner_image"), button_class: "button button__sm button__transparent-secondary" %>
         </div>
 
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.upload :introductory_image, label: t(".introductory_image"), button_class: "button button__sm button__transparent-secondary" %>
         </div>
       </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
@@ -26,11 +26,11 @@
 
             <% if @form.signature_dates_required? %>
               <div class="row">
-                <div class="columns xlarge-6">
+                <div class="columns">
                   <%= f.date_field :signature_start_date, disabled: !@form.signature_dates_required? %>
                 </div>
 
-                <div class="columns xlarge-6">
+                <div class="columns">
                   <%= f.date_field :signature_end_date, disabled: !@form.signature_dates_required? %>
                 </div>
               </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
@@ -19,7 +19,7 @@
       </div>
 
       <div class="row column">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.text_field :hashtag, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative) %>
         </div>
       </div>
@@ -38,7 +38,7 @@
 
     <div id="panel-settings" class="card-section">
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.select :state,
                           Decidim::Initiative.states.keys.map { |state| [I18n.t(state, scope: "decidim.initiatives.admin_states"), state] },
                           {},
@@ -48,7 +48,7 @@
 
       <div class="row">
         <% unless single_initiative_type? %>
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.select :type_id,
                           initiative_type_options,
                           {},
@@ -63,18 +63,18 @@
                           } %>
         </div>
         <% end %>
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.select :decidim_scope_id, [], {}, { disabled: !@form.signature_type_updatable? } %>
         </div>
       </div>
 
       <% if current_initiative.published? && current_user.admin? %>
         <div class="row">
-          <div class="columns xlarge-6">
+          <div class="columns">
             <%= form.date_field :signature_start_date %>
           </div>
 
-          <div class="columns xlarge-6">
+          <div class="columns">
             <%= form.date_field :signature_end_date %>
           </div>
         </div>
@@ -99,14 +99,14 @@
       <% end %>
 
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.select :signature_type, [], {}, { disabled: !@form.signature_type_updatable? } %>
         </div>
       </div>
 
       <% if current_initiative.accepts_offline_votes? && current_user.admin? %>
         <div class="row">
-          <div class="columns xlarge-6">
+          <div class="columns">
             <% @form.offline_votes.each do |scope_id, (votes, scope_name)| %>
               <%= label_tag "initiative_offline_votes_#{scope_id}", t("activemodel.attributes.initiative.offline_votes_for_scope", scope_name: translated_attribute(scope_name)) %>
               <%= number_field_tag "initiative[offline_votes][#{scope_id}]", votes, min: 0, id: "initiative_offline_votes_#{scope_id}" %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_initiative_attachments.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_initiative_attachments.erb
@@ -1,5 +1,5 @@
 <div class="row column">
-  <div class="columns xlarge-12">
+  <div class="columns">
     <% if current_initiative.documents.any? %>
       <div class="row column">
         <strong><%= t ".documents" %>:</strong>
@@ -27,7 +27,7 @@
       </div>
     <% end %>
   </div>
-  <div class="columns xlarge-12">
+  <div class="columns">
     <% if allowed_to?(:update, :initiative, initiative: current_initiative) %>
       <%= aria_selected_link_to t(".edit"),
                                 decidim_admin_initiatives.initiative_attachments_path(current_participatory_space),

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
@@ -19,7 +19,7 @@
       </div>
 
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.upload :banner_image, button_class: "button button__sm button__transparent-secondary" %>
         </div>
       </div>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meeting_closes/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meeting_closes/_form.html.erb
@@ -10,11 +10,11 @@
       </div>
 
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.number_field :attendees_count, min: 0 %>
         </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.number_field :contributions_count, min: 0 %>
         </div>
       </div>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -51,22 +51,22 @@
       </div>
 
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.datetime_field :start_time %>
         </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.datetime_field :end_time %>
         </div>
       </div>
       <div class="row">
         <% if current_component.has_subscopes? %>
-          <div class="columns xlarge-6">
+          <div class="columns">
             <%= scopes_select_field form, :decidim_scope_id, root: current_component.scope %>
           </div>
         <% end %>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.categories_select :decidim_category_id, current_participatory_space.categories, include_blank: "", disable_parents: false %>
         </div>
       </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_copies/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_copies/_form.html.erb
@@ -14,15 +14,15 @@
           </div>
           <div class="card-section">
             <div class="row">
-              <div class="columns xlarge-3">
+              <div class="columns">
                 <%= form.check_box :copy_steps %>
               </div>
 
-              <div class="columns xlarge-3">
+              <div class="columns">
                 <%= form.check_box :copy_categories %>
               </div>
 
-              <div class="columns xlarge-6">
+              <div class="columns">
                 <%= form.check_box :copy_components %>
               </div>
             </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/_form.html.erb
@@ -9,20 +9,20 @@
         <%= form.translated :editor, :description, aria: { label: :description } %>
       </div>
 
-      <div class="row column xlarge-6">
+      <div class="row column">
         <%= form.datetime_field :start_date %>
       </div>
 
-      <div class="row column xlarge-6">
+      <div class="row column">
         <%= form.datetime_field :end_date %>
       </div>
 
-      <div class="row column xlarge-6 slug">
+      <div class="row column slug">
         <%= form.text_field :cta_path,
           help_text: t(".cta_path_help_html", url: decidim_form_slug_url("processes/" + current_participatory_process.slug, form.object.cta_path)) %>
       </div>
 
-      <div class="row column xlarge-6">
+      <div class="row column">
         <%= form.translated :text_field, :cta_text, help_text: t(".cta_text_help") %>
       </div>
     </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/_form.html.erb
@@ -2,13 +2,13 @@
   <div class="card pt-4">
     <div id="panel-title" class="card-section">
       <div class="row">
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.text_field :name, readonly: @form.persisted? %>
         </div>
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.email_field :email, readonly: @form.persisted? %>
         </div>
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.label :role %>
           <%= select :participatory_process_user_role, :role, @form.roles, include_blank: false %>
         </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -22,11 +22,11 @@
       </div>
 
       <div class="row">
-        <div class="columns xlarge-6 slug">
+        <div class="columns slug">
           <%= form.text_field :slug, help_text: t(".slug_help_html", url: decidim_form_slug_url(:processes, form.object.slug)) %>
         </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.text_field :hashtag %>
         </div>
       </div>
@@ -60,11 +60,11 @@
 
     <div id="panel-duration" class="card-section">
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.date_field :start_date %>
         </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.date_field :end_date %>
         </div>
       </div>
@@ -83,11 +83,11 @@
 
     <div id="panel-images" class="card-section">
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.upload :hero_image, button_class: "button button__sm button__transparent-secondary" %>
         </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.upload :banner_image, button_class: "button button__sm button__transparent-secondary" %>
         </div>
       </div>
@@ -105,11 +105,11 @@
     </div>
     <div id="panel-metadata" class="card-section">
       <div class="row">
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.translated :text_field, :developer_group, aria: { label: :developer_group } %>
         </div>
 
-        <div class="columns xlarge-6">
+        <div class="columns">
           <%= form.translated :text_field, :local_area, aria: { label: :local_area } %>
         </div>
       </div>

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/_form.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/_form.html.erb
@@ -2,35 +2,35 @@
   <div class="card pt-4">
     <div class="card-section">
       <div class="row">
-        <div class="columns xlarge-12">
+        <div class="columns">
           <%= form.translated :text_field, :title, autofocus: true, aria: { label: :title } %>
         </div>
 
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.select :decidim_proposals_component_id,
                           components_options(proposal_components),
                           prompt: t(".select_proposal_component") %>
         </div>
 
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.categories_select :decidim_category_id,
                                      @form.categories,
                                      include_blank: t(".all_categories") %>
         </div>
 
-        <div class="columns xlarge-4">
+        <div class="columns">
           <%= form.number_field :target_items, min: 1, step: 1 %>
         </div>
 
-        <div class="columns xlarge-12">
+        <div class="columns">
           <%= form.translated :editor, :witnesses, lines: 10, toolbar: :content, aria: { label: :witnesses } %>
         </div>
 
-        <div class="columns xlarge-12">
+        <div class="columns">
           <%= form.translated :editor, :additional_info, lines: 10, aria: { label: :additional_info } %>
         </div>
 
-        <div class="columns xlarge-2">
+        <div class="columns">
           <%= form.number_field :dice, min: 1, max: 6, step: 1 %>
         </div>
       </div>

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/confirm_destroy.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/confirm_destroy.html.erb
@@ -13,7 +13,7 @@
         <div class="card pt-4">
           <div class="card-section">
             <div class="row">
-              <div class="columns xlarge-12">
+              <div class="columns">
                 <%= form.translated :editor, :cancel_reason, lines: 10, toolbar: :content, aria: { label: :cancel_reason } %>
               </div>
             </div>

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/edit.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/edit.html.erb
@@ -11,11 +11,11 @@
         <div class="card pt-4">
           <div class="card-section">
             <div class="row">
-              <div class="columns xlarge-12">
+              <div class="columns">
                 <%= form.translated :text_field, :title, autofocus: true, aria: { label: :title } %>
               </div>
 
-              <div class="columns xlarge-12">
+              <div class="columns">
                 <%= form.translated :editor, :additional_info, lines: 10, aria: { label: :additional_info } %>
               </div>
             </div>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR attempts to clean up the HTML markup in admin by removing useless class xlarge-*

#### Testing
1. Login as admin go to admin panel 
2. From the files section try to find the changed forms 
3. See there are no changes regarding UI

:hearts: Thank you!
