### PR TITLE
Redesign: accountability home empty content

### DIFF
--- a/decidim-accountability/app/cells/decidim/accountability/status_cell.rb
+++ b/decidim-accountability/app/cells/decidim/accountability/status_cell.rb
@@ -19,11 +19,15 @@ module Decidim
         render
       end
 
-      private
-
       def render?
-        options[:render_blank] || (results_count&.positive? || progress.present?)
+        options[:render_blank] || has_results?
       end
+
+      def has_results?
+        results_count&.positive? || progress.present?
+      end
+
+      private
 
       def scope
         current_scope.presence

--- a/decidim-accountability/app/packs/stylesheets/accountability.scss
+++ b/decidim-accountability/app/packs/stylesheets/accountability.scss
@@ -107,6 +107,10 @@
     &-title {
       @apply block md:hidden mb-8 text-gray-2 uppercase font-semibold;
     }
+
+    .flash {
+      @apply m-0;
+    }
   }
 
   &__subgrid {

--- a/decidim-accountability/app/views/decidim/accountability/results/_home_categories.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_home_categories.html.erb
@@ -1,27 +1,34 @@
 <div class="accountability__grid">
   <% first_class_categories.each do |category| %>
+    <% subelements = cell(
+      "decidim/accountability/status",
+      category,
+      extra_classes: "accountability__status__background",
+      url: results_path(filter: { with_category: category, with_scope: current_scope }),
+      render_blank: true
+    ) %>
+
     <div>
       <span class="accountability__grid-title"><%= categories_label %></span>
-      <%= cell(
-            "decidim/accountability/status",
-            category,
-            extra_classes: "accountability__status__background",
-            url: results_path(filter: { with_category: category, with_scope: current_scope })
-          ) %>
+      <%= subelements.call %>
     </div>
 
     <div>
       <span class="accountability__grid-title"><%= subcategories_label %></span>
-      <div class="accountability__subgrid">
-        <% category.subcategories.each do |subcategory| %>
-          <%= cell(
-                "decidim/accountability/status",
-                subcategory,
-                extra_classes: "accountability__status__border",
-                url: results_path(filter: { with_category: subcategory, with_scope: current_scope })
-              ) %>
+        <% if subelements.has_results? %>
+          <div class="accountability__subgrid">
+            <% category.subcategories.each do |subcategory| %>
+              <%= cell(
+                    "decidim/accountability/status",
+                    subcategory,
+                    extra_classes: "accountability__status__border",
+                    url: results_path(filter: { with_category: subcategory, with_scope: current_scope })
+                  ) %>
+            <% end %>
+          </div>
+        <% else %>
+          <%= cell("decidim/announcement", t("no_results", scope: "decidim.accountability.results")) %>
         <% end %>
       </div>
-    </div>
   <% end %>
 </div>

--- a/decidim-accountability/spec/requests/result_search_spec.rb
+++ b/decidim-accountability/spec/requests/result_search_spec.rb
@@ -60,12 +60,9 @@ RSpec.describe "Result search" do
 
     it "displays all categories that have top-level results" do
       expect(subject).to include(translated(result1.category.name))
+      expect(subject).to include(translated(result2.category.name))
+      expect(subject).to include(translated(result3.category.name))
       expect(subject).to include(translated(result4.category.name))
-    end
-
-    it "does not display the categories that only have sub-results" do
-      expect(subject).not_to include(translated(result2.category.name))
-      expect(subject).not_to include(translated(result3.category.name))
     end
   end
 

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -94,7 +94,7 @@ describe "Explore results", versioning: true do
           if category_count.positive?
             expect(page).to have_content(translated(category.name))
           else
-            expect(page).not_to have_content(translated(category.name))
+            expect(page).to have_content("There are no projects")
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Includes an empty message for each category depicted in the home page.

Co-author: @entantoencuanto 

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/11869

### :camera: Screenshots
![imagen](https://github.com/decidim/decidim/assets/817526/8630815c-ee86-4e4f-99a8-46cff36e5cb6)
![imagen](https://github.com/decidim/decidim/assets/817526/29caa8f6-e9f4-4bb1-a54e-9e5fe9451e9b)

:hearts: Thank you!
