### PR TITLE
Fix help text for initiative types in admin

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
@@ -58,11 +58,11 @@
       </div>
 
     <div class="row column">
-      <%= form.check_box :child_scope_threshold_enabled, help_text: t(".child_scope_threshold_enabled_help") %>
+      <%= form.check_box :child_scope_threshold_enabled, help_text: t(".child_scope_threshold_enabled_help_html") %>
     </div>
 
     <div class="row column">
-      <%= form.check_box :only_global_scope_enabled, help_text: t(".only_global_scope_enabled_help") %>
+      <%= form.check_box :only_global_scope_enabled, help_text: t(".only_global_scope_enabled_help_html") %>
     </div>
 
       <div class="row column" id="promoting-committee-details">

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -301,8 +301,8 @@ en:
             update: Update
           form:
             authorizations: Authorization settings
-            child_scope_threshold_enabled_help: 'This config flag doesn''t support offline votes. It enables sub-scopes and works with an authorization handler that associates a scope to the user. Make sure you select that authorization, below in authorization settings. For it to work, scopes need to be configured in a hierarchical way: 1 Parent - N Child. For more info on how this configuration works, see <a href="https://docs.decidim.org/en/admin/spaces/initiatives/" target="_blank">initiatives'' admin documentation page</a>.'
-            only_global_scope_enabled_help: Tick this flag if you enabled "Child scope signature" and configured the global scope as your parent scope. By enabling this, initiative type selection will be skipped in the initiative creation wizard. For more info on how this configuration works, see this <a href="https://docs.decidim.org/en/admin/spaces/initiatives/" target="_blank">link</a>.
+            child_scope_threshold_enabled_help_html: 'This config flag doesn''t support offline votes. It enables sub-scopes and works with an authorization handler that associates a scope to the user. Make sure you select that authorization, below in authorization settings. For it to work, scopes need to be configured in a hierarchical way: 1 Parent - N Child. For more info on how this configuration works, see <a href="https://docs.decidim.org/en/admin/spaces/initiatives/" target="_blank">initiatives'' admin documentation page</a>.'
+            only_global_scope_enabled_help_html: Tick this flag if you enabled "Child scope signature" and configured the global scope as your parent scope. By enabling this, initiative type selection will be skipped in the initiative creation wizard. For more info on how this configuration works, see this <a href="https://docs.decidim.org/en/admin/spaces/initiatives/" target="_blank">link</a>.
             options: Options
           initiative_type_scopes:
             title: Scopes for the initiative type


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR fixes the help messages that are rendered as raw HTML  in page. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes  #11677

#### Testing

1. Login to admin and visit initiatives section
2. From manage button choose "initiative types"
3. From action menu choose "New Initiative type"
4. Scroll to Options accordion
5. See error
6. Apply patch 
7. See the help messages are displayed in a friendly manner

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
Before: 
![image](https://github.com/decidim/decidim/assets/105683/f4b60c0c-2560-48fa-af62-3a8ee0959df9)

After:
![image](https://github.com/decidim/decidim/assets/105683/0117e60a-8bc7-4a1f-b21f-9b6f81557a78)


:hearts: Thank you!
