### PR TITLE
Fix boilerplate description in header menu and in footer

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/footer_sub_hero/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/footer_sub_hero/show.erb
@@ -5,7 +5,7 @@
     </h2>
   </div>
   <p class="text-lg text-gray-2">
-    <%== t("decidim.pages.home.footer_sub_hero.footer_sub_hero_body") %>
+    <%== t("decidim.pages.home.footer_sub_hero.footer_sub_hero_body_html") %>
   </p>
   <% if current_organization.sign_up_enabled? && !current_user %>
     <%= link_to decidim.new_user_registration_path, class: "button button__sm md:button__lg button__secondary mt-4", title: t("decidim.pages.home.sub_hero.register_title") do %>

--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -161,7 +161,7 @@ module Decidim
 
     def organization_description_label
       @organization_description_label ||= if translated_attribute(current_organization.description).blank?
-                                            t("decidim.pages.home.footer_sub_hero.footer_sub_hero_body")
+                                            t("decidim.pages.home.footer_sub_hero.footer_sub_hero_body_html")
                                           else
                                             decidim_sanitize_admin(translated_attribute(current_organization.description))
                                           end

--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -159,6 +159,14 @@ module Decidim
       end
     end
 
+    def organization_description_label
+      @organization_description_label ||= if translated_attribute(current_organization.description).blank?
+                                            t("decidim.pages.home.footer_sub_hero.footer_sub_hero_body")
+                                          else
+                                            decidim_sanitize_admin(translated_attribute(current_organization.description))
+                                          end
+    end
+
     private
 
     def tag_builder

--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -160,7 +160,7 @@ module Decidim
     end
 
     def organization_description_label
-      @organization_description_label ||= if translated_attribute(current_organization.description).blank?
+      @organization_description_label ||= if empty_organization_description?
                                             t("decidim.pages.home.footer_sub_hero.footer_sub_hero_body_html")
                                           else
                                             decidim_sanitize_admin(translated_attribute(current_organization.description))
@@ -168,6 +168,12 @@ module Decidim
     end
 
     private
+
+    def empty_organization_description?
+      organization_description = translated_attribute(current_organization.description)
+
+      organization_description.blank? || organization_description == "<p></p>"
+    end
 
     def tag_builder
       @tag_builder ||= ActionView::Helpers::TagHelper::TagBuilder.new(self)

--- a/decidim-core/app/views/layouts/decidim/footer/_main_intro.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_intro.html.erb
@@ -5,5 +5,5 @@
 <% end %>
 <div class="text-sm text-white prose">
   <p><%= t("decidim.pages.home.footer_sub_hero.footer_sub_hero_headline", organization: current_organization.name) %></p>
-  <p><%== t("decidim.pages.home.footer_sub_hero.footer_sub_hero_body") %></p>
+  <p><%= organization_description_label %></p>
 </div>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_main_dropdown_top_left.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_main_dropdown_top_left.html.erb
@@ -1,2 +1,2 @@
 <h3 class="menu-bar__main-dropdown__title"><%= t("decidim.pages.home.footer_sub_hero.footer_sub_hero_headline", organization: current_organization.name) %></h3>
-<p class="menu-bar__main-dropdown__subtitle"><%== t("decidim.pages.home.footer_sub_hero.footer_sub_hero_body") %></p>
+<p class="menu-bar__main-dropdown__subtitle"><%= organization_description_label %></p>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1301,7 +1301,7 @@ en:
           proposals: Proposals
           proposals_explanation: Make proposals, support existing ones and promote the changes you want to see.
         footer_sub_hero:
-          footer_sub_hero_body: Let's build a more open, transparent and collaborative society.<br /> Join, participate and decide.
+          footer_sub_hero_body_html: Let's build a more open, transparent and collaborative society.<br /> Join, participate and decide.
           footer_sub_hero_headline: Welcome to %{organization} participatory platform.
           register: Register
         hero:

--- a/decidim-core/spec/helpers/decidim/layout_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/layout_helper_spec.rb
@@ -4,6 +4,14 @@ require "spec_helper"
 
 module Decidim
   describe LayoutHelper do
+    let(:helper) do
+      Class.new(ActionView::Base) do
+        include LayoutHelper
+        include SanitizeHelper
+        include TranslatableAttributes
+      end.new(ActionView::LookupContext.new(ActionController::Base.view_paths), {}, [])
+    end
+
     describe "#external_icon" do
       subject { helper.external_icon(path) }
 
@@ -104,6 +112,29 @@ module Decidim
           expect(subject.to_s).to match(
             %r{^#{Rails.public_path}/packs-test/media/images/google-[a-z0-9]+\.svg}
           )
+        end
+      end
+    end
+
+    describe "#organization_description_label" do
+      subject { helper.organization_description_label }
+      before do
+        allow(helper).to receive(:current_organization).and_return(organization)
+      end
+
+      context "when the organization does not have a description" do
+        let(:organization) { create(:organization, description: { en: nil }) }
+
+        it "shows the default message" do
+          expect(subject).to eq("Let's build a more open, transparent and collaborative society.<br /> Join, participate and decide.")
+        end
+      end
+
+      context "when the organization has a description" do
+        let(:organization) { create(:organization) }
+
+        it "shows the organization description" do
+          expect(subject).to have_text(strip_tags(translated(organization.description)))
         end
       end
     end

--- a/decidim-core/spec/helpers/decidim/layout_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/layout_helper_spec.rb
@@ -130,6 +130,14 @@ module Decidim
         end
       end
 
+      context "when the organization have a description with an empty paragraph" do
+        let(:organization) { create(:organization, description: { en: "<p></p>" }) }
+
+        it "shows the default message" do
+          expect(subject).to eq("Let's build a more open, transparent and collaborative society.<br /> Join, participate and decide.")
+        end
+      end
+
       context "when the organization has a description" do
         let(:organization) { create(:organization) }
 

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -489,6 +489,27 @@ describe "Homepage" do
           end
         end
       end
+
+      describe "footer message" do
+        context "when the organization does not have a description" do
+          let(:organization) { create(:organization, description: { en: nil }) }
+
+          it "shows the default message" do
+            within "footer" do
+              expect(page).to have_text("Let's build a more open, transparent and collaborative society.")
+            end
+          end
+        end
+
+        context "when the organization has a description" do
+          it "shows the organization description" do
+            within "footer" do
+              expect(page).not_to have_text("Let's build a more open, transparent and collaborative society.")
+              expect(page).to have_text(strip_tags(translated(organization.description)))
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/system/menu_spec.rb
+++ b/decidim-core/spec/system/menu_spec.rb
@@ -49,4 +49,35 @@ describe "Menu" do
       expect(page).to have_selector(".menu-bar__breadcrumb-desktop__dropdown-wrapper", text: component_name)
     end
   end
+
+  describe "header message in desktop" do
+    let(:participatory_space) { create(:participatory_process, organization:) }
+    let(:component) { create(:proposal_component, participatory_space:) }
+    let(:proposal) { create(:proposal, component:) }
+    let(:proposal_path) { Decidim::ResourceLocatorPresenter.new(proposal).path }
+
+    before do
+      visit proposal_path
+      find("#main-dropdown-summary").hover
+    end
+
+    context "when the organization does not have a description" do
+      let(:organization) { create(:organization, description: { en: nil }) }
+
+      it "shows the default message" do
+        within "#breadcrumb-main-dropdown-desktop" do
+          expect(page).to have_text("Let's build a more open, transparent and collaborative society.")
+        end
+      end
+    end
+
+    context "when the organization has a description" do
+      it "shows the organization description" do
+        within "#breadcrumb-main-dropdown-desktop" do
+          expect(page).not_to have_text("Let's build a more open, transparent and collaborative society.")
+          expect(page).to have_text(strip_tags(translated(organization.description)))
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

There are a couple of places where we're showing allways the same boilerplate text:

> Let's build a more open, transparent and collaborative society.
Join, participate and decide.

These places are the header menu on desktop and also in the footer. 

This PR changes it for the organizations' description if it's defined. 

#### Testing

1. Make sure there's a description defined in http://localhost:3000/admin/organization/appearance/edit
2. Go to any page with the menu (i.e. not the hompeage)
3. Open the header menu, see the description there
4. Go to the footer, see the description there
5. Delete the description from the admin
6. See that you have the boilerplate in these places 

### :camera: Screenshots

##### Before

![Screenshot of the footer (with the boilerplate text)](https://github.com/decidim/decidim/assets/717367/d946e994-ab47-4205-a18c-b51be865a73a)
![Screenshot of the header menu (with the boilerplate text)](https://github.com/decidim/decidim/assets/717367/3d7550ef-04b9-411f-95c0-1eaecdd96606)

##### After
 
![Screenshot of the footer (with the defined text)](https://github.com/decidim/decidim/assets/717367/746f0e32-b876-4d2f-81cb-6afeff48b4b0)
![Screenshot of the header menu (with the defined text)](https://github.com/decidim/decidim/assets/717367/11dc752a-2710-4979-bdbb-d76ec2dfcbb5)

:hearts: Thank you!
