### PR TITLE
Make HTML header snippets its own section and fix textearea heights

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_item_edit.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_item_edit.scss
@@ -64,9 +64,12 @@
       [type="tel"],
       [type="time"],
       [type="url"],
-      [type="color"],
-      textarea {
+      [type="color"] {
         @apply shadow-none bg-background-2 text-md h-[40px];
+      }
+
+      textarea {
+        @apply shadow-none bg-background-2 text-md;
       }
 
       .editor-container .editor-input .ProseMirror {

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
@@ -96,4 +96,5 @@
   </div>
   <%= render partial: "decidim/admin/organization_appearance/form/images", locals: { form: } %>
   <%= render partial: "decidim/admin/organization_appearance/form/colors", locals: { form: } %>
+  <%= render partial: "decidim/admin/organization_appearance/form/header_snippets", locals: { form: } %>
 </div>

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/form/_colors.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/form/_colors.html.erb
@@ -65,11 +65,5 @@
         <%= form.color_field :alert_color, value: current_organization.colors["alert"] %>
       </div>
     </div>
-
-    <% if Decidim.enable_html_header_snippets %>
-      <div class="row column">
-        <%= form.text_area :header_snippets, help_text: t(".header_snippets_help_html") %>
-      </div>
-    <% end %>
   </div>
 </div>

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/form/_header_snippets.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/form/_header_snippets.html.erb
@@ -1,0 +1,5 @@
+<% if Decidim.enable_html_header_snippets %>
+  <div class="row column">
+    <%= form.text_area :header_snippets, help_text: t(".header_snippets_help_html") %>
+  </div>
+<% end %>

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/form/_header_snippets.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/form/_header_snippets.html.erb
@@ -10,7 +10,7 @@
     </div>
     <div id="panel-header-snippets" class="card-section">
       <div class="row column">
-        <%= form.text_area :header_snippets, help_text: t(".header_snippets_help_html") %>
+        <%= form.text_area :header_snippets, help_text: t(".header_snippets_help_html"), rows: 20 %>
       </div>
     </div>
   </div>

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/form/_header_snippets.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/form/_header_snippets.html.erb
@@ -1,5 +1,17 @@
 <% if Decidim.enable_html_header_snippets %>
-  <div class="row column">
-    <%= form.text_area :header_snippets, help_text: t(".header_snippets_help_html") %>
+  <div class="card" data-component="accordion" id="accordion-header-snippets">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-header-snippets" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title">
+          <%= t("title", scope: "decidim.admin.organization_appearance.form.header_snippets") %>
+        </h2>
+      </button>
+    </div>
+    <div id="panel-header-snippets" class="card-section">
+      <div class="row column">
+        <%= form.text_area :header_snippets, help_text: t(".header_snippets_help_html") %>
+      </div>
+    </div>
   </div>
 <% end %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -845,13 +845,15 @@ en:
             colors_title: Organization colors
             colors_warning_html: Warning! Changing these colors can break the accessibility contrasts. You can check the contrast of your choosing with <a href="https://webaim.org/resources/contrastchecker">WebAIM Contrast Checker</a> or other similar tools.
             explanation: This tool helps you out to choose a color scheme, made up of hues equally spaced around the color wheel, that will be used in the organization's website.
-            header_snippets_help_html: Use this field to add things to the HTML head. The most common use is to integrate third-party services that require some extra JavaScript or CSS. Also, you can use it to add extra meta tags to the HTML. Note that this will only be rendered in public pages, not in the admin section. If the code interacts with external APIs or does not comply with the application security guidelines, it will be necessary to change the Content Security Policy. Read more about <a href="https://docs.decidim.org/develop/en/customize/content_security_policy">on the documentation site</a> .
             legend_html: Main application colors, based on the <a href="https://www.color-meanings.com/triadic-colors/">Triadic algorithm</a>. The <i>secondary</i> color is auto-calculated from the primary color and the saturation you chose.
             saturation: Saturation
             title: Color chooser
             update_suggested_colors: Update suggested colors
           cta_button_path_help_html: 'You can overwrite where the Call To Action button in the homepage links to. Use partial paths, not full URLs here. Accepts letters, numbers, dashes and slashes, and must start with a letter. The Call To Action button is shown in the homepage between the welcome text and the description. Example: %{url}'
           cta_button_text_help: You can overwrite the Call To Action button text in the homepage for each available language in your organization. If not set, the default value will be used. The Call To Action button is shown in the homepage between the welcome text and the description.
+          header_snippets:
+            header_snippets_help_html: Use this field to add things to the HTML head. The most common use is to integrate third-party services that require some extra JavaScript or CSS. Also, you can use it to add extra meta tags to the HTML. Note that this will only be rendered in public pages, not in the admin section. If the code interacts with external APIs or does not comply with the application security guidelines, it will be necessary to change the Content Security Policy. Read more about <a href="https://docs.decidim.org/develop/en/customize/content_security_policy">on the documentation site</a> .
+            title: HTML header snippets
           homepage_appearance_title: Edit homepage appearance
           homepage_highlighted_content_banner_title: Highligted content banner
           images:


### PR DESCRIPTION
#### :tophat: What? Why?

While working on #11885 I saw a couple of things that I didn't like about the "HTML header snippets" field:

1. It's in the same accordion section than the "Organizations colors" but it isn't a color
2. It has a really small area to actually implement things. I've always used for hacking the CSS and JS, but now it's too small to be useful. (I know I can make it bigger manually but that's lost in a refresh).

This PR fixes both of these issues.  

#### Testing

1. Sign in as admin
2. Go to http://localhost:3000/admin/organization/appearance/edit 
3. See the "HTML header snippets" section 

### :camera: Screenshots
 
#### Before
![Screenshot of the HTML header snippets field](https://github.com/decidim/decidim/assets/717367/3a8f49f9-594a-4f26-af7f-82f0c281979b)

#### After 
![Screenshot of the HTML header snippets field](https://github.com/decidim/decidim/assets/717367/8f69064f-f6cc-4f6c-9a12-89d1662fb14a)

:hearts: Thank you!
