### PR TITLE
Redesign: endorsers-list spacing

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_endorsers_list.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_endorsers_list.scss
@@ -1,5 +1,5 @@
 .endorsers-list {
-  @apply space-y-3 opacity-0 -translate-y-full invisible transition-all;
+  @apply space-y-3 opacity-0 -translate-y-full invisible transition-all absolute;
 
   &__text {
     @apply text-sm text-gray-2;
@@ -40,6 +40,6 @@
   }
 
   &[id*="dropdown-menu"][aria-hidden="false"] {
-    @apply opacity-100 visible translate-y-0 transition-all;
+    @apply opacity-100 visible translate-y-0 transition-all relative;
   }
 }


### PR DESCRIPTION
#### :tophat: What? Why?
When there are many endorsers for a resource, the list is no longer taking any space, but when is shown, and pushes downward all the content

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/11978

### :camera: Screenshots
[Screencast from 13-11-23 12:29:13.webm](https://github.com/decidim/decidim/assets/817526/8f457513-ceb9-4adc-8245-9f4a0af8693f)

:hearts: Thank you!
