### PR TITLE
Fix admin breadcrumb in Process

### DIFF
--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/concerns/participatory_process_admin.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/concerns/participatory_process_admin.rb
@@ -33,10 +33,6 @@ module Decidim
                 organization_processes.find_by!(slug: params[:participatory_process_slug] || params[:slug])
             end
 
-            def current_participatory_space_path
-              Decidim::ResourceLocatorPresenter.new(current_participatory_space).show
-            end
-
             def permissions_context
               super.merge(current_participatory_space:)
             end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_processes_controller.rb
@@ -98,10 +98,6 @@ module Decidim
         def participatory_process_params
           { id: params[:slug] }.merge(params[:participatory_process].to_unsafe_h)
         end
-
-        def current_participatory_space_path
-          Decidim::ResourceLocatorPresenter.new(current_participatory_space).show
-        end
       end
     end
   end


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR tries to fix a wrong link error in the breadcrumb within Participatory space.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/decidim/decidim/pull/11682
- Related to https://github.com/decidim/decidim/pull/11683

#### Testing

1. Visit admin section 
2. Go to a Participatory process 
3. Click on side components ( ex meetings ) 
4. Click space name from breadcrumb
5. Will generate a 500 error ... 
6. Apply patch 
7. repeat 2, 3, 4
8. See the Participatory Space edit form loads as expected.

### :camera: Screenshots
![image](https://github.com/decidim/decidim/assets/105683/ef4cc69c-1239-4f27-9dd4-1a3dc0b2b569)

:hearts: Thank you!
