### PR TITLE
Initiative types form indentation

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
@@ -56,7 +56,7 @@
       <div class="row column">
         <%= form.check_box :area_enabled %>
       </div>
-  
+
       <div class="row column">
         <%= form.check_box :child_scope_threshold_enabled, help_text: t(".child_scope_threshold_enabled_help_html") %>
       </div>
@@ -66,7 +66,7 @@
       </div>
 
       <div id="promoting-committee-details">
-        <div class="row column" >
+        <div class="row column">
           <%= form.check_box :promoting_committee_enabled %>
         </div>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
@@ -56,17 +56,19 @@
       <div class="row column">
         <%= form.check_box :area_enabled %>
       </div>
+  
+      <div class="row column">
+        <%= form.check_box :child_scope_threshold_enabled, help_text: t(".child_scope_threshold_enabled_help_html") %>
+      </div>
 
-    <div class="row column">
-      <%= form.check_box :child_scope_threshold_enabled, help_text: t(".child_scope_threshold_enabled_help_html") %>
-    </div>
+      <div class="row column">
+        <%= form.check_box :only_global_scope_enabled, help_text: t(".only_global_scope_enabled_help_html") %>
+      </div>
 
-    <div class="row column">
-      <%= form.check_box :only_global_scope_enabled, help_text: t(".only_global_scope_enabled_help_html") %>
-    </div>
-
-      <div class="row column" id="promoting-committee-details">
-        <%= form.check_box :promoting_committee_enabled %>
+      <div id="promoting-committee-details">
+        <div class="row column" >
+          <%= form.check_box :promoting_committee_enabled %>
+        </div>
 
         <div class="row column minimum-committee-members-details">
           <%= form.number_field :minimum_committee_members, min: 0, step: 1 %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the classes on initiative types edit form with regard to "Minimum of committee members". 

#### Testing
1. Login as admin and visit initiative types admin panel 
2. See the field indentation around: " Minimum of committee members "
3. Apply patch 
4. See there is no indentation

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

before:
![image](https://github.com/decidim/decidim/assets/105683/17a492b8-c8cd-4c21-bd43-9df422690da9)

after:
![image](https://github.com/decidim/decidim/assets/105683/964a647a-ae8f-452a-8efb-eb49b741a987)


:hearts: Thank you!
