### PR TITLE
Change order and style in initiatives' page sidebar

### DIFF
--- a/decidim-initiatives/app/packs/stylesheets/initiatives.scss
+++ b/decidim-initiatives/app/packs/stylesheets/initiatives.scss
@@ -142,14 +142,6 @@
   &__aside__element-title {
     @apply inline-block text-gray-2 font-bold text-md align-middle;
   }
-
-  &__aside__element__signature {
-    @apply bg-white rounded md:py-4 md:px-6;
-  }
-
-  &__aside__element__signature-title {
-    @apply text-sm text-gray-2 font-semibold mb-4 block;
-  }
 }
 
 #initiatives {

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -39,28 +39,6 @@ edit_link(
       <%= cell("decidim/nav_links", initiative_nav_items(current_initiative)) %>
     </section>
 
-    <% if current_initiative.offline_signature_type? || current_initiative.online_signature_type? %>
-      <section class="layout-aside__section initiative__aside__element__signature">
-        <span class="initiative__aside__element__signature-title">
-          <%= t("signature_collection", scope: "decidim.initiatives.initiatives.show") %>
-        </span>
-        <div>
-          <% if current_initiative.offline_signature_type? %>
-            <%= icon "community-line", class: "fill-gray inline-block" %>
-            <span class="text-md font-normal text-gray-2 inline-block align-middle ml–2">
-              <%= t("offline", scope: "activemodel.attributes.initiative.signature_type_values") %>
-            </span>
-          <% end %>
-          <% if current_initiative.online_signature_type? %>
-            <%= icon "device-line", class: "fill-gray inline-block" %>
-            <span class="text-md font-normal text-gray-2 inline-block align-middle ml–2">
-              <%= t("online", scope: "activemodel.attributes.initiative.signature_type_values") %>
-            </span>
-          <% end %>
-        </div>
-      </section>
-    <% end %>
-
     <% if current_initiative.type.promoting_committee_enabled? && current_user&.admin? %>
       <div class="layout-aside__section">
         <div class="initiative__aside__element__committee">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -61,6 +61,36 @@ edit_link(
       </section>
     <% end %>
 
+    <% if current_initiative.type.promoting_committee_enabled? && current_user&.admin? %>
+      <div class="layout-aside__section">
+        <div class="initiative__aside__element__committee">
+          <%= icon "account-circle-line", class: "fill-gray inline-block" %>
+          <span class="ml-2 initiative__aside__element-title">
+            <%= t("title", scope: "decidim.initiatives.admin.committee_requests.index") %>
+          </span>
+          <div class="ml-auto fill-secondary inline-block">
+            <input id="urlShareLink-committee" type="text" class="!hidden" value="<%= decidim_initiatives.new_initiative_committee_request_url(current_initiative) %>" readonly>
+            <button type="button" class="button button__sm button__text-secondary" data-clipboard-copy="#urlShareLink-committee">
+              <%= render_committee_tooltip %>
+              <span class="sr-only"><%= t("decidim.shared.share_modal.copy_share_link") %></span>
+            </button>
+          </div>
+        </div>
+          <% if current_initiative.committee_members.empty? %>
+            <span class="initiative__aside__element__data-text">
+              <%= t("no_members_yet", scope: "decidim.initiatives.admin.committee_requests.index") %>
+            </span>
+          <% end %>
+          <% current_initiative.committee_members.each do |request| %>
+            <div class="author" data-id="<%= request.id %>">
+              <div class="profile__group__list">
+                <%= card_for request.user %>
+              </div>
+            </div>
+          <% end %>
+      </div>
+    <% end %>
+
     <section class="layout-aside__section">
       <div class="mb-6">
         <%= icon "apps-line", class: "fill-gray inline-block" %>
@@ -111,36 +141,6 @@ edit_link(
         </div>
       <% end %>
     </section>
-
-    <% if current_initiative.type.promoting_committee_enabled? && current_user&.admin? %>
-      <div class="layout-aside__section">
-        <div class="initiative__aside__element__committee">
-          <%= icon "account-circle-line", class: "fill-gray inline-block" %>
-          <span class="ml-2 initiative__aside__element-title">
-            <%= t("title", scope: "decidim.initiatives.admin.committee_requests.index") %>
-          </span>
-          <div class="ml-auto fill-secondary inline-block">
-            <input id="urlShareLink-committee" type="text" class="!hidden" value="<%= decidim_initiatives.new_initiative_committee_request_url(current_initiative) %>" readonly>
-            <button type="button" class="button button__sm button__text-secondary" data-clipboard-copy="#urlShareLink-committee">
-              <%= render_committee_tooltip %>
-              <span class="sr-only"><%= t("decidim.shared.share_modal.copy_share_link") %></span>
-            </button>
-          </div>
-        </div>
-          <% if current_initiative.committee_members.empty? %>
-            <span class="initiative__aside__element__data-text">
-              <%= t("no_members_yet", scope: "decidim.initiatives.admin.committee_requests.index") %>
-            </span>
-          <% end %>
-          <% current_initiative.committee_members.each do |request| %>
-            <div class="author" data-id="<%= request.id %>">
-              <div class="profile__group__list">
-                <%= card_for request.user %>
-              </div>
-            </div>
-          <% end %>
-      </div>
-    <% end %>
   </section>
 <% end %>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -86,6 +86,24 @@ edit_link(
         </span>
       </div>
 
+      <% if current_initiative.offline_signature_type? || current_initiative.online_signature_type? %>
+        <div class="initiative__aside__element__data">
+          <p class="initiative__aside__element__data-title">
+          <%= t("signature_collection", scope: "decidim.initiatives.initiatives.show") %>
+          </p>
+          <span class="initiative__aside__element__data-text">
+            <span class="text-sm font-normal text-gray-2 block">
+              <% if current_initiative.offline_signature_type? %>
+                <%= t("offline", scope: "activemodel.attributes.initiative.signature_type_values") %>
+              <% end %>
+              <% if current_initiative.online_signature_type? %>
+                <%= t("online", scope: "activemodel.attributes.initiative.signature_type_values") %>
+              <% end %>
+            </span>
+          </span>
+        </div>
+      <% end %>
+
       <div class="initiative__aside__element__data">
         <p class="initiative__aside__element__data-title">
           <%= t("scope", scope: "decidim.initiatives.initiatives.show") %>


### PR DESCRIPTION
#### :tophat: What? Why?

On one of the last @decidim/product meetings, we saw some inconsistencies in the current initiatives show page and how we present some information in the sidebar.

This PR fixes these inconsistencies: 

1. Remove the "Signature type" block, as we feel there are just too many types of things in this sidebar
2. Integrate the "Signature type" in the "Initiative data" block
3. Move the "Committee members" block so it isn't missed

#### Testing

The sidebar should show the information differently, but the same information should be available 

### :camera: Screenshots

#### Before 
![Screenshot of the initiatives show page sidebar](https://github.com/decidim/decidim/assets/717367/016a993c-f0a2-48ee-a5db-06171e856453)

#### After
![Screenshot of the initiatives show page sidebar](https://github.com/decidim/decidim/assets/717367/3f8ff0e9-a9bc-4b4c-80b1-789e68fa47e8)

:hearts: Thank you!
