### PR TITLE
Fix the proposals map width

### DIFF
--- a/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
+++ b/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
@@ -13,12 +13,6 @@
   }
 }
 
-/* overwrite defaults */
-.static-map,
-[data-decidim-map] {
-  @apply aspect-[5/1];
-}
-
 .proposal {
   &__cost {
     @apply space-y-3 bg-background rounded p-4 text-black;

--- a/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
+++ b/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
@@ -27,6 +27,12 @@
       @apply flex flex-row-reverse md:flex-col gap-4 items-center md:items-stretch justify-between first:[&>*]:grow last:[&>*]:w-1/4 md:last:[&>*]:w-auto;
     }
   }
+
+  &__container {
+    [data-decidim-map] {
+      @apply aspect-[5/1];
+    }
+  }
 }
 
 .proposal-participatory {


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR fixes the map display on proposal listing. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes  #11799

#### Testing
1. Make sure you have the maps and geocoding enabled on your system
2. Login as admin and visit Components area of a Participatory space 
3. Click configure proposals 
4. Enable Geocoding and save
5. Select a proposal that is being editable in admin and set a geocodable address, then save 
6. Visit the Proposals public interface of the Participatory space
7. See error, then apply patch 
8. Refresh the page. See the maps being correctly displayed. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
