### PR TITLE
Show small static map on admin's meetings index with big screens 

### DIFF
--- a/decidim-core/app/helpers/decidim/map_helper.rb
+++ b/decidim-core/app/helpers/decidim/map_helper.rb
@@ -28,7 +28,13 @@ module Decidim
         # creating the static map utility. If it does not, the image would be
         # otherwise blank.
         if map_utility_static.url(latitude: resource.latitude, longitude: resource.longitude)
-          return link_to(map_url, class: "static-map", target: "_blank", rel: "noopener", data: { "external-link": false }) do
+          html_options = {
+            class: "static-map",
+            target: "_blank",
+            rel: "noopener",
+            data: { "external-link": false }
+          }.merge(map_html_options)
+          return link_to(map_url, html_options) do
             image_tag decidim.static_map_path(sgid: resource.to_sgid.to_s), alt: "#{map_service_brand} - #{address_text}"
           end
         end

--- a/decidim-core/app/packs/stylesheets/decidim/_static-map.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_static-map.scss
@@ -4,4 +4,12 @@
   &__container {
     @apply flex flex-col-reverse md:flex-row items-start md:items-center gap-2 [&>*]:w-full md:[&>*]:w-1/2 last:[&>*]:h-[120px] last:[&>*]:grow;
   }
+
+  &__admin {
+    @apply flex justify-center;
+
+    img {
+      @apply w-52;
+    }
+  }
 }

--- a/decidim-core/spec/helpers/decidim/map_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/map_helper_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe MapHelper do
+    describe "#static_map_link" do
+      subject { helper.static_map_link(resource, options, map_html_options) }
+      let(:resource) { create(:meeting) }
+      let(:organization) { create(:organization) }
+      let(:options) { {} }
+      let(:map_html_options) { {} }
+
+      before do
+        allow(helper).to receive(:current_organization).and_return(organization)
+      end
+
+      it "returns the map" do
+        expect(subject).to match(/^<a class="static-map".*/)
+        expect(subject).to match(/img alt/)
+      end
+
+      context "when there is a map_html_options parameter defined" do
+        let(:map_html_options) { { class: "another-static-map" } }
+
+        it "returns the map with the new html options" do
+          expect(subject).to match(/^<a class="another-static-map".*/)
+          expect(subject).to match(/img alt/)
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -69,7 +69,7 @@
             </td>
             <% if maps_enabled? && Decidim::Map.available?(:static, :geocoding) %>
               <td>
-                <%= static_map_link(meeting) %>
+                <%= static_map_link(meeting) unless meeting.online? %>
               </td>
             <% end %>
             <%= td_resource_scope_for(meeting.scope) %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -69,7 +69,7 @@
             </td>
             <% if maps_enabled? && Decidim::Map.available?(:static, :geocoding) %>
               <td>
-                <%= static_map_link(meeting, {}, { class: "flex justify-center" }) unless meeting.online? %>
+                <%= static_map_link(meeting, {}, { class: "static-map__admin" }) unless meeting.online? %>
               </td>
             <% end %>
             <%= td_resource_scope_for(meeting.scope) %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -69,7 +69,7 @@
             </td>
             <% if maps_enabled? && Decidim::Map.available?(:static, :geocoding) %>
               <td>
-                <%= static_map_link(meeting) unless meeting.online? %>
+                <%= static_map_link(meeting, {}, { class: "flex justify-center" }) unless meeting.online? %>
               </td>
             <% end %>
             <%= td_resource_scope_for(meeting.scope) %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

If the maps are enabled and you have a big screen, the maps in admin's meetings' index are really big. This fixes it. 

It also fixes a problem where we were showing maps even if its an Online Meeting. 
 
#### Testing

1. Enable maps
2. Sign in as admin
3. Go to the admin's meetings index
4. Create an hybrid meeting with an address. Change it to an Online Meeting and go to the admin's meetings index. You should not see the map anymore.
5. Use a big screen (or reduce the zoom in the browser). See that you have smallish maps now. 

### :camera: Screenshots

#### Before

![Screenshot of the admin's meetings' index with big maps](https://github.com/decidim/decidim/assets/717367/5ba41683-d0d0-4d39-8a00-3239f2eb3f2a)

#### After

![Screenshot of the admin's meetings' index with small maps](https://github.com/decidim/decidim/assets/717367/1017813e-2618-443f-937b-d2e4617bed34)


:hearts: Thank you!
