### PR TITLE
Fix contrast of some admin texts

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_moderations.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_moderations.scss
@@ -22,7 +22,7 @@
   }
 
   dd {
-    @apply p-4 bg-gray mb-1;
+    @apply p-4 bg-gray-3 mb-1;
   }
 
   .reportable-authors {

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_show_email.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_show_email.scss
@@ -6,7 +6,7 @@
   }
 
   > div {
-    @apply bg-gray mb-2 p-2;
+    @apply bg-gray-3 mb-2 p-2;
   }
 
   #user_email + p {


### PR DESCRIPTION
#### :tophat: What? Why?

There are some texts in the admin panel that are difficult to read because of contrasts. This PR fixes them.
 
#### Testing

##### Show participant's email address

1. Sign in as admin
2. Go to the participants list in http://localhost:3000/admin/officializations 
3. Click in the "Show email address" in any participant. 
4. See the contrast

#### Moderation reports

1. Sign in as admin
2. Report a comment
3. Go to "Reported content" in http://localhost:3000/admin/moderations
4. Click in "Expand" button in the report
5. See the contrast

### :camera: Screenshots

####  Show participant's email address

##### Before
![Screenshot of this page](https://github.com/decidim/decidim/assets/717367/b715955a-041b-4902-9b2c-8e8a77bdd245)

##### After
![Screenshot of this page](https://github.com/decidim/decidim/assets/717367/0c4e87b2-d60b-4204-9b46-bd62557f5aed)

####  Moderation reports

##### Before
![Screenshot of this page](https://github.com/decidim/decidim/assets/717367/d37012bc-ea10-4cb6-abf1-bc84a79a6033)

##### After
![Screenshot of this page](https://github.com/decidim/decidim/assets/717367/b24f9eae-1c81-4319-b60e-58f396811171)

:hearts: Thank you!
