### PR TITLE
Add default colors to new organizations

### DIFF
--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -65,8 +65,20 @@ module Decidim
           smtp_settings: form.encrypted_smtp_settings,
           send_welcome_notification: true,
           file_upload_settings: form.file_upload_settings.final,
+          colors: default_colors,
           content_security_policy: form.content_security_policy
         )
+      end
+
+      def default_colors
+        {
+          alert: "#ec5840",
+          primary: "#53bf40",
+          success: "#57d685",
+          warning: "#ffae00",
+          tertiary: "#bf4053",
+          secondary: "#4053bf"
+        }
       end
 
       def invite_user_form(organization)

--- a/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
@@ -107,6 +107,18 @@ module Decidim
             expect(organization.tos_version).to eq(tos_page.updated_at)
           end
 
+          it "sets the default colors" do
+            command.call
+            organization = Organization.last
+
+            expect(organization.colors["alert"]).to eq("#ec5840")
+            expect(organization.colors["primary"]).to eq("#53bf40")
+            expect(organization.colors["success"]).to eq("#57d685")
+            expect(organization.colors["warning"]).to eq("#ffae00")
+            expect(organization.colors["tertiary"]).to eq("#bf4053")
+            expect(organization.colors["secondary"]).to eq("#4053bf")
+          end
+
           describe "#encrypted_smtp_settings" do
             it "concatenates from_email and from_label" do
               expect do


### PR DESCRIPTION
#### :tophat: What? Why?

After a change in the organizations colors in #11451, we've 

#### :pushpin: Related Issues
 
- Related to #11451

#### Testing

1. Sign in to http://localhost:3000/system
2. Create a new organization
3. Go to http://localhost:3000/letter_opener
4. Accept the invitation
5. (without the patch) See the organizations colors and see that you can't actually create the user (as the button is invisible) 
5. (with the patch) See the organizations colors and see that you can create the user

### :camera: Screenshots

#### Without the patch

(Mind that is not the same form that I'm referring in the Testing section, but so you can have an idea on how the buttons look like now)
![Screenshot of the login form (broken)](https://github.com/decidim/decidim/assets/717367/15f3e1a5-57be-4a31-87a9-9e90a5ef650f)

![Screenshot of the organization colors section in the admin](https://github.com/decidim/decidim/assets/717367/6717352b-4162-4f07-95dc-97681ae4b053)


#### With the patch

![Screenshot of the login form (fixed)](https://github.com/decidim/decidim/assets/717367/87c48d5e-4661-4c43-9414-be215ba6862b)


:hearts: Thank you!
