### PR TITLE
Randomly add (or not) the spaces' images in seeds

### DIFF
--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -56,6 +56,19 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
       published_at: Time.current
     )
 
+    hero_image = ActiveStorage::Blob.create_and_upload!(
+      io: File.open(File.join(seeds_root, "city.jpeg")),
+      filename: "hero_image.jpeg",
+      content_type: "image/jpeg",
+      metadata: nil
+    )
+    banner_image = ActiveStorage::Blob.create_and_upload!(
+      io: File.open(File.join(seeds_root, "city2.jpeg")),
+      filename: "banner_image.jpeg",
+      content_type: "image/jpeg",
+      metadata: nil
+    )
+
     2.times do |n|
       params = {
         title: Decidim::Faker::Localized.sentence(word_count: 5),
@@ -69,18 +82,8 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
           Decidim::Faker::Localized.paragraph(sentence_count: 3)
         end,
         organization:,
-        hero_image: ActiveStorage::Blob.create_and_upload!(
-          io: File.open(File.join(seeds_root, "city.jpeg")),
-          filename: "hero_image.jpeg",
-          content_type: "image/jpeg",
-          metadata: nil
-        ), # Keep after organization
-        banner_image: ActiveStorage::Blob.create_and_upload!(
-          io: File.open(File.join(seeds_root, "city2.jpeg")),
-          filename: "banner_image.jpeg",
-          content_type: "image/jpeg",
-          metadata: nil
-        ), # Keep after organization
+        hero_image: Faker::Boolean.boolean(true_ratio: 0.5) ? hero_image : nil, # Keep after organization
+        banner_image: Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil, # Keep after organization
         promoted: true,
         published_at: 2.weeks.ago,
         meta_scope: Decidim::Faker::Localized.word,
@@ -161,18 +164,8 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
           Decidim::Faker::Localized.paragraph(sentence_count: 3)
         end,
         organization:,
-        hero_image: ActiveStorage::Blob.create_and_upload!(
-          io: File.open(File.join(seeds_root, "city.jpeg")),
-          filename: "hero_image.jpeg",
-          content_type: "image/jpeg",
-          metadata: nil
-        ), # Keep after organization
-        banner_image: ActiveStorage::Blob.create_and_upload!(
-          io: File.open(File.join(seeds_root, "city2.jpeg")),
-          filename: "banner_image.jpeg",
-          content_type: "image/jpeg",
-          metadata: nil
-        ), # Keep after organization
+        hero_image: Faker::Boolean.boolean(true_ratio: 0.5) ? hero_image : nil, # Keep after organization
+        banner_image: Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil, # Keep after organization
         promoted: true,
         published_at: 2.weeks.ago,
         meta_scope: Decidim::Faker::Localized.word,

--- a/decidim-conferences/lib/decidim/conferences/participatory_space.rb
+++ b/decidim-conferences/lib/decidim/conferences/participatory_space.rb
@@ -53,6 +53,19 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
       published_at: Time.current
     )
 
+    hero_image = ActiveStorage::Blob.create_and_upload!(
+      io: File.open(File.join(seeds_root, "city.jpeg")),
+      filename: "hero_image.jpeg",
+      content_type: "image/jpeg",
+      metadata: nil
+    )
+    banner_image = ActiveStorage::Blob.create_and_upload!(
+      io: File.open(File.join(seeds_root, "city2.jpeg")),
+      filename: "banner_image.jpeg",
+      content_type: "image/jpeg",
+      metadata: nil
+    )
+
     2.times do |_n|
       conference = Decidim::Conference.create!(
         title: Decidim::Faker::Localized.sentence(word_count: 5),
@@ -66,18 +79,8 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
           Decidim::Faker::Localized.paragraph(sentence_count: 3)
         end,
         organization:,
-        hero_image: ActiveStorage::Blob.create_and_upload!(
-          io: File.open(File.join(seeds_root, "city.jpeg")),
-          filename: "hero_image.jpeg",
-          content_type: "image/jpeg",
-          metadata: nil
-        ), # Keep after organization
-        banner_image: ActiveStorage::Blob.create_and_upload!(
-          io: File.open(File.join(seeds_root, "city2.jpeg")),
-          filename: "banner_image.jpeg",
-          content_type: "image/jpeg",
-          metadata: nil
-        ), # Keep after organization
+        hero_image: Faker::Boolean.boolean(true_ratio: 0.5) ? hero_image : nil, # Keep after organization
+        banner_image: Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil, # Keep after organization
         promoted: true,
         published_at: 2.weeks.ago,
         objectives: Decidim::Faker::Localized.wrapped("<p>", "</p>") do

--- a/decidim-elections/lib/decidim/votings/participatory_space.rb
+++ b/decidim-elections/lib/decidim/votings/participatory_space.rb
@@ -45,6 +45,13 @@ Decidim.register_participatory_space(:votings) do |participatory_space|
     organization = Decidim::Organization.first
     seeds_root = File.join(__dir__, "..", "..", "..", "db", "seeds")
 
+    banner_image = ActiveStorage::Blob.create_and_upload!(
+      io: File.open(File.join(seeds_root, "city2.jpeg")),
+      filename: "banner_image.jpeg",
+      content_type: "image/jpeg",
+      metadata: nil
+    )
+
     3.times do |n|
       params = {
         organization:,
@@ -54,12 +61,7 @@ Decidim.register_participatory_space(:votings) do |participatory_space|
           Decidim::Faker::Localized.paragraph(sentence_count: 3)
         end,
         scope: n.positive? ? nil : Decidim::Scope.reorder(Arel.sql("RANDOM()")).first,
-        banner_image: ActiveStorage::Blob.create_and_upload!(
-          io: File.open(File.join(seeds_root, "city.jpeg")),
-          filename: "banner_image.jpeg",
-          content_type: "image/jpeg",
-          metadata: nil
-        ), # Keep after organization
+        banner_image: Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil, # Keep after organization
         published_at: 2.weeks.ago,
         start_time: n.weeks.from_now,
         end_time: (n + 1).weeks.from_now + 4.hours,

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -58,17 +58,19 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
       published_at: Time.current
     )
 
+    banner_image = ActiveStorage::Blob.create_and_upload!(
+      io: File.open(File.join(seeds_root, "city2.jpeg")),
+      filename: "banner_image.jpeg",
+      content_type: "image/jpeg",
+      metadata: nil
+    )
+
     3.times do |n|
       type = Decidim::InitiativesType.create!(
         title: Decidim::Faker::Localized.sentence(word_count: 5),
         description: Decidim::Faker::Localized.sentence(word_count: 25),
         organization:,
-        banner_image: ActiveStorage::Blob.create_and_upload!(
-          io: File.open(File.join(seeds_root, "city2.jpeg")),
-          filename: "banner_image.jpeg",
-          content_type: "image/jpeg",
-          metadata: nil
-        )
+        banner_image: Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil # Keep after organization
       )
 
       organization.top_scopes.each do |scope|

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -68,6 +68,19 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
       published_at: Time.current
     )
 
+    hero_image = ActiveStorage::Blob.create_and_upload!(
+      io: File.open(File.join(seeds_root, "city.jpeg")),
+      filename: "hero_image.jpeg",
+      content_type: "image/jpeg",
+      metadata: nil
+    )
+    banner_image = ActiveStorage::Blob.create_and_upload!(
+      io: File.open(File.join(seeds_root, "city2.jpeg")),
+      filename: "banner_image.jpeg",
+      content_type: "image/jpeg",
+      metadata: nil
+    )
+
     process_groups = []
     2.times do
       process_groups << Decidim::ParticipatoryProcessGroup.create!(
@@ -78,12 +91,7 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
         hashtag: Faker::Internet.slug,
         group_url: Faker::Internet.url,
         organization:,
-        hero_image: ActiveStorage::Blob.create_and_upload!(
-          io: File.open(File.join(seeds_root, "city.jpeg")),
-          filename: "hero_image.jpeg",
-          content_type: "image/jpeg",
-          metadata: nil
-        ), # Keep after organization
+        hero_image: Faker::Boolean.boolean(true_ratio: 0.5) ? hero_image : nil, # Keep after organization
         developer_group: Decidim::Faker::Localized.sentence(word_count: 1),
         local_area: Decidim::Faker::Localized.sentence(word_count: 2),
         meta_scope: Decidim::Faker::Localized.word,
@@ -118,18 +126,8 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
           Decidim::Faker::Localized.paragraph(sentence_count: 3)
         end,
         organization:,
-        hero_image: ActiveStorage::Blob.create_and_upload!(
-          io: File.open(File.join(seeds_root, "city.jpeg")),
-          filename: "hero_image.jpeg",
-          content_type: "image/jpeg",
-          metadata: nil
-        ), # Keep after organization
-        banner_image: ActiveStorage::Blob.create_and_upload!(
-          io: File.open(File.join(seeds_root, "city2.jpeg")),
-          filename: "banner_image.jpeg",
-          content_type: "image/jpeg",
-          metadata: nil
-        ), # Keep after organization
+        hero_image: Faker::Boolean.boolean(true_ratio: 0.5) ? hero_image : nil, # Keep after organization
+        banner_image: Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil, # Keep after organization
         promoted: true,
         published_at: 2.weeks.ago,
         meta_scope: Decidim::Faker::Localized.word,


### PR DESCRIPTION
#### :tophat: What? Why?

As all the seeds for spaces always have images, it's difficult for developers to check bugs like #11819

This PR changes the seeds, so the hero and banner images are added randomly: sometimes it is and sometimes it isn't

#### Testing

1. Regenerate seeds with: 

```console
$ bin/rails db:drop db:create db:migrate db:seed 
``` 

2. See that now in the homepage there are some spaces without images

### :camera: Screenshots
![Screenshot of the homepage with some spaces without images](https://github.com/decidim/decidim/assets/717367/60fc47f6-19ba-41c2-b590-ffe8e6344b11)

:hearts: Thank you!
