### PR TITLE
Fix order proposals by comments and follows using the column instead of a subquery

### DIFF
--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -59,11 +59,11 @@ module Decidim
         def reorder(proposals)
           case order
           when "most_commented"
-            proposals.left_joins(:comments).group(:id).order(Arel.sql("COUNT(decidim_comments_comments.id) DESC"))
+            proposals.order(comments_count: :desc)
           when "most_endorsed"
             proposals.order(endorsements_count: :desc)
           when "most_followed"
-            proposals.left_joins(:follows).group(:id).order(Arel.sql("COUNT(decidim_follows.id) DESC"))
+            proposals.order(follows_count: :desc)
           when "most_voted"
             proposals.order(proposal_votes_count: :desc)
           when "random"

--- a/decidim-proposals/spec/system/filter_proposals_spec.rb
+++ b/decidim-proposals/spec/system/filter_proposals_spec.rb
@@ -114,9 +114,13 @@ describe "Filter Proposals", :slow do
 
   context "when filtering proposals by SCOPE" do
     let!(:scope2) { create(:scope, organization: participatory_process.organization) }
+    let!(:proposals) { create_list(:proposal, 2, component:, scope:) }
+    let(:first_proposal) { proposals.first }
+    let(:last_proposal) { proposals.last }
+    let!(:proposal_comment) { create(:comment, commentable: first_proposal) }
+    let!(:proposal_follow) { create(:follow, followable: last_proposal) }
 
     before do
-      create_list(:proposal, 2, component:, scope:)
       create(:proposal, component:, scope: scope2)
       create(:proposal, component:, scope: nil)
       visit_component
@@ -147,6 +151,27 @@ describe "Filter Proposals", :slow do
         end
 
         expect(page).to have_css("[id^='proposals__proposal']", count: 2)
+      end
+
+      it "can be ordered by most commented and most followed after filtering" do
+        within "#dropdown-menu-filters div.filter-container", text: "Scope" do
+          uncheck "All"
+          check scope.name[I18n.locale.to_s]
+        end
+
+        within "#dropdown-menu-order" do
+          click_link "Most commented"
+        end
+
+        expect(page).to have_css("[id^='proposals__proposal']", count: 2)
+        expect(page).to have_selector("[id^='proposals__proposal']:first-child", text: translated(first_proposal.title))
+
+        within "#dropdown-menu-order" do
+          click_link "Most followed"
+        end
+
+        expect(page).to have_css("[id^='proposals__proposal']", count: 2)
+        expect(page).to have_selector("[id^='proposals__proposal']:first-child", text: translated(last_proposal.title))
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
First, I tried to fix it the same way I did with a similar issue (https://github.com/decidim/decidim/pull/11473) without any good result.

I tried a different solution and checked Proposals `orderable.rb` file. I saw it used a subquery to order by comments and follows instead of using the columns. These columns were created after the concern and maybe that's the cause it wasn't them.

#### :pushpin: Related Issues
- Fixes #11975

#### Testing
1. Go to a participatory space with a proposals component.
2. Go to the proposals component.
3. Filter by scope.
4. Order by "most commented" or "most followed" and see it works.

### :camera: Screenshots
https://github.com/decidim/decidim/assets/6973564/8eb56b60-4e76-4dbe-b46a-279b9d128153

:hearts: Thank you!
