### PR TITLE
Redesign: design a11y components

### DIFF
--- a/decidim-design/app/packs/stylesheets/design.scss
+++ b/decidim-design/app/packs/stylesheets/design.scss
@@ -79,7 +79,7 @@
 }
 
 .design__heading__description {
-  @apply mt-10 text-gray-2 text-md font-normal [&>*+*]:mt-4;
+  @apply mt-10 text-gray-2 text-md font-normal [&>*+*]:mt-4 [&_a]:underline;
 }
 
 .design__section {

--- a/decidim-design/app/views/decidim/design/components/accordions.html.erb
+++ b/decidim-design/app/views/decidim/design/components/accordions.html.erb
@@ -34,7 +34,7 @@
     <ul class="tab-x-container">
       <% 3.times do |tab| %>
         <li>
-          <button id="trigger-1-<%= tab %>" class="tab-x" data-controls="panel-1-<%= tab %>" >
+          <button id="trigger-1-<%= tab %>" class="tab-x" data-controls="panel-1-<%= tab %>">
             Trigger <%= tab %>
           </button>
         </li>

--- a/decidim-design/app/views/decidim/design/components/accordions.html.erb
+++ b/decidim-design/app/views/decidim/design/components/accordions.html.erb
@@ -14,27 +14,13 @@
 <section id="demo" class="design__section">
   <h2>Demo</h2>
 
-  <p>It is import to remark this is a ONLY a javascript feature. Styles are provided apart.</p>
-
-  <div data-component="accordion" id="example-accordion">
-    <% 3.times do |element| %>
-      <button id="trigger-<%= element %>" data-controls="panel-<%= element %>">
-        Trigger <%= element %>
-      </button>
-
-      <div id="panel-<%= element %>" aria-hidden="true">
-        Panel <%= element %>
-      </div>
-    <% end %>
-  </div>
-
-  <p>The following example shows an better-looking accordion with some styles attached.</p>
+  <p>Throughout the application the accordions are used, mainly, to show/hide content in tabs or fold/unfold visible texts.</p>
 
   <div data-component="accordion" data-multiselectable="false" id="example-accordion-1">
     <ul class="tab-x-container">
       <% 3.times do |tab| %>
         <li>
-          <button id="trigger-1-<%= tab %>" class="tab-x" data-controls="panel-1-<%= tab %>">
+          <button id="trigger-1-<%= tab %>" class="tab-x" data-controls="panel-1-<%= tab %>" <%= "data-open=true" if tab.zero? %>>
             Trigger <%= tab %>
           </button>
         </li>

--- a/decidim-design/app/views/decidim/design/components/accordions.html.erb
+++ b/decidim-design/app/views/decidim/design/components/accordions.html.erb
@@ -1,0 +1,80 @@
+<% content_for :heading do %>
+  Accordions
+<% end %>
+
+<% content_for :description do %>
+  Accordions are a javascript feature available thanks to an external library called <a href="https://github.com/jonathanlevaillant/a11y-accordion-component" target="_blank" rel="noopener noreferrer">a11y-accordion-component</a>.
+<% end %>
+
+<% content_for :toc do %>
+  <a href="#example">Demo</a>
+  <a href="#usage">Usage</a>
+<% end %>
+
+<section id="demo" class="design__section">
+  <h2>Demo</h2>
+
+  <p>It is import to remark this is a ONLY a javascript feature. Styles are provided apart.</p>
+
+  <div data-component="accordion" id="example-accordion">
+    <% 5.times do |element| %>
+      <button id="trigger-<%= element %>" data-controls="panel-<%= element %>">
+        Trigger <%= element %>
+      </button>
+
+      <div id="panel-<%= element %>" aria-hidden="true">
+        Panel <%= element %>
+      </div>
+    <% end %>
+  </div>
+
+  <p>The following example shows an better-looking accordion with some styles attached.</p>
+
+  <div data-component="accordion" data-multiselectable="false" id="example-accordion-1">
+    <ul class="tab-x-container">
+      <% 3.times do |tab| %>
+        <li>
+          <button id="trigger-1-<%= tab %>" class="tab-x" data-controls="panel-1-<%= tab %>" >
+            Trigger <%= tab %>
+          </button>
+        </li>
+      <% end %>
+    </ul>
+
+    <% 3.times do |panel| %>
+      <div id="panel-1-<%= panel %>" class="py-8 text-sm font-italic">
+        Content of the panel <%= panel %>
+      </div>
+    <% end %>
+  </div>
+</section>
+
+<section id="usage" class="design__section">
+  <h2>Usage</h2>
+
+  <p>An accordion requires at least three elements:</p>
+
+  <p>1. A wrapper <code>div</code>, with the data-attribute <code>data-component="accordion"</code>, over all the available triggers and panels</p>
+
+  <p>2. A trigger element, user actionable (as a button), pointing to the collapsable element through <code>data-controls="panel"</code>, where <i>panel</i> is the <code>id</code> of the panel</p>
+
+  <p>3. A hideable element, whose <code>id</code> matches the data-controls value the trigger refers to.</p>
+
+  <div class="design__section-snippet" style="margin-top: inherit;">
+    <p>Source code on GitHub: <%= link_to("a11y.js", "https://github.com/decidim/decidim/blob/develop/decidim-core/app/packs/src/decidim/a11y.js", target: "_blank", rel: "noopener noreferrer") %></p>
+
+    <code>
+      <textarea rows="8">
+        <div data-component="accordion" id="example-accordion">
+          <button id="trigger" data-controls="panel">
+            Trigger
+          </button>
+
+          <div id="panel" aria-hidden="true">
+            Panel
+          </div>
+        </div>
+      </textarea>
+    </code>
+  </div>
+</section>

--- a/decidim-design/app/views/decidim/design/components/accordions.html.erb
+++ b/decidim-design/app/views/decidim/design/components/accordions.html.erb
@@ -17,7 +17,7 @@
   <p>It is import to remark this is a ONLY a javascript feature. Styles are provided apart.</p>
 
   <div data-component="accordion" id="example-accordion">
-    <% 5.times do |element| %>
+    <% 3.times do |element| %>
       <button id="trigger-<%= element %>" data-controls="panel-<%= element %>">
         Trigger <%= element %>
       </button>
@@ -54,26 +54,26 @@
 
   <p>An accordion requires at least three elements:</p>
 
-  <p>1. A wrapper <code>div</code>, with the data-attribute <code>data-component="accordion"</code>, over all the available triggers and panels</p>
+  <p>1. A wrapper <code>div</code>, with the data-attribute <code>data-component="accordion"</code>, over all the available triggers and panels.</p>
 
-  <p>2. A trigger element, user actionable (as a button), pointing to the collapsable element through <code>data-controls="panel"</code>, where <i>panel</i> is the <code>id</code> of the panel</p>
+  <p>2. A trigger element, user actionable (as a button), pointing to the collapsable element through <code>data-controls="panel"</code>, where <i>panel</i> is the <code>id</code> of the panel.</p>
 
   <p>3. A hideable element, whose <code>id</code> matches the data-controls value the trigger refers to.</p>
 
   <div class="design__section-snippet" style="margin-top: inherit;">
-    <p>Source code on GitHub: <%= link_to("a11y.js", "https://github.com/decidim/decidim/blob/develop/decidim-core/app/packs/src/decidim/a11y.js", target: "_blank", rel: "noopener noreferrer") %></p>
+    <p>Source code on GitHub: <%= link_to("decidim-core/app/packs/src/decidim/a11y.js", "https://github.com/decidim/decidim/blob/develop/decidim-core/app/packs/src/decidim/a11y.js", target: "_blank", rel: "noopener noreferrer") %></p>
 
     <code>
       <textarea rows="8">
-        <div data-component="accordion" id="example-accordion">
-          <button id="trigger" data-controls="panel">
-            Trigger
-          </button>
+<div data-component="accordion" id="example-accordion">
+  <button id="trigger" data-controls="panel">
+    Trigger
+  </button>
 
-          <div id="panel" aria-hidden="true">
-            Panel
-          </div>
-        </div>
+  <div id="panel" aria-hidden="true">
+    Panel
+  </div>
+</div>
       </textarea>
     </code>
   </div>

--- a/decidim-design/app/views/decidim/design/components/dialogs.html.erb
+++ b/decidim-design/app/views/decidim/design/components/dialogs.html.erb
@@ -1,0 +1,89 @@
+<% content_for :heading do %>
+  Dialogs
+<% end %>
+
+<% content_for :description do %>
+  Dialogs are a javascript feature available thanks to an external library called <a href="https://github.com/jonathanlevaillant/a11y-dialog-component" target="_blank" rel="noopener noreferrer">a11y-dialog-component</a>.
+<% end %>
+
+<% content_for :toc do %>
+  <a href="#example">Demo</a>
+  <a href="#usage">Usage</a>
+  <a href="#html">HTML tips</a>
+<% end %>
+
+<section id="demo" class="design__section">
+  <h2>Demo</h2>
+
+  <p>The dialogs, or modal components, are implemented thorugh the rails helper <code>decidim_modal</code>. </p>
+
+  <button data-dialog-open="example" class="button button__lg button__secondary">
+    Show modal
+  </button>
+
+  <%= decidim_modal id: "example" do %>
+    I am a modal
+  <% end %>
+</section>
+
+<section id="usage" class="design__section">
+  <h2>Usage</h2>
+
+  <p>An dialog requires two elements:</p>
+
+  <p>1. A user actionable element, with the data-attribute <code>data-dialog-open="example"</code>, where example is the <code>id</code> of the modal.</p>
+
+  <p>2. A modal element, whose <code>id</code> matches the data-target value the trigger refers to.</p>
+
+  <div class="design__section-snippet" style="margin-top: inherit;">
+    <p>Source code on GitHub: <%= link_to("decidim-core/app/packs/src/decidim/a11y.js", "https://github.com/decidim/decidim/blob/develop/decidim-core/app/packs/src/decidim/a11y.js", target: "_blank", rel: "noopener noreferrer") %></p>
+
+    <code>
+      <textarea rows="7">
+<button data-dialog-open="example" class="button button__lg button__secondary">
+  Show modal
+</button>
+
+&#60;%= decidim_modal id: "example" do %&#62;
+  I am a modal
+&#60;% end %&#62;
+      </textarea>
+    </code>
+  </div>
+</section>
+
+<section id="html" class="design__section">
+  <h2>HTML tips</h2>
+
+  <p>In order to display a complex modal, matching up the styles, do the following markup:</p>
+
+  <p>Pay attention to the <i>data-attributes</i> and the <i>ids</i>. For instance, the <code>[data-dialog-title]</code>'s id starts with <i>dialog-title</i> plus the <i>modal id</i>.</p>
+
+  <div class="design__section-snippet" style="margin-top: inherit;">
+    <code>
+      <textarea rows="20">
+&#60;%= decidim_modal id: "example" do %&#62;
+  <div data-dialog-container>
+    &#60;%= icon "icon_identificator" %&#62; // ... pick a desired icon
+    <h3 id="dialog-title-example" tabindex="-1" data-dialog-title>
+      Modal title
+    </h3>
+    <div>
+      <p id="dialog-desc-example">
+        Modal description (optional)
+      </p>
+
+      // ... add more HTML
+    </div>
+  </div>
+  <div data-dialog-actions>
+    <button data-dialog-close="example">
+      Close modal
+    </button>
+    // ... add more buttons
+  </div>
+&#60;% end %&#62;
+      </textarea>
+    </code>
+  </div>
+</section>

--- a/decidim-design/app/views/decidim/design/components/dialogs.html.erb
+++ b/decidim-design/app/views/decidim/design/components/dialogs.html.erb
@@ -40,9 +40,9 @@
 
     <code>
       <textarea rows="7">
-<button data-dialog-open="example" class="button button__lg button__secondary">
+&lt;button data-dialog-open=&quot;example&quot; class=&quot;button button__lg button__secondary&quot;&gt;
   Show modal
-</button>
+&lt;/button&gt;
 
 &#60;%= decidim_modal id: "example" do %&#62;
   I am a modal

--- a/decidim-design/app/views/decidim/design/components/dropdowns.html.erb
+++ b/decidim-design/app/views/decidim/design/components/dropdowns.html.erb
@@ -1,0 +1,64 @@
+<% content_for :heading do %>
+  Dropdowns
+<% end %>
+
+<% content_for :description do %>
+  Dropdowns are a javascript feature available thanks to an external library called <a href="https://github.com/jonathanlevaillant/a11y-dropdown-component" target="_blank" rel="noopener noreferrer">a11y-dropdown-component</a>.
+<% end %>
+
+<% content_for :toc do %>
+  <a href="#example">Demo</a>
+  <a href="#usage">Usage</a>
+<% end %>
+
+<section id="demo" class="design__section">
+  <h2>Demo</h2>
+
+  <p>The dropdowns are used along the application in order to collapse large, easy-readable menus for desktop devices, but too wordy for mobile devices.</p>
+
+  <p>This javascript feature is enhanced with a small css, through the naming: the hideable content MUST HAVE an <code>id</code> starting with <i>dropdown-menu</i>.</p>
+
+  <p>The following example will not be noticeable in desktop, but mobile:</p>
+
+  <button id="dropdown-trigger-element" data-component="dropdown" data-target="dropdown-menu-element" data-auto-close="true">
+    <span><%= t("decidim.searches.filters.jump_to") %></span>
+    <%= icon "arrow-down-s-line" %>
+    <%= icon "arrow-up-s-line" %>
+  </button>
+
+  <ul id="dropdown-menu-element">
+    <% 3.times do |item| %>
+      <li class="p-2 text-gray-2">
+        Item <%= item %>
+      </li>
+    <% end %>
+  </ul>
+</section>
+
+<section id="usage" class="design__section">
+  <h2>Usage</h2>
+
+  <p>An accordion requires two elements:</p>
+
+  <p>1. A user actionable element, with the data-attributes <code>data-component="dropdown" data-target="dropdown-menu-element"</code>.</p>
+
+  <p>2. A hideable element, whose <code>id</code> matches the data-target value the trigger refers to.</p>
+
+  <div class="design__section-snippet" style="margin-top: inherit;">
+    <p>Source code on GitHub: <%= link_to("decidim-core/app/packs/src/decidim/a11y.js", "https://github.com/decidim/decidim/blob/develop/decidim-core/app/packs/src/decidim/a11y.js", target: "_blank", rel: "noopener noreferrer") %></p>
+
+    <code>
+      <textarea rows="8">
+<button id="dropdown-trigger-element" data-component="dropdown" data-target="dropdown-menu-element">
+  Trigger
+</button>
+
+<ul id="dropdown-menu-element">
+  <li>Item</li>
+  <li>Item</li>
+  <li>Item</li>
+</ul>
+      </textarea>
+    </code>
+  </div>
+</section>

--- a/decidim-design/app/views/decidim/design/components/dropdowns.html.erb
+++ b/decidim-design/app/views/decidim/design/components/dropdowns.html.erb
@@ -49,15 +49,15 @@
 
     <code>
       <textarea rows="8">
-<button id="dropdown-trigger-element" data-component="dropdown" data-target="dropdown-menu-element">
+&lt;button id=&quot;dropdown-trigger-element&quot; data-component=&quot;dropdown&quot; data-target=&quot;dropdown-menu-element&quot;&gt;
   Trigger
-</button>
+&lt;/button&gt;
 
-<ul id="dropdown-menu-element">
-  <li>Item</li>
-  <li>Item</li>
-  <li>Item</li>
-</ul>
+&lt;ul id=&quot;dropdown-menu-element&quot;&gt;
+  &lt;li&gt;Item&lt;/li&gt;
+  &lt;li&gt;Item&lt;/li&gt;
+  &lt;li&gt;Item&lt;/li&gt;
+&lt;/ul&gt;
       </textarea>
     </code>
   </div>

--- a/decidim-design/app/views/decidim/design/components/dropdowns.html.erb
+++ b/decidim-design/app/views/decidim/design/components/dropdowns.html.erb
@@ -38,7 +38,7 @@
 <section id="usage" class="design__section">
   <h2>Usage</h2>
 
-  <p>An accordion requires two elements:</p>
+  <p>An dropdown requires two elements:</p>
 
   <p>1. A user actionable element, with the data-attributes <code>data-component="dropdown" data-target="dropdown-menu-element"</code>.</p>
 


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR are included the three current accessibility libraries empowered by javascript. They are not cells, they are instantiated as components or independent features, as they're front-end code.

### :camera: Screenshots
![imagen](https://github.com/decidim/decidim/assets/817526/d876b8cc-0517-424a-9957-68ddb463bbed)
![imagen](https://github.com/decidim/decidim/assets/817526/dd22a823-d14f-4d60-bd39-9fa7c57d08b5)
![imagen](https://github.com/decidim/decidim/assets/817526/679d8e30-68b1-4d82-82e5-64798e993166)

:hearts: Thank you!
