### PR TITLE
Show message when there are no sortitions

### DIFF
--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/_sortitions.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/_sortitions.html.erb
@@ -1,9 +1,13 @@
-<h2 class="h5 md:h3 decorator"><%= t("count", scope: "decidim.sortitions.sortitions.sortitions_count", count: @sortitions.total_count) %></h2>
+<% if @sortitions.any? %>
+  <h2 class="h5 md:h3 decorator"><%= t("count", scope: "decidim.sortitions.sortitions.sortitions_count", count: @sortitions.total_count) %></h2>
 
-<%= order_selector available_orders, i18n_scope: "decidim.sortitions.sortitions.orders" %>
+  <%= order_selector available_orders, i18n_scope: "decidim.sortitions.sortitions.orders" %>
 
-<div class="card__list-list">
-  <%= render @sortitions %>
-</div>
+  <div class="card__list-list">
+    <%= render @sortitions %>
+  </div>
 
-<%= decidim_paginate @sortitions %>
+  <%= decidim_paginate @sortitions %>
+<% else %>
+  <%= cell "decidim/announcement", t("empty", scope: "decidim.sortitions.sortitions.index") %>
+<% end %>

--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/index.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/index.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title component_name %>
+
 <% content_for :aside do %>
   <h1 class="title-decorator"><%= component_name %></h1>
 

--- a/decidim-sortitions/config/locales/en.yml
+++ b/decidim-sortitions/config/locales/en.yml
@@ -97,6 +97,8 @@ en:
           cancelled: Cancelled
           category: Category
           state: Status
+        index:
+          empty: There are no sortitions yet.
         linked_sortitions:
           selected_proposals: Selected proposals
         orders:

--- a/decidim-sortitions/spec/system/decidim/sortitions/sortitions_spec.rb
+++ b/decidim-sortitions/spec/system/decidim/sortitions/sortitions_spec.rb
@@ -8,6 +8,16 @@ describe "sortitions" do
   let(:manifest_name) { "sortitions" }
   let!(:user) { create(:user, :confirmed, organization: participatory_process.organization) }
 
+  context "when there are no sortitions" do
+    it "shows an empty page with a message" do
+      visit_component
+
+      within "main" do
+        expect(page).to have_content("There are no sortitions yet.")
+      end
+    end
+  end
+
   context "when listing sortitions in a participatory process" do
     it "lists all the sortitions" do
       create_list(:sortition, 3, component:)


### PR DESCRIPTION
#### :tophat: What? Why?

When there are no sortitions, we don't show any message, just a blank page.

This PR changes it to show a message.

I've found about this error while reviewing #11480. 

#### :pushpin: Related Issues
 
- Related to #11875

#### Testing

1. Create a new process 
2. Create a sortitions component
3. Click in the "Preview" icon in the admin's component page
4. See the page

### :camera: Screenshots

![Screenshot of the no sortitions page in sortitions module](https://github.com/decidim/decidim/assets/717367/bb02adfc-c2cd-43de-a9b8-02895d7a2f1c)
 
:hearts: Thank you!