### PR TITLE
Add "Resend invitation" button in system

### DIFF
--- a/decidim-system/app/controllers/decidim/system/organizations_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/organizations_controller.rb
@@ -38,8 +38,8 @@ module Decidim
       end
 
       def edit
-        organization = Organization.find(params[:id])
-        @form = form(UpdateOrganizationForm).from_model(organization)
+        @organization = Organization.find(params[:id])
+        @form = form(UpdateOrganizationForm).from_model(@organization)
       end
 
       def update
@@ -56,6 +56,21 @@ module Decidim
             render :edit
           end
         end
+      end
+
+      def resend_invitation
+        organization = Organization.find(params[:id])
+        InviteUserAgain.call(organization.users.first, "invite_admin") do
+          on(:ok) do
+            flash[:notice] = t("organizations.resend_invitation.success", scope: "decidim.system")
+          end
+
+          on(:invalid) do
+            flash[:alert] = I18n.t("organizations.resend_invitation.error", scope: "decidim.system")
+          end
+        end
+
+        redirect_to organizations_path
       end
 
       private

--- a/decidim-system/app/views/decidim/system/organizations/edit.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/edit.html.erb
@@ -34,7 +34,14 @@
     <%= render partial: "advanced_settings", locals: { f: } %>
   </div>
 
-  <div class="form__wrapper-block">
+  <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
+    <% if @organization.users.first&.invitation_pending? %>
+      <%= link_to t(".resend_invitation"),
+                  resend_invitation_organization_path(@organization),
+                  method: :post,
+                  class: "button button__sm md:button__lg button__transparent-secondary",
+                  data: { confirm: t(".confirm_resend_invitation") } %>
+    <% end %>
     <%= f.submit t("decidim.system.actions.save"), class: "button button__sm md:button__lg button__primary" %>
   </div>
 <% end %>

--- a/decidim-system/app/views/decidim/system/shared/_organizations_list.html.erb
+++ b/decidim-system/app/views/decidim/system/shared/_organizations_list.html.erb
@@ -17,6 +17,13 @@
           <%= l organization.created_at, format: :short %>
         </td>
         <td class="actions">
+          <% if organization.users.first&.invitation_pending? %>
+            <%= link_to t(".resend_invitation"),
+                        resend_invitation_organization_path(organization),
+                        method: :post,
+                        class: "button button__sm button__transparent-secondary no-underline",
+                        data: { confirm: t(".confirm_resend_invitation") } %>
+          <% end %>
           <%= link_to t("actions.edit", scope: "decidim.system"), edit_organization_path(organization) %>
         </td>
       </tr>

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -189,6 +189,8 @@ en:
             The style-src directive restricts the URLs which can be loaded using <style> elements.
             The platform will add "'self' 'unsafe-inline'", but allows you to add more. leave it blank if you are unsure.
         edit:
+          confirm_resend_invitation: Are you sure you want to resend the invitation?
+          resend_invitation: Resend invitation
           secondary_hosts_hint: Enter each one of them in a new line
           title: Edit organization
         file_upload_settings:
@@ -237,6 +239,9 @@ en:
           twitter:
             api_key: API key
             api_secret: API secret
+        resend_invitation:
+          error: There was a problem sending the invitation.
+          success: Invitation successfully sent.
         smtp_settings:
           fieldsets:
             sender: Sender
@@ -256,6 +261,9 @@ en:
         notices:
           no_organization_warning_html: You must create an organization to get started. Make sure you read %{guide} before proceeding.
           our_getting_started_guide: our getting started guide
+        organizations_list:
+          confirm_resend_invitation: Are you sure you want to resend the invitation?
+          resend_invitation: Resend invitation
       titles:
         dashboard: Dashboard
         decidim: Decidim

--- a/decidim-system/config/routes.rb
+++ b/decidim-system/config/routes.rb
@@ -11,7 +11,11 @@ Decidim::System::Engine.routes.draw do
              }
 
   authenticate(:admin) do
-    resources :organizations, except: [:show, :destroy]
+    resources :organizations, except: [:show, :destroy] do
+      member do
+        post :resend_invitation
+      end
+    end
     resources :admins, except: [:show]
     resources :oauth_applications
 


### PR DESCRIPTION
#### :tophat: What? Why?

There's a typical problem with the initial set-up of Decidim where an implementer creates a new organization for the first time. The thing is that they don't have a working SMTP configured (yet), so the initial email with the invitation isn't sent. 

This PR mitigates this difficulty by allowing to resend the invitation, so if this email isn't received, the implementers can resend this email, as long the invitation isn't accepted. 

#### Testing

1. Log in to http://localhost:3000/system
2. Create a new organization
3. Go to http://localhost:3000/letter_opener and see that you have the invitation 
4. Go back to http://localhost:3000/system and click the "Resend invitation" button
5. Go to http://localhost:3000/letter_opener and see that you have another invitation 

### :camera: Screenshots

![Screenshot of the organizations list with the button](https://github.com/decidim/decidim/assets/717367/33de4ff6-8d25-4357-b750-c92a97ace749)


:hearts: Thank you!
