### PR TITLE
Allow apps to configure the document types in the elections module

### DIFF
--- a/decidim-elections/README.md
+++ b/decidim-elections/README.md
@@ -60,6 +60,29 @@ bundle
 
 ## Configuration
 
+### Identification numbers
+
+For the verification of the participants' data in the Voting's census, you can configure which type of documents a participant can have. By default these documents are `identification_number` and `passport`, but in some countries you may need to adapt these to your specifics needs. For instance, in Spain there are `dni`, `nie` and `passport`.
+
+For configuring these you can do so with the Environment Variable `ELECTIONS_DOCUMENT_TYPES`.
+
+```env
+ELECTIONS_DOCUMENT_TYPES="dni,nie,passport"
+```
+
+You need to also add the following keys in your i18n files (i.e. `config/locales/en.yml`).
+
+```yaml
+en:
+  decidim:
+    votings:
+      census:
+        document_types:
+          dni: DNI
+          nie: NIE
+          passport: Passport
+```
+
 ### Scheduled tasks
 
 For the Elections module to function as expected, there are some background tasks that should be scheduled to be executed regularly. Alternatively you could use `whenever` gem or the scheduled jobs of your hosting provider.

--- a/decidim-elections/app/forms/decidim/votings/census/in_person_fields.rb
+++ b/decidim-elections/app/forms/decidim/votings/census/in_person_fields.rb
@@ -10,8 +10,6 @@ module Decidim
         extend ActiveSupport::Concern
 
         included do
-          DOCUMENT_TYPES = %w(DNI NIE PASSPORT).freeze
-
           attribute :document_number, String
           attribute :document_type, String
           attribute :birthdate, String
@@ -21,7 +19,7 @@ module Decidim
                     :birthdate,
                     presence: true
 
-          validates :document_type, inclusion: { in: DOCUMENT_TYPES }
+          validates :document_type, inclusion: { in: :document_types }
         end
 
         # hash of birth, document type and number
@@ -35,12 +33,18 @@ module Decidim
         end
 
         def options_for_document_type_select
-          DOCUMENT_TYPES.map do |document_type|
+          document_types.map do |document_type|
             [
               I18n.t(document_type.downcase, scope: "decidim.votings.census.document_types"),
               document_type
             ]
           end
+        end
+
+        private
+
+        def document_types
+          Decidim::Elections.document_types
         end
       end
     end

--- a/decidim-elections/app/views/decidim/votings/census/admin/census/_upload_info.html.erb
+++ b/decidim-elections/app/views/decidim/votings/census/admin/census/_upload_info.html.erb
@@ -6,12 +6,12 @@
 
 <%= content_tag :p, sanitize(t("upload_info.csv_example_with_ballot_style", scope: "decidim.votings.census.admin.census")) %>
   <pre class="code-block"><%= "Document ID;Document Type;Date of Birth;Full name;Full address;Postal Code;Mobile phone number;Email address;#{ballot_style_code_header}
-12345678X;DNI;20011130;John Doe;The full address;08001;123456789;user@example.org;DISTRICT1
-87654321X;DNI;20010808;Alice Doe;The full address;08002;987654321;user2@example.org;DISTRICT2" %>
+12345678X;passport;20011130;John Doe;The full address;08001;123456789;user@example.org;DISTRICT1
+87654321X;passport;20010808;Alice Doe;The full address;08002;987654321;user2@example.org;DISTRICT2" %>
 ...</pre>
 
 <%= content_tag :p, sanitize(t("upload_info.csv_example_without_ballot_style", scope: "decidim.votings.census.admin.census")) %>
   <pre class="code-block">Document ID;Document Type;Date of Birth;Full name;Full address;Postal Code;Mobile phone number;Email address
-12345678X;DNI;20011130;John Doe;The full address;08001;123456789;user@example.org
-87654321X;DNI;20010808;Alice Doe;The full address;08002;987654321;user2@example.org
+12345678X;passport;20011130;John Doe;The full address;08001;123456789;user@example.org
+87654321X;passport;20010808;Alice Doe;The full address;08002;987654321;user2@example.org
 ...</pre>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -1121,8 +1121,7 @@ en:
               csv_header_after: Do not include the last field ("%{ballot_style_code_header}") if you do not need ballot styles/conditional questions
               csv_header_before: 'The census file must be a CSV file with the following header:'
         document_types:
-          dni: DNI
-          nie: NIE
+          identification_number: Identification number
           passport: Passport
         export_mailer:
           access_codes_export:

--- a/decidim-elections/lib/decidim/elections.rb
+++ b/decidim-elections/lib/decidim/elections.rb
@@ -36,8 +36,14 @@ module Decidim
       6
     end
 
+    # Public Setting that defines how many minutes will pass until the token of the voter expires
     config_accessor :voter_token_expiration_minutes do
       120
+    end
+
+    # Public Setting that defines which kind of documents a participant can have
+    config_accessor :document_types do
+      %w(identification_number passport)
     end
   end
 end

--- a/decidim-elections/lib/decidim/votings/test/factories.rb
+++ b/decidim-elections/lib/decidim/votings/test/factories.rb
@@ -158,7 +158,7 @@ FactoryBot.define do
 
     transient do
       document_number { Faker::IDNumber.spanish_citizen_number }
-      document_type { %w(DNI NIE PASSPORT).sample }
+      document_type { %w(identification_number passport).sample }
       birthdate { Faker::Date.birthday(min_age: 18, max_age: 65) }
     end
 

--- a/decidim-elections/spec/commands/decidim/votings/census/admin/create_datum_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/census/admin/create_datum_spec.rb
@@ -15,7 +15,7 @@ module Decidim::Votings::Census::Admin
     let(:params) do
       {
         document_number:,
-        document_type: "DNI",
+        document_type: "passport",
         birthdate:,
         full_name: "Jane Doe",
         full_address: "Nowhere street 1",

--- a/decidim-elections/spec/commands/decidim/votings/check_census_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/check_census_spec.rb
@@ -22,7 +22,7 @@ module Decidim::Votings
     end
     let(:birthdate) { Date.civil(year, month, day) }
     let(:document_number) { "123456789Y" }
-    let(:document_type) { "DNI" }
+    let(:document_type) { "passport" }
     let(:year) { 1985 }
     let(:month) { 3 }
     let(:day) { 1 }

--- a/decidim-elections/spec/commands/decidim/votings/voter/in_person_vote_spec.rb
+++ b/decidim-elections/spec/commands/decidim/votings/voter/in_person_vote_spec.rb
@@ -28,7 +28,7 @@ describe Decidim::Votings::Voter::InPersonVote do
   let(:polling_station) { create(:polling_station, id: 1, voting:) }
   let(:polling_station_slug) { polling_station.slug }
   let(:polling_officer) { create(:polling_officer, voting:, user:, presided_polling_station: polling_station) }
-  let(:datum) { create(:datum, dataset:, full_name: "Jon Doe", document_type: "DNI", document_number: "12345678X", birthdate: Date.civil(1980, 5, 11)) }
+  let(:datum) { create(:datum, dataset:, full_name: "Jon Doe", document_type: "passport", document_number: "12345678X", birthdate: Date.civil(1980, 5, 11)) }
   let(:dataset) { create(:dataset, voting:) }
   let(:in_person_vote_method) { :in_person_vote }
 

--- a/decidim-elections/spec/forms/decidim/votings/census/admin/datum_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/votings/census/admin/datum_form_spec.rb
@@ -8,7 +8,7 @@ describe Decidim::Votings::Census::Admin::DatumForm do
   let(:dataset) { create(:dataset) }
   let(:user) { create(:user, :admin, organization: dataset.voting.organization) }
   let(:document_number) { "123456789Y" }
-  let(:document_type) { "DNI" }
+  let(:document_type) { "passport" }
   let(:birthdate) { "20010414" }
   let(:full_name) { "Jane Doe" }
   let(:full_address) { "Nowhere street 1" }

--- a/decidim-elections/spec/forms/decidim/votings/census/check_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/votings/census/check_form_spec.rb
@@ -7,7 +7,7 @@ describe Decidim::Votings::Census::CheckForm do
 
   let(:current_participatory_space) { create(:voting) }
   let(:document_number) { "123456789Y" }
-  let(:document_type) { "DNI" }
+  let(:document_type) { "passport" }
   let(:day) { 14 }
   let(:month) { 8 }
   let(:year) { 1982 }
@@ -61,6 +61,6 @@ describe Decidim::Votings::Census::CheckForm do
   end
 
   describe "generate hash for data" do
-    it { expect(subject.hashed_check_data).to eql("81c540096460067c2f795349480c38786a1308a22d1434cd5b9799326676e15d") }
+    it { expect(subject.hashed_check_data).to eql("dc97180b483fbe65d9df598323ded13a72b846b87b5648a6db5f92a14c4532b9") }
   end
 end

--- a/decidim-elections/spec/forms/decidim/votings/census/in_person_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/votings/census/in_person_form_spec.rb
@@ -7,7 +7,7 @@ describe Decidim::Votings::Census::InPersonForm do
 
   let(:current_participatory_space) { create(:voting) }
   let(:document_number) { "123456789Y" }
-  let(:document_type) { "DNI" }
+  let(:document_type) { "passport" }
   let(:day) { 14 }
   let(:month) { 8 }
   let(:year) { 1982 }
@@ -59,6 +59,6 @@ describe Decidim::Votings::Census::InPersonForm do
   end
 
   describe "generate hash for data" do
-    it { expect(subject.hashed_in_person_data).to eql("9f7afe479fef6eed220e090b48867aad58a83ba6ff37c641865a652bc39241fe") }
+    it { expect(subject.hashed_in_person_data).to eql("7da41362d26ed32dc57a16cffaf600c17a895dabf3b878fd8d2da1b293001116") }
   end
 end

--- a/decidim-elections/spec/forms/decidim/votings/census/login_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/votings/census/login_form_spec.rb
@@ -7,7 +7,7 @@ describe Decidim::Votings::Census::LoginForm do
 
   let(:current_participatory_space) { create(:voting) }
   let(:document_number) { "123456789Y" }
-  let(:document_type) { "DNI" }
+  let(:document_type) { "passport" }
   let(:day) { 14 }
   let(:month) { 8 }
   let(:year) { 1982 }
@@ -69,6 +69,6 @@ describe Decidim::Votings::Census::LoginForm do
   end
 
   describe "generate hash for data" do
-    it { expect(subject.hashed_online_data).to eql("8782f5d25e944a227ca3d9a444919ff0ea479151b6733127ff04bf9cc7ce3240") }
+    it { expect(subject.hashed_online_data).to eql("e058aeb3d82f1f4f20bb7204f9aee80256bbdcb1e255e87b891700b42d33b215") }
   end
 end

--- a/decidim-elections/spec/jobs/decidim/votings/census/admin/create_datum_job_spec.rb
+++ b/decidim-elections/spec/jobs/decidim/votings/census/admin/create_datum_job_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe Decidim::Votings::Census::Admin::CreateDatumJob do
   let!(:dataset) { create(:dataset) }
   let(:user) { create(:user, :admin, organization: dataset.voting.organization) }
-  let!(:csv_row) { ["12345678X", "DNI", "20011202", "John Doe", "The full address one", "08001", "123456789", "user@example.org", "BS1"] }
+  let!(:csv_row) { ["12345678X", "passport", "20011202", "John Doe", "The full address one", "08001", "123456789", "user@example.org", "BS1"] }
 
   describe "queue" do
     it "is queued to events" do

--- a/decidim-elections/spec/services/decidim/votings/census_vote_flow_spec.rb
+++ b/decidim-elections/spec/services/decidim/votings/census_vote_flow_spec.rb
@@ -36,7 +36,7 @@ module Decidim::Votings
       }
     end
     let(:datum_params_changes) { {} }
-    let(:document_type) { "DNI" }
+    let(:document_type) { "passport" }
     let(:document_number) { "00000001R" }
     let(:birthdate) { Date.civil(1980, 1, 1) }
     let(:postal_code) { "08001" }

--- a/decidim-elections/spec/system/check_census_spec.rb
+++ b/decidim-elections/spec/system/check_census_spec.rb
@@ -9,7 +9,7 @@ describe "Check Census" do
   let!(:voting) { create(:voting, :published, organization:, census_contact_information: "census_help@example.com") }
   let!(:dataset) { create(:dataset, :data_created, voting:) }
   let!(:datum) do
-    create(:datum, document_type: "DNI", document_number: "12345678X", birthdate: Date.civil(1980, 5, 11), postal_code: "04001", dataset:, mobile_phone_number:, email:)
+    create(:datum, document_type: "passport", document_number: "12345678X", birthdate: Date.civil(1980, 5, 11), postal_code: "04001", dataset:, mobile_phone_number:, email:)
   end
   let!(:user) { create(:user, :confirmed, organization:) }
   let(:mobile_phone_number) { "123456789" }
@@ -52,7 +52,7 @@ describe "Check Census" do
     before do
       visit decidim_votings.voting_check_census_path(voting)
       within "[data-content]" do
-        select("DNI", from: "Document type")
+        select("Passport", from: "Document type")
         fill_in "Document number", with: "12345678X"
         fill_in "Postal code", with: "04001"
         fill_in "Day", with: "11"
@@ -82,7 +82,7 @@ describe "Check Census" do
 
       visit decidim_votings.voting_check_census_path(voting)
       within "[data-content]" do
-        select("DNI", from: "Document type")
+        select("Passport", from: "Document type")
         fill_in "Document number", with: "12345678X"
         fill_in "Postal code", with: "04001"
         fill_in "Day", with: "11"
@@ -107,7 +107,7 @@ describe "Check Census" do
     before do
       visit decidim_votings.voting_check_census_path(voting)
       within "[data-content]" do
-        select("DNI", from: "Document type")
+        select("Passport", from: "Document type")
         fill_in "Document number", with: "12345678X"
         fill_in "Postal code", with: "04001"
         fill_in "Day", with: "11"
@@ -162,7 +162,7 @@ describe "Check Census" do
     before do
       visit decidim_votings.voting_check_census_path(voting)
       within "[data-content]" do
-        select("DNI", from: "Document type")
+        select("Passport", from: "Document type")
         fill_in "Document number", with: "987654321X"
         fill_in "Postal code", with: "04004"
         fill_in "Day", with: "01"
@@ -191,7 +191,7 @@ describe "Check Census" do
       visit decidim_votings.voting_check_census_path(voting)
       6.times do
         within "[data-content]" do
-          select("DNI", from: "Document type")
+          select("Passport", from: "Document type")
           fill_in "Document number", with: "987654321X"
           fill_in "Postal code", with: "04004"
           fill_in "Day", with: "01"

--- a/decidim-elections/spec/system/vote_in_person_spec.rb
+++ b/decidim-elections/spec/system/vote_in_person_spec.rb
@@ -8,7 +8,7 @@ describe "Polling Officer zone" do
   let!(:election) { create(:election, :complete, :bb_test, :vote, component:) }
   let(:polling_station) { create(:polling_station, id: 1, voting:) }
   let!(:polling_officer) { create(:polling_officer, voting:, user:, presided_polling_station: polling_station) }
-  let!(:datum) { create(:datum, dataset:, full_name: "Jon Doe", document_type: "DNI", document_number: "12345678X", birthdate: Date.civil(1980, 5, 11)) }
+  let!(:datum) { create(:datum, dataset:, full_name: "Jon Doe", document_type: "passport", document_number: "12345678X", birthdate: Date.civil(1980, 5, 11)) }
   let(:dataset) { create(:dataset, voting:) }
 
   include_context "with a component" do
@@ -75,7 +75,7 @@ describe "Polling Officer zone" do
     let(:voter_id) { vote_flow.voter_id }
     let(:vote_flow) do
       ret = Decidim::Votings::CensusVoteFlow.new(election)
-      ret.voter_in_person(document_type: "DNI", document_number: "12345678X", day: "11", month: "5", year: "1980")
+      ret.voter_in_person(document_type: "passport", document_number: "12345678X", day: "11", month: "5", year: "1980")
       ret
     end
 
@@ -90,7 +90,7 @@ describe "Polling Officer zone" do
     let(:voter_id) { vote_flow.voter_id }
     let(:vote_flow) do
       ret = Decidim::Votings::CensusVoteFlow.new(election)
-      ret.voter_in_person(document_type: "DNI", document_number: "12345678X", day: "11", month: "5", year: "1980")
+      ret.voter_in_person(document_type: "passport", document_number: "12345678X", day: "11", month: "5", year: "1980")
       ret
     end
 
@@ -134,7 +134,7 @@ describe "Polling Officer zone" do
 
   def fill_person_data(correct: true)
     within "[data-content]" do
-      select("DNI", from: "Document type")
+      select("Passport", from: "Document type")
       fill_in "Document number", with: "12345678X"
       fill_in "Day", with: correct ? "11" : "1"
       fill_in "Month", with: "5"

--- a/decidim-elections/spec/system/vote_online_inside_a_voting_spec.rb
+++ b/decidim-elections/spec/system/vote_online_inside_a_voting_spec.rb
@@ -8,7 +8,7 @@ describe "Vote online in an election inside a Voting" do
   let!(:election) { create(:election, :bb_test, :vote, component:, questionnaire:) }
   let(:user) { create(:user, :confirmed, organization: component.organization) }
   let!(:datum) do
-    create(:datum, :with_access_code, document_type: "DNI", document_number: "12345678X", birthdate: Date.civil(1980, 5, 11), postal_code: "04001", access_code: "1234", dataset:)
+    create(:datum, :with_access_code, document_type: "passport", document_number: "12345678X", birthdate: Date.civil(1980, 5, 11), postal_code: "04001", access_code: "1234", dataset:)
   end
   let!(:elections) { create_list(:election, 2, :vote, component:) } # prevents redirect to single election page
   let(:router) { Decidim::EngineRouter.main_proxy(component).decidim_voting_elections }
@@ -137,7 +137,7 @@ describe "Vote online in an election inside a Voting" do
       click_link "Start voting"
 
       within "[data-content]" do
-        select("DNI", from: "Document type")
+        select("Passport", from: "Document type")
         fill_in "Document number", with: "12345678X"
         fill_in "Postal code", with: "04001"
         fill_in "Day", with: "11"
@@ -159,7 +159,7 @@ describe "Vote online in an election inside a Voting" do
     let(:voter_id) { vote_flow.voter_id }
     let(:vote_flow) do
       ret = Decidim::Votings::CensusVoteFlow.new(election)
-      ret.voter_in_person(document_type: "DNI", document_number: "12345678X", day: "11", month: "05", year: "1980")
+      ret.voter_in_person(document_type: "passport", document_number: "12345678X", day: "11", month: "05", year: "1980")
       ret
     end
 
@@ -169,7 +169,7 @@ describe "Vote online in an election inside a Voting" do
       click_link "Start voting"
 
       within "[data-content]" do
-        select("DNI", from: "Document type")
+        select("Passport", from: "Document type")
         fill_in "Document number", with: "12345678X"
         fill_in "Postal code", with: "04001"
         fill_in "Day", with: "11"
@@ -206,7 +206,7 @@ describe "Vote online in an election inside a Voting" do
     click_link "Start voting"
 
     within "[data-content]" do
-      select("DNI", from: "Document type")
+      select("Passport", from: "Document type")
       fill_in "Document number", with: "12345678X"
       fill_in "Postal code", with: "04001"
       fill_in "Day", with: "11"

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -476,6 +476,7 @@ if Decidim.module_installed? :elections
     config.setup_minimum_hours_before_start = Rails.application.secrets.dig(:elections, :setup_minimum_hours_before_start).presence || 1
     config.start_vote_maximum_hours_before_start = Rails.application.secrets.dig(:elections, :start_vote_maximum_hours_before_start).presence || 6
     config.voter_token_expiration_minutes = Rails.application.secrets.dig(:elections, :voter_token_expiration_minutes).presence || 120
+    config.document_types = Rails.application.secrets.dig(:elections, :document_types).presence || %w(identification_number passport)
   end
 
   Decidim::Votings.configure do |config|

--- a/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
@@ -90,6 +90,7 @@ elections_default: &elections_default
   quorum: 2
   number_of_trustees: 3
   setup_minimum_hours_before_start: 1
+  document_types: <%%= Decidim::Env.new("ELECTIONS_DOCUMENT_TYPES", "identification_number,passport").to_array.to_json %>
 
 storage_default: &storage_default
   provider: <%%= Decidim::Env.new("STORAGE_PROVIDER", "local").to_s %>
@@ -213,6 +214,7 @@ production:
     setup_minimum_hours_before_start: <%%= Decidim::Env.new("ELECTIONS_SETUP_MINIMUM_HOURS_BEFORE_START", 1).to_i %>
     start_vote_maximum_hours_before_start: <%%= Decidim::Env.new("ELECTIONS_START_VOTE_MAXIMUM_HOURS_BEFORE_START", 6).to_i %>
     voter_token_expiration_minutes: <%%= Decidim::Env.new("ELECTIONS_VOTER_TOKEN_EXPIRATION_MINUTES", 120).to_i %>
+    document_types: <%%= Decidim::Env.new("ELECTIONS_DOCUMENT_TYPES", "identification_number,passport").to_array.to_json %>
     votings:
       check_census_max_requests: <%%= Decidim::Env.new("VOTINGS_CHECK_CENSUS_MAX_REQUESTS", 5).to_i %>
       throttling_period: <%%= Decidim::Env.new("VOTINGS_THROTTLING_PERIOD", 1).to_i %>


### PR DESCRIPTION
#### :tophat: What? Why?

The elections module has a feature in the Census voting that talks about DNI and NIE, some document types specific from Spain.

This PR changes it to "Identification number" and also allows applications to configure whatever document types they need. 

The idea is to implement this first for `decidim-elections` and then make a pretty similar change for #9297 

#### :pushpin: Related Issues

- Fixes #9296 

#### Testing

Everthing should be green
Following the documentation should allow you to change these values 

:hearts: Thank you!
