### PR TITLE
Redesign: CTA content block for process groups

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/cta/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/cta/show.erb
@@ -1,14 +1,12 @@
-<section class="section">
-  <div class="expanded hero" style="background-image:url('<%= background_image %>');">
-    <div class="hero__container">
-      <div class="row">
-        <div class="columns small-centered medium-6 text-center">
-          <%= cta_button %>
-          <p>
-            <%= translated_description %>
-          </p>
-        </div>
-      </div>
-    </div>
+<section id="hero-<%= model.id %>" class="hero__container" style="--hero-image:url('<%= background_image %>')" data-process-hero>
+  <div class="hero">
+    <h1 class="hero__title">
+      <%= translated_description %>
+    </h1>
+
+    <%= link_to button_url, class: "button button__lg md:button__xl button__secondary" do %>
+      <span><%= translated_button_text %></span>
+      <%= icon "login-box-line" %>
+    <% end %>
   </div>
 </section>

--- a/decidim-core/app/cells/decidim/content_blocks/cta_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/cta_cell.rb
@@ -23,10 +23,6 @@ module Decidim
         @button_url ||= model.settings.button_url
       end
 
-      def cta_button
-        link_to translated_button_text, button_url, class: "button button--sc medium-6", title: translated_button_text
-      end
-
       def background_image
         model.images_container.attached_uploader(:background_image).path(variant: :big)
       end

--- a/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
@@ -146,13 +146,13 @@ describe "Participatory Process Groups", type: :system do
       end
 
       it "shows the description" do
-        within("div.hero__container") do
+        within("[data-process-hero]") do
           expect(page).to have_content(cta_settings[:description_en])
         end
       end
 
       it "Shows the action button" do
-        within("div.hero__container") do
+        within("[data-process-hero]") do
           expect(page).to have_link(cta_settings[:button_text_en], href: cta_settings[:button_url])
         end
       end
@@ -161,7 +161,7 @@ describe "Participatory Process Groups", type: :system do
         let(:cta_settings) { nil }
 
         it "does not show the block" do
-          expect(page).not_to have_selector("div.hero__container")
+          expect(page).not_to have_selector("[data-process-hero]")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Apply the redesign to the CTA block present for process groups

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/11843

### :camera: Screenshots
Before:
![imagen](https://github.com/decidim/decidim/assets/817526/78a96dc0-d48f-4aac-bf13-b76b4fac753f)
After:
![imagen](https://github.com/decidim/decidim/assets/817526/c86ee38d-9506-400b-b235-ccc6568eae0c)

:hearts: Thank you!
