### PR TITLE
Enable fail_ci_if_error flag on CodeCov

### DIFF
--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -104,3 +104,5 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-generators
           flags: decidim-generators
+          verbose: true
+          fail_ci_if_error: true

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -122,6 +122,7 @@ jobs:
           name: ${{ inputs.working-directory }}
           flags: ${{ inputs.working-directory }}
           verbose: true
+          fail_ci_if_error: true
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -121,6 +121,7 @@ jobs:
           token: ${{ inputs.codecov_token }}
           name: ${{ inputs.working-directory }}
           flags: ${{ inputs.working-directory }}
+          verbose: true
       - uses: actions/upload-artifact@v3
         if: always()
         with:


### PR DESCRIPTION
#### :tophat: What? Why?
This PR tries to fix the codecov consistency issue. The code coverage inconsistency that we have seems to be caused by a an error on the codecov side, which is cause a 502 error in the upload action. 
This PR makes sure that the pipeline would fail if there is an error in codecov upload process ( like the upload endpoint errors with a 5xx error. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/codecov/codecov-action/issues/926
- Related to #9832
- Related to #9684

#### Testing
Make sure the pipeline is green: 
- No workflows failing 
- No Codecov failing

:hearts: Thank you!
