### PR TITLE
Show error message when there are no budgets nor projects in budgets

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/budgets/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/budgets/index.html.erb
@@ -9,6 +9,10 @@
 <%= render layout: "layouts/decidim/shared/layout_two_col" do %>
   <%= render partial: "decidim/shared/component_announcement" %>
 
+  <% if current_workflow.budgets.empty? %>
+    <%= cell("decidim/announcement", t("empty", scope: "decidim.budgets.budgets_list")) %>
+  <% end %>
+
   <section class="layout-main__section">
     <%= cell("decidim/budgets/budgets_header", current_workflow) %>
   </section>

--- a/decidim-budgets/app/views/decidim/budgets/budgets/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/budgets/index.html.erb
@@ -1,3 +1,4 @@
+<% add_decidim_page_title component_name %>
 <%= append_javascript_pack_tag "decidim_budgets" %>
 <%= append_stylesheet_pack_tag "decidim_budgets", media: "all" %>
 

--- a/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
@@ -1,4 +1,4 @@
-
+<% add_decidim_page_title t("decidim.budgets.projects.projects_for", name: translated_attribute(budget.title)) %>
 <%= append_javascript_pack_tag "decidim_budgets" %>
 <%= append_stylesheet_pack_tag "decidim_budgets" %>
 

--- a/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
@@ -14,49 +14,53 @@
 <% end %>
 
 <%= render layout: "layouts/decidim/shared/layout_two_col" do %>
-  <%= render partial: "exit_modal" %>
-  <%= render partial: "budget_excess" %>
-  <%= render partial: "budget_confirm" %>
+  <% if projects.any? %>
+    <%= render partial: "exit_modal" %>
+    <%= render partial: "budget_excess" %>
+    <%= render partial: "budget_confirm" %>
 
-  <% unless voting_finished? %>
-    <div class="budget-summary__container">
-      <%= render partial: "budget_summary", locals: { include_heading: true, project_item: false, responsive: false } %>
-    </div>
-  <% end %>
+    <% unless voting_finished? %>
+      <div class="budget-summary__container">
+        <%= render partial: "budget_summary", locals: { include_heading: true, project_item: false, responsive: false } %>
+      </div>
+    <% end %>
 
-  <% if Decidim::Map.available?(:geocoding, :dynamic) && component_settings.geocoding_enabled? %>
-    <div class="budget-list__map">
-      <%= dynamic_map_for projects_data_for_map(all_geocoded_projects) do %>
-        <template id="marker-popup">
-          <div class="space-y-6">
-            <a href="${link}" class="card__list">
-              <div class="card__list-content">
-                <h3 class="h4 card__list-title">${title}</h3>
-                <div class="card__list-metadata">
-                  {{each JSON.parse(items)}}
-                    <span>{{html icon}}{{html text}}</span>
-                  {{/each}}
+    <% if Decidim::Map.available?(:geocoding, :dynamic) && component_settings.geocoding_enabled? %>
+      <div class="budget-list__map">
+        <%= dynamic_map_for projects_data_for_map(all_geocoded_projects) do %>
+          <template id="marker-popup">
+            <div class="space-y-6">
+              <a href="${link}" class="card__list">
+                <div class="card__list-content">
+                  <h3 class="h4 card__list-title">${title}</h3>
+                  <div class="card__list-metadata">
+                    {{each JSON.parse(items)}}
+                      <span>{{html icon}}{{html text}}</span>
+                    {{/each}}
+                  </div>
                 </div>
-              </div>
-            </a>
-          </div>
-        </template>
-      <% end %>
-    </div>
-  <% end %>
+              </a>
+            </div>
+          </template>
+        <% end %>
+      </div>
+    <% end %>
 
-  <%= cell("decidim/budgets/limit_announcement", budget) %>
+    <%= cell("decidim/budgets/limit_announcement", budget) %>
 
-  <% unless voting_finished? %>
-    <section class="layout-main__section">
-      <span class="text-xl font-semibold">
-        <%= t("select_projects", scope: "decidim.budgets.projects") %>
-      </span>
+    <% unless voting_finished? %>
+      <section class="layout-main__section">
+        <span class="text-xl font-semibold">
+          <%= t("select_projects", scope: "decidim.budgets.projects") %>
+        </span>
+      </section>
+    <% end %>
+
+    <section id="projects" class="layout-main__section layout-main__heading">
+      <%= render partial: "projects" %>
     </section>
+  <% else %>
+    <%= cell("decidim/announcement", t("empty", scope: "decidim.budgets.projects")) %>
   <% end %>
-
-  <section id="projects" class="layout-main__section layout-main__heading">
-    <%= render partial: "projects" %>
-  </section>
 
 <% end %>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -178,6 +178,7 @@ en:
         count:
           one: "%{count} budget"
           other: "%{count} budgets"
+        empty: There are no budgets yet
         finished_message: You have finished the voting process. Thanks for participating!
         highlighted_cta: Vote on %{name}
         if_change_opinion: If you have changed your mind, you can

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -237,6 +237,7 @@ en:
           projects_count:
             one: 1 project
             other: "%{count} projects"
+        empty: There are no projects yet
         exit_modal:
           cancel: Return to voting
           exit: Exit voting

--- a/decidim-budgets/spec/system/explore_budgets_spec.rb
+++ b/decidim-budgets/spec/system/explore_budgets_spec.rb
@@ -29,7 +29,7 @@ describe "Explore Budgets", :slow do
     it "redirects to the only budget details" do
       visit_component
 
-      expect(page).to have_content("More information")
+      expect(page).to have_content("Projects for #{translated(budgets.first.title)}")
     end
   end
 

--- a/decidim-budgets/spec/system/explore_budgets_spec.rb
+++ b/decidim-budgets/spec/system/explore_budgets_spec.rb
@@ -15,6 +15,14 @@ describe "Explore Budgets", :slow do
            participatory_space: participatory_process)
   end
 
+  context "with no budgets" do
+    it "shows an empty page with a message" do
+      visit_component
+
+      expect(page).to have_content("There are no budgets yet")
+    end
+  end
+
   context "with only one budget" do
     let!(:budgets) { create_list(:budget, 1, component:) }
 

--- a/decidim-budgets/spec/system/explore_projects_spec.rb
+++ b/decidim-budgets/spec/system/explore_projects_spec.rb
@@ -26,6 +26,17 @@ describe "Explore projects", :slow do
   end
 
   describe "index" do
+    context "when there are no projects" do
+      let!(:projects) { nil }
+      let(:project) { nil }
+
+      it "shows an empty page with a message" do
+        visit_budget
+
+        expect(page).to have_content("There are no projects yet")
+      end
+    end
+
     it "shows all resources for the given component" do
       visit_budget
       within "#projects" do


### PR DESCRIPTION
#### :tophat: What? Why?

When there are no budgets in budgets, we don't show any message, just a blank page. On this case as budgets can have projects, we also add the announcement in this page too. 

This PR changes it to show a message.

I've found about this error while reviewing #11480. 

#### :pushpin: Related Issues
 
- Related to #11875

#### Testing

1. Create a new process 
2. Create a budgets component
3. Click in the "Preview" icon in the admin's component page
4. See the page
5. Go back to the admin
6. Go to the "Manage budgets" page
7. Create a New budget
3. Click in the "Preview" icon in the admin's manage budgets page
4. See the page

### :camera: Screenshots

![Screenshot of the no budgets page in budgets module](https://github.com/decidim/decidim/assets/717367/01df9113-3591-45ad-9ce8-263117920f74)
 
![Screenshot of the no projects page in budgets module](https://github.com/decidim/decidim/assets/717367/062aa5e4-eda8-495d-8158-20c2576788f5)

:hearts: Thank you!