### PR TITLE
(deprecated) Redesign: clean-up of deprecated classes

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -31,7 +31,7 @@ linters:
     rule_set:
       - deprecated: ['process-content']
         suggestion: "This class is deprecated. Please remove the surrounding element"
-      - deprecated: ['xlarge-[\w]*']
+      - deprecated: ['xlarge-[\w]*', 'mediumlarge-[\w]']
         suggestion: "Foundation classes are deprecated."
 
   Rubocop:

--- a/decidim-accountability/app/views/decidim/accountability/results/_stats_box.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_stats_box.html.erb
@@ -1,4 +1,4 @@
-<div class="columns section mediumlarge-4 large-3">
+<div class="columns section large-3">
 
   <% if result.children.any? && component_settings.display_progress_enabled? && result.progress.present? %>
     <div class="progress-level section">

--- a/decidim-initiatives/app/views/layouts/decidim/_initiative_header.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/_initiative_header.html.erb
@@ -4,7 +4,7 @@
         style="background-image:url('<%= current_participatory_space.type.attached_uploader(:banner_image).path %>');">
     </div>
     <div class="process-header__container row collapse column">
-      <div class="columns mediumlarge-8 process-header__info">
+      <div class="columns process-header__info">
         <div>
           <h1>
             <%= participatory_space_helpers.translated_attribute(current_participatory_space.title) %>


### PR DESCRIPTION
#### :tophat: What? Why?

As explained in #11752, we found lots of classes that aren't used anymore by the new CSS that are still in the HTML. This PR continues the process that we've started to clean-up the codebase. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #11752

#### Testing

As potentially some of these classes could still be used (as they may be generated by SCSS or used as selectors by Capybara), all the specs should be green and everything should work as before.  

:hearts: Thank you!
