### PR TITLE
Fix filter by scope on search page

### DIFF
--- a/decidim-core/app/commands/decidim/search.rb
+++ b/decidim-core/app/commands/decidim/search.rb
@@ -3,7 +3,7 @@
 module Decidim
   # A command that will act as a search service, with all the business logic for performing searches.
   class Search < Decidim::Command
-    ACCEPTED_FILTERS = [:decidim_scope_id_eq].freeze
+    ACCEPTED_FILTERS = [:decidim_scope_id_in].freeze
     HIGHLIGHTED_RESULTS_COUNT = 4
 
     # Public: Initializes the command.

--- a/decidim-core/app/controllers/decidim/searches_controller.rb
+++ b/decidim-core/app/controllers/decidim/searches_controller.rb
@@ -26,7 +26,7 @@ module Decidim
         term: params[:term],
         with_resource_type: nil,
         with_space_state: nil,
-        decidim_scope_id_eq: nil
+        decidim_scope_id_in: nil
       }
     end
 

--- a/decidim-core/app/views/decidim/searches/_filters.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters.html.erb
@@ -12,8 +12,10 @@
 <%= render partial: "resources_filter_block", locals: { sections: @sections, types: Decidim::Searchable.searchable_resources_of_type_comment } %>
 <div class="card card--secondary">
   <%= filter_form_for filter do |form| %>
-    <%= scopes_picker_filter form, :decidim_scope_id_eq %>
+    <%= scopes_picker_filter form, :decidim_scope_id_in %>
     <%= form.hidden_field :term %>
+    <%= form.hidden_field :with_space_state %>
+    <%= form.hidden_field :with_resource_type %>
   <% end %>
 </div>
 <div class="row collapse order-by">

--- a/decidim-core/spec/commands/decidim/search_spec.rb
+++ b/decidim-core/spec/commands/decidim/search_spec.rb
@@ -283,7 +283,7 @@ describe Decidim::Search do
 
       context "when scope is setted" do
         it "only return resources in the given scope" do
-          described_class.call(term, current_organization, "decidim_scope_id_eq" => scope.id.to_s) do
+          described_class.call(term, current_organization, "decidim_scope_id_in" => [scope.id.to_s]) do
             on(:ok) do |results_by_type|
               results = results_by_type["Decidim::DummyResources::DummyResource"]
               expect(results[:count]).to eq 1
@@ -296,7 +296,7 @@ describe Decidim::Search do
 
       context "when scope is blank" do
         it "does not apply scope filter" do
-          described_class.call(term, current_organization, "decidim_scope_id_eq" => "") do
+          described_class.call(term, current_organization, "decidim_scope_id_in" => nil) do
             on(:ok) do |results_by_type|
               results = results_by_type["Decidim::DummyResources::DummyResource"]
               expect(results[:results]).not_to be_empty

--- a/decidim-core/spec/controllers/decidim/searches_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/searches_controller_spec.rb
@@ -61,9 +61,9 @@ module Decidim
       before { allow(Decidim::Search).to receive(:call) }
 
       it "takes the scope filter into account" do
-        expect(Decidim::Search).to receive(:call).with(any_args, hash_including(decidim_scope_id_eq: scope_id), a_kind_of(Hash))
+        expect(Decidim::Search).to receive(:call).with(any_args, hash_including(decidim_scope_id_in: [scope_id]), a_kind_of(Hash))
 
-        get :index, params: { term: "Blues", "filter[decidim_scope_id_eq]" => scope_id }
+        get :index, params: { term: "Blues", "filter[decidim_scope_id_in]" => [scope_id] }
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Fix the error raised when filtering by scope on the search page. The scope filter has been removed on the redesign, that's why this PR targets the `release/0.27-stable` branch instead of `develop`.

This error raises because we are using the ransack `_eq` filter instead of the `_in` using an array as input. In the front end, we use the `scopes_picker_filter` helper to render the scope multi-picker, and it produces an array argument instead of a single value. That's why I have changed the ransack filter in this PR.

IMO, we should remove the references to the scope filter in the search controller and command in the `develop` branch, as we are no longer using it since the redesign was merged.

#### :pushpin: Related Issues

- Fixes #12023

#### Testing

1. Go to the search bar and find by text
2. Scroll down and filter by scope
3. See it filters by scope

### :camera: Screenshots

https://github.com/decidim/decidim/assets/6973564/f4bf2a99-174c-48ee-828f-67a51e80ecdf

:hearts: Thank you!
