### PR TITLE
Fix further issues with the redesigned file uploader file name display

### DIFF
--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_field.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_field.js
@@ -1,5 +1,6 @@
 import UploadModal from "src/decidim/direct_uploads/upload_modal";
 import { truncateFilename } from "src/decidim/direct_uploads/upload_utility";
+import { escapeHtml, escapeQuotes } from "src/decidim/utilities/text";
 
 const updateModalTitle = (modal) => {
   if (modal.uploadItems.children.length === 0) {
@@ -56,7 +57,7 @@ const updateActiveUploads = (modal) => {
       const titleValue = modal.modal.querySelectorAll('input[type="text"]')[ix].value
       // NOTE - Renaming the attachment is not supported when multiple uploader is disabled
       const titleField = `${modal.options.resourceName}[${modal.options.addAttribute}][${ix}][title]`
-      hidden += `<input type="hidden" name="${titleField}" value="${titleValue}" />`
+      hidden += `<input type="hidden" name="${titleField}" value="${escapeQuotes(titleValue)}" />`
 
       title = titleValue
     }
@@ -67,9 +68,9 @@ const updateActiveUploads = (modal) => {
       : `data-hidden-field="${file.hiddenField}"`
 
     const template = `
-      <div ${attachmentIdOrHiddenField} data-filename="${file.name}" data-title="${title}">
-        ${(/image/).test(file.type) && `<div><img src="" alt="${file.name}" /></div>` || ""}
-        <span>${title} (${truncateFilename(file.name)})</span>
+      <div ${attachmentIdOrHiddenField} data-filename="${escapeQuotes(file.name)}" data-title="${escapeQuotes(title)}">
+        ${(/image/).test(file.type) && `<div><img src="" alt="${escapeQuotes(file.name)}" /></div>` || ""}
+        <span>${escapeHtml(title)} (${escapeHtml(truncateFilename(file.name))})</span>
         ${hidden}
       </div>
     `

--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
@@ -168,7 +168,7 @@ export default class UploadModal {
 
   createUploadItem(file, errors, opts = {}) {
     const okTemplate = `
-      <img src="" alt="${file.name}" />
+      <img src="" alt="${escapeQuotes(file.name)}" />
       <span>${escapeHtml(truncateFilename(file.name))}</span>
     `
 
@@ -182,7 +182,7 @@ export default class UploadModal {
     `
 
     const titleTemplate = `
-      <img src="" alt="${file.name}" />
+      <img src="" alt="${escapeQuotes(file.name)}" />
       <div>
         <div>
           <label>${this.locales.filename}</label>


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed a couple more changes needed for the redesigned uploader while reviewing the backport.

This is a continuation for #11612 that missed these spots. This does not need backporting as it only concerns the redesigned file uploader.

#### :pushpin: Related Issues
- Related to #11612