### PR TITLE
Redesign: replace `assembly__block-grid` deprecated class

### DIFF
--- a/decidim-assemblies/app/cells/decidim/assemblies/assemblies/show.erb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/assemblies/show.erb
@@ -9,7 +9,7 @@
   <% end %>
 </div>
 
-<div class="assembly__block-grid">
+<div class="participatory-space__block-grid">
   <% assemblies.each do |assembly| %>
     <%= card_for(assembly) %>
   <% end %>

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -299,7 +299,7 @@ describe "Assemblies", type: :system do
         end
 
         it "shows only the published children assemblies" do
-          within(".assembly__block-grid") do
+          within(".participatory-space__block-grid") do
             expect(page).to have_link translated(child_assembly.title)
             expect(page).not_to have_link translated(unpublished_child_assembly.title)
           end
@@ -321,7 +321,7 @@ describe "Assemblies", type: :system do
         end
 
         it "shows only the published, private and transparent children assemblies" do
-          within(".assembly__block-grid") do
+          within(".participatory-space__block-grid") do
             expect(page).to have_link translated(private_transparent_child_assembly.title)
             expect(page).not_to have_link translated(private_transparent_unpublished_child_assembly.title)
           end
@@ -337,7 +337,7 @@ describe "Assemblies", type: :system do
         end
 
         it "not shows any children assemblies" do
-          expect(page).not_to have_css(".assembly__block-grid")
+          expect(page).not_to have_css(".participatory-space__block-grid")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Related assemblies content block included deprecated css class, no longer existent. It updates such classes

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/11841

### :camera: Screenshots
Before:
![imagen](https://github.com/decidim/decidim/assets/817526/a59bcac5-d1a3-4d8b-852e-b2ab3c344c20)
After:
![imagen](https://github.com/decidim/decidim/assets/817526/df1a8039-9337-47a9-9417-2f773f7c9d0a)

:hearts: Thank you!
