### PR TITLE
Fix backports_checker script with edge cases

### DIFF
--- a/lib/decidim/github_manager/querier/by_label.rb
+++ b/lib/decidim/github_manager/querier/by_label.rb
@@ -79,6 +79,7 @@ module Decidim
 
         def merged?(item)
           return false if item["pull_request"].nil?
+          return false if item["pull_request"]["merged_at"].nil?
 
           merged_at(item).present?
         rescue TypeError, Date::Error

--- a/lib/decidim/github_manager/querier/by_label.rb
+++ b/lib/decidim/github_manager/querier/by_label.rb
@@ -78,6 +78,8 @@ module Decidim
         end
 
         def merged?(item)
+          return false if item["pull_request"].nil?
+
           merged_at(item).present?
         rescue TypeError, Date::Error
           false

--- a/lib/decidim/github_manager/querier/related_issues.rb
+++ b/lib/decidim/github_manager/querier/related_issues.rb
@@ -40,7 +40,7 @@ module Decidim
 
             {
               id: issue["number"],
-              title: issue["title"],
+              title: issue["title"].strip,
               state: issue.dig("pull_request", "merged_at").nil? ? issue["state"] : "merged"
             }
           end

--- a/lib/decidim/github_manager/querier/related_issues.rb
+++ b/lib/decidim/github_manager/querier/related_issues.rb
@@ -33,7 +33,7 @@ module Decidim
         # @return [Hash]
         def parse(metadata)
           references = metadata.select do |item|
-            item["event"] == "cross-referenced"
+            item["event"] == "cross-referenced" && item["source"]["issue"]["repository"]["full_name"] == "decidim/decidim"
           end
           references.map do |item|
             issue = item["source"]["issue"]

--- a/spec/lib/decidim/github_manager/querier/by_label_spec.rb
+++ b/spec/lib/decidim/github_manager/querier/by_label_spec.rb
@@ -91,6 +91,26 @@ describe Decidim::GithubManager::Querier::ByLabel do
       end
     end
 
+    context "when there are issues labeled with `type: fix`" do
+      let(:stubbed_body) do
+        <<~RESPONSE
+          [
+            {"number": 12345, "title": "Fix whatever", "labels": [{"name": "type: fix"}, {"name": "module: admin"}], "pull_request": { "merged_at": "2020-01-01T01:01:01Z" }},
+            {"number": 98765, "title": "An issue labeled incorrectly with type: fix", "labels": [{"name": "type: fix"}, {"name": "module: admin"}]}
+          ]
+        RESPONSE
+      end
+      let(:result) do
+        [
+          { id: 12_345, title: "Fix whatever" }
+        ]
+      end
+
+      it "returns a valid result" do
+        expect(querier.call).to eq result
+      end
+    end
+
     context "when there are pull requests that were not merged" do
       let(:stubbed_body) do
         <<~RESPONSE

--- a/spec/lib/decidim/github_manager/querier/by_label_spec.rb
+++ b/spec/lib/decidim/github_manager/querier/by_label_spec.rb
@@ -116,7 +116,8 @@ describe Decidim::GithubManager::Querier::ByLabel do
         <<~RESPONSE
           [
             {"number": 12345, "title": "Fix whatever", "labels": [{"name": "type: fix"}, {"name": "module: admin"}], "pull_request": { "merged_at": "2020-01-01T01:01:01Z" }},
-            {"number": 98765, "title": "Fix another thing", "labels": [{"name": "type: fix"}, {"name": "module: admin"}], "pull_request": { "merged_at": "nil" }}
+            {"number": 98765, "title": "Fix another thing", "labels": [{"name": "type: fix"}, {"name": "module: admin"}], "pull_request": { "merged_at": "nil" }},
+            {"number": 45678, "title": "Fix another thing without being merged", "labels": [{"name": "type: fix"}, {"name": "module: admin"}], "pull_request": { "created_at": "2020-01-01T01:01:01Z" }}
           ]
         RESPONSE
       end

--- a/spec/lib/decidim/github_manager/querier/related_issues_spec.rb
+++ b/spec/lib/decidim/github_manager/querier/related_issues_spec.rb
@@ -5,27 +5,28 @@ require "webmock/rspec"
 
 describe Decidim::GithubManager::Querier::RelatedIssues do
   let(:querier) { described_class.new(token: "abc", issue_id: 12_345) }
-
-  before do
-    stubbed_response = <<~RESPONSE
+  let(:stubbed_body) do
+    <<~RESPONSE
       [
         {
           "event": "cross-referenced",
           "source": {
-            "issue": { "number": 456, "title": "Backport 'Fix whatever' to v0.1", "state": "merged" }
+            "issue": { "number": 456, "title": "Backport 'Fix whatever' to v0.1", "state": "merged", "repository": { "full_name": "decidim/decidim" } }
           }
         },
         {
           "event": "cross-referenced",
           "source": {
-            "issue": { "number": 457, "title": "Backport 'Fix whatever' to v0.2", "state": "merged" }
+            "issue": { "number": 457, "title": "Backport 'Fix whatever' to v0.2", "state": "merged", "repository": { "full_name": "decidim/decidim" } }
           }
         }
       ]
     RESPONSE
+  end
 
+  before do
     stub_request(:get, "https://api.github.com/repos/decidim/decidim/issues/12345/timeline?per_page=100")
-      .to_return(status: 200, body: stubbed_response, headers: {})
+      .to_return(status: 200, body: stubbed_body, headers: {})
   end
 
   describe ".call" do
@@ -37,6 +38,36 @@ describe Decidim::GithubManager::Querier::RelatedIssues do
     end
 
     it "returns a valid response" do
+      expect(querier.call).to eq response
+    end
+  end
+
+  context "when the reference comes from a fork" do
+    let(:stubbed_body) do
+      <<~RESPONSE
+        [
+          {
+            "event": "cross-referenced",
+            "source": {
+              "issue": { "number": 456, "title": "Backport 'Fix whatever' to v0.1", "state": "merged", "repository": { "full_name": "decidim/decidim" } }
+            }
+          },
+          {
+            "event": "cross-referenced",
+            "source": {
+              "issue": { "number": 457, "title": "Backport 'Fix whatever' to v0.1", "state": "merged", "repository": { "full_name": "a_decidim_fork/decidim" } }
+            }
+          }
+        ]
+      RESPONSE
+    end
+    let(:response) do
+      [
+        { id: 456, title: "Backport 'Fix whatever' to v0.1", state: "merged" }
+      ]
+    end
+
+    it "gets ignored" do
       expect(querier.call).to eq response
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

While trying out the backports_checker script I found a couple of edge cases: 

1. we didn't check properly for unmerged PRs with the `type: fix` label (like #11812)
2. we didn't check properly for issues with the `type: fix` label (like #11284)
3. we didn't check for backports from forks (like #11450)
4. we didn't check when the title had leading spaces (like #11499)

This PR fixes both of these issues
 
#### Testing

Running the command

```console
./bin/backports_checker --github-token=(gh auth token) --days_to_check_from=120 --last_version_number=0.27 
``` 

Should work 

:hearts: Thank you!
