### PR TITLE
Fix a bug in  html validator

### DIFF
--- a/decidim-core/app/packs/src/decidim/direct_uploads/redesigned_upload_modal.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/redesigned_upload_modal.js
@@ -120,10 +120,12 @@ export default class UploadModal {
     let type = "";
 
     if (src) {
-      buffer = await fetch(src).then((res) => res.arrayBuffer())
-      // since we cannot know the exact mime-type of the file,
-      // we assume as "image" if it has the src attribute in order to load the preview
-      type = "image"
+      const res = await fetch(src);
+      buffer = await res.arrayBuffer();
+      // In case the server does not know the exact mime-type of the file,
+      // we fallback it to "image" if it has the src attribute in order to load
+      // the preview
+      type = res.headers.get("Content-Type") || "image";
     }
 
     const file = new File([buffer], element.dataset.filename, { type })
@@ -159,10 +161,8 @@ export default class UploadModal {
     this.input.disabled = !continueUpload
     if (continueUpload) {
       this.emptyItems.classList.remove("is-disabled");
-      this.emptyItems.querySelector("label").removeAttribute("disabled");
     } else {
       this.emptyItems.classList.add("is-disabled");
-      this.emptyItems.querySelector("label").setAttribute("disabled", true);
     }
   }
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Currently, the html validations fail locally, because the uploader is creating invalid html. Running tests that uses `be_valid_html` might break the test on pages like account page locally, or any other location that might have uploader.
Please note that html validation might pass on CI because the validator version might be different from local.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
- Install Test app locally
- Run `bundle exec rspec spec/system/account_spec.rb -e"Account when on the account page behaves like accessible page passes HTML validation"` from decidim-core
- See the failing test
 

### :camera: Screenshots
![image](https://github.com/decidim/decidim/assets/104360479/3539ae76-42d5-4f75-ba17-26a5a38c5bcf)



:hearts: Thank you!
