### PR TITLE
Remove redesign warning in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,3 @@
-<!--
-NOTE: We are in the middle of a big redesign of the frontend.
-That could mean that your PR will not get through on the next few months.
-Please see https://github.com/decidim/decidim/discussions/9512
--->
-
 #### :tophat: What? Why?
 *Please describe your pull request.*
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR removes the warning from PR template.

```
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->
```

:hearts: Thank you!
