### PR TITLE
Tune fields in initiatives' new and edit forms

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -10,28 +10,7 @@
   <div class="form__wrapper">
     <%= form_required_explanation %>
 
-    <% if single_initiative_type? %>
-      <%= f.hidden_field :type_id %>
-    <% else %>
-      <%= f.select :type_id,
-                   initiative_type_options,
-                   {},
-                   {
-                     disabled: !@form.signature_type_updatable?,
-                     "data-scope-selector": "initiative_scope_id",
-                     "data-scope-id": f.object.scope_id.to_s,
-                     "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url,
-                     "data-signature-types-selector": "initiative_signature_type",
-                     "data-signature-type": current_initiative&.signature_type.presence || initiative_type.signature_type,
-                     "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url
-                   } %>
-    <% end %>
-
-    <% unless single_initiative_type? %>
-      <label for="type_description"><%= t ".initiative_type" %>
-        <%= text_field_tag :type_description, strip_tags(translated_attribute(initiative_type.title)), readonly: true %>
-      </label>
-    <% end %>
+    <%= f.hidden_field :type_id %>
 
     <%= f.text_field :title, autofocus: true, value: translated_attribute(f.object.title) %>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
@@ -1,15 +1,5 @@
 <%= form_required_explanation %>
 
-<%= form.text_field :title, autofocus: true, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.title) %>
-
-<%= text_editor_for(form, :description, toolbar: :content, lines: 8, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.description)) %>
-
-<%= form.text_field :hashtag, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative) %>
-
-<% if @form.state_updatable? %>
-  <%= form.select :state, Decidim::Initiative.states.keys.map { |state| [I18n.t(state, scope: "decidim.initiatives.admin_states"), state] }, {} %>
-<% end %>
-
 <% unless single_initiative_type? %>
   <%= form.select :type_id,
                   initiative_type_options,
@@ -23,6 +13,16 @@
                     "data-signature-type": current_initiative.signature_type,
                     "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url
                   } %>
+<% end %>
+
+<%= form.text_field :title, autofocus: true, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.title) %>
+
+<%= text_editor_for(form, :description, toolbar: :content, lines: 8, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.description)) %>
+
+<%= form.text_field :hashtag, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative) %>
+
+<% if @form.state_updatable? %>
+  <%= form.select :state, Decidim::Initiative.states.keys.map { |state| [I18n.t(state, scope: "decidim.initiatives.admin_states"), state] }, {} %>
 <% end %>
 
 <%= form.select :scope_id, @form.available_scopes.map { |scope| [translated_attribute(scope.scope_name), scope.scope&.id] }, {}, { disabled: !@form.state_updatable? } %>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -359,7 +359,6 @@ en:
           back: Back
           continue: Continue
           fill_data_help: "<ul> <li>Review the content of your initiative. Is your title easy to understand? Is the objective of your initiative clear?</li> <li>You have to choose the type of signature. In-person, online or a combination of both</li> <li>Which is the geographic scope of the initiative?</li> </ul>"
-          initiative_type: Initiative type
           more_information: "(More information)"
           select_area: Select an area
           select_scope: Select a scope

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -470,9 +470,9 @@ describe "Initiative", type: :system do
           first("button.card__highlight").click
         end
 
-        it "shows select input for initiative_type" do
-          expect(page).to have_content("Type")
-          expect(find(:xpath, "//select[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
+        it "does not show the select input for initiative_type" do
+          expect(page).not_to have_content("Type")
+          expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
         end
 
         it "have fields for title and description" do
@@ -582,9 +582,9 @@ describe "Initiative", type: :system do
             end
           end
 
-          it "shows select input for initiative_type" do
-            expect(page).to have_content("Type")
-            expect(find(:xpath, "//select[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
+          it "does not show the select input for initiative_type" do
+            expect(page).not_to have_content("Type")
+            expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
           end
 
           it "shows input for signature collection type" do
@@ -604,7 +604,7 @@ describe "Initiative", type: :system do
             it "hides and automatically selects the values" do
               expect(page).not_to have_content("Signature collection type")
               expect(page).not_to have_content("Scope")
-              expect(find(:xpath, "//select[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
+              expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
               expect(find(:xpath, "//input[@id='initiative_signature_type']", visible: :all).value).to eq("offline")
             end
           end


### PR DESCRIPTION
#### :tophat: What? Why?

On one of the last @decidim/product meetings we saw some inconsistencies in the current initiatives' creation form and the fields. 

This PR fixes two small errors that we've seen: 

1. When creating an Initiative, I have two steps initially: one for choosing the initiative type, and then for filling out the form with the metadata (title, description, etc). The problem is that in this second field I can change the initiative type (that I've just selected!). Oh! and I have the same field but disabled (??). This PR removes this field altogether. 
2. Then, when editing the initiative, I can change the Initiative Type. This isn't a problem, but the field is in the middle of the others. This PR makes it the first field in the edit form (as it was the first information when filling out the initiative) 

#### Testing

Initiative creation and edit should work well.
All the specs should pass.

### :camera: Screenshots

#### Before

##### New initiative
![Screenshot of the new form of an initiative (with the bug)](https://github.com/decidim/decidim/assets/717367/0869bee4-50ea-41e4-bba8-a19f53f2087c)

##### Edit initiative
![Screenshot of the edit form of an initiative (with the bug)](https://github.com/decidim/decidim/assets/717367/bde6ad10-c5d3-444e-a9b3-37840809e8c4)

#### After 

##### New initiative
![Screenshot of the new form of an initiative (fixed)](https://github.com/decidim/decidim/assets/717367/0b4eb0b8-bf1a-47e1-b3a5-6cb067b68979)

##### Edit initiative
![Screenshot of the edit form of an initiative (fixed)](https://github.com/decidim/decidim/assets/717367/7157cdf0-312c-411c-a491-3bd107f05e73)

:hearts: Thank you!
