### PR TITLE
Add missing activerecord budget locales for search

### DIFF
--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -21,12 +21,12 @@ en:
         scope_id: Scope
   activerecord:
     models:
-      decidim/budgets/project:
-        one: Project
-        other: Projects
       decidim/budgets/budget:
         one: Budget
         other: Budgets
+      decidim/budgets/project:
+        one: Project
+        other: Projects
   decidim:
     admin:
       filters:

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -24,6 +24,9 @@ en:
       decidim/budgets/project:
         one: Project
         other: Projects
+      decidim/budgets/budget:
+        one: Budget
+        other: Budgets
   decidim:
     admin:
       filters:


### PR DESCRIPTION
#### :tophat: What? Why?
This PR aims to add missing translations for the Budgets item in global search filters. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/decidim/decidim/issues/11765?

#### Testing
*Describe the best way to test or validate your PR.*
1. Go to the global search in english locale
2. See that the budget filter label is "Budget"
3. Update the decidim/budgets/budget/one translation key
4. See that the translation is updated

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
Before: Budget is not translated in other locales
<img width="1230" alt="Capture d’écran 2023-10-16 à 12 47 34" src="https://github.com/decidim/decidim/assets/52420208/e810db2e-f9a2-4921-a1c6-630d5cc36526">

After: the translation is tranlated
<img width="344" alt="Capture d’écran 2023-10-16 à 13 10 13" src="https://github.com/decidim/decidim/assets/52420208/49ec1d50-dc02-4fa2-a692-3a2587b65bf0">
<img width="1240" alt="Capture d’écran 2023-10-16 à 13 12 50" src="https://github.com/decidim/decidim/assets/52420208/f836bf5c-9b7d-4a5d-b26f-d0b5d61ec16c">


:hearts: Thank you!
