### PR TITLE
Allow ternary operator in ESLint rules

### DIFF
--- a/decidim-admin/app/packs/src/decidim/admin/sortable.js
+++ b/decidim-admin/app/packs/src/decidim/admin/sortable.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-ternary */
-
 import createSortList from "src/decidim/admin/sort_list.component"
 
 // Once in DOM

--- a/decidim-core/app/packs/src/decidim/append_redirect_url_to_modals.js
+++ b/decidim-core/app/packs/src/decidim/append_redirect_url_to_modals.js
@@ -1,4 +1,4 @@
-/* eslint-disable multiline-ternary, no-ternary */
+/* eslint-disable multiline-ternary */
 
 /*
  *

--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_field.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_field.js
@@ -33,7 +33,6 @@ const updateActiveUploads = (modal) => {
     let hidden = ""
     if (file.hiddenField) {
       // if there is hiddenField, this file is new
-      // eslint-disable-next-line no-ternary
       const fileField = isMultiple
         ? `${modal.options.resourceName}[${modal.options.addAttribute}][${ix}][file]`
         : `${modal.options.resourceName}[${modal.options.addAttribute}]`
@@ -41,7 +40,6 @@ const updateActiveUploads = (modal) => {
       hidden = `<input type="hidden" name="${fileField}" value="${file.hiddenField}" />`
     } else {
       // otherwise, we keep the attachmentId
-      // eslint-disable-next-line no-ternary
       const fileField = isMultiple
         ? `${modal.options.resourceName}[${modal.options.addAttribute}][${ix}][id]`
         : `${modal.options.resourceName}[${modal.options.addAttribute}]`
@@ -61,7 +59,6 @@ const updateActiveUploads = (modal) => {
       title = titleValue
     }
 
-    // eslint-disable-next-line no-ternary
     const attachmentIdOrHiddenField = file.attachmentId
       ? `data-attachment-id="${file.attachmentId}"`
       : `data-hidden-field="${file.hiddenField}"`

--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
@@ -210,7 +210,6 @@ export default class UploadModal {
       template = "titled"
     }
 
-    // eslint-disable-next-line no-ternary
     const attachmentId = opts.attachmentId
       ? `data-attachment-id="${opts.attachmentId}"`
       : ""

--- a/decidim-core/app/packs/src/decidim/vizzs/areachart.js
+++ b/decidim-core/app/packs/src/decidim/vizzs/areachart.js
@@ -1,4 +1,4 @@
-/* eslint-disable require-jsdoc, id-length, no-undefined, no-unused-vars, multiline-ternary, no-ternary, no-nested-ternary, no-invalid-this */
+/* eslint-disable require-jsdoc, id-length, no-undefined, no-unused-vars, multiline-ternary, no-nested-ternary, no-invalid-this */
 /* eslint prefer-reflect: ["error", { "exceptions": ["call"] }] */
 /* eslint dot-location: ["error", "property"] */
 /* eslint no-unused-vars: 0 */

--- a/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.js
+++ b/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-ternary, no-plusplus, require-jsdoc */
+/* eslint-disable no-plusplus, require-jsdoc */
 
 class DisplayCondition {
   constructor(options = {}) {

--- a/decidim_app-design/packages/eslint-config/index.js
+++ b/decidim_app-design/packages/eslint-config/index.js
@@ -190,7 +190,7 @@ module.exports = { // eslint-disable-line
     "no-sync": "error",
     "no-tabs": "error",
     "no-template-curly-in-string": "error",
-    "no-ternary": "error",
+    "no-ternary": "off",
     "no-throw-literal": "error",
     "no-trailing-spaces": "off",
     "no-undef-init": "error",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -190,7 +190,7 @@ module.exports = { // eslint-disable-line
     "no-sync": "error",
     "no-tabs": "error",
     "no-template-curly-in-string": "error",
-    "no-ternary": "error",
+    "no-ternary": "off",
     "no-throw-literal": "error",
     "no-trailing-spaces": "off",
     "no-undef-init": "error",


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While making a review, I noticed that we were adding disabling the no-ternary rule in ESLint. For me it doesn't make much sense as we use that (extensively, 10 times more) in Ruby, so I prefer to change this rule. There are more details about the reasoning in the original issue (#11730).

#### :pushpin: Related Issues
 
- Fixes #11730

#### Testing

CI should be green
There shouldn't be any `/* eslint-disable no-ternary */` or `// eslint-disable-next-line no-ternary` in the code. 

:hearts: Thank you!
