### PR TITLE
Backport 'Raise an error if the export format is unknown' to v0.27

### DIFF
--- a/decidim-core/lib/decidim/exporters.rb
+++ b/decidim-core/lib/decidim/exporters.rb
@@ -9,6 +9,11 @@ module Decidim
     autoload :PDF, "decidim/exporters/pdf"
     autoload :ExportData, "decidim/exporters/export_data"
 
+    # Lock the export formats to one of the available exporters
+    EXPORT_FORMATS = [:JSON, :CSV, :Excel, :PDF, :FormPDF].freeze
+
+    class UnknownFormatError < StandardError; end
+
     # Necessary for the i18n normalizer to locate strings not directly invoked in views:
 
     # i18n-tasks-use t('decidim.admin.exports.formats.JSON')
@@ -19,7 +24,11 @@ module Decidim
     #
     # format - The exporter format as a string. i.e "CSV"
     def self.find_exporter(format)
-      const_get(format)
+      raise UnknownFormatError unless format.respond_to?(:to_sym)
+      raise UnknownFormatError unless EXPORT_FORMATS.include?(format.to_sym)
+      raise UnknownFormatError unless const_defined?(format.to_sym)
+
+      const_get(format.to_sym)
     end
   end
 end

--- a/decidim-core/spec/lib/exporters_spec.rb
+++ b/decidim-core/spec/lib/exporters_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Exporters do
+    describe ".find_exporter" do
+      subject { described_class.find_exporter(format) }
+
+      described_class::EXPORT_FORMATS.each do |format|
+        let(:format) { format }
+
+        context "with the #{format} format" do
+          subject { described_class.find_exporter(format) }
+
+          it "returns the correct exporter" do
+            expect(subject).to eq(described_class.const_get(format))
+          end
+        end
+      end
+
+      context "with an unknown format" do
+        let(:format) { "XYZ" }
+
+        it "raises an UnknownFormatError" do
+          expect { subject }.to raise_error(described_class::UnknownFormatError)
+        end
+      end
+
+      context "with nil format" do
+        let(:format) { nil }
+
+        it "raises an UnknownFormatError" do
+          expect { subject }.to raise_error(described_class::UnknownFormatError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #11618 to v0.27

:hearts: Thank you!