### PR TITLE
Sort components in "Add component" alphabetically

### DIFF
--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -624,7 +624,7 @@ module Decidim
   #
   # Returns an Array[ComponentManifest].
   def self.component_manifests
-    component_registry.manifests
+    component_registry.manifests.sort_by(&:name)
   end
 
   # Public: Finds all registered participatory space manifest's via the

--- a/decidim-core/spec/lib/decidim_spec.rb
+++ b/decidim-core/spec/lib/decidim_spec.rb
@@ -89,6 +89,15 @@ describe Decidim do
     end
   end
 
+  describe ".component_manifests" do
+    subject { described_class.component_manifests }
+
+    it "returns the manifests sorted alphabetically" do
+      components_name = subject.pluck(:name)
+      expect(components_name).to eq(components_name.sort)
+    end
+  end
+
   describe ".module_installed?" do
     subject { described_class.module_installed?(mod) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

When an admin goes to add a component, it needs to scan where this component is, as they aren't sorted alphabetically.

Weirdly, the table is sorted alphabetically, so we don't have this problem there.

This PR changes the behaviour of the "Add component" button so it's always sorted by name.
 
#### Testing

1. Sign in as admin
2. Go to a process, click in Components
3. Click in "Add component"
4. See that the list of components is sorted alphabetically 

### :camera: Screenshots

#### Before
![Screenshot of the "Add component" button without any sort](https://github.com/decidim/decidim/assets/717367/73daf454-dec2-48af-8b32-684a1890fbc0)

#### After
![Screenshot of the "Add component" button with sorting](https://github.com/decidim/decidim/assets/717367/ad8327bf-e953-4324-827b-3034fd1a973d)


:hearts: Thank you!
