### PR TITLE
Fix linter offense in processes' admin manage button

### DIFF
--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb
@@ -11,24 +11,24 @@
         <li class="dropdown__item">
           <%= icon "treasure-map-line", class: "fill-gray-2" %>
           <%= link_to t("menu.participatory_processes", scope: "decidim.admin"),
-            decidim_admin_participatory_processes.participatory_processes_path,
-            class: "text-secondary" %>
+                      decidim_admin_participatory_processes.participatory_processes_path,
+                      class: "text-secondary" %>
         </li>
       <% end %>
       <% if allowed_to? :import, :process %>
         <li class="dropdown__item">
           <%= icon "upload-line", class: "fill-gray-2" %>
           <%= link_to t("actions.import_process", scope: "decidim.admin"),
-            new_import_path,
-            class: "text-secondary" %>
+                      new_import_path,
+                      class: "text-secondary" %>
         </li>
       <% end %>
       <% if allowed_to? :manage, :participatory_process_type %>
         <li class="dropdown__item">
           <%= icon "price-tag-3-line", class: "fill-gray-2" %>
           <%= link_to t("menu.participatory_process_types", scope: "decidim.admin"),
-            decidim_admin_participatory_processes.participatory_process_types_path,
-            class: "text-secondary" %>
+                      decidim_admin_participatory_processes.participatory_process_types_path,
+                      class: "text-secondary" %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
#### :tophat: What? Why?

We have a failing spec in `develop` introduced on #11823: 

```console
Run ./.github/run_erblint.sh
fatal: ref refs/remotes/origin/HEAD is not a symbolic ref
basename: missing operand
Try 'basename --help' for more information.
fatal: ambiguous argument '': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
warning: parser/current is loading parser/ruby31, which recognizes 3.1.4-compliant syntax, but you are running 3.1.1.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
6 error(s) were found in ERB files
Linting 1392 files with 15 linters...

Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
In file: decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb:14

Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
In file: decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb:15

Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
In file: decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb:22

Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
In file: decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb:23

Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
In file: decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb:30

Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
In file: decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb:31

Error: Process completed with exit code 1.
``` 

This PR fixes it.

I think it was introduced by two reasons:

1. My IDE configuration doesn't seems to work well with erblint. I need to set it up 
2. As we usually have the failing spec from codecov in the CI, it's easy to miss it. For that, we need to introduce a new rule in the review process: before merging a PR, the reviewer that's merging it needs to acknowledge the failing specs. [Here's an example](https://github.com/decidim/decidim/pull/11498#issuecomment-1780575377)


#### Testing
 
The "[CI] Lint code / Lint code" check should be green

:hearts: Thank you!
