### PR TITLE
Redesign: Flash close button on password change field

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_flash.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_flash.scss
@@ -18,7 +18,7 @@
   }
 
   .close-button {
-    @apply ml-auto self-start;
+    @apply ml-auto;
 
     svg {
       @apply w-5 h-5 fill-current;


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
By removing the ```self-start``` in ```decidim-core/app/packs/stylesheets/decidim/_flash.scss``` on the ```.close-button```class, the close button changes to be more centred.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11810 

#### Testing
1. Login
2. Head over to account
3. Find change your password
4. In the fields asking to confirm your "new" and "current", make sure they're both different from each other.
5. Click change
6. See the alert in the header with a close button centered.

### :camera: Screenshots

<img width="1440" alt="Screenshot 2023-10-24 at 10 40 25" src="https://github.com/decidim/decidim/assets/101816158/b21f37ea-7434-4616-b890-fbc52fb01e23">


:hearts: Thank you!
