### PR TITLE
Remove unused scope filter from search controller and command

### DIFF
--- a/decidim-core/app/commands/decidim/search.rb
+++ b/decidim-core/app/commands/decidim/search.rb
@@ -3,7 +3,6 @@
 module Decidim
   # A command that will act as a search service, with all the business logic for performing searches.
   class Search < Decidim::Command
-    ACCEPTED_FILTERS = [:decidim_scope_id_eq].freeze
     HIGHLIGHTED_RESULTS_COUNT = 4
 
     # Public: Initializes the command.
@@ -56,12 +55,6 @@ module Decidim
       collection.page(page_params[:page]).per(page_params[:per_page])
     end
 
-    def clean_filters
-      @clean_filters ||= filters.select do |attribute_name, value|
-        ACCEPTED_FILTERS.include?(attribute_name.to_sym) && value.present?
-      end.compact
-    end
-
     def spaces_to_filter
       return nil if filters[:with_space_state].blank?
 
@@ -91,7 +84,6 @@ module Decidim
       if (spaces = spaces_to_filter)
         query = query.where(decidim_participatory_space: spaces)
       end
-      query = query.ransack(clean_filters).result if clean_filters.any?
 
       query = query.order("datetime DESC")
       query = query.global_search(I18n.transliterate(term)) if term.present?

--- a/decidim-core/app/controllers/decidim/searches_controller.rb
+++ b/decidim-core/app/controllers/decidim/searches_controller.rb
@@ -31,8 +31,7 @@ module Decidim
       {
         term: params[:term],
         with_resource_type: nil,
-        with_space_state: nil,
-        decidim_scope_id_eq: nil
+        with_space_state: nil
       }
     end
 

--- a/decidim-core/spec/commands/decidim/search_spec.rb
+++ b/decidim-core/spec/commands/decidim/search_spec.rb
@@ -270,42 +270,6 @@ describe Decidim::Search do
       end
     end
 
-    context "with scope" do
-      let!(:scoped_resource) do
-        create(:searchable_resource, organization: current_organization, scope:, content_a: "Where is your crown king nothing?")
-      end
-
-      before do
-        create(:searchable_resource, organization: current_organization, content_a: "Where is your crown king nothing?")
-      end
-
-      context "when scope is setted" do
-        it "only return resources in the given scope" do
-          described_class.call(term, current_organization, "decidim_scope_id_eq" => scope.id.to_s) do
-            on(:ok) do |results_by_type|
-              results = results_by_type["Decidim::DummyResources::DummyResource"]
-              expect(results[:count]).to eq 1
-              expect(results[:results]).to eq [scoped_resource.resource]
-            end
-            on(:invalid) { raise("Should not happen") }
-          end
-        end
-      end
-
-      context "when scope is blank" do
-        it "does not apply scope filter" do
-          described_class.call(term, current_organization, "decidim_scope_id_eq" => "") do
-            on(:ok) do |results_by_type|
-              results = results_by_type["Decidim::DummyResources::DummyResource"]
-              expect(results[:results]).not_to be_empty
-              expect(results[:count]).to eq 2
-            end
-            on(:invalid) { raise("Should not happen") }
-          end
-        end
-      end
-    end
-
     describe "with space state" do
       let!(:active) do
         create(

--- a/decidim-core/spec/controllers/decidim/searches_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/searches_controller_spec.rb
@@ -54,19 +54,6 @@ module Decidim
       end
     end
 
-    context "when applying scope filter" do
-      let(:search) { instance_dobule(Decidim::Search) }
-      let(:scope_id) { "SomeScopeId" }
-
-      before { allow(Decidim::Search).to receive(:call) }
-
-      it "takes the scope filter into account" do
-        expect(Decidim::Search).to receive(:call).with(any_args, hash_including(decidim_scope_id_eq: scope_id), a_kind_of(Hash))
-
-        get :index, params: { term: "Blues", "filter[decidim_scope_id_eq]" => scope_id }
-      end
-    end
-
     context "when applying space state filter" do
       let(:search) { instance_dobule(Decidim::Search) }
       let(:space_state) { "SpaceState" }


### PR DESCRIPTION
#### :tophat: What? Why?

As mentioned in the related issue (with the redesign already merged) we no longer filter by scope on the search page. In this PR I remove the unused code.

#### :pushpin: Related Issues

- Related to #12036

:hearts: Thank you!
