### PR TITLE
Redesign: progress metadata for result card

### DIFF
--- a/decidim-accountability/app/cells/decidim/accountability/result_l_cell.rb
+++ b/decidim-accountability/app/cells/decidim/accountability/result_l_cell.rb
@@ -16,6 +16,10 @@ module Decidim
         controller.try(:component_settings) || result.component.settings
       end
 
+      def render_extra_data?
+        true
+      end
+
       private
 
       def metadata_cell

--- a/decidim-accountability/app/cells/decidim/accountability/result_l_cell.rb
+++ b/decidim-accountability/app/cells/decidim/accountability/result_l_cell.rb
@@ -10,9 +10,11 @@ module Decidim
       include ApplicationHelper
       include ActiveSupport::NumberHelper
 
-      delegate :component_settings, to: :controller
-
       alias result model
+
+      def component_settings
+        controller.try(:component_settings) || result.component.settings
+      end
 
       private
 

--- a/decidim-accountability/app/cells/decidim/accountability/result_metadata_cell.rb
+++ b/decidim-accountability/app/cells/decidim/accountability/result_metadata_cell.rb
@@ -32,7 +32,7 @@ module Decidim
         return [dates_item, status_item, status_description] if template == :project_aside
         return [reference, versions] if template == :show_footer
 
-        [dates_item_compact, status_item_compact, category_item]
+        [progress_result, dates_item_compact, status_item_compact, category_item]
       end
 
       def template
@@ -130,6 +130,13 @@ module Decidim
 
       def has_dates?
         start_date.present? && end_date.present?
+      end
+
+      def progress_result
+        {
+          icon: "loader-4-line",
+          text: "50%"
+        }
       end
     end
   end

--- a/decidim-accountability/app/cells/decidim/accountability/result_metadata_cell.rb
+++ b/decidim-accountability/app/cells/decidim/accountability/result_metadata_cell.rb
@@ -32,7 +32,7 @@ module Decidim
         return [dates_item, status_item, status_description] if template == :project_aside
         return [reference, versions] if template == :show_footer
 
-        [progress_result, dates_item_compact, status_item_compact, category_item]
+        [dates_item_compact, status_item_compact, category_item]
       end
 
       def template
@@ -130,13 +130,6 @@ module Decidim
 
       def has_dates?
         start_date.present? && end_date.present?
-      end
-
-      def progress_result
-        {
-          icon: "loader-4-line",
-          text: "50%"
-        }
       end
     end
   end

--- a/decidim-accountability/app/cells/decidim/accountability/results/show.erb
+++ b/decidim-accountability/app/cells/decidim/accountability/results/show.erb
@@ -1,6 +1,6 @@
 <% if results.any? %>
   <% results.each do |result| %>
-    <%= card_for result, render_extra_data: true %>
+    <%= card_for result %>
   <% end %>
 <% else %>
   <%= cell("decidim/announcement", t("no_results", scope: "decidim.accountability.results")) %>

--- a/decidim-accountability/spec/cells/decidim/accountability/result_cell_spec.rb
+++ b/decidim-accountability/spec/cells/decidim/accountability/result_cell_spec.rb
@@ -7,11 +7,34 @@ module Decidim::Accountability
     controller Decidim::Accountability::ResultsController
 
     let!(:result) { create(:result) }
+    let(:display_progress) { true }
+    let(:component_settings) do
+      double(
+        display_progress_enabled?: display_progress
+      )
+    end
+
+    before do
+      allow(controller).to receive(:component_settings).and_return(component_settings)
+    end
 
     context "when rendering" do
+      let(:html) { cell("decidim/accountability/result", result).call }
+
       it "renders the card" do
-        html = cell("decidim/accountability/result", result).call
         expect(html).to have_css(".card__list")
+      end
+
+      it "renders the progress" do
+        expect(html).to have_css("div.accountability__progress")
+      end
+
+      context "when displaying progress is disabled in component settings" do
+        let(:display_progress) { false }
+
+        it "does not render the progress" do
+          expect(html).not_to have_css("div.accountability__progress")
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Displays the execution progress in the Result L cards unless component settings set it not to be shown.

Prevouisly to this PR, progress was only shown in the project lists within the component itself, but not in the content blocks for example. Whith the changes of the PR the default behavior is to show the progress.

### :camera: Screenshots
![Screenshot from 2023-10-30 21-05-33](https://github.com/decidim/decidim/assets/446459/67e60277-8f55-4af6-8ab6-9451e2368e60)

:hearts: Thank you!
