### PR TITLE
Add titles in initiatives' public pages

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -1,3 +1,4 @@
+<% add_decidim_page_title(t("new", scope: "decidim.initiatives.create_initiative.select_initiative_type")) %>
 <% announcement_body = capture do %>
   <div class="max-w-full prose">
     <%= t("fill_data_help", scope: "decidim.initiatives.create_initiative.fill_data").html_safe %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
@@ -1,3 +1,4 @@
+<% add_decidim_page_title(t("new", scope: "decidim.initiatives.create_initiative.select_initiative_type")) %>
 <% content_for :back_link do %>
   <%= link_to :back do %>
     <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
@@ -1,3 +1,4 @@
+<% add_decidim_page_title(t("new", scope: "decidim.initiatives.create_initiative.select_initiative_type")) %>
 <% announcement_body = capture do %>
   <%= t ".individual_help_text", committee_size: current_initiative.minimum_committee_members %>
   <%= link_to t(".more_information"), decidim.page_path("initiatives"), target: "_blank", class: "button button__sm button__text-secondary block text-left" %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
@@ -1,3 +1,4 @@
+<% add_decidim_page_title(t("new", scope: "decidim.initiatives.create_initiative.select_initiative_type")) %>
 <% default_type = available_initiative_types.first %>
 <% announcement_body = capture do %>
   <%= t("select_initiative_type_help", scope: "decidim.initiatives.create_initiative.select_initiative_type") %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/edit.html.erb
@@ -1,4 +1,4 @@
-<% add_decidim_page_title(action_name) %>
+<% add_decidim_page_title(t("title", scope: "decidim.initiatives.edit")) %>
 
 <%= render layout:"layouts/decidim/shared/layout_center" do %>
   <div class="text-center py-10">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/index.html.erb
@@ -1,3 +1,4 @@
+<% add_decidim_page_title(component_name) %>
 <%= append_javascript_pack_tag "decidim_initiatives" %>
 <%= append_stylesheet_pack_tag "decidim_initiatives", media: "all" %>
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing Initiatives, I noticed that there are some missing document titles. This PR adds them  

This is reproducible in v0.27 so we would need to backport this one 

#### Testing

Navigate to /initiatives, create an initiative and follow the wizard. Afterwards edit it. See that you always have a page title that corresponds with the `h1` 

:hearts: Thank you!
