### PR TITLE
Bump codecov-action from v3 to v4.0.0-beta.3

### DIFF
--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -98,7 +98,7 @@ jobs:
         working-directory: ${{ env.DECIDIM_MODULE }}
         env:
           SIMPLECOV: "true"
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4.0.0-beta.3
         name: Upload coverage
         with:
           token: ${{ env.CODECOV_TOKEN }}

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -115,7 +115,7 @@ jobs:
           PARALLEL_TEST_PROCESSORS: 2
           SHAKAPACKER_RUNTIME_COMPILE: "false"
           NODE_ENV: "test"
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4.0.0-beta.3
         name: Upload coverage
         with:
           token: ${{ inputs.codecov_token }}


### PR DESCRIPTION
#### :tophat: What? Why?

Codecov has a [new version](https://github.com/codecov/codecov-action/releases) of its action, and hopefully they've improved the uploader situation: 

> v4 represents a move from the [universal uploader](https://github.com/codecov/uploader) to the [Codecov CLI](https://github.com/codecov/codecov-cli). Although this will unlock new features for our users, the CLI is not yet at feature parity with the universal uploader.

As we're not doing and advance usage of the uploader, I don't think this would be an issue for us. 

I know it's still a beta, but:

- they're already in v4.0.0-beta.3
- v4.0.0-beta.3 started more than 1 month ago (2023-09-13)
- I don't think this should be worst than what we have (taking a quick look of the PRs merged from yesterday, almost 50% had failing uploads)
 

#### Testing

The check should be green
 
:hearts: Thank you!
