### PR TITLE
Clean-up Foundation CSS comments 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -98,11 +98,18 @@ These are one time actions that need to be done after the code is updated in the
 
 The redesign has introduced Tailwind CSS framework to compile CSS. It integrates with Webpacker, which generates Tailwind configuration dynamically when Webpacker is invoked.
 
-You will need to add `tailwind.config.js` to your app `.gitignore`. If you generate a new Decidim app from scratch, that entry will already be included in the `.gitignore`.
+There are some actions that you will need to do in your existing application that's already done in new applications:
 
-You will also need to migrate your settings from your applications's `_decidim-settings.scss` file, available at `app/packs/stylesheets/decidim/_decidim-settings.scss`.
-
+1. Add `tailwind.config.js` to your app's `.gitignore`.
+```console
+echo tailwind.config.js >> .gitignore
+```
+2. Migrate your settings from your applications's `_decidim-settings.scss` file, available at `app/packs/stylesheets/decidim/_decidim-settings.scss`.
 If you want to define the colors and other Tailwind related configurations, you can do it following the instructions on the documentation on how to [customize Tailwind](https://docs.decidim.org/en/develop/customize/styles.html#_tailwind_css).
+3. After that's done, remove your `_decidim-settings.scss` file.
+```console
+rm app/packs/stylesheets/decidim/_decidim-settings.scss
+```
 
 You can read more about this change on PR [\#9480](https://github.com/decidim/decidim/pull/9480).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -110,6 +110,10 @@ If you want to define the colors and other Tailwind related configurations, you 
 ```console
 rm app/packs/stylesheets/decidim/_decidim-settings.scss
 ```
+4. Remove this comment from your `decidim-application.scss` file, available at `app/packs/stylesheets/decidim/decidim_application.scss`.
+```javascript
+// To override CSS variables or Foundation settings use _decidim-settings.scss
+```
 
 You can read more about this change on PR [\#9480](https://github.com/decidim/decidim/pull/9480).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -100,6 +100,10 @@ The redesign has introduced Tailwind CSS framework to compile CSS. It integrates
 
 You will need to add `tailwind.config.js` to your app `.gitignore`. If you generate a new Decidim app from scratch, that entry will already be included in the `.gitignore`.
 
+You will also need to migrate your settings from your applications's `_decidim-settings.scss` file, available at `app/packs/stylesheets/decidim/_decidim-settings.scss`.
+
+If you want to define the colors and other Tailwind related configurations, you can do it following the instructions on the documentation on how to [customize Tailwind](https://docs.decidim.org/en/develop/customize/styles.html#_tailwind_css).
+
 You can read more about this change on PR [\#9480](https://github.com/decidim/decidim/pull/9480).
 
 ### 3.2. Content migration for rich text editor

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -116,7 +116,7 @@ module Decidim
       end
 
       # Get the translation for a given attribute
-      # Returns a translation or nil. If nil, ZURB Foundation will not add the help_text.
+      # Returns a translation or nil. If nil, FoundationRailsHelper will not add the help_text.
       #
       # @param name (see #settings_attribute_input)
       # @param suffix [String] What suffix the i18n key has

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_table-list.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_table-list.scss
@@ -1,4 +1,3 @@
-//Override Foundation defaults
 .table-scroll {
   @apply overflow-x-auto;
 

--- a/decidim-core/app/cells/decidim/upload_modal_cell.rb
+++ b/decidim-core/app/cells/decidim/upload_modal_cell.rb
@@ -72,7 +72,7 @@ module Decidim
       options[:required] == true
     end
 
-    # By default Foundation adds form errors next to input, but since input is in the modal
+    # By default FoundationRailsHelper adds form errors next to input, but since input is in the modal
     # and modal is hidden by default, we need to add an additional validation field to the form.
     # This should only be necessary when file is required by the form.
     def input_validation_field

--- a/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
+++ b/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
@@ -8,7 +8,7 @@ module Decidim
 
     included do
       # Displays the flash messages found in ActionDispatch's +flash+ hash using
-      # Foundation's +callout+ component.
+      # FoundationRailsHelper's +callout+ component.
       #
       # Overrides original function from foundation_rails_helper gem to allow
       # flash messages with links inside.
@@ -34,7 +34,7 @@ module Decidim
 
       private
 
-      # Private: Foundation alert box.
+      # Private: FoundationRailsHelper alert box.
       #
       # Overrides the foundation alert box helper for adding accessibility tags.
       #
@@ -65,7 +65,7 @@ module Decidim
         end
       end
 
-      # Private: Foudation alert box close link.
+      # Private: FoundationRailsHelper alert box close link.
       #
       # Overrides the foundation alert box close link helper for the aria-label
       # translations.

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -856,7 +856,7 @@ module Decidim
     end
 
     # Private: Creates a tag from the given options for the field prefix and
-    # suffix. Overridden from Foundation Rails helper to make the generated HTML
+    # suffix. Overridden from FoundationRailsHelper to make the generated HTML
     # valid since these elements are printed within <label> elements and <div>'s
     # are not allowed there.
     def tag_from_options(name, options)
@@ -868,7 +868,7 @@ module Decidim
     end
 
     # Private: Wraps the prefix and postfix for the field. Overridden from
-    # Foundation Rails helper to make the generated HTML valid since these
+    # FoundationRailsHelper to make the generated HTML valid since these
     # elements are printed within <label> elements and <div>'s are not allowed
     # there.
     def wrap_prefix_and_postfix(block, prefix_options, postfix_options)

--- a/decidim-generators/lib/decidim/generators/app_templates/_decidim-settings.scss
+++ b/decidim-generators/lib/decidim/generators/app_templates/_decidim-settings.scss
@@ -1,7 +1,0 @@
-// This is a file that can be overridden by the application in order to override
-// some of the Foundation/Decidim SCSS settings and variables after the default
-// settings have been loaded.
-//
-// To override styles use decidim_application.scss
-//
-// By default this is empty.

--- a/decidim-generators/lib/decidim/generators/app_templates/decidim_application.scss
+++ b/decidim-generators/lib/decidim/generators/app_templates/decidim_application.scss
@@ -2,6 +2,7 @@
 // Notice that this file is included at the very end of the stylesheets packs to have
 // more priority
 //
-// To override CSS variables or Foundation settings use _decidim-settings.scss
+// To override the Tailwind CSS configuration you can do so by following the instructions
+// available at https://docs.decidim.org/en/develop/customize/styles.html#_tailwind_css
 //
 // By default this is empty.

--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -78,9 +78,8 @@ module Decidim
       end
 
       def install_decidim_webpacker
-        # Copy CSS files
+        # Copy CSS file
         copy_file "decidim_application.scss", "app/packs/stylesheets/decidim/decidim_application.scss"
-        copy_file "_decidim-settings.scss", "app/packs/stylesheets/decidim/_decidim-settings.scss"
 
         # Copy JS application file
         copy_file "decidim_application.js", "app/packs/src/decidim/decidim_application.js"

--- a/docs/modules/develop/pages/managing_translations_i18n.adoc
+++ b/docs/modules/develop/pages/managing_translations_i18n.adoc
@@ -13,7 +13,6 @@ Decidim uses https://crowdin.com/[Crowdin] to manage the translations.
 * Setup the new language in https://crowdin.com/project/decidim[_Crowdin's Decidim project_] (or open an issue on Github asking an admin to do that).
 * Add the locale mapping in the `crowdin.yml` file
 * Translate at least one key from every engine, so, your _yaml_ files are not empty. The easiest way to do this is to automatically translate and sync all the content. Later you will be able to fix the content that was not properly translated.
-* Add https://github.com/najlepsiwebdesigner/foundation-datepicker/tree/master/js/locales[Foundation Datepicker]'s translations (https://github.com/decidim/decidim/pull/2039[PR]).
 * Add the new language to `available_locales` (https://github.com/decidim/decidim/pull/1991[PR]).
 * Add the language in https://github.com/decidim/decidim/pull/5080/files#diff-9c9dc1c8c25dcecdfb8ce555d5ef5e47R15[decidim-core/spec/lib/available_locales_spec.rb].
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing #11767, I found even more mentions to Foundation CSS in comments. This PR tries to align our Foundation comments and code to the (current) reality. 

* Removes the `_decidim-settings.css` file from generated apps (and adds instructions for existing apps) 
* Adds instructions for existing apps about the tailwind customization (related to #11763)
* Change some comments to refer to `FoundationRailsHelper` instead of Foundation or ZURB Foundation, so it's easier to exclude it from searches. Also, it makes clearer to differentiate that we're talking about that gem. 
* Removes some references that weren't true any more (Foundation Datepicker that's already removed, one comment that talks about "Overrides foundation defaults" that isn't true)  

#### Testing

Comments should be truthful 
Instructions on Foundation clean-up should be clear for existing apps
Generated apps should not have references to Foundation

:hearts: Thank you!
