### PR TITLE
Improve system dashboard: new organization button + admins table

### DIFF
--- a/decidim-system/app/controllers/decidim/system/dashboard_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/dashboard_controller.rb
@@ -7,6 +7,7 @@ module Decidim
 
       def show
         @organizations = Organization.all
+        @admins = Admin.all
       end
 
       def check_organizations_presence

--- a/decidim-system/app/views/decidim/system/admins/index.html.erb
+++ b/decidim-system/app/views/decidim/system/admins/index.html.erb
@@ -4,30 +4,4 @@
 
 <%= link_to t("actions.new_admin", scope: "decidim.system"), [:new, :admin], class: "button button__sm md:button__lg button__primary" %>
 
-<table>
-  <thead>
-    <tr>
-      <th><%= t("models.admin.fields.email", scope: "decidim.system") %></th>
-      <th><%= t("models.admin.fields.created_at", scope: "decidim.system") %></th>
-      <th class="actions"><%= t("actions.title", scope: "decidim.system") %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @admins.each do |admin| %>
-      <tr>
-        <td>
-          <%= link_to admin.email, admin %><br>
-        </td>
-        <td>
-          <%= l admin.created_at, format: :short %>
-        </td>
-        <td class="actions">
-          <%= link_to t("actions.edit", scope: "decidim.system"), [:edit, admin] %>
-          <% unless current_admin?(admin) %>
-            <%= link_to t("actions.destroy", scope: "decidim.system"), admin, method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.system") } %>
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render partial: "decidim/system/shared/admins_list", locals: { admins: @admins } %>

--- a/decidim-system/app/views/decidim/system/dashboard/show.html.erb
+++ b/decidim-system/app/views/decidim/system/dashboard/show.html.erb
@@ -1,6 +1,13 @@
 <% provide :title do %>
   <h1 class="h1"><%= t("decidim.system.titles.dashboard") %></h1>
-  <h2 class="h3"><%= t ".current_organizations" %></h2>
 <% end %>
 
+<h2 class="h3"><%= t ".current_organizations" %></h2>
+
 <%= render partial: "decidim/system/shared/organizations_list", locals: { organizations: @organizations } %>
+
+<h2 class="h3"><%= t ".admins" %></h2>
+
+<%= link_to t("actions.new_admin", scope: "decidim.system"), [:new, :admin], class: "button button__sm md:button__lg button__primary" %>
+
+<%= render partial: "decidim/system/shared/admins_list", locals: { admins: @admins } %>

--- a/decidim-system/app/views/decidim/system/dashboard/show.html.erb
+++ b/decidim-system/app/views/decidim/system/dashboard/show.html.erb
@@ -4,6 +4,8 @@
 
 <h2 class="h3"><%= t ".current_organizations" %></h2>
 
+<%= link_to t("actions.new_organization", scope: "decidim.system"), [:new, :organization], class: "button button__sm md:button__lg button__primary" %>
+
 <%= render partial: "decidim/system/shared/organizations_list", locals: { organizations: @organizations } %>
 
 <h2 class="h3"><%= t ".admins" %></h2>

--- a/decidim-system/app/views/decidim/system/shared/_admins_list.html.erb
+++ b/decidim-system/app/views/decidim/system/shared/_admins_list.html.erb
@@ -1,0 +1,27 @@
+<table>
+  <thead>
+    <tr>
+      <th><%= t("models.admin.fields.email", scope: "decidim.system") %></th>
+      <th><%= t("models.admin.fields.created_at", scope: "decidim.system") %></th>
+      <th class="actions"><%= t("actions.title", scope: "decidim.system") %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% admins.each do |admin| %>
+      <tr>
+        <td>
+          <%= link_to admin.email, admin %><br>
+        </td>
+        <td>
+          <%= l admin.created_at, format: :short %>
+        </td>
+        <td class="actions">
+          <%= link_to t("actions.edit", scope: "decidim.system"), [:edit, admin] %>
+          <% unless current_admin?(admin) %>
+            <%= link_to t("actions.destroy", scope: "decidim.system"), admin, method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.system") } %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/decidim-system/app/views/layouts/decidim/system/_login_items.html.erb
+++ b/decidim-system/app/views/layouts/decidim/system/_login_items.html.erb
@@ -1,4 +1,4 @@
 <div class="flex items-center justify-between border-t border-black p-4">
   <span><%= current_admin.email %></span>
-  <%= link_to((".logout"), destroy_admin_session_path, method: :delete, class: "button button__sm md:button__lg button__text-primary") %>
+  <%= link_to(t(".logout"), destroy_admin_session_path, method: :delete, class: "button button__sm md:button__lg button__text-primary") %>
 </div>

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -245,3 +245,8 @@ en:
       titles:
         dashboard: Dashboard
         decidim: Decidim
+  layouts:
+    decidim:
+      system:
+        login_items:
+          logout: Logout

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
           success: Admin successfully updated.
       dashboard:
         show:
+          admins: Admins
           current_organizations: Current organizations
       default_pages:
         placeholders:

--- a/decidim-system/spec/system/dashboard_spec.rb
+++ b/decidim-system/spec/system/dashboard_spec.rb
@@ -13,6 +13,12 @@ describe "Organizations" do
     end
 
     describe "current organizations section" do
+      it "has a link for creating a new organization" do
+        click_link "New organization"
+        expect(page).to have_content("New organization")
+        expect(page).to have_button("Create organization & invite admin")
+      end
+
       it "has a list of the current organizations" do
         expect(page).to have_content("Citizen Corp")
       end

--- a/decidim-system/spec/system/dashboard_spec.rb
+++ b/decidim-system/spec/system/dashboard_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Organizations" do
+  let(:admin) { create(:admin, email: "system@example.org") }
+  let(:organization) { create(:organization, name: "Citizen Corp") }
+
+  context "when an admin authenticated" do
+    before do
+      login_as admin, scope: :admin
+      visit decidim_system.root_path
+    end
+
+    describe "current organizations section" do
+      it "has a list of the current organizations" do
+        expect(page).to have_content("Citizen Corp")
+      end
+    end
+
+    describe "admins section" do
+      it "has a link for creating a new admin" do
+        click_link "New admin"
+        expect(page).to have_content("New admin")
+        expect(page).to have_button("Create")
+      end
+
+      it "has a list of the current admins" do
+        expect(page).to have_content("system@example.org")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Until now, the system dashboard didn't have much information. It's pretty similar to the organizations index page (http://localhost:3000/system/organizations), but without the button for creating a new organization, so sometimes I forgot about its existence and I thought that something was wrong because I didn't saw this button.

This PR fixes it by adding this button and also by adding the "Admins" section, to better differentiate with the organizations index page 

I've also fixed a missing translation in the "logout" string

#### Testing

1. Log in to http://localhost:3000/system/
2. See the new dashboard

### :camera: Screenshots

![Screenshot of the system dashboard](https://github.com/decidim/decidim/assets/717367/1e522eae-b741-4465-887c-5f1e6680b9c2)

:hearts: Thank you!
