### PR TITLE
Redesign: comment threads decorator

### DIFF
--- a/decidim-comments/app/packs/stylesheets/comments.scss
+++ b/decidim-comments/app/packs/stylesheets/comments.scss
@@ -107,7 +107,7 @@
   }
 
   &-reply::after {
-    @apply bg-gray inline-block absolute top-8 h-4/5 w-px z-0;
+    @apply bg-background-3 inline-block absolute top-8 h-4/5 w-px -z-10;
 
     content: "";
   }


### PR DESCRIPTION
#### :tophat: What? Why?
The decorator of the comments thread puts on top of the avatar itself, besides the color is too much emphasised.

### :camera: Screenshots
Before:
![imagen](https://github.com/decidim/decidim/assets/817526/3c951843-19f5-4fe8-b72e-79ef12d74b5c)
After:
![imagen](https://github.com/decidim/decidim/assets/817526/6c2e7b44-33e3-4439-8b3e-97c7ff2236b8)


:hearts: Thank you!
