### PR TITLE
Fix n+1 query on assemblies permissions

### DIFF
--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
@@ -72,7 +72,7 @@ module Decidim
         private
 
         def collection
-          @collection ||= OrganizationAssemblies.new(current_user.organization).query.includes(:children)
+          @collection ||= AssembliesWithUserRole.new(current_user).query.includes(:children)
         end
 
         def current_assembly

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
@@ -72,7 +72,7 @@ module Decidim
         private
 
         def collection
-          @collection ||= AssembliesWithUserRole.new(current_user).query.includes(:children)
+          @collection ||= OrganizationAssemblies.new(current_user.organization).query
         end
 
         def current_assembly

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
@@ -72,7 +72,7 @@ module Decidim
         private
 
         def collection
-          @collection ||= OrganizationAssemblies.new(current_user.organization).query
+          @collection ||= OrganizationAssemblies.new(current_user.organization).query.includes(:children)
         end
 
         def current_assembly

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -307,11 +307,9 @@ module Decidim
         assembly_user_role.present? ? assembly_user_role.role : :any
       end
 
+      # We are trying to see if the user can manage the current assembly or its children or not.
       def assembly_admin_allowed_assemblies
-        assemblies = AssembliesWithUserRole.for(user, :admin)
-        child_assemblies = assemblies.flat_map { |assembly| [assembly.id] + assembly.children.pluck(:id) }
-
-        Decidim::Assembly.where(id: assemblies + child_assemblies)
+        AssembliesWithUserRole.for(user, :admin).where(id: [assembly.id] + assembly.children.pluck(:id))
       end
     end
   end

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -309,7 +309,7 @@ module Decidim
 
       def assembly_admin_allowed_assemblies
         @assembly_admin_allowed ||= begin
-          assemblies = AssembliesWithUserRole.for(user, :admin).where(id:[ assembly.id, assembly.parent_id])
+          assemblies = AssembliesWithUserRole.for(user, :admin).where(id: [assembly.id, assembly.parent_id])
           child_assemblies = assemblies.flat_map { |assembly| [assembly.id] + assembly.children.pluck(:id) }
 
           Decidim::Assembly.where(id: assemblies + child_assemblies)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR is aiming to optimize the assembly controller, which is misbehaving when there is a big number of assemblies, by scoping a small number of assemblies instead of all each time. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11964

#### Testing
The pipeline should be green on relevant actions.

1. Login as admin and visit admin area 
2. Using the seeds class, generate a big number of assemblies ( you can only create the assembles, not the entire script), we could use ~200 
3. Visit admin area and see how is the interface acting 
4. Apply patch 
5. See improvement

:hearts: Thank you!
