### PR TITLE
Apply flash styles to Announcements (part 2)

### DIFF
--- a/decidim-admin/app/cells/decidim/admin/attachments_privacy_warning/show.erb
+++ b/decidim-admin/app/cells/decidim/admin/attachments_privacy_warning/show.erb
@@ -1,3 +1,3 @@
 <% if private_space? && !(transparent_space?) %>
-  <div class="callout warning"><%= t("decidim.admin.attachments_privacy_warning.message") %></div>
+  <%= cell("decidim/announcement", t("decidim.admin.attachments_privacy_warning.message"), callout_class: "warning") %>
 <% end %>

--- a/decidim-comments/app/cells/decidim/comments/comments/blocked_comments_warning.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/blocked_comments_warning.erb
@@ -1,3 +1,1 @@
-<div class="callout warning">
-  <p><%= t("decidim.components.comments.blocked_comments_warning") %></p>
-</div>
+<%= cell("decidim/announcement", t("decidim.components.comments.blocked_comments_warning"), callout_class: "warning") %>

--- a/decidim-comments/app/cells/decidim/comments/comments/comments_loading.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/comments_loading.erb
@@ -1,3 +1,1 @@
-<div class="callout primary loading-comments mb-4">
-  <p><%= t("decidim.components.comments.loading") %></p>
-</div>
+<%= cell("decidim/announcement", t("decidim.components.comments.loading"), callout_class: "primary loading-comments mb-4") %>

--- a/decidim-comments/app/cells/decidim/comments/comments/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/show.erb
@@ -25,8 +25,6 @@
       <%= add_comment %>
       <%= user_comments_blocked_warning %>
     </div>
-    <div class="callout primary loading-comments hidden">
-      <p><%= t("decidim.components.comments.loading") %></p>
-    </div>
+    <%= cell("decidim/announcement", t("decidim.components.comments.loading"), callout_class: "primary loading-comments hidden") %>
   </div>
 <% end %>

--- a/decidim-comments/app/cells/decidim/comments/comments/single_comment_warning.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/single_comment_warning.erb
@@ -1,9 +1,6 @@
-<div class="callout secondary">
-  <h5><%= t("decidim.components.comments.single_comment_warning_title") %></h5>
-  <p>
-    <%== t(
-    "decidim.components.comments.single_comment_warning",
-    url: "#{commentable_path}##{node_id}"
-    ) %>
-  </p>
-</div>
+<%= cell("decidim/announcement", {
+           title: t("decidim.components.comments.single_comment_warning_title"),
+           body: t("decidim.components.comments.single_comment_warning", url: "#{commentable_path}##{node_id}")
+         },
+         callout_class: "secondary"
+) %>

--- a/decidim-comments/app/cells/decidim/comments/comments/user_comments_blocked_warning.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/user_comments_blocked_warning.erb
@@ -1,4 +1,10 @@
-<%= cell("decidim/announcement", comment_permissions? ?
-                                blocked_comments_for_unauthorized_user_warning_link :
-                                t("decidim.components.comments.blocked_comments_for_user_warning"),
-         callout_class: "warning") %>
+<%# We cannot use the AnnouncementCell directly here as the link is escaped and it would not work %>
+<div class="flash warning" data-announcement="">
+  <span class="flash__message">
+    <% if comment_permissions? %>
+      <p><%= blocked_comments_for_unauthorized_user_warning_link %></p>
+    <% else %>
+      <p><%= t("decidim.components.comments.blocked_comments_for_user_warning") %></p>
+    <% end %>
+  </span>
+</div>

--- a/decidim-comments/app/cells/decidim/comments/comments/user_comments_blocked_warning.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/user_comments_blocked_warning.erb
@@ -1,7 +1,4 @@
-<div class="callout warning">
-  <% if comment_permissions? %>
-    <p><%= blocked_comments_for_unauthorized_user_warning_link %></p>
-  <% else %>
-    <p><%= t("decidim.components.comments.blocked_comments_for_user_warning") %></p>
-  <% end %>
-</div>
+<%= cell("decidim/announcement", comment_permissions? ?
+                                blocked_comments_for_unauthorized_user_warning_link :
+                                t("decidim.components.comments.blocked_comments_for_user_warning"),
+         callout_class: "warning") %>

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
@@ -343,8 +343,10 @@ describe("CommentsComponent", () => {
               </div>
               ${generateCommentForm("Dummy", 123)}
             </div>
-            <div class="callout primary loading-comments hidden">
-              <p>Loading comments ...</p>
+            <div class="flash primary loading-comments hidden">
+              <span class="flash__message">
+                Loading comments ...
+              </span>
             </div>
         </div>
       </div>

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -18,7 +18,7 @@ module Decidim::Comments
     context "when rendering" do
       it "renders the thread" do
         expect(subject).to have_css(".comments-count", text: "1 comment")
-        expect(subject).to have_css(".callout.primary.loading-comments p", text: "Loading comments ...")
+        expect(subject).to have_css(".flash.primary.loading-comments", text: "Loading comments ...")
         expect(subject).not_to have_content(comment.body.values.first)
         expect(subject).to have_css(".add-comment")
         expect(subject).to have_content("Log in with your account or sign up to add your comment.")
@@ -46,8 +46,8 @@ module Decidim::Comments
         end
 
         it "renders the single comment warning" do
-          expect(subject).to have_css(".callout.secondary", text: "You are seeing a single comment")
-          expect(subject).to have_css(".callout.secondary", text: "View all comments")
+          expect(subject).to have_css(".flash.secondary", text: "You are seeing a single comment")
+          expect(subject).to have_css(".flash.secondary", text: "View all comments")
         end
 
         context "with the single comment being moderated" do
@@ -61,14 +61,14 @@ module Decidim::Comments
           end
 
           it "renders the thread" do
-            expect(subject).to have_css(".callout.primary.loading-comments p", text: "Loading comments ...")
+            expect(subject).to have_css(".flash.primary.loading-comments", text: "Loading comments ...")
             expect(subject).not_to have_content(comment.body.values.first)
             expect(subject).not_to have_css(".add-comment")
           end
 
           it "renders the single comment warning" do
-            expect(subject).to have_css(".callout.secondary", text: "You are seeing a single comment")
-            expect(subject).to have_css(".callout.secondary", text: "View all comments")
+            expect(subject).to have_css(".flash.secondary", text: "You are seeing a single comment")
+            expect(subject).to have_css(".flash.secondary", text: "View all comments")
           end
         end
       end
@@ -105,8 +105,8 @@ module Decidim::Comments
           end
 
           it "renders the comments blocked warning" do
-            expect(subject).to have_css(".callout.warning", text: I18n.t("decidim.components.comments.blocked_comments_warning"))
-            expect(subject).not_to have_css(".callout.warning", text: I18n.t("decidim.components.comments.blocked_comments_for_user_warning"))
+            expect(subject).to have_css(".flash.warning", text: I18n.t("decidim.components.comments.blocked_comments_warning"))
+            expect(subject).not_to have_css(".flash.warning", text: I18n.t("decidim.components.comments.blocked_comments_for_user_warning"))
           end
         end
 
@@ -117,8 +117,8 @@ module Decidim::Comments
           end
 
           it "renders the user comments blocked warning" do
-            expect(subject).not_to have_css(".callout.warning", text: I18n.t("decidim.components.comments.blocked_comments_for_unauthorized_user_warning"))
-            expect(subject).to have_css(".callout.warning", text: I18n.t("decidim.components.comments.blocked_comments_for_user_warning"))
+            expect(subject).not_to have_css(".flash.warning", text: I18n.t("decidim.components.comments.blocked_comments_for_unauthorized_user_warning"))
+            expect(subject).to have_css(".flash.warning", text: I18n.t("decidim.components.comments.blocked_comments_for_user_warning"))
           end
         end
 
@@ -142,8 +142,8 @@ module Decidim::Comments
           end
 
           it "renders the user not authorized to comment warning" do
-            expect(subject).to have_css(".callout.warning", text: I18n.t("decidim.components.comments.blocked_comments_for_unauthorized_user_warning"))
-            expect(subject).not_to have_css(".callout.warning", text: I18n.t("decidim.components.comments.blocked_comments_for_user_warning"))
+            expect(subject).to have_css(".flash.warning", text: I18n.t("decidim.components.comments.blocked_comments_for_unauthorized_user_warning"))
+            expect(subject).not_to have_css(".flash.warning", text: I18n.t("decidim.components.comments.blocked_comments_for_user_warning"))
           end
         end
       end

--- a/decidim-core/app/cells/decidim/user_timeline/show.erb
+++ b/decidim-core/app/cells/decidim/user_timeline/show.erb
@@ -1,9 +1,7 @@
 <div class="user-activity">
   <div id="activities" class="columns small-12">
     <% if activities.length == 0 %>
-      <div class="callout warning">
-        <%= t "decidim.user_activity.index.no_activities_warning" %>
-      </div>
+      <%= cell("decidim/announcement", t("decidim.user_activity.index.no_activities_warning"), callout_class: "warning") %>
     <% else %>
       <div class="row">
         <%= cell "decidim/activities", activities %>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_filters/show.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_filters/show.erb
@@ -10,8 +10,7 @@
 </div>
 <% if process_count_by_filter["active"] == 0 && process_count_by_filter["upcoming"] == 0 %>
   <div class="row column">
-    <div class="callout warning mb-sm">
-      <p><%= t("decidim.participatory_processes.participatory_processes.filters.explanations.no_active_nor_upcoming_callout") %></p>
+    <%= cell("decidim/announcement", t("decidim.participatory_processes.participatory_processes.filters.explanations.no_active_nor_upcoming_callout"), callout_class: "warning") %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing the application I found one old callout that I missed on #11708 
I then searched for these same CSS classes (`callout warning`) and found a couple more, so I fixed them too 

#### :pushpin: Related Issues

- Related to #11708

### :camera: Screenshots
 
![Screenshot of a new announcement found](https://github.com/decidim/decidim/assets/717367/422599b7-bc45-463c-89f5-e0ba25bab82f)

:hearts: Thank you!
