### PR TITLE
Fix spec for i18n change in Crowdin in release/0.26-stable

### DIFF
--- a/decidim-core/spec/system/locales_spec.rb
+++ b/decidim-core/spec/system/locales_spec.rb
@@ -57,7 +57,7 @@ describe "Locales", type: :system do
       fill_in "session_user_email", with: "toto@example.org"
       fill_in "session_user_password", with: "toto"
 
-      click_button "Iniciar sessió"
+      click_button "Entra"
 
       expect(page).to have_content("Email o la contrasenya no són vàlids.")
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Fix the release/0.26-stable pipeline

This was already solved in develop with #11750 and in release/0.27-stable with #11625

#### Testing

All specs should be green

:hearts: Thank you!
