### PR TITLE
Backport 'Don't use a CTA for canceling a registration in a meeting' to v0.27

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/cancel_registration_meeting_button/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/cancel_registration_meeting_button/show.erb
@@ -1,0 +1,10 @@
+<%= render :cancelation_modal %>
+<%= action_authorized_button_to(
+  :join,
+  "#",
+  class: button_classes,
+  data: { "dialog-open": "meeting-cancelation-confirm-#{model.id}" }
+) do %>
+  <%= t("leave", scope: "decidim.meetings.meetings.show") %>
+  <%= icon icon_name %>
+<% end %>

--- a/decidim-meetings/app/cells/decidim/meetings/cancel_registration_meeting_button/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/cancel_registration_meeting_button/show.erb
@@ -1,10 +1,13 @@
-<%= render :cancelation_modal %>
-<%= action_authorized_button_to(
-  :join,
-  "#",
-  class: button_classes,
-  data: { "dialog-open": "meeting-cancelation-confirm-#{model.id}" }
-) do %>
-  <%= t("leave", scope: "decidim.meetings.meetings.show") %>
-  <%= icon icon_name %>
-<% end %>
+<div class="text-center">
+  <%= action_authorized_link_to(
+    :join,
+    meeting_registration_path(model),
+    resource: model,
+    method: :delete,
+    class: button_classes,
+    data: { disable: true, confirm: t("leave_confirmation", scope: "decidim.meetings.meetings.show") }
+  ) do %>
+    <%= t("leave", scope: "decidim.meetings.meetings.show") %>
+    <%= icon icon_name %>
+  <% end %>
+</div>

--- a/decidim-meetings/app/cells/decidim/meetings/cancel_registration_meeting_button_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/cancel_registration_meeting_button_cell.rb
@@ -21,11 +21,11 @@ module Decidim
       end
 
       def button_classes
-        "button button__sm button__text-secondary"
+        ""
       end
 
       def icon_name
-        "calendar-close-line"
+        "circle-x"
       end
 
       def registration_form

--- a/decidim-meetings/app/cells/decidim/meetings/cancel_registration_meeting_button_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/cancel_registration_meeting_button_cell.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    # This cell renders the button to cancel a meeting registation.
+    class CancelRegistrationMeetingButtonCell < Decidim::ViewModel
+      include Decidim::IconHelper
+      include MeetingCellsHelper
+
+      def show
+        return unless model.can_be_joined_by?(current_user)
+        return unless model.has_registration_for?(current_user)
+
+        render
+      end
+
+      private
+
+      def current_component
+        model.component
+      end
+
+      def button_classes
+        "button button__sm button__text-secondary"
+      end
+
+      def icon_name
+        "calendar-close-line"
+      end
+
+      def registration_form
+        @registration_form ||= Decidim::Meetings::JoinMeetingForm.new
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/cells/decidim/meetings/join_meeting_button/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/join_meeting_button/show.erb
@@ -1,22 +1,24 @@
 <% if model.can_be_joined_by?(current_user) %>
-  <% if model.registration_form_enabled? %>
-    <%= action_authorized_link_to(
-      :join,
-      i18n_join_text,
-      join_meeting_registration_path(model),
-      class: button_classes,
-      disabled: !model.has_available_slots?,
-    ) %>
-  <% else %>
-    <%= render :registration_confirm %>
-    <%= action_authorized_button_to(
-      :join,
-      i18n_join_text,
-      "#",
-      class: button_classes,
-      disabled: !model.has_available_slots?,
-      data: { open: current_user.present? ? "meeting-registration-confirm-#{model.id}" : "loginModal" }
-    ) %>
+  <% unless model.has_registration_for? current_user %>
+    <% if model.registration_form_enabled? %>
+      <%= action_authorized_link_to(
+        :join,
+        i18n_join_text,
+        join_meeting_registration_path(model),
+        class: button_classes,
+        disabled: !model.has_available_slots?,
+      ) %>
+    <% else %>
+      <%= render :registration_confirm %>
+      <%= action_authorized_button_to(
+        :join,
+        i18n_join_text,
+        "#",
+        class: button_classes,
+        disabled: !model.has_available_slots?,
+        data: { open: current_user.present? ? "meeting-registration-confirm-#{model.id}" : "loginModal" }
+      ) %>
+    <% end %>
   <% end %>
   <% if shows_remaining_slots? %>
     <span><%= t("remaining_slots", scope: "decidim.meetings.meetings.show", count: model.remaining_slots) %></span>

--- a/decidim-meetings/app/cells/decidim/meetings/join_meeting_button/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/join_meeting_button/show.erb
@@ -1,38 +1,22 @@
 <% if model.can_be_joined_by?(current_user) %>
-  <% if model.has_registration_for? current_user %>
-    <span>
-      <%= icon("check", class: "icon--small") %>
-      <%= t("going", scope: "decidim.meetings.meetings.show") %>
-    </span>
-    <%= action_authorized_button_to(
+  <% if model.registration_form_enabled? %>
+    <%= action_authorized_link_to(
       :join,
-      t("leave", scope: "decidim.meetings.meetings.show"),
-      meeting_registration_path(model),
-      resource: model,
-      method: :delete,
+      i18n_join_text,
+      join_meeting_registration_path(model),
       class: button_classes,
-      data: { disable: true, confirm: t("leave_confirmation", scope: "decidim.meetings.meetings.show") }
+      disabled: !model.has_available_slots?,
     ) %>
   <% else %>
-    <% if model.registration_form_enabled? %>
-      <%= action_authorized_link_to(
-        :join,
-        i18n_join_text,
-        join_meeting_registration_path(model),
-        class: button_classes,
-        disabled: !model.has_available_slots?,
-      ) %>
-    <% else %>
-      <%= render :registration_confirm %>
-      <%= action_authorized_button_to(
-        :join,
-        i18n_join_text,
-        "#",
-        class: button_classes,
-        disabled: !model.has_available_slots?,
-        data: { open: current_user.present? ? "meeting-registration-confirm-#{model.id}" : "loginModal" }
-      ) %>
-    <% end %>
+    <%= render :registration_confirm %>
+    <%= action_authorized_button_to(
+      :join,
+      i18n_join_text,
+      "#",
+      class: button_classes,
+      disabled: !model.has_available_slots?,
+      data: { open: current_user.present? ? "meeting-registration-confirm-#{model.id}" : "loginModal" }
+    ) %>
   <% end %>
   <% if shows_remaining_slots? %>
     <span><%= t("remaining_slots", scope: "decidim.meetings.meetings.show", count: model.remaining_slots) %></span>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -103,6 +103,7 @@ edit_link(
 
     <%= resource_reference(meeting) %>
     <%= resource_version(meeting, versions_path: meeting_versions_path(meeting)) %>
+    <%= cell "decidim/meetings/cancel_registration_meeting_button", meeting %>
     <%= render partial: "decidim/shared/share_modal" %>
     <%= embed_modal_for meeting_widget_url(meeting, format: :js) %>
     <%= render partial: "calendar_modal", locals: { ics_url: calendar_meeting_url(meeting), google_url: google_calendar_event_url(meeting) } %>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -547,7 +547,6 @@ en:
           date: Date
           edit_close_meeting: Edit meeting report
           edit_meeting: Edit meeting
-          going: You have signed up for this meeting
           join: Join meeting
           leave: Cancel your registration
           leave_confirmation: Are you sure you want to cancel your registration for this meeting?

--- a/decidim-meetings/spec/shared/manage_invites_examples.rb
+++ b/decidim-meetings/spec/shared/manage_invites_examples.rb
@@ -83,7 +83,7 @@ shared_examples "manage invites" do
           end
 
           expect(page).to have_content "successfully"
-          expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
+          expect(page).to have_css("a", text: "Cancel your registration")
         end
 
         it "the invited user sign up into the application and declines the invitation" do
@@ -116,7 +116,7 @@ shared_examples "manage invites" do
 
           visit last_email_link
 
-          expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
+          expect(page).to have_css("a", text: "Cancel your registration")
         end
 
         it "the invited user declines the invitation" do

--- a/decidim-meetings/spec/shared/manage_invites_examples.rb
+++ b/decidim-meetings/spec/shared/manage_invites_examples.rb
@@ -140,7 +140,7 @@ shared_examples "manage invites" do
 
           visit last_email_link
 
-          expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
+          expect(page).to have_css("a", text: "Cancel your registration")
         end
 
         it "the invited user declines the invitation" do

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -190,8 +190,8 @@ describe "Meeting registrations", type: :system do
               expect(page).to have_content("successfully")
             end
 
-            expect(page).to have_text("You have signed up for this meeting")
-            expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
+            expect(page).to have_text("You have joined the meeting")
+            expect(page).to have_css("a", text: "Cancel your registration")
             expect(page).to have_text("19 slots remaining")
             expect(page).to have_text("Stop following")
             expect(page).to have_no_text("ATTENDING PARTICIPANTS")
@@ -214,7 +214,7 @@ describe "Meeting registrations", type: :system do
 
             expect(page).to have_content("successfully")
 
-            expect(page).to have_text("You have signed up for this meeting")
+            expect(page).to have_text("You have joined the meeting")
             expect(page).to have_text("19 slots remaining")
             expect(page).to have_text("Stop following")
             expect(page).to have_text("ATTENDING PARTICIPANTS")
@@ -275,8 +275,8 @@ describe "Meeting registrations", type: :system do
               expect(page).to have_content("successfully")
             end
 
-            expect(page).to have_text("You have signed up for this meeting")
-            expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
+            expect(page).to have_text("You have joined the meeting")
+            expect(page).to have_css("a", text: "Cancel your registration")
             expect(page).to have_text("19 slots remaining")
 
             expect(page).to have_text("ATTENDING ORGANIZATIONS")
@@ -376,7 +376,7 @@ describe "Meeting registrations", type: :system do
       it "shows the confirmation modal when leaving the meeting" do
         visit_meeting
 
-        click_button "Cancel your registration"
+        click_link "Cancel your registration"
 
         within ".confirm-modal-content" do
           expect(page).to have_content("Are you sure you want to cancel your registration for this meeting?")
@@ -386,7 +386,7 @@ describe "Meeting registrations", type: :system do
       it "they can leave the meeting" do
         visit_meeting
 
-        accept_confirm { click_button "Cancel your registration" }
+        accept_confirm { click_link "Cancel your registration" }
 
         within_flash_messages do
           expect(page).to have_content("successfully")

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -243,8 +243,8 @@ describe "Meeting registrations", type: :system do
               expect(page).to have_content("successfully")
             end
 
-            expect(page).to have_text("You have signed up for this meeting")
-            expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
+            expect(page).to have_text("You have joined the meeting successfully")
+            expect(page).to have_css("a", text: "Cancel your registration")
             expect(page).to have_text("19 slots remaining")
             expect(page).to have_text("Stop following")
           end

--- a/decidim-meetings/spec/system/private_meetings_spec.rb
+++ b/decidim-meetings/spec/system/private_meetings_spec.rb
@@ -112,7 +112,7 @@ describe "Private meetings", type: :system do
 
             expect(page).to have_current_path resource_locator(private_meeting).path
             expect(page).to have_content "Private"
-            expect(page).to have_css(".button", text: "CANCEL YOUR REGISTRATION")
+            expect(page).to have_css("a", text: "Cancel your registration")
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12002 to v0.27

:hearts: Thank you!