### PR TITLE
Show message when there are no debates

### DIFF
--- a/decidim-debates/app/views/decidim/debates/debates/_debates.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_debates.html.erb
@@ -1,9 +1,13 @@
-<h2 class="h5 md:h3 decorator"><%= t("debates_count", scope: "decidim.debates.debates.count", count: paginated_debates.total_count) %></h2>
+<% if debates.empty? %>
+  <%= cell("decidim/announcement", params[:filter].present? ? t(".empty_filters") : t(".empty")) %>
+<% else %>
+  <h2 class="h5 md:h3 decorator"><%= t("debates_count", scope: "decidim.debates.debates.count", count: paginated_debates.total_count) %></h2>
 
-<%= order_selector available_orders, i18n_scope: "decidim.debates.debates.orders" %>
+  <%= order_selector available_orders, i18n_scope: "decidim.debates.debates.orders" %>
 
-<div class="card__list-list">
-  <%= render paginated_debates %>
-</div>
+  <div class="card__list-list">
+    <%= render paginated_debates %>
+  </div>
 
-<%= decidim_paginate paginated_debates %>
+  <%= decidim_paginate paginated_debates %>
+<% end %>

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -104,6 +104,9 @@ en:
         create:
           invalid: There was a problem creating the debate.
           success: Debate successfully created.
+        debates:
+          empty: There are no debates yet.
+          empty_filters: There are no debates with this criteria.
         edit:
           back: Back
           save: Save changes

--- a/decidim-debates/spec/system/explore_debates_spec.rb
+++ b/decidim-debates/spec/system/explore_debates_spec.rb
@@ -43,6 +43,32 @@ describe "Explore debates" do
       end
     end
 
+    context "when there are no debates" do
+      let(:debates) { nil }
+
+      it "shows an empty page with a message" do
+        visit_component
+
+        within "main.layout-2col__main" do
+          expect(page).to have_content "There are no debates yet"
+        end
+      end
+
+      context "when filtering by scope" do
+        it "shows an empty page with a message" do
+          visit_component
+
+          within "#panel-dropdown-menu-category" do
+            check category.name[I18n.locale.to_s]
+          end
+
+          within "main.layout-2col__main" do
+            expect(page).to have_content("There are no debates with this criteria")
+          end
+        end
+      end
+    end
+
     context "when there are a lot of debates" do
       let!(:debates) do
         create_list(:debate, Decidim::Paginable::OPTIONS.first + 5, component:)


### PR DESCRIPTION
#### :tophat: What? Why?

When there are no debates in debates, we don't show any message, just a blank page.

This PR changes it to show a message.

I've found about this error while reviewing #11480. 

#### :pushpin: Related Issues
 
- Related to #11875

#### Testing

1. Create a new process 
2. Create a debates component
3. Click in the "Preview" icon in the admin's component page
4. See the page


### :camera: Screenshots

![Screenshot of the no debates page in debates module](https://github.com/decidim/decidim/assets/717367/b241624a-c677-4b9e-8e0c-0c5f01567a82)


:hearts: Thank you!