### PR TITLE
Fix photos upload in admin panel

### DIFF
--- a/decidim-admin/app/views/decidim/admin/shared/_gallery.html.erb
+++ b/decidim-admin/app/views/decidim/admin/shared/_gallery.html.erb
@@ -2,18 +2,6 @@
   <fieldset>
     <legend><%= t(".gallery_legend") %></legend>
 
-    <% if @form.photos.any? %>
-      <% @form.photos.each do |photo| %>
-        <div class="callout gallery__item" data-closable>
-          <%= image_tag photo.thumbnail_url, class: "thumbnail", alt: photo.file.filename %>
-          <%= form.hidden_field :photos, multiple: true, value: photo.id, id: "photo-#{photo.id}" %>
-          <button class="close-button" aria-label="<%= t(".delete_image") %>" title="<%= t(".delete_image") %>" type="button" data-close>
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-      <% end %>
-    <% end %>
-
     <div>
       <%= form.attachment :photos,
         multiple: true,

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -964,7 +964,6 @@ en:
       shared:
         gallery:
           add_images: Add images
-          delete_image: Delete Image
           edit_images: Edit images
           gallery_legend: Add an image gallery (Optional)
       static_page_topics:


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While working in #11708, I found that in the attachments photo gallery we're showing the images duplicated. It also seems like you can remove these photos from the callouts but it actually doesn't do anything, as you need to update them through the modal. 

This PR removes this duplication.  

#### Testing

1. Sign in as admin
2. In a Proposals component, enable the setting "Allow attachments" 
3. Create or edit a proposal, Add images in the Image gallery
4. Save it
5. Edit the proposal, see the uploaded images 


### :camera: Screenshots
#### Before
![Screenshot of the bug](https://github.com/decidim/decidim/assets/717367/71f07fa2-73d4-43e4-be36-a652f4cb2469)

#### After
![Screenshot of the fix](https://github.com/decidim/decidim/assets/717367/97ac0a8b-7f91-44d8-adce-18dd1f00d017)

:hearts: Thank you!
