### PR TITLE
Redesign: Proposal counter total number avaliable

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
@@ -7,7 +7,7 @@
 <% if @proposals.empty? %>
   <%= cell("decidim/announcement", params[:filter].present? ? t(".empty_filters") : t(".empty")) %>
 <% else %>
-  <h2 class="h5 md:h3 decorator"><%= t("count", scope: "decidim.proposals.proposals.index", count: @proposals.length) %></h2>
+  <h2 class="h5 md:h3 decorator"><%= t("count", scope: "decidim.proposals.proposals.index", count: @proposals.total_count) %></h2>
 
   <%= order_selector available_orders, i18n_scope: "decidim.proposals.proposals.orders" %>
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
@@ -5,7 +5,7 @@
 
 <% content_for :aside do %>
   <h1 id="proposals-count" class="title-decorator"><%= component_name %></h1>
-
+xxx
   <div class="proposal-list__aside__button-container">
     <% if current_settings.creation_enabled && current_component.participatory_space.can_participate?(current_user) %>
       <%= action_authorized_link_to :create, new_proposal_path, class: "button button__xl button__secondary w-full", data: { "redirect_url" => new_proposal_path } do %>

--- a/decidim-proposals/spec/system/index_proposals_spec.rb
+++ b/decidim-proposals/spec/system/index_proposals_spec.rb
@@ -7,7 +7,7 @@ describe "Index proposals" do
   let(:manifest_name) { "proposals" }
 
   context "when there are proposals" do
-    let!(:proposals) { create_list(:proposal, 3, component:) }
+    let!(:proposals) { create_list(:proposal, 20, component:) }
 
     it "does not display empty message" do
       visit_component
@@ -18,7 +18,7 @@ describe "Index proposals" do
 
   context "when checking withdrawn proposals" do
     context "when there are no withrawn proposals" do
-      let!(:proposals) { create_list(:proposal, 3, component:) }
+      let!(:proposals) { create_list(:proposal, 20, component:) }
 
       before do
         visit_component
@@ -34,8 +34,8 @@ describe "Index proposals" do
     end
 
     context "when there are withrawn proposals" do
-      let!(:proposals) { create_list(:proposal, 3, component:) }
-      let!(:withdrawn_proposals) { create_list(:proposal, 3, :withdrawn, component:) }
+      let!(:proposals) { create_list(:proposal, 20, component:) }
+      let!(:withdrawn_proposals) { create_list(:proposal, 20, :withdrawn, component:) }
 
       before do
         visit_component


### PR DESCRIPTION
#### :tophat: What? Why?
The proposal component wouldn't count the no. of proposals availiable instead only per page. This proposals allows the ActiveRecord method ```total_count```to replace the ```@proposals.length```counting proposals per page.

Further investigation hasn't discovered whether this is a issue affecting all modules (for example: Projects, Assemblies etc), however this fix should be applicable fix to all modules if affected with the same bug. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related #12005 
- Fixes #11874

#### Testing
1. Access the Decidim solution (no need to login).
2. Head to a Process with Proposals active.
3. Make sure you have a like 20/30 proposals
4. See the proposals counting the total no. instead of per page.

PR: https://github.com/decidim/decidim/pull/12005, should help in terms of testing if you wish to seed more proposals.

### :camera: Screenshots

Before: 
![photo_2023-11-16 12 09 38](https://github.com/decidim/decidim/assets/101816158/bdaf4296-72fe-466b-b405-b47cab3e28f6)


After:
![photo_2023-11-16 12 09 34](https://github.com/decidim/decidim/assets/101816158/a3ce2522-400a-458c-97e0-56913dff1071)


:hearts: Thank you!
