### PR TITLE
Hide omnipresent in media print of initiatives

### DIFF
--- a/decidim-initiatives/app/packs/stylesheets/decidim/initiatives/print-initiative.scss
+++ b/decidim-initiatives/app/packs/stylesheets/decidim/initiatives/print-initiative.scss
@@ -110,6 +110,10 @@
 }
 
 @media print {
+  .omnipresent-banner {
+    display: none;
+  }
+
   .decidim-accessibility-indicator {
     display: none;
   }

--- a/decidim-initiatives/app/packs/stylesheets/decidim/initiatives/print-initiative.scss
+++ b/decidim-initiatives/app/packs/stylesheets/decidim/initiatives/print-initiative.scss
@@ -110,6 +110,13 @@
 }
 
 @media print {
+  h3.print-section-title {
+    display: none;
+  }
+  .print-button {
+    display: none;
+  }
+
   .omnipresent-banner {
     display: none;
   }

--- a/decidim-initiatives/app/packs/stylesheets/decidim/initiatives/print-initiative.scss
+++ b/decidim-initiatives/app/packs/stylesheets/decidim/initiatives/print-initiative.scss
@@ -113,6 +113,7 @@
   h3.print-section-title {
     display: none;
   }
+
   .print-button {
     display: none;
   }

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/print.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/print.html.erb
@@ -153,6 +153,6 @@
     <%= t ".legal_text" %>
   </p>
 
-  <a href="#" onclick="window.print();return false;" class="button button__sm button__secondary w-full"><%= t ".print" %></a>
+  <a href="#" onclick="window.print();return false;" class="button button__sm button__secondary w-full print-button"><%= t ".print" %></a>
   <%= append_stylesheet_pack_tag "decidim_initiatives_print" %>
 </div>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
This PR hides omnipresent banner when initiatives.

#### Testing
1. Login as admin, edit organiztion appearence and set a visible omnipresent 
2. Visit initiatives admin panel 
3. Click print icon 
4. Click print and check Print Preview thumbnail
5. Omnipresent banner visible 
6. Apply patch 
7. Repeat 3 and 4 
8. Omnipresent banner is *NOT* visible

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
Before:
![image](https://github.com/decidim/decidim/assets/105683/9d32597c-aa54-4f85-9be5-6208cac7ac2f)

After: 
![image](https://github.com/decidim/decidim/assets/105683/95806fd6-0f5a-45a1-b032-86400a0d2476)


:hearts: Thank you!
