### PR TITLE
Backport 'Fix autocomplete result list duplicates' to v0.26

### DIFF
--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -26,6 +26,25 @@ describe "Conversations", type: :system do
         expect(page).to have_selector("a.topbar__conversations")
       end
     end
+
+    context "when searching for a user group to a new conversation" do
+      let!(:user_group) { create(:user_group, :confirmed, name: "Example user group", nickname: "example", organization: organization) }
+
+      it "only shows one match even if the keyword matches both name and nickname" do
+        visit decidim.conversations_path
+
+        click_button "New conversation"
+
+        fill_in "add_conversation_users", with: "example"
+
+        expect(find(".tribute-container #results")).to have_css("li", count: 1)
+
+        within ".tribute-container #results .highlight" do
+          expect(page).to have_content("example")
+          expect(page).to have_content("Example user group")
+        end
+      end
+    end
   end
 
   shared_examples "create new conversation" do


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #11442 to v0.26

##### Note for reviewer

The bug can't be reproduced as it was introduced by the refactors of autocompletes (#8524) available since v0.27. Just to be sure I'm backporting (and adapting) the spec 

:hearts: Thank you!