### PR TITLE
Fix the proposal map display

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -76,10 +76,10 @@ extra_admin_link(
     </section>
   <% end %>
 
-  <% if component_settings.geocoding_enabled? %>
-    <section class="layout-main__section">
+  <% if component_settings.geocoding_enabled? && @proposal.geocoded? %>
+    <div class="static-map__container">
       <%= render partial: "decidim/shared/static_map", locals: { icon_name: "proposals", geolocalizable: @proposal } %>
-    </section>
+    </div>
   <% end %>
 
   <%= cell "decidim/tab_panels", tab_panel_items %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR fixes the way map is displayed on proposal. 

#### Testing
1. Make sure the Maps and Geolocation is enabled on your app
2. Login as admin , and visit a single participatory process admin pages 
3. From sidebar click on "components"
4. On proposal click configure and Tick the"geolocation enabled"
5. Edit a proposal from admin and assign an address 
6. Visit the public website 
7. See the error 
8. Apply patch 
9. VIsit public website 
10. The map should be nicely displayed

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
Before: 
![image](https://github.com/decidim/decidim/assets/105683/d75e89e0-4d58-421d-8a11-d44fd80f57b8)

After : 
![image](https://github.com/decidim/decidim/assets/105683/d3fe56cf-9d6e-400e-9dad-dc305d293c1d)



:hearts: Thank you!
