### PR TITLE
Fix display of attachment titles

### DIFF
--- a/decidim-core/app/cells/decidim/documents_panel_cell.rb
+++ b/decidim-core/app/cells/decidim/documents_panel_cell.rb
@@ -17,6 +17,7 @@ module Decidim
     include Decidim::AttachmentsHelper
     include Cell::ViewModel::Partial
     include ActiveSupport::NumberHelper
+    include ERB::Util
 
     alias resource model
 

--- a/decidim-core/app/views/decidim/application/_document.html.erb
+++ b/decidim-core/app/views/decidim/application/_document.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id(document) %>">
   <div class="card__list-content">
     <%= link_to document.url, target: "_blank", rel: "noopener noreferrer", class: "card__list-title", title: t("decidim.application.document.download") do %>
-      <%= attachment_title(document) %>
+      <%= h attachment_title(document) %>
     <% end %>
     <% if document.description.present? %>
       <div class="card__list-text"><%= translated_attribute(document.description) %></div>

--- a/decidim-proposals/spec/shared/proposals_wizards_examples.rb
+++ b/decidim-proposals/spec/shared/proposals_wizards_examples.rb
@@ -195,6 +195,37 @@ shared_examples "proposals wizards" do |options|
           expect(page).to have_content("Edit Proposal Draft")
         end
       end
+
+      context "with attachments" do
+        let!(:component) do
+          create(
+            :proposal_component,
+            :with_creation_enabled,
+            :with_attachments_allowed,
+            participatory_space: participatory_process
+          )
+        end
+
+        let!(:photo) { create(:attachment, :with_image, title: { en: "<svg onload=alert('ALERT')>.jpg" }, weight: 0, attached_to: proposal_draft) }
+        let!(:file) { create(:attachment, :with_pdf, title: { en: "<svg onload=alert('ALERT')>.pdf" }, weight: 1, attached_to: proposal_draft) }
+
+        before do
+          expect(page).to have_content(translated(proposal_draft.title))
+
+          visit component_path.preview_proposal_path(proposal_draft)
+        end
+
+        it "displays the attachments correctly" do
+          within "#panel-images" do
+            expect(find("img")["alt"]).to eq(".jpg")
+          end
+
+          click_button("trigger-documents")
+          within "#panel-documents" do
+            expect(find("a.card__list-title")["innerHTML"]).to include("&lt;svg onload=alert('ALERT')&gt;.pdf")
+          end
+        end
+      end
     end
 
     context "when editing a proposal draft" do


### PR DESCRIPTION
#### :tophat: What? Why?
The attachments display is problematic with some special characters. This PR fixes that problem.

#### :pushpin: Related Issues
- Related to #11741

#### Testing
See that CI is green, the added specs cover the problematic case.