### PR TITLE
Fix randomness on nickname and emails for seeded users

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -125,6 +125,10 @@ module Decidim
         end
       end
 
+      def random_nickname
+        "#{::Faker::Twitter.unique.screen_name}-#{SecureRandom.hex(4)}"[0, 20]
+      end
+
       def create_emendation!(proposal:)
         n = rand(5)
         email = "amendment-author-#{participatory_space.underscored_name}-#{participatory_space.id}-#{n}-amend#{n}@example.org"
@@ -134,7 +138,7 @@ module Decidim
         author.update!(
           password: "decidim123456789",
           name:,
-          nickname: ::Faker::Twitter.unique.screen_name,
+          nickname: random_nickname,
           organization:,
           tos_agreement: "1",
           confirmed_at: Time.current
@@ -142,7 +146,7 @@ module Decidim
 
         group = Decidim::UserGroup.create!(
           name: ::Faker::Name.name,
-          nickname: ::Faker::Twitter.unique.screen_name,
+          nickname: random_nickname,
           email: ::Faker::Internet.email,
           extended_data: {
             document_number: ::Faker::Code.isbn,
@@ -203,7 +207,7 @@ module Decidim
         author.update!(
           password: "decidim123456789",
           name:,
-          nickname: ::Faker::Twitter.unique.screen_name,
+          nickname: random_nickname,
           organization:,
           tos_agreement: "1",
           confirmed_at: Time.current,

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -129,15 +129,17 @@ module Decidim
         "#{::Faker::Twitter.unique.screen_name}-#{SecureRandom.hex(4)}"[0, 20]
       end
 
-      def create_emendation!(proposal:)
-        n = rand(5)
-        email = "amendment-author-#{participatory_space.underscored_name}-#{participatory_space.id}-#{n}-amend#{n}@example.org"
-        name = "#{::Faker::Name.name} #{participatory_space.id} #{n} amend#{n}"
+      def random_email(suffix:)
+        r = SecureRandom.hex(4)
 
-        author = Decidim::User.find_or_initialize_by(email:)
+        "#{suffix}-author-#{participatory_space.underscored_name}-#{participatory_space.id}-#{r}@example.org"
+      end
+
+      def create_emendation!(proposal:)
+        author = Decidim::User.find_or_initialize_by(email: random_email(suffix: "amendment"))
         author.update!(
           password: "decidim123456789",
-          name:,
+          name: "#{::Faker::Name.name} #{participatory_space.id}",
           nickname: random_nickname,
           organization:,
           tos_agreement: "1",
@@ -198,15 +200,10 @@ module Decidim
       end
 
       def create_proposal_votes!(proposal:, emendation: nil)
-        n = rand(5)
-        m = rand(5)
-        email = "vote-author-#{participatory_space.underscored_name}-#{participatory_space.id}-#{n}-#{m}@example.org"
-        name = "#{::Faker::Name.name} #{participatory_space.id} #{n} #{m}"
-
-        author = Decidim::User.find_or_initialize_by(email:)
+        author = Decidim::User.find_or_initialize_by(email: random_email(suffix: "vote"))
         author.update!(
           password: "decidim123456789",
-          name:,
+          name: "#{::Faker::Name.name} #{participatory_space.id}",
           nickname: random_nickname,
           organization:,
           tos_agreement: "1",


### PR DESCRIPTION
#### :tophat: What? Why?

After merging #12005, we started to see some flaky apps generations with the seeds. The errors were related to some uniqueness validations that we're doing in our models, and with the change of the proposals seeds we've broken this.

This PR adds some randomness on the nickname and the email generation so we don't have these validations problem. 

#### :pushpin: Related Issues

- Related to #12005 

#### Testing

Run this command before and after this patch. Before you should see a validation error while running it, and after you should not see any validation error:
```console
bin/rails runner 'require "decidim/proposals/seeds"; component = Decidim::Component.where(manifest_name: :proposals).first ; 200.times { Decidim::Proposals::Seeds.new(participatory_space: component.participatory_space).call }' 
``` 

:hearts: Thank you!
