### PR TITLE
Add max results setting to highlighted conferences content block

### DIFF
--- a/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
@@ -7,7 +7,11 @@ module Decidim
         delegate :current_user, to: :controller
 
         def highlighted_spaces
-          OrganizationPrioritizedConferences.new(current_organization, current_user)
+          @highlighted_spaces ||= OrganizationPrioritizedConferences
+                                  .new(current_organization, current_user)
+                                  .query
+                                  .with_attached_hero_image
+                                  .includes([:organization])
         end
 
         def i18n_scope
@@ -16,6 +20,10 @@ module Decidim
 
         def all_path
           Decidim::Conferences::Engine.routes.url_helpers.conferences_path
+        end
+
+        def max_results
+          model.settings.max_results
         end
 
         private

--- a/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
@@ -1,0 +1,3 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <%= settings_fields.select :max_results, [6, 9, 12], prompt: "", label: %>
+<% end %>

--- a/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form_cell.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Conferences
+    module ContentBlocks
+      class HighlightedConferencesSettingsFormCell < Decidim::ViewModel
+        alias form model
+
+        def content_block
+          options[:content_block]
+        end
+
+        def label
+          I18n.t("decidim.conferences.admin.content_blocks.highlighted_conferences.max_results")
+        end
+      end
+    end
+  end
+end

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -378,6 +378,9 @@ en:
               one: There has been 1 registration.
               other: There has been %{count} registrations.
             slug_help_html: 'URL slugs are used to generate the URLs that point to this conference. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
+        content_blocks:
+          highlighted_conferences:
+            max_results: Maximum amount of elements to show
         diplomas:
           edit:
             save: Save

--- a/decidim-conferences/lib/decidim/conferences/engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/engine.rb
@@ -84,6 +84,11 @@ module Decidim
         Decidim.content_blocks.register(:homepage, :highlighted_conferences) do |content_block|
           content_block.cell = "decidim/conferences/content_blocks/highlighted_conferences"
           content_block.public_name_key = "decidim.conferences.content_blocks.highlighted_conferences.name"
+          content_block.settings_form_cell = "decidim/conferences/content_blocks/highlighted_conferences_settings_form"
+
+          content_block.settings do |settings|
+            settings.attribute :max_results, type: :integer, default: 6
+          end
         end
       end
 

--- a/decidim-conferences/spec/cells/decidim/conferences/content_blocks/highlighted_conferences_cell_spec.rb
+++ b/decidim-conferences/spec/cells/decidim/conferences/content_blocks/highlighted_conferences_cell_spec.rb
@@ -7,7 +7,7 @@ describe Decidim::Conferences::ContentBlocks::HighlightedConferencesCell, type: 
 
   let(:organization) { create(:organization) }
   let(:content_block) { create(:content_block, organization:, manifest_name: :highlighted_conferences, scope_name: :homepage, settings:) }
-  let!(:conferences) { create_list(:conference, 5, :published, organization:) }
+  let!(:conferences) { create_list(:conference, 8, :published, organization:) }
   let(:settings) { {} }
 
   let(:highlighted_conferences) { subject.find("#highlighted-conferences") }
@@ -18,15 +18,13 @@ describe Decidim::Conferences::ContentBlocks::HighlightedConferencesCell, type: 
     allow(controller).to receive(:current_organization).and_return(organization)
   end
 
-  # Conferences do not have a max_results settings number selector yet, we might want this back when they do
-  # context "when the content block has no settings" do
-  #   it "shows 4 processes" do
-  #     expect(highlighted_conferences).to have_selector("a.card__grid", count: 4)
-  #   end
-  # end
+  context "when the content block has no settings" do
+    it "shows 6 conferences" do
+      expect(highlighted_conferences).to have_css("a.card__grid", count: 6)
+    end
+  end
 
   context "when the content block has customized the max results setting value" do
-    # note that settings is doing nothing here, just left it for when conferences block is improved
     let(:settings) do
       {
         "max_results" => "8"
@@ -34,7 +32,7 @@ describe Decidim::Conferences::ContentBlocks::HighlightedConferencesCell, type: 
     end
 
     it "shows up to 8 conferences" do
-      expect(highlighted_conferences).to have_selector("a.card__grid", count: 5)
+      expect(highlighted_conferences).to have_css("a.card__grid", count: 8)
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

The highlighted conferences content block don't implement the `max results` settings, so it isn't consistent with the rest of spaces (assemblies, processes, etc).

This PR adds this setting. 

#### :pushpin: Related Issues

- Fixes #11136 

#### Testing

1. Create more than 6 conferences
2. Change the setting in the "Homepage" configuration in the admin for this content block 

### :camera: Screenshots

![Screenshot of the content block configuration](https://github.com/decidim/decidim/assets/717367/cc3a5bf0-55ec-4929-92d5-0fa08f89ba10)

![Screenshot of the result](https://github.com/decidim/decidim/assets/717367/4a8056f2-7410-4c49-b59e-c3e9aed745e9)

:hearts: Thank you!
