### PR TITLE
Fix the JS icons path in admin panel

### DIFF
--- a/decidim-admin/app/views/layouts/decidim/admin/_js_configuration.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_js_configuration.html.erb
@@ -1,6 +1,6 @@
 <%
 js_configs = {
-  icons_path: Decidim.cors_enabled ? "" : asset_pack_path("media/images/icons.svg"),
+  icons_path: Decidim.cors_enabled ? "" : asset_pack_path("media/images/remixicon.symbol.svg"),
   messages: {
     "selfxssWarning": t("decidim.security.selfxss_warning"),
     editor: t("editor")


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed the a11y tool icons were not displayed correctly while at the admin path. The reason is that the JS configuration points the icons path to the legacy icon set currently but the a11y tool already uses the redesigned icons (reminxicon).

#### :pushpin: Related Issues
- Related to #11175
- Fixes #11748 

#### Testing
- Go to admin panel
- See that the a11y tool icons are displayed correctly

### :camera: Screenshots

**Before**
![A11y tool icons broken](https://github.com/decidim/decidim/assets/864340/6fe098c8-ca72-4437-b4e4-4c398abc0d9f)

**After**
![A11y tool icons working](https://github.com/decidim/decidim/assets/864340/3dbc8a7d-ae7e-4603-9bdf-fa8ea04ff12e)
