### PR TITLE
Redesign: removal background color lang in Admin

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_tabs.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_tabs.scss
@@ -23,7 +23,6 @@
   .tabs-title > a[aria-selected="true"] {
     @apply font-bold text-secondary;
 
-
     &::before {
       @apply border-white;
 

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_tabs.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_tabs.scss
@@ -4,15 +4,9 @@
   li {
     @apply p-0.5 rounded-t-sm text-secondary text-xs;
 
-    background-color: rgba(243, 244, 247, 1);
-
     &.is-active,
     &:hover {
       @apply border-b border-secondary;
-    }
-
-    &:hover {
-      background-color: rgba(243, 244, 247, 1);
     }
   }
 
@@ -29,7 +23,6 @@
   .tabs-title > a[aria-selected="true"] {
     @apply font-bold text-secondary;
 
-    background-color: rgba(243, 244, 247, 1);
 
     &::before {
       @apply border-white;


### PR DESCRIPTION
#### :tophat: What? Why?
Removal of language background colour on languages (including hover) in admin panel. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11673

#### Testing
1. Login and head over to edit 
2. Head over to a process for example
3. Click a component where the language can be changed.
4. Notice the background colour has been removed.

### :camera: Screenshots
Before: 
![image](https://github.com/decidim/decidim/assets/101816158/05538e7d-b39d-452e-b533-9e25a7d867c4)


After:
<img width="990" alt="Screenshot 2023-11-06 at 10 00 59" src="https://github.com/decidim/decidim/assets/101816158/489cff6c-5805-4756-9317-32faa8ba267d">


:hearts: Thank you!
