### PR TITLE
Add GH Action for verifying labels in Pull Requests

### DIFF
--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -21,3 +21,9 @@ jobs:
           regex: "^[A-Z].+"
           min_length: 5
           max_length: 100
+      - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          valid-labels: "type: feature, type:change, type: fix, type: removal, target: developer-experience, type: internal"
+          invalid-labels: "type: bug"
+          pull-request-number: "${{ github.event.pull_request.number }}"


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

For the generation of changelogs, we need to have all the PRs using a limited number of labels. This PR adds this check in the pipeline.

See https://github.com/decidim/decidim/blob/a32b7acaabc7298e303aacd759d8f72a64da5a78/bin/changelog_generator#L38 

#### Testing

Change the labels in this PR and see them fail or pass according to the valid labels in the configuration.  

:hearts: Thank you!
