### PR TITLE
Do not show counters and filters when there isn't any election

### DIFF
--- a/decidim-elections/app/controllers/decidim/elections/elections_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/elections_controller.rb
@@ -64,8 +64,7 @@ module Decidim
       end
 
       def paginated_elections
-        @paginated_elections ||= reorder(search.result.published)
-        @paginated_elections = paginate(@paginated_elections)
+        @paginated_elections ||= paginate(reorder(search.result.published))
       end
 
       def scheduled_elections

--- a/decidim-elections/app/controllers/decidim/elections/elections_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/elections_controller.rb
@@ -16,6 +16,8 @@ module Decidim
 
       def index
         redirect_to election_path(single, single: true) if single?
+
+        @forced_past_elections = true if elections.any? && scheduled_elections.none?
       end
 
       def show

--- a/decidim-elections/app/views/decidim/elections/elections/_elections.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/_elections.html.erb
@@ -1,7 +1,7 @@
 <% if elections.none? %>
   <%= cell("decidim/announcement", t("decidim.elections.warnings.no_elections_warning"), callout_class: "warning") %>
 <% elsif scheduled_elections.none? %>
-  <%= cell("decidim/announcement", t("decidim.elections.warnings.no_scheduled_elections_warning"), callout_class: "warning") %>
+  <%= cell("decidim/announcement", t("decidim.elections.warnings.no_scheduled_elections_warning") %>
 <% else %>
   <h2 class="h5 md:h3 decorator"><%= t("elections_count", scope: "decidim.elections.elections.count", count: paginated_elections.total_count) %></h2>
 

--- a/decidim-elections/app/views/decidim/elections/elections/_elections.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/_elections.html.erb
@@ -1,7 +1,7 @@
 <% if elections.none? %>
   <%= cell("decidim/announcement", t("decidim.elections.warnings.no_elections_warning"), callout_class: "warning") %>
 <% elsif scheduled_elections.none? %>
-  <%= cell("decidim/announcement", t("decidim.elections.warnings.no_scheduled_elections_warning") %>
+  <%= cell("decidim/announcement", t("decidim.elections.warnings.no_scheduled_elections_warning")) %>
 <% else %>
   <h2 class="h5 md:h3 decorator"><%= t("elections_count", scope: "decidim.elections.elections.count", count: paginated_elections.total_count) %></h2>
 

--- a/decidim-elections/app/views/decidim/elections/elections/_elections.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/_elections.html.erb
@@ -2,16 +2,16 @@
   <%= cell("decidim/announcement", t("decidim.elections.warnings.no_elections_warning"), callout_class: "warning") %>
 <% elsif scheduled_elections.none? %>
   <%= cell("decidim/announcement", t("decidim.elections.warnings.no_scheduled_elections_warning"), callout_class: "warning") %>
+<% else %>
+  <h2 class="h5 md:h3 decorator"><%= t("elections_count", scope: "decidim.elections.elections.count", count: paginated_elections.total_count) %></h2>
+
+  <%= order_selector available_orders, i18n_scope: "decidim.elections.orders" %>
+
+  <div class="card__grid-grid">
+    <% paginated_elections.each do |election| %>
+      <%= card_for election %>
+    <% end %>
+  </div>
+
+  <%= decidim_paginate paginated_elections %>
 <% end %>
-
-<h2 class="h5 md:h3 decorator"><%= t("elections_count", scope: "decidim.elections.elections.count", count: paginated_elections.total_count) %></h2>
-
-<%= order_selector available_orders, i18n_scope: "decidim.elections.orders" %>
-
-<div class="card__grid-grid">
-  <% paginated_elections.each do |election| %>
-    <%= card_for election %>
-  <% end %>
-</div>
-
-<%= decidim_paginate paginated_elections %>

--- a/decidim-elections/app/views/decidim/elections/elections/_elections.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/_elections.html.erb
@@ -1,5 +1,5 @@
 <% if elections.none? %>
-  <%= cell("decidim/announcement", t("decidim.elections.warnings.no_elections_warning"), callout_class: "warning") %>
+  <%= cell("decidim/announcement", t("decidim.elections.warnings.no_elections_warning")) %>
 <% elsif scheduled_elections.none? %>
   <%= cell("decidim/announcement", t("decidim.elections.warnings.no_scheduled_elections_warning")) %>
 <% else %>

--- a/decidim-elections/app/views/decidim/elections/elections/_elections.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/_elections.html.erb
@@ -1,11 +1,11 @@
 <% if elections.none? %>
-  <%= cell("decidim/announcement", t("decidim.elections.warnings.no_elections_warning")) %>
+  <%= cell("decidim/announcement", t("decidim.elections.warnings.no_elections")) %>
 <% else %>
 
   <% if paginated_elections.none? && params[:filter].present? %>
     <%= cell("decidim/announcement", t("decidim.elections.warnings.empty_filters")) %>
   <% else %>
-    <%= cell("decidim/announcement", t("decidim.elections.warnings.no_scheduled_elections_warning")) if @forced_past_elections %>
+    <%= cell("decidim/announcement", t("decidim.elections.warnings.no_scheduled_elections")) if @forced_past_elections %>
 
     <h2 class="h5 md:h3 decorator"><%= t("elections_count", scope: "decidim.elections.elections.count", count: paginated_elections.total_count) %></h2>
 

--- a/decidim-elections/app/views/decidim/elections/elections/_elections.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/_elections.html.erb
@@ -1,17 +1,22 @@
 <% if elections.none? %>
   <%= cell("decidim/announcement", t("decidim.elections.warnings.no_elections_warning")) %>
-<% elsif scheduled_elections.none? %>
-  <%= cell("decidim/announcement", t("decidim.elections.warnings.no_scheduled_elections_warning")) %>
 <% else %>
-  <h2 class="h5 md:h3 decorator"><%= t("elections_count", scope: "decidim.elections.elections.count", count: paginated_elections.total_count) %></h2>
 
-  <%= order_selector available_orders, i18n_scope: "decidim.elections.orders" %>
+  <% if paginated_elections.none? && params[:filter].present? %>
+    <%= cell("decidim/announcement", t("decidim.elections.warnings.empty_filters")) %>
+  <% else %>
+    <%= cell("decidim/announcement", t("decidim.elections.warnings.no_scheduled_elections_warning")) if @forced_past_elections %>
 
-  <div class="card__grid-grid">
-    <% paginated_elections.each do |election| %>
-      <%= card_for election %>
-    <% end %>
-  </div>
+    <h2 class="h5 md:h3 decorator"><%= t("elections_count", scope: "decidim.elections.elections.count", count: paginated_elections.total_count) %></h2>
 
-  <%= decidim_paginate paginated_elections %>
+    <%= order_selector available_orders, i18n_scope: "decidim.elections.orders" %>
+
+    <div class="card__grid-grid">
+      <% paginated_elections.each do |election| %>
+        <%= card_for election %>
+      <% end %>
+    </div>
+
+    <%= decidim_paginate paginated_elections %>
+  <% end %>
 <% end %>

--- a/decidim-elections/app/views/decidim/elections/elections/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/index.html.erb
@@ -6,7 +6,11 @@
 <% content_for :aside do %>
   <h1 class="title-decorator"><%= component_name %></h1>
 
-  <%= render layout: "decidim/shared/filters", locals: { filter_sections: , search_variable: :search_text_cont, skip_to_id: "elections" } do %>
+  <%= render layout: "decidim/shared/filters", locals: {
+        filter_sections: @forced_past_elections ? [] : filter_sections,
+        search_variable: :search_text_cont,
+        skip_to_id: "elections"
+      } do %>
     <%= hidden_field_tag :order, order, id: nil, class: "order_filter" %>
   <% end %>
 <% end %>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -727,6 +727,7 @@ en:
           back: Back
           continue: Next
       warnings:
+        empty_filters: There are no elections with this criteria.
         no_elections_warning: No elections match your search criteria or there is not any election scheduled.
         no_scheduled_elections_warning: Currently, there are no scheduled elections, but here you can find all the past elections listed.
     events:

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -728,8 +728,8 @@ en:
           continue: Next
       warnings:
         empty_filters: There are no elections with this criteria.
-        no_elections_warning: No elections match your search criteria or there is not any election scheduled.
-        no_scheduled_elections_warning: Currently, there are no scheduled elections, but here you can find all the past elections listed.
+        no_elections: There is not any election scheduled.
+        no_scheduled_elections: Currently, there are no scheduled elections, but here you can find all the past elections listed.
     events:
       elections:
         election_published:

--- a/decidim-elections/spec/system/explore_elections_spec.rb
+++ b/decidim-elections/spec/system/explore_elections_spec.rb
@@ -104,6 +104,21 @@ describe "Explore elections", :slow do
           expect(page).to have_css("[id^=elections]", count: 7)
         end
       end
+
+      context "when there are no elections in a filter" do
+        it "shows the filters empty message" do
+          visit_component
+
+          within "#panel-dropdown-menu-date" do
+            uncheck "Active"
+            check "Upcoming"
+          end
+
+          within ".flash" do
+            expect(page).to have_content("There are no elections with this criteria.")
+          end
+        end
+      end
     end
 
     context "when no active or upcoming elections scheduled" do
@@ -117,8 +132,17 @@ describe "Explore elections", :slow do
 
       it "shows the correct warning" do
         visit_component
+
         within ".flash" do
-          expect(page).to have_content("no scheduled elections")
+          expect(page).to have_content("Currently, there are no scheduled elections, but here you can find all the past elections listed.")
+        end
+      end
+
+      it "does not show the date filter" do
+        visit_component
+
+        within "aside.layout-2col__aside" do
+          expect(page).not_to have_content("Date")
         end
       end
     end
@@ -126,12 +150,19 @@ describe "Explore elections", :slow do
     context "when no elections is given" do
       before do
         Decidim::Elections::Election.destroy_all
+
+        visit_component
       end
 
       it "shows the correct warning" do
-        visit_component
         within ".flash" do
-          expect(page).to have_content("any election scheduled")
+          expect(page).to have_content("There is not any election scheduled")
+        end
+      end
+
+      it "shows the date filter" do
+        within "aside.layout-2col__aside" do
+          expect(page).to have_content("Date")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Related to #11875, on elections we're showing a  message but we're also showing it with the counter and sorting controls. This PR changes it to not showing these controls to be consistent with the rest of modules. 

#### :pushpin: Related Issues
 
- Related to #11875

#### Testing

1. Create a new process 
2. Create a elections component
3. Click in the "Preview" icon in the admin's component page

### :camera: Screenshots

#### Before
![Screenshot of the elections index page empty](https://github.com/decidim/decidim/assets/717367/503d996a-d086-47fd-9c7a-1f037f91c1a5)

#### After
![Screenshot of the elections index page empty](https://github.com/decidim/decidim/assets/717367/e94abe0b-e7e3-437a-b508-d3710c691c44)
 

:hearts: Thank you!
