### PR TITLE
Redesign: fix layout-2col heights when few items

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_layout.scss
@@ -31,7 +31,7 @@
 }
 
 .layout-2col {
-  @apply md:grid grid-cols-12 auto-rows-max container grow;
+  @apply md:grid grid-cols-12 container grow;
 
   &__aside {
     @apply col-span-4 lg:col-span-3 md:pr-16 py-6 md:py-12 gap-6 md:gap-12 flex flex-col justify-between items-start md:justify-start before:content-[''] before:absolute before:top-0 before:left-0 before:h-full before:w-1/2 before:-z-10 md:before:bg-background;


### PR DESCRIPTION
#### :tophat: What? Why?
Fix the height of the layout-2col children, when there are few items. This error was introduced in https://github.com/decidim/decidim/pull/11557 to solve https://github.com/decidim/decidim/issues/11556

Tested in Safari and the original issue error was unable to reproduce again

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/issues/11556
- Related to https://github.com/decidim/decidim/issues/11557

### :camera: Screenshots
Before:
![imagen](https://github.com/decidim/decidim/assets/817526/492df67e-3587-4bb2-a93b-8608daa67aeb)
After:
![imagen](https://github.com/decidim/decidim/assets/817526/83581e98-c5a2-4ea8-9d53-e1d7395752d7)

:hearts: Thank you!
