### PR TITLE
Fix map geocoding for proposals under redesign

### DIFF
--- a/decidim-proposals/app/packs/src/decidim/proposals/add_proposal.js
+++ b/decidim-proposals/app/packs/src/decidim/proposals/add_proposal.js
@@ -31,8 +31,8 @@ $(() => {
         // Remove previous marker when user updates address in address field
         ctrl.removeMarker();
         ctrl.addMarker({
-          latitude: coordinates[1],
-          longitude: coordinates[0],
+          latitude: coordinates[0],
+          longitude: coordinates[1],
           address: $addressInputField.val()
         });
       });


### PR DESCRIPTION
#### :tophat: What? Why?
While fixing a problem with the Photon geocoder (#11572) @alecslupu discovered an issue with the proposals geocoding during his review. It was particularly odd as I was seeing the exact opposite behavior because I was testing the feature under version 0.27 where it works fine (apart from the bug with Photon geocoder).

After investigating this issue, it turns out that the proposals geocoding is actually broken right now under redesign. If you repeat the test procedure documented at #11572 with the HERE Maps geocoding API, you will see the problem: it works fine for Photon but is broken for HERE.

Apparently #11184 tried to fix the same issue for Photon but it has broken the expected behavior for the Geocoding API, i.e. the order in which we are expecting the geocoder to return the coordinates (i.e. latitude first, longitude second).

This reverts the change done to the proposal geocoding at #11184 in order to proceed with the proper fix at #11572.

#### :pushpin: Related Issues
- Related to
  * #11572
  * #11184

#### Testing
See testing instructions from #11572 but instead of Photon, use HERE for the "autocomplete" configuration.