### PR TITLE
Conference map render in show

### DIFF
--- a/decidim-core/app/helpers/decidim/view_hooks_helper.rb
+++ b/decidim-core/app/helpers/decidim/view_hooks_helper.rb
@@ -12,7 +12,7 @@ module Decidim
     #
     # @return [String] an HTML safe String
     def render_hook(hook_name)
-      Decidim.view_hooks.render(hook_name, deep_dup)
+      Decidim.view_hooks.render(hook_name, self)
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/view_hooks_helper.rb
+++ b/decidim-core/app/helpers/decidim/view_hooks_helper.rb
@@ -5,9 +5,6 @@ module Decidim
   module ViewHooksHelper
     # Public: Renders all hooks registered as `hook_name`.
     #
-    #   Note: We are passing a deep copy of the view context to allow
-    #   us to extend it without polluting the original view context
-    #
     # @param hook_name [Symbol] representing the name of the hook.
     #
     # @return [String] an HTML safe String


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Thanks to @alecslupu, we have a fix which takes place in the ```decidim-core/app/helpers/decidim/view_hooks_helper.rb```, that allows the page to copy and render in the view.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11686

#### Testing
1. Head over to conferences and click a conference
2. See at the bottom the map rendered.

### :camera: Screenshots

<img width="1202" alt="Screenshot 2023-10-18 at 12 51 24" src="https://github.com/decidim/decidim/assets/101816158/bf7e0a27-b81b-4aa3-8402-17bbc50ede8d">

:hearts: Thank you!
