### PR TITLE
Fix size in flashes/announcements icons

### DIFF
--- a/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
+++ b/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
@@ -52,16 +52,28 @@ module Decidim
         }.merge(opts)
 
         options[:data] = options[:data].merge(closable: "") if closable
+        content_tag(:div, options) do
+          concat flash_icon(alert_class)
+          concat message(value)
+          concat close_link if closable
+        end
+      end
+
+      # Private: Icon with wrapper class
+      #
+      # alert_class - The foundation class of the alert message.
+      #
+      # Returns a HTML string
+      def flash_icon(alert_class)
         icon = {
           secondary: "information-line",
           alert: "alert-line",
           warning: "alert-line",
           success: "checkbox-circle-line"
         }
-        content_tag(:div, options) do
-          concat icon(icon[alert_class])
-          concat message(value)
-          concat close_link if closable
+
+        content_tag(:div, class: "flash__icon") do
+          icon(icon[alert_class])
         end
       end
 

--- a/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
+++ b/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
@@ -13,11 +13,12 @@ module Decidim
       # Overrides original function from foundation_rails_helper gem to allow
       # flash messages with links inside.
       #
-      # Parameters:
-      # * +closable+ - A boolean to determine whether the displayed flash messages
-      # should be closable by the user. Defaults to true.
-      # * +key_matching+ - A Hash of key/value pairs mapping flash keys to the
-      # corresponding class to use for the callout box.
+      # @param closable [Boolean] - Whether the displayed flash messages
+      #                             should be closable by the user. Defaults to true.
+      # @param key_matching [Hash] - A mapping of the flash keys to the
+      #                              corresponding class to use for the callout box.
+      #
+      # @return [String] the HTML with all the flash messages
       def display_flash_messages(closable: true, key_matching: {})
         key_matching = FoundationRailsHelper::FlashHelper::DEFAULT_KEY_MATCHING.merge(key_matching)
         key_matching.default = :primary
@@ -34,15 +35,17 @@ module Decidim
 
       private
 
-      # Private: FoundationRailsHelper alert box.
+      # FoundationRailsHelper alert box.
       #
       # Overrides the foundation alert box helper for adding accessibility tags.
       #
-      # value - The flash message.
-      # alert_class - The foundation class of the alert message.
-      # closable - A boolean indicating whether the close icon is added.
+      # @private
       #
-      # Returns a HTML string.
+      # @param value [String] - The flash message.
+      # @param alert_class [String] - The foundation class of the alert message.
+      # @param closable [Boolean] - Wether the close icon is added.
+      #
+      # @return [String] the HTML with the alert box
       def alert_box(value, alert_class, closable, opts = {})
         options = {
           class: "flash #{alert_class}",
@@ -59,11 +62,13 @@ module Decidim
         end
       end
 
-      # Private: Icon with wrapper class
+      # Icon with wrapper class
       #
-      # alert_class - The foundation class of the alert message.
+      # @private
       #
-      # Returns a HTML string
+      # @param alert_class [String] - The foundation class of the alert message.
+      #
+      # @return [String] the HTML with the icon
       def flash_icon(alert_class)
         icon = {
           secondary: "information-line",
@@ -77,10 +82,14 @@ module Decidim
         end
       end
 
-      # Private: FoundationRailsHelper alert box close link.
+      # FoundationRailsHelper alert box close link.
       #
       # Overrides the foundation alert box close link helper for the aria-label
       # translations.
+      #
+      # @private
+      #
+      # @return [String] the HTML with the close link
       def close_link
         button_tag(
           class: "close-button",

--- a/decidim-core/app/packs/stylesheets/decidim/_flash.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_flash.scss
@@ -1,8 +1,10 @@
 .flash {
   @apply flex justify-start items-center gap-4 rounded border-2 border-secondary text-secondary my-4 p-4 bg-secondary/5;
 
-  svg {
-    @apply w-12 h-12 fill-current flex-none;
+  &__icon {
+    svg {
+      @apply w-12 h-12 fill-current flex-none;
+    }
   }
 
   &__message {


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

There's a bug in the flash icons, where some are shown too big. This PR fixes it.

While I was here I've also didn't like the format of the methods comments so I changed them to the YARD format  
 

#### Testing

1. Go to http://localhost:3000/create_initiative/select_initiative_type 
2. See that the icon size is correct (see screenshot)
3. Go to another flash/announcement with big icons and see that still has big icons. For instance go to http://localhost:3000/admin/organization/edit and click in the "Update" button

### :camera: Screenshots
![Screenshot of the "Select initiative" page with the bug](https://github.com/decidim/decidim/assets/717367/abb91845-77bc-481f-868d-a26c9a9f68f5)

#### After 
![Screenshot of the "Select initiative" page fixed](https://github.com/decidim/decidim/assets/717367/dce2fa42-b9a0-4abc-a616-43c84911aae3)

:hearts: Thank you!
