### PR TITLE
Add link explicitly in the meetings' icalendar event

### DIFF
--- a/decidim-meetings/app/services/decidim/meetings/calendar/meeting_to_event.rb
+++ b/decidim-meetings/app/services/decidim/meetings/calendar/meeting_to_event.rb
@@ -66,7 +66,7 @@ module Decidim
         end
 
         def description_with_link
-          link = "\n\n#{I18n.t(".read_more", scope: "decidim.meetings.calendar.meeting_to_event")} #{url_for(meeting)}"
+          link = "\n\n#{I18n.t("read_more", scope: "decidim.meetings.calendar.meeting_to_event")} #{url_for(meeting)}"
           strip_tags(CGI.unescapeHTML(present(meeting).description)) + link
         end
       end

--- a/decidim-meetings/app/services/decidim/meetings/calendar/meeting_to_event.rb
+++ b/decidim-meetings/app/services/decidim/meetings/calendar/meeting_to_event.rb
@@ -39,7 +39,7 @@ module Decidim
           @event.dtstart = Icalendar::Values::DateTime.new(meeting.start_time.utc, "tzid" => "UTC")
           @event.dtend = Icalendar::Values::DateTime.new(meeting.end_time.utc, "tzid" => "UTC")
           @event.summary = present(meeting).title
-          @event.description = strip_tags(CGI.unescapeHTML(present(meeting).description))
+          @event.description = description_with_link
           @event.location = meeting.address
           @event.geo = [meeting.latitude, meeting.longitude]
           @event.url = url_for(meeting)
@@ -63,6 +63,11 @@ module Decidim
 
         def present(meeting)
           Decidim::Meetings::MeetingPresenter.new(meeting)
+        end
+
+        def description_with_link
+          link = "\n\n#{I18n.t(".read_more", scope: "decidim.meetings.calendar.meeting_to_event")} #{url_for(meeting)}"
+          strip_tags(CGI.unescapeHTML(present(meeting).description)) + link
         end
       end
     end

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -396,6 +396,9 @@ en:
           all: All
         filter_meeting_space_values:
           all: All
+      calendar:
+        meeting_to_event:
+          read_more: Read more about this meeting
       calendar_modal:
         calendar_url: Calendar URL
         copy_calendar_url: Copy

--- a/decidim-meetings/spec/mailers/registration_mailer_spec.rb
+++ b/decidim-meetings/spec/mailers/registration_mailer_spec.rb
@@ -71,7 +71,8 @@ module Decidim::Meetings
       events = Icalendar::Event.parse(attachment.read)
       event = events.first
       expect(event.summary).to eq(translated(meeting.title))
-      expect(event.description).to eq(strip_tags(translated(meeting.description)))
+      expect(event.description).to include(strip_tags(translated(meeting.description)))
+      expect(event.description).to include(Decidim::ResourceLocatorPresenter.new(meeting).url)
       expect(event.dtstart.value.to_i).to eq(Icalendar::Values::DateTime.new(meeting.start_time).value.to_i)
       expect(event.dtend.value.to_i).to eq(Icalendar::Values::DateTime.new(meeting.end_time).value.to_i)
       expect(event.geo).to eq([meeting.latitude, meeting.longitude])

--- a/decidim-meetings/spec/services/calendar/meeting_to_event_spec.rb
+++ b/decidim-meetings/spec/services/calendar/meeting_to_event_spec.rb
@@ -12,7 +12,8 @@ module Decidim::Meetings::Calendar
     describe "#event" do
       it "converts the meeting to an event" do
         expect(event.summary).to eq(translated(meeting.title))
-        expect(event.description).to eq(strip_tags(translated(meeting.description)))
+        expect(event.description).to include(strip_tags(translated(meeting.description)))
+        expect(event.description).to include(Decidim::ResourceLocatorPresenter.new(meeting).url)
         expect(event.dtstart.value.to_i).to eq(Icalendar::Values::DateTime.new(meeting.start_time).value.to_i)
         expect(event.dtend.value.to_i).to eq(Icalendar::Values::DateTime.new(meeting.end_time).value.to_i)
         expect(event.geo).to eq([meeting.latitude, meeting.longitude])


### PR DESCRIPTION
#### :tophat: What? Why?

In the "Export calendar" feature of Meetings, we don't have a link to the meeting itself. There are much more details in the bug report (#11994)

The problem is that although we're using the URL attribute of the iCal, the clients do not parse it. 

For the fix, I'm following the example from https://icalendar.org/ 

#### :pushpin: Related Issues

- Fixes #11994

#### Testing

1. Go to a meetings index and click in "Export calendar" button
2. See that the file has the URL for the meeting in the description field

:hearts: Thank you!
