### PR TITLE
Fix issues in "Verify your identity"

### DIFF
--- a/decidim-verifications/app/views/decidim/verifications/authorizations/first_login.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/first_login.html.erb
@@ -2,14 +2,20 @@
   <h1 class="title-decorator inline-block text-left mb-12">
     <%= t("decidim.verifications.authorizations.first_login.title") %>
   </h1>
-  <p class="text-lg text-gray-2">
+  <p class="text-lg text-gray-2 text-left">
     <%= t("decidim.verifications.authorizations.first_login.verify_with_these_options") %>
   </p>
 </div>
 
 <div class="space-y-4">
-  <% unauthorized_methods.each do |unauthorized_method| %>
-    <%= link_to t("decidim.verifications.authorizations.first_login.actions.#{unauthorized_method.key}"), unauthorized_method.root_path, class: "block text-secondary" %>
-  <% end %>
+  <ul class="space-y-4">
+    <% unauthorized_methods.each do |unauthorized_method| %>
+      <li>
+        <%= link_to t("decidim.verifications.authorizations.first_login.actions.#{unauthorized_method.key}"),
+                    unauthorized_method.root_path,
+                    class: "button button__sm button__transparent-secondary" %>
+      </li>
+    <% end %>
+  </ul>
   <p class="prose prose-a:text-secondary"><%= t("decidim.verifications.authorizations.skip_verification", link: link_to(t("decidim.verifications.authorizations.start_exploring"), cta_button_path).html_safe).html_safe %>.</p>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?

There are some complains in the page that a newly registered participant sees after creating its account and when there are multiple verification methods enabled (http://localhost:3000/authorizations/first_login?locale=en):

1. The flash alert is too bold (this has been fixed already in another PR)
2. The first paragraph is centered, it should be aligned in the left
3. The list of links is too plain 
4. And it can confuse people with the last link ("start exploring") that should be different

This PR fixes this page.

#### :pushpin: Related Issues
 
- Fixes #11267 

#### Testing

1. Sign in
2. Go to http://localhost:3000/authorizations/first_login?locale=en 

### :camera: Screenshots
 
![Screenshot of the fixed page](https://github.com/decidim/decidim/assets/717367/5fe4cbd7-7649-446a-945c-8ec32eb71c43)

:hearts: Thank you!
