### PR TITLE
Fix missing results on Geocoded when search without diacritics

### DIFF
--- a/decidim-core/app/packs/src/decidim/autocomplete.js
+++ b/decidim-core/app/packs/src/decidim/autocomplete.js
@@ -74,6 +74,7 @@ export default class AutoComplete {
 
     this.autocomplete = new AutoCompleteJS({
       selector: () => this.element,
+      diacritics: true,
       placeHolder: options.placeholder,
       // Delay (milliseconds) before autocomplete engine starts. It is preventing many queries when user is typing fast.
       debounce: 200,


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR enables the diacritics param on [autoComplete.js](https://tarekraafat.github.io/autoComplete.js/#/configuration?id=diacritics-optional).

The default of the param is *FALSE*, yet the argument description states:  - Enable to normalize query and data values using String.normalize

#### :pushpin: Related Issues
- Fixes  #11760

#### Testing
1. Configure geocoding and maps support on your dev instance
2. Signin as admin and navigate to meetings in a participatory process
3. Edit the meeting and search for a popular address to validate that geocoding is working (ex Times Square)
4. Fill in a new address like *Stenbäckinkatu 24* - See that you have results 
5. Fill in another address like *Stenbackinkatu 24* - See there are no results 
6. Apply patch 
4. Fill in a new address like *Stenbäckinkatu 24* - See that you have results 
5. Fill in another address like *Stenbackinkatu 24* - See that you have results  ( mind the *ä*)

*No specs have been implemented*

:hearts: Thank you!
