### PR TITLE
Add replies to comments in seeds

### DIFF
--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -28,7 +28,7 @@ module Decidim
         # Private - creates a comment for a given resource.
         #
         # resource - the resource to add the coments to.
-        # root_commentable - the root commentable resource. It's optional, used for making nested comments.
+        # root_commentable - the root commentable resource. It is optional, used for making nested comments.
         #
         # Returns the created comment.
         def create_comment(resource, root_commentable = nil)

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -30,9 +30,8 @@ module Decidim
         #
         # @private
         #
-        # @param resource [Object] - the Decidim resource to add the coments to.
-        #                            examples: Decidim::Proposals::CollaborativeDraft, Decidim::Proposals::Proposal,
-        # @param root_commentable [Decidim::Comments::Comment|nil] - the root commentable resource. It is optional, used for making nested comments.
+        # @param resource [Object] - the Decidim resource to add the comments to.
+        # @param root_commentable - the root commentable resource. It is optional, used for making nested comments.
         #
         # @return [Decidim::Comments::Comment]
         def create_comment(resource, root_commentable = nil)

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -7,11 +7,12 @@ module Decidim
     # app.
     class Seed
       class << self
-        # Public: adds a random amount of comments for a given resource.
+        # Adds a random amount of comments for a given resource.
         #
-        # resource - the resource to add the coments to.
+        # @param resource [Object] - the Decidim resource to add the coments to.
+        #                            examples: Decidim::Proposals::CollaborativeDraft, Decidim::Proposals::Proposal,
         #
-        # Returns nothing.
+        # @return nil
         def comments_for(resource)
           return unless resource.accepts_new_comments?
 
@@ -25,12 +26,15 @@ module Decidim
 
         private
 
-        # Private - creates a comment for a given resource.
+        # Creates a comment for a given resource.
         #
-        # resource - the resource to add the coments to.
-        # root_commentable - the root commentable resource. It is optional, used for making nested comments.
+        # @private
         #
-        # Returns the created comment.
+        # @param resource [Object] - the Decidim resource to add the coments to.
+        #                            examples: Decidim::Proposals::CollaborativeDraft, Decidim::Proposals::Proposal,
+        # @param root_commentable [Decidim::Comments::Comment|nil] - the root commentable resource. It is optional, used for making nested comments.
+        #
+        # @return [Decidim::Comments::Comment]
         def create_comment(resource, root_commentable = nil)
           author = Decidim::User.where(organization: resource.organization).all.sample
           user_group = [true, false].sample ? Decidim::UserGroups::ManageableUserGroups.for(author).verified.sample : nil

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -6,25 +6,38 @@ module Decidim
     # to Seed those models in order to be able to use them in the development
     # app.
     class Seed
-      # Public: adds a random amount of comments for a given resource.
-      #
-      # resource - the resource to add the coments to.
-      #
-      # Returns nothing.
-      def self.comments_for(resource)
-        return unless resource.accepts_new_comments?
+      class << self
+        # Public: adds a random amount of comments for a given resource.
+        #
+        # resource - the resource to add the coments to.
+        #
+        # Returns nothing.
+        def comments_for(resource)
+          return unless resource.accepts_new_comments?
 
-        Decidim::Comments::Comment.reset_column_information
+          Decidim::Comments::Comment.reset_column_information
 
-        organization = resource.organization
+          rand(0..6).times do
+            comment = create_comment(resource)
+            create_comment(comment, resource) if [true, false].sample
+          end
+        end
 
-        2.times do
-          author = Decidim::User.where(organization:).all.sample
+        private
+
+        # Private - creates a comment for a given resource.
+        #
+        # resource - the resource to add the coments to.
+        # root_commentable - the root commentable resource. It's optional, used for making nested comments.
+        #
+        # Returns the created comment.
+        def create_comment(resource, root_commentable = nil)
+          author = Decidim::User.where(organization: resource.organization).all.sample
           user_group = [true, false].sample ? Decidim::UserGroups::ManageableUserGroups.for(author).verified.sample : nil
 
           params = {
             commentable: resource,
-            root_commentable: resource,
+            root_commentable: root_commentable || resource,
             body: { en: ::Faker::Lorem.sentence(word_count: 50) },
             author:,
             user_group:


### PR DESCRIPTION
#### :tophat: What? Why?
 
From time to time we need to check for comments replies during development (see #11829). This PR adds replies to comments in seeds. 

#### Testing

1. Regenerate seeds with `bin/rails db:drop db:create db:migrate db:seed `
2. Go to a proposals index in a process and go to a proposal with lots of comments

### :camera: Screenshots

![Screenshot of a proposal with seeded comments](https://github.com/decidim/decidim/assets/717367/e4ce2001-d72b-4240-b3c3-e4bc6973501a)


:hearts: Thank you!
