### PR TITLE
Fix process groups component content blocks

### DIFF
--- a/decidim-core/lib/decidim/content_blocks/has_related_components.rb
+++ b/decidim-core/lib/decidim/content_blocks/has_related_components.rb
@@ -34,10 +34,14 @@ module Decidim
         end
 
         def base_model_name(scope_name)
-          scope_manifest = Decidim.participatory_space_manifests.find { |manifest| manifest.content_blocks_scope_name == scope_name }
+          scope_manifest = detect_manifest(Decidim.participatory_space_manifests, scope_name) || detect_manifest(Decidim.resource_manifests, scope_name)
           return scope_manifest.model_class_name if scope_manifest.present?
 
           Decidim::ContentBlocks::BaseCell::SCOPE_ASSOCIATIONS[scope_name]
+        end
+
+        def detect_manifest(manifests_set, scope_name)
+          manifests_set.find { |manifest| manifest.content_blocks_scope_name == scope_name }
         end
       end
     end

--- a/decidim-core/lib/decidim/content_blocks/has_related_components.rb
+++ b/decidim-core/lib/decidim/content_blocks/has_related_components.rb
@@ -33,6 +33,8 @@ module Decidim
           end
         end
 
+        private
+
         def base_model_name(scope_name)
           scope_manifest = detect_manifest(Decidim.participatory_space_manifests, scope_name) || detect_manifest(Decidim.resource_manifests, scope_name)
           return scope_manifest.model_class_name if scope_manifest.present?

--- a/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_groups_spec.rb
@@ -18,6 +18,7 @@ describe "Participatory Process Groups" do
   let(:group_processes) { participatory_process_group.participatory_processes }
   let(:process) { group_processes.first }
   let(:other_process) { group_processes.last }
+  let(:out_of_group_process) { create(:participatory_process, :active, organization:) }
   let(:cta_settings) do
     {
       button_url: "https://example.org/action",
@@ -169,8 +170,10 @@ describe "Participatory Process Groups" do
     context "when the proposals block is enabled" do
       let!(:proposals_component) { create(:component, :published, participatory_space: process, manifest_name: :proposals) }
       let!(:other_process_proposals_component) { create(:component, :published, participatory_space: other_process, manifest_name: :proposals) }
+      let!(:out_of_group_process_proposals_component) { create(:component, :published, participatory_space: out_of_group_process, manifest_name: :proposals) }
       let!(:proposal1) { create(:proposal, component: proposals_component, title: { en: "First awesome proposal!" }) }
       let!(:proposal2) { create(:proposal, component: other_process_proposals_component, title: { en: "Second fabulous proposal!" }) }
+      let!(:independent_proposal) { create(:proposal, component: out_of_group_process_proposals_component, title: { en: "Independent proposal!" }) }
 
       before do
         create(
@@ -200,13 +203,21 @@ describe "Participatory Process Groups" do
           end
         end
       end
+
+      it "does not show cards of proposals from process out of group" do
+        expect(page).not_to have_selector("#proposals__proposal_#{independent_proposal.id}")
+        expect(page).not_to have_content "Independent proposal!"
+        expect(page).not_to have_i18n_content out_of_group_process.title
+      end
     end
 
     context "when the results block is enabled" do
       let!(:accountability_component) { create(:component, :published, participatory_space: process, manifest_name: :accountability) }
       let!(:other_process_accountability_component) { create(:component, :published, participatory_space: other_process, manifest_name: :accountability) }
+      let!(:out_of_group_process_accountability_component) { create(:component, :published, participatory_space: out_of_group_process, manifest_name: :accountability) }
       let!(:result1) { create(:result, component: accountability_component, title: { en: "First awesome result!" }) }
       let!(:result2) { create(:result, component: other_process_accountability_component, title: { en: "Second fabulous result!" }) }
+      let!(:independent_result) { create(:result, component: out_of_group_process_accountability_component, title: { en: "Independent result!" }) }
 
       before do
         create(
@@ -235,6 +246,12 @@ describe "Participatory Process Groups" do
             expect(page).to have_i18n_content other_process.title
           end
         end
+      end
+
+      it "does not show cards of results from process out of group" do
+        expect(page).not_to have_selector("#accountability__result_#{independent_result.id}")
+        expect(page).not_to have_content "Independent result!"
+        expect(page).not_to have_i18n_content out_of_group_process.title
       end
     end
 
@@ -270,8 +287,10 @@ describe "Participatory Process Groups" do
   context "when the meetings block is enabled" do
     let!(:meetings_component) { create(:component, :published, participatory_space: process, manifest_name: :meetings) }
     let!(:other_process_meetings_component) { create(:component, :published, participatory_space: other_process, manifest_name: :meetings) }
+    let!(:out_of_group_process_meetings_component) { create(:component, :published, participatory_space: out_of_group_process, manifest_name: :meetings) }
     let!(:meeting1) { create(:meeting, :published, component: meetings_component, title: { en: "First awesome meeting!" }) }
     let!(:meeting2) { create(:meeting, :published, component: other_process_meetings_component, title: { en: "Second fabulous meeting!" }) }
+    let!(:independent_meeting) { create(:meeting, :published, component: out_of_group_process_meetings_component, title: { en: "Independent meeting!" }) }
 
     before do
       create(
@@ -291,6 +310,10 @@ describe "Participatory Process Groups" do
         expect(page).to have_content "First awesome meeting!"
         expect(page).to have_content "Second fabulous meeting!"
       end
+    end
+
+    it "does not show cards of meetings from process out of group" do
+      expect(page).not_to have_content "Independent meeting!"
     end
   end
 
@@ -318,11 +341,15 @@ describe "Participatory Process Groups" do
       let!(:other_process_proposals_component) { create(:component, :published, participatory_space: other_process, manifest_name: :proposals) }
       let!(:other_process_meetings_component) { create(:component, :published, participatory_space: other_process, manifest_name: :meetings) }
       let!(:user) { create(:user, organization:) }
+      let!(:out_of_group_process_proposals_component) { create(:component, :published, participatory_space: out_of_group_process, manifest_name: :proposals) }
+      let!(:out_of_group_process_meetings_component) { create(:component, :published, participatory_space: out_of_group_process, manifest_name: :meetings) }
 
       before do
         create_list(:proposal, 3, component: proposals_component)
         create_list(:proposal, 7, component: other_process_proposals_component)
         create_list(:meeting, 4, :published, component: other_process_meetings_component)
+        create_list(:proposal, 50, component: out_of_group_process_proposals_component)
+        create_list(:meeting, 50, component: out_of_group_process_meetings_component)
 
         # Set same coauthorships for all proposals
         Decidim::Proposals::Proposal.where(component: [proposals_component, other_process_proposals_component]).each do |proposal|


### PR DESCRIPTION
#### :tophat: What? Why?

This PR:
* Fixes a wrong behavior of participatory processes groups landing page content blocks associated to components because the blocks select resources from all components of the same type instead of selecting only resources from components defined on the processes included in the group.
* Adds some tests

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11594 
- Fixes #11595

#### Testing

Define a participatory process group and include in the landing page blocks for meetings, results or proposals,
Publish meetings, results or proposals in components defined and published on participatory spaces not included in the group. Those resources should not appear in the group landing page