### PR TITLE
Use correct command when destroying topics

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/destroy_static_page_topic.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_static_page_topic.rb
@@ -24,7 +24,7 @@ module Decidim
 
       attr_reader :page, :current_user
 
-      def destroy_page
+      def destroy_topic
         transaction do
           Decidim.traceability.perform_action!(
             "delete",

--- a/decidim-admin/app/controllers/decidim/admin/static_page_topics_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/static_page_topics_controller.rb
@@ -53,7 +53,7 @@ module Decidim
       def destroy
         enforce_permission_to :destroy, :static_page_topic, static_page_topic: topic
 
-        DestroyStaticPage.call(topic, current_user) do
+        DestroyStaticPageTopic.call(topic, current_user) do
           on(:ok) do
             flash[:notice] = I18n.t("static_page_topics.destroy.success", scope: "decidim.admin")
             redirect_to static_pages_path


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
While working at #11795, i have noticed that `DestroyStaticPageTopic` may not be used. This PR fixes the usage. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #11795

#### Testing
Make sure the pipeline is green. 
Make sure the topics can be deleted from admin area. 

:hearts: Thank you!
