### PR TITLE
Fix rubocop offense for RSpec/Rails/InferredSpecType on `user_groups_spec.rb`

### DIFF
--- a/decidim-core/spec/controllers/concerns/user_groups_spec.rb
+++ b/decidim-core/spec/controllers/concerns/user_groups_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module Decidim
-  describe "UserGroups", type: :controller do
+  describe "UserGroups" do
     let!(:organization) { create(:organization) }
     let!(:user) { create(:user, :confirmed, organization:) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

We've enabled some new rubocop rules on #11856 and at the same time we've merged #9684 that doesn't apply that rule.

This means that we have a broken linter in `develop`. This PR fixes it. 
 
#### Testing

The ` [CI] Lint code / Lint code (bundle exec rubocop -P)` check should be green 

:hearts: Thank you!
