### PR TITLE
Extract menu registry logic

### DIFF
--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -11,6 +11,8 @@ require "doorkeeper"
 require "doorkeeper-i18n"
 require "hashdiff"
 
+require "decidim/admin/menu"
+
 module Decidim
   module Admin
     # Decidim's core Rails Engine.
@@ -29,277 +31,39 @@ module Decidim
       end
 
       initializer "decidim_admin.global_moderation_menu" do
-        Decidim.menu :admin_global_moderation_menu do |menu|
-          moderations_count = Decidim::Admin::ModerationStats.new(current_user).count_content_moderations
-
-          caption = I18n.t("menu.content", scope: "decidim.admin")
-          caption += content_tag(:span, moderations_count, class: moderations_count.zero? ? "component-counter component-counter--off" : "component-counter")
-
-          menu.add_item :moderations,
-                        caption.html_safe,
-                        decidim_admin.moderations_path,
-                        position: 1,
-                        active: is_active_link?(decidim_admin.moderations_path),
-                        if: allowed_to?(:read, :global_moderation)
-
-          user_reports = Decidim::Admin::ModerationStats.new(current_user).count_user_pending_reports
-
-          caption = I18n.t("menu.reported_users", scope: "decidim.admin")
-          caption += content_tag(:span, user_reports, class: user_reports.zero? ? "component-counter component-counter--off" : "component-counter")
-
-          menu.add_item :moderated_users,
-                        caption.html_safe,
-                        decidim_admin.moderated_users_path,
-                        active: is_active_link?(decidim_admin.moderated_users_path),
-                        if: allowed_to?(:index, :moderate_users)
-        end
+        Decidim::Admin::Menu.register_admin_global_moderation_menu!
       end
 
       initializer "decidim_admin.workflows_menu" do
-        Decidim.menu :workflows_menu do |menu|
-          Decidim::Verifications.admin_workflows.each do |manifest|
-            next unless current_organization.available_authorizations.include?(manifest.name.to_s)
-
-            workflow = Decidim::Verifications::Adapter.new(manifest)
-
-            menu.add_item manifest.name.to_s,
-                          workflow.fullname,
-                          workflow.admin_root_path,
-                          active: is_active_link?(workflow.admin_root_path)
-          end
-        end
+        Decidim::Admin::Menu.register_workflows_menu!
       end
 
       initializer "decidim_admin.impersonate_menu" do
-        Decidim.menu :impersonate_menu do |menu|
-          menu.add_item :conflicts,
-                        I18n.t("title", scope: "decidim.admin.conflicts"),
-                        decidim_admin.conflicts_path,
-                        active: is_active_link?(decidim_admin.conflicts_path),
-                        if: allowed_to?(:index, :impersonatable_user)
-        end
+        Decidim::Admin::Menu.register_impersonate_menu!
       end
 
       initializer "decidim_admin.static_pages_menu" do
-        Decidim.menu :admin_static_pages_menu do |menu|
-          menu.add_item :static_pages,
-                        I18n.t("menu.static_pages", scope: "decidim.admin"),
-                        decidim_admin.static_pages_path,
-                        icon_name: "pages-line",
-                        position: 1,
-                        active: is_active_link?(decidim_admin.static_pages_path, :inclusive),
-                        if: allowed_to?(:read, :static_page)
-          menu.add_item :static_page_topics,
-                        I18n.t("menu.static_page_topics", scope: "decidim.admin"),
-                        decidim_admin.static_page_topics_path,
-                        icon_name: "pages-line",
-                        position: 2,
-                        active: is_active_link?(decidim_admin.static_page_topics_path, :inclusive),
-                        if: allowed_to?(:create, :static_page_topic)
-        end
+        Decidim::Admin::Menu.register_admin_static_pages_menu!
       end
 
       initializer "decidim_admin.user_menu" do
-        Decidim.menu :admin_user_menu do |menu|
-          menu.add_item :users,
-                        I18n.t("menu.admins", scope: "decidim.admin"), decidim_admin.users_path,
-                        icon_name: "user-line",
-                        active: is_active_link?(decidim_admin.users_path),
-                        if: allowed_to?(:read, :admin_user)
-          menu.add_item :user_groups,
-                        I18n.t("menu.user_groups", scope: "decidim.admin"), decidim_admin.user_groups_path,
-                        icon_name: "group-line",
-                        active: is_active_link?(decidim_admin.user_groups_path),
-                        if: current_organization.user_groups_enabled? && allowed_to?(:index, :user_group)
-          menu.add_item :officializations,
-                        I18n.t("menu.participants", scope: "decidim.admin"), decidim_admin.officializations_path,
-                        icon_name: "service-line",
-                        active: is_active_link?(decidim_admin.officializations_path),
-                        if: allowed_to?(:index, :officialization)
-          menu.add_item :impersonatable_users,
-                        I18n.t("menu.impersonations", scope: "decidim.admin"), decidim_admin.impersonatable_users_path,
-                        icon_name: "user-add-line",
-                        active: is_active_link?(decidim_admin.impersonatable_users_path),
-                        if: allowed_to?(:index, :impersonatable_user),
-                        submenu: { target_menu: :impersonate_menu }
-          menu.add_item :authorization_workflows,
-                        I18n.t("menu.authorization_workflows", scope: "decidim.admin"), decidim_admin.authorization_workflows_path,
-                        icon_name: "key-2-line",
-                        active: is_active_link?(decidim_admin.authorization_workflows_path),
-                        if: allowed_to?(:index, :authorization),
-                        submenu: { target_menu: :workflows_menu }
-        end
+        Decidim::Admin::Menu.register_admin_user_menu!
       end
 
       initializer "decidim_admin.scopes_menu" do
-        Decidim.menu :admin_scopes_menu do |menu|
-          menu.add_item :scopes,
-                        I18n.t("menu.scopes", scope: "decidim.admin"),
-                        decidim_admin.scopes_path,
-                        icon_name: "price-tag-3-line",
-                        position: 1.3,
-                        if: allowed_to?(:read, :scope)
-          menu.add_item :scope_types,
-                        I18n.t("menu.scope_types", scope: "decidim.admin"),
-                        decidim_admin.scope_types_path,
-                        icon_name: "price-tag-3-line",
-                        position: 1.4,
-                        if: allowed_to?(:read, :scope_type)
-        end
+        Decidim::Admin::Menu.register_admin_scopes_menu!
       end
 
       initializer "decidim_admin.areas_menu" do
-        Decidim.menu :admin_areas_menu do |menu|
-          menu.add_item :areas,
-                        I18n.t("menu.areas", scope: "decidim.admin"),
-                        decidim_admin.areas_path,
-                        icon_name: "layout-masonry-line",
-                        position: 1.5,
-                        if: allowed_to?(:read, :area)
-          menu.add_item :area_types,
-                        I18n.t("menu.area_types", scope: "decidim.admin"),
-                        decidim_admin.area_types_path,
-                        icon_name: "layout-masonry-line",
-                        position: 1.6,
-                        if: allowed_to?(:read, :area_type)
-        end
+        Decidim::Admin::Menu.register_admin_areas_menu!
       end
 
       initializer "decidim_admin.settings_menu" do
-        Decidim.menu :admin_settings_menu do |menu|
-          menu.add_item :edit_organization,
-                        I18n.t("menu.configuration", scope: "decidim.admin"),
-                        decidim_admin.edit_organization_path,
-                        position: 1.0,
-                        icon_name: "pencil-line",
-                        if: allowed_to?(:update, :organization, organization: current_organization)
-
-          menu.add_item :edit_organization_appearance,
-                        I18n.t("menu.appearance", scope: "decidim.admin"),
-                        decidim_admin.edit_organization_appearance_path,
-                        position: 1.1,
-                        icon_name: "tools-line",
-                        if: allowed_to?(:update, :organization, organization: current_organization)
-
-          menu.add_item :edit_organization_homepage,
-                        I18n.t("menu.homepage", scope: "decidim.admin"),
-                        decidim_admin.edit_organization_homepage_path,
-                        position: 1.2,
-                        icon_name: "home-gear-line",
-                        if: allowed_to?(:update, :organization, organization: current_organization)
-
-          menu.add_item :scopes,
-                        I18n.t("menu.scopes", scope: "decidim.admin"),
-                        decidim_admin.scopes_path,
-                        icon_name: "price-tag-3-line",
-                        position: 1.3,
-                        if: allowed_to?(:read, :scope)
-          menu.add_item :areas,
-                        I18n.t("menu.areas", scope: "decidim.admin"),
-                        decidim_admin.areas_path,
-                        icon_name: "layout-masonry-line",
-                        position: 1.5,
-                        if: allowed_to?(:read, :area)
-
-          menu.add_item :help_sections,
-                        I18n.t("menu.help_sections", scope: "decidim.admin"),
-                        decidim_admin.help_sections_path,
-                        icon_name: "question-line",
-                        position: 1.6,
-                        if: allowed_to?(:update, :help_sections)
-
-          menu.add_item :external_domain_whitelist,
-                        I18n.t("menu.external_domain_whitelist", scope: "decidim.admin"),
-                        decidim_admin.edit_organization_external_domain_whitelist_path,
-                        icon_name: "computer-line",
-                        position: 1.7,
-                        if: allowed_to?(:update, :organization, organization: current_organization)
-        end
+        Decidim::Admin::Menu.register_admin_settings_menu!
       end
 
       initializer "decidim_admin.menu" do
-        Decidim.menu :admin_menu do |menu|
-          menu.add_item :moderations,
-                        I18n.t("menu.moderation", scope: "decidim.admin"),
-                        decidim_admin.moderations_path,
-                        icon_name: "flag-line",
-                        position: 4,
-                        active: [%w(
-                          decidim/admin/global_moderations
-                          decidim/admin/global_moderations/reports
-                          decidim/admin/moderated_users
-                        ), []],
-                        if: allowed_to?(:read, :global_moderation) || allowed_to?(:index, :moderate_users)
-
-          menu.add_item :static_pages,
-                        I18n.t("menu.static_pages", scope: "decidim.admin"),
-                        decidim_admin.static_pages_path,
-                        icon_name: "pages-line",
-                        position: 4.5,
-                        active: is_active_link?(decidim_admin.static_pages_path, :inclusive) ||
-                                is_active_link?(decidim_admin.static_page_topics_path, :inclusive),
-                        if: allowed_to?(:read, :static_page)
-
-          menu.add_item :impersonatable_users,
-                        I18n.t("menu.users", scope: "decidim.admin"),
-                        allowed_to?(:read, :admin_user) ? decidim_admin.users_path : decidim_admin.impersonatable_users_path,
-                        icon_name: "team-line",
-                        position: 5,
-                        active: [%w(
-                          decidim/admin/users
-                          decidim/admin/user_groups
-                          decidim/admin/user_groups_csv_verifications
-                          decidim/admin/officializations
-                          decidim/admin/impersonatable_users
-                          decidim/admin/conflicts
-                          decidim/admin/managed_users/impersonation_logs
-                          decidim/admin/managed_users/promotions
-                          decidim/admin/authorization_workflows
-                          decidim/verifications/id_documents/admin/pending_authorizations
-                          decidim/verifications/id_documents/admin/config
-                          decidim/verifications/postal_letter/admin/pending_authorizations
-                          decidim/verifications/csv_census/admin/census
-                        ), []],
-                        if: allowed_to?(:read, :admin_user) || allowed_to?(:read, :managed_user)
-
-          menu.add_item :newsletters,
-                        I18n.t("menu.newsletters", scope: "decidim.admin"),
-                        decidim_admin.newsletters_path,
-                        icon_name: "mail-add-line",
-                        position: 6,
-                        active: is_active_link?(decidim_admin.newsletters_path, :inclusive) ||
-                                is_active_link?(decidim_admin.newsletter_templates_path, :inclusive),
-                        if: allowed_to?(:index, :newsletter)
-
-          menu.add_item :edit_organization,
-                        I18n.t("menu.settings", scope: "decidim.admin"),
-                        decidim_admin.edit_organization_path,
-                        icon_name: "tools-line",
-                        position: 7,
-                        active: [
-                          %w(
-                            decidim/admin/organization
-                            decidim/admin/organization_appearance
-                            decidim/admin/organization_homepage
-                            decidim/admin/organization_homepage_content_blocks
-                            decidim/admin/scopes
-                            decidim/admin/scope_types
-                            decidim/admin/areas decidim/admin/area_types
-                            decidim/admin/help_sections
-                            decidim/admin/organization_external_domain_whitelist
-                          ),
-                          []
-                        ],
-                        if: allowed_to?(:update, :organization, organization: current_organization)
-
-          menu.add_item :logs,
-                        I18n.t("menu.admin_log", scope: "decidim.admin"),
-                        decidim_admin.logs_path,
-                        icon_name: "pages-line",
-                        position: 10,
-                        active: [%w(decidim/admin/logs), []],
-                        if: allowed_to?(:read, :admin_log)
-        end
+        Decidim::Admin::Menu.register_admin_menu!
       end
 
       initializer "decidim_admin.add_cells_view_paths" do

--- a/decidim-admin/lib/decidim/admin/menu.rb
+++ b/decidim-admin/lib/decidim/admin/menu.rb
@@ -1,0 +1,281 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    class Menu
+      def self.register_admin_global_moderation_menu!
+        Decidim.menu :admin_global_moderation_menu do |menu|
+          moderations_count = Decidim::Admin::ModerationStats.new(current_user).count_content_moderations
+
+          caption = I18n.t("menu.content", scope: "decidim.admin")
+          caption += content_tag(:span, moderations_count, class: moderations_count.zero? ? "component-counter component-counter--off" : "component-counter")
+
+          menu.add_item :moderations,
+                        caption.html_safe,
+                        decidim_admin.moderations_path,
+                        position: 1,
+                        active: is_active_link?(decidim_admin.moderations_path),
+                        if: allowed_to?(:read, :global_moderation)
+
+          user_reports = Decidim::Admin::ModerationStats.new(current_user).count_user_pending_reports
+
+          caption = I18n.t("menu.reported_users", scope: "decidim.admin")
+          caption += content_tag(:span, user_reports, class: user_reports.zero? ? "component-counter component-counter--off" : "component-counter")
+
+          menu.add_item :moderated_users,
+                        caption.html_safe,
+                        decidim_admin.moderated_users_path,
+                        active: is_active_link?(decidim_admin.moderated_users_path),
+                        if: allowed_to?(:index, :moderate_users)
+        end
+      end
+
+      def self.register_workflows_menu!
+        Decidim.menu :workflows_menu do |menu|
+          Decidim::Verifications.admin_workflows.each do |manifest|
+            next unless current_organization.available_authorizations.include?(manifest.name.to_s)
+
+            workflow = Decidim::Verifications::Adapter.new(manifest)
+
+            menu.add_item manifest.name.to_s,
+                          workflow.fullname,
+                          workflow.admin_root_path,
+                          active: is_active_link?(workflow.admin_root_path)
+          end
+        end
+      end
+
+      def self.register_impersonate_menu!
+        Decidim.menu :impersonate_menu do |menu|
+          menu.add_item :conflicts,
+                        I18n.t("title", scope: "decidim.admin.conflicts"),
+                        decidim_admin.conflicts_path,
+                        active: is_active_link?(decidim_admin.conflicts_path),
+                        if: allowed_to?(:index, :impersonatable_user)
+        end
+      end
+
+      def self.register_admin_static_pages_menu!
+        Decidim.menu :admin_static_pages_menu do |menu|
+          menu.add_item :static_pages,
+                        I18n.t("menu.static_pages", scope: "decidim.admin"),
+                        decidim_admin.static_pages_path,
+                        icon_name: "pages-line",
+                        position: 1,
+                        active: is_active_link?(decidim_admin.static_pages_path, :inclusive),
+                        if: allowed_to?(:read, :static_page)
+          menu.add_item :static_page_topics,
+                        I18n.t("menu.static_page_topics", scope: "decidim.admin"),
+                        decidim_admin.static_page_topics_path,
+                        icon_name: "pages-line",
+                        position: 2,
+                        active: is_active_link?(decidim_admin.static_page_topics_path, :inclusive),
+                        if: allowed_to?(:create, :static_page_topic)
+        end
+      end
+
+      def self.register_admin_user_menu!
+        Decidim.menu :admin_user_menu do |menu|
+          menu.add_item :users,
+                        I18n.t("menu.admins", scope: "decidim.admin"), decidim_admin.users_path,
+                        icon_name: "user-line",
+                        active: is_active_link?(decidim_admin.users_path),
+                        if: allowed_to?(:read, :admin_user)
+          menu.add_item :user_groups,
+                        I18n.t("menu.user_groups", scope: "decidim.admin"), decidim_admin.user_groups_path,
+                        icon_name: "group-line",
+                        active: is_active_link?(decidim_admin.user_groups_path),
+                        if: current_organization.user_groups_enabled? && allowed_to?(:index, :user_group)
+          menu.add_item :officializations,
+                        I18n.t("menu.participants", scope: "decidim.admin"), decidim_admin.officializations_path,
+                        icon_name: "service-line",
+                        active: is_active_link?(decidim_admin.officializations_path),
+                        if: allowed_to?(:index, :officialization)
+          menu.add_item :impersonatable_users,
+                        I18n.t("menu.impersonations", scope: "decidim.admin"), decidim_admin.impersonatable_users_path,
+                        icon_name: "user-add-line",
+                        active: is_active_link?(decidim_admin.impersonatable_users_path),
+                        if: allowed_to?(:index, :impersonatable_user),
+                        submenu: { target_menu: :impersonate_menu }
+          menu.add_item :authorization_workflows,
+                        I18n.t("menu.authorization_workflows", scope: "decidim.admin"), decidim_admin.authorization_workflows_path,
+                        icon_name: "key-2-line",
+                        active: is_active_link?(decidim_admin.authorization_workflows_path),
+                        if: allowed_to?(:index, :authorization),
+                        submenu: { target_menu: :workflows_menu }
+        end
+      end
+
+      def self.register_admin_scopes_menu!
+        Decidim.menu :admin_scopes_menu do |menu|
+          menu.add_item :scopes,
+                        I18n.t("menu.scopes", scope: "decidim.admin"),
+                        decidim_admin.scopes_path,
+                        icon_name: "price-tag-3-line",
+                        position: 1.3,
+                        if: allowed_to?(:read, :scope)
+          menu.add_item :scope_types,
+                        I18n.t("menu.scope_types", scope: "decidim.admin"),
+                        decidim_admin.scope_types_path,
+                        icon_name: "price-tag-3-line",
+                        position: 1.4,
+                        if: allowed_to?(:read, :scope_type)
+        end
+      end
+
+      def self.register_admin_areas_menu!
+        Decidim.menu :admin_areas_menu do |menu|
+          menu.add_item :areas,
+                        I18n.t("menu.areas", scope: "decidim.admin"),
+                        decidim_admin.areas_path,
+                        icon_name: "layout-masonry-line",
+                        position: 1.5,
+                        if: allowed_to?(:read, :area)
+          menu.add_item :area_types,
+                        I18n.t("menu.area_types", scope: "decidim.admin"),
+                        decidim_admin.area_types_path,
+                        icon_name: "layout-masonry-line",
+                        position: 1.6,
+                        if: allowed_to?(:read, :area_type)
+        end
+      end
+
+      def self.register_admin_settings_menu!
+        Decidim.menu :admin_settings_menu do |menu|
+          menu.add_item :edit_organization,
+                        I18n.t("menu.configuration", scope: "decidim.admin"),
+                        decidim_admin.edit_organization_path,
+                        position: 1.0,
+                        icon_name: "pencil-line",
+                        if: allowed_to?(:update, :organization, organization: current_organization)
+
+          menu.add_item :edit_organization_appearance,
+                        I18n.t("menu.appearance", scope: "decidim.admin"),
+                        decidim_admin.edit_organization_appearance_path,
+                        position: 1.1,
+                        icon_name: "tools-line",
+                        if: allowed_to?(:update, :organization, organization: current_organization)
+
+          menu.add_item :edit_organization_homepage,
+                        I18n.t("menu.homepage", scope: "decidim.admin"),
+                        decidim_admin.edit_organization_homepage_path,
+                        position: 1.2,
+                        icon_name: "home-gear-line",
+                        if: allowed_to?(:update, :organization, organization: current_organization)
+
+          menu.add_item :scopes,
+                        I18n.t("menu.scopes", scope: "decidim.admin"),
+                        decidim_admin.scopes_path,
+                        icon_name: "price-tag-3-line",
+                        position: 1.3,
+                        if: allowed_to?(:read, :scope)
+          menu.add_item :areas,
+                        I18n.t("menu.areas", scope: "decidim.admin"),
+                        decidim_admin.areas_path,
+                        icon_name: "layout-masonry-line",
+                        position: 1.5,
+                        if: allowed_to?(:read, :area)
+
+          menu.add_item :help_sections,
+                        I18n.t("menu.help_sections", scope: "decidim.admin"),
+                        decidim_admin.help_sections_path,
+                        icon_name: "question-line",
+                        position: 1.6,
+                        if: allowed_to?(:update, :help_sections)
+
+          menu.add_item :external_domain_whitelist,
+                        I18n.t("menu.external_domain_whitelist", scope: "decidim.admin"),
+                        decidim_admin.edit_organization_external_domain_whitelist_path,
+                        icon_name: "computer-line",
+                        position: 1.7,
+                        if: allowed_to?(:update, :organization, organization: current_organization)
+        end
+      end
+
+      def self.register_admin_menu!
+        Decidim.menu :admin_menu do |menu|
+          menu.add_item :moderations,
+                        I18n.t("menu.moderation", scope: "decidim.admin"),
+                        decidim_admin.moderations_path,
+                        icon_name: "flag-line",
+                        position: 4,
+                        active: [%w(
+                          decidim/admin/global_moderations
+                          decidim/admin/global_moderations/reports
+                          decidim/admin/moderated_users
+                        ), []],
+                        if: allowed_to?(:read, :global_moderation) || allowed_to?(:index, :moderate_users)
+
+          menu.add_item :static_pages,
+                        I18n.t("menu.static_pages", scope: "decidim.admin"),
+                        decidim_admin.static_pages_path,
+                        icon_name: "pages-line",
+                        position: 4.5,
+                        active: is_active_link?(decidim_admin.static_pages_path, :inclusive) ||
+                                is_active_link?(decidim_admin.static_page_topics_path, :inclusive),
+                        if: allowed_to?(:read, :static_page)
+
+          menu.add_item :impersonatable_users,
+                        I18n.t("menu.users", scope: "decidim.admin"),
+                        allowed_to?(:read, :admin_user) ? decidim_admin.users_path : decidim_admin.impersonatable_users_path,
+                        icon_name: "team-line",
+                        position: 5,
+                        active: [%w(
+                          decidim/admin/users
+                          decidim/admin/user_groups
+                          decidim/admin/user_groups_csv_verifications
+                          decidim/admin/officializations
+                          decidim/admin/impersonatable_users
+                          decidim/admin/conflicts
+                          decidim/admin/managed_users/impersonation_logs
+                          decidim/admin/managed_users/promotions
+                          decidim/admin/authorization_workflows
+                          decidim/verifications/id_documents/admin/pending_authorizations
+                          decidim/verifications/id_documents/admin/config
+                          decidim/verifications/postal_letter/admin/pending_authorizations
+                          decidim/verifications/csv_census/admin/census
+                        ), []],
+                        if: allowed_to?(:read, :admin_user) || allowed_to?(:read, :managed_user)
+
+          menu.add_item :newsletters,
+                        I18n.t("menu.newsletters", scope: "decidim.admin"),
+                        decidim_admin.newsletters_path,
+                        icon_name: "mail-add-line",
+                        position: 6,
+                        active: is_active_link?(decidim_admin.newsletters_path, :inclusive) ||
+                                is_active_link?(decidim_admin.newsletter_templates_path, :inclusive),
+                        if: allowed_to?(:index, :newsletter)
+
+          menu.add_item :edit_organization,
+                        I18n.t("menu.settings", scope: "decidim.admin"),
+                        decidim_admin.edit_organization_path,
+                        icon_name: "tools-line",
+                        position: 7,
+                        active: [
+                          %w(
+                            decidim/admin/organization
+                            decidim/admin/organization_appearance
+                            decidim/admin/organization_homepage
+                            decidim/admin/organization_homepage_content_blocks
+                            decidim/admin/scopes
+                            decidim/admin/scope_types
+                            decidim/admin/areas decidim/admin/area_types
+                            decidim/admin/help_sections
+                            decidim/admin/organization_external_domain_whitelist
+                          ),
+                          []
+                        ],
+                        if: allowed_to?(:update, :organization, organization: current_organization)
+
+          menu.add_item :logs,
+                        I18n.t("menu.admin_log", scope: "decidim.admin"),
+                        decidim_admin.logs_path,
+                        icon_name: "pages-line",
+                        position: 10,
+                        active: [%w(decidim/admin/logs), []],
+                        if: allowed_to?(:read, :admin_log)
+        end
+      end
+    end
+  end
+end

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -4,6 +4,7 @@ require "rails"
 require "active_support/all"
 
 require "decidim/core"
+require "decidim/assemblies/menu"
 
 module Decidim
   module Assemblies
@@ -101,140 +102,23 @@ module Decidim
       end
 
       initializer "decidim_assemblies_admin.menu" do
-        Decidim.menu :admin_menu_modules do |menu|
-          menu.add_item :assemblies,
-                        I18n.t("menu.assemblies", scope: "decidim.admin"),
-                        decidim_admin_assemblies.assemblies_path,
-                        icon_name: "government-line",
-                        position: 2.2,
-                        active: is_active_link?(decidim_admin_assemblies.assemblies_path) ||
-                                is_active_link?(decidim_admin_assemblies.assemblies_types_path) ||
-                                is_active_link?(decidim_admin_assemblies.edit_assemblies_settings_path),
-                        if: allowed_to?(:enter, :space_area, space_name: :assemblies)
-        end
+        Decidim::Assemblies::Menu.register_admin_engine_menu!
       end
 
       initializer "decidim_assemblies_admin.attachments_menu" do
-        Decidim.menu :assemblies_admin_attachments_menu do |menu|
-          menu.add_item :assembly_attachments,
-                        I18n.t("attachment_files", scope: "decidim.admin.menu.assemblies_submenu"),
-                        decidim_admin_assemblies.assembly_attachments_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_assemblies.assembly_attachments_path(current_participatory_space)),
-                        if: allowed_to?(:read, :attachment, assembly: current_participatory_space),
-                        icon_name: "attachment-line"
-          menu.add_item :assembly_attachment_collections,
-                        I18n.t("attachment_collections", scope: "decidim.admin.menu.assemblies_submenu"),
-                        decidim_admin_assemblies.assembly_attachment_collections_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_assemblies.assembly_attachment_collections_path(current_participatory_space)),
-                        if: allowed_to?(:read, :attachment_collection, assembly: current_participatory_space),
-                        icon_name: "folder-line"
-        end
+        Decidim::Assemblies::Menu.register_admin_attachments_menu!
       end
+
       initializer "decidim_assemblies_admin.components_menu" do
-        Decidim.menu :admin_assemblies_components_menu do |menu|
-          current_participatory_space.components.each do |component|
-            caption = translated_attribute(component.name)
-            if component.primary_stat.present?
-              caption += content_tag(:span, component.primary_stat, class: component.primary_stat.zero? ? "component-counter component-counter--off" : "component-counter")
-            end
-
-            menu.add_item [component.manifest_name, component.id].join("_"),
-                          caption.html_safe,
-                          manage_component_path(component),
-                          active: is_active_link?(manage_component_path(component)) ||
-                                  is_active_link?(decidim_admin_assemblies.edit_component_path(current_participatory_space, component)) ||
-                                  is_active_link?(decidim_admin_assemblies.edit_component_permissions_path(current_participatory_space, component)) ||
-                                  participatory_space_active_link?(component),
-                          if: component.manifest.admin_engine && user_role_config.component_is_accessible?(component.manifest_name)
-          end
-        end
+        Decidim::Assemblies::Menu.register_admin_components_menu!
       end
+
       initializer "decidim_assemblies_admin.assembly_menu" do
-        Decidim.menu :admin_assembly_menu do |menu|
-          menu.add_item :edit_assembly,
-                        I18n.t("info", scope: "decidim.admin.menu.assemblies_submenu"),
-                        decidim_admin_assemblies.edit_assembly_path(current_participatory_space),
-                        position: 1,
-                        icon_name: "information-line",
-                        if: allowed_to?(:update, :assembly, assembly: current_participatory_space)
-
-          menu.add_item :edit_assembly_landing_page,
-                        I18n.t("landing_page", scope: "decidim.admin.menu.assemblies_submenu"),
-                        decidim_admin_assemblies.edit_assembly_landing_page_path(current_participatory_space),
-                        icon_name: "layout-masonry-line",
-                        if: allowed_to?(:update, :assembly, assembly: current_participatory_space)
-
-          menu.add_item :components,
-                        I18n.t("components", scope: "decidim.admin.menu.assemblies_submenu"),
-                        decidim_admin_assemblies.components_path(current_participatory_space),
-                        icon_name: "tools-line",
-                        active: is_active_link?(decidim_admin_assemblies.components_path(current_participatory_space), ["decidim/assemblies/admin/components", %w(index new edit)]),
-                        if: allowed_to?(:read, :component, assembly: current_participatory_space),
-                        submenu: { target_menu: :admin_assemblies_components_menu }
-
-          menu.add_item :categories,
-                        I18n.t("categories", scope: "decidim.admin.menu.assemblies_submenu"),
-                        decidim_admin_assemblies.categories_path(current_participatory_space),
-                        icon_name: "price-tag-3-line",
-                        if: allowed_to?(:read, :category, assembly: current_participatory_space)
-
-          menu.add_item :attachments,
-                        I18n.t("attachments", scope: "decidim.admin.menu.assemblies_submenu"),
-                        decidim_admin_assemblies.assembly_attachments_path(current_participatory_space),
-                        icon_name: "attachment-2",
-                        active: is_active_link?(decidim_admin_assemblies.assembly_attachments_path(current_participatory_space)) ||
-                                is_active_link?(decidim_admin_assemblies.assembly_attachment_collections_path(current_participatory_space)),
-                        if: allowed_to?(:read, :attachment_collection, assembly: current_participatory_space) ||
-                            allowed_to?(:read, :attachment, assembly: current_participatory_space)
-
-          menu.add_item :assembly_members,
-                        I18n.t("assembly_members", scope: "decidim.admin.menu.assemblies_submenu"),
-                        decidim_admin_assemblies.assembly_members_path(current_participatory_space),
-                        icon_name: "user-settings-line",
-                        if: allowed_to?(:read, :assembly_member, assembly: current_participatory_space)
-
-          menu.add_item :assembly_user_roles,
-                        I18n.t("assembly_admins", scope: "decidim.admin.menu.assemblies_submenu"),
-                        decidim_admin_assemblies.assembly_user_roles_path(current_participatory_space),
-                        icon_name: "user-settings-line",
-                        if: allowed_to?(:read, :assembly_user_role, assembly: current_participatory_space)
-
-          menu.add_item :participatory_space_private_users,
-                        I18n.t("private_users", scope: "decidim.admin.menu.assemblies_submenu"),
-                        decidim_admin_assemblies.participatory_space_private_users_path(current_participatory_space),
-                        icon_name: "spy-line",
-                        if: allowed_to?(:read, :space_private_user, assembly: current_participatory_space)
-
-          menu.add_item :moderations,
-                        I18n.t("moderations", scope: "decidim.admin.menu.assemblies_submenu"),
-                        decidim_admin_assemblies.moderations_path(current_participatory_space),
-                        icon_name: "flag-line",
-                        if: allowed_to?(:read, :moderation, assembly: current_participatory_space)
-        end
+        Decidim::Assemblies::Menu.register_admin_assembly_menu!
       end
+
       initializer "decidim_assemblies_admin.assemblies_menu" do
-        Decidim.menu :admin_assemblies_menu do |menu|
-          menu.add_item :assemblies,
-                        I18n.t("menu.assemblies", scope: "decidim.admin"),
-                        decidim_admin_assemblies.assemblies_path,
-                        position: 1.0,
-                        active: is_active_link?(decidim_admin_assemblies.assemblies_path),
-                        if: allowed_to?(:read, :assembly_list)
-
-          menu.add_item :assemblies_types,
-                        I18n.t("menu.assemblies_types", scope: "decidim.admin"),
-                        decidim_admin_assemblies.assemblies_types_path,
-                        active: is_active_link?(decidim_admin_assemblies.assemblies_types_path),
-                        position: 1.1,
-                        if: allowed_to?(:manage, :assemblies_type)
-
-          menu.add_item :edit_assemblies_settings,
-                        I18n.t("menu.assemblies_settings", scope: "decidim.admin"),
-                        decidim_admin_assemblies.edit_assemblies_settings_path,
-                        active: is_active_link?(decidim_admin_assemblies.edit_assemblies_settings_path),
-                        position: 1.3,
-                        if: allowed_to?(:read, :assemblies_setting)
-        end
+        Decidim::Assemblies::Menu.register_admin_assemblies_menu!
       end
     end
   end

--- a/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/admin_engine.rb
@@ -102,15 +102,15 @@ module Decidim
       end
 
       initializer "decidim_assemblies_admin.menu" do
-        Decidim::Assemblies::Menu.register_admin_engine_menu!
+        Decidim::Assemblies::Menu.register_admin_menu_modules!
       end
 
       initializer "decidim_assemblies_admin.attachments_menu" do
-        Decidim::Assemblies::Menu.register_admin_attachments_menu!
+        Decidim::Assemblies::Menu.register_assemblies_admin_attachments_menu!
       end
 
       initializer "decidim_assemblies_admin.components_menu" do
-        Decidim::Assemblies::Menu.register_admin_components_menu!
+        Decidim::Assemblies::Menu.register_admin_assemblies_components_menu!
       end
 
       initializer "decidim_assemblies_admin.assembly_menu" do

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -52,7 +52,8 @@ module Decidim
 
 
       initializer "decidim_assemblies.menu" do
-        Decidim::Assemblies::Menu.register_engine_menu!
+        Decidim::Assemblies::Menu.register_engine_assemblies_menu!
+        Decidim::Assemblies::Menu.register_engine_home_content_block_menu!
       end
 
       initializer "decidim_assemblies.view_hooks" do

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -52,8 +52,8 @@ module Decidim
 
 
       initializer "decidim_assemblies.menu" do
-        Decidim::Assemblies::Menu.register_engine_assemblies_menu!
-        Decidim::Assemblies::Menu.register_engine_home_content_block_menu!
+        Decidim::Assemblies::Menu.register_menu!
+        Decidim::Assemblies::Menu.register_home_content_block_menu!
       end
 
       initializer "decidim_assemblies.view_hooks" do

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -50,7 +50,6 @@ module Decidim
         end
       end
 
-
       initializer "decidim_assemblies.menu" do
         Decidim::Assemblies::Menu.register_menu!
         Decidim::Assemblies::Menu.register_home_content_block_menu!

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -5,6 +5,7 @@ require "active_support/all"
 
 require "decidim/core"
 require "decidim/assemblies/query_extensions"
+require "decidim/assemblies/menu"
 
 module Decidim
   module Assemblies
@@ -49,24 +50,8 @@ module Decidim
         end
       end
 
-      initializer "decidim_assemblies.menu" do
-        Decidim.menu :menu do |menu|
-          menu.add_item :assemblies,
-                        I18n.t("menu.assemblies", scope: "decidim"),
-                        decidim_assemblies.assemblies_path,
-                        position: 2.2,
-                        if: OrganizationPublishedAssemblies.new(current_organization, current_user).any?,
-                        active: :inclusive
-        end
 
-        Decidim.menu :home_content_block_menu do |menu|
-          menu.add_item :assemblies,
-                        I18n.t("menu.assemblies", scope: "decidim"),
-                        decidim_assemblies.assemblies_path,
-                        position: 20,
-                        if: OrganizationPublishedAssemblies.new(current_organization, current_user).any?,
-                        active: :inclusive
-        end
+        Decidim::Assemblies::Menu.register_engine_menu!
       end
 
       initializer "decidim_assemblies.view_hooks" do

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -51,6 +51,7 @@ module Decidim
       end
 
 
+      initializer "decidim_assemblies.menu" do
         Decidim::Assemblies::Menu.register_engine_menu!
       end
 

--- a/decidim-assemblies/lib/decidim/assemblies/menu.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/menu.rb
@@ -5,7 +5,7 @@ require "decidim/seeds"
 module Decidim
   module Assemblies
     class Menu
-      def self.register_engine_menu!
+      def self.register_engine_assemblies_menu!
         Decidim.menu :menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim"),
@@ -14,7 +14,9 @@ module Decidim
                         if: OrganizationPublishedAssemblies.new(current_organization, current_user).any?,
                         active: :inclusive
         end
+      end
 
+      def self.register_engine_home_content_block_menu!
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim"),

--- a/decidim-assemblies/lib/decidim/assemblies/menu.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/menu.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-require "decidim/seeds"
-
 module Decidim
   module Assemblies
     class Menu
-      def self.register_engine_assemblies_menu!
+      def self.register_menu!
         Decidim.menu :menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim"),
@@ -16,7 +14,7 @@ module Decidim
         end
       end
 
-      def self.register_engine_home_content_block_menu!
+      def self.register_home_content_block_menu!
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim"),
@@ -27,7 +25,7 @@ module Decidim
         end
       end
 
-      def self.register_admin_engine_menu!
+      def self.register_admin_menu_modules!
         Decidim.menu :admin_menu_modules do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim.admin"),
@@ -41,7 +39,7 @@ module Decidim
         end
       end
 
-      def self.register_admin_attachments_menu!
+      def self.register_assemblies_admin_attachments_menu!
         Decidim.menu :assemblies_admin_attachments_menu do |menu|
           menu.add_item :assembly_attachments,
                         I18n.t("attachment_files", scope: "decidim.admin.menu.assemblies_submenu"),
@@ -58,7 +56,7 @@ module Decidim
         end
       end
 
-      def self.register_admin_components_menu!
+      def self.register_admin_assemblies_components_menu!
         Decidim.menu :admin_assemblies_components_menu do |menu|
           current_participatory_space.components.each do |component|
             caption = translated_attribute(component.name)

--- a/decidim-assemblies/lib/decidim/assemblies/menu.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/menu.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require "decidim/seeds"
+
+module Decidim
+  module Assemblies
+    class Menu
+      def self.register_engine_menu!
+        Decidim.menu :menu do |menu|
+          menu.add_item :assemblies,
+                        I18n.t("menu.assemblies", scope: "decidim"),
+                        decidim_assemblies.assemblies_path,
+                        position: 2.2,
+                        if: OrganizationPublishedAssemblies.new(current_organization, current_user).any?,
+                        active: :inclusive
+        end
+
+        Decidim.menu :home_content_block_menu do |menu|
+          menu.add_item :assemblies,
+                        I18n.t("menu.assemblies", scope: "decidim"),
+                        decidim_assemblies.assemblies_path,
+                        position: 20,
+                        if: OrganizationPublishedAssemblies.new(current_organization, current_user).any?,
+                        active: :inclusive
+        end
+      end
+
+      def self.register_admin_engine_menu!
+        Decidim.menu :admin_menu_modules do |menu|
+          menu.add_item :assemblies,
+                        I18n.t("menu.assemblies", scope: "decidim.admin"),
+                        decidim_admin_assemblies.assemblies_path,
+                        icon_name: "government-line",
+                        position: 2.2,
+                        active: is_active_link?(decidim_admin_assemblies.assemblies_path) ||
+                                is_active_link?(decidim_admin_assemblies.assemblies_types_path) ||
+                                is_active_link?(decidim_admin_assemblies.edit_assemblies_settings_path),
+                        if: allowed_to?(:enter, :space_area, space_name: :assemblies)
+        end
+      end
+
+      def self.register_admin_attachments_menu!
+        Decidim.menu :assemblies_admin_attachments_menu do |menu|
+          menu.add_item :assembly_attachments,
+                        I18n.t("attachment_files", scope: "decidim.admin.menu.assemblies_submenu"),
+                        decidim_admin_assemblies.assembly_attachments_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_assemblies.assembly_attachments_path(current_participatory_space)),
+                        if: allowed_to?(:read, :attachment, assembly: current_participatory_space),
+                        icon_name: "attachment-line"
+          menu.add_item :assembly_attachment_collections,
+                        I18n.t("attachment_collections", scope: "decidim.admin.menu.assemblies_submenu"),
+                        decidim_admin_assemblies.assembly_attachment_collections_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_assemblies.assembly_attachment_collections_path(current_participatory_space)),
+                        if: allowed_to?(:read, :attachment_collection, assembly: current_participatory_space),
+                        icon_name: "folder-line"
+        end
+      end
+
+      def self.register_admin_components_menu!
+        Decidim.menu :admin_assemblies_components_menu do |menu|
+          current_participatory_space.components.each do |component|
+            caption = translated_attribute(component.name)
+            if component.primary_stat.present?
+              caption += content_tag(:span, component.primary_stat, class: component.primary_stat.zero? ? "component-counter component-counter--off" : "component-counter")
+            end
+
+            menu.add_item [component.manifest_name, component.id].join("_"),
+                          caption.html_safe,
+                          manage_component_path(component),
+                          active: is_active_link?(manage_component_path(component)) ||
+                                  is_active_link?(decidim_admin_assemblies.edit_component_path(current_participatory_space, component)) ||
+                                  is_active_link?(decidim_admin_assemblies.edit_component_permissions_path(current_participatory_space, component)) ||
+                                  participatory_space_active_link?(component),
+                          if: component.manifest.admin_engine && user_role_config.component_is_accessible?(component.manifest_name)
+          end
+        end
+      end
+
+      def self.register_admin_assembly_menu!
+        Decidim.menu :admin_assembly_menu do |menu|
+          menu.add_item :edit_assembly,
+                        I18n.t("info", scope: "decidim.admin.menu.assemblies_submenu"),
+                        decidim_admin_assemblies.edit_assembly_path(current_participatory_space),
+                        position: 1,
+                        icon_name: "information-line",
+                        if: allowed_to?(:update, :assembly, assembly: current_participatory_space)
+
+          menu.add_item :edit_assembly_landing_page,
+                        I18n.t("landing_page", scope: "decidim.admin.menu.assemblies_submenu"),
+                        decidim_admin_assemblies.edit_assembly_landing_page_path(current_participatory_space),
+                        icon_name: "layout-masonry-line",
+                        if: allowed_to?(:update, :assembly, assembly: current_participatory_space)
+
+          menu.add_item :components,
+                        I18n.t("components", scope: "decidim.admin.menu.assemblies_submenu"),
+                        decidim_admin_assemblies.components_path(current_participatory_space),
+                        icon_name: "tools-line",
+                        active: is_active_link?(decidim_admin_assemblies.components_path(current_participatory_space), ["decidim/assemblies/admin/components", %w(index new edit)]),
+                        if: allowed_to?(:read, :component, assembly: current_participatory_space),
+                        submenu: { target_menu: :admin_assemblies_components_menu }
+
+          menu.add_item :categories,
+                        I18n.t("categories", scope: "decidim.admin.menu.assemblies_submenu"),
+                        decidim_admin_assemblies.categories_path(current_participatory_space),
+                        icon_name: "price-tag-3-line",
+                        if: allowed_to?(:read, :category, assembly: current_participatory_space)
+
+          menu.add_item :attachments,
+                        I18n.t("attachments", scope: "decidim.admin.menu.assemblies_submenu"),
+                        decidim_admin_assemblies.assembly_attachments_path(current_participatory_space),
+                        icon_name: "attachment-2",
+                        active: is_active_link?(decidim_admin_assemblies.assembly_attachments_path(current_participatory_space)) ||
+                                is_active_link?(decidim_admin_assemblies.assembly_attachment_collections_path(current_participatory_space)),
+                        if: allowed_to?(:read, :attachment_collection, assembly: current_participatory_space) ||
+                            allowed_to?(:read, :attachment, assembly: current_participatory_space)
+
+          menu.add_item :assembly_members,
+                        I18n.t("assembly_members", scope: "decidim.admin.menu.assemblies_submenu"),
+                        decidim_admin_assemblies.assembly_members_path(current_participatory_space),
+                        icon_name: "user-settings-line",
+                        if: allowed_to?(:read, :assembly_member, assembly: current_participatory_space)
+
+          menu.add_item :assembly_user_roles,
+                        I18n.t("assembly_admins", scope: "decidim.admin.menu.assemblies_submenu"),
+                        decidim_admin_assemblies.assembly_user_roles_path(current_participatory_space),
+                        icon_name: "user-settings-line",
+                        if: allowed_to?(:read, :assembly_user_role, assembly: current_participatory_space)
+
+          menu.add_item :participatory_space_private_users,
+                        I18n.t("private_users", scope: "decidim.admin.menu.assemblies_submenu"),
+                        decidim_admin_assemblies.participatory_space_private_users_path(current_participatory_space),
+                        icon_name: "spy-line",
+                        if: allowed_to?(:read, :space_private_user, assembly: current_participatory_space)
+
+          menu.add_item :moderations,
+                        I18n.t("moderations", scope: "decidim.admin.menu.assemblies_submenu"),
+                        decidim_admin_assemblies.moderations_path(current_participatory_space),
+                        icon_name: "flag-line",
+                        if: allowed_to?(:read, :moderation, assembly: current_participatory_space)
+        end
+      end
+
+      def self.register_admin_assemblies_menu!
+        Decidim.menu :admin_assemblies_menu do |menu|
+          menu.add_item :assemblies,
+                        I18n.t("menu.assemblies", scope: "decidim.admin"),
+                        decidim_admin_assemblies.assemblies_path,
+                        position: 1.0,
+                        active: is_active_link?(decidim_admin_assemblies.assemblies_path),
+                        if: allowed_to?(:read, :assembly_list)
+
+          menu.add_item :assemblies_types,
+                        I18n.t("menu.assemblies_types", scope: "decidim.admin"),
+                        decidim_admin_assemblies.assemblies_types_path,
+                        active: is_active_link?(decidim_admin_assemblies.assemblies_types_path),
+                        position: 1.1,
+                        if: allowed_to?(:manage, :assemblies_type)
+
+          menu.add_item :edit_assemblies_settings,
+                        I18n.t("menu.assemblies_settings", scope: "decidim.admin"),
+                        decidim_admin_assemblies.edit_assemblies_settings_path,
+                        active: is_active_link?(decidim_admin_assemblies.edit_assemblies_settings_path),
+                        position: 1.3,
+                        if: allowed_to?(:read, :assemblies_setting)
+        end
+      end
+    end
+  end
+end

--- a/decidim-conferences/lib/decidim/conferences/admin_engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/admin_engine.rb
@@ -3,6 +3,7 @@
 require "rails"
 require "active_support/all"
 require "decidim/core"
+require "decidim/conferences/menu"
 
 module Decidim
   module Conferences
@@ -89,153 +90,23 @@ module Decidim
       end
 
       initializer "decidim_conferences_admin.components_menu" do
-        Decidim.menu :admin_conferences_components_menu do |menu|
-          current_participatory_space.components.each do |component|
-            caption = translated_attribute(component.name)
-            if component.primary_stat.present?
-              caption += content_tag(:span, component.primary_stat, class: component.primary_stat.zero? ? "component-counter component-counter--off" : "component-counter")
-            end
-
-            menu.add_item [component.manifest_name, component.id].join("_"),
-                          caption.html_safe,
-                          manage_component_path(component),
-                          active: is_active_link?(manage_component_path(component)) ||
-                                  is_active_link?(decidim_admin_conferences.edit_component_path(current_participatory_space, component)) ||
-                                  is_active_link?(decidim_admin_conferences.edit_component_permissions_path(current_participatory_space, component)) ||
-                                  participatory_space_active_link?(component),
-                          if: component.manifest.admin_engine && user_role_config.component_is_accessible?(component.manifest_name)
-          end
-        end
+        Decidim::Conferences::Menu.register_admin_conferences_components_menu!
       end
+
       initializer "decidim_conferences_admin.registrations_menu" do
-        Decidim.menu :conferences_admin_registrations_menu do |menu|
-          menu.add_item :conference_registration_types,
-                        I18n.t("registration_types", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.conference_registration_types_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_conferences.conference_registration_types_path(current_participatory_space)),
-                        if: allowed_to?(:read, :registration_type, conference: current_participatory_space)
-
-          menu.add_item :conference_conference_registrations,
-                        I18n.t("user_registrations", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.conference_conference_registrations_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_conferences.conference_conference_registrations_path(current_participatory_space)),
-                        if: allowed_to?(:read, :conference_registration, conference: current_participatory_space)
-
-          menu.add_item :conference_conference_invites,
-                        I18n.t("conference_invites", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.conference_conference_invites_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_conferences.conference_conference_invites_path(current_participatory_space)),
-                        if: allowed_to?(:read, :conference_invite, conference: current_participatory_space)
-
-          menu.add_item :edit_conference_diploma,
-                        I18n.t("diploma", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.edit_conference_diploma_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_conferences.edit_conference_diploma_path(current_participatory_space)),
-                        if: allowed_to?(:update, :conference, conference: current_participatory_space)
-        end
+        Decidim::Conferences::Menu.register_conferences_admin_registrations_menu!
       end
+
       initializer "decidim_conferences_admin.attachments_menu" do
-        Decidim.menu :conferences_admin_attachments_menu do |menu|
-          menu.add_item :conference_attachments,
-                        I18n.t("attachment_files", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.conference_attachments_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_conferences.conference_attachments_path(current_participatory_space)),
-                        if: allowed_to?(:read, :attachment, conference: current_participatory_space),
-                        icon_name: "attachment-line"
-
-          menu.add_item :conference_attachment_collections,
-                        I18n.t("attachment_collections", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.conference_attachment_collections_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_conferences.conference_attachment_collections_path(current_participatory_space)),
-                        if: allowed_to?(:read, :attachment_collection, conference: current_participatory_space),
-                        icon_name: "folder-line"
-        end
+        Decidim::Conferences::Menu.register_conferences_admin_attachments_menu!
       end
+
       initializer "decidim_conferences_admin.conferences_menu" do
-        Decidim.menu :conferences_admin_menu do |menu|
-          menu.add_item :edit_conference,
-                        I18n.t("info", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.edit_conference_path(current_participatory_space),
-                        position: 1,
-                        icon_name: "information-line",
-                        if: allowed_to?(:update, :conference, conference: current_participatory_space)
-
-          menu.add_item :components,
-                        I18n.t("components", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.components_path(current_participatory_space),
-                        icon_name: "tools-line",
-                        if: allowed_to?(:read, :component, conference: current_participatory_space),
-                        active: is_active_link?(decidim_admin_conferences.components_path(current_participatory_space),
-                                                ["decidim/conferences/admin/components", %w(index new edit)]),
-                        submenu: { target_menu: :admin_conferences_components_menu }
-
-          menu.add_item :categories,
-                        I18n.t("categories", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.categories_path(current_participatory_space),
-                        icon_name: "price-tag-3-line",
-                        if: allowed_to?(:read, :category, conference: current_participatory_space)
-
-          menu.add_item :attachments,
-                        I18n.t("attachments", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.conference_attachments_path(current_participatory_space),
-                        icon_name: "attachment-2",
-                        active: is_active_link?(decidim_admin_conferences.conference_attachment_collections_path(current_participatory_space)) ||
-                                is_active_link?(decidim_admin_conferences.conference_attachments_path(current_participatory_space)),
-                        if: allowed_to?(:read, :attachment, conference: current_participatory_space) ||
-                            allowed_to?(:read, :attachment_collection, conference: current_participatory_space)
-
-          menu.add_item :conference_media_links,
-                        I18n.t("media_links", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.conference_media_links_path(current_participatory_space),
-                        icon_name: "film-line",
-                        active: is_active_link?(decidim_admin_conferences.conference_media_links_path(current_participatory_space))
-
-          menu.add_item :conference_partners,
-                        I18n.t("partners", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.conference_partners_path(current_participatory_space),
-                        icon_name: "service-line",
-                        if: allowed_to?(:read, :partner, conference: current_participatory_space)
-
-          menu.add_item :conference_speakers,
-                        I18n.t("conference_speakers", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.conference_speakers_path(current_participatory_space),
-                        icon_name: "user-voice-line",
-                        if: allowed_to?(:read, :conference_speaker, conference: current_participatory_space)
-
-          menu.add_item :registrations,
-                        I18n.t("registrations", scope: "decidim.admin.menu.conferences_submenu"),
-                        "#",
-                        active: false,
-                        icon_name: "group-line",
-                        if: allowed_to?(:read, :conference_invite, conference: current_participatory_space) ||
-                            allowed_to?(:read, :registration_type, conference: current_participatory_space) ||
-                            allowed_to?(:read, :conference_registration, conference: current_participatory_space),
-                        submenu: { target_menu: :conferences_admin_registrations_menu }
-
-          menu.add_item :conference_user_roles,
-                        I18n.t("conference_admins", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.conference_user_roles_path(current_participatory_space),
-                        icon_name: "user-settings-line",
-                        if: allowed_to?(:read, :conference_user_role, conference: current_participatory_space)
-
-          menu.add_item :moderations,
-                        I18n.t("moderations", scope: "decidim.admin.menu.conferences_submenu"),
-                        decidim_admin_conferences.moderations_path(current_participatory_space),
-                        icon_name: "flag-line",
-                        if: allowed_to?(:read, :moderation, conference: current_participatory_space)
-        end
+        Decidim::Conferences::Menu.register_conferences_admin_menu!
       end
 
       initializer "decidim_conferences_admin.menu" do
-        Decidim.menu :admin_menu_modules do |menu|
-          menu.add_item :conferences,
-                        I18n.t("menu.conferences", scope: "decidim.admin"),
-                        decidim_admin_conferences.conferences_path,
-                        icon_name: "live-line",
-                        position: 2.8,
-                        active: :inclusive,
-                        if: allowed_to?(:enter, :space_area, space_name: :conferences)
-        end
+        Decidim::Conferences::Menu.register_admin_menu_modules!
       end
     end
   end

--- a/decidim-conferences/lib/decidim/conferences/engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/engine.rb
@@ -6,6 +6,7 @@ require "decidim/core"
 require "wicked_pdf"
 
 require "decidim/conferences/query_extensions"
+require "decidim/conferences/menu"
 
 module Decidim
   module Conferences
@@ -61,23 +62,8 @@ module Decidim
       end
 
       initializer "decidim_conferences.menu" do
-        Decidim.menu :menu do |menu|
-          menu.add_item :conferences,
-                        I18n.t("menu.conferences", scope: "decidim"),
-                        decidim_conferences.conferences_path,
-                        position: 2.8,
-                        if: Decidim::Conference.where(organization: current_organization).published.any?,
-                        active: :inclusive
-        end
-
-        Decidim.menu :home_content_block_menu do |menu|
-          menu.add_item :conferences,
-                        I18n.t("menu.conferences", scope: "decidim"),
-                        decidim_conferences.conferences_path,
-                        position: 50,
-                        if: Decidim::Conference.where(organization: current_organization).published.any?,
-                        active: :inclusive
-        end
+        Decidim::Conferences::Menu.register_menu!
+        Decidim::Conferences::Menu.register_home_content_block_menu!
       end
 
       initializer "decidim_conferences.content_blocks" do

--- a/decidim-conferences/lib/decidim/conferences/menu.rb
+++ b/decidim-conferences/lib/decidim/conferences/menu.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Conferences
+    class Menu
+      def self.register_menu!
+        Decidim.menu :menu do |menu|
+          menu.add_item :conferences,
+                        I18n.t("menu.conferences", scope: "decidim"),
+                        decidim_conferences.conferences_path,
+                        position: 2.8,
+                        if: Decidim::Conference.where(organization: current_organization).published.any?,
+                        active: :inclusive
+        end
+      end
+
+      def self.register_home_content_block_menu!
+        Decidim.menu :home_content_block_menu do |menu|
+          menu.add_item :conferences,
+                        I18n.t("menu.conferences", scope: "decidim"),
+                        decidim_conferences.conferences_path,
+                        position: 50,
+                        if: Decidim::Conference.where(organization: current_organization).published.any?,
+                        active: :inclusive
+        end
+      end
+
+      def self.register_admin_conferences_components_menu!
+        Decidim.menu :admin_conferences_components_menu do |menu|
+          current_participatory_space.components.each do |component|
+            caption = translated_attribute(component.name)
+            if component.primary_stat.present?
+              caption += content_tag(:span, component.primary_stat, class: component.primary_stat.zero? ? "component-counter component-counter--off" : "component-counter")
+            end
+
+            menu.add_item [component.manifest_name, component.id].join("_"),
+                          caption.html_safe,
+                          manage_component_path(component),
+                          active: is_active_link?(manage_component_path(component)) ||
+                                  is_active_link?(decidim_admin_conferences.edit_component_path(current_participatory_space, component)) ||
+                                  is_active_link?(decidim_admin_conferences.edit_component_permissions_path(current_participatory_space, component)) ||
+                                  participatory_space_active_link?(component),
+                          if: component.manifest.admin_engine && user_role_config.component_is_accessible?(component.manifest_name)
+          end
+        end
+      end
+
+      def self.register_conferences_admin_registrations_menu!
+        Decidim.menu :conferences_admin_registrations_menu do |menu|
+          menu.add_item :conference_registration_types,
+                        I18n.t("registration_types", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.conference_registration_types_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_conferences.conference_registration_types_path(current_participatory_space)),
+                        if: allowed_to?(:read, :registration_type, conference: current_participatory_space)
+
+          menu.add_item :conference_conference_registrations,
+                        I18n.t("user_registrations", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.conference_conference_registrations_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_conferences.conference_conference_registrations_path(current_participatory_space)),
+                        if: allowed_to?(:read, :conference_registration, conference: current_participatory_space)
+
+          menu.add_item :conference_conference_invites,
+                        I18n.t("conference_invites", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.conference_conference_invites_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_conferences.conference_conference_invites_path(current_participatory_space)),
+                        if: allowed_to?(:read, :conference_invite, conference: current_participatory_space)
+
+          menu.add_item :edit_conference_diploma,
+                        I18n.t("diploma", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.edit_conference_diploma_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_conferences.edit_conference_diploma_path(current_participatory_space)),
+                        if: allowed_to?(:update, :conference, conference: current_participatory_space)
+        end
+      end
+
+      def self.register_conferences_admin_attachments_menu!
+        Decidim.menu :conferences_admin_attachments_menu do |menu|
+          menu.add_item :conference_attachments,
+                        I18n.t("attachment_files", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.conference_attachments_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_conferences.conference_attachments_path(current_participatory_space)),
+                        if: allowed_to?(:read, :attachment, conference: current_participatory_space),
+                        icon_name: "attachment-line"
+
+          menu.add_item :conference_attachment_collections,
+                        I18n.t("attachment_collections", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.conference_attachment_collections_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_conferences.conference_attachment_collections_path(current_participatory_space)),
+                        if: allowed_to?(:read, :attachment_collection, conference: current_participatory_space),
+                        icon_name: "folder-line"
+        end
+      end
+
+      def self.register_conferences_admin_menu!
+        Decidim.menu :conferences_admin_menu do |menu|
+          menu.add_item :edit_conference,
+                        I18n.t("info", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.edit_conference_path(current_participatory_space),
+                        position: 1,
+                        icon_name: "information-line",
+                        if: allowed_to?(:update, :conference, conference: current_participatory_space)
+
+          menu.add_item :components,
+                        I18n.t("components", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.components_path(current_participatory_space),
+                        icon_name: "tools-line",
+                        if: allowed_to?(:read, :component, conference: current_participatory_space),
+                        active: is_active_link?(decidim_admin_conferences.components_path(current_participatory_space),
+                                                ["decidim/conferences/admin/components", %w(index new edit)]),
+                        submenu: { target_menu: :admin_conferences_components_menu }
+
+          menu.add_item :categories,
+                        I18n.t("categories", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.categories_path(current_participatory_space),
+                        icon_name: "price-tag-3-line",
+                        if: allowed_to?(:read, :category, conference: current_participatory_space)
+
+          menu.add_item :attachments,
+                        I18n.t("attachments", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.conference_attachments_path(current_participatory_space),
+                        icon_name: "attachment-2",
+                        active: is_active_link?(decidim_admin_conferences.conference_attachment_collections_path(current_participatory_space)) ||
+                                is_active_link?(decidim_admin_conferences.conference_attachments_path(current_participatory_space)),
+                        if: allowed_to?(:read, :attachment, conference: current_participatory_space) ||
+                            allowed_to?(:read, :attachment_collection, conference: current_participatory_space)
+
+          menu.add_item :conference_media_links,
+                        I18n.t("media_links", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.conference_media_links_path(current_participatory_space),
+                        icon_name: "film-line",
+                        active: is_active_link?(decidim_admin_conferences.conference_media_links_path(current_participatory_space))
+
+          menu.add_item :conference_partners,
+                        I18n.t("partners", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.conference_partners_path(current_participatory_space),
+                        icon_name: "service-line",
+                        if: allowed_to?(:read, :partner, conference: current_participatory_space)
+
+          menu.add_item :conference_speakers,
+                        I18n.t("conference_speakers", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.conference_speakers_path(current_participatory_space),
+                        icon_name: "user-voice-line",
+                        if: allowed_to?(:read, :conference_speaker, conference: current_participatory_space)
+
+          menu.add_item :registrations,
+                        I18n.t("registrations", scope: "decidim.admin.menu.conferences_submenu"),
+                        "#",
+                        active: false,
+                        icon_name: "group-line",
+                        if: allowed_to?(:read, :conference_invite, conference: current_participatory_space) ||
+                            allowed_to?(:read, :registration_type, conference: current_participatory_space) ||
+                            allowed_to?(:read, :conference_registration, conference: current_participatory_space),
+                        submenu: { target_menu: :conferences_admin_registrations_menu }
+
+          menu.add_item :conference_user_roles,
+                        I18n.t("conference_admins", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.conference_user_roles_path(current_participatory_space),
+                        icon_name: "user-settings-line",
+                        if: allowed_to?(:read, :conference_user_role, conference: current_participatory_space)
+
+          menu.add_item :moderations,
+                        I18n.t("moderations", scope: "decidim.admin.menu.conferences_submenu"),
+                        decidim_admin_conferences.moderations_path(current_participatory_space),
+                        icon_name: "flag-line",
+                        if: allowed_to?(:read, :moderation, conference: current_participatory_space)
+        end
+      end
+
+      def self.register_admin_menu_modules!
+        Decidim.menu :admin_menu_modules do |menu|
+          menu.add_item :conferences,
+                        I18n.t("menu.conferences", scope: "decidim.admin"),
+                        decidim_admin_conferences.conferences_path,
+                        icon_name: "live-line",
+                        position: 2.8,
+                        active: :inclusive,
+                        if: allowed_to?(:enter, :space_area, space_name: :conferences)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -44,6 +44,7 @@ require "shakapacker"
 require "decidim/webpacker"
 
 require "decidim/api"
+require "decidim/core/menu"
 require "decidim/middleware/strip_x_forwarded_host"
 require "decidim/middleware/static_dispatcher"
 require "decidim/middleware/current_organization"
@@ -212,64 +213,11 @@ module Decidim
       end
 
       initializer "decidim_core.menu" do
-        Decidim.menu :menu do |menu|
-          menu.add_item :root,
-                        I18n.t("menu.home", scope: "decidim"),
-                        decidim.root_path,
-                        position: 1,
-                        active: :exclusive
-
-          menu.add_item :pages,
-                        I18n.t("menu.help", scope: "decidim"),
-                        decidim.pages_path,
-                        position: 7,
-                        active: :inclusive
-        end
+        Decidim::Core::Menu.register_menu!
       end
 
       initializer "decidim_core.user_menu" do
-        Decidim.menu :user_menu do |menu|
-          menu.add_item :account,
-                        t("account", scope: "layouts.decidim.user_profile"),
-                        decidim.account_path,
-                        position: 1.0,
-                        active: :exact
-
-          menu.add_item :notifications_settings,
-                        t("notifications_settings", scope: "layouts.decidim.user_profile"),
-                        decidim.notifications_settings_path,
-                        position: 1.1
-
-          if available_verification_workflows.any?
-            menu.add_item :authorizations,
-                          t("authorizations", scope: "layouts.decidim.user_profile"),
-                          decidim_verifications.authorizations_path,
-                          position: 1.2
-          end
-
-          if current_organization.user_groups_enabled? && user_groups.any?
-            menu.add_item :own_user_groups,
-                          t("user_groups", scope: "layouts.decidim.user_profile"),
-                          decidim.own_user_groups_path,
-                          position: 1.3
-          end
-
-          menu.add_item :user_interests,
-                        t("my_interests", scope: "layouts.decidim.user_profile"),
-                        decidim.user_interests_path,
-                        position: 1.4
-
-          menu.add_item :download_your_data,
-                        t("my_data", scope: "layouts.decidim.user_profile"),
-                        decidim.download_your_data_path,
-                        position: 1.5
-
-          menu.add_item :delete_account,
-                        t("delete_my_account", scope: "layouts.decidim.user_profile"),
-                        decidim.delete_account_path,
-                        position: 999,
-                        active: :exact
-        end
+        Decidim::Core::Menu.register_user_menu!
       end
 
       initializer "decidim_core.notifications" do

--- a/decidim-core/lib/decidim/core/menu.rb
+++ b/decidim-core/lib/decidim/core/menu.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    class Menu
+      def self.register_menu!
+        Decidim.menu :menu do |menu|
+          menu.add_item :root,
+                        I18n.t("menu.home", scope: "decidim"),
+                        decidim.root_path,
+                        position: 1,
+                        active: :exclusive
+
+          menu.add_item :pages,
+                        I18n.t("menu.help", scope: "decidim"),
+                        decidim.pages_path,
+                        position: 7,
+                        active: :inclusive
+        end
+      end
+
+      def self.register_user_menu!
+        Decidim.menu :user_menu do |menu|
+          menu.add_item :account,
+                        t("account", scope: "layouts.decidim.user_profile"),
+                        decidim.account_path,
+                        position: 1.0,
+                        active: :exact
+
+          menu.add_item :notifications_settings,
+                        t("notifications_settings", scope: "layouts.decidim.user_profile"),
+                        decidim.notifications_settings_path,
+                        position: 1.1
+
+          if available_verification_workflows.any?
+            menu.add_item :authorizations,
+                          t("authorizations", scope: "layouts.decidim.user_profile"),
+                          decidim_verifications.authorizations_path,
+                          position: 1.2
+          end
+
+          if current_organization.user_groups_enabled? && user_groups.any?
+            menu.add_item :own_user_groups,
+                          t("user_groups", scope: "layouts.decidim.user_profile"),
+                          decidim.own_user_groups_path,
+                          position: 1.3
+          end
+
+          menu.add_item :user_interests,
+                        t("my_interests", scope: "layouts.decidim.user_profile"),
+                        decidim.user_interests_path,
+                        position: 1.4
+
+          menu.add_item :download_your_data,
+                        t("my_data", scope: "layouts.decidim.user_profile"),
+                        decidim.download_your_data_path,
+                        position: 1.5
+
+          menu.add_item :delete_account,
+                        t("delete_my_account", scope: "layouts.decidim.user_profile"),
+                        decidim.delete_account_path,
+                        position: 999,
+                        active: :exact
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/lib/decidim/elections/admin_engine.rb
+++ b/decidim-elections/lib/decidim/elections/admin_engine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/elections/menu"
+
 module Decidim
   module Elections
     # This is the engine that runs on the public interface of `Elections`.
@@ -51,25 +53,7 @@ module Decidim
       end
 
       initializer "decidim_elections_admin.menu_entry" do
-        Decidim.participatory_space_registry.manifests.each do |participatory_space|
-          menu_id = :"admin_#{participatory_space.name.to_s.singularize}_menu"
-          Decidim.menu menu_id do |menu|
-            component = current_participatory_space.try(:components)&.find_by(manifest_name: :elections)
-            next unless component
-
-            link = Decidim::EngineRouter.admin_proxy(component).trustees_path(locale: I18n.locale)
-
-            has_election_components = current_participatory_space.components.select { |c| c.manifest_name == "elections" }.any?
-
-            menu.add_item :trustees,
-                          I18n.t("trustees", scope: "decidim.elections.admin.menu"),
-                          link,
-                          if: has_election_components && (allowed_to?(:manage, :trustees) || current_user.admin?),
-                          icon_name: "safe-line",
-                          position: 100,
-                          active: is_active_link?(link)
-          end
-        end
+        Decidim::Elections::Menu.register_participatory_space_registry_manifests!
       end
 
       def load_seed

--- a/decidim-elections/lib/decidim/elections/menu.rb
+++ b/decidim-elections/lib/decidim/elections/menu.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Elections
+    class Menu
+      def self.register_user_menu!
+        Decidim.menu :user_menu do |menu|
+          menu.add_item :decidim_elections_trustee_zone,
+                        I18n.t("menu.trustee_zone", scope: "decidim.elections.trustee_zone"),
+                        decidim.decidim_elections_trustee_zone_path,
+                        active: :inclusive,
+                        if: Decidim::Elections::Trustee.trustee?(current_user)
+        end
+      end
+
+      def self.register_participatory_space_registry_manifests!
+        Decidim.participatory_space_registry.manifests.each do |participatory_space|
+          menu_id = :"admin_#{participatory_space.name.to_s.singularize}_menu"
+          Decidim.menu menu_id do |menu|
+            component = current_participatory_space.try(:components)&.find_by(manifest_name: :elections)
+            next unless component
+
+            link = Decidim::EngineRouter.admin_proxy(component).trustees_path(locale: I18n.locale)
+
+            has_election_components = current_participatory_space.components.select { |c| c.manifest_name == "elections" }.any?
+
+            menu.add_item :trustees,
+                          I18n.t("trustees", scope: "decidim.elections.admin.menu"),
+                          link,
+                          if: has_election_components && (allowed_to?(:manage, :trustees) || current_user.admin?),
+                          icon_name: "safe-line",
+                          position: 100,
+                          active: is_active_link?(link)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/lib/decidim/elections/trustee_zone_engine.rb
+++ b/decidim-elections/lib/decidim/elections/trustee_zone_engine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/elections/menu"
+
 module Decidim
   module Elections
     # This is the engine that runs on the public interface for trustees of `decidim-elections`.
@@ -23,13 +25,7 @@ module Decidim
       end
 
       initializer "decidim_elections.trustee_zone.menu" do
-        Decidim.menu :user_menu do |menu|
-          menu.add_item :decidim_elections_trustee_zone,
-                        I18n.t("menu.trustee_zone", scope: "decidim.elections.trustee_zone"),
-                        decidim.decidim_elections_trustee_zone_path,
-                        active: :inclusive,
-                        if: Decidim::Elections::Trustee.trustee?(current_user)
-        end
+        Decidim::Elections::Menu.register_user_menu!
       end
     end
   end

--- a/decidim-elections/lib/decidim/votings/admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/admin_engine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/votings/menu"
+
 module Decidim
   module Votings
     # Decidim's Votings Rails Admin Engine.
@@ -70,136 +72,23 @@ module Decidim
       end
 
       initializer "decidim_votings_admin.menu" do
-        Decidim.menu :admin_menu_modules do |menu|
-          menu.add_item :votings,
-                        I18n.t("menu.votings", scope: "decidim.votings.admin"),
-                        decidim_admin_votings.votings_path,
-                        icon_name: "mail-line",
-                        position: 2.6,
-                        active: :inclusive,
-                        if: allowed_to?(:enter, :space_area, space_name: :votings)
-        end
+        Decidim::Votings::Menu.register_admin_menu_modules!
       end
 
       initializer "decidim_votings_admin.votings_components_menu" do
-        Decidim.menu :admin_votings_components_menu do |menu|
-          current_participatory_space.components.each do |component|
-            caption = translated_attribute(component.name)
-            if component.primary_stat.present?
-              caption += content_tag(:span, component.primary_stat, class: component.primary_stat.zero? ? "component-counter component-counter--off" : "component-counter")
-            end
-
-            menu.add_item [component.manifest_name, component.id].join("_"),
-                          caption.html_safe,
-                          manage_component_path(component),
-                          active: is_active_link?(manage_component_path(component)) ||
-                                  is_active_link?(decidim_admin_votings.edit_component_path(current_participatory_space, component)) ||
-                                  is_active_link?(decidim_admin_votings.edit_component_permissions_path(current_participatory_space, component)) ||
-                                  participatory_space_active_link?(component),
-                          if: component.manifest.admin_engine # && user_role_config.component_is_accessible?(component.manifest_name)
-          end
-        end
+        Decidim::Votings::Menu.register_admin_votings_components_menu!
       end
 
       initializer "decidim_votings_admin.attachments_menu" do
-        Decidim.menu :votings_admin_attachments_menu do |menu|
-          menu.add_item :voting_attachments,
-                        I18n.t("attachment_files", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.voting_attachments_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_votings.voting_attachments_path(current_participatory_space)),
-                        if: allowed_to?(:read, :attachment, voting: current_participatory_space),
-                        icon_name: "attachment-line"
-          menu.add_item :voting_attachment_collections,
-                        I18n.t("attachment_collections", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.voting_attachment_collections_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_votings.voting_attachment_collections_path(current_participatory_space)),
-                        if: allowed_to?(:read, :attachment_collection, voting: current_participatory_space),
-                        icon_name: "folder-line"
-        end
+        Decidim::Votings::Menu.register_votings_admin_attachments_menu!
       end
 
       initializer "decidim_votings_admin.monitoring_committee_menu" do
-        Decidim.menu :decidim_votings_monitoring_committee_menu do |menu|
-          menu.add_item :voting_monitoring_committee_members,
-                        I18n.t("monitoring_committee_members", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.voting_monitoring_committee_members_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_votings.voting_monitoring_committee_members_path(current_participatory_space)),
-                        if: allowed_to?(:read, :monitoring_committee_members)
-          menu.add_item :monitoring_committee_polling_station_closures,
-                        I18n.t("monitoring_committee_polling_station_closures", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.voting_monitoring_committee_polling_station_closures_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_votings.voting_monitoring_committee_polling_station_closures_path(current_participatory_space)),
-                        if: allowed_to?(:read, :monitoring_committee_polling_station_closures, voting: current_participatory_space)
-          menu.add_item :monitoring_committee_verify_elections,
-                        I18n.t("monitoring_committee_verify_elections", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.voting_monitoring_committee_verify_elections_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_votings.voting_monitoring_committee_verify_elections_path(current_participatory_space)),
-                        if: allowed_to?(:read, :monitoring_committee_verify_elections, voting: current_participatory_space)
-          menu.add_item :monitoring_committee_election_results,
-                        I18n.t("monitoring_committee_election_results", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.voting_monitoring_committee_election_results_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_votings.voting_monitoring_committee_election_results_path(current_participatory_space)),
-                        if: allowed_to?(:read, :monitoring_committee_election_results, voting: current_participatory_space)
-        end
+        Decidim::Votings::Menu.register_decidim_votings_monitoring_committee_menu!
       end
 
       initializer "decidim_votings_admin.voting_menu" do
-        Decidim.menu :admin_voting_menu do |menu|
-          menu.add_item :edit_voting,
-                        I18n.t("info", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.edit_voting_path(current_participatory_space),
-                        icon_name: "information-line",
-                        if: allowed_to?(:edit, :voting, voting: current_participatory_space)
-
-          menu.add_item :edit_voting_landing_page,
-                        I18n.t("landing_page", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.edit_voting_landing_page_path(current_participatory_space),
-                        icon_name: "layout-masonry-line",
-                        if: allowed_to?(:update, :landing_page)
-
-          menu.add_item :components,
-                        I18n.t("components", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.components_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_votings.components_path(current_participatory_space), ["decidim/votings/admin/components", %w(index new edit)]),
-                        icon_name: "tools-line",
-                        if: allowed_to?(:read, :components, voting: current_participatory_space),
-                        submenu: { target_menu: :admin_votings_components_menu }
-
-          menu.add_item :attachments,
-                        I18n.t("attachments", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.voting_attachments_path(current_participatory_space),
-                        icon_name: "attachment-2",
-                        active: is_active_link?(decidim_admin_votings.voting_attachments_path(current_participatory_space)) ||
-                                is_active_link?(decidim_admin_votings.voting_attachment_collections_path(current_participatory_space)),
-                        if: allowed_to?(:read, :attachment, voting: current_participatory_space) ||
-                            allowed_to?(:read, :attachment_collection, voting: current_participatory_space)
-
-          menu.add_item :voting_polling_stations,
-                        I18n.t("polling_stations", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.voting_polling_stations_path(current_participatory_space),
-                        icon_name: "mail-line",
-                        if: !current_participatory_space.online_voting? && allowed_to?(:read, :polling_stations)
-
-          menu.add_item :voting_polling_officers,
-                        I18n.t("polling_officers", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.voting_polling_officers_path(current_participatory_space),
-                        icon_name: "mail-line",
-                        if: !current_participatory_space.online_voting? && allowed_to?(:read, :polling_officers)
-
-          menu.add_item :voting_monitoring_committee,
-                        I18n.t("monitoring_committee", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        "#",
-                        icon_name: "mail-line",
-                        active: false,
-                        if: !current_participatory_space.online_voting? && allowed_to?(:read, :monitoring_committee_menu, voting: current_participatory_space),
-                        submenu: { target_menu: :decidim_votings_monitoring_committee_menu }
-
-          menu.add_item :voting_ballot_styles,
-                        I18n.t("ballot_styles", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.voting_ballot_styles_path(current_participatory_space),
-                        icon_name: "mail-line",
-                        if: allowed_to?(:read, :ballot_styles)
-        end
+        Decidim::Votings::Menu.register_admin_voting_menu!
       end
     end
   end

--- a/decidim-elections/lib/decidim/votings/census_admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/census_admin_engine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/votings/menu"
+
 module Decidim
   module Votings
     class CensusEngine < ::Rails::Engine
@@ -9,14 +11,7 @@ module Decidim
       paths["lib/tasks"] = nil
 
       initializer "decidim_votings_census.admin_voting_menu" do
-        Decidim.menu :admin_voting_menu do |menu|
-          menu.add_item :voting_census,
-                        I18n.t("census", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.voting_census_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_votings.voting_census_path(current_participatory_space)),
-                        icon_name: "mail-line",
-                        if: allowed_to?(:manage, :census)
-        end
+        Decidim::Votings::Menu.register_admin_voting_menu!
       end
     end
   end

--- a/decidim-elections/lib/decidim/votings/census_admin_engine.rb
+++ b/decidim-elections/lib/decidim/votings/census_admin_engine.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "decidim/votings/menu"
+require "decidim/votings/census_menu"
 
 module Decidim
   module Votings
@@ -11,7 +11,7 @@ module Decidim
       paths["lib/tasks"] = nil
 
       initializer "decidim_votings_census.admin_voting_menu" do
-        Decidim::Votings::Menu.register_admin_voting_menu!
+        Decidim::Votings::CensusMenu.register_admin_voting_menu!
       end
     end
   end

--- a/decidim-elections/lib/decidim/votings/census_menu.rb
+++ b/decidim-elections/lib/decidim/votings/census_menu.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    class CensusMenu
+      def self.register_admin_voting_menu!
+        Decidim.menu :admin_voting_menu do |menu|
+          menu.add_item :voting_census,
+                        I18n.t("census", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.voting_census_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_votings.voting_census_path(current_participatory_space)),
+                        icon_name: "mail-line",
+                        if: allowed_to?(:manage, :census)
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/lib/decidim/votings/engine.rb
+++ b/decidim-elections/lib/decidim/votings/engine.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "decidim/votings/menu"
 require "decidim/votings/query_extensions"
 
 module Decidim
@@ -53,23 +54,8 @@ module Decidim
       end
 
       initializer "decidim_votings.menu" do
-        Decidim.menu :menu do |menu|
-          menu.add_item :votings,
-                        I18n.t("menu.votings", scope: "decidim"),
-                        decidim_votings.votings_path,
-                        position: 2.6,
-                        if: Decidim::Votings::Voting.where(organization: current_organization).published.any?,
-                        active: :inclusive
-        end
-
-        Decidim.menu :home_content_block_menu do |menu|
-          menu.add_item :votings,
-                        I18n.t("menu.votings", scope: "decidim"),
-                        decidim_votings.votings_path,
-                        position: 40,
-                        if: Decidim::Votings::Voting.where(organization: current_organization).published.any?,
-                        active: :inclusive
-        end
+        Decidim::Votings::Menu.register_menu!
+        Decidim::Votings::Menu.register_home_content_block_menu!
       end
 
       initializer "decidim_votings.content_blocks" do

--- a/decidim-elections/lib/decidim/votings/menu.rb
+++ b/decidim-elections/lib/decidim/votings/menu.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    class Menu
+      def self.register_user_menu!
+        Decidim.menu :user_menu do |menu|
+          menu.add_item :decidim_votings_polling_officer_zone,
+                        I18n.t("menu.polling_officer_zone", scope: "decidim.votings.polling_officer_zone"),
+                        decidim.decidim_votings_polling_officer_zone_path,
+                        active: :inclusive,
+                        if: Decidim::Votings::PollingOfficer.polling_officer?(current_user)
+        end
+      end
+
+      def self.register_menu!
+        Decidim.menu :menu do |menu|
+          menu.add_item :votings,
+                        I18n.t("menu.votings", scope: "decidim"),
+                        decidim_votings.votings_path,
+                        position: 2.6,
+                        if: Decidim::Votings::Voting.where(organization: current_organization).published.any?,
+                        active: :inclusive
+        end
+      end
+
+      def self.register_home_content_block_menu!
+        Decidim.menu :home_content_block_menu do |menu|
+          menu.add_item :votings,
+                        I18n.t("menu.votings", scope: "decidim"),
+                        decidim_votings.votings_path,
+                        position: 40,
+                        if: Decidim::Votings::Voting.where(organization: current_organization).published.any?,
+                        active: :inclusive
+        end
+      end
+
+      def self.register_admin_voting_menu!
+        Decidim.menu :admin_voting_menu do |menu|
+          menu.add_item :voting_census,
+                        I18n.t("census", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.voting_census_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_votings.voting_census_path(current_participatory_space)),
+                        icon_name: "mail-line",
+                        if: allowed_to?(:manage, :census)
+        end
+      end
+
+      def self.register_admin_menu_modules!
+        Decidim.menu :admin_menu_modules do |menu|
+          menu.add_item :votings,
+                        I18n.t("menu.votings", scope: "decidim.votings.admin"),
+                        decidim_admin_votings.votings_path,
+                        icon_name: "mail-line",
+                        position: 2.6,
+                        active: :inclusive,
+                        if: allowed_to?(:enter, :space_area, space_name: :votings)
+        end
+      end
+
+      def self.register_admin_votings_components_menu!
+        Decidim.menu :admin_votings_components_menu do |menu|
+          current_participatory_space.components.each do |component|
+            caption = translated_attribute(component.name)
+            if component.primary_stat.present?
+              caption += content_tag(:span, component.primary_stat,
+                                     class: component.primary_stat.zero? ? "component-counter component-counter--off" : "component-counter")
+            end
+
+            menu.add_item [component.manifest_name, component.id].join("_"),
+                          caption.html_safe,
+                          manage_component_path(component),
+                          active: is_active_link?(manage_component_path(component)) ||
+                                  is_active_link?(decidim_admin_votings.edit_component_path(current_participatory_space, component)) ||
+                                  is_active_link?(decidim_admin_votings.edit_component_permissions_path(current_participatory_space, component)) ||
+                                  participatory_space_active_link?(component),
+                          if: component.manifest.admin_engine # && user_role_config.component_is_accessible?(component.manifest_name)
+          end
+        end
+      end
+
+      def self.register_votings_admin_attachments_menu!
+        Decidim.menu :votings_admin_attachments_menu do |menu|
+          menu.add_item :voting_attachments,
+                        I18n.t("attachment_files", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.voting_attachments_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_votings.voting_attachments_path(current_participatory_space)),
+                        if: allowed_to?(:read, :attachment, voting: current_participatory_space),
+                        icon_name: "attachment-line"
+          menu.add_item :voting_attachment_collections,
+                        I18n.t("attachment_collections", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.voting_attachment_collections_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_votings.voting_attachment_collections_path(current_participatory_space)),
+                        if: allowed_to?(:read, :attachment_collection, voting: current_participatory_space),
+                        icon_name: "folder-line"
+        end
+      end
+
+      def self.register_decidim_votings_monitoring_committee_menu!
+        Decidim.menu :decidim_votings_monitoring_committee_menu do |menu|
+          menu.add_item :voting_monitoring_committee_members,
+                        I18n.t("monitoring_committee_members", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.voting_monitoring_committee_members_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_votings.voting_monitoring_committee_members_path(current_participatory_space)),
+                        if: allowed_to?(:read, :monitoring_committee_members)
+          menu.add_item :monitoring_committee_polling_station_closures,
+                        I18n.t("monitoring_committee_polling_station_closures", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.voting_monitoring_committee_polling_station_closures_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_votings.voting_monitoring_committee_polling_station_closures_path(current_participatory_space)),
+                        if: allowed_to?(:read, :monitoring_committee_polling_station_closures, voting: current_participatory_space)
+          menu.add_item :monitoring_committee_verify_elections,
+                        I18n.t("monitoring_committee_verify_elections", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.voting_monitoring_committee_verify_elections_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_votings.voting_monitoring_committee_verify_elections_path(current_participatory_space)),
+                        if: allowed_to?(:read, :monitoring_committee_verify_elections, voting: current_participatory_space)
+          menu.add_item :monitoring_committee_election_results,
+                        I18n.t("monitoring_committee_election_results", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.voting_monitoring_committee_election_results_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_votings.voting_monitoring_committee_election_results_path(current_participatory_space)),
+                        if: allowed_to?(:read, :monitoring_committee_election_results, voting: current_participatory_space)
+        end
+      end
+
+      def self.register_admin_voting_menu!
+        Decidim.menu :admin_voting_menu do |menu|
+          menu.add_item :edit_voting,
+                        I18n.t("info", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.edit_voting_path(current_participatory_space),
+                        icon_name: "information-line",
+                        if: allowed_to?(:edit, :voting, voting: current_participatory_space)
+
+          menu.add_item :edit_voting_landing_page,
+                        I18n.t("landing_page", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.edit_voting_landing_page_path(current_participatory_space),
+                        icon_name: "layout-masonry-line",
+                        if: allowed_to?(:update, :landing_page)
+
+          menu.add_item :components,
+                        I18n.t("components", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.components_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_votings.components_path(current_participatory_space),
+                                                ["decidim/votings/admin/components", %w(index new edit)]),
+                        icon_name: "tools-line",
+                        if: allowed_to?(:read, :components, voting: current_participatory_space),
+                        submenu: { target_menu: :admin_votings_components_menu }
+
+          menu.add_item :attachments,
+                        I18n.t("attachments", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.voting_attachments_path(current_participatory_space),
+                        icon_name: "attachment-2",
+                        active: is_active_link?(decidim_admin_votings.voting_attachments_path(current_participatory_space)) ||
+                                is_active_link?(decidim_admin_votings.voting_attachment_collections_path(current_participatory_space)),
+                        if: allowed_to?(:read, :attachment, voting: current_participatory_space) ||
+                            allowed_to?(:read, :attachment_collection, voting: current_participatory_space)
+
+          menu.add_item :voting_polling_stations,
+                        I18n.t("polling_stations", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.voting_polling_stations_path(current_participatory_space),
+                        icon_name: "mail-line",
+                        if: !current_participatory_space.online_voting? && allowed_to?(:read, :polling_stations)
+
+          menu.add_item :voting_polling_officers,
+                        I18n.t("polling_officers", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.voting_polling_officers_path(current_participatory_space),
+                        icon_name: "mail-line",
+                        if: !current_participatory_space.online_voting? && allowed_to?(:read, :polling_officers)
+
+          menu.add_item :voting_monitoring_committee,
+                        I18n.t("monitoring_committee", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        "#",
+                        icon_name: "mail-line",
+                        active: false,
+                        if: !current_participatory_space.online_voting? && allowed_to?(:read, :monitoring_committee_menu, voting: current_participatory_space),
+                        submenu: { target_menu: :decidim_votings_monitoring_committee_menu }
+
+          menu.add_item :voting_ballot_styles,
+                        I18n.t("ballot_styles", scope: "decidim.votings.admin.menu.votings_submenu"),
+                        decidim_admin_votings.voting_ballot_styles_path(current_participatory_space),
+                        icon_name: "mail-line",
+                        if: allowed_to?(:read, :ballot_styles)
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/lib/decidim/votings/menu.rb
+++ b/decidim-elections/lib/decidim/votings/menu.rb
@@ -35,17 +35,6 @@ module Decidim
         end
       end
 
-      def self.register_admin_voting_menu!
-        Decidim.menu :admin_voting_menu do |menu|
-          menu.add_item :voting_census,
-                        I18n.t("census", scope: "decidim.votings.admin.menu.votings_submenu"),
-                        decidim_admin_votings.voting_census_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_votings.voting_census_path(current_participatory_space)),
-                        icon_name: "mail-line",
-                        if: allowed_to?(:manage, :census)
-        end
-      end
-
       def self.register_admin_menu_modules!
         Decidim.menu :admin_menu_modules do |menu|
           menu.add_item :votings,

--- a/decidim-elections/lib/decidim/votings/menu.rb
+++ b/decidim-elections/lib/decidim/votings/menu.rb
@@ -3,16 +3,6 @@
 module Decidim
   module Votings
     class Menu
-      def self.register_user_menu!
-        Decidim.menu :user_menu do |menu|
-          menu.add_item :decidim_votings_polling_officer_zone,
-                        I18n.t("menu.polling_officer_zone", scope: "decidim.votings.polling_officer_zone"),
-                        decidim.decidim_votings_polling_officer_zone_path,
-                        active: :inclusive,
-                        if: Decidim::Votings::PollingOfficer.polling_officer?(current_user)
-        end
-      end
-
       def self.register_menu!
         Decidim.menu :menu do |menu|
           menu.add_item :votings,

--- a/decidim-elections/lib/decidim/votings/polling_officer_zone_engine.rb
+++ b/decidim-elections/lib/decidim/votings/polling_officer_zone_engine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/votings/menu"
+
 module Decidim
   module Votings
     # This is the engine that runs on the public interface for polling officers of `decidim-elections`.
@@ -29,13 +31,7 @@ module Decidim
       end
 
       initializer "decidim_elections.polling_officer_zone.menu" do
-        Decidim.menu :user_menu do |menu|
-          menu.add_item :decidim_votings_polling_officer_zone,
-                        I18n.t("menu.polling_officer_zone", scope: "decidim.votings.polling_officer_zone"),
-                        decidim.decidim_votings_polling_officer_zone_path,
-                        active: :inclusive,
-                        if: Decidim::Votings::PollingOfficer.polling_officer?(current_user)
-        end
+        Decidim::Votings::Menu.register_user_menu!
       end
     end
   end

--- a/decidim-elections/lib/decidim/votings/polling_officer_zone_engine.rb
+++ b/decidim-elections/lib/decidim/votings/polling_officer_zone_engine.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "decidim/votings/menu"
+require "decidim/votings/polling_officer_zone_menu"
 
 module Decidim
   module Votings
@@ -31,7 +31,7 @@ module Decidim
       end
 
       initializer "decidim_elections.polling_officer_zone.menu" do
-        Decidim::Votings::Menu.register_user_menu!
+        Decidim::Votings::PollingOfficerZoneMenu.register_user_menu!
       end
     end
   end

--- a/decidim-elections/lib/decidim/votings/polling_officer_zone_menu.rb
+++ b/decidim-elections/lib/decidim/votings/polling_officer_zone_menu.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Votings
+    class PollingOfficerZoneMenu
+      def self.register_user_menu!
+        Decidim.menu :user_menu do |menu|
+          menu.add_item :decidim_votings_polling_officer_zone,
+                        I18n.t("menu.polling_officer_zone", scope: "decidim.votings.polling_officer_zone"),
+                        decidim.decidim_votings_polling_officer_zone_path,
+                        active: :inclusive,
+                        if: Decidim::Votings::PollingOfficer.polling_officer?(current_user)
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -3,6 +3,7 @@
 require "rails"
 require "active_support/all"
 require "decidim/core"
+require "decidim/initiatives/menu"
 
 module Decidim
   module Initiatives
@@ -84,122 +85,23 @@ module Decidim
       end
 
       initializer "decidim_initiatives_admin.menu" do
-        Decidim.menu :admin_menu_modules do |menu|
-          menu.add_item :initiatives,
-                        I18n.t("menu.initiatives", scope: "decidim.admin"),
-                        decidim_admin_initiatives.initiatives_path,
-                        icon_name: "lightbulb-flash-line",
-                        position: 2.4,
-                        active: is_active_link?(decidim_admin_initiatives.initiatives_path) ||
-                                is_active_link?(decidim_admin_initiatives.initiatives_types_path) ||
-                                is_active_link?(
-                                  decidim_admin_initiatives.edit_initiatives_setting_path(
-                                    Decidim::InitiativesSettings.find_or_create_by!(organization: current_organization)
-                                  )
-                                ),
-                        if: allowed_to?(:enter, :space_area, space_name: :initiatives)
-        end
+        Decidim::Initiatives::Menu.register_admin_menu_modules!
       end
 
       initializer "decidim_initiatives_admin.components_menu" do
-        Decidim.menu :admin_initiatives_components_menu do |menu|
-          current_participatory_space.components.each do |component|
-            caption = translated_attribute(component.name)
-            if component.primary_stat.present?
-              caption += content_tag(:span, component.primary_stat, class: component.primary_stat.zero? ? "component-counter component-counter--off" : "component-counter")
-            end
-
-            menu.add_item [component.manifest_name, component.id].join("_"),
-                          caption.html_safe,
-                          manage_component_path(component),
-                          active: is_active_link?(manage_component_path(component)) ||
-                                  is_active_link?(decidim_admin_initiatives.edit_component_path(current_participatory_space, component)) ||
-                                  is_active_link?(decidim_admin_initiatives.edit_component_permissions_path(current_participatory_space, component)) ||
-                                  participatory_space_active_link?(component),
-                          if: component.manifest.admin_engine # && user_role_config.component_is_accessible?(component.manifest_name)
-          end
-        end
+        Decidim::Initiatives::Menu.register_admin_initiatives_components_menu!
       end
 
       initializer "decidim_initiatives_admin.initiative_menu" do
-        Decidim.menu :admin_initiative_menu do |menu|
-          menu.add_item :edit_initiative,
-                        I18n.t("menu.information", scope: "decidim.admin"),
-                        decidim_admin_initiatives.edit_initiative_path(current_participatory_space),
-                        icon_name: "information-line",
-                        if: allowed_to?(:edit, :initiative, initiative: current_participatory_space)
-
-          menu.add_item :initiative_committee_requests,
-                        I18n.t("menu.committee_members", scope: "decidim.admin"),
-                        decidim_admin_initiatives.initiative_committee_requests_path(current_participatory_space),
-                        icon_name: "group-line",
-                        if: current_participatory_space.promoting_committee_enabled? && allowed_to?(:manage_membership, :initiative, initiative: current_participatory_space)
-
-          menu.add_item :components,
-                        I18n.t("menu.components", scope: "decidim.admin"),
-                        decidim_admin_initiatives.components_path(current_participatory_space),
-                        icon_name: "tools-line",
-                        active: is_active_link?(decidim_admin_initiatives.components_path(current_participatory_space),
-                                                ["decidim/initiatives/admin/components", %w(index new edit)]),
-                        if: allowed_to?(:read, :component, initiative: current_participatory_space),
-                        submenu: { target_menu: :admin_initiatives_components_menu }
-          menu.add_item :initiative_attachments,
-                        I18n.t("menu.attachments", scope: "decidim.admin"),
-                        decidim_admin_initiatives.initiative_attachments_path(current_participatory_space),
-                        icon_name: "attachment-2",
-                        if: allowed_to?(:read, :attachment, initiative: current_participatory_space)
-
-          menu.add_item :moderations,
-                        I18n.t("menu.moderations", scope: "decidim.admin"),
-                        decidim_admin_initiatives.moderations_path(current_participatory_space),
-                        icon_name: "flag-line",
-                        if: allowed_to?(:read, :moderation)
-        end
+        Decidim::Initiatives::Menu.register_admin_initiative_menu!
       end
 
       initializer "decidim_initiatives_admin.initiative_actions_menu" do
-        Decidim.menu :admin_initiative_actions_menu do |menu|
-          menu.add_item :answer_initiative,
-                        I18n.t("actions.answer", scope: "decidim.initiatives"),
-                        decidim_admin_initiatives.edit_initiative_answer_path(current_participatory_space),
-                        if: allowed_to?(:answer, :initiative, initiative: current_participatory_space)
-
-          menu.add_item :initiative_permissions,
-                        I18n.t("actions.permissions", scope: "decidim.admin"),
-                        decidim_admin_initiatives.edit_initiative_permissions_path(current_participatory_space, resource_name: :initiative),
-                        if: current_participatory_space.allow_resource_permissions? && allowed_to?(:update, :initiative, initiative: current_participatory_space)
-        end
+        Decidim::Initiatives::Menu.register_admin_initiative_actions_menu!
       end
 
       initializer "decidim_initiatives_admin.initiatives_menu" do
-        Decidim.menu :admin_initiatives_menu do |menu|
-          menu.add_item :initiatives,
-                        I18n.t("menu.initiatives", scope: "decidim.admin"),
-                        decidim_admin_initiatives.initiatives_path,
-                        position: 1.0,
-                        active: is_active_link?(decidim_admin_initiatives.initiatives_path),
-                        if: allowed_to?(:index, :initiative)
-
-          menu.add_item :initiatives_types,
-                        I18n.t("menu.initiatives_types", scope: "decidim.admin"),
-                        decidim_admin_initiatives.initiatives_types_path,
-                        active: is_active_link?(decidim_admin_initiatives.initiatives_types_path),
-                        if: allowed_to?(:manage, :initiative_type)
-
-          menu.add_item :initiatives_settings,
-                        I18n.t("menu.initiatives_settings", scope: "decidim.admin"),
-                        decidim_admin_initiatives.edit_initiatives_setting_path(
-                          Decidim::InitiativesSettings.find_or_create_by!(
-                            organization: current_organization
-                          )
-                        ),
-                        active: is_active_link?(
-                          decidim_admin_initiatives.edit_initiatives_setting_path(
-                            Decidim::InitiativesSettings.find_or_create_by!(organization: current_organization)
-                          )
-                        ),
-                        if: allowed_to?(:update, :initiatives_settings)
-        end
+        Decidim::Initiatives::Menu.register_admin_initiatives_menu!
       end
     end
   end

--- a/decidim-initiatives/lib/decidim/initiatives/engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/engine.rb
@@ -5,6 +5,7 @@ require "active_support/all"
 require "decidim/core"
 require "decidim/initiatives/current_locale"
 require "decidim/initiatives/initiative_slug"
+require "decidim/initiatives/menu"
 require "decidim/initiatives/query_extensions"
 
 module Decidim
@@ -103,23 +104,8 @@ module Decidim
       end
 
       initializer "decidim_initiatives.menu" do
-        Decidim.menu :menu do |menu|
-          menu.add_item :initiatives,
-                        I18n.t("menu.initiatives", scope: "decidim"),
-                        decidim_initiatives.initiatives_path,
-                        position: 2.4,
-                        active: %r{^/(initiatives|create_initiative)},
-                        if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).all.empty?
-        end
-
-        Decidim.menu :home_content_block_menu do |menu|
-          menu.add_item :initiatives,
-                        I18n.t("menu.initiatives", scope: "decidim"),
-                        decidim_initiatives.initiatives_path,
-                        position: 30,
-                        active: :inclusive,
-                        if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).all.empty?
-        end
+        Decidim::Initiatives::Menu.register_menu!
+        Decidim::Initiatives::Menu.register_home_content_block_menu!
       end
 
       initializer "decidim_initiatives.badges" do

--- a/decidim-initiatives/lib/decidim/initiatives/menu.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/menu.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    class Menu
+      def self.register_menu!
+        Decidim.menu :menu do |menu|
+          menu.add_item :initiatives,
+                        I18n.t("menu.initiatives", scope: "decidim"),
+                        decidim_initiatives.initiatives_path,
+                        position: 2.4,
+                        active: %r{^/(initiatives|create_initiative)},
+                        if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).all.empty?
+        end
+      end
+
+      def self.register_home_content_block_menu!
+        Decidim.menu :home_content_block_menu do |menu|
+          menu.add_item :initiatives,
+                        I18n.t("menu.initiatives", scope: "decidim"),
+                        decidim_initiatives.initiatives_path,
+                        position: 30,
+                        active: :inclusive,
+                        if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).all.empty?
+        end
+      end
+
+      def self.register_admin_menu_modules!
+        Decidim.menu :admin_menu_modules do |menu|
+          menu.add_item :initiatives,
+                        I18n.t("menu.initiatives", scope: "decidim.admin"),
+                        decidim_admin_initiatives.initiatives_path,
+                        icon_name: "lightbulb-flash-line",
+                        position: 2.4,
+                        active: is_active_link?(decidim_admin_initiatives.initiatives_path) ||
+                                is_active_link?(decidim_admin_initiatives.initiatives_types_path) ||
+                                is_active_link?(
+                                  decidim_admin_initiatives.edit_initiatives_setting_path(
+                                    Decidim::InitiativesSettings.find_or_create_by!(organization: current_organization)
+                                  )
+                                ),
+                        if: allowed_to?(:enter, :space_area, space_name: :initiatives)
+        end
+      end
+
+      def self.register_admin_initiatives_components_menu!
+        Decidim.menu :admin_initiatives_components_menu do |menu|
+          current_participatory_space.components.each do |component|
+            caption = translated_attribute(component.name)
+            if component.primary_stat.present?
+              caption += content_tag(:span, component.primary_stat,
+                                     class: component.primary_stat.zero? ? "component-counter component-counter--off" : "component-counter")
+            end
+
+            menu.add_item [component.manifest_name, component.id].join("_"),
+                          caption.html_safe,
+                          manage_component_path(component),
+                          active: is_active_link?(manage_component_path(component)) ||
+                                  is_active_link?(decidim_admin_initiatives.edit_component_path(current_participatory_space, component)) ||
+                                  is_active_link?(decidim_admin_initiatives.edit_component_permissions_path(current_participatory_space, component)) ||
+                                  participatory_space_active_link?(component),
+                          if: component.manifest.admin_engine # && user_role_config.component_is_accessible?(component.manifest_name)
+          end
+        end
+      end
+
+      def self.register_admin_initiative_menu!
+        Decidim.menu :admin_initiative_menu do |menu|
+          menu.add_item :edit_initiative,
+                        I18n.t("menu.information", scope: "decidim.admin"),
+                        decidim_admin_initiatives.edit_initiative_path(current_participatory_space),
+                        icon_name: "information-line",
+                        if: allowed_to?(:edit, :initiative, initiative: current_participatory_space)
+
+          menu.add_item :initiative_committee_requests,
+                        I18n.t("menu.committee_members", scope: "decidim.admin"),
+                        decidim_admin_initiatives.initiative_committee_requests_path(current_participatory_space),
+                        icon_name: "group-line",
+                        if: current_participatory_space.promoting_committee_enabled? && allowed_to?(:manage_membership, :initiative,
+                                                                                                    initiative: current_participatory_space)
+
+          menu.add_item :components,
+                        I18n.t("menu.components", scope: "decidim.admin"),
+                        decidim_admin_initiatives.components_path(current_participatory_space),
+                        icon_name: "tools-line",
+                        active: is_active_link?(decidim_admin_initiatives.components_path(current_participatory_space),
+                                                ["decidim/initiatives/admin/components", %w(index new edit)]),
+                        if: allowed_to?(:read, :component, initiative: current_participatory_space),
+                        submenu: { target_menu: :admin_initiatives_components_menu }
+          menu.add_item :initiative_attachments,
+                        I18n.t("menu.attachments", scope: "decidim.admin"),
+                        decidim_admin_initiatives.initiative_attachments_path(current_participatory_space),
+                        icon_name: "attachment-2",
+                        if: allowed_to?(:read, :attachment, initiative: current_participatory_space)
+
+          menu.add_item :moderations,
+                        I18n.t("menu.moderations", scope: "decidim.admin"),
+                        decidim_admin_initiatives.moderations_path(current_participatory_space),
+                        icon_name: "flag-line",
+                        if: allowed_to?(:read, :moderation)
+        end
+      end
+
+      def self.register_admin_initiative_actions_menu!
+        Decidim.menu :admin_initiative_actions_menu do |menu|
+          menu.add_item :answer_initiative,
+                        I18n.t("actions.answer", scope: "decidim.initiatives"),
+                        decidim_admin_initiatives.edit_initiative_answer_path(current_participatory_space),
+                        if: allowed_to?(:answer, :initiative, initiative: current_participatory_space)
+
+          menu.add_item :initiative_permissions,
+                        I18n.t("actions.permissions", scope: "decidim.admin"),
+                        decidim_admin_initiatives.edit_initiative_permissions_path(current_participatory_space, resource_name: :initiative),
+                        if: current_participatory_space.allow_resource_permissions? && allowed_to?(:update, :initiative, initiative: current_participatory_space)
+        end
+      end
+
+      def self.register_admin_initiatives_menu!
+        Decidim.menu :admin_initiatives_menu do |menu|
+          menu.add_item :initiatives,
+                        I18n.t("menu.initiatives", scope: "decidim.admin"),
+                        decidim_admin_initiatives.initiatives_path,
+                        position: 1.0,
+                        active: is_active_link?(decidim_admin_initiatives.initiatives_path),
+                        if: allowed_to?(:index, :initiative)
+
+          menu.add_item :initiatives_types,
+                        I18n.t("menu.initiatives_types", scope: "decidim.admin"),
+                        decidim_admin_initiatives.initiatives_types_path,
+                        active: is_active_link?(decidim_admin_initiatives.initiatives_types_path),
+                        if: allowed_to?(:manage, :initiative_type)
+
+          menu.add_item :initiatives_settings,
+                        I18n.t("menu.initiatives_settings", scope: "decidim.admin"),
+                        decidim_admin_initiatives.edit_initiatives_setting_path(
+                          Decidim::InitiativesSettings.find_or_create_by!(
+                            organization: current_organization
+                          )
+                        ),
+                        active: is_active_link?(
+                          decidim_admin_initiatives.edit_initiatives_setting_path(
+                            Decidim::InitiativesSettings.find_or_create_by!(organization: current_organization)
+                          )
+                        ),
+                        if: allowed_to?(:update, :initiatives_settings)
+        end
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/admin_engine.rb
@@ -4,6 +4,7 @@ require "rails"
 require "active_support/all"
 
 require "decidim/core"
+require "decidim/participatory_processes/menu"
 
 module Decidim
   module ParticipatoryProcesses
@@ -99,164 +100,27 @@ module Decidim
       end
 
       initializer "decidim_participatory_processes_admin.menu" do
-        Decidim.menu :admin_menu_modules do |menu|
-          menu.add_item :participatory_processes,
-                        I18n.t("menu.participatory_processes", scope: "decidim.admin"),
-                        decidim_admin_participatory_processes.participatory_processes_path,
-                        icon_name: "treasure-map-line",
-                        position: 2,
-                        active: is_active_link?(decidim_admin_participatory_processes.participatory_processes_path, :inclusive) ||
-                                is_active_link?(decidim_admin_participatory_processes.participatory_process_groups_path, :inclusive) ||
-                                is_active_link?(decidim_admin_participatory_processes.participatory_process_types_path),
-                        if: allowed_to?(:enter, :space_area, space_name: :processes) || allowed_to?(:enter, :space_area, space_name: :process_groups)
-        end
+        Decidim::ParticipatoryProcesses::Menu.register_admin_menu_modules!
       end
 
       initializer "decidim_participatory_processes_admin.participatory_processes_menu" do
-        Decidim.menu :admin_participatory_processes_menu do |menu|
-          menu.add_item :participatory_processes,
-                        I18n.t("menu.participatory_processes", scope: "decidim.admin"),
-                        decidim_admin_participatory_processes.participatory_processes_path,
-                        position: 1,
-                        icon_name: "home-8-line",
-                        if: allowed_to?(:enter, :space_area, space_name: :processes),
-                        active: is_active_link?(decidim_admin_participatory_processes.participatory_processes_path)
-
-          menu.add_item :participatory_process_groups,
-                        I18n.t("menu.participatory_process_groups", scope: "decidim.admin"),
-                        decidim_admin_participatory_processes.participatory_process_groups_path,
-                        position: 2,
-                        icon_name: "home-8-line",
-                        if: allowed_to?(:enter, :space_area, space_name: :process_groups),
-                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_groups_path)
-        end
+        Decidim::ParticipatoryProcesses::Menu.register_admin_participatory_processes_menu!
       end
 
       initializer "decidim_participatory_processes_admin.process_attachments_menu" do
-        Decidim.menu :participatory_process_admin_attachments_menu do |menu|
-          menu.add_item :participatory_process_attachments,
-                        I18n.t("attachment_files", scope: "decidim.admin.menu.participatory_processes_submenu"),
-                        decidim_admin_participatory_processes.participatory_process_attachments_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_attachments_path(current_participatory_space)),
-                        if: allowed_to?(:read, :attachment),
-                        icon_name: "attachment-line"
-
-          menu.add_item :participatory_process_attachment_collections,
-                        I18n.t("attachment_collections", scope: "decidim.admin.menu.participatory_processes_submenu"),
-                        decidim_admin_participatory_processes.participatory_process_attachment_collections_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_attachment_collections_path(current_participatory_space)),
-                        if: allowed_to?(:read, :attachment_collection),
-                        icon_name: "folder-line"
-        end
+        Decidim::ParticipatoryProcesses::Menu.register_participatory_process_admin_attachments_menu!
       end
 
       initializer "decidim_participatory_processes_admin.process_components_menu" do
-        Decidim.menu :admin_participatory_process_components_menu do |menu|
-          current_participatory_space.components.each do |component|
-            caption = translated_attribute(component.name)
-            if component.primary_stat.present?
-              caption += content_tag(:span, component.primary_stat, class: component.primary_stat.zero? ? "component-counter component-counter--off" : "component-counter")
-            end
-
-            menu.add_item [component.manifest_name, component.id].join("_"),
-                          caption.html_safe,
-                          manage_component_path(component),
-                          active: is_active_link?(manage_component_path(component)) ||
-                                  is_active_link?(decidim_admin_participatory_processes.edit_component_path(current_participatory_space, component)) ||
-                                  is_active_link?(decidim_admin_participatory_processes.edit_component_permissions_path(current_participatory_space, component)) ||
-                                  participatory_space_active_link?(component),
-                          if: component.manifest.admin_engine && user_role_config.component_is_accessible?(component.manifest_name)
-          end
-        end
+        Decidim::ParticipatoryProcesses::Menu.register_admin_participatory_process_components_menu!
       end
 
       initializer "decidim_participatory_processes_admin.process_menu" do
-        Decidim.menu :admin_participatory_process_menu do |menu|
-          menu.add_item :edit_participatory_process,
-                        I18n.t("info", scope: "decidim.admin.menu.participatory_processes_submenu"),
-                        decidim_admin_participatory_processes.edit_participatory_process_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_participatory_processes.edit_participatory_process_path(current_participatory_space)),
-                        icon_name: "information-line",
-                        if: allowed_to?(:update, :process, process: current_participatory_space)
-
-          menu.add_item :edit_participatory_process_landing_page,
-                        I18n.t("landing_page", scope: "decidim.admin.menu.participatory_processes_submenu"),
-                        decidim_admin_participatory_processes.edit_participatory_process_landing_page_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_landing_page_path(current_participatory_space)),
-                        icon_name: "layout-masonry-line",
-                        if: allowed_to?(:update, :process, process: current_participatory_space)
-
-          menu.add_item :participatory_process_steps,
-                        I18n.t("steps", scope: "decidim.admin.menu.participatory_processes_submenu"),
-                        decidim_admin_participatory_processes.participatory_process_steps_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_steps_path(current_participatory_space)),
-                        icon_name: "direction-line",
-                        if: allowed_to?(:read, :process_step)
-
-          menu.add_item :components,
-                        I18n.t("components", scope: "decidim.admin.menu.participatory_processes_submenu"),
-                        decidim_admin_participatory_processes.components_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_participatory_processes.components_path(current_participatory_space),
-                                                ["decidim/participatory_processes/admin/components", %w(index new edit)]),
-                        icon_name: "tools-line",
-                        if: allowed_to?(:read, :component),
-                        submenu: { target_menu: :admin_participatory_process_components_menu }
-
-          menu.add_item :categories,
-                        I18n.t("categories", scope: "decidim.admin.menu.participatory_processes_submenu"),
-                        decidim_admin_participatory_processes.categories_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_participatory_processes.categories_path(current_participatory_space)),
-                        icon_name: "price-tag-3-line",
-                        if: allowed_to?(:read, :category)
-
-          menu.add_item :attachments,
-                        I18n.t("attachments", scope: "decidim.admin.menu.participatory_processes_submenu"),
-                        decidim_admin_participatory_processes.participatory_process_attachments_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_attachment_collections_path(current_participatory_space)) ||
-                                is_active_link?(decidim_admin_participatory_processes.participatory_process_attachments_path(current_participatory_space)),
-                        icon_name: "attachment-2",
-                        if: allowed_to?(:read, :attachment_collection) || allowed_to?(:read, :attachment)
-
-          menu.add_item :participatory_process_user_roles,
-                        I18n.t("process_admins", scope: "decidim.admin.menu.participatory_processes_submenu"),
-                        decidim_admin_participatory_processes.participatory_process_user_roles_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_user_roles_path(current_participatory_space)),
-                        icon_name: "user-settings-line",
-                        if: allowed_to?(:read, :process_user_role)
-
-          menu.add_item :participatory_space_private_users,
-                        I18n.t("private_users", scope: "decidim.admin.menu.participatory_processes_submenu"),
-                        decidim_admin_participatory_processes.participatory_space_private_users_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_participatory_processes.participatory_space_private_users_path(current_participatory_space)),
-                        icon_name: "spy-line",
-                        if: allowed_to?(:read, :space_private_user)
-
-          menu.add_item :moderations,
-                        I18n.t("moderations", scope: "decidim.admin.menu.participatory_processes_submenu"),
-                        decidim_admin_participatory_processes.moderations_path(current_participatory_space),
-                        active: is_active_link?(decidim_admin_participatory_processes.moderations_path(current_participatory_space)),
-                        icon_name: "flag-line",
-                        if: allowed_to?(:read, :moderation)
-        end
+        Decidim::ParticipatoryProcesses::Menu.register_admin_participatory_process_menu!
       end
 
       initializer "decidim_participatory_processes_admin.process_group_menu" do
-        Decidim.menu :admin_participatory_process_group_menu do |menu|
-          menu.add_item :edit_participatory_process_group,
-                        I18n.t("info", scope: "decidim.admin.menu.participatory_process_groups_submenu"),
-                        decidim_admin_participatory_processes.edit_participatory_process_group_path(participatory_process_group),
-                        position: 1,
-                        icon_name: "information-line",
-                        if: allowed_to?(:update, :process_group, process_group: participatory_process_group),
-                        active: is_active_link?(decidim_admin_participatory_processes.edit_participatory_process_group_path(participatory_process_group))
-          menu.add_item :edit_participatory_process_group_landing_page,
-                        I18n.t("landing_page", scope: "decidim.admin.menu.participatory_process_groups_submenu"),
-                        decidim_admin_participatory_processes.edit_participatory_process_group_landing_page_path(participatory_process_group),
-                        position: 2,
-                        icon_name: "layout-masonry-line",
-                        if: allowed_to?(:update, :process_group, process_group: participatory_process_group),
-                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_group_landing_page_path(participatory_process_group))
-        end
+        Decidim::ParticipatoryProcesses::Menu.register_admin_participatory_process_group_menu!
       end
     end
   end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -4,6 +4,7 @@ require "rails"
 require "active_support/all"
 
 require "decidim/core"
+require "decidim/participatory_processes/menu"
 require "decidim/participatory_processes/query_extensions"
 
 module Decidim
@@ -54,23 +55,8 @@ module Decidim
       end
 
       initializer "decidim_participatory_processes.menu" do
-        Decidim.menu :menu do |menu|
-          menu.add_item :participatory_processes,
-                        I18n.t("menu.processes", scope: "decidim"),
-                        decidim_participatory_processes.participatory_processes_path,
-                        position: 2,
-                        if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
-                        active: %r{^/process(es|_groups)}
-        end
-
-        Decidim.menu :home_content_block_menu do |menu|
-          menu.add_item :participatory_processes,
-                        I18n.t("menu.processes", scope: "decidim"),
-                        decidim_participatory_processes.participatory_processes_path,
-                        position: 10,
-                        if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
-                        active: %r{^/process(es|_groups)}
-        end
+        Decidim::ParticipatoryProcesses::Menu.register_menu!
+        Decidim::ParticipatoryProcesses::Menu.register_home_content_block_menu!
       end
 
       initializer "decidim_participatory_processes.content_blocks" do

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/menu.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/menu.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    class Menu
+      def self.register_menu!
+        Decidim.menu :menu do |menu|
+          menu.add_item :participatory_processes,
+                        I18n.t("menu.processes", scope: "decidim"),
+                        decidim_participatory_processes.participatory_processes_path,
+                        position: 2,
+                        if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
+                        active: %r{^/process(es|_groups)}
+        end
+      end
+
+      def self.register_home_content_block_menu!
+        Decidim.menu :home_content_block_menu do |menu|
+          menu.add_item :participatory_processes,
+                        I18n.t("menu.processes", scope: "decidim"),
+                        decidim_participatory_processes.participatory_processes_path,
+                        position: 10,
+                        if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
+                        active: %r{^/process(es|_groups)}
+        end
+      end
+
+      def self.register_admin_menu_modules!
+        Decidim.menu :admin_menu_modules do |menu|
+          menu.add_item :participatory_processes,
+                        I18n.t("menu.participatory_processes", scope: "decidim.admin"),
+                        decidim_admin_participatory_processes.participatory_processes_path,
+                        icon_name: "treasure-map-line",
+                        position: 2,
+                        active: is_active_link?(decidim_admin_participatory_processes.participatory_processes_path, :inclusive) ||
+                                is_active_link?(decidim_admin_participatory_processes.participatory_process_groups_path, :inclusive) ||
+                                is_active_link?(decidim_admin_participatory_processes.participatory_process_types_path),
+                        if: allowed_to?(:enter, :space_area, space_name: :processes) || allowed_to?(:enter, :space_area, space_name: :process_groups)
+        end
+      end
+
+      def self.register_admin_participatory_processes_menu!
+        Decidim.menu :admin_participatory_processes_menu do |menu|
+          menu.add_item :participatory_processes,
+                        I18n.t("menu.participatory_processes", scope: "decidim.admin"),
+                        decidim_admin_participatory_processes.participatory_processes_path,
+                        position: 1,
+                        icon_name: "home-8-line",
+                        if: allowed_to?(:enter, :space_area, space_name: :processes),
+                        active: is_active_link?(decidim_admin_participatory_processes.participatory_processes_path)
+
+          menu.add_item :participatory_process_groups,
+                        I18n.t("menu.participatory_process_groups", scope: "decidim.admin"),
+                        decidim_admin_participatory_processes.participatory_process_groups_path,
+                        position: 2,
+                        icon_name: "home-8-line",
+                        if: allowed_to?(:enter, :space_area, space_name: :process_groups),
+                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_groups_path)
+        end
+      end
+
+      def self.register_participatory_process_admin_attachments_menu!
+        Decidim.menu :participatory_process_admin_attachments_menu do |menu|
+          menu.add_item :participatory_process_attachments,
+                        I18n.t("attachment_files", scope: "decidim.admin.menu.participatory_processes_submenu"),
+                        decidim_admin_participatory_processes.participatory_process_attachments_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_attachments_path(current_participatory_space)),
+                        if: allowed_to?(:read, :attachment),
+                        icon_name: "attachment-line"
+
+          menu.add_item :participatory_process_attachment_collections,
+                        I18n.t("attachment_collections", scope: "decidim.admin.menu.participatory_processes_submenu"),
+                        decidim_admin_participatory_processes.participatory_process_attachment_collections_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_attachment_collections_path(current_participatory_space)),
+                        if: allowed_to?(:read, :attachment_collection),
+                        icon_name: "folder-line"
+        end
+      end
+
+      def self.register_admin_participatory_process_components_menu!
+        Decidim.menu :admin_participatory_process_components_menu do |menu|
+          current_participatory_space.components.each do |component|
+            caption = translated_attribute(component.name)
+            if component.primary_stat.present?
+              caption += content_tag(:span, component.primary_stat, class: component.primary_stat.zero? ? "component-counter component-counter--off" : "component-counter")
+            end
+
+            menu.add_item [component.manifest_name, component.id].join("_"),
+                          caption.html_safe,
+                          manage_component_path(component),
+                          active: is_active_link?(manage_component_path(component)) ||
+                                  is_active_link?(decidim_admin_participatory_processes.edit_component_path(current_participatory_space, component)) ||
+                                  is_active_link?(decidim_admin_participatory_processes.edit_component_permissions_path(current_participatory_space, component)) ||
+                                  participatory_space_active_link?(component),
+                          if: component.manifest.admin_engine && user_role_config.component_is_accessible?(component.manifest_name)
+          end
+        end
+      end
+
+      def self.register_admin_participatory_process_menu!
+        Decidim.menu :admin_participatory_process_menu do |menu|
+          menu.add_item :edit_participatory_process,
+                        I18n.t("info", scope: "decidim.admin.menu.participatory_processes_submenu"),
+                        decidim_admin_participatory_processes.edit_participatory_process_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_participatory_processes.edit_participatory_process_path(current_participatory_space)),
+                        icon_name: "information-line",
+                        if: allowed_to?(:update, :process, process: current_participatory_space)
+
+          menu.add_item :edit_participatory_process_landing_page,
+                        I18n.t("landing_page", scope: "decidim.admin.menu.participatory_processes_submenu"),
+                        decidim_admin_participatory_processes.edit_participatory_process_landing_page_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_landing_page_path(current_participatory_space)),
+                        icon_name: "layout-masonry-line",
+                        if: allowed_to?(:update, :process, process: current_participatory_space)
+
+          menu.add_item :participatory_process_steps,
+                        I18n.t("steps", scope: "decidim.admin.menu.participatory_processes_submenu"),
+                        decidim_admin_participatory_processes.participatory_process_steps_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_steps_path(current_participatory_space)),
+                        icon_name: "direction-line",
+                        if: allowed_to?(:read, :process_step)
+
+          menu.add_item :components,
+                        I18n.t("components", scope: "decidim.admin.menu.participatory_processes_submenu"),
+                        decidim_admin_participatory_processes.components_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_participatory_processes.components_path(current_participatory_space),
+                                                ["decidim/participatory_processes/admin/components", %w(index new edit)]),
+                        icon_name: "tools-line",
+                        if: allowed_to?(:read, :component),
+                        submenu: { target_menu: :admin_participatory_process_components_menu }
+
+          menu.add_item :categories,
+                        I18n.t("categories", scope: "decidim.admin.menu.participatory_processes_submenu"),
+                        decidim_admin_participatory_processes.categories_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_participatory_processes.categories_path(current_participatory_space)),
+                        icon_name: "price-tag-3-line",
+                        if: allowed_to?(:read, :category)
+
+          menu.add_item :attachments,
+                        I18n.t("attachments", scope: "decidim.admin.menu.participatory_processes_submenu"),
+                        decidim_admin_participatory_processes.participatory_process_attachments_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_attachment_collections_path(current_participatory_space)) ||
+                                is_active_link?(decidim_admin_participatory_processes.participatory_process_attachments_path(current_participatory_space)),
+                        icon_name: "attachment-2",
+                        if: allowed_to?(:read, :attachment_collection) || allowed_to?(:read, :attachment)
+
+          menu.add_item :participatory_process_user_roles,
+                        I18n.t("process_admins", scope: "decidim.admin.menu.participatory_processes_submenu"),
+                        decidim_admin_participatory_processes.participatory_process_user_roles_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_user_roles_path(current_participatory_space)),
+                        icon_name: "user-settings-line",
+                        if: allowed_to?(:read, :process_user_role)
+
+          menu.add_item :participatory_space_private_users,
+                        I18n.t("private_users", scope: "decidim.admin.menu.participatory_processes_submenu"),
+                        decidim_admin_participatory_processes.participatory_space_private_users_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_participatory_processes.participatory_space_private_users_path(current_participatory_space)),
+                        icon_name: "spy-line",
+                        if: allowed_to?(:read, :space_private_user)
+
+          menu.add_item :moderations,
+                        I18n.t("moderations", scope: "decidim.admin.menu.participatory_processes_submenu"),
+                        decidim_admin_participatory_processes.moderations_path(current_participatory_space),
+                        active: is_active_link?(decidim_admin_participatory_processes.moderations_path(current_participatory_space)),
+                        icon_name: "flag-line",
+                        if: allowed_to?(:read, :moderation)
+        end
+      end
+
+      def self.register_admin_participatory_process_group_menu!
+        Decidim.menu :admin_participatory_process_group_menu do |menu|
+          menu.add_item :edit_participatory_process_group,
+                        I18n.t("info", scope: "decidim.admin.menu.participatory_process_groups_submenu"),
+                        decidim_admin_participatory_processes.edit_participatory_process_group_path(participatory_process_group),
+                        position: 1,
+                        icon_name: "information-line",
+                        if: allowed_to?(:update, :process_group, process_group: participatory_process_group),
+                        active: is_active_link?(decidim_admin_participatory_processes.edit_participatory_process_group_path(participatory_process_group))
+          menu.add_item :edit_participatory_process_group_landing_page,
+                        I18n.t("landing_page", scope: "decidim.admin.menu.participatory_process_groups_submenu"),
+                        decidim_admin_participatory_processes.edit_participatory_process_group_landing_page_path(participatory_process_group),
+                        position: 2,
+                        icon_name: "layout-masonry-line",
+                        if: allowed_to?(:update, :process_group, process_group: participatory_process_group),
+                        active: is_active_link?(decidim_admin_participatory_processes.participatory_process_group_landing_page_path(participatory_process_group))
+        end
+      end
+    end
+  end
+end

--- a/decidim-system/lib/decidim/system/engine.rb
+++ b/decidim-system/lib/decidim/system/engine.rb
@@ -6,6 +6,7 @@ require "active_support/all"
 require "devise"
 require "devise-i18n"
 require "decidim/core"
+require "decidim/system/menu"
 require "foundation_rails_helper"
 
 module Decidim
@@ -21,31 +22,7 @@ module Decidim
       end
 
       initializer "decidim_system.menu" do
-        Decidim.menu :system_menu do |menu|
-          menu.add_item :root,
-                        I18n.t("menu.dashboard", scope: "decidim.system"),
-                        decidim_system.root_path,
-                        position: 1,
-                        active: ["decidim/system/dashboard" => :show]
-
-          menu.add_item :organizations,
-                        I18n.t("menu.organizations", scope: "decidim.system"),
-                        decidim_system.organizations_path,
-                        position: 2,
-                        active: :inclusive
-
-          menu.add_item :admins,
-                        I18n.t("menu.admins", scope: "decidim.system"),
-                        decidim_system.admins_path,
-                        position: 3,
-                        active: :inclusive
-
-          menu.add_item :oauth_applications,
-                        I18n.t("menu.oauth_applications", scope: "decidim.system"),
-                        decidim_system.oauth_applications_path,
-                        position: 4,
-                        active: [%w(decidim/system/oauth_applications), []]
-        end
+        Decidim::System::Menu.register_system_menu!
       end
 
       initializer "decidim_system.webpacker.assets_path" do

--- a/decidim-system/lib/decidim/system/menu.rb
+++ b/decidim-system/lib/decidim/system/menu.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module System
+    class Menu
+      def self.register_system_menu!
+        Decidim.menu :system_menu do |menu|
+          menu.add_item :root,
+                        I18n.t("menu.dashboard", scope: "decidim.system"),
+                        decidim_system.root_path,
+                        position: 1,
+                        active: ["decidim/system/dashboard" => :show]
+
+          menu.add_item :organizations,
+                        I18n.t("menu.organizations", scope: "decidim.system"),
+                        decidim_system.organizations_path,
+                        position: 2,
+                        active: :inclusive
+
+          menu.add_item :admins,
+                        I18n.t("menu.admins", scope: "decidim.system"),
+                        decidim_system.admins_path,
+                        position: 3,
+                        active: :inclusive
+
+          menu.add_item :oauth_applications,
+                        I18n.t("menu.oauth_applications", scope: "decidim.system"),
+                        decidim_system.oauth_applications_path,
+                        position: 4,
+                        active: [%w(decidim/system/oauth_applications), []]
+        end
+      end
+    end
+  end
+end

--- a/decidim-templates/lib/decidim/templates/admin_engine.rb
+++ b/decidim-templates/lib/decidim/templates/admin_engine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/templates/menu"
+
 module Decidim
   module Templates
     # This is the engine that runs on the public interface of `Templates`.
@@ -48,44 +50,11 @@ module Decidim
       end
 
       initializer "decidim_templates_admin.participatory_processes_menu" do
-        Decidim.menu :admin_template_types_menu do |menu|
-          menu.add_item :questionnaires,
-                        I18n.t("template_types.questionnaires", scope: "decidim.templates"),
-                        decidim_admin_templates.questionnaire_templates_path,
-                        icon_name: "clipboard-line",
-                        if: allowed_to?(:index, :templates),
-                        active: (
-                          is_active_link?(decidim_admin_templates.questionnaire_templates_path) ||
-                            is_active_link?(decidim_admin_templates.root_path)
-                        ) && !is_active_link?(decidim_admin_templates.block_user_templates_path) &&
-                                !is_active_link?(decidim_admin_templates.proposal_answer_templates_path)
-
-          menu.add_item :user_reports,
-                        I18n.t("template_types.block_user", scope: "decidim.templates"),
-                        decidim_admin_templates.block_user_templates_path,
-                        icon_name: "user-forbid-line",
-                        if: allowed_to?(:index, :templates),
-                        active: is_active_link?(decidim_admin_templates.block_user_templates_path)
-
-          menu.add_item :proposal_answers,
-                        I18n.t("template_types.proposal_answer_templates", scope: "decidim.templates"),
-                        decidim_admin_templates.proposal_answer_templates_path,
-                        icon_name: "file-copy-line",
-                        if: allowed_to?(:index, :templates),
-                        active: is_active_link?(decidim_admin_templates.proposal_answer_templates_path)
-        end
+        Decidim::Templates::Menu.register_admin_template_types_menu!
       end
 
       initializer "decidim_templates_admin.menu" do
-        Decidim.menu :admin_menu do |menu|
-          menu.add_item :questionnaire_templates,
-                        I18n.t("menu.templates", scope: "decidim.admin", default: "Templates"),
-                        decidim_admin_templates.questionnaire_templates_path,
-                        icon_name: "file-copy-line",
-                        position: 12,
-                        active: is_active_link?(decidim_admin_templates.root_path),
-                        if: allowed_to?(:read, :templates)
-        end
+        Decidim::Templates::Menu.register_admin_menu!
       end
 
       def load_seed

--- a/decidim-templates/lib/decidim/templates/menu.rb
+++ b/decidim-templates/lib/decidim/templates/menu.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Templates
+    class Menu
+      def self.register_admin_template_types_menu!
+        Decidim.menu :admin_template_types_menu do |menu|
+          menu.add_item :questionnaires,
+                        I18n.t("template_types.questionnaires", scope: "decidim.templates"),
+                        decidim_admin_templates.questionnaire_templates_path,
+                        icon_name: "clipboard-line",
+                        if: allowed_to?(:index, :templates),
+                        active: (
+                          is_active_link?(decidim_admin_templates.questionnaire_templates_path) ||
+                            is_active_link?(decidim_admin_templates.root_path)
+                        ) && !is_active_link?(decidim_admin_templates.block_user_templates_path) &&
+                                !is_active_link?(decidim_admin_templates.proposal_answer_templates_path)
+
+          menu.add_item :user_reports,
+                        I18n.t("template_types.block_user", scope: "decidim.templates"),
+                        decidim_admin_templates.block_user_templates_path,
+                        icon_name: "user-forbid-line",
+                        if: allowed_to?(:index, :templates),
+                        active: is_active_link?(decidim_admin_templates.block_user_templates_path)
+
+          menu.add_item :proposal_answers,
+                        I18n.t("template_types.proposal_answer_templates", scope: "decidim.templates"),
+                        decidim_admin_templates.proposal_answer_templates_path,
+                        icon_name: "file-copy-line",
+                        if: allowed_to?(:index, :templates),
+                        active: is_active_link?(decidim_admin_templates.proposal_answer_templates_path)
+        end
+      end
+
+      def self.register_admin_menu!
+        Decidim.menu :admin_menu do |menu|
+          menu.add_item :questionnaire_templates,
+                        I18n.t("menu.templates", scope: "decidim.admin", default: "Templates"),
+                        decidim_admin_templates.questionnaire_templates_path,
+                        icon_name: "file-copy-line",
+                        position: 12,
+                        active: is_active_link?(decidim_admin_templates.root_path),
+                        if: allowed_to?(:read, :templates)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

In the last maintainers meeting we've talked that in most modules some files were too big (like engine.rb, admin_engine.rb, participatory_space.rb and component.rb). 

This PR extracts the menu registry logic in another file to keep them easier to work with.

Related to #12008
 
#### Testing

As it's a refactor, this should work the same as before
All the specs should work the same 

:hearts: Thank you!
