### PR TITLE
Password helper typo change

### DIFF
--- a/decidim-core/app/helpers/decidim/passwords_helper.rb
+++ b/decidim-core/app/helpers/decidim/passwords_helper.rb
@@ -17,9 +17,9 @@ module Decidim
       min_length = ::PasswordValidator.minimum_length_for(user)
       help_text =
         if needs_admin_password?(user)
-          t("devise.passwords.edit.password_help_admin", minimun_characters: min_length)
+          t("devise.passwords.edit.password_help_admin", minimum_characters: min_length)
         else
-          t("devise.passwords.edit.password_help", minimun_characters: min_length)
+          t("devise.passwords.edit.password_help", minimum_characters: min_length)
         end
 
       {

--- a/decidim-core/config/locales/ca.yml
+++ b/decidim-core/config/locales/ca.yml
@@ -1669,8 +1669,8 @@ ca:
         change_my_password: Canvia la meva contrasenya
         confirm_new_password: Confirmar la nova contrasenya
         new_password: Nova contrasenya
-        password_help: "%{minimun_characters} caràcters mínim, no ha de ser massa comú (per exemple 123456) i ha de ser diferent del teu nom d'usuari i la teva adreça de correu electrònic."
-        password_help_admin: "%{minimun_characters} caràcters mínim, no ha de ser massa comú (per exemple 123456) i ha de ser diferent del teu àlies, de la teva adreça de correu electrònic i de les teves antigues contrasenyes."
+        password_help: "%{minimum_characters} caràcters mínim, no ha de ser massa comú (per exemple 123456) i ha de ser diferent del teu nom d'usuari i la teva adreça de correu electrònic."
+        password_help_admin: "%{minimum_characters} caràcters mínim, no ha de ser massa comú (per exemple 123456) i ha de ser diferent del teu àlies, de la teva adreça de correu electrònic i de les teves antigues contrasenyes."
         title: Canvi de contrasenya
       new:
         forgot_your_password: Has oblidat la teva contrasenya?

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1687,8 +1687,8 @@ en:
         change_my_password: Change my password
         confirm_new_password: Confirm new password
         new_password: New password
-        password_help: "%{minimun_characters} characters minimum, must not be too common (e.g. 123456) and must be different from your nickname and your email."
-        password_help_admin: "%{minimun_characters} characters minimum, must not be too common (e.g. 123456), must be different from your nickname and your email and must be different from your old passwords."
+        password_help: "%{minimum_characters} characters minimum, must not be too common (e.g. 123456) and must be different from your nickname and your email."
+        password_help_admin: "%{minimum_characters} characters minimum, must not be too common (e.g. 123456), must be different from your nickname and your email and must be different from your old passwords."
         title: Password change
       new:
         forgot_your_password: Forgot your password?

--- a/decidim-core/config/locales/es.yml
+++ b/decidim-core/config/locales/es.yml
@@ -1667,8 +1667,8 @@ es:
         change_my_password: Cambiar mi contraseña
         confirm_new_password: Confirmar la nueva contraseña
         new_password: Nueva contraseña
-        password_help: "%{minimun_characters} caracteres mínimos, no debe ser demasiado común (por ejemplo, 123456) y debe ser diferente de tu apodo y tu correo electrónico."
-        password_help_admin: "%{minimun_characters} caracteres como mínimo, no debe ser demasiado común (por ejemplo, 123456) y debe ser diferente de tu alias, correo electrónico y antiguas contraseñas."
+        password_help: "%{minimum_characters} caracteres mínimos, no debe ser demasiado común (por ejemplo, 123456) y debe ser diferente de tu apodo y tu correo electrónico."
+        password_help_admin: "%{minimum_characters} caracteres como mínimo, no debe ser demasiado común (por ejemplo, 123456) y debe ser diferente de tu alias, correo electrónico y antiguas contraseñas."
         title: Cambio de contraseña
       new:
         forgot_your_password: '¿Olvidaste tu contraseña?'


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Typo identified in the passwords_helper.rb file: ```decidim-core/app/helpers/decidim/passwords_helper.rb```, this change updates the typo.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11732

#### Testing

### :camera: Screenshots

:hearts: Thank you!
