### PR TITLE
Show message when there are no contents in accountability 

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/results/home.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/home.html.erb
@@ -1,3 +1,4 @@
+<% add_decidim_page_title component_name %>
 <%= append_javascript_pack_tag "decidim_accountability" %>
 <%= append_stylesheet_pack_tag "decidim_accountability" %>
 

--- a/decidim-accountability/app/views/decidim/accountability/results/home.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/home.html.erb
@@ -24,6 +24,12 @@
   </section>
 
   <section class="layout-main__section">
+    <% if first_class_categories.empty? %>
+      <%= cell("decidim/announcement",
+               params[:filter].present? ?
+               t("empty_filters", scope: "decidim.accountability.results.home") :
+               t("empty", scope: "decidim.accountability.results.home")) %>
+    <% end %>
     <%= render partial: "home_categories" %>
   </section>
 

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -224,6 +224,8 @@ en:
           all: All
         home:
           categories_label: Categories
+          empty: There are no results yet.
+          empty_filters: There are no results with this criteria.
           subcategories_label: Subcategories
         home_header:
           global_status: Global execution status

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -6,6 +6,44 @@ describe "Explore results", :versioning do
   include_context "with a component"
 
   let(:manifest_name) { "accountability" }
+  let(:path) { decidim_participatory_process_accountability.root_path(participatory_process_slug: participatory_process.slug, component_id: component.id) }
+
+  context "when there are no results" do
+    before do
+      visit path
+    end
+
+    context "without any category" do
+      let(:category) { nil }
+
+      it "shows an empty page with a message" do
+        expect(page).to have_content "There are no results yet"
+      end
+
+      context "when filtering by scope" do
+        it "shows an empty page with a message" do
+          within "div.filter-container" do
+            click_link translated(scope.name)
+          end
+
+          within "main" do
+            expect(page).to have_content("There are no results with this criteria")
+          end
+        end
+      end
+    end
+
+    context "with a category" do
+      let!(:category) { create(:category, participatory_space:) }
+
+      it "shows an empty page with a message" do
+        within "main" do
+          expect(page).to have_i18n_content(category.name)
+          expect(page).to have_content "There are no projects"
+        end
+      end
+    end
+  end
 
   context "when there are results" do
     let(:results_count) { 5 }
@@ -30,8 +68,6 @@ describe "Explore results", :versioning do
 
       let(:subcategory) { create(:subcategory, parent: category) }
       let(:other_subcategory) { create(:subcategory, parent: other_category) }
-
-      let(:path) { decidim_participatory_process_accountability.root_path(participatory_process_slug: participatory_process.slug, component_id: component.id) }
 
       before do
         # Add scopes and categories for the results to test they work correctly

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -2,404 +2,407 @@
 
 require "spec_helper"
 
-describe "Explore results", versioning: true do
+describe "Explore results", :versioning do
   include_context "with a component"
 
   let(:manifest_name) { "accountability" }
-  let(:results_count) { 5 }
-  let!(:scope) { create(:scope, organization:) }
-  let!(:results) do
-    create_list(
-      :result,
-      results_count,
-      component:
-    )
-  end
 
-  before do
-    component.update(settings: { scopes_enabled: true })
-
-    visit path
-  end
-
-  describe "home" do
-    let!(:other_category) { create(:category, participatory_space:) }
-    let!(:other_scope) { create(:scope, organization:) }
-
-    let(:subcategory) { create(:subcategory, parent: category) }
-    let(:other_subcategory) { create(:subcategory, parent: other_category) }
-
-    let(:path) { decidim_participatory_process_accountability.root_path(participatory_process_slug: participatory_process.slug, component_id: component.id) }
+  context "when there are results" do
+    let(:results_count) { 5 }
+    let!(:scope) { create(:scope, organization:) }
+    let!(:results) do
+      create_list(
+        :result,
+        results_count,
+        component:
+      )
+    end
 
     before do
-      # Add scopes and categories for the results to test they work correctly
-      results[0..2].each { |r| r.update!(category: subcategory, scope:) }
-      results[3..-1].each { |r| r.update!(category: other_subcategory, scope: other_scope) }
+      component.update(settings: { scopes_enabled: true })
 
-      # Revisit the path to load updated results
       visit path
     end
 
-    it "shows the component name in the sidebar" do
-      within("aside") do
-        expect(page).to have_content(translated(component.name))
-      end
-    end
+    describe "home" do
+      let!(:other_category) { create(:category, participatory_space:) }
+      let!(:other_scope) { create(:scope, organization:) }
 
-    it "shows categories and subcategories with results" do
-      participatory_process.categories.each do |category|
-        category_count = Decidim::Accountability::ResultsCalculator.new(component, nil, category.id).count
-        expect(page).to have_content(translated(category.name)) if category_count.positive?
-      end
-    end
+      let(:subcategory) { create(:subcategory, parent: category) }
+      let(:other_subcategory) { create(:subcategory, parent: other_category) }
 
-    it "shows progress" do
-      expect(page).to have_content("Global execution status")
-      within("aside") do
-        expect(page).to have_selector(".accountability__status-value")
-      end
-    end
+      let(:path) { decidim_participatory_process_accountability.root_path(participatory_process_slug: participatory_process.slug, component_id: component.id) }
 
-    context "with progress disabled" do
       before do
-        component.update!(settings: { display_progress_enabled: false })
-      end
+        # Add scopes and categories for the results to test they work correctly
+        results[0..2].each { |r| r.update!(category: subcategory, scope:) }
+        results[3..-1].each { |r| r.update!(category: other_subcategory, scope: other_scope) }
 
-      it "does not show progress" do
+        # Revisit the path to load updated results
         visit path
+      end
 
-        expect(page).not_to have_content("Global execution status")
+      it "shows the component name in the sidebar" do
         within("aside") do
-          expect(page).not_to have_selector(".accountability__status-value")
-        end
-      end
-    end
-
-    context "with a scope" do
-      before do
-        within "div.filter-container" do
-          click_link translated(scope.name)
+          expect(page).to have_content(translated(component.name))
         end
       end
 
-      it "shows current scope active" do
-        within "div.filter-container a.is-active" do
-          expect(page).to have_content(translated(scope.name))
-        end
-      end
-
-      it "shows only the categories with results matching the current scope" do
+      it "shows categories and subcategories with results" do
         participatory_process.categories.each do |category|
-          category_count = Decidim::Accountability::ResultsCalculator.new(component, scope.id, category.id).count
-          if category_count.positive?
-            expect(page).to have_content(translated(category.name))
-          else
-            expect(page).to have_content("There are no projects")
+          category_count = Decidim::Accountability::ResultsCalculator.new(component, nil, category.id).count
+          expect(page).to have_content(translated(category.name)) if category_count.positive?
+        end
+      end
+
+      it "shows progress" do
+        expect(page).to have_content("Global execution status")
+        within("aside") do
+          expect(page).to have_css(".accountability__status-value")
+        end
+      end
+
+      context "with progress disabled" do
+        before do
+          component.update!(settings: { display_progress_enabled: false })
+        end
+
+        it "does not show progress" do
+          visit path
+
+          expect(page).not_to have_content("Global execution status")
+          within("aside") do
+            expect(page).not_to have_css(".accountability__status-value")
+          end
+        end
+      end
+
+      context "with a scope" do
+        before do
+          within "div.filter-container" do
+            click_link translated(scope.name)
+          end
+        end
+
+        it "shows current scope active" do
+          within "div.filter-container a.is-active" do
+            expect(page).to have_content(translated(scope.name))
+          end
+        end
+
+        it "shows only the categories with results matching the current scope" do
+          participatory_process.categories.each do |category|
+            category_count = Decidim::Accountability::ResultsCalculator.new(component, scope.id, category.id).count
+            if category_count.positive?
+              expect(page).to have_content(translated(category.name))
+            else
+              expect(page).to have_content("There are no projects")
+            end
+          end
+        end
+      end
+
+      context "when searching" do
+        let!(:matching_result1) do
+          create(
+            :result,
+            title: Decidim::Faker::Localized.literal("A doggo in the title"),
+            component:
+          )
+        end
+        let!(:matching_result2) do
+          create(
+            :result,
+            title: Decidim::Faker::Localized.literal("Other matching result"),
+            description: Decidim::Faker::Localized.literal("There is a doggo in the office"),
+            component:
+          )
+        end
+
+        it "displays the correct search results" do
+          fill_in :filter_search_text_cont, with: "doggo"
+          within "form .filter-search" do
+            find("*[type=submit]").click
+          end
+
+          within("#results") do
+            expect(page).to have_content(translated(matching_result1.title))
+            expect(page).to have_content(translated(matching_result2.title))
+
+            results.each do |result|
+              expect(page).not_to have_content(translated(result.title))
+            end
           end
         end
       end
     end
 
-    context "when searching" do
-      let!(:matching_result1) do
-        create(
-          :result,
-          title: Decidim::Faker::Localized.literal("A doggo in the title"),
-          component:
-        )
-      end
-      let!(:matching_result2) do
-        create(
-          :result,
-          title: Decidim::Faker::Localized.literal("Other matching result"),
-          description: Decidim::Faker::Localized.literal("There is a doggo in the office"),
-          component:
-        )
-      end
+    describe "index" do
+      let(:path) { decidim_participatory_process_accountability.results_path(participatory_process_slug: participatory_process.slug, component_id: component.id) }
 
-      it "displays the correct search results" do
-        fill_in :filter_search_text_cont, with: "doggo"
-        within "form .filter-search" do
-          find("*[type=submit]").click
-        end
-
+      it "shows all results for the given process and category" do
         within("#results") do
-          expect(page).to have_content(translated(matching_result1.title))
-          expect(page).to have_content(translated(matching_result2.title))
+          expect(page).to have_css(".card__list", count: results_count)
 
           results.each do |result|
-            expect(page).not_to have_content(translated(result.title))
+            expect(page).to have_content(translated(result.title))
           end
         end
       end
-    end
-  end
 
-  describe "index" do
-    let(:path) { decidim_participatory_process_accountability.results_path(participatory_process_slug: participatory_process.slug, component_id: component.id) }
-
-    it "shows all results for the given process and category" do
-      within("#results") do
-        expect(page).to have_selector(".card__list", count: results_count)
-
-        results.each do |result|
-          expect(page).to have_content(translated(result.title))
-        end
-      end
-    end
-
-    context "with a category and a scope" do
-      let!(:category) { create(:category, participatory_space: participatory_process) }
-      let!(:scope) { create(:scope, organization:) }
-      let!(:result) do
-        result = results.first
-        result.category = category
-        result.scope = scope
-        result.save
-        result
-      end
-
-      let(:path) do
-        decidim_participatory_process_accountability.results_path(
-          participatory_process_slug: participatory_process.slug, component_id: component.id, filter: { with_category: category.id, with_scope: scope.id }
-        )
-      end
-
-      it "shows current scope active" do
-        within "div.filter-container a.is-active" do
-          expect(page).to have_content(translated(scope.name))
-        end
-      end
-
-      it "maintains scope filter" do
-        click_link translated(category.name)
-
-        within "div.filter-container a.is-active" do
-          expect(page).to have_content(translated(scope.name))
-        end
-      end
-    end
-  end
-
-  describe "show" do
-    let(:path) { decidim_participatory_process_accountability.result_path(id: result.id, participatory_process_slug: participatory_process.slug, component_id: component.id) }
-    let(:results_count) { 1 }
-    let(:result) { results.first }
-
-    it "shows all result info" do
-      expect(page).to have_i18n_content(result.title)
-      expect(page).to have_i18n_content(result.description)
-      expect(page).to have_content(result.reference)
-      expect(page).to have_content("#{result.progress.to_i}%")
-    end
-
-    context "when it has no versions" do
-      before do
-        result.versions.destroy_all
-        visit current_path
-      end
-
-      it "does not show version data" do
-        expect(page).not_to have_content("Version number")
-      end
-    end
-
-    context "when it has some versions" do
-      it "does shows version data" do
-        expect(page).to have_content("Version number 1")
-      end
-    end
-
-    context "without category or scope" do
-      it "does not show any tag" do
-        expect(page).not_to have_selector("[data-tags]")
-      end
-    end
-
-    context "with a category" do
-      let(:result) do
-        result = results.first
-        result.category = create :category, participatory_space: participatory_process
-        result.save
-        result
-      end
-
-      it "shows tags for category" do
-        expect(page).to have_selector("[data-tags]")
-        within "[data-tags]" do
-          expect(page).to have_content(translated(result.category.name))
-        end
-      end
-    end
-
-    context "with a scope" do
-      let(:result) do
-        result = results.first
-        result.scope = create(:scope, organization:)
-        result.save
-        result
-      end
-
-      before do
-        visit current_path
-      end
-
-      it "shows tags for scope" do
-        expect(page).to have_selector("[data-tags]")
-        within "[data-tags]" do
-          expect(page).to have_content(translated(result.scope.name))
-        end
-      end
-    end
-
-    context "when a proposal has comments" do
-      let(:result) { results.first }
-      let(:author) { create(:user, :confirmed, organization: component.organization) }
-      let!(:comments) { create_list(:comment, 3, commentable: result) }
-
-      before do
-        visit current_path
-      end
-
-      it "shows the comments" do
-        comments.each do |comment|
-          expect(page).to have_content(comment.body.values.first)
-        end
-      end
-    end
-
-    context "with linked proposals" do
-      let(:proposal_component) do
-        create(:component, manifest_name: :proposals, participatory_space: result.component.participatory_space)
-      end
-      let(:proposals) { create_list(:proposal, 3, component: proposal_component) }
-      let(:proposal) { proposals.first }
-
-      before do
-        result.link_resources(proposals, "included_proposals")
-        visit current_path
-      end
-
-      it "shows the tab" do
-        expect(page).to have_content("Included proposals")
-      end
-
-      it "shows related proposals" do
-        proposals.each do |proposal|
-          expect(page).to have_content(translated(proposal.title))
-          expect(page).to have_content(proposal.creator_author.name)
-          expect(page).to have_content(proposal.votes.size)
-        end
-      end
-
-      it "the result is mentioned in the proposal page" do
-        click_link translated(proposal.title)
-        expect(page).to have_i18n_content(result.title)
-      end
-
-      it "a banner links back to the result" do
-        click_link translated(proposal.title)
-        expect(page).to have_content("Included in #{translated(result.title)}")
-      end
-    end
-
-    context "with linked projects" do
-      let(:budgets_component) do
-        create(:component, manifest_name: :budgets, participatory_space: result.component.participatory_space)
-      end
-      let(:budget) { create(:budget, component: budgets_component) }
-      let(:projects) { create_list(:project, 3, budget:) }
-      let(:project) { projects.first }
-
-      before do
-        result.link_resources(projects, "included_projects")
-        visit current_path
-      end
-
-      it "shows the tab" do
-        expect(page).to have_content("Included projects")
-      end
-
-      it "shows related projects" do
-        projects.each do |project|
-          expect(page).to have_content(translated(project.title))
-        end
-      end
-
-      it "the result is mentioned in the project page" do
-        click_link translated(project.title)
-        expect(page).to have_i18n_content(result.title)
-      end
-    end
-
-    context "with linked meetings" do
-      let(:meeting_component) do
-        create(:component, manifest_name: :meetings, participatory_space: result.component.participatory_space)
-      end
-      let(:meetings) { create_list(:meeting, 3, :published, component: meeting_component) }
-      let(:meeting) { meetings.first }
-
-      before do
-        result.link_resources(meetings, "meetings_through_proposals")
-        visit current_path
-      end
-
-      it "shows the tab" do
-        expect(page).to have_content("Included meetings")
-      end
-
-      it "shows related meetings" do
-        meetings.each do |meeting|
-          expect(page).to have_i18n_content(meeting.title)
-        end
-      end
-
-      it "the result is mentioned in the meeting page" do
-        click_link translated(meeting.title)
-        expect(page).to have_i18n_content(result.title)
-      end
-
-      it "a banner links back to the result" do
-        click_link translated(meeting.title)
-        expect(page).to have_content("Included in #{translated(result.title)}")
-      end
-    end
-
-    context "when filtering" do
-      before do
-        create(:result, component:, scope:)
-        visit_component
-      end
-
-      context "when the process has a linked scope and the component has scopes disabled" do
-        before do
-          participatory_process.update(scope:)
-          component.update(settings: { scopes_enabled: false })
-          visit current_path
+      context "with a category and a scope" do
+        let!(:category) { create(:category, participatory_space: participatory_process) }
+        let!(:scope) { create(:scope, organization:) }
+        let!(:result) do
+          result = results.first
+          result.category = category
+          result.scope = scope
+          result.save
+          result
         end
 
-        it "disables filtering by scope" do
-          expect(page).not_to have_selector("[data-scope-filters]")
-        end
-      end
-
-      context "when the process has no linked scope" do
-        before do
-          participatory_process.update(scope: nil)
-          visit current_path
+        let(:path) do
+          decidim_participatory_process_accountability.results_path(
+            participatory_process_slug: participatory_process.slug, component_id: component.id, filter: { with_category: category.id, with_scope: scope.id }
+          )
         end
 
-        it "enables filtering by scope" do
-          within "[data-scope-filters]" do
-            expect(page).to have_content(/All/i)
+        it "shows current scope active" do
+          within "div.filter-container a.is-active" do
+            expect(page).to have_content(translated(scope.name))
+          end
+        end
+
+        it "maintains scope filter" do
+          click_link translated(category.name)
+
+          within "div.filter-container a.is-active" do
             expect(page).to have_content(translated(scope.name))
           end
         end
       end
     end
 
-    it_behaves_like "has attachments tabs" do
-      let(:attached_to) { result }
+    describe "show" do
+      let(:path) { decidim_participatory_process_accountability.result_path(id: result.id, participatory_process_slug: participatory_process.slug, component_id: component.id) }
+      let(:results_count) { 1 }
+      let(:result) { results.first }
+
+      it "shows all result info" do
+        expect(page).to have_i18n_content(result.title)
+        expect(page).to have_i18n_content(result.description)
+        expect(page).to have_content(result.reference)
+        expect(page).to have_content("#{result.progress.to_i}%")
+      end
+
+      context "when it has no versions" do
+        before do
+          result.versions.destroy_all
+          visit current_path
+        end
+
+        it "does not show version data" do
+          expect(page).not_to have_content("Version number")
+        end
+      end
+
+      context "when it has some versions" do
+        it "does shows version data" do
+          expect(page).to have_content("Version number 1")
+        end
+      end
+
+      context "without category or scope" do
+        it "does not show any tag" do
+          expect(page).not_to have_css("[data-tags]")
+        end
+      end
+
+      context "with a category" do
+        let(:result) do
+          result = results.first
+          result.category = create :category, participatory_space: participatory_process
+          result.save
+          result
+        end
+
+        it "shows tags for category" do
+          expect(page).to have_css("[data-tags]")
+          within "[data-tags]" do
+            expect(page).to have_content(translated(result.category.name))
+          end
+        end
+      end
+
+      context "with a scope" do
+        let(:result) do
+          result = results.first
+          result.scope = create(:scope, organization:)
+          result.save
+          result
+        end
+
+        before do
+          visit current_path
+        end
+
+        it "shows tags for scope" do
+          expect(page).to have_css("[data-tags]")
+          within "[data-tags]" do
+            expect(page).to have_content(translated(result.scope.name))
+          end
+        end
+      end
+
+      context "when a proposal has comments" do
+        let(:result) { results.first }
+        let(:author) { create(:user, :confirmed, organization: component.organization) }
+        let!(:comments) { create_list(:comment, 3, commentable: result) }
+
+        before do
+          visit current_path
+        end
+
+        it "shows the comments" do
+          comments.each do |comment|
+            expect(page).to have_content(comment.body.values.first)
+          end
+        end
+      end
+
+      context "with linked proposals" do
+        let(:proposal_component) do
+          create(:component, manifest_name: :proposals, participatory_space: result.component.participatory_space)
+        end
+        let(:proposals) { create_list(:proposal, 3, component: proposal_component) }
+        let(:proposal) { proposals.first }
+
+        before do
+          result.link_resources(proposals, "included_proposals")
+          visit current_path
+        end
+
+        it "shows the tab" do
+          expect(page).to have_content("Included proposals")
+        end
+
+        it "shows related proposals" do
+          proposals.each do |proposal|
+            expect(page).to have_content(translated(proposal.title))
+            expect(page).to have_content(proposal.creator_author.name)
+            expect(page).to have_content(proposal.votes.size)
+          end
+        end
+
+        it "the result is mentioned in the proposal page" do
+          click_link translated(proposal.title)
+          expect(page).to have_i18n_content(result.title)
+        end
+
+        it "a banner links back to the result" do
+          click_link translated(proposal.title)
+          expect(page).to have_content("Included in #{translated(result.title)}")
+        end
+      end
+
+      context "with linked projects" do
+        let(:budgets_component) do
+          create(:component, manifest_name: :budgets, participatory_space: result.component.participatory_space)
+        end
+        let(:budget) { create(:budget, component: budgets_component) }
+        let(:projects) { create_list(:project, 3, budget:) }
+        let(:project) { projects.first }
+
+        before do
+          result.link_resources(projects, "included_projects")
+          visit current_path
+        end
+
+        it "shows the tab" do
+          expect(page).to have_content("Included projects")
+        end
+
+        it "shows related projects" do
+          projects.each do |project|
+            expect(page).to have_content(translated(project.title))
+          end
+        end
+
+        it "the result is mentioned in the project page" do
+          click_link translated(project.title)
+          expect(page).to have_i18n_content(result.title)
+        end
+      end
+
+      context "with linked meetings" do
+        let(:meeting_component) do
+          create(:component, manifest_name: :meetings, participatory_space: result.component.participatory_space)
+        end
+        let(:meetings) { create_list(:meeting, 3, :published, component: meeting_component) }
+        let(:meeting) { meetings.first }
+
+        before do
+          result.link_resources(meetings, "meetings_through_proposals")
+          visit current_path
+        end
+
+        it "shows the tab" do
+          expect(page).to have_content("Included meetings")
+        end
+
+        it "shows related meetings" do
+          meetings.each do |meeting|
+            expect(page).to have_i18n_content(meeting.title)
+          end
+        end
+
+        it "the result is mentioned in the meeting page" do
+          click_link translated(meeting.title)
+          expect(page).to have_i18n_content(result.title)
+        end
+
+        it "a banner links back to the result" do
+          click_link translated(meeting.title)
+          expect(page).to have_content("Included in #{translated(result.title)}")
+        end
+      end
+
+      context "when filtering" do
+        before do
+          create(:result, component:, scope:)
+          visit_component
+        end
+
+        context "when the process has a linked scope and the component has scopes disabled" do
+          before do
+            participatory_process.update(scope:)
+            component.update(settings: { scopes_enabled: false })
+            visit current_path
+          end
+
+          it "disables filtering by scope" do
+            expect(page).not_to have_css("[data-scope-filters]")
+          end
+        end
+
+        context "when the process has no linked scope" do
+          before do
+            participatory_process.update(scope: nil)
+            visit current_path
+          end
+
+          it "enables filtering by scope" do
+            within "[data-scope-filters]" do
+              expect(page).to have_content(/All/i)
+              expect(page).to have_content(translated(scope.name))
+            end
+          end
+        end
+      end
+
+      it_behaves_like "has attachments tabs" do
+        let(:attached_to) { result }
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

When there are no results projects nor categories in accountability, we don't show any message, just a blank page.

This PR changes it to show a message.

I've found about this error while reviewing #11480. On that case it's showing the error when there's a category, but if there isn't any category we don't show anything. I've added specs for that case too. 

As I needed to change the indentation on the spec file, I recommend making the review on a commit by commit basis to see it better.

#### :pushpin: Related Issues
 
- Related to #11875

#### Testing

1. Create a new process 
2. Create an accountability component
3. Click in the "Preview" icon in the admin's component page

### :camera: Screenshots

![Screenshot of the no results page in accountability module](https://github.com/decidim/decidim/assets/717367/6ec66820-4c69-48a8-9477-10ec9ab364fc)

:hearts: Thank you!