### PR TITLE
Fix for searching not published projects

### DIFF
--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -28,6 +28,7 @@ module Decidim
       has_many :orders, through: :line_items, foreign_key: "decidim_project_id", class_name: "Decidim::Budgets::Order"
 
       delegate :organization, :participatory_space, :can_participate_in_space?, to: :component
+      delegate :visible?, to: :budget
 
       alias can_participate? can_participate_in_space?
 
@@ -45,13 +46,15 @@ module Decidim
 
       scope_search_multi :with_any_status, [:selected, :not_selected]
 
-      searchable_fields(
-        scope_id: :decidim_scope_id,
-        participatory_space: { component: :participatory_space },
-        A: :title,
-        D: :description,
-        datetime: :created_at
-      )
+      searchable_fields({
+                          scope_id: :decidim_scope_id,
+                          participatory_space: { component: :participatory_space },
+                          A: :title,
+                          D: :description,
+                          datetime: :created_at
+                        },
+                        index_on_create: ->(project) { project.visible? },
+                        index_on_update: ->(project) { project.visible? })
 
       def self.ordered_ids(ids)
         # Make sure each ID in the matching text has a "," character as their

--- a/decidim-budgets/spec/models/decidim/budgets/project_spec.rb
+++ b/decidim-budgets/spec/models/decidim/budgets/project_spec.rb
@@ -109,5 +109,25 @@ module Decidim::Budgets
         end
       end
     end
+
+    describe "#visible?" do
+      subject { project.visible? }
+
+      context "when component is not published" do
+        before do
+          allow(project.budget.component).to receive(:published?).and_return(false)
+        end
+
+        it { is_expected.not_to be_truthy }
+      end
+
+      context "when participatory space is visible" do
+        before do
+          allow(project.budget.component.participatory_space).to receive(:visible?).and_return(false)
+        end
+
+        it { is_expected.not_to be_truthy }
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Projects from the budgets' module can be searched even though they are not published. This PR fixes that.

#### :pushpin: Related Issues
 
- Fixes #11721

#### Testing

1. Unpublish a process or a budgets' component
2. Change the name to a project from budgets and call it "NOT PUBLISHED"
3. Search for "NOT PUBLISHED" in the general search
4. See that you can't find that  

:hearts: Thank you!
