### PR TITLE
Fix proposal listing fields arrangements

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
@@ -26,14 +26,7 @@
     </div>
   </td>
   <td class="table-list__date">
-    <%= l proposal.created_at, format: :decidim_short %>
-  </td>
-
-  <td>
-    <strong class="label <%= proposal_state_css_class proposal %>">
-      <%= t("decidim/amendment", scope: "activerecord.models", count: 1) if proposal.emendation? %>
-      <%= proposal_complete_state proposal %>
-    </strong>
+    <%= l proposal.published_at, format: :decidim_short %>
   </td>
 
   <% unless current_settings.publish_answers_immediately? %>
@@ -64,6 +57,13 @@
 
   <td class="valuators-count">
     <%= proposal.valuation_assignments.count %>
+  </td>
+
+  <td>
+    <strong class="label <%= proposal_state_css_class proposal %>">
+      <%= t("decidim/amendment", scope: "activerecord.models", count: 1) if proposal.emendation? %>
+      <%= proposal_complete_state proposal %>
+    </strong>
   </td>
 
   <td class="table-list__actions">


### PR DESCRIPTION
#### :tophat: What? Why?
While working on the proposal admin fields, i have noticed that the admin proposals table header and the proposal row fields are not arranged. 

Also, I changed the value of "published at" field from creation date, to actual publication timestamp. 

As we can see in the below image, Votes are "Rejected / Amendment Evaluating" yet, the status is "0".

![image](https://github.com/decidim/decidim/assets/105683/72413ed2-73d4-4122-9cfa-e905880c0ad3)

#### Testing
*Describe the best way to test or validate your PR.*
1. Login as admin, and visit any Proposals admin listing 
2. See the field orders 
3. Apply patch 
4. See new order 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

![image](https://github.com/decidim/decidim/assets/105683/b86da0a4-22bb-48de-9888-b5d2c588af3a)

:hearts: Thank you!
