### PR TITLE
Do not show the titles in the admin proposals page if there isn't any

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
@@ -107,19 +107,22 @@
             </div>
           </div>
         <% end %>
-        <div class="card-section">
-          <div class="row column">
-            <span class="component__show-title"><%= t ".related_meetings" %></span>
-            <ul id="related-meetings">
-              <% proposal.linked_resources(:meetings, "proposals_from_meeting").each do |meeting| %>
-                <% presented_meeting = present(meeting) %>
-                <li>
-                  <%= link_to presented_meeting.title(html_escape: true), presented_meeting.profile_path %>
-                </li>
-              <% end %>
-            </ul>
+        <% proposal_meetings = proposal.linked_resources(:meetings, "proposals_from_meeting") %>
+        <% if proposal_meetings.any? %>
+          <div class="card-section">
+            <div class="row column">
+              <span class="component__show-title"><%= t ".related_meetings" %></span>
+              <ul id="related-meetings">
+                <% proposal_meetings.each do |meeting| %>
+                  <% presented_meeting = present(meeting) %>
+                  <li>
+                    <%= link_to presented_meeting.title(html_escape: true), presented_meeting.profile_path %>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
           </div>
-        </div>
+        <% end %>
         <% if allowed_to?(:create, :proposal_note, proposal: proposal) %>
           <div class="card-section">
             <%= render "decidim/proposals/admin/proposal_notes/proposal_notes" %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
@@ -49,32 +49,34 @@
             </p>
           </div>
         </div>
-        <div class="card-section">
-          <div class="row column">
-            <span class="component__show-title"><%= t ".endorsers" %></span>
-            <ul id="proposal-endorsers-list">
-              <% presented_endorsers = endorsers_presenters_for(proposal).to_a %>
-              <% presented_endorsers.first(5).each do |presented_endorser| %>
-                <li>
-                  <%= link_to_if(
-                        presented_endorser.profile_path.present?,
-                        presented_endorser.name,
-                        presented_endorser.profile_path,
-                        target: :blank
-                      ) %>
-                </li>
-              <% end %>
-              <% if presented_endorsers.count > 5 %>
-                <li>
-                  <%= link_to(
-                        t(".n_more_endorsers", count: presented_endorsers.count - 5),
-                        resource_locator(proposal).path
-                      ) %>
-                </li>
-              <% end %>
-            </ul>
+        <% presented_endorsers = endorsers_presenters_for(proposal).to_a %>
+        <% if presented_endorsers.any? %>
+          <div class="card-section">
+            <div class="row column">
+              <span class="component__show-title"><%= t ".endorsers" %></span>
+              <ul id="proposal-endorsers-list">
+                <% presented_endorsers.first(5).each do |presented_endorser| %>
+                  <li>
+                    <%= link_to_if(
+                          presented_endorser.profile_path.present?,
+                          presented_endorser.name,
+                          presented_endorser.profile_path,
+                          target: :blank
+                        ) %>
+                  </li>
+                <% end %>
+                <% if presented_endorsers.count > 5 %>
+                  <li>
+                    <%= link_to(
+                          t(".n_more_endorsers", count: presented_endorsers.count - 5),
+                          resource_locator(proposal).path
+                        ) %>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
           </div>
-        </div>
+        <% end %>
         <% if proposal.documents.any? %>
           <div class="card-section">
             <div class="row column">

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
@@ -49,7 +49,7 @@
             </p>
           </div>
         </div>
-        <% presented_endorsers = endorsers_presenters_for(proposal).to_a %>
+        <% presented_endorsers = endorsers_presenters_for(proposal).first(6).to_a %>
         <% if presented_endorsers.any? %>
           <div class="card-section">
             <div class="row column">

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -123,6 +123,7 @@ describe "Admin views proposal details from admin" do
 
     context "when there are endorsements" do
       let!(:endorsements) do
+        # We can not use `create_list`, as it gives a "Validation failed: Resource has already been taken"
         2.times.collect do
           create(:endorsement, resource: proposal, author: build(:user, organization:))
         end
@@ -156,6 +157,7 @@ describe "Admin views proposal details from admin" do
 
       context "with more than 5 endorsements" do
         let!(:endorsements) do
+          # We can not use `create_list`, as it gives a "Validation failed: Resource has already been taken"
           6.times.collect do
             create(:endorsement, resource: proposal, author: build(:user, organization:))
           end

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -202,28 +202,38 @@ describe "Admin views proposal details from admin" do
   end
 
   context "with related meetings" do
-    let(:meeting_component) { create(:meeting_component, participatory_space: participatory_process) }
-    let(:meeting) { create(:meeting, :published, component: meeting_component) }
-    let(:moderated_meeting) { create(:meeting, component: meeting_component) }
-    let!(:moderation) { create(:moderation, reportable: moderated_meeting) }
+    context "when there is not any meeting" do
+      it "does not show the title" do
+        go_to_admin_proposal_page(proposal)
 
-    it "lists the related meetings" do
-      proposal.link_resources(meeting, "proposals_from_meeting")
-      go_to_admin_proposal_page(proposal)
-
-      within "#related-meetings" do
-        expect(page).to have_selector("a", text: translated(meeting.title))
+        expect(page).not_to have_content "Related meetings"
       end
     end
 
-    it "hides the moderated related meeting" do
-      proposal.link_resources(moderated_meeting, "proposals_from_meeting")
-      moderation.update(hidden_at: Time.current)
+    context "when there are meetings" do
+      let(:meeting_component) { create(:meeting_component, participatory_space: participatory_process) }
+      let(:meeting) { create(:meeting, :published, component: meeting_component) }
+      let(:moderated_meeting) { create(:meeting, component: meeting_component) }
+      let!(:moderation) { create(:moderation, reportable: moderated_meeting) }
 
-      go_to_admin_proposal_page(proposal)
+      it "lists the related meetings" do
+        proposal.link_resources(meeting, "proposals_from_meeting")
+        go_to_admin_proposal_page(proposal)
 
-      within "#related-meetings" do
-        expect(page).not_to have_selector("a", text: translated(moderated_meeting.title))
+        within "#related-meetings" do
+          expect(page).to have_css("a", text: translated(meeting.title))
+        end
+      end
+
+      it "hides the moderated related meeting" do
+        proposal.link_resources(moderated_meeting, "proposals_from_meeting")
+        moderation.update(hidden_at: Time.current)
+
+        go_to_admin_proposal_page(proposal)
+
+        within "#related-meetings" do
+          expect(page).not_to have_css("a", text: translated(moderated_meeting.title))
+        end
       end
     end
   end

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -113,49 +113,60 @@ describe "Admin views proposal details from admin" do
   end
 
   describe "with endorsements" do
-    let!(:endorsements) do
-      2.times.collect do
-        create(:endorsement, resource: proposal, author: build(:user, organization:))
+    context "when there is not any endorsements" do
+      it "does not show the title" do
+        go_to_admin_proposal_page(proposal)
+
+        expect(page).not_to have_content "Endorsers"
       end
     end
 
-    it "shows the number of endorsements" do
-      go_to_admin_proposal_page(proposal)
-
-      expect(page).to have_css("[data-endorsements] [data-count]", text: "2")
-    end
-
-    it "shows the ranking by endorsements" do
-      another_proposal = create(:proposal, component:)
-      create(:endorsement, resource: another_proposal, author: build(:user, organization:))
-      go_to_admin_proposal_page(proposal)
-
-      expect(page).to have_css("[data-endorsements] [data-ranking]", text: "1 of ")
-    end
-
-    it "has a link to each endorser profile" do
-      go_to_admin_proposal_page(proposal)
-
-      within "#proposal-endorsers-list" do
-        proposal.endorsements.for_listing.each do |endorsement|
-          endorser = endorsement.normalized_author
-          expect(page).to have_selector("a", text: endorser.name)
-        end
-      end
-    end
-
-    context "with more than 5 endorsements" do
+    context "when there are endorsements" do
       let!(:endorsements) do
-        6.times.collect do
+        2.times.collect do
           create(:endorsement, resource: proposal, author: build(:user, organization:))
         end
       end
 
-      it "links to the proposal page to check the rest of endorsements" do
+      it "shows the number of endorsements" do
+        go_to_admin_proposal_page(proposal)
+
+        expect(page).to have_content "Endorsers"
+        expect(page).to have_css("[data-endorsements] [data-count]", text: "2")
+      end
+
+      it "shows the ranking by endorsements" do
+        another_proposal = create(:proposal, component:)
+        create(:endorsement, resource: another_proposal, author: build(:user, organization:))
+        go_to_admin_proposal_page(proposal)
+
+        expect(page).to have_css("[data-endorsements] [data-ranking]", text: "1 of ")
+      end
+
+      it "has a link to each endorser profile" do
         go_to_admin_proposal_page(proposal)
 
         within "#proposal-endorsers-list" do
-          expect(page).to have_selector("a", text: "and 1 more")
+          proposal.endorsements.for_listing.each do |endorsement|
+            endorser = endorsement.normalized_author
+            expect(page).to have_css("a", text: endorser.name)
+          end
+        end
+      end
+
+      context "with more than 5 endorsements" do
+        let!(:endorsements) do
+          6.times.collect do
+            create(:endorsement, resource: proposal, author: build(:user, organization:))
+          end
+        end
+
+        it "links to the proposal page to check the rest of endorsements" do
+          go_to_admin_proposal_page(proposal)
+
+          within "#proposal-endorsers-list" do
+            expect(page).to have_css("a", text: "and 1 more")
+          end
         end
       end
     end

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -123,9 +123,8 @@ describe "Admin views proposal details from admin" do
 
     context "when there are endorsements" do
       let!(:endorsements) do
-        2.times.collect do
-          create(:endorsement, resource: proposal, author: build(:user, organization:))
-        end
+          create_list(:endorsement, 2, resource: proposal, author: build(:user, organization:))
+
       end
 
       it "shows the number of endorsements" do
@@ -156,9 +155,7 @@ describe "Admin views proposal details from admin" do
 
       context "with more than 5 endorsements" do
         let!(:endorsements) do
-          6.times.collect do
-            create(:endorsement, resource: proposal, author: build(:user, organization:))
-          end
+            create_list(:endorsement, 6, resource: proposal, author: build(:user, organization:))
         end
 
         it "links to the proposal page to check the rest of endorsements" do

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -123,7 +123,9 @@ describe "Admin views proposal details from admin" do
 
     context "when there are endorsements" do
       let!(:endorsements) do
-        create_list(:endorsement, 2, resource: proposal, author: build(:user, organization:))
+        2.times.collect do
+          create(:endorsement, resource: proposal, author: build(:user, organization:))
+        end
       end
 
       it "shows the number of endorsements" do
@@ -154,7 +156,9 @@ describe "Admin views proposal details from admin" do
 
       context "with more than 5 endorsements" do
         let!(:endorsements) do
-          create_list(:endorsement, 6, resource: proposal, author: build(:user, organization:))
+          6.times.collect do
+            create(:endorsement, resource: proposal, author: build(:user, organization:))
+          end
         end
 
         it "links to the proposal page to check the rest of endorsements" do

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -123,7 +123,7 @@ describe "Admin views proposal details from admin" do
 
     context "when there are endorsements" do
       let!(:endorsements) do
-        # We can not use `create_list`, as it gives a "Validation failed: Resource has already been taken"
+        # We cannot use `create_list`, as it gives a "Validation failed: Resource has already been taken"
         2.times.collect do
           create(:endorsement, resource: proposal, author: build(:user, organization:))
         end
@@ -157,7 +157,7 @@ describe "Admin views proposal details from admin" do
 
       context "with more than 5 endorsements" do
         let!(:endorsements) do
-          # We can not use `create_list`, as it gives a "Validation failed: Resource has already been taken"
+          # We cannot use `create_list`, as it gives a "Validation failed: Resource has already been taken"
           6.times.collect do
             create(:endorsement, resource: proposal, author: build(:user, organization:))
           end

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -231,9 +231,7 @@ describe "Admin views proposal details from admin" do
 
         go_to_admin_proposal_page(proposal)
 
-        within "#related-meetings" do
-          expect(page).not_to have_css("a", text: translated(moderated_meeting.title))
-        end
+        expect(page).not_to have_content "Related meetings"
       end
     end
   end

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -123,8 +123,7 @@ describe "Admin views proposal details from admin" do
 
     context "when there are endorsements" do
       let!(:endorsements) do
-          create_list(:endorsement, 2, resource: proposal, author: build(:user, organization:))
-
+        create_list(:endorsement, 2, resource: proposal, author: build(:user, organization:))
       end
 
       it "shows the number of endorsements" do
@@ -155,7 +154,7 @@ describe "Admin views proposal details from admin" do
 
       context "with more than 5 endorsements" do
         let!(:endorsements) do
-            create_list(:endorsement, 6, resource: proposal, author: build(:user, organization:))
+          create_list(:endorsement, 6, resource: proposal, author: build(:user, organization:))
         end
 
         it "links to the proposal page to check the rest of endorsements" do


### PR DESCRIPTION
#### :tophat: What? Why?

When seeing the page for a proposal in the admin panel, it's showing some sections that don't have any content ("Endorsers" and "Related meetings"). 

This PR fixes it by only showing them if they have content

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing

1. Sign in as admin
2. Go to a proposal page in the admin
3. (without the patch) see that you have these title sections even though there isn't any Endorsement nor Related meeting
4. (with the patch):
4.1. See that you don't have these titles if there isn't any content
4.2. See that you have them if there is content

### :camera: Screenshots

#### Before
![Screenshot of this page](https://github.com/decidim/decidim/assets/717367/73922272-020f-4671-8704-2a8c2418beb6)

#### After
![Screenshot of this page](https://github.com/decidim/decidim/assets/717367/f922dbbb-1ffa-46eb-8e2c-cd6f67f8111b)

:hearts: Thank you!
