### PR TITLE
Add more endorsements in seeds 

### DIFF
--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -167,6 +167,22 @@ module Decidim
       end
     end
 
+    resources_types = Decidim.resource_manifests
+                             .map { |resource| resource.attributes[:model_class_name] }
+                             .select { |resource| resource.constantize.include? Decidim::Endorsable }
+
+    resources_types.each do |resource_type|
+      resource_type.constantize.find_each do |resource|
+        # exclude the users that already endorsed
+        users = resource.endorsements.map(&:author)
+        rand(50).times do
+          user = (Decidim::User.all - users).sample
+          Decidim::Endorsement.create!(resource:, author: user)
+          users << user
+        end
+      end
+    end
+
     I18n.available_locales = original_locale
   end
 

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -145,17 +145,29 @@ module Decidim
     participatory_space_manifests.each do |manifest|
       manifest.seed!
 
-      Organization.all.each do |organization|
-        ContextualHelpSection.set_content(
-          organization,
-          manifest.name,
-          Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-            Decidim::Faker::Localized.sentence(word_count: 15)
-          end
-        )
-      end
+      seed_contextual_help_sections!(manifest)
     end
 
+    seed_gamification_badges!
+
+    seed_endorsements!
+
+    I18n.available_locales = original_locale
+  end
+
+  def self.seed_contextual_help_sections!(manifest)
+    Organization.all.each do |organization|
+      ContextualHelpSection.set_content(
+        organization,
+        manifest.name,
+        Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+          Decidim::Faker::Localized.sentence(word_count: 15)
+        end
+      )
+    end
+  end
+
+  def self.seed_gamification_badges!
     Gamification.badges.each do |badge|
       puts "Setting random values for the \"#{badge.name}\" badge..."
       User.all.find_each do |user|
@@ -166,7 +178,9 @@ module Decidim
         )
       end
     end
+  end
 
+  def self.seed_endorsements!
     resources_types = Decidim.resource_manifests
                              .map { |resource| resource.attributes[:model_class_name] }
                              .select { |resource| resource.constantize.include? Decidim::Endorsable }
@@ -182,8 +196,6 @@ module Decidim
         end
       end
     end
-
-    I18n.available_locales = original_locale
   end
 
   # Finds all currently loaded Decidim ActiveRecord classes and resets their


### PR DESCRIPTION
#### :tophat: What? Why?

In the last few days, there were a couple of issues and bugs that could be detected more easily if we had more endorsements in the Seeds: 

1. On the proposals' admin show page: https://github.com/decidim/decidim/pull/11984/files/325e076458fffd8f6f88d536d516934fdb065bd6#r1391588816 - where we detected it because there was one proposal with 8 endorsements
2. On the proposals show page: #11978 - where the margin was growing if there were more than X endorsements 

This PR adds much more endorsements in the seeds

Mind that I'm doing this after all the seeds are created, so I can benefit from the large number of users.

#### Testing

Regenerating the `development_app` database should have much more endorsements in some resources:

```console
$ bin/rails db:drop db:create db:migrate db:seed
``` 

### :camera: Screenshots

![Screenshot of the proposals index page](https://github.com/decidim/decidim/assets/717367/d6af2ca5-8a6d-42a8-b5e0-d357c707a2f5)

:hearts: Thank you!
