### PR TITLE
Extract methods from meetings seeds

### DIFF
--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -17,6 +17,18 @@ module Decidim
       @admin_user ||= Decidim::User.find_by(organization:, email: "admin@example.org")
     end
 
+    def random_scope(participatory_space:)
+      if participatory_space.scope
+        scopes = participatory_space.scope.descendants
+        global = participatory_space.scope
+      else
+        scopes = participatory_space.organization.scopes
+        global = nil
+      end
+
+      ::Faker::Boolean.boolean(true_ratio: 0.5) ? global : scopes.sample
+    end
+
     def seeds_root = File.join(__dir__, "..", "..", "db", "seeds")
 
     def hero_image = create_blob!(seeds_file: "city.jpeg", filename: "hero_image.jpeg", content_type: "image/jpeg")

--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -13,6 +13,10 @@ module Decidim
       @organization ||= Decidim::Organization.first
     end
 
+    def admin_user
+      @admin_user ||= Decidim::User.find_by(organization:, email: "admin@example.org")
+    end
+
     def seeds_root = File.join(__dir__, "..", "..", "db", "seeds")
 
     def hero_image = create_blob!(seeds_file: "city.jpeg", filename: "hero_image.jpeg", content_type: "image/jpeg")

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -13,21 +13,7 @@ module Decidim
       end
 
       def call
-        params = {
-          name: Decidim::Components::Namer.new(participatory_space.organization.available_locales, :meetings).i18n_name,
-          published_at: Time.current,
-          manifest_name: :meetings,
-          participatory_space:
-        }
-
-        component = Decidim.traceability.perform_action!(
-          "publish",
-          Decidim::Component,
-          admin_user,
-          visibility: "all"
-        ) do
-          Decidim::Component.create!(params)
-        end
+        component = create_component!
 
         if participatory_space.scope
           scopes = participatory_space.scope.descendants
@@ -181,6 +167,24 @@ module Decidim
             params,
             visibility: "all"
           )
+        end
+      end
+
+      def create_component!
+        params = {
+          name: Decidim::Components::Namer.new(participatory_space.organization.available_locales, :meetings).i18n_name,
+          published_at: Time.current,
+          manifest_name: :meetings,
+          participatory_space:
+        }
+
+        Decidim.traceability.perform_action!(
+          "publish",
+          Decidim::Component,
+          admin_user,
+          visibility: "all"
+        ) do
+          Decidim::Component.create!(params)
         end
       end
     end

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -22,16 +22,7 @@ module Decidim
             create_service!(meeting:)
           end
 
-          Decidim::Forms::Questionnaire.create!(
-            title: Decidim::Faker::Localized.paragraph,
-            description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
-            tos: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 2)
-            end,
-            questionnaire_for: meeting
-          )
+          create_questionnaire_for!(meeting:)
 
           2.times do |n|
             email = "meeting-registered-user-#{meeting.id}-#{n}@example.org"
@@ -185,6 +176,19 @@ module Decidim
           meeting:,
           title: Decidim::Faker::Localized.sentence(word_count: 2),
           description: Decidim::Faker::Localized.sentence(word_count: 5)
+        )
+      end
+
+      def create_questionnaire_for!(meeting:)
+        Decidim::Forms::Questionnaire.create!(
+          title: Decidim::Faker::Localized.paragraph,
+          description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.paragraph(sentence_count: 3)
+          end,
+          tos: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.paragraph(sentence_count: 2)
+          end,
+          questionnaire_for: meeting
         )
       end
     end

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -33,8 +33,8 @@ module Decidim
           create_attachments!(attached_to: meeting)
         end
 
-        create_meeting!(component:, author_type: :user)
-        create_meeting!(component:, author_type: :user_group)
+        create_meeting!(component:, type: [:in_person, :online, :hybrid].sample, author_type: :user)
+        create_meeting!(component:, type: [:in_person, :online, :hybrid].sample, author_type: :user_group)
       end
 
       def create_component!

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -28,10 +28,7 @@ module Decidim
             create_meeting_registration!(meeting:)
           end
 
-          attachment_collection = create_attachment_collection(collection_for: meeting)
-          create_attachment(attached_to: meeting, filename: "Exampledocument.pdf", attachment_collection:)
-          create_attachment(attached_to: meeting, filename: "city.jpeg")
-          create_attachment(attached_to: meeting, filename: "Exampledocument.pdf")
+          create_attachments!(attached_to: meeting)
         end
 
         authors = [

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -16,6 +16,8 @@ module Decidim
         component = create_component!
 
         2.times do
+          create_meeting!(component:, type: :in_person)
+          create_meeting!(component:, type: :hybrid)
           meeting = create_meeting!(component:)
 
           2.times do
@@ -105,30 +107,29 @@ module Decidim
         }
       end
 
-      def create_meeting!(component:)
+      def create_meeting!(component:, type: :in_person)
         params = meeting_params(component:)
 
-        _hybrid_meeting = Decidim.traceability.create!(
-          Decidim::Meetings::Meeting,
-          admin_user,
-          params.merge(
-            title: Decidim::Faker::Localized.sentence(word_count: 2),
-            type_of_meeting: :hybrid,
-            online_meeting_url: "http://example.org"
-          ),
-          visibility: "all"
-        )
-
-        _online_meeting = Decidim.traceability.create!(
-          Decidim::Meetings::Meeting,
-          admin_user,
-          params.merge(
-            title: Decidim::Faker::Localized.sentence(word_count: 2),
-            type_of_meeting: :online,
-            online_meeting_url: "http://example.org"
-          ),
-          visibility: "all"
-        )
+        params = case type
+                 when :hybrid
+                   params.merge(
+                     title: Decidim::Faker::Localized.sentence(word_count: 2),
+                     type_of_meeting: :hybrid,
+                     online_meeting_url: "http://example.org"
+                   )
+                 when :online
+                   params.merge(
+                     location: nil,
+                     location_hints: nil,
+                     latitude: nil,
+                     longitude: nil,
+                     title: Decidim::Faker::Localized.sentence(word_count: 2),
+                     type_of_meeting: :online,
+                     online_meeting_url: "http://example.org"
+                   )
+                 else
+                   params
+                 end
 
         Decidim.traceability.create!(
           Decidim::Meetings::Meeting,

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -160,9 +160,9 @@ module Decidim
       end
 
       def create_meeting_registration!(meeting:)
-        n = rand(2)
-        email = "meeting-registered-user-#{meeting.id}-#{n}@example.org"
-        name = "#{::Faker::Name.name} #{meeting.id} #{n}"
+        r = SecureRandom.hex(4)
+        email = "meeting-registered-user-#{meeting.id}-#{r}@example.org"
+        name = "#{::Faker::Name.name} #{meeting.id} #{r}"
         user = Decidim::User.find_or_initialize_by(email:)
 
         user.update!(

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -16,60 +16,7 @@ module Decidim
         component = create_component!
 
         2.times do
-          start_time = ::Faker::Date.between(from: 20.weeks.ago, to: 20.weeks.from_now)
-          end_time = start_time + [rand(1..4).hours, rand(1..20).days].sample
-          params = {
-            component:,
-            scope: random_scope(participatory_space:),
-            category: participatory_space.categories.sample,
-            title: Decidim::Faker::Localized.sentence(word_count: 2),
-            description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
-            location: Decidim::Faker::Localized.sentence,
-            location_hints: Decidim::Faker::Localized.sentence,
-            start_time:,
-            end_time:,
-            address: "#{::Faker::Address.street_address} #{::Faker::Address.zip} #{::Faker::Address.city}",
-            latitude: ::Faker::Address.latitude,
-            longitude: ::Faker::Address.longitude,
-            registrations_enabled: [true, false].sample,
-            available_slots: (10..50).step(10).to_a.sample,
-            author: participatory_space.organization,
-            registration_terms: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
-            published_at: ::Faker::Boolean.boolean(true_ratio: 0.8) ? Time.current : nil
-          }
-
-          _hybrid_meeting = Decidim.traceability.create!(
-            Decidim::Meetings::Meeting,
-            admin_user,
-            params.merge(
-              title: Decidim::Faker::Localized.sentence(word_count: 2),
-              type_of_meeting: :hybrid,
-              online_meeting_url: "http://example.org"
-            ),
-            visibility: "all"
-          )
-
-          _online_meeting = Decidim.traceability.create!(
-            Decidim::Meetings::Meeting,
-            admin_user,
-            params.merge(
-              title: Decidim::Faker::Localized.sentence(word_count: 2),
-              type_of_meeting: :online,
-              online_meeting_url: "http://example.org"
-            ),
-            visibility: "all"
-          )
-
-          meeting = Decidim.traceability.create!(
-            Decidim::Meetings::Meeting,
-            admin_user,
-            params,
-            visibility: "all"
-          )
+          meeting = create_meeting!(component:)
 
           2.times do
             Decidim::Meetings::Service.create!(
@@ -178,6 +125,63 @@ module Decidim
         ) do
           Decidim::Component.create!(params)
         end
+      end
+
+      def create_meeting!(component:)
+        start_time = ::Faker::Date.between(from: 20.weeks.ago, to: 20.weeks.from_now)
+        end_time = start_time + [rand(1..4).hours, rand(1..20).days].sample
+        params = {
+          component:,
+          scope: random_scope(participatory_space:),
+          category: participatory_space.categories.sample,
+          title: Decidim::Faker::Localized.sentence(word_count: 2),
+          description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.paragraph(sentence_count: 3)
+          end,
+          location: Decidim::Faker::Localized.sentence,
+          location_hints: Decidim::Faker::Localized.sentence,
+          start_time:,
+          end_time:,
+          address: "#{::Faker::Address.street_address} #{::Faker::Address.zip} #{::Faker::Address.city}",
+          latitude: ::Faker::Address.latitude,
+          longitude: ::Faker::Address.longitude,
+          registrations_enabled: [true, false].sample,
+          available_slots: (10..50).step(10).to_a.sample,
+          author: participatory_space.organization,
+          registration_terms: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.paragraph(sentence_count: 3)
+          end,
+          published_at: ::Faker::Boolean.boolean(true_ratio: 0.8) ? Time.current : nil
+        }
+
+        _hybrid_meeting = Decidim.traceability.create!(
+          Decidim::Meetings::Meeting,
+          admin_user,
+          params.merge(
+            title: Decidim::Faker::Localized.sentence(word_count: 2),
+            type_of_meeting: :hybrid,
+            online_meeting_url: "http://example.org"
+          ),
+          visibility: "all"
+        )
+
+        _online_meeting = Decidim.traceability.create!(
+          Decidim::Meetings::Meeting,
+          admin_user,
+          params.merge(
+            title: Decidim::Faker::Localized.sentence(word_count: 2),
+            type_of_meeting: :online,
+            online_meeting_url: "http://example.org"
+          ),
+          visibility: "all"
+        )
+
+        Decidim.traceability.create!(
+          Decidim::Meetings::Meeting,
+          admin_user,
+          params,
+          visibility: "all"
+        )
       end
     end
   end

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -13,11 +13,6 @@ module Decidim
       end
 
       def call
-        admin_user = Decidim::User.find_by(
-          organization: participatory_space.organization,
-          email: "admin@example.org"
-        )
-
         params = {
           name: Decidim::Components::Namer.new(participatory_space.organization.available_locales, :meetings).i18n_name,
           published_at: Time.current,

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -24,26 +24,8 @@ module Decidim
 
           create_questionnaire_for!(meeting:)
 
-          2.times do |n|
-            email = "meeting-registered-user-#{meeting.id}-#{n}@example.org"
-            name = "#{::Faker::Name.name} #{meeting.id} #{n}"
-            user = Decidim::User.find_or_initialize_by(email:)
-
-            user.update!(
-              password: "decidim123456789",
-              name:,
-              nickname: ::Faker::Twitter.unique.screen_name,
-              organization: component.organization,
-              tos_agreement: "1",
-              confirmed_at: Time.current,
-              personal_url: ::Faker::Internet.url,
-              about: ::Faker::Lorem.paragraph(sentence_count: 2)
-            )
-
-            Decidim::Meetings::Registration.create!(
-              meeting:,
-              user:
-            )
+          2.times do |_n|
+            create_meeting_registration!(meeting:)
           end
 
           attachment_collection = create_attachment_collection(collection_for: meeting)
@@ -189,6 +171,29 @@ module Decidim
             Decidim::Faker::Localized.paragraph(sentence_count: 2)
           end,
           questionnaire_for: meeting
+        )
+      end
+
+      def create_meeting_registration!(meeting:)
+        n = rand(2)
+        email = "meeting-registered-user-#{meeting.id}-#{n}@example.org"
+        name = "#{::Faker::Name.name} #{meeting.id} #{n}"
+        user = Decidim::User.find_or_initialize_by(email:)
+
+        user.update!(
+          password: "decidim123456789",
+          name:,
+          nickname: ::Faker::Twitter.unique.screen_name,
+          organization:,
+          tos_agreement: "1",
+          confirmed_at: Time.current,
+          personal_url: ::Faker::Internet.url,
+          about: ::Faker::Lorem.paragraph(sentence_count: 2)
+        )
+
+        Decidim::Meetings::Registration.create!(
+          meeting:,
+          user:
         )
       end
     end

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -122,6 +122,13 @@ module Decidim
         end
       end
 
+      # Create a meeting
+      #
+      # @param component [Decidim::Component] The component where this class will be created
+      # @param type [:in_person, :hybrid, :online] The meeting type
+      # @param author_type [:official, :user, :user_group] Which type the author of the meeting will be
+      #
+      # @return [Decidim::Meeting]
       def create_meeting!(component:, type: :in_person, author_type: :official)
         params = meeting_params(component:, type:, author_type:)
 

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -33,31 +33,8 @@ module Decidim
           create_attachments!(attached_to: meeting)
         end
 
-        authors = [
-          Decidim::UserGroup.where(decidim_organization_id: participatory_space.decidim_organization_id).verified.sample,
-          Decidim::User.where(decidim_organization_id: participatory_space.decidim_organization_id).all.sample
-        ]
-
-        authors.each do |author|
-          user_group = nil
-
-          if author.is_a?(Decidim::UserGroup)
-            user_group = author
-            author = user_group.users.sample
-          end
-
-          params = meeting_params(component:)
-
-          Decidim.traceability.create!(
-            Decidim::Meetings::Meeting,
-            authors[0],
-            params.merge(
-              author:,
-              user_group:
-            ),
-            visibility: "all"
-          )
-        end
+        create_user_group_meeting!(component:)
+        create_user_meeting!(component:)
       end
 
       def create_component!
@@ -135,6 +112,36 @@ module Decidim
           Decidim::Meetings::Meeting,
           admin_user,
           params,
+          visibility: "all"
+        )
+      end
+
+      def create_user_group_meeting!(component:)
+        params = meeting_params(component:)
+        user_group = Decidim::UserGroup.where(decidim_organization_id: participatory_space.decidim_organization_id).verified.sample
+        author = user_group.users.sample
+
+        Decidim.traceability.create!(
+          Decidim::Meetings::Meeting,
+          author,
+          params.merge(
+            author:,
+            user_group:
+          ),
+          visibility: "all"
+        )
+      end
+
+      def create_user_meeting!(component:)
+        params = meeting_params(component:)
+        author = Decidim::User.where(decidim_organization_id: participatory_space.decidim_organization_id).all.sample
+
+        Decidim.traceability.create!(
+          Decidim::Meetings::Meeting,
+          author,
+          params.merge(
+            author:
+          ),
           visibility: "all"
         )
       end

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -15,20 +15,12 @@ module Decidim
       def call
         component = create_component!
 
-        if participatory_space.scope
-          scopes = participatory_space.scope.descendants
-          global = participatory_space.scope
-        else
-          scopes = participatory_space.organization.scopes
-          global = nil
-        end
-
         2.times do
           start_time = ::Faker::Date.between(from: 20.weeks.ago, to: 20.weeks.from_now)
           end_time = start_time + [rand(1..4).hours, rand(1..20).days].sample
           params = {
             component:,
-            scope: ::Faker::Boolean.boolean(true_ratio: 0.5) ? global : scopes.sample,
+            scope: random_scope(participatory_space:),
             category: participatory_space.categories.sample,
             title: Decidim::Faker::Localized.sentence(word_count: 2),
             description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
@@ -142,7 +134,7 @@ module Decidim
           start_time = ::Faker::Date.between(from: 20.weeks.ago, to: 20.weeks.from_now)
           params = {
             component:,
-            scope: ::Faker::Boolean.boolean(true_ratio: 0.5) ? global : scopes.sample,
+            scope: random_scope(participatory_space:),
             category: participatory_space.categories.sample,
             title: Decidim::Faker::Localized.sentence(word_count: 2),
             description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -19,11 +19,7 @@ module Decidim
           meeting = create_meeting!(component:)
 
           2.times do
-            Decidim::Meetings::Service.create!(
-              meeting:,
-              title: Decidim::Faker::Localized.sentence(word_count: 2),
-              description: Decidim::Faker::Localized.sentence(word_count: 5)
-            )
+            create_service!(meeting:)
           end
 
           Decidim::Forms::Questionnaire.create!(
@@ -181,6 +177,14 @@ module Decidim
           admin_user,
           params,
           visibility: "all"
+        )
+      end
+
+      def create_service!(meeting:)
+        Decidim::Meetings::Service.create!(
+          meeting:,
+          title: Decidim::Faker::Localized.sentence(word_count: 2),
+          description: Decidim::Faker::Localized.sentence(word_count: 5)
         )
       end
     end

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -47,32 +47,15 @@ module Decidim
             author = user_group.users.sample
           end
 
-          start_time = ::Faker::Date.between(from: 20.weeks.ago, to: 20.weeks.from_now)
-          params = {
-            component:,
-            scope: random_scope(participatory_space:),
-            category: participatory_space.categories.sample,
-            title: Decidim::Faker::Localized.sentence(word_count: 2),
-            description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
-            location: Decidim::Faker::Localized.sentence,
-            location_hints: Decidim::Faker::Localized.sentence,
-            start_time:,
-            end_time: start_time + rand(1..4).hours,
-            address: "#{::Faker::Address.street_address} #{::Faker::Address.zip} #{::Faker::Address.city}",
-            latitude: ::Faker::Address.latitude,
-            longitude: ::Faker::Address.longitude,
-            registrations_enabled: [true, false].sample,
-            available_slots: (10..50).step(10).to_a.sample,
-            author:,
-            user_group:
-          }
+          params = meeting_params(component:)
 
           Decidim.traceability.create!(
             Decidim::Meetings::Meeting,
             authors[0],
-            params,
+            params.merge(
+              author:,
+              user_group:
+            ),
             visibility: "all"
           )
         end
@@ -96,10 +79,11 @@ module Decidim
         end
       end
 
-      def create_meeting!(component:)
+      def meeting_params(component:)
         start_time = ::Faker::Date.between(from: 20.weeks.ago, to: 20.weeks.from_now)
         end_time = start_time + [rand(1..4).hours, rand(1..20).days].sample
-        params = {
+
+        {
           component:,
           scope: random_scope(participatory_space:),
           category: participatory_space.categories.sample,
@@ -122,6 +106,10 @@ module Decidim
           end,
           published_at: ::Faker::Boolean.boolean(true_ratio: 0.8) ? Time.current : nil
         }
+      end
+
+      def create_meeting!(component:)
+        params = meeting_params(component:)
 
         _hybrid_meeting = Decidim.traceability.create!(
           Decidim::Meetings::Meeting,

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -86,7 +86,7 @@ module Decidim
         params = {
           component:,
           category: participatory_space.categories.sample,
-          scope: random_scope,
+          scope: random_scope(participatory_space:),
           title: { en: ::Faker::Lorem.sentence(word_count: 2) },
           body: { en: ::Faker::Lorem.paragraphs(number: 2).join("\n") },
           state:,
@@ -158,7 +158,7 @@ module Decidim
         params = {
           component: proposal.component,
           category: participatory_space.categories.sample,
-          scope: random_scope,
+          scope: random_scope(participatory_space:),
           title: { en: "#{proposal.title["en"]} #{::Faker::Lorem.sentence(word_count: 1)}" },
           body: { en: "#{proposal.body["en"]} #{::Faker::Lorem.sentence(word_count: 3)}" },
           state: "evaluating",
@@ -236,7 +236,7 @@ module Decidim
           draft = Decidim::Proposals::CollaborativeDraft.new(
             component:,
             category: participatory_space.categories.sample,
-            scope: random_scope,
+            scope: random_scope(participatory_space:),
             title: ::Faker::Lorem.sentence(word_count: 2),
             body: ::Faker::Lorem.paragraphs(number: 2).join("\n"),
             state:,
@@ -267,22 +267,10 @@ module Decidim
           Decidim::User.where(organization:).all.sample,
           component:,
           category: participatory_space.categories.sample,
-          scope: random_scope,
+          scope: random_scope(participatory_space:),
           title: ::Faker::Lorem.sentence(word_count: 2),
           body: ::Faker::Lorem.paragraphs(number: 2).join("\n")
         )
-      end
-
-      def random_scope
-        if participatory_space.scope
-          scopes = participatory_space.scope.descendants
-          global = participatory_space.scope
-        else
-          scopes = participatory_space.organization.scopes
-          global = nil
-        end
-
-        ::Faker::Boolean.boolean(true_ratio: 0.5) ? global : scopes.sample
       end
     end
   end

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -5,7 +5,7 @@ require "decidim/faker/localized"
 
 module Decidim
   module Proposals
-    class Seeds
+    class Seeds < Decidim::Seeds
       attr_reader :participatory_space
 
       def initialize(participatory_space:)
@@ -38,10 +38,6 @@ module Decidim
 
       def organization
         @organization ||= participatory_space.organization
-      end
-
-      def admin_user
-        @admin_user ||= Decidim::User.find_by(organization:, email: "admin@example.org")
       end
 
       def create_component!


### PR DESCRIPTION
#### :tophat: What? Why?

Refactors the meetings seeds to individual methods.

This is following the same methodology and reasoning from #12005, so refer to that issue for the explanations.   

To ease-up the review process, I was disciplined and made the changes in a commit by commit basis 😎 
 
#### Testing

Regenerating the `development_app` database should have different kind of meetings (almost the same as before):

```console
$ bin/rails db:drop db:create db:migrate db:seed
``` 

:hearts: Thank you!
