### PR TITLE
Backport 'Bump devise_invitable from v2.0.8 to v2.0.9' to v0.26

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ PATH
       decidim-core (= 0.26.8)
       devise (~> 4.7)
       devise-i18n (~> 1.2)
-      devise_invitable (~> 2.0)
+      devise_invitable (~> 2.0, >= 2.0.9)
     decidim-api (0.26.8)
       graphql (~> 1.12, < 1.13)
       rack-cors (~> 1.0)
@@ -200,7 +200,7 @@ PATH
       decidim-core (= 0.26.8)
       devise (~> 4.7)
       devise-i18n (~> 1.2)
-      devise_invitable (~> 2.0)
+      devise_invitable (~> 2.0, >= 2.0.9)
     decidim-templates (0.26.8)
       decidim-core (= 0.26.8)
       decidim-forms (= 0.26.8)
@@ -285,7 +285,7 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     batch-loader (1.5.0)
-    bcrypt (3.1.18)
+    bcrypt (3.1.19)
     better_html (1.0.16)
       actionview (>= 4.0)
       activesupport (>= 4.0)
@@ -343,12 +343,13 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorize (0.8.1)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
     crass (1.0.6)
     css_parser (1.14.0)
       addressable
+    date (3.3.3)
     date_validator (0.9.0)
       activemodel
       activesupport
@@ -366,7 +367,7 @@ GEM
     declarative-option (0.1.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (4.9.2)
+    devise (4.9.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -374,7 +375,7 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.11.0)
       devise (>= 4.9.0)
-    devise_invitable (2.0.8)
+    devise_invitable (2.0.9)
       actionmailer (>= 5.0)
       devise (>= 4.6)
     diff-lcs (1.5.0)
@@ -398,7 +399,7 @@ GEM
       smart_properties
     erbse (0.1.4)
       temple
-    erubi (1.10.0)
+    erubi (1.12.0)
     excon (0.99.0)
     execjs (2.8.1)
     factory_bot (4.11.1)
@@ -446,7 +447,7 @@ GEM
       fog-core (>= 1.27, < 3.0)
     formatador (1.1.0)
     geocoder (1.7.5)
-    globalid (0.5.2)
+    globalid (1.1.0)
       activesupport (>= 5.0)
     graphlient (0.4.0)
       faraday (>= 1.0)
@@ -461,7 +462,7 @@ GEM
     highline (2.1.0)
     html_tokenizer (0.0.7)
     htmlentities (4.3.4)
-    i18n (1.8.11)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.37)
       activesupport (>= 4.0.2)
@@ -514,8 +515,11 @@ GEM
     loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     mdl (0.12.0)
@@ -529,9 +533,9 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
-    mini_mime (1.1.1)
+    mini_mime (1.1.5)
     mini_portile2 (2.6.1)
-    minitest (5.14.4)
+    minitest (5.20.0)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
@@ -541,6 +545,11 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.3.0)
     mustache (1.1.1)
+    net-imap (0.4.4)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
     net-protocol (0.2.1)
       timeout
     net-smtp (0.3.3)
@@ -609,8 +618,8 @@ GEM
     public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
-    racc (1.6.0)
-    rack (2.2.3)
+    racc (1.7.3)
+    rack (2.2.8)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
     rack-cors (1.1.1)
@@ -619,8 +628,8 @@ GEM
       rack
     rack-proxy (0.7.6)
       rack
-    rack-test (1.1.0)
-      rack (>= 1.0, < 3)
+    rack-test (2.1.0)
+      rack (>= 1.3)
     rails (6.0.4.1)
       actioncable (= 6.0.4.1)
       actionmailbox (= 6.0.4.1)
@@ -640,10 +649,11 @@ GEM
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
       activesupport (>= 5.0.1.rc1)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.2)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
@@ -655,7 +665,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
-    rake (13.0.6)
+    rake (13.1.0)
     ransack (2.4.2)
       activerecord (>= 5.2.4)
       activesupport (>= 5.2.4)
@@ -674,7 +684,7 @@ GEM
     regexp_parser (2.1.1)
     request_store (1.5.1)
       rack (>= 1.4)
-    responders (3.1.0)
+    responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.5)
@@ -772,12 +782,12 @@ GEM
     temple (0.10.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    thor (1.1.0)
+    thor (1.3.0)
     thread_safe (0.3.6)
     tilt (2.1.0)
     timeout (0.3.2)
     tomlrb (2.0.3)
-    tzinfo (1.2.9)
+    tzinfo (1.2.11)
       thread_safe (~> 0.1)
     uber (0.1.0)
     unicode-display_width (1.8.0)
@@ -832,7 +842,7 @@ GEM
     wkhtmltopdf-binary (0.12.6.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.5.1)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   ruby
@@ -860,7 +870,7 @@ DEPENDENCIES
   web-console (= 4.0.4)
 
 RUBY VERSION
-   ruby 2.7.5p203
+   ruby 3.1.1p18
 
 BUNDLED WITH
    2.3.5

--- a/decidim-admin/decidim-admin.gemspec
+++ b/decidim-admin/decidim-admin.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-core", Decidim::Admin.version
   s.add_dependency "devise", "~> 4.7"
   s.add_dependency "devise-i18n", "~> 1.2"
-  s.add_dependency "devise_invitable", "~> 2.0"
+  s.add_dependency "devise_invitable", "~> 2.0", ">= 2.0.9"
 
   s.add_development_dependency "decidim-dev", Decidim::Admin.version
   s.add_development_dependency "decidim-participatory_processes", Decidim::Admin.version

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -30,7 +30,7 @@ PATH
       decidim-core (= 0.26.8)
       devise (~> 4.7)
       devise-i18n (~> 1.2)
-      devise_invitable (~> 2.0)
+      devise_invitable (~> 2.0, >= 2.0.9)
     decidim-api (0.26.8)
       graphql (~> 1.12, < 1.13)
       rack-cors (~> 1.0)
@@ -190,7 +190,7 @@ PATH
       decidim-core (= 0.26.8)
       devise (~> 4.7)
       devise-i18n (~> 1.2)
-      devise_invitable (~> 2.0)
+      devise_invitable (~> 2.0, >= 2.0.9)
     decidim-templates (0.26.8)
       decidim-core (= 0.26.8)
       decidim-forms (= 0.26.8)
@@ -333,12 +333,13 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorize (0.8.1)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
     crass (1.0.6)
     css_parser (1.14.0)
       addressable
+    date (3.3.3)
     date_validator (0.9.0)
       activemodel
       activesupport
@@ -356,7 +357,7 @@ GEM
     declarative-option (0.1.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (4.9.2)
+    devise (4.9.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -364,7 +365,7 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.11.0)
       devise (>= 4.9.0)
-    devise_invitable (2.0.8)
+    devise_invitable (2.0.9)
       actionmailer (>= 5.0)
       devise (>= 4.6)
     diff-lcs (1.5.0)
@@ -388,7 +389,7 @@ GEM
       smart_properties
     erbse (0.1.4)
       temple
-    erubi (1.10.0)
+    erubi (1.12.0)
     excon (0.100.0)
     execjs (2.8.1)
     factory_bot (4.11.1)
@@ -441,7 +442,7 @@ GEM
       activesupport (>= 4.1, < 7.1)
       railties (>= 4.1, < 7.1)
     geocoder (1.7.5)
-    globalid (0.5.2)
+    globalid (1.1.0)
       activesupport (>= 5.0)
     graphlient (0.4.0)
       faraday (>= 1.0)
@@ -456,7 +457,7 @@ GEM
     highline (2.1.0)
     html_tokenizer (0.0.7)
     htmlentities (4.3.4)
-    i18n (1.8.11)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.37)
       activesupport (>= 4.0.2)
@@ -509,8 +510,11 @@ GEM
     loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     mdl (0.12.0)
@@ -524,9 +528,9 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
-    mini_mime (1.1.1)
+    mini_mime (1.1.5)
     mini_portile2 (2.6.1)
-    minitest (5.14.4)
+    minitest (5.20.0)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
@@ -536,6 +540,11 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.3.0)
     mustache (1.1.1)
+    net-imap (0.4.4)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
     net-protocol (0.2.1)
       timeout
     net-smtp (0.3.3)
@@ -605,8 +614,8 @@ GEM
     public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
-    racc (1.6.0)
-    rack (2.2.3)
+    racc (1.7.3)
+    rack (2.2.8)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
     rack-cors (1.1.1)
@@ -615,8 +624,8 @@ GEM
       rack
     rack-proxy (0.7.6)
       rack
-    rack-test (1.1.0)
-      rack (>= 1.0, < 3)
+    rack-test (2.1.0)
+      rack (>= 1.3)
     rails (6.0.4.1)
       actioncable (= 6.0.4.1)
       actionmailbox (= 6.0.4.1)
@@ -636,10 +645,11 @@ GEM
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
       activesupport (>= 5.0.1.rc1)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.2)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
@@ -651,7 +661,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.1.0)
     ransack (2.4.2)
       activerecord (>= 5.2.4)
       activesupport (>= 5.2.4)
@@ -670,7 +680,7 @@ GEM
     regexp_parser (2.8.1)
     request_store (1.5.1)
       rack (>= 1.4)
-    responders (3.1.0)
+    responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.5)
@@ -765,12 +775,12 @@ GEM
     temple (0.10.2)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    thor (1.1.0)
+    thor (1.3.0)
     thread_safe (0.3.6)
     tilt (2.2.0)
     timeout (0.4.0)
     tomlrb (2.0.3)
-    tzinfo (1.2.9)
+    tzinfo (1.2.11)
       thread_safe (~> 0.1)
     uber (0.1.0)
     unicode-display_width (1.8.0)
@@ -825,7 +835,7 @@ GEM
     wkhtmltopdf-binary (0.12.6.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.5.1)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   ruby
@@ -851,7 +861,7 @@ DEPENDENCIES
   wicked_pdf (~> 2.1)
 
 RUBY VERSION
-   ruby 2.7.5p203
+   ruby 3.1.1p18
 
 BUNDLED WITH
    2.3.5

--- a/decidim-system/decidim-system.gemspec
+++ b/decidim-system/decidim-system.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-core", Decidim::System.version
   s.add_dependency "devise", "~> 4.7"
   s.add_dependency "devise-i18n", "~> 1.2"
-  s.add_dependency "devise_invitable", "~> 2.0"
+  s.add_dependency "devise_invitable", "~> 2.0", ">= 2.0.9"
 
   s.add_development_dependency "decidim-dev", Decidim::System.version
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #11888 to v0.26

:hearts: Thank you!