### PR TITLE
Fix robots.txt override warning

### DIFF
--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -102,6 +102,7 @@ module Decidim
         rails "decidim:procfile:install"
 
         # Replace robots.txt
+        remove_file"public/robots.txt"
         rails "decidim:robots:replace"
       end
 

--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -102,7 +102,7 @@ module Decidim
         rails "decidim:procfile:install"
 
         # Replace robots.txt
-        remove_file"public/robots.txt"
+        remove_file "public/robots.txt"
         rails "decidim:robots:replace"
       end
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
In #11693 we have added an override of robots.txt file. It was discovered by @ahukkanen that the installation process may block in the pipeline due to override prompt. This PR removes the file generated by generator, so we can add decidim version without any conflict. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #11693

#### Testing
1. Create a development app starting from develop branch 
2. See there is a prompt to replace robots.txt
3. Apply the patch
4. Generate a new development application 
5. See there is no prompt to replace robots.txt  

:hearts: Thank you!
