### PR TITLE
Extract methods from assemblies seeds

### DIFF
--- a/decidim-assemblies/lib/decidim/assemblies/seeds.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/seeds.rb
@@ -33,31 +33,7 @@ module Decidim
             )
           end
 
-          child = Decidim::Assembly.create!(
-            title: Decidim::Faker::Localized.sentence(word_count: 5),
-            slug: Decidim::Faker::Internet.unique.slug(words: nil, glue: "-"),
-            subtitle: Decidim::Faker::Localized.sentence(word_count: 2),
-            hashtag: "##{::Faker::Lorem.word}",
-            short_description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.sentence(word_count: 3)
-            end,
-            description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
-            organization:,
-            hero_image: ::Faker::Boolean.boolean(true_ratio: 0.5) ? hero_image : nil, # Keep after organization
-            banner_image: ::Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil, # Keep after organization
-            promoted: true,
-            published_at: 2.weeks.ago,
-            meta_scope: Decidim::Faker::Localized.word,
-            developer_group: Decidim::Faker::Localized.sentence(word_count: 1),
-            local_area: Decidim::Faker::Localized.sentence(word_count: 2),
-            target: Decidim::Faker::Localized.sentence(word_count: 3),
-            participatory_scope: Decidim::Faker::Localized.sentence(word_count: 1),
-            participatory_structure: Decidim::Faker::Localized.sentence(word_count: 2),
-            scope: n.positive? ? Decidim::Scope.reorder(Arel.sql("RANDOM()")).first : nil,
-            parent: assembly
-          )
+          child = create_assembly!(parent: assembly)
 
           [assembly, child].each do |current_assembly|
             current_assembly.add_to_index_as_search_resource
@@ -122,7 +98,7 @@ module Decidim
         )
       end
 
-      def create_assembly!
+      def create_assembly!(parent: nil)
         n = rand(2)
         params = {
           title: Decidim::Faker::Localized.sentence(word_count: 5),
@@ -172,7 +148,8 @@ module Decidim
           facebook_handler: ::Faker::Lorem.word,
           instagram_handler: ::Faker::Lorem.word,
           youtube_handler: ::Faker::Lorem.word,
-          github_handler: ::Faker::Lorem.word
+          github_handler: ::Faker::Lorem.word,
+          parent:
         }
 
         Decidim.traceability.perform_action!(

--- a/decidim-assemblies/lib/decidim/assemblies/seeds.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/seeds.rb
@@ -18,10 +18,7 @@ module Decidim
           [assembly, child].each do |current_assembly|
             current_assembly.add_to_index_as_search_resource
 
-            attachment_collection = create_attachment_collection(collection_for: current_assembly)
-            create_attachment(attached_to: assembly, filename: "Exampledocument.pdf", attachment_collection:)
-            create_attachment(attached_to: assembly, filename: "city.jpeg")
-            create_attachment(attached_to: assembly, filename: "Exampledocument.pdf")
+            create_attachments!(attached_to: current_assembly)
 
             2.times do
               create_category!(participatory_space: current_assembly)

--- a/decidim-assemblies/lib/decidim/assemblies/seeds.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/seeds.rb
@@ -11,27 +11,7 @@ module Decidim
         2.times do |_n|
           assembly = create_assembly!
 
-          # Create users with specific roles
-          Decidim::AssemblyUserRole::ROLES.each do |role|
-            email = "assembly_#{assembly.id}_#{role}@example.org"
-
-            user = Decidim::User.find_or_initialize_by(email:)
-            user.update!(
-              name: ::Faker::Name.name,
-              nickname: ::Faker::Twitter.unique.screen_name,
-              password: "decidim123456789",
-              organization:,
-              confirmed_at: Time.current,
-              locale: I18n.default_locale,
-              tos_agreement: true
-            )
-
-            Decidim::AssemblyUserRole.find_or_create_by!(
-              user:,
-              assembly:,
-              role:
-            )
-          end
+          create_assembly_user_roles!(assembly:)
 
           child = create_assembly!(parent: assembly)
 
@@ -153,6 +133,30 @@ module Decidim
           visibility: "all"
         ) do
           Decidim::Assembly.create!(params)
+        end
+      end
+
+      def create_assembly_user_roles!(assembly:)
+        # Create users with specific roles
+        Decidim::AssemblyUserRole::ROLES.each do |role|
+          email = "assembly_#{assembly.id}_#{role}@example.org"
+
+          user = Decidim::User.find_or_initialize_by(email:)
+          user.update!(
+            name: ::Faker::Name.name,
+            nickname: ::Faker::Twitter.unique.screen_name,
+            password: "decidim123456789",
+            organization:,
+            confirmed_at: Time.current,
+            locale: I18n.default_locale,
+            tos_agreement: true
+          )
+
+          Decidim::AssemblyUserRole.find_or_create_by!(
+            user:,
+            assembly:,
+            role:
+          )
         end
       end
     end

--- a/decidim-assemblies/lib/decidim/assemblies/seeds.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/seeds.rb
@@ -27,29 +27,7 @@ module Decidim
               create_category!(participatory_space: current_assembly)
             end
 
-            Decidim::AssemblyMember::POSITIONS.each do |position|
-              Decidim::AssemblyMember.create!(
-                full_name: ::Faker::Name.name,
-                gender: ::Faker::Lorem.word,
-                birthday: ::Faker::Date.birthday(min_age: 18, max_age: 65),
-                birthplace: ::Faker::Demographic.demonym,
-                designation_date: ::Faker::Date.between(from: 1.year.ago, to: 1.month.ago),
-                position:,
-                position_other: position == "other" ? ::Faker::Job.position : nil,
-                assembly: current_assembly
-              )
-            end
-
-            Decidim::AssemblyMember.create!(
-              user: current_assembly.organization.users.first,
-              gender: ::Faker::Lorem.word,
-              birthday: ::Faker::Date.birthday(min_age: 18, max_age: 65),
-              birthplace: ::Faker::Demographic.demonym,
-              designation_date: ::Faker::Date.between(from: 1.year.ago, to: 1.month.ago),
-              position: "other",
-              position_other: ::Faker::Job.position,
-              assembly: current_assembly
-            )
+            create_assembly_members!(assembly: current_assembly)
 
             Decidim.component_manifests.each do |manifest|
               manifest.seed!(current_assembly.reload)
@@ -158,6 +136,32 @@ module Decidim
             role:
           )
         end
+      end
+
+      def create_assembly_members!(assembly:)
+        Decidim::AssemblyMember::POSITIONS.each do |position|
+          Decidim::AssemblyMember.create!(
+            full_name: ::Faker::Name.name,
+            gender: ::Faker::Lorem.word,
+            birthday: ::Faker::Date.birthday(min_age: 18, max_age: 65),
+            birthplace: ::Faker::Demographic.demonym,
+            designation_date: ::Faker::Date.between(from: 1.year.ago, to: 1.month.ago),
+            position:,
+            position_other: position == "other" ? ::Faker::Job.position : nil,
+            assembly:
+          )
+        end
+
+        Decidim::AssemblyMember.create!(
+          user: assembly.organization.users.first,
+          gender: ::Faker::Lorem.word,
+          birthday: ::Faker::Date.birthday(min_age: 18, max_age: 65),
+          birthplace: ::Faker::Demographic.demonym,
+          designation_date: ::Faker::Date.between(from: 1.year.ago, to: 1.month.ago),
+          position: "other",
+          position_other: ::Faker::Job.position,
+          assembly:
+        )
       end
     end
   end

--- a/decidim-assemblies/lib/decidim/assemblies/seeds.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/seeds.rb
@@ -7,8 +7,6 @@ module Decidim
     class Seeds < Decidim::Seeds
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def call
-        organization = Decidim::Organization.first
-
         Decidim::ContentBlock.create(
           organization:,
           weight: 32,
@@ -177,6 +175,8 @@ module Decidim
         end
       end
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+      def organization = Decidim::Organization.first
     end
   end
 end

--- a/decidim-assemblies/lib/decidim/assemblies/seeds.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/seeds.rb
@@ -5,70 +5,11 @@ require "decidim/seeds"
 module Decidim
   module Assemblies
     class Seeds < Decidim::Seeds
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def call
         create_content_block!
 
         2.times do |n|
-          params = {
-            title: Decidim::Faker::Localized.sentence(word_count: 5),
-            slug: Decidim::Faker::Internet.unique.slug(words: nil, glue: "-"),
-            subtitle: Decidim::Faker::Localized.sentence(word_count: 2),
-            hashtag: "##{::Faker::Lorem.word}",
-            short_description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.sentence(word_count: 3)
-            end,
-            description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
-            organization:,
-            hero_image: ::Faker::Boolean.boolean(true_ratio: 0.5) ? hero_image : nil, # Keep after organization
-            banner_image: ::Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil, # Keep after organization
-            promoted: true,
-            published_at: 2.weeks.ago,
-            meta_scope: Decidim::Faker::Localized.word,
-            developer_group: Decidim::Faker::Localized.sentence(word_count: 1),
-            local_area: Decidim::Faker::Localized.sentence(word_count: 2),
-            target: Decidim::Faker::Localized.sentence(word_count: 3),
-            participatory_scope: Decidim::Faker::Localized.sentence(word_count: 1),
-            participatory_structure: Decidim::Faker::Localized.sentence(word_count: 2),
-            scope: n.positive? ? Decidim::Scope.reorder(Arel.sql("RANDOM()")).first : nil,
-            purpose_of_action: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
-            composition: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
-            assembly_type: Decidim::AssembliesType.create!(organization:, title: Decidim::Faker::Localized.word),
-            creation_date: 1.day.from_now,
-            created_by: "others",
-            created_by_other: Decidim::Faker::Localized.word,
-            duration: 2.days.from_now,
-            included_at: 5.days.from_now,
-            closing_date: 5.days.from_now,
-            closing_date_reason: Decidim::Faker::Localized.sentence(word_count: 3),
-            internal_organisation: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
-            is_transparent: true,
-            special_features: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
-            twitter_handler: ::Faker::Lorem.word,
-            facebook_handler: ::Faker::Lorem.word,
-            instagram_handler: ::Faker::Lorem.word,
-            youtube_handler: ::Faker::Lorem.word,
-            github_handler: ::Faker::Lorem.word
-          }
-
-          assembly = Decidim.traceability.perform_action!(
-            "publish",
-            Decidim::Assembly,
-            organization.users.first,
-            visibility: "all"
-          ) do
-            Decidim::Assembly.create!(params)
-          end
+          assembly = create_assembly!
 
           # Create users with specific roles
           Decidim::AssemblyUserRole::ROLES.each do |role|
@@ -168,7 +109,6 @@ module Decidim
           end
         end
       end
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       def organization = Decidim::Organization.first
 
@@ -180,6 +120,69 @@ module Decidim
           manifest_name: :highlighted_assemblies,
           published_at: Time.current
         )
+      end
+
+      def create_assembly!
+        n = rand(2)
+        params = {
+          title: Decidim::Faker::Localized.sentence(word_count: 5),
+          slug: Decidim::Faker::Internet.unique.slug(words: nil, glue: "-"),
+          subtitle: Decidim::Faker::Localized.sentence(word_count: 2),
+          hashtag: "##{::Faker::Lorem.word}",
+          short_description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.sentence(word_count: 3)
+          end,
+          description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.paragraph(sentence_count: 3)
+          end,
+          organization:,
+          hero_image: ::Faker::Boolean.boolean(true_ratio: 0.5) ? hero_image : nil, # Keep after organization
+          banner_image: ::Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil, # Keep after organization
+          promoted: true,
+          published_at: 2.weeks.ago,
+          meta_scope: Decidim::Faker::Localized.word,
+          developer_group: Decidim::Faker::Localized.sentence(word_count: 1),
+          local_area: Decidim::Faker::Localized.sentence(word_count: 2),
+          target: Decidim::Faker::Localized.sentence(word_count: 3),
+          participatory_scope: Decidim::Faker::Localized.sentence(word_count: 1),
+          participatory_structure: Decidim::Faker::Localized.sentence(word_count: 2),
+          scope: n.positive? ? Decidim::Scope.reorder(Arel.sql("RANDOM()")).first : nil,
+          purpose_of_action: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.paragraph(sentence_count: 3)
+          end,
+          composition: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.paragraph(sentence_count: 3)
+          end,
+          assembly_type: Decidim::AssembliesType.create!(organization:, title: Decidim::Faker::Localized.word),
+          creation_date: 1.day.from_now,
+          created_by: "others",
+          created_by_other: Decidim::Faker::Localized.word,
+          duration: 2.days.from_now,
+          included_at: 5.days.from_now,
+          closing_date: 5.days.from_now,
+          closing_date_reason: Decidim::Faker::Localized.sentence(word_count: 3),
+          internal_organisation: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.paragraph(sentence_count: 3)
+          end,
+          is_transparent: true,
+          special_features: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.paragraph(sentence_count: 3)
+          end,
+          twitter_handler: ::Faker::Lorem.word,
+          facebook_handler: ::Faker::Lorem.word,
+          instagram_handler: ::Faker::Lorem.word,
+          youtube_handler: ::Faker::Lorem.word,
+          github_handler: ::Faker::Lorem.word
+        }
+
+        Decidim.traceability.perform_action!(
+          "publish",
+          Decidim::Assembly,
+          organization.users.first,
+          visibility: "all"
+        ) do
+          Decidim::Assembly.create!(params)
+        end
       end
     end
   end

--- a/decidim-assemblies/lib/decidim/assemblies/seeds.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/seeds.rb
@@ -8,7 +8,7 @@ module Decidim
       def call
         create_content_block!
 
-        2.times do |n|
+        2.times do |_n|
           assembly = create_assembly!
 
           # Create users with specific roles
@@ -44,13 +44,7 @@ module Decidim
             create_attachment(attached_to: assembly, filename: "Exampledocument.pdf")
 
             2.times do
-              Decidim::Category.create!(
-                name: Decidim::Faker::Localized.sentence(word_count: 5),
-                description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-                  Decidim::Faker::Localized.paragraph(sentence_count: 3)
-                end,
-                participatory_space: current_assembly
-              )
+              create_category!(participatory_space: current_assembly)
             end
 
             Decidim::AssemblyMember::POSITIONS.each do |position|

--- a/decidim-assemblies/lib/decidim/assemblies/seeds.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/seeds.rb
@@ -7,13 +7,7 @@ module Decidim
     class Seeds < Decidim::Seeds
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def call
-        Decidim::ContentBlock.create(
-          organization:,
-          weight: 32,
-          scope_name: :homepage,
-          manifest_name: :highlighted_assemblies,
-          published_at: Time.current
-        )
+        create_content_block!
 
         2.times do |n|
           params = {
@@ -177,6 +171,16 @@ module Decidim
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       def organization = Decidim::Organization.first
+
+      def create_content_block!
+        Decidim::ContentBlock.create(
+          organization:,
+          weight: 32,
+          scope_name: :homepage,
+          manifest_name: :highlighted_assemblies,
+          published_at: Time.current
+        )
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -46,5 +46,15 @@ module Decidim
         metadata: nil
       )
     end
+
+    def create_category!(participatory_space:)
+      Decidim::Category.create!(
+        name: Decidim::Faker::Localized.sentence(word_count: 5),
+        description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+          Decidim::Faker::Localized.paragraph(sentence_count: 3)
+        end,
+        participatory_space:
+      )
+    end
   end
 end

--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -13,6 +13,13 @@ module Decidim
 
     def banner_image = create_blob!(seeds_file: "city2.jpeg", filename: "banner_image.jpeg", content_type: "image/jpeg")
 
+    def create_attachments!(attached_to:)
+      attachment_collection = create_attachment_collection(collection_for: attached_to)
+      create_attachment(attached_to:, filename: "Exampledocument.pdf", attachment_collection:)
+      create_attachment(attached_to:, filename: "city.jpeg")
+      create_attachment(attached_to:, filename: "Exampledocument.pdf")
+    end
+
     def create_attachment(attached_to:, filename:, attachment_collection: nil)
       content_type = {
         jpg: "image/jpeg",

--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "faker"
+require "decidim/faker/internet"
+require "decidim/faker/localized"
 
 module Decidim
   # Base class to be inherited from the different modules' seeds classes


### PR DESCRIPTION
#### :tophat: What? Why?

Refactors the assemblies seeds to individual methods.

This is following the same methodology and reasoning from #12005, so refer to that issue for the explanations.  
 
#### Testing

Regenerating the `development_app` database should have different kind of proposals (almost the same as before):

```console
$ bin/rails db:drop db:create db:migrate db:seed
``` 

For making magic: 

```console
bin/rails runner "200.times { Decidim::Assemblies::Seeds.new.create_assembly! }"
```

:hearts: Thank you!
