### PR TITLE
Uniform CTA Buttons (New Proposals & Meetings)

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/shared/_meetings_aside.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/shared/_meetings_aside.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <% if allowed_to?(:create, :meeting) %>
-  <%= action_authorized_link_to :create, new_meeting_path, class: "button button__lg button__secondary", data: { "redirect_url" => new_meeting_path } do %>
+  <%= action_authorized_link_to :create, new_meeting_path, class: "button button__xl button__secondary w-full", data: { "redirect_url" => new_meeting_path } do %>
     <span><%= t("new_meeting", scope: "decidim.meetings.meetings.index") %></span>
     <%= icon "add-line" %>
   <% end %>

--- a/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
+++ b/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
@@ -3,7 +3,7 @@
 .proposal-list {
   &__aside {
     &__button-container {
-      @apply flex flex-col gap-4 md:gap-10 w-full md:w-fit;
+      @apply flex flex-col gap-4 md:gap-10 w-full;
     }
   }
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
@@ -8,7 +8,7 @@
 
   <div class="proposal-list__aside__button-container">
     <% if current_settings.creation_enabled && current_component.participatory_space.can_participate?(current_user) %>
-      <%= action_authorized_link_to :create, new_proposal_path, class: "button button__sm md:button__lg button__secondary", data: { "redirect_url" => new_proposal_path } do %>
+      <%= action_authorized_link_to :create, new_proposal_path, class: "button button__xl button__secondary w-full", data: { "redirect_url" => new_proposal_path } do %>
         <span><%= t("new_proposal", scope: "decidim.proposals.proposals.index") %></span>
         <%= icon "add-line" %>
       <% end %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Update to buttons (New) on Proposals and Meetings to conform to the same UX as Debates. Update in responsiveness for mobile also.   

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11742

#### Testing
1. Login (if you need to update permissions)
2. Click a process to update your permissions in "Config" in **Meetings** and **Proposals**
3. Head over to the front end and click the index of either **Meetings** and **Proposals**
4. See the "New" button of either component updated.

### :camera: Screenshots
Before: 

<img width="1123" alt="Screenshot 2023-10-17 at 11 09 02" src="https://github.com/decidim/decidim/assets/101816158/f0a560bf-9c80-4a10-9117-458e005d56cb">

After (web):

<img width="1033" alt="Screenshot 2023-10-17 at 11 08 16" src="https://github.com/decidim/decidim/assets/101816158/6930e935-ef88-4b4e-9578-1bc16a5dbe5e">

After mobile: 

<img width="653" alt="Screenshot 2023-10-17 at 11 09 46" src="https://github.com/decidim/decidim/assets/101816158/c43126b8-759e-4da5-a7ed-cc99056324ac">


:hearts: Thank you!
