### PR TITLE
Make consistent the processes' admin manage button behavior 

### DIFF
--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb
@@ -7,6 +7,14 @@
   <% end %>
   <div id="processes-dropdown-menu-settings">
     <ul class="dropdown dropdown__bottom">
+      <% if allowed_to? :read, :process_list %>
+        <li class="dropdown__item">
+          <%= icon "treasure-map-line", class: "fill-gray-2" %>
+          <%= link_to t("menu.participatory_processes", scope: "decidim.admin"),
+            decidim_admin_participatory_processes.participatory_processes_path,
+            class: "text-secondary" %>
+        </li>
+      <% end %>
       <% if allowed_to? :import, :process %>
         <li class="dropdown__item">
           <%= icon "upload-line", class: "fill-gray-2" %>

--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb
@@ -1,0 +1,28 @@
+<div class="inline-block relative">
+  <%= button_tag id: "processes-menu-trigger", data: { component: "dropdown", target: "processes-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
+    <span>
+      <%= t("menu.manage", scope: "decidim.admin") %>
+    </span>
+    <%= icon "arrow-down-s-line" %>
+  <% end %>
+  <div id="processes-dropdown-menu-settings">
+    <ul class="dropdown dropdown__bottom">
+      <% if allowed_to? :import, :process %>
+        <li class="dropdown__item">
+          <%= icon "upload-line", class: "fill-gray-2" %>
+          <%= link_to t("actions.import_process", scope: "decidim.admin"),
+            new_import_path,
+            class: "text-secondary" %>
+        </li>
+      <% end %>
+      <% if allowed_to? :manage, :participatory_process_type %>
+        <li class="dropdown__item">
+          <%= icon "price-tag-3-line", class: "fill-gray-2" %>
+          <%= link_to t("menu.participatory_process_types", scope: "decidim.admin"),
+            decidim_admin_participatory_processes.participatory_process_types_path,
+            class: "text-secondary" %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_process_type.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_process_type.html.erb
@@ -8,26 +8,7 @@
         </span>
       <% end %>
     <% end %>
-    <div class="inline-block relative">
-      <%= button_tag id: "processes-menu-trigger", data: { component: "dropdown", target: "processes-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
-        <span>
-          <%= t("menu.manage", scope: "decidim.admin") %>
-        </span>
-        <%= icon "arrow-down-s-line" %>
-      <% end %>
-      <div id="processes-dropdown-menu-settings">
-        <ul class="dropdown dropdown__bottom">
-          <li class="dropdown__item">
-            <% if allowed_to? :import, :process %>
-              <%= icon "upload-line", class: "fill-gray-2" %>
-              <%= link_to t("actions.import_process", scope: "decidim.admin"),
-                          new_import_path,
-                          class: "text-secondary" %>
-            <% end %>
-          </li>
-        </ul>
-      </div>
-    </div>
+    <%= render partial: "layouts/decidim/admin/manage_processes" %>
   </div>
 <% end %>
 

--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_processes.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_processes.html.erb
@@ -8,34 +8,7 @@
         </span>
       <% end %>
     <% end %>
-    <div class="inline-block relative">
-      <%= button_tag id: "processes-menu-trigger", data: { component: "dropdown", target: "processes-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
-        <span>
-          <%= t("menu.manage", scope: "decidim.admin") %>
-        </span>
-        <%= icon "arrow-down-s-line" %>
-      <% end %>
-      <div id="processes-dropdown-menu-settings">
-        <ul class="dropdown dropdown__bottom">
-          <li class="dropdown__item">
-            <% if allowed_to? :import, :process %>
-              <%= icon "upload-line", class: "fill-gray-2" %>
-              <%= link_to t("actions.import_process", scope: "decidim.admin"),
-                          new_import_path,
-                          class: "text-secondary" %>
-            <% end %>
-          </li>
-          <li class="dropdown__item">
-            <% if allowed_to? :manage, :participatory_process_type %>
-              <%= icon "price-tag-3-line", class: "fill-gray-2" %>
-              <%= link_to t("menu.participatory_process_types", scope: "decidim.admin"),
-                          decidim_admin_participatory_processes.participatory_process_types_path,
-                          class: "text-secondary" %>
-            <% end %>
-          </li>
-        </ul>
-      </div>
-    </div>
+    <%= render partial: "layouts/decidim/admin/manage_processes" %>
   </div>
 <% end %>
 


### PR DESCRIPTION
#### :tophat: What? Why?

There were a couple inconsistencies in how the manage button in admin's processes work:

1. In the "Import" page it didn't have the link to "Processes type"
2. In neither of these pages there was the main option of "Processes" (Assemblies and Initiatives have them for instance) 

This PR fixes both of these problems.

#### Testing

1. Sign in as admin
2. Go to these 3 pages. It should always have the same "Manage" button:

- [ ] http://localhost:3000/admin/participatory_processes
- [ ] http://localhost:3000/admin/participatory_processes/imports/new 
- [ ] http://localhost:3000/admin/participatory_process_types

### :camera: Screenshots

![Screenshot of the manage button in processes admin](https://github.com/decidim/decidim/assets/717367/384a4d9a-6ddd-4697-8e2a-a88c22010980)


:hearts: Thank you!
