### PR TITLE
Show error message when there are no posts in blogs

### DIFF
--- a/decidim-blogs/app/views/decidim/blogs/posts/index.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/index.html.erb
@@ -1,3 +1,4 @@
+<% add_decidim_page_title component_name %>
 <%= append_javascript_pack_tag "decidim_blogs" %>
 <%= append_stylesheet_pack_tag "decidim_blogs" %>
 

--- a/decidim-blogs/app/views/decidim/blogs/posts/index.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/index.html.erb
@@ -10,7 +10,11 @@
   <%= render partial: "decidim/shared/component_announcement" %>
 
   <section id="blogs" class="layout-main__section layout-main__heading">
-    <h2 class="h5 md:h3 decorator"><%= t("count", scope: "decidim.blogs.posts.index", count: posts.length) %></h2>
+    <% if posts.empty? %>
+      <%= cell("decidim/announcement", t("empty", scope: "decidim.blogs.posts.index")) %>
+    <% else %>
+      <h2 class="h5 md:h3 decorator"><%= t("count", scope: "decidim.blogs.posts.index", count: posts.length) %></h2>
+    <% end %>
 
     <% paginate_posts.each do |post| %>
       <%= card_for post, size: :l %>

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -64,10 +64,10 @@ en:
             title: Title
       posts:
         index:
-          empty: There are no posts yet.
           count:
             one: "%{count} post"
             other: "%{count} posts"
+          empty: There are no posts yet.
     components:
       blogs:
         actions:

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -64,6 +64,7 @@ en:
             title: Title
       posts:
         index:
+          empty: There are no posts yet.
           count:
             one: "%{count} post"
             other: "%{count} posts"

--- a/decidim-blogs/spec/system/explore_posts_spec.rb
+++ b/decidim-blogs/spec/system/explore_posts_spec.rb
@@ -6,101 +6,103 @@ describe "Explore posts" do
   include_context "with a component"
   let(:manifest_name) { "blogs" }
 
-  let!(:old_post) { create(:post, component:, created_at: 2.days.ago) }
-  let!(:new_post) { create(:post, component:, created_at: Time.current) }
+  context "when there are posts" do
+    let!(:old_post) { create(:post, component:, created_at: 2.days.ago) }
+    let!(:new_post) { create(:post, component:, created_at: Time.current) }
 
-  let!(:image) { create(:attachment, attached_to: old_post) }
+    let!(:image) { create(:attachment, attached_to: old_post) }
 
-  describe "index" do
-    let!(:old_post_id) { "[id$='#{old_post.id}']" }
-    let!(:new_post_id) { "[id$='#{new_post.id}']" }
-
-    before do
-      create(:comment, commentable: old_post)
-      create(:endorsement, resource: old_post, author: build(:user, organization: old_post.participatory_space.organization))
-
-      visit_component
-    end
-
-    it "shows the component name in the sidebar" do
-      within("aside") do
-        expect(page).to have_content(translated(component.name))
-      end
-    end
-
-    it "shows all posts for the given process" do
-      expect(page).to have_selector("#blogs > a", count: 2)
-    end
-
-    context "when paginating" do
-      let(:collection_size) { 15 }
-      let!(:collection) { create_list(:post, collection_size, component:) }
+    describe "index" do
+      let!(:old_post_id) { "[id$='#{old_post.id}']" }
+      let!(:new_post_id) { "[id$='#{new_post.id}']" }
 
       before do
+        create(:comment, commentable: old_post)
+        create(:endorsement, resource: old_post, author: build(:user, organization: old_post.participatory_space.organization))
+
         visit_component
       end
 
-      it "lists 10 resources per page by default" do
-        expect(page).to have_selector("#blogs > a", count: 10)
-        expect(page).to have_css("[data-pages] [data-page]", count: 2)
+      it "shows the component name in the sidebar" do
+        within("aside") do
+          expect(page).to have_content(translated(component.name))
+        end
       end
-    end
 
-    context "with some unpublished posts" do
-      let!(:unpublished) { create(:post, component:, published_at: 2.days.from_now) }
-
-      it "shows only published blogs" do
-        expect(Decidim::Blogs::Post.count).to eq(3)
+      it "shows all posts for the given process" do
         expect(page).to have_selector("#blogs > a", count: 2)
       end
-    end
-  end
 
-  describe "show" do
-    let(:posts_count) { 1 }
-    let(:author) { organization }
-    let(:body) { { en: "Short description", ca: "Descripció curta", es: "Descripción corta" } }
-    let!(:post) { create(:post, component:, author:, body:) }
+      context "when paginating" do
+        let(:collection_size) { 15 }
+        let!(:collection) { create_list(:post, collection_size, component:) }
 
-    before do
-      visit resource_locator(post).path
-    end
+        before do
+          visit_component
+        end
 
-    context "when author is an organization" do
-      it "shows 'Official' as the author" do
-        within ".author__name" do
-          expect(page).to have_content("Official")
+        it "lists 10 resources per page by default" do
+          expect(page).to have_selector("#blogs > a", count: 10)
+          expect(page).to have_css("[data-pages] [data-page]", count: 2)
+        end
+      end
+
+      context "with some unpublished posts" do
+        let!(:unpublished) { create(:post, component:, published_at: 2.days.from_now) }
+
+        it "shows only published blogs" do
+          expect(Decidim::Blogs::Post.count).to eq(3)
+          expect(page).to have_selector("#blogs > a", count: 2)
         end
       end
     end
 
-    context "when author is a user_group" do
-      let(:author) { create(:user_group, :verified, organization:) }
+    describe "show" do
+      let(:posts_count) { 1 }
+      let(:author) { organization }
+      let(:body) { { en: "Short description", ca: "Descripció curta", es: "Descripción corta" } }
+      let!(:post) { create(:post, component:, author:, body:) }
 
-      it "shows user group as the author" do
-        within ".author__name" do
-          expect(page).to have_content(author.name)
+      before do
+        visit resource_locator(post).path
+      end
+
+      context "when author is an organization" do
+        it "shows 'Official' as the author" do
+          within ".author__name" do
+            expect(page).to have_content("Official")
+          end
         end
       end
-    end
 
-    context "when author is a user" do
-      let(:author) { user }
+      context "when author is a user_group" do
+        let(:author) { create(:user_group, :verified, organization:) }
 
-      it "shows user as the author" do
-        within ".author__name" do
-          expect(page).to have_content(user.name)
+        it "shows user group as the author" do
+          within ".author__name" do
+            expect(page).to have_content(author.name)
+          end
         end
       end
-    end
 
-    it "show post info" do
-      expect(page).to have_i18n_content(post.title)
-      expect(page).to have_i18n_content(post.body)
-      expect(page).to have_content(post.author.name)
-      expect(page).to have_content(post.created_at.strftime("%d/%m/%Y %H:%M"))
-    end
+      context "when author is a user" do
+        let(:author) { user }
 
-    it_behaves_like "has embedded video in description", :body
+        it "shows user as the author" do
+          within ".author__name" do
+            expect(page).to have_content(user.name)
+          end
+        end
+      end
+
+      it "show post info" do
+        expect(page).to have_i18n_content(post.title)
+        expect(page).to have_i18n_content(post.body)
+        expect(page).to have_content(post.author.name)
+        expect(page).to have_content(post.created_at.strftime("%d/%m/%Y %H:%M"))
+      end
+
+      it_behaves_like "has embedded video in description", :body
+    end
   end
 end

--- a/decidim-blogs/spec/system/explore_posts_spec.rb
+++ b/decidim-blogs/spec/system/explore_posts_spec.rb
@@ -6,6 +6,20 @@ describe "Explore posts" do
   include_context "with a component"
   let(:manifest_name) { "blogs" }
 
+  context "when there are no posts" do
+    describe "index" do
+      before do
+        visit_component
+      end
+
+      it "shows an empty page with a message" do
+        within "main" do
+          expect(page).to have_content "There are no posts yet"
+        end
+      end
+    end
+  end
+
   context "when there are posts" do
     let!(:old_post) { create(:post, component:, created_at: 2.days.ago) }
     let!(:new_post) { create(:post, component:, created_at: Time.current) }


### PR DESCRIPTION
#### :tophat: What? Why?

When there are no posts in blogs, we don't show any message, just a blank page.

This PR changes it to show a message.

I've found about this error while reviewing #11480. 

As I needed to change the indentation on the spec file, I recommend making the review on a commit by commit basis to see it better.

#### :pushpin: Related Issues
 
- Related to #11875

#### Testing

1. Create a new process 
2. Create a blogs component
3. Click in the "Preview" icon in the admin's component page

### :camera: Screenshots

![Screenshot of the no posts page in blogs module](https://github.com/decidim/decidim/assets/717367/6a28bb5e-91d4-4510-a3ba-be19f7450b5d)

:hearts: Thank you!