### PR TITLE
Improve organization success flash after creation

### DIFF
--- a/decidim-system/app/controllers/decidim/system/organizations_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/organizations_controller.rb
@@ -18,7 +18,7 @@ module Decidim
 
         RegisterOrganization.call(@form) do
           on(:ok) do
-            flash[:notice] = t("organizations.create.success", scope: "decidim.system")
+            flash[:notice] = t("organizations.create.success_html", scope: "decidim.system", host: @form.host, email: @form.organization_admin_email)
             redirect_to organizations_path
           end
 

--- a/decidim-system/app/packs/stylesheets/decidim/system/application.scss
+++ b/decidim-system/app/packs/stylesheets/decidim/system/application.scss
@@ -89,6 +89,16 @@ dl {
   }
 }
 
+.flash__message {
+  p {
+    @apply my-4;
+  }
+
+  ol {
+    @apply list-decimal;
+  }
+}
+
 /* overwrite tom-select defaults */
 .ts-control {
   margin-bottom: 0.5rem;

--- a/decidim-system/app/views/decidim/system/organizations/new.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/new.html.erb
@@ -14,7 +14,7 @@
 
     <%= f.text_field :organization_admin_name %>
 
-    <%= f.email_field :organization_admin_email %>
+    <%= f.email_field :organization_admin_email, help_text: t(".organization_admin_email_hint") %>
 
     <%= f.fields_for :locales do |fields| %>
       <%= f.label :organization_locales, "", class: @form.respond_to?(:errors) && @form.errors[:default_locale].present? ? "is-invalid-label" : "" %>

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -141,7 +141,22 @@ en:
           show: Show advanced settings
         create:
           error: There was a problem creating a new organization.
-          success: Organization successfully created.
+          success_html: |
+            <p>
+              Organization successfully created.
+            </p>
+            <ol>
+              <li>You may need to update your application code, as to allow requests to %{host} you need to add the following to your
+              environment configuration (i.e. <code>config/environment/production.rb</code>) or your <code>config/application.rb</code>:
+                <p> config.hosts << "%{host}" </p>
+              </li>
+              <li>
+                After that is done, you will be able to access to your platform through <a href="http://%{host}">http://%{host}</a>
+              </li>
+              <li>
+                We have sent an email to <b>%{email}</b> that you need to confirm.
+              </li>
+            </ol>
         csp_settings:
           connect_src: Connect src
           connect_src_hint: |

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -216,6 +216,7 @@ en:
           default: Default?
           enabled: Enabled
           locale: Locale
+          organization_admin_email_hint: We will send an email to this address so you can confirm it and set up your password.
           reference_prefix_hint: The reference prefix is used to uniquely identify resources across all organization.
           secondary_hosts_hint: Enter each one of them in a new line.
           title: New organization

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -41,7 +41,12 @@ describe "Organizations" do
         check "Example authorization (Direct)"
         click_button "Create organization & invite admin"
 
-        expect(page).to have_css("div.flash.success")
+        within ".flash__message" do
+          expect(page).to have_content("Organization successfully created.")
+          expect(page).to have_content("config/environment/production.rb")
+          expect(page).to have_content("config.hosts << \"www.example.org\"")
+          expect(page).to have_content("mayor@example.org")
+        end
         expect(page).to have_content("Citizen Corp")
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

#### :pushpin: Related Issues

After a new organization is created in System, we only say "Organization successfully created", but then people don't know what to actually do. This PR improves this flow by explaining what needs to be done in the flash success.

I've also added a hint the admin organization email so people know that's actually pretty important for the flow.

#### Testing

1. Log in in /system
1. Go to http://localhost:3000/system/organizations/new 
2. See the help text in the admin org email
3. Create a new organization
5. Read the flash alert

### :camera: Screenshots

![Screenshot of the success flash](https://github.com/decidim/decidim/assets/717367/a9e34d5f-230c-4741-99ab-a1b67526c7d7)

:hearts: Thank you!
