### PR TITLE
Fix possible JavaScript console error with geocoding inputs

### DIFF
--- a/decidim-core/app/packs/src/decidim/geocoding/attach_input.js
+++ b/decidim-core/app/packs/src/decidim/geocoding/attach_input.js
@@ -125,7 +125,10 @@ export default function attachGeocoding($input, options, callback) {
   $input.on("geocoder-suggest-coordinates.decidim", (_ev, coordinates) => {
     setCoordinates(coordinates);
     geocoded = true;
-    callback(coordinates)
+    if (typeof callback === "function") {
+      callback(coordinates);
+      return;
+    }
   });
 
   // Set the initial values if the field defines the coordinates


### PR DESCRIPTION
#### :tophat: What? Why?
In case the `attachGeocoding` method does not get a callback as a parameter (e.g. on the meeting form), the following JS error is printed into the JS console:
```
attach_input.js:128 Uncaught TypeError: callback is not a function
    at HTMLInputElement.<anonymous> (attach_input.js:128:1)
    at HTMLInputElement.dispatch (jquery.js:5145:1)
    at elemData.handle (jquery.js:4949:1)
    at Object.trigger (jquery.js:8629:1)
    at HTMLInputElement.<anonymous> (jquery.js:8707:1)
    at Function.each (jquery.js:383:1)
    at jQuery.fn.init.each (jquery.js:205:1)
    at jQuery.fn.init.trigger (jquery.js:8706:1)
    at Object.<anonymous> (here.js:90:1)
    at fire (jquery.js:3223:1)
```

Noticed this while working on another bug related to geocoding.

#### :pushpin: Related Issues
- Related to #8088

#### Testing
- Create the default dummy app
- Enable meetings creation for participants in the meetings component
- Create a new "In person" meeting as a participant
- Type in address and select an address from the geocoder autocomplete list
- Look into the JS console after selecting the address and you should see the described error without this fix
- Repeat the testing process with this patch applied and the error should be gone

In addition, if you want to ensure this is not breaking the functionality added at #8088, test also creating a proposal with geocoding enabled and it should work as (see instructions from #8088).

### :camera: Screenshots
![JS error at the console](https://github.com/decidim/decidim/assets/864340/c0f7b766-c833-4047-b61f-49c98d218c77)