### PR TITLE
Proposal link in admin UX

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
@@ -32,8 +32,8 @@
         </div>
       </div>
       <div class="ml-auto">
-        <%= link_to resource_locator(proposal).url, class: "button button__sm button__transparent-secondary" do %>
-          <%= icon "arrow-left-line", class: "fill-current" %>
+        <%= link_to resource_locator(proposal).url, class: "button button__sm button__transparent-secondary", target: :blank, data: { "external-link": false } do %>
+          <%= icon "eye-line", class: "fill-current" %>
           <%= t ".link" %>
         <% end %>
       </div>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -537,7 +537,7 @@ en:
             documents: Documents
             endorsements_count: Endorsements count
             endorsers: Endorsers
-            link: Link
+            link: See proposal
             n_more_endorsers:
               one: and 1 more
               other: and %{count} more

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -21,7 +21,7 @@ describe "Admin views proposal details from admin", type: :system do
     path = "processes/#{participatory_process.slug}/f/#{component.id}/proposals/#{proposal.id}"
 
     within ".component__show_nav" do
-      expect(page).to have_link("Link", href: /#{path}/)
+      expect(page).to have_link("See proposal", href: /#{path}/)
     end
   end
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Fixes a issue allowing users to open and preview the proposal in a new tab in their browser. Updates the wording and appropriate icon for use.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11722

#### Testing
1. login as an admin
2. head to processes and click one
3. open a proposal to which you view 
4. see the link on top right corner working as it should with better UX

### :camera: Screenshots
![Screenshot 2023-10-05 at 16 31 17](https://github.com/decidim/decidim/assets/101816158/743f6b28-0d9f-420d-8999-8078745ceaed)


:hearts: Thank you!
