### PR TITLE
Fix order initiatives by comments using the column instead of a subquery

### DIFF
--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -101,12 +101,7 @@ module Decidim
     scope :order_by_most_recent, -> { order(created_at: :desc) }
     scope :order_by_supports, -> { order(Arel.sql("(coalesce((online_votes->>'total')::int,0) + coalesce((offline_votes->>'total')::int,0)) DESC")) }
     scope :order_by_most_recently_published, -> { order(published_at: :desc) }
-    scope :order_by_most_commented, lambda {
-      select("decidim_initiatives.*")
-        .left_joins(:comments)
-        .group("decidim_initiatives.id")
-        .order(Arel.sql("count(decidim_comments_comments.id) desc"))
-    }
+    scope :order_by_most_commented, -> { order(comments_count: :desc) }
     scope :future_spaces, -> { none }
     scope :past_spaces, -> { closed }
 

--- a/decidim-initiatives/spec/system/filter_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/filter_initiatives_spec.rb
@@ -21,8 +21,11 @@ describe "Filter Initiatives", :slow do
   end
 
   context "when filtering initiatives by SCOPE" do
+    let!(:initiatives) { create_list(:initiative, 2, organization:, scoped_type: scoped_type1) }
+    let(:first_initiative) { initiatives.first }
+    let!(:proposal_comment) { create(:comment, commentable: first_initiative) }
+
     before do
-      create_list(:initiative, 2, organization:, scoped_type: scoped_type1)
       create(:initiative, organization:, scoped_type: scoped_type2)
       create(:initiative, organization:, scoped_type: scoped_type3)
 
@@ -67,6 +70,20 @@ describe "Filter Initiatives", :slow do
 
         expect(page).to have_css(".card__grid", count: 2)
         expect(page).to have_content("2 initiatives")
+      end
+
+      it "can be ordered by most commented after filtering" do
+        within "#panel-dropdown-menu-scope" do
+          click_filter_item "All"
+          click_filter_item scoped_type1.scope_name[I18n.locale.to_s]
+        end
+
+        within "#dropdown-menu-order" do
+          click_link "Most commented"
+        end
+
+        expect(page).to have_css(".card__grid[id^='initiative']", count: 2)
+        expect(page).to have_selector(".card__grid[id^='initiative']:first-child", text: translated(first_initiative.title))
       end
     end
   end
@@ -192,7 +209,7 @@ describe "Filter Initiatives", :slow do
       end
     end
 
-    context "when there is more than on initiative_type" do
+    context "when there is more than one initiative_type" do
       before do
         create_list(:initiative, 2, organization:, scoped_type: scoped_type1)
         create(:initiative, organization:, scoped_type: scoped_type2)


### PR DESCRIPTION
#### :tophat: What? Why?

Same error as #11975 but affects the initiatives. So I followed the same solution as #11976.

#### :pushpin: Related Issues

- Related to #11975 
- Fixes #11977 

#### Testing

1. Go to the initiatives page.
2. Filter by scope.
3. Order by "most commented" and see it works.

### :camera: Screenshots

https://github.com/decidim/decidim/assets/6973564/c8049e9a-06cb-48aa-83e0-f75a8e96ffa2

:hearts: Thank you!
