### PR TITLE
Improve layout of initiatives' print page

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/print.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/print.html.erb
@@ -6,60 +6,60 @@
 
     <%= current_organization.name %>
   </div>
-  <h3 class="print-section-title"><%= t ".section" %></h3>
+  <h3 class="print-section-title"><%= t "section", scope: "decidim.initiatives.initiatives.print" %></h3>
   <div class="initiative-print-title">
-    <%= t ".general_title" %>
+    <%= t "general_title", scope: "decidim.initiatives.initiatives.print" %>
   </div>
 
   <div class="print-table">
     <div class="print-table-header">
-      <%= t ".author_title" %>
+      <%= t "author_title", scope: "decidim.initiatives.initiatives.print" %>
     </div>
 
     <div class="print-table-row">
       <div class="print-table-cell">
-        <div class="cell-header"><%= t ".id_number" %></div>
-        <div class="cell-content"></div>
-      </div>
-    </div>
-
-    <div class="print-table-row">
-      <div class="print-table-cell">
-        <div class="cell-header"><%= t ".full_name" %></div>
+        <div class="cell-header"><%= t "id_number", scope: "decidim.initiatives.initiatives.print" %></div>
         <div class="cell-content"></div>
       </div>
     </div>
 
     <div class="print-table-row">
       <div class="print-table-cell">
-        <div class="cell-header"><%= t ".address" %></div>
+        <div class="cell-header"><%= t "full_name", scope: "decidim.initiatives.initiatives.print" %></div>
+        <div class="cell-content"></div>
+      </div>
+    </div>
+
+    <div class="print-table-row">
+      <div class="print-table-cell">
+        <div class="cell-header"><%= t "address", scope: "decidim.initiatives.initiatives.print" %></div>
         <div class="cell-content"></div>
       </div>
     </div>
 
     <div class="print-table-row">
       <div class="print-table-cell w33">
-        <div class="cell-header"><%= t ".city" %></div>
+        <div class="cell-header"><%= t "city", scope: "decidim.initiatives.initiatives.print" %></div>
         <div class="cell-content"></div>
       </div>
       <div class="print-table-cell w33">
-        <div class="cell-header"><%= t ".province" %></div>
+        <div class="cell-header"><%= t "province", scope: "decidim.initiatives.initiatives.print" %></div>
         <div class="cell-content"></div>
       </div>
       <div class="print-table-cell w33">
-        <div class="cell-header"><%= t ".postal_code" %></div>
+        <div class="cell-header"><%= t "postal_code", scope: "decidim.initiatives.initiatives.print" %></div>
         <div class="cell-content"></div>
       </div>
     </div>
 
     <div class="print-table-row">
       <div class="print-table-cell w33">
-        <div class="cell-header"><%= t ".phone_number" %></div>
+        <div class="cell-header"><%= t "phone_number", scope: "decidim.initiatives.initiatives.print" %></div>
         <div class="cell-content"></div>
       </div>
 
       <div class="print-table-cell">
-        <div class="cell-header"><%= t ".email" %></div>
+        <div class="cell-header"><%= t "email", scope: "decidim.initiatives.initiatives.print" %></div>
         <div class="cell-content"></div>
       </div>
     </div>
@@ -67,13 +67,13 @@
   <br><br>
   <div class="print-table">
     <div class="print-table-header">
-      <%= t ".members_header" %>
+      <%= t "members_header", scope: "decidim.initiatives.initiatives.print" %>
     </div>
 
     <div class="print-table-row">
-      <div class="print-table-cell w33"><%= t ".full_name" %></div>
-      <div class="print-table-cell w33"><%= t ".id_number" %></div>
-      <div class="print-table-cell w33"><%= t ".address" %></div>
+      <div class="print-table-cell w33"><%= t "full_name", scope: "decidim.initiatives.initiatives.print" %></div>
+      <div class="print-table-cell w33"><%= t "id_number", scope: "decidim.initiatives.initiatives.print" %></div>
+      <div class="print-table-cell w33"><%= t "address", scope: "decidim.initiatives.initiatives.print" %></div>
     </div>
 
     <% 4.times do %>
@@ -85,18 +85,18 @@
     <% end %>
   </div>
 
-  <h2 class="print-section-title"><%= t ".initiative.type" %></h2>
+  <h2 class="print-section-title"><%= t "initiative.type", scope: "decidim.initiatives.initiatives.print" %></h2>
   <%= translated_attribute(current_initiative.type.title) %>
 
-  <h2 class="print-section-title"><%= t ".initiative.title" %></h2>
+  <h2 class="print-section-title"><%= t "initiative.title", scope: "decidim.initiatives.initiatives.print" %></h2>
   <%= translated_attribute(current_initiative.title) %>
 
-  <h2 class="print-section-title"><%= t ".initiative.description" %></h2>
+  <h2 class="print-section-title"><%= t "initiative.description", scope: "decidim.initiatives.initiatives.print" %></h2>
   <%= decidim_sanitize_editor translated_attribute(current_initiative.description) %>
 
   <div class="print-table">
     <div class="print-table-header">
-      <%= t ".initiative.attachments" %>
+      <%= t "initiative.attachments", scope: "decidim.initiatives.initiatives.print" %>
     </div>
 
     <div class="print-table-row">
@@ -144,15 +144,16 @@
   <br>
   <div class="print-table no-border">
     <div class="print-table-row no-border">
-      <div class="print-table-cell w50 no-border" style="font-weight: bold"><%= t ".place_date" %></div>
-      <div class="print-table-cell w50 no-border" style="font-weight: bold"><%= t ".signature" %></div>
+      <div class="print-table-cell w50 no-border" style="font-weight: bold"><%= t "place_date", scope: "decidim.initiatives.initiatives.print" %></div>
+      <div class="print-table-cell w50 no-border" style="font-weight: bold"><%= t "signature", scope: "decidim.initiatives.initiatives.print" %></div>
     </div>
   </div>
 
   <p class="print-initiative-legal-text">
-    <%= t ".legal_text" %>
+    <%= t "legal_text", scope: "decidim.initiatives.initiatives.print" %>
   </p>
 
   <a href="#" onclick="window.print();return false;" class="button button__sm button__secondary w-full print-button"><%= t ".print" %></a>
   <%= append_stylesheet_pack_tag "decidim_initiatives_print" %>
+
 </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/print.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/print.html.erb
@@ -154,7 +154,7 @@
     <%= t "legal_text", scope: "decidim.initiatives.initiatives.print" %>
     </p>
 
-    <a href="#" onclick="window.print();return false;" class="button button__sm button__secondary w-full print-button"><%= t "print", scope: "decidim.initiatives.initiatives.print" %></a>
+    <a href="#" onclick="window.print();return false;" class="button button__lg button__secondary mt-4 print-button"><%= t "print", scope: "decidim.initiatives.initiatives.print" %></a>
     <%= append_stylesheet_pack_tag "decidim_initiatives_print" %>
 
   </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/print.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/print.html.erb
@@ -1,159 +1,161 @@
-<div class="wrapper">
-  <div class="initiative-letterhead">
-    <% if current_organization.logo.present? %>
-      <%= image_tag current_organization.attached_uploader(:logo).path(variant: :medium), title: current_organization.name %>
-    <% end %>
+<%= render layout: "layouts/decidim/shared/layout_center", locals: { columns: 10 } do %>
+  <div class="pt-10">
+    <div class="initiative-letterhead">
+      <% if current_organization.logo.present? %>
+        <%= image_tag current_organization.attached_uploader(:logo).path(variant: :medium), title: current_organization.name %>
+      <% end %>
 
-    <%= current_organization.name %>
-  </div>
-  <h3 class="print-section-title"><%= t "section", scope: "decidim.initiatives.initiatives.print" %></h3>
-  <div class="initiative-print-title">
-    <%= t "general_title", scope: "decidim.initiatives.initiatives.print" %>
-  </div>
-
-  <div class="print-table">
-    <div class="print-table-header">
-      <%= t "author_title", scope: "decidim.initiatives.initiatives.print" %>
+      <%= current_organization.name %>
+    </div>
+    <h3 class="print-section-title"><%= t "section", scope: "decidim.initiatives.initiatives.print" %></h3>
+    <div class="initiative-print-title">
+      <%= t "general_title", scope: "decidim.initiatives.initiatives.print" %>
     </div>
 
-    <div class="print-table-row">
-      <div class="print-table-cell">
-        <div class="cell-header"><%= t "id_number", scope: "decidim.initiatives.initiatives.print" %></div>
-        <div class="cell-content"></div>
-      </div>
-    </div>
-
-    <div class="print-table-row">
-      <div class="print-table-cell">
-        <div class="cell-header"><%= t "full_name", scope: "decidim.initiatives.initiatives.print" %></div>
-        <div class="cell-content"></div>
-      </div>
-    </div>
-
-    <div class="print-table-row">
-      <div class="print-table-cell">
-        <div class="cell-header"><%= t "address", scope: "decidim.initiatives.initiatives.print" %></div>
-        <div class="cell-content"></div>
-      </div>
-    </div>
-
-    <div class="print-table-row">
-      <div class="print-table-cell w33">
-        <div class="cell-header"><%= t "city", scope: "decidim.initiatives.initiatives.print" %></div>
-        <div class="cell-content"></div>
-      </div>
-      <div class="print-table-cell w33">
-        <div class="cell-header"><%= t "province", scope: "decidim.initiatives.initiatives.print" %></div>
-        <div class="cell-content"></div>
-      </div>
-      <div class="print-table-cell w33">
-        <div class="cell-header"><%= t "postal_code", scope: "decidim.initiatives.initiatives.print" %></div>
-        <div class="cell-content"></div>
-      </div>
-    </div>
-
-    <div class="print-table-row">
-      <div class="print-table-cell w33">
-        <div class="cell-header"><%= t "phone_number", scope: "decidim.initiatives.initiatives.print" %></div>
-        <div class="cell-content"></div>
+    <div class="print-table">
+      <div class="print-table-header">
+        <%= t "author_title", scope: "decidim.initiatives.initiatives.print" %>
       </div>
 
-      <div class="print-table-cell">
-        <div class="cell-header"><%= t "email", scope: "decidim.initiatives.initiatives.print" %></div>
-        <div class="cell-content"></div>
-      </div>
-    </div>
-  </div>
-  <br><br>
-  <div class="print-table">
-    <div class="print-table-header">
-      <%= t "members_header", scope: "decidim.initiatives.initiatives.print" %>
-    </div>
-
-    <div class="print-table-row">
-      <div class="print-table-cell w33"><%= t "full_name", scope: "decidim.initiatives.initiatives.print" %></div>
-      <div class="print-table-cell w33"><%= t "id_number", scope: "decidim.initiatives.initiatives.print" %></div>
-      <div class="print-table-cell w33"><%= t "address", scope: "decidim.initiatives.initiatives.print" %></div>
-    </div>
-
-    <% 4.times do %>
       <div class="print-table-row">
-        <div class="print-table-cell w33"></div>
-        <div class="print-table-cell w33"></div>
-        <div class="print-table-cell w33"></div>
+        <div class="print-table-cell">
+          <div class="cell-header"><%= t "id_number", scope: "decidim.initiatives.initiatives.print" %></div>
+          <div class="cell-content"></div>
+        </div>
       </div>
-    <% end %>
-  </div>
 
-  <h2 class="print-section-title"><%= t "initiative.type", scope: "decidim.initiatives.initiatives.print" %></h2>
-  <%= translated_attribute(current_initiative.type.title) %>
-
-  <h2 class="print-section-title"><%= t "initiative.title", scope: "decidim.initiatives.initiatives.print" %></h2>
-  <%= translated_attribute(current_initiative.title) %>
-
-  <h2 class="print-section-title"><%= t "initiative.description", scope: "decidim.initiatives.initiatives.print" %></h2>
-  <%= decidim_sanitize_editor translated_attribute(current_initiative.description) %>
-
-  <div class="print-table">
-    <div class="print-table-header">
-      <%= t "initiative.attachments", scope: "decidim.initiatives.initiatives.print" %>
-    </div>
-
-    <div class="print-table-row">
-      <div class="print-table-cell checkbox-cell"></div>
-      <div class="print-table-cell">
-        <div class="cell-content"></div>
+      <div class="print-table-row">
+        <div class="print-table-cell">
+          <div class="cell-header"><%= t "full_name", scope: "decidim.initiatives.initiatives.print" %></div>
+          <div class="cell-content"></div>
+        </div>
       </div>
-    </div>
 
-    <div class="print-table-row">
-      <div class="print-table-cell checkbox-cell"></div>
-      <div class="print-table-cell">
-        <div class="cell-content"><div class="cell-content"></div></div>
+      <div class="print-table-row">
+        <div class="print-table-cell">
+          <div class="cell-header"><%= t "address", scope: "decidim.initiatives.initiatives.print" %></div>
+          <div class="cell-content"></div>
+        </div>
       </div>
-    </div>
 
-    <div class="print-table-row">
-      <div class="print-table-cell checkbox-cell"></div>
-      <div class="print-table-cell">
-        <div class="cell-content"></div>
+      <div class="print-table-row">
+        <div class="print-table-cell w33">
+          <div class="cell-header"><%= t "city", scope: "decidim.initiatives.initiatives.print" %></div>
+          <div class="cell-content"></div>
+        </div>
+        <div class="print-table-cell w33">
+          <div class="cell-header"><%= t "province", scope: "decidim.initiatives.initiatives.print" %></div>
+          <div class="cell-content"></div>
+        </div>
+        <div class="print-table-cell w33">
+          <div class="cell-header"><%= t "postal_code", scope: "decidim.initiatives.initiatives.print" %></div>
+          <div class="cell-content"></div>
+        </div>
       </div>
-    </div>
 
-    <div class="print-table-row">
-      <div class="print-table-cell checkbox-cell"></div>
-      <div class="print-table-cell">
-        <div class="cell-content"></div>
-      </div>
-    </div>
+      <div class="print-table-row">
+        <div class="print-table-cell w33">
+          <div class="cell-header"><%= t "phone_number", scope: "decidim.initiatives.initiatives.print" %></div>
+          <div class="cell-content"></div>
+        </div>
 
-    <div class="print-table-row">
-      <div class="print-table-cell checkbox-cell"></div>
-      <div class="print-table-cell">
-        <div class="cell-content"></div>
+        <div class="print-table-cell">
+          <div class="cell-header"><%= t "email", scope: "decidim.initiatives.initiatives.print" %></div>
+          <div class="cell-content"></div>
+        </div>
       </div>
     </div>
+    <br><br>
+    <div class="print-table">
+      <div class="print-table-header">
+        <%= t "members_header", scope: "decidim.initiatives.initiatives.print" %>
+      </div>
 
-    <div class="print-table-row">
-      <div class="print-table-cell checkbox-cell"></div>
-      <div class="print-table-cell">
-        <div class="cell-content"></div>
+      <div class="print-table-row">
+        <div class="print-table-cell w33"><%= t "full_name", scope: "decidim.initiatives.initiatives.print" %></div>
+        <div class="print-table-cell w33"><%= t "id_number", scope: "decidim.initiatives.initiatives.print" %></div>
+        <div class="print-table-cell w33"><%= t "address", scope: "decidim.initiatives.initiatives.print" %></div>
+      </div>
+
+      <% 4.times do %>
+        <div class="print-table-row">
+          <div class="print-table-cell w33"></div>
+          <div class="print-table-cell w33"></div>
+          <div class="print-table-cell w33"></div>
+        </div>
+      <% end %>
+    </div>
+
+    <h2 class="print-section-title"><%= t "initiative.type", scope: "decidim.initiatives.initiatives.print" %></h2>
+    <%= translated_attribute(current_initiative.type.title) %>
+
+    <h2 class="print-section-title"><%= t "initiative.title", scope: "decidim.initiatives.initiatives.print" %></h2>
+    <%= translated_attribute(current_initiative.title) %>
+
+    <h2 class="print-section-title"><%= t "initiative.description", scope: "decidim.initiatives.initiatives.print" %></h2>
+    <%= decidim_sanitize_editor translated_attribute(current_initiative.description) %>
+
+    <div class="print-table">
+      <div class="print-table-header">
+        <%= t "initiative.attachments", scope: "decidim.initiatives.initiatives.print" %>
+      </div>
+
+      <div class="print-table-row">
+        <div class="print-table-cell checkbox-cell"></div>
+        <div class="print-table-cell">
+          <div class="cell-content"></div>
+        </div>
+      </div>
+
+      <div class="print-table-row">
+        <div class="print-table-cell checkbox-cell"></div>
+        <div class="print-table-cell">
+          <div class="cell-content"><div class="cell-content"></div></div>
+        </div>
+      </div>
+
+      <div class="print-table-row">
+        <div class="print-table-cell checkbox-cell"></div>
+        <div class="print-table-cell">
+          <div class="cell-content"></div>
+        </div>
+      </div>
+
+      <div class="print-table-row">
+        <div class="print-table-cell checkbox-cell"></div>
+        <div class="print-table-cell">
+          <div class="cell-content"></div>
+        </div>
+      </div>
+
+      <div class="print-table-row">
+        <div class="print-table-cell checkbox-cell"></div>
+        <div class="print-table-cell">
+          <div class="cell-content"></div>
+        </div>
+      </div>
+
+      <div class="print-table-row">
+        <div class="print-table-cell checkbox-cell"></div>
+        <div class="print-table-cell">
+          <div class="cell-content"></div>
+        </div>
       </div>
     </div>
-  </div>
-  <br>
-  <div class="print-table no-border">
-    <div class="print-table-row no-border">
-      <div class="print-table-cell w50 no-border" style="font-weight: bold"><%= t "place_date", scope: "decidim.initiatives.initiatives.print" %></div>
-      <div class="print-table-cell w50 no-border" style="font-weight: bold"><%= t "signature", scope: "decidim.initiatives.initiatives.print" %></div>
+    <br>
+    <div class="print-table no-border">
+      <div class="print-table-row no-border">
+        <div class="print-table-cell w50 no-border" style="font-weight: bold"><%= t "place_date", scope: "decidim.initiatives.initiatives.print" %></div>
+        <div class="print-table-cell w50 no-border" style="font-weight: bold"><%= t "signature", scope: "decidim.initiatives.initiatives.print" %></div>
+      </div>
     </div>
-  </div>
 
-  <p class="print-initiative-legal-text">
+    <p class="print-initiative-legal-text">
     <%= t "legal_text", scope: "decidim.initiatives.initiatives.print" %>
-  </p>
+    </p>
 
-  <a href="#" onclick="window.print();return false;" class="button button__sm button__secondary w-full print-button"><%= t ".print" %></a>
-  <%= append_stylesheet_pack_tag "decidim_initiatives_print" %>
+    <a href="#" onclick="window.print();return false;" class="button button__sm button__secondary w-full print-button"><%= t "print", scope: "decidim.initiatives.initiatives.print" %></a>
+    <%= append_stylesheet_pack_tag "decidim_initiatives_print" %>
 
-</div>
+  </div>
+<% end %>


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?

While reviewing #11802, I have some suggestions to make in the Initiatives print page. 

I tried to make the commits granular so it's easy to review each of these changes 
 

#### Testing

1. Go to the print page of an initiative. For instance:  http://localhost:3000/initiatives/i-4/print 

### :camera: Screenshots

#### Before

![Screenshot of the initiative print page (before)](https://github.com/decidim/decidim/assets/717367/d9d7b64f-4c56-4b68-a7d1-da6c60fcc612)

#### After
![Screenshot of the initiative print page (after)](https://github.com/decidim/decidim/assets/717367/dd47c8b6-c2b8-4bc1-94e3-c028577407bd)

:hearts: Thank you!
