### PR TITLE
Add specs for new content blocks

### DIFF
--- a/decidim-assemblies/spec/cells/decidim/assemblies/content_blocks/related_assemblies_cell_spec.rb
+++ b/decidim-assemblies/spec/cells/decidim/assemblies/content_blocks/related_assemblies_cell_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Assemblies::ContentBlocks::RelatedAssembliesCell, type: :cell do
+  subject { cell(content_block.cell, content_block).call }
+
+  controller Decidim::Assemblies::AssembliesController
+
+  let(:organization) { create(:organization) }
+  let(:content_block) { create(:content_block, organization:, manifest_name:, scope_name:, settings:, scoped_resource_id: parent_assembly.id) }
+  let(:manifest_name) { :related_assemblies }
+  let(:scope_name) { :assembly_homepage }
+  let(:settings) { {} }
+  let(:parent_assembly) { create(:assembly, organization:) }
+  let!(:child_assemblies) { create_list(:assembly, 8, organization:, parent: parent_assembly, created_at: 1.day.ago) }
+
+  context "when the content block has no settings" do
+    it "shows 6 assemblies" do
+      expect(subject).to have_css("a.card__grid", count: 6)
+    end
+  end
+
+  context "when the content block has customized the welcome text setting value" do
+    let(:settings) do
+      {
+        "max_results" => "9"
+      }
+    end
+
+    it "shows up to 8 assemblies" do
+      expect(subject).to have_css("a.card__grid", count: 8)
+    end
+  end
+end

--- a/decidim-blogs/spec/cells/decidim/blogs/content_blocks/highlighted_posts_cell_spec.rb
+++ b/decidim-blogs/spec/cells/decidim/blogs/content_blocks/highlighted_posts_cell_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Blogs::ContentBlocks::HighlightedPostsCell, type: :cell do
+  subject { cell("decidim/blogs/content_blocks/highlighted_posts", content_block).call }
+
+  controller Decidim::Blogs::PostsController
+
+  let(:organization) { create(:organization) }
+  let(:participatory_space) { create(:participatory_process, organization:) }
+  let(:component) { create(:component, participatory_space:, manifest_name: "blogs") }
+  let(:manifest_name) { :highlighted_posts }
+  let(:scope_name) { :participatory_process_homepage }
+  let(:content_block) { create(:content_block, organization:, manifest_name:, scope_name:, scoped_resource_id: participatory_space.id) }
+
+  context "with 1 post" do
+    let!(:post) { create(:post, title: { en: "Blog post title" }, component:) }
+
+    it "renders the post" do
+      expect(subject).to have_content("Last published")
+      expect(subject).to have_content("Blog post title")
+      expect(subject).to have_css(".card__grid", count: 1)
+    end
+  end
+
+  context "with 4 posts" do
+    let!(:posts) { create_list(:post, 3, component:, created_at: 1.day.ago) }
+    let!(:post) { create(:post, title: { en: "Blog post title" }, component:, created_at: 1.year.ago) }
+
+    it "renders 3 posts" do
+      expect(subject).to have_content("Last published")
+      expect(subject).not_to have_content("Blog post title")
+      expect(subject).to have_css(".card__grid", count: 3)
+    end
+  end
+
+  context "with no posts" do
+    it "renders nothing" do
+      expect(subject).not_to have_content("Last published")
+      expect(subject).not_to have_css(".card__grid", count: 1)
+    end
+  end
+end

--- a/decidim-proposals/spec/cells/decidim/proposals/highlighted_proposals_for_component_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/highlighted_proposals_for_component_cell_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Proposals::HighlightedProposalsForComponentCell, type: :cell do
+  controller Decidim::Proposals::ProposalsController
+
+  subject { my_cell.call }
+
+  let(:my_cell) { cell("decidim/proposals/highlighted_proposals_for_component", model) }
+  let!(:official_proposal) { create(:proposal, :official) }
+  let!(:user_proposal) { create(:proposal) }
+  let!(:current_user) { create(:user, :confirmed, organization: model.participatory_space.organization) }
+  let(:model) { create(:proposal_component) }
+  let!(:proposal) { create(:proposal, title: { en: "A nice title" }, component: model) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(current_user)
+  end
+
+  context "when no proposals" do
+    let!(:proposal) { nil }
+
+    it "renders nothing" do
+      expect(subject).not_to have_content("A nice title")
+      expect(subject).not_to have_content("Last proposals")
+      expect(subject).not_to have_css(".card__list-title", count: 1)
+    end
+  end
+
+  context "with proposals" do
+    let!(:proposal2) { create(:proposal, title: { en: "Another nice title" }, component: model) }
+
+    it "renders the proposals" do
+      expect(subject).to have_content("A nice title")
+      expect(subject).to have_content("Another nice title")
+      expect(subject).to have_content("Last proposals")
+      expect(subject).to have_css(".card__list-title", count: 2)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds some specs for new content blocks.

It doesn't try to be exhaustive in the tests nor catch any bug. It may be useful in the future when we found some bug in the CBs, as it'll make the debugging/testing process a bit faster. 

#### :pushpin: Related Issues

- Related to #10415

#### Testing

The CI should be green

:hearts: Thank you!
