### PR TITLE
Show message when there are no content in the page

### DIFF
--- a/decidim-pages/app/views/decidim/pages/application/show.html.erb
+++ b/decidim-pages/app/views/decidim/pages/application/show.html.erb
@@ -1,3 +1,4 @@
+<% add_decidim_page_title(translated_attribute(@page.title)) %>
 <% add_decidim_meta_tags({
                            description: translated_attribute(@page.body)
                          }) %>

--- a/decidim-pages/app/views/decidim/pages/application/show.html.erb
+++ b/decidim-pages/app/views/decidim/pages/application/show.html.erb
@@ -14,7 +14,11 @@
     <%= render partial: "decidim/shared/component_announcement" %>
 
     <div class="editor-content">
-      <%= decidim_sanitize_editor_admin translated_attribute(@page.body) %>
+      <% if translated_attribute(@page.body).empty? || translated_attribute(@page.body) == "<p></p>" %>
+        <%= cell("decidim/announcement", t("empty", scope: "decidim.pages.show")) %>
+      <% else %>
+        <%= decidim_sanitize_editor_admin translated_attribute(@page.body) %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/decidim-pages/config/locales/en.yml
+++ b/decidim-pages/config/locales/en.yml
@@ -29,3 +29,5 @@ en:
           update:
             invalid: There was a problem saving the page.
             success: Page successfully saved.
+      show:
+        empty: There are no contents in this page yet.

--- a/decidim-pages/spec/system/page_show_spec.rb
+++ b/decidim-pages/spec/system/page_show_spec.rb
@@ -33,5 +33,59 @@ describe "Show a page" do
         expect(page).to have_content("Content")
       end
     end
+
+    context "when there is no content in the page" do
+      let(:body) { nil }
+
+      before do
+        visit_component
+      end
+
+      it "shows an empty page with a message" do
+        within "main" do
+          expect(page).to have_content("There are no contents in this page yet.")
+        end
+      end
+    end
+
+    context "when the content is an empty paragraph" do
+      let(:body) do
+        {
+          "en" => "<p></p>",
+          "ca" => "<p></p>",
+          "es" => "<p></p>"
+        }
+      end
+
+      before do
+        visit_component
+      end
+
+      it "shows an empty page with a message" do
+        within "main" do
+          expect(page).to have_content("There are no contents in this page yet.")
+        end
+      end
+    end
+
+    context "when there is no content in the current locale" do
+      let(:body) do
+        {
+          "en" => "<p>Content</p>",
+          "ca" => "<p></p>",
+          "es" => "<p></p>"
+        }
+      end
+
+      it "shows the default locale content" do
+        I18n.with_locale :ca do
+          visit_component
+
+          within "main" do
+            expect(page).to have_content("Content")
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

When there are no content in a page, we don't show any message, just a blank page.

This PR changes it to show a message.

I've found about this error while reviewing #11480. 

#### :pushpin: Related Issues
 
- Related to #11875

#### Testing

1. Create a new process 
2. Create a pages component
3. Click in the "Preview" icon in the admin's component page
4. See the page

### :camera: Screenshots

![Screenshot of the no content page in pages module](https://github.com/decidim/decidim/assets/717367/7e8a2935-6e67-4db1-937b-302c28ff23cf)

:hearts: Thank you!