### PR TITLE
Fix PWA availability for organizations with forced sign in

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
+++ b/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
@@ -35,11 +35,15 @@ module Decidim
     end
 
     def unauthorized_paths
-      # /locale is for changing the locale
-      %w(/locale) + Decidim::StaticPage.where(
+      default_unauthorized_paths + Decidim::StaticPage.where(
         organization: current_organization,
         allow_public_access: true
       ).pluck(Arel.sql("CONCAT('/pages/', slug)"))
+    end
+
+    def default_unauthorized_paths
+      # /locale is for changing the locale and /manifest.webmanifest to request PWA manifest
+      %w(/locale /manifest.webmanifest)
     end
   end
 end

--- a/decidim-core/spec/system/user_redirect_spec.rb
+++ b/decidim-core/spec/system/user_redirect_spec.rb
@@ -12,6 +12,20 @@ describe "UserRedirect", type: :system do
 
     let(:user) { create(:user, :confirmed, organization:) }
 
+    context "when accessing manifest" do
+      before do
+        visit decidim.manifest_path(format: "webmanifest")
+      end
+
+      it "does not redirect to login page" do
+        expect(page).not_to have_content("Log in")
+      end
+
+      it "renders a JSON with the manifest" do
+        expect(page).to have_content("\"display\": \"standalone\"")
+      end
+    end
+
     context "when logging for the first time" do
       before do
         visit decidim.pages_path


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Fix PWA availability for organizations with forced sign in by including `/manifest.webmanifest` to `unauthorized_paths` on `ForceAuthentication` concern.

#### :pushpin: Related Issues
- Fixes #11776

#### Testing
1. Go to `/system` and edit an organization setting `force_users_to_authenticate_before_access_organization` to `true`.
2. Go to `/manifest.webmanifest` and see it doesn't redirect to `/users/sign_in`

### :camera: Screenshots
https://github.com/decidim/decidim/assets/6973564/dcf4a0f2-53d4-43a2-8b70-1913fb96bbd1

:hearts: Thank you!
