### PR TITLE
Fix styles for "Managed users" flow 

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/impersonatable_users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/impersonatable_users_controller.rb
@@ -26,7 +26,7 @@ module Decidim
       private
 
       def collection
-        @collection ||= current_organization.users.where(admin: false, roles: [])
+        @collection ||= current_organization.users.where(admin: false, roles: []).order(created_at: :desc)
       end
 
       def new_managed_user

--- a/decidim-admin/app/views/decidim/admin/managed_users/promotions/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/managed_users/promotions/_form.html.erb
@@ -1,3 +1,9 @@
-<div class="row column">
-  <%= form.text_field :email %>
+<div class="form__wrapper">
+  <div class="card pt-4">
+    <div class="card-section">
+      <div class="row column">
+        <%= form.email_field :email %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/decidim-admin/app/views/decidim/admin/managed_users/promotions/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/managed_users/promotions/new.html.erb
@@ -1,19 +1,24 @@
-<h2 class="process-title-summary">
-  <%= t(".new_managed_user_promotion") %>
-</h2>
+<% add_decidim_page_title(t(".new_managed_user_promotion")) %>
+
+<div class="item_show__header">
+  <h2 class="item_show__header-title">
+    <%= t(".new_managed_user_promotion") %>
+  </h2>
+</div>
 
 <div class="section">
   <%= cell("decidim/announcement", t(".explanation"), callout_class: "warning" ) %>
 </div>
 
-<%= decidim_form_for(@form, url: impersonatable_user_promotions_path, html: { class: "form new_managed_user_promotion" }) do |f| %>
-  <div class="card">
-    <div class="card-section">
+<div class="item__edit item__edit-1col">
+  <div class="item__edit-form">
+    <%= decidim_form_for(@form, url: impersonatable_user_promotions_path, html: { class: "form form-defaults" }) do |f| %>
       <%= render partial: "form", object: f %>
-    </div>
+      <div class="item__edit-sticky">
+        <div class="item__edit-sticky-container">
+          <%= f.submit t(".promote"), class: "button button__sm button__secondary" %>
+        </div>
+      </div>
+    <% end %>
   </div>
-
-  <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
-    <%= f.submit t(".promote"), class: "button button__sm button__secondary" %>
-  </div>
-<% end %>
+</div>

--- a/decidim-admin/spec/shared/manage_impersonations_examples.rb
+++ b/decidim-admin/spec/shared/manage_impersonations_examples.rb
@@ -241,7 +241,7 @@ shared_examples "manage impersonations examples" do
         click_link "Promote"
       end
 
-      within "form.new_managed_user_promotion" do
+      within ".item__edit form" do
         fill_in :managed_user_promotion_email, with: "foo@example.org"
       end
 

--- a/decidim-core/app/views/layouts/decidim/_impersonation_warning.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_impersonation_warning.html.erb
@@ -1,9 +1,11 @@
 <% if current_user_impersonated? %>
-  <div class="impersonation-warning" data-session-ends-at="<%= impersonation_session_ends_at.iso8601 %>">
-    <%= t(".description_html", user_name: current_user.name) %>
-    <%= t(".expire_time_html", minutes: impersonation_session_remaining_duration_in_minutes) %>
-    <div class="impersonation-warning__action">
-      <%= button_to t(".close_session"), decidim_admin.close_session_impersonatable_user_impersonations_path(current_user), class: "button tiny impersonation-bar__button", data: { disable: true } %>
+  <div class="impersonation-warning flash warning my-0 flex justify-center text-center" data-session-ends-at="<%= impersonation_session_ends_at.iso8601 %>">
+    <div class="flash__message">
+      <%= t(".description_html", user_name: current_user.name) %>
+      <%= t(".expire_time_html", minutes: impersonation_session_remaining_duration_in_minutes) %>
+      <div class="mt-4">
+        <%= button_to t(".close_session"), decidim_admin.close_session_impersonatable_user_impersonations_path(current_user), class: "button button__secondary button__sm impersonation-bar__button", data: { disable: true } %>
+      </div>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing the new design, it was detected that the "Managed users" feature had some unstyled parts. This PR fixes it. 

#### Testing

1. Sign in as admin
2. Go to http://localhost:3000/admin/impersonatable_users 
3. Click on the "Manage new participant" button
4. Select the "Example authorization" 
5. Fill the "Name" and the "Document number". This should finish in "X".
![Screenshot of the form](https://github.com/decidim/decidim/assets/717367/ff928b6f-b143-4b49-90d5-6c2192e580d1)
7. Click on the "Impersonate" button
Until this step mind that there isn't any problem 😄. Now we start with the fixes: 
8. See that the impersonation banner is fixed. (There's an screenshot below)
9. Click on the "Close session" button
10. See that the last managed user is the first
11. Click on the "Promote" button of this user
12. See that the form is fixed. (There's an screenshot below)

### :camera: Screenshots

#### Before 
![Screenshot of the managed user banner (broken)](https://github.com/decidim/decidim/assets/717367/115a24fe-7bc2-41f5-935e-1eadbec0a4ec)

![Screenshot of the "promoted" form (broken)](https://github.com/decidim/decidim/assets/717367/fd3cae0d-6ec9-4511-8ffa-52eea7de1e28)

#### After 

![Screenshot of the managed user banner (fixed)](https://github.com/decidim/decidim/assets/717367/2aea5c8c-2e62-4766-a5ce-1f1ea16cff29)

![Screenshot of the "promoted" form (fixed)](https://github.com/decidim/decidim/assets/717367/e571b52e-b480-49b1-b003-2ba848459b83)


:hearts: Thank you!
