### PR TITLE
Backport 'Fix shortlink references' to 0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Upgrade notes
+
+We have identified that some of the short links for components are not working properly. We have added a new task that helps you fix the short links for components.
+
+```bash
+bundle exec rails decidim:upgrade:fix_short_urls
+```
+
+You can see more details about this change on PR [\#12004](https://github.com/decidim/decidim/pull/12004)
+
 ### Added
 
 Nothing.

--- a/decidim-core/app/helpers/decidim/short_link_helper.rb
+++ b/decidim-core/app/helpers/decidim/short_link_helper.rb
@@ -21,7 +21,7 @@ module Decidim
       target ||= respond_to?(:current_organization) && current_organization
       target ||= Rails.application
 
-      mounted_engine = EngineResolver.new(_routes).mounted_name
+      mounted_engine = target.try(:mounted_engine) || EngineResolver.new(_routes).mounted_name
       ShortLink.to(target, mounted_engine, **kwargs).short_url
     end
   end

--- a/decidim-core/lib/tasks/upgrade/decidim_fix_short_url_resolver.rake
+++ b/decidim-core/lib/tasks/upgrade/decidim_fix_short_url_resolver.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :upgrade do
+    desc "Fix wrongly mapped short links components"
+    task fix_short_urls: :environment do
+      logger = Logger.new($stdout)
+      logger.info("Fixing wrongly mapped short links...")
+
+      Decidim::ShortLink.where(target_type: "Decidim::Component").find_each do |short_url|
+        real_component = Decidim::Component.find_by(id: short_url.target_id)
+
+        next if real_component.nil?
+        next if short_url.mounted_engine_name == real_component.mounted_engine
+
+        logger.info("Fixing #{short_url.identifier}: #{short_url.mounted_engine_name} to #{real_component.mounted_engine}")
+        short_url.update(mounted_engine_name: real_component.mounted_engine)
+      end
+      logger.info("Done fixing wrongly mapped short links.")
+    end
+  end
+end

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -30,6 +30,31 @@ describe "Explore meetings", :slow, type: :system do
       end
     end
 
+    context "when displaying calendar" do
+      let(:component) { create(:meeting_component, participatory_space:) }
+      let(:link) { Decidim::ShortLink.find_by(target_type: "Decidim::Component", target_id: component.id) }
+
+      before do
+        visit_component
+      end
+
+      context "when meetings mounted under paraticipatory process" do
+        let(:participatory_space) { create(:participatory_process, organization:) }
+
+        it "properly saves the shortened link" do
+          expect(link.mounted_engine_name).to eq("decidim_participatory_process_meetings")
+        end
+      end
+
+      context "when meetings mounted under assemblies" do
+        let(:participatory_space) { create(:assembly, organization:) }
+
+        it "properly saves the shortened link" do
+          expect(link.mounted_engine_name).to eq("decidim_assembly_meetings")
+        end
+      end
+    end
+
     context "with default filter" do
       let!(:past_meeting) { create(:meeting, :published, start_time: 2.weeks.ago, component: component) }
       let!(:upcoming_meeting) { create(:meeting, :published, :not_official, component: component) }


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12004 to v0.27

:hearts: Thank you!