### PR TITLE
Extract proposals' show sections in admin to partials

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_documents.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_documents.html.erb
@@ -1,0 +1,13 @@
+<div class="card-section">
+  <div class="row column">
+    <strong><%= t "documents", scope: "decidim.proposals.admin.proposals.show" %>:</strong>
+    <ul id="documents">
+      <% proposal.documents.each do |document| %>
+        <li>
+          <%= link_to translated_attribute(document.title), document.url %>
+          <small><%= document.file_type %> <%= number_to_human_size(document.file_size) %></small>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_endorsers.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_endorsers.html.erb
@@ -1,0 +1,25 @@
+<div class="card-section">
+  <div class="row column">
+    <span class="component__show-title"><%= t "endorsers", scope: "decidim.proposals.admin.proposals.show" %></span>
+    <ul id="proposal-endorsers-list">
+      <% presented_endorsers.first(5).each do |presented_endorser| %>
+        <li>
+          <%= link_to_if(
+                presented_endorser.profile_path.present?,
+                presented_endorser.name,
+                presented_endorser.profile_path,
+                target: :blank
+              ) %>
+        </li>
+      <% end %>
+      <% if presented_endorsers.count > 5 %>
+        <li>
+          <%= link_to(
+                t("n_more_endorsers", scope: "decidim.proposals.admin.proposals.show", count: presented_endorsers.count - 5),
+                resource_locator(proposal).path
+              ) %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_meetings.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_meetings.html.erb
@@ -1,0 +1,13 @@
+<div class="card-section">
+  <div class="row column">
+    <span class="component__show-title"><%= t "related_meetings", scope: "decidim.proposals.admin.proposals.show" %></span>
+    <ul id="related-meetings">
+      <% proposal_meetings.each do |meeting| %>
+        <% presented_meeting = present(meeting) %>
+        <li>
+          <%= link_to presented_meeting.title(html_escape: true), presented_meeting.profile_path %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_photos.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_photos.html.erb
@@ -1,0 +1,13 @@
+<div class="card-section">
+  <div class="row column">
+    <strong><%= t("photos", scope: "decidim.proposals.admin.proposals.show") %>:</strong>
+    <div id="photos" class="gallery row" data-gallery>
+      <% proposal.photos.each do |photo| %>
+        <%= link_to photo.big_url, target: "_blank", rel: "noopener" do %>
+          <%= image_tag photo.thumbnail_url,
+                        class: "thumbnail", alt: strip_tags(translated_attribute(photo.title)) %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
@@ -50,7 +50,7 @@
           </div>
         </div>
 
-        <% presented_endorsers = endorsers_presenters_for(proposal).first(6).to_a %>
+        <% presented_endorsers = endorsers_presenters_for(proposal) %>
         <% if presented_endorsers.any? %>
           <%= render partial: "endorsers", locals: { presented_endorsers:, proposal: } %>
         <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
@@ -49,80 +49,25 @@
             </p>
           </div>
         </div>
+
         <% presented_endorsers = endorsers_presenters_for(proposal).first(6).to_a %>
         <% if presented_endorsers.any? %>
-          <div class="card-section">
-            <div class="row column">
-              <span class="component__show-title"><%= t ".endorsers" %></span>
-              <ul id="proposal-endorsers-list">
-                <% presented_endorsers.first(5).each do |presented_endorser| %>
-                  <li>
-                    <%= link_to_if(
-                          presented_endorser.profile_path.present?,
-                          presented_endorser.name,
-                          presented_endorser.profile_path,
-                          target: :blank
-                        ) %>
-                  </li>
-                <% end %>
-                <% if presented_endorsers.count > 5 %>
-                  <li>
-                    <%= link_to(
-                          t(".n_more_endorsers", count: presented_endorsers.count - 5),
-                          resource_locator(proposal).path
-                        ) %>
-                  </li>
-                <% end %>
-              </ul>
-            </div>
-          </div>
+          <%= render partial: "endorsers", locals: { presented_endorsers:, proposal: } %>
         <% end %>
+
         <% if proposal.documents.any? %>
-          <div class="card-section">
-            <div class="row column">
-              <strong><%= t ".documents" %>:</strong>
-              <ul id="documents">
-                <% proposal.documents.each do |document| %>
-                  <li>
-                    <%= link_to translated_attribute(document.title), document.url %>
-                    <small><%= document.file_type %> <%= number_to_human_size(document.file_size) %></small>
-                  </li>
-                <% end %>
-              </ul>
-            </div>
-          </div>
+          <%= render partial: "documents", locals: { proposal: } %>
         <% end %>
+
         <% if proposal.photos.any? %>
-          <div class="card-section">
-            <div class="row column">
-              <strong><%= t(".photos") %>:</strong>
-              <div id="photos" class="gallery row" data-gallery>
-                <% proposal.photos.each do |photo| %>
-                  <%= link_to photo.big_url, target: "_blank", rel: "noopener" do %>
-                    <%= image_tag photo.thumbnail_url,
-                                  class: "thumbnail", alt: strip_tags(translated_attribute(photo.title)) %>
-                  <% end %>
-                <% end %>
-              </div>
-            </div>
-          </div>
+          <%= render partial: "photos", locals: { proposal: } %>
         <% end %>
+
         <% proposal_meetings = proposal.linked_resources(:meetings, "proposals_from_meeting") %>
         <% if proposal_meetings.any? %>
-          <div class="card-section">
-            <div class="row column">
-              <span class="component__show-title"><%= t ".related_meetings" %></span>
-              <ul id="related-meetings">
-                <% proposal_meetings.each do |meeting| %>
-                  <% presented_meeting = present(meeting) %>
-                  <li>
-                    <%= link_to presented_meeting.title(html_escape: true), presented_meeting.profile_path %>
-                  </li>
-                <% end %>
-              </ul>
-            </div>
-          </div>
+          <%= render partial: "meetings", locals: { proposal_meetings: } %>
         <% end %>
+
         <% if allowed_to?(:create, :proposal_note, proposal: proposal) %>
           <div class="card-section">
             <%= render "decidim/proposals/admin/proposal_notes/proposal_notes" %>
@@ -134,6 +79,7 @@
             <%= render "decidim/proposals/admin/proposal_answers/form" %>
           </div>
         <% end %>
+
       </div>
       <div class="component__show_grid-item">
         <% if proposal.category.present? %>


### PR DESCRIPTION
#### :tophat: What? Why?

During the #11963 review, we agreed to extract some partials on the proposals admin show page. This PR does that.

#### :pushpin: Related Issues

- Related to  https://github.com/decidim/decidim/pull/11963#discussion_r1386489462 

#### Testing

1. Sign in as admin
2. Allow attachments in a proposals component
3. Add a photo and a document
4. Add a related meeting with the "Close meeting' form in the meeting component
5. Go to the public page and endorse the proposal
6. See the show proposal answer page

Or you know, just wait for the green suite, as it's a refactor it should work as before 😄 
 

:hearts: Thank you!
