### PR TITLE
Fix button in initiatives' commitee members

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_committee_members.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_committee_members.html.erb
@@ -27,10 +27,14 @@
       <div class="profile__group__list">
         <%= card_for request.user %>
         <% if allowed_to? :approve, :initiative_committee_member, initiative: current_initiative, request: request %>
-          <%= icon_link_to "forbid-line",
-                           approve_initiative_committee_request_path(current_initiative, request),
-                           t(".approve"),
-                           class: "action-icon--check" %>
+          <%= link_to(
+                  approve_initiative_committee_request_path(current_initiative, request),
+                  data: { confirm: t(".confirm_approve") },
+                  class: "button button__sm button__transparent-secondary"
+                ) do %>
+                  <span><%= t(".approve") %></span>
+                  <%= icon "check-line" %>
+                <% end %>
         <% end %>
         <% if allowed_to? :revoke, :initiative_committee_member, initiative: current_initiative, request: request %>
           <%= link_to(
@@ -39,7 +43,7 @@
                   data: { confirm: t(".confirm_revoke") },
                   class: "button button__sm button__transparent-secondary"
                 ) do %>
-                  <span><%= t("decidim.group_admins.actions.demote_admin") %></span>
+                  <span><%= t(".revoke") %></span>
                   <%= icon "forbid-line" %>
                 <% end %>
         <% end %>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -465,10 +465,12 @@ en:
             other: and %{count} more people
         committee_members:
           approve: Approve
-          confirm_revoke: Are you sure?
+          confirm_approve: Are you sure you want to approve this member?
+          confirm_revoke: Are you sure you want to revoke this member?
           invite_to_committee_help: Share this link to invite other participants to the promoter committee.
           link: Link
           no_members_yet: There are no members in the promoter committee.
+          revoke: Revoke
           title: Committee members
         count:
           title:


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing the design it was detected that the "Approve" committe member button in the Initiative edit page was broken.

This PR fixes it. 

#### Testing

1. Create an initiative type that requires a committee member
2. Create an initiative of this type
3. In another browser, sign in with another user (i.e. user@example.org) and request to be a member of this initiative
4. With the author user, edit the Initiative
5. See the "Committee members" section 

### :camera: Screenshots

#### Before

![Screenshot of the form broken](https://github.com/decidim/decidim/assets/717367/2947a325-a570-43f7-9019-14712c6c1282)

#### After 
![Screenshot of the form fixed](https://github.com/decidim/decidim/assets/717367/9a057697-3749-4108-b671-9a367213be3d)

:hearts: Thank you!
