### PR TITLE
Display meeting button for unauthenticated users

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/shared/_meetings_aside.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/shared/_meetings_aside.html.erb
@@ -5,7 +5,7 @@
   <h2 class="title-decorator"><%= t("decidim.components.meetings.name") %></h2>
 <% end %>
 
-<% if allowed_to?(:create, :meeting) %>
+<% if try(:component_settings) && component_settings&.creation_enabled_for_participants? && current_component.participatory_space.can_participate?(current_user) %>
   <%= action_authorized_link_to :create, new_meeting_path, class: "button button__xl button__secondary w-full", data: { "redirect_url" => new_meeting_path } do %>
     <span><%= t("new_meeting", scope: "decidim.meetings.meetings.index") %></span>
     <%= icon "add-line" %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR aligns the proposals and meetings interface and behavior by allowing "create meeting" button to be visible for unauthenticated users, applying the same behavior as for proposals 

#### Testing
1.  Login as admin , and visit a participatory space component settings 
2. Edit a meeting component and enable "Participants can create meetings"
3. Visit the public interface of that component and see that "New Meeting" is visible
4. Open an Incognito session with the URL from step 3 
5. See the create button is displayed
6. When clicking the button as Unauthenticated user, the login pop-up should be revealed. 

### :camera: Screenshots

![image](https://github.com/decidim/decidim/assets/105683/d75ea588-71be-4d30-a30d-5c4c7fdf732b)

:hearts: Thank you!
