### PR TITLE
Fix faker requirement in production environment

### DIFF
--- a/decidim-accountability/lib/decidim/accountability/component.rb
+++ b/decidim-accountability/lib/decidim/accountability/component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/accountability/seeds"
-
 Decidim.register_component(:accountability) do |component|
   component.engine = Decidim::Accountability::Engine
   component.admin_engine = Decidim::Accountability::AdminEngine
@@ -72,6 +70,8 @@ Decidim.register_component(:accountability) do |component|
   end
 
   component.seeds do |participatory_space|
+    require "decidim/accountability/seeds"
+
     Decidim::Accountability::Seeds.new(participatory_space:).call
   end
 end

--- a/decidim-accountability/lib/decidim/accountability/test/factories.rb
+++ b/decidim-accountability/lib/decidim/accountability/test/factories.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
 require "decidim/faker/localized"
 require "decidim/dev"
 

--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/assemblies/seeds"
-
 Decidim.register_participatory_space(:assemblies) do |participatory_space|
   participatory_space.icon = "media/images/decidim_assemblies.svg"
   participatory_space.model_class_name = "Decidim::Assembly"
@@ -47,6 +45,8 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
   end
 
   participatory_space.seeds do
+    require "decidim/assemblies/seeds"
+
     Decidim::Assemblies::Seeds.new.call
   end
 end

--- a/decidim-blogs/lib/decidim/blogs/component.rb
+++ b/decidim-blogs/lib/decidim/blogs/component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/blogs/seeds"
-
 Decidim.register_component(:blogs) do |component|
   component.engine = Decidim::Blogs::Engine
   component.admin_engine = Decidim::Blogs::AdminEngine
@@ -42,6 +40,8 @@ Decidim.register_component(:blogs) do |component|
   end
 
   component.seeds do |participatory_space|
+    require "decidim/blogs/seeds"
+
     Decidim::Blogs::Seeds.new(participatory_space:).call
   end
 end

--- a/decidim-blogs/lib/decidim/blogs/test/factories.rb
+++ b/decidim-blogs/lib/decidim/blogs/test/factories.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
 require "decidim/faker/localized"
 require "decidim/core/test/factories"
 require "decidim/participatory_processes/test/factories"

--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/budgets/seeds"
-
 Decidim.register_component(:budgets) do |component|
   component.engine = Decidim::Budgets::Engine
   component.admin_engine = Decidim::Budgets::AdminEngine
@@ -111,6 +109,8 @@ Decidim.register_component(:budgets) do |component|
   end
 
   component.seeds do |participatory_space|
+    require "decidim/budgets/seeds"
+
     Decidim::Budgets::Seeds.new(participatory_space:).call
   end
 end

--- a/decidim-budgets/lib/decidim/budgets/test/factories.rb
+++ b/decidim-budgets/lib/decidim/budgets/test/factories.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
 require "decidim/faker/localized"
 require "decidim/dev"
 

--- a/decidim-conferences/lib/decidim/conferences/participatory_space.rb
+++ b/decidim-conferences/lib/decidim/conferences/participatory_space.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/conferences/seeds"
-
 Decidim.register_participatory_space(:conferences) do |participatory_space|
   participatory_space.icon = "media/images/decidim_conferences.svg"
   participatory_space.model_class_name = "Decidim::Conference"
@@ -44,6 +42,8 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
   end
 
   participatory_space.seeds do
+    require "decidim/conferences/seeds"
+
     Decidim::Conferences::Seeds.new.call
   end
 end

--- a/decidim-debates/lib/decidim/debates/component.rb
+++ b/decidim-debates/lib/decidim/debates/component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/debates/seeds"
-
 Decidim.register_component(:debates) do |component|
   component.engine = Decidim::Debates::Engine
   component.admin_engine = Decidim::Debates::AdminEngine
@@ -69,6 +67,8 @@ Decidim.register_component(:debates) do |component|
   end
 
   component.seeds do |participatory_space|
+    require "decidim/debates/seeds"
+
     Decidim::Debates::Seeds.new(participatory_space:).call
   end
 end

--- a/decidim-debates/lib/decidim/debates/test/factories.rb
+++ b/decidim-debates/lib/decidim/debates/test/factories.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
+
 def generate_localized_debate_title
   Decidim::Faker::Localized.localized { "<script>alert(\"TITLE\");</script> #{generate(:title)}" }
 end

--- a/decidim-dev/lib/decidim/dev/test/factories.rb
+++ b/decidim-dev/lib/decidim/dev/test/factories.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
+
 FactoryBot.define do
   factory :dummy_component, parent: :component do
     name { Decidim::Components::Namer.new(participatory_space.organization.available_locales, :surveys).i18n_name }

--- a/decidim-elections/lib/decidim/elections/component.rb
+++ b/decidim-elections/lib/decidim/elections/component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/elections/seeds"
-
 Decidim.register_component(:elections) do |component|
   component.engine = Decidim::Elections::Engine
   component.admin_engine = Decidim::Elections::AdminEngine
@@ -67,6 +65,8 @@ Decidim.register_component(:elections) do |component|
   end
 
   component.seeds do |participatory_space|
+    require "decidim/elections/seeds"
+
     Decidim::Elections::Seeds.new(participatory_space:).call
   end
 end

--- a/decidim-elections/lib/decidim/elections/test/factories.rb
+++ b/decidim-elections/lib/decidim/elections/test/factories.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
 require "decidim/core/test/factories"
 require "decidim/forms/test/factories"
 

--- a/decidim-elections/lib/decidim/votings/participatory_space.rb
+++ b/decidim-elections/lib/decidim/votings/participatory_space.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/votings/seeds"
-
 Decidim.register_participatory_space(:votings) do |participatory_space|
   participatory_space.icon = "media/images/decidim_votings.svg"
   participatory_space.model_class_name = "Decidim::Votings::Voting"
@@ -44,6 +42,8 @@ Decidim.register_participatory_space(:votings) do |participatory_space|
   end
 
   participatory_space.seeds do
+    require "decidim/votings/seeds"
+
     Decidim::Votings::Seeds.new.call
   end
 end

--- a/decidim-generators/lib/decidim/generators/component_templates/lib/decidim/component/test/factories.rb.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/lib/decidim/component/test/factories.rb.erb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
 require "decidim/core/test/factories"
 
 FactoryBot.define do

--- a/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
+
 module Decidim
   module Initiatives
     # A command with all the business logic that creates a new initiative.

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/initiatives/seeds"
-
 Decidim.register_participatory_space(:initiatives) do |participatory_space|
   participatory_space.icon = "media/images/decidim_initiatives.svg"
   participatory_space.stylesheet = "decidim/initiatives/initiatives"
@@ -49,6 +47,8 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
   end
 
   participatory_space.seeds do
+    require "decidim/initiatives/seeds"
+
     Decidim::Initiatives::Seeds.new.call
   end
 end

--- a/decidim-initiatives/lib/decidim/initiatives/seeds.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/seeds.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
 require "decidim/seeds"
 
 module Decidim

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/meetings/seeds"
-
 Decidim.register_component(:meetings) do |component|
   component.engine = Decidim::Meetings::Engine
   component.admin_engine = Decidim::Meetings::AdminEngine
@@ -98,6 +96,8 @@ Decidim.register_component(:meetings) do |component|
   end
 
   component.seeds do |participatory_space|
+    require "decidim/meetings/seeds"
+
     Decidim::Meetings::Seeds.new(participatory_space:).call
   end
 end

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
 require "decidim/core/test/factories"
 require "decidim/forms/test/factories"
 require "decidim/participatory_processes/test/factories"

--- a/decidim-pages/lib/decidim/pages/component.rb
+++ b/decidim-pages/lib/decidim/pages/component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/pages/seeds"
-
 Decidim.register_component(:pages) do |component|
   component.engine = Decidim::Pages::Engine
   component.admin_engine = Decidim::Pages::AdminEngine
@@ -52,6 +50,8 @@ Decidim.register_component(:pages) do |component|
   end
 
   component.seeds do |participatory_space|
+    require "decidim/pages/seeds"
+
     Decidim::Pages::Seeds.new(participatory_space:).call
   end
 end

--- a/decidim-pages/spec/factories.rb
+++ b/decidim-pages/spec/factories.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
 require "decidim/core/test/factories"
 require "decidim/participatory_processes/test/factories"
 

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/participatory_processes/seeds"
-
 Decidim.register_participatory_space(:participatory_processes) do |participatory_space|
   participatory_space.icon = "media/images/decidim_participatory_processes.svg"
   participatory_space.model_class_name = "Decidim::ParticipatoryProcess"
@@ -59,6 +57,8 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
   end
 
   participatory_space.seeds do
+    require "decidim/participatory_processes/seeds"
+
     Decidim::ParticipatoryProcesses::Seeds.new.call
   end
 end

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/proposals/seeds"
 require "decidim/meetings"
 
 Decidim.register_component(:proposals) do |component|
@@ -198,6 +197,8 @@ Decidim.register_component(:proposals) do |component|
   end
 
   component.seeds do |participatory_space|
+    require "decidim/proposals/seeds"
+
     Decidim::Proposals::Seeds.new(participatory_space:).call
   end
 end

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
 require "decidim/core/test/factories"
 require "decidim/participatory_processes/test/factories"
 require "decidim/meetings/test/factories"

--- a/decidim-sortitions/lib/decidim/sortitions/component.rb
+++ b/decidim-sortitions/lib/decidim/sortitions/component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/sortitions/seeds"
-
 Decidim.register_component(:sortitions) do |component|
   component.engine = Decidim::Sortitions::Engine
   component.admin_engine = Decidim::Sortitions::AdminEngine
@@ -36,6 +34,8 @@ Decidim.register_component(:sortitions) do |component|
   end
 
   component.seeds do |participatory_space|
+    require "decidim/sortitions/seeds"
+
     Decidim::Sortitions::Seeds.new(participatory_space:).call
   end
 end

--- a/decidim-sortitions/lib/decidim/sortitions/test/factories.rb
+++ b/decidim-sortitions/lib/decidim/sortitions/test/factories.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
 require "decidim/faker/localized"
 require "decidim/core/test/factories"
 require "decidim/participatory_processes/test/factories"

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/surveys/seeds"
-
 Decidim.register_component(:surveys) do |component|
   component.engine = Decidim::Surveys::Engine
   component.admin_engine = Decidim::Surveys::AdminEngine
@@ -86,6 +84,8 @@ Decidim.register_component(:surveys) do |component|
   end
 
   component.seeds do |participatory_space|
+    require "decidim/surveys/seeds"
+
     Decidim::Surveys::Seeds.new(participatory_space:).call
   end
 end

--- a/decidim-surveys/lib/decidim/surveys/test/factories.rb
+++ b/decidim-surveys/lib/decidim/surveys/test/factories.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "decidim/components/namer"
 require "decidim/core/test/factories"
 require "decidim/forms/test/factories"
 require "decidim/participatory_processes/test/factories"


### PR DESCRIPTION
#### :tophat: What? Why?

I've messed up some requires and generated a problem with production. 

It's really well explained by @microstudi in [this comment](https://github.com/decidim/decidim/pull/11968#issuecomment-1816117461).

Then @alecslupu made a way of solving this, but it generates a mini pain-point, where developers using the seed classes would need to do the requires for themselves and I don't like that, as it's not comfortable. See [my comment with the explanation](https://github.com/decidim/decidim/pull/12026#issuecomment-1817486982).

This PR implements an alternative way of solving it, by only kicking in these requirements when we're actually seeding the database.

#### :pushpin: Related Issues

- Related to #11968 
- Related to #12026

#### Testing

1. Create the development application 
2. Comment Gemfile and run `bundle clean --force` ( this will clean all the gems in your system !!!)
3. run `BUNDLE_WITHOUT="development:test" bundle install`
4. run `RAILS_ENV=production BUNDLE_WITHOUT="development:test" bundle exec rails assets:precompile`
5. See error 
6. Apply patch 
7. repeat 3 + 4 
8. See there is no error 

:hearts: Thank you!
