### PR TITLE
Fix HTML for initiative edit with area field

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
@@ -87,7 +87,7 @@
       <% end %>
 
       <% if current_initiative.area_enabled? %>
-        <div class="field">
+        <div class="row column">
           <%= form.areas_select :area_id,
                                 areas_for_select(current_organization),
                                 {


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing the admin redesign, it was found an error in the edit form of an Initiative if there's areas enabled in the Initiative type.

This PR fixes that.
 

#### Testing

1. Sign in as admin
2. Go to http://localhost:3000/admin/initiatives_types 
3. Edit one Type and enable the setting "Enable authors to choose the area for their initiative" 
4. Go to an Initiative of this type and click on the "Edit" button in the admin
5. See the form

### :camera: Screenshots

#### Before
![Screenshot of the (broken) form](https://github.com/decidim/decidim/assets/717367/e263251f-884e-47bc-a138-f4c447ec1785)

#### After
![Screenshot of the (fixed) form](https://github.com/decidim/decidim/assets/717367/019c2a0b-cdc3-4746-8281-99c799022bbf)

:hearts: Thank you!
