### PR TITLE
Redesign: design tab-panels

### DIFF
--- a/decidim-design/app/controllers/decidim/design/components_controller.rb
+++ b/decidim-design/app/controllers/decidim/design/components_controller.rb
@@ -9,6 +9,7 @@ module Decidim
       helper ButtonsHelper
       helper ShareHelper
       helper AnnouncementHelper
+      helper TabPanelsHelper
     end
   end
 end

--- a/decidim-design/app/helpers/decidim/design/application_helper.rb
+++ b/decidim-design/app/helpers/decidim/design/application_helper.rb
@@ -3,6 +3,8 @@
 module Decidim
   module Design
     module ApplicationHelper
+      include Decidim::IconHelper
+
       # For the moment keep this as a constant and later decide where to move
       # this
       RELEASE_ID = "develop"

--- a/decidim-design/app/helpers/decidim/design/tab_panels_helper.rb
+++ b/decidim-design/app/helpers/decidim/design/tab_panels_helper.rb
@@ -12,7 +12,7 @@ module Decidim
                 type: :text,
                 values: [
                   "This tab-panel component gathers all the related contents or another resources of the main element displayed, in order to save vertical space. Clicking on the tab will activate the reated panel to show the content.",
-                  "Mainly is used within the <i>layout_item</i> or the <i>layout_center</i>, after the main content of the resource.",
+                  "Mainly is used within the <i>layout_item</i> or the <i>layout_center</i>, after the main content of the resource."
                 ]
               }
             ]
@@ -29,15 +29,15 @@ module Decidim
                   "<strong>text</strong>: <i>String</i>. Tab title",
                   "<strong>icon</strong>: <i>String</i>. Remixicon key",
                   "<strong>method</strong>: <i>Symbol</i>. Any function rails understands",
-                  "<strong>args</strong>: <i>Array</i>. Arguments for the previous method",
+                  "<strong>args</strong>: <i>Array</i>. Arguments for the previous method"
                 ]
               },
               {
                 type: :table,
-                options: { headings: ["Display", "Values"], style: "--cell-width: 50%;" },
+                options: { headings: %w(Display Values), style: "--cell-width: 50%;" },
                 items: tab_panels_table(
                   { values: tab_panels_items },
-                  { values: tab_panels_items_2 },
+                  { values: tab_panels_items_2 }
                 ),
                 cell_snippet: {
                   cell: "decidim/tab_panels",
@@ -75,7 +75,7 @@ module Decidim
             icon: resource_type_icon_key("documents"),
             method: :cell,
             args: ["decidim/announcement", "I am an annoucement"]
-          },
+          }
         ]
       end
 
@@ -86,15 +86,15 @@ module Decidim
             id: "icon",
             text: "Icon",
             method: :icon,
-            args: ["question-line", class: "w-4 h-4"]
+            args: ["question-line", { class: "w-4 h-4" }]
           },
           {
             enabled: true,
             id: "text",
             text: "Plain",
             method: :content_tag,
-            args: ["p", "plain text", class: "text-left"]
-          },
+            args: ["p", "plain text", { class: "text-left" }]
+          }
         ]
       end
     end

--- a/decidim-design/app/helpers/decidim/design/tab_panels_helper.rb
+++ b/decidim-design/app/helpers/decidim/design/tab_panels_helper.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Design
+    module TabPanelsHelper
+      def tab_panels_sections
+        [
+          {
+            id: "usage",
+            contents: [
+              {
+                type: :text,
+                values: [
+                  "This component receives an array of hashes, and rearrange the output of each item into a tab-panel structure",
+                  "Available properties for each panel:",
+                  "<i>enabled</i>: Boolean. conditionally render the tab",
+                  "<i>id</i>: String. unique id",
+                  "<i>text</i>: String. tab title",
+                  "<i>icon</i>: String. remixicon key",
+                  "<i>method</i>: Symbol. any function rails understands",
+                  "<i>args</i>: Array. arguments for the previous method",
+                ]
+              },
+              {
+                type: :table,
+                options: { headings: ["Display", "Values"], style: "--cell-width: 50%;" },
+                items: tab_panels_table(
+                  { values: tab_panels_items },
+                  { values: tab_panels_items_2 },
+                ),
+                cell_snippet: {
+                  cell: "decidim/tab_panels",
+                  args: [tab_panels_items]
+                }
+              }
+            ]
+          }
+        ]
+      end
+
+      def tab_panels_table(*table_rows, **_opts)
+        table_rows.each_with_index.map do |table_cell, _ix|
+          row = []
+          row << { method: :cell, args: ["decidim/tab_panels", table_cell[:values]] }
+          row << content_tag(:pre, content_tag(:code, JSON.pretty_generate(table_cell[:values])), class: "text-left")
+          row
+        end
+      end
+
+      def tab_panels_items
+        [
+          {
+            enabled: true,
+            id: "button",
+            text: "Button",
+            icon: resource_type_icon_key("images"),
+            method: :cell,
+            args: ["decidim/button", { text: "Send" }]
+          },
+          {
+            enabled: true,
+            id: "announce",
+            text: "Announcement",
+            icon: resource_type_icon_key("documents"),
+            method: :cell,
+            args: ["decidim/announcement", "I am an annoucement"]
+          },
+        ]
+      end
+
+      def tab_panels_items_2
+        [
+          {
+            enabled: true,
+            id: "icon",
+            text: "Icon",
+            method: :icon,
+            args: ["question-line", class: "w-4 h-4"]
+          },
+          {
+            enabled: true,
+            id: "text",
+            text: "Plain",
+            method: :content_tag,
+            args: ["p", "plain text", class: "text-left"]
+          },
+        ]
+      end
+    end
+  end
+end

--- a/decidim-design/app/helpers/decidim/design/tab_panels_helper.rb
+++ b/decidim-design/app/helpers/decidim/design/tab_panels_helper.rb
@@ -6,19 +6,30 @@ module Decidim
       def tab_panels_sections
         [
           {
+            id: "context",
+            contents: [
+              {
+                type: :text,
+                values: [
+                  "This tab-panel component gathers all the related contents or another resources of the main element displayed, in order to save vertical space. Clicking on the tab will activate the reated panel to show the content.",
+                  "Mainly is used within the <i>layout_item</i> or the <i>layout_center</i>, after the main content of the resource.",
+                ]
+              }
+            ]
+          },
+          {
             id: "usage",
             contents: [
               {
                 type: :text,
                 values: [
-                  "This component receives an array of hashes, and rearrange the output of each item into a tab-panel structure",
-                  "Available properties for each panel:",
-                  "<i>enabled</i>: Boolean. conditionally render the tab",
-                  "<i>id</i>: String. unique id",
-                  "<i>text</i>: String. tab title",
-                  "<i>icon</i>: String. remixicon key",
-                  "<i>method</i>: Symbol. any function rails understands",
-                  "<i>args</i>: Array. arguments for the previous method",
+                  "This component receives an array of hashes, and rearrange the output of each item into a tab-panel structure. Available properties for each panel:",
+                  "<strong>enabled</strong>: <i>Boolean</i>. Conditionally render the tab",
+                  "<strong>id</strong>: <i>String</i>. Unique id",
+                  "<strong>text</strong>: <i>String</i>. Tab title",
+                  "<strong>icon</strong>: <i>String</i>. Remixicon key",
+                  "<strong>method</strong>: <i>Symbol</i>. Any function rails understands",
+                  "<strong>args</strong>: <i>Array</i>. Arguments for the previous method",
                 ]
               },
               {

--- a/decidim-design/app/helpers/decidim/design/tab_panels_helper.rb
+++ b/decidim-design/app/helpers/decidim/design/tab_panels_helper.rb
@@ -11,7 +11,8 @@ module Decidim
               {
                 type: :text,
                 values: [
-                  "This tab-panel component gathers all the related contents or another resources of the main element displayed, in order to save vertical space. Clicking on the tab will activate the reated panel to show the content.",
+                  "This tab-panel component gathers all the related contents or another resources of the main element displayed,
+                    in order to save vertical space. Clicking on the tab will activate the reated panel to show the content.",
                   "Mainly is used within the <i>layout_item</i> or the <i>layout_center</i>, after the main content of the resource."
                 ]
               }
@@ -37,7 +38,7 @@ module Decidim
                 options: { headings: %w(Display Values), style: "--cell-width: 50%;" },
                 items: tab_panels_table(
                   { values: tab_panels_items },
-                  { values: tab_panels_items_2 }
+                  { values: tab_panels_items_alt }
                 ),
                 cell_snippet: {
                   cell: "decidim/tab_panels",
@@ -79,7 +80,7 @@ module Decidim
         ]
       end
 
-      def tab_panels_items_2
+      def tab_panels_items_alt
         [
           {
             enabled: true,

--- a/decidim-design/app/packs/stylesheets/design.scss
+++ b/decidim-design/app/packs/stylesheets/design.scss
@@ -105,6 +105,8 @@
 .design__table {
   @apply w-full text-center text-sm text-gray-2;
 
+  --cell-width: ;
+
   thead {
     @apply bg-gray-3;
   }
@@ -114,6 +116,6 @@
   }
 
   td {
-    @apply px-6 py-4 border border-background;
+    @apply px-6 py-4 border border-background w-[var(--cell-width)];
   }
 }

--- a/decidim-design/app/views/decidim/design/components/tab_panels.html.erb
+++ b/decidim-design/app/views/decidim/design/components/tab_panels.html.erb
@@ -1,0 +1,11 @@
+<% content_for :heading do %>
+  Tab panels
+<% end %>
+
+<% content_for :toc do %>
+  <% tab_panels_sections.each do |section| %>
+    <%= link_to(section_text(section), "##{section[:id]}") %>
+  <% end %>
+<% end %>
+
+<%= render partial: "decidim/design/shared/sections", locals: { sections: tab_panels_sections } %>

--- a/decidim-design/app/views/decidim/design/shared/_table.html.erb
+++ b/decidim-design/app/views/decidim/design/shared/_table.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag :table, class: "design__table", style: do %>
+<%= content_tag :table, local_assigns.slice(:style).merge(class: "design__table") do %>
   <thead>
     <% headings.each do |heading| %>
       <th><%= heading %></th>

--- a/decidim-design/app/views/decidim/design/shared/_table.html.erb
+++ b/decidim-design/app/views/decidim/design/shared/_table.html.erb
@@ -1,4 +1,4 @@
-<table class="design__table">
+<%= content_tag :table, class: "design__table", style: do %>
   <thead>
     <% headings.each do |heading| %>
       <th><%= heading %></th>
@@ -9,4 +9,4 @@
         <tr><%= render_row(row) %></tr>
     <% end %>
   </tbody>
-</table>
+<% end %>

--- a/decidim-design/app/views/layouts/decidim/design/_layout.html.erb
+++ b/decidim-design/app/views/layouts/decidim/design/_layout.html.erb
@@ -48,7 +48,7 @@
             <ul>
               <% items.each do |item| %>
                 <li>
-                  <%= link_to item[:name], item[:path], class: params[:id] == item[:name] && controller_name == section[:path] ? "font-bold" : "" %>
+                  <%= link_to item[:name].titleize, item[:path], class: params[:id] == item[:name] && controller_name == section[:path] ? "font-bold" : "" %>
                   <%= icon "arrow-right-line" %>
                 </li>
               <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR includes the usage of the tab-panels cell, widely used for the resources to enclose related stuff they want to show.

### :camera: Screenshots
![imagen](https://github.com/decidim/decidim/assets/817526/3db92f37-600c-434d-a273-20af6ab6d661)

:hearts: Thank you!
