### PR TITLE
Prefill some values in the "New organization" form

### DIFF
--- a/decidim-system/app/controllers/decidim/system/organizations_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/organizations_controller.rb
@@ -66,7 +66,7 @@ module Decidim
           organization_admin_name: current_admin.email.split("@")[0],
           organization_admin_email: current_admin.email,
           available_locales: Decidim.available_locales.map(&:to_s),
-          default_locale: Decidim.default_locale.first.to_s,
+          default_locale: Decidim.default_locale,
           users_registration_mode: "enabled"
         }
       end

--- a/decidim-system/app/controllers/decidim/system/organizations_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/organizations_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       helper Decidim::OmniauthHelper
 
       def new
-        @form = form(RegisterOrganizationForm).instance
+        @form = form(RegisterOrganizationForm).from_params(default_params)
         @form.file_upload_settings = form(FileUploadSettingsForm).from_model({})
       end
 
@@ -59,6 +59,17 @@ module Decidim
       end
 
       private
+
+      def default_params
+        {
+          host: request.host,
+          organization_admin_name: current_admin.email.split("@")[0],
+          organization_admin_email: current_admin.email,
+          available_locales: I18n.available_locales.map(&:to_s),
+          default_locale: I18n.available_locales.first.to_s,
+          users_registration_mode: "enabled"
+        }
+      end
 
       # The current organization for the request.
       #

--- a/decidim-system/app/controllers/decidim/system/organizations_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/organizations_controller.rb
@@ -65,8 +65,8 @@ module Decidim
           host: request.host,
           organization_admin_name: current_admin.email.split("@")[0],
           organization_admin_email: current_admin.email,
-          available_locales: I18n.available_locales.map(&:to_s),
-          default_locale: I18n.available_locales.first.to_s,
+          available_locales: Decidim.available_locales.map(&:to_s),
+          default_locale: Decidim.default_locale.first.to_s,
           users_registration_mode: "enabled"
         }
       end

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -28,6 +28,18 @@ describe "Organizations" do
 
       it_behaves_like "form hiding advanced settings"
 
+      it "has some fields filled by default" do
+        expect(find(:xpath, "//input[@id='organization_host']").value).to eq("127.0.0.1")
+        expect(find(:xpath, "//input[@id='organization_organization_admin_name']").value).to eq(admin.email.split("@")[0])
+        expect(find(:xpath, "//input[@id='organization_organization_admin_email']").value).to eq(admin.email)
+        within "table" do
+          expect(all("input[type=checkbox]")).to all(be_checked)
+          expect(find(:xpath, "//input[@name='organization[default_locale]']", match: :first)).to be_checked
+        end
+        expect(find(:xpath, "//input[@name='organization[users_registration_mode]']", match: :first).value).to eq("enabled")
+        expect(find(:xpath, "//input[@name='organization[users_registration_mode]']", match: :first)).to be_checked
+      end
+
       it "creates a new organization" do
         fill_in "Name", with: "Citizen Corp"
         fill_in "Host", with: "www.example.org"


### PR DESCRIPTION
#### :tophat: What? Why?

New comers to Decidim need to make lots of choices when filling the first form that usually see when interacting with the platform: the "New organization" form. 

This PR tries to make it easy by adding some default values to this form.
 
#### Testing

1. Sign in in the system panel
2. Go to http://localhost:3000/system/organizations/new 

### :camera: Screenshots

![Screenshot of the "New organization" form](https://github.com/decidim/decidim/assets/717367/825f2d4a-1501-4c55-923e-5f588a791e0e)

:hearts: Thank you!
