### PR TITLE
Lock tom-select and core-js

### DIFF
--- a/decidim_app-design/package-lock.json
+++ b/decidim_app-design/package-lock.json
@@ -21390,7 +21390,7 @@
         "react-i18nify": "^1.8.8",
         "select": "^1.1.2",
         "svg4everybody": "2.1.9",
-        "tom-select": "^2.2.2",
+        "tom-select": "2.2.2",
         "tributejs": "5.1.3",
         "unfetch": "^3.0.0",
         "uuid": "^9.0.0"
@@ -21481,6 +21481,7 @@
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "compression-webpack-plugin": "^10.0.0",
+        "core-js": "~3.33.1",
         "css-loader": "^6.8.1",
         "expose-loader": "^4.1.0",
         "glob": "^10.3.3",
@@ -21520,6 +21521,16 @@
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/webpacker/node_modules/core-js": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.1.tgz",
+      "integrity": "sha512-qVSq3s+d4+GsqN0teRCJtM6tdEEXyWxjzbhVrCHmBS5ZTM0FS2MOS0D13dUXAWDUN6a+lHI/N1hF9Ytz6iLl9Q==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "packages/webpacker/node_modules/glob": {
@@ -23163,7 +23174,7 @@
         "react-i18nify": "^1.8.8",
         "select": "^1.1.2",
         "svg4everybody": "2.1.9",
-        "tom-select": "^2.2.2",
+        "tom-select": "2.2.2",
         "tributejs": "5.1.3",
         "unfetch": "^3.0.0",
         "uuid": "^9.0.0"
@@ -23297,6 +23308,7 @@
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "compression-webpack-plugin": "^10.0.0",
+        "core-js": "~3.33.1",
         "css-loader": "^6.8.1",
         "expose-loader": "^4.1.0",
         "glob": "^10.3.3",
@@ -23336,6 +23348,11 @@
           "requires": {
             "balanced-match": "^1.0.0"
           }
+        },
+        "core-js": {
+          "version": "3.33.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.1.tgz",
+          "integrity": "sha512-qVSq3s+d4+GsqN0teRCJtM6tdEEXyWxjzbhVrCHmBS5ZTM0FS2MOS0D13dUXAWDUN6a+lHI/N1hF9Ytz6iLl9Q=="
         },
         "glob": {
           "version": "10.3.3",

--- a/decidim_app-design/packages/core/package.json
+++ b/decidim_app-design/packages/core/package.json
@@ -69,7 +69,7 @@
     "react-i18nify": "^1.8.8",
     "select": "^1.1.2",
     "svg4everybody": "2.1.9",
-    "tom-select": "^2.2.2",
+    "tom-select": "2.2.2",
     "tributejs": "5.1.3",
     "unfetch": "^3.0.0",
     "uuid": "^9.0.0"

--- a/decidim_app-design/packages/webpacker/package.json
+++ b/decidim_app-design/packages/webpacker/package.json
@@ -24,6 +24,7 @@
     "autoprefixer": "^10.4.14",
     "babel-loader": "^9.1.3",
     "compression-webpack-plugin": "^10.0.0",
+    "core-js": "~3.33.1",
     "css-loader": "^6.8.1",
     "expose-loader": "^4.1.0",
     "glob": "^10.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21390,7 +21390,7 @@
         "react-i18nify": "^1.8.8",
         "select": "^1.1.2",
         "svg4everybody": "2.1.9",
-        "tom-select": "^2.2.2",
+        "tom-select": "2.2.2",
         "tributejs": "5.1.3",
         "unfetch": "^3.0.0",
         "uuid": "^9.0.0"
@@ -21481,6 +21481,7 @@
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "compression-webpack-plugin": "^10.0.0",
+        "core-js": "~3.33.1",
         "css-loader": "^6.8.1",
         "expose-loader": "^4.1.0",
         "glob": "^10.3.3",
@@ -21520,6 +21521,16 @@
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/webpacker/node_modules/core-js": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.1.tgz",
+      "integrity": "sha512-qVSq3s+d4+GsqN0teRCJtM6tdEEXyWxjzbhVrCHmBS5ZTM0FS2MOS0D13dUXAWDUN6a+lHI/N1hF9Ytz6iLl9Q==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "packages/webpacker/node_modules/glob": {
@@ -23163,7 +23174,7 @@
         "react-i18nify": "^1.8.8",
         "select": "^1.1.2",
         "svg4everybody": "2.1.9",
-        "tom-select": "^2.2.2",
+        "tom-select": "2.2.2",
         "tributejs": "5.1.3",
         "unfetch": "^3.0.0",
         "uuid": "^9.0.0"
@@ -23297,6 +23308,7 @@
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "compression-webpack-plugin": "^10.0.0",
+        "core-js": "~3.33.1",
         "css-loader": "^6.8.1",
         "expose-loader": "^4.1.0",
         "glob": "^10.3.3",
@@ -23336,6 +23348,11 @@
           "requires": {
             "balanced-match": "^1.0.0"
           }
+        },
+        "core-js": {
+          "version": "3.33.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.1.tgz",
+          "integrity": "sha512-qVSq3s+d4+GsqN0teRCJtM6tdEEXyWxjzbhVrCHmBS5ZTM0FS2MOS0D13dUXAWDUN6a+lHI/N1hF9Ytz6iLl9Q=="
         },
         "glob": {
           "version": "10.3.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,7 +69,7 @@
     "react-i18nify": "^1.8.8",
     "select": "^1.1.2",
     "svg4everybody": "2.1.9",
-    "tom-select": "^2.2.2",
+    "tom-select": "2.2.2",
     "tributejs": "5.1.3",
     "unfetch": "^3.0.0",
     "uuid": "^9.0.0"

--- a/packages/webpacker/package.json
+++ b/packages/webpacker/package.json
@@ -24,6 +24,7 @@
     "autoprefixer": "^10.4.14",
     "babel-loader": "^9.1.3",
     "compression-webpack-plugin": "^10.0.0",
+    "core-js": "~3.33.1",
     "css-loader": "^6.8.1",
     "expose-loader": "^4.1.0",
     "glob": "^10.3.3",


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
While working on different PRs i have noticed that my pipeline is starting to fail due to unrelated assets compiling error. 
![image](https://github.com/decidim/decidim/assets/105683/35575d1f-41bf-4f83-840b-54fd9030623f)

I traced the below error to be related to latest release of tom-select (upgrade from 2.2.2 to 2.2.3). 

After tom select has been fixed, i could see there is another error that takes place 
![image](https://github.com/decidim/decidim/assets/105683/2013677e-678b-4b76-bebd-8b513e12c915)

Which i have tracked down to be related to `core-js`. We have a lot of libraries that are using `core-js` 2.x version, yet some others which are using the 3.x version. The tailwind error, is caused by by the fact that npm is resolving the core-js to 2.x version instead of 3.x version.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #11794
- Related to #11706
- Related to #11669
- Related to #11787

#### Testing
Make sure the pipeline is green

:hearts: Thank you!
