### PR TITLE
Improve verifying labels in PRs configuration

### DIFF
--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -1,5 +1,17 @@
 name: "[CI] Lint PR format"
 on:
+  # WARNING: we're using `pull_request_target` on this workflow.
+  # This is necessary so the `verify-pr-label-action` can work with forks,
+  # but it introduces a potential security risk, specially if we checkout
+  # code from the forks.
+  #
+  # DO NOT checkout code from forks never in this workflow1
+  #
+  # @see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
+    branches-ignore:
+      - "chore/l10n*"
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
   pull_request:
     branches-ignore:
       - "chore/l10n*"

--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -24,6 +24,6 @@ jobs:
       - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          valid-labels: "type: feature, type:change, type: fix, type: removal, target: developer-experience, type: internal"
+          valid-labels: "type: feature, type: change, type: fix, type: removal, target: developer-experience, type: internal"
           invalid-labels: "type: bug"
           pull-request-number: "${{ github.event.pull_request.number }}"

--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -33,6 +33,10 @@ jobs:
           regex: "^[A-Z].+"
           min_length: 5
           max_length: 100
+  check_label:
+    name: Check PR labels
+    runs-on: ubuntu-latest
+    steps:
       - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
#### :tophat: What? Why?

After the introduction of the action for checking the labels, I've found a couple of improvements to be made in its configuration: 

1. There's a typo in `type:change`. Example in #11790, where we're labeling it correctly but the error message puts "type:change" 
2. It can't be run on forks. Example in #10761. The error message is: 

> ERROR: PRs from forks are only supported when trigger on "pull_request_target" 

The problem is that `pull_request_target` could bring security issues **if** the code is checked out, as the run will have more permissions in the GH CI environment. To prevent this problem I've added a big warning to not do that. 

#### :pushpin: Related Issues

- Related to #11803 

#### Testing

Labeling with `type: change` should work.
The other check is difficult to made, so I guess we should merge this and then merge develop against a PR that's a forked branch. 

:hearts: Thank you!
