### PR TITLE
Fix flash of dropdowns in buttons from the title bar and "Manage" button

### DIFF
--- a/decidim-admin/app/views/layouts/decidim/admin/_title_bar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_title_bar.html.erb
@@ -15,7 +15,7 @@
               <%= icon "arrow-down-s-line" %>
           <% end %>
 
-          <div id="admin-dropdown-menu-language">
+          <div id="admin-dropdown-menu-language" aria-hidden="true">
             <ul class="dropdown dropdown__bottom">
               <% (available_locales - [I18n.locale.to_s]).each do |locale| %>
                 <li class="dropdown__item">
@@ -32,7 +32,8 @@
           <%= current_user.email %>
           <%= icon "arrow-down-s-line" %>
         <% end %>
-        <div id="admin-dropdown-menu-login">
+
+        <div id="admin-dropdown-menu-login" aria-hidden="true">
           <ul class="dropdown dropdown__bottom">
             <li class="dropdown__item">
               <%= link_to(t("layouts.decidim.user_menu.log_out"), decidim.destroy_user_session_path, method: :delete, tabindex: "-1") %>

--- a/decidim-assemblies/app/views/layouts/decidim/admin/_manage_assemblies.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/admin/_manage_assemblies.html.erb
@@ -5,7 +5,7 @@
     </span>
     <%= icon "arrow-down-s-line" %>
   <% end %>
-  <div id="assemblies-dropdown-menu-settings">
+  <div id="assemblies-dropdown-menu-settings" aria-hidden="true">
     <ul class="dropdown dropdown__bottom">
       <% if allowed_to? :import, :assembly %>
         <li class="dropdown__item">

--- a/decidim-assemblies/app/views/layouts/decidim/admin/_manage_assemblies.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/admin/_manage_assemblies.html.erb
@@ -1,5 +1,5 @@
 <div class="inline-block relative">
-  <%= button_tag id: "assemblies-menu-trigger", data: { component: "dropdown", target: "assemblies-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
+  <%= button_tag data: { component: "dropdown", target: "assemblies-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
     <span>
       <%= t("menu.manage", scope: "decidim.admin") %>
     </span>

--- a/decidim-initiatives/app/views/layouts/decidim/admin/initiatives.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/admin/initiatives.html.erb
@@ -1,10 +1,10 @@
 <% content_for :breadcrumb_context_menu do %>
   <div class="inline-block relative">
-    <%= button_tag data: { component: "dropdown", target: "assemblies-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
+    <%= button_tag data: { component: "dropdown", target: "initiatives-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
       <%= t("actions.manage", scope: "decidim.admin") %>
       <%= icon "arrow-down-s-line" %>
     <% end %>
-    <div id="assemblies-dropdown-menu-settings" aria-hidden="true">
+    <div id="initiatives-dropdown-menu-settings" aria-hidden="true">
       <ul class="dropdown dropdown__bottom">
         <li class="dropdown__item">
           <% if allowed_to?(:index, :initiative) %>

--- a/decidim-initiatives/app/views/layouts/decidim/admin/initiatives.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/admin/initiatives.html.erb
@@ -4,7 +4,7 @@
       <%= t("actions.manage", scope: "decidim.admin") %>
       <%= icon "arrow-down-s-line" %>
     <% end %>
-    <div id="assemblies-dropdown-menu-settings">
+    <div id="assemblies-dropdown-menu-settings" aria-hidden="true">
       <ul class="dropdown dropdown__bottom">
         <li class="dropdown__item">
           <% if allowed_to?(:index, :initiative) %>

--- a/decidim-initiatives/app/views/layouts/decidim/admin/initiatives.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/admin/initiatives.html.erb
@@ -1,6 +1,6 @@
 <% content_for :breadcrumb_context_menu do %>
   <div class="inline-block relative">
-    <%= button_tag id: "assemblies-menu-trigger", data: { component: "dropdown", target: "assemblies-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
+    <%= button_tag data: { component: "dropdown", target: "assemblies-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
       <%= t("actions.manage", scope: "decidim.admin") %>
       <%= icon "arrow-down-s-line" %>
     <% end %>

--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb
@@ -5,7 +5,7 @@
     </span>
     <%= icon "arrow-down-s-line" %>
   <% end %>
-  <div id="processes-dropdown-menu-settings">
+  <div id="processes-dropdown-menu-settings" aria-hidden="true">
     <ul class="dropdown dropdown__bottom">
       <% if allowed_to? :read, :process_list %>
         <li class="dropdown__item">

--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb
@@ -1,5 +1,5 @@
 <div class="inline-block relative">
-  <%= button_tag id: "processes-menu-trigger", data: { component: "dropdown", target: "processes-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
+  <%= button_tag data: { component: "dropdown", target: "processes-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
     <span>
       <%= t("menu.manage", scope: "decidim.admin") %>
     </span>


### PR DESCRIPTION
#### :tophat: What? Why?

Fix the flash of unstyled content in some of the admin dropdowns: 

- the title bar buttons (mind that it was only broken in desktop viewports)
- the manage button

#### :pushpin: Related Issues
 
- Related to #11783
 
#### Testing

1. Load the page and see that the lists inside these dropdowns are shown and then hidden

### :camera: Screenshots

![Screenshot with the selection of the buttons that were fixed](https://github.com/decidim/decidim/assets/717367/c269a99a-2140-4ef1-becc-8f01cbb1488f)


:hearts: Thank you!
