### PR TITLE
Backport 'Fix dependency resolver trying to fetch gem paths from lazy specifications' to v0.26

### DIFF
--- a/decidim-core/spec/lib/dependency_resolver_spec.rb
+++ b/decidim-core/spec/lib/dependency_resolver_spec.rb
@@ -138,8 +138,8 @@ module Decidim
         describe "#lookup" do
           subject { resolver.lookup(gem) }
 
-          it "returns Bundler::LazySpecification" do
-            expect(subject).to be_instance_of(Bundler::LazySpecification)
+          it "returns Gem::Specification" do
+            expect(subject).to be_instance_of(Gem::Specification)
             expect(subject.name).to eq(gem)
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #10220 to v0.26

I've done this because @sdelcroix gave us a heads-up that this is actually needed (thanks!).

- Fixes #11636 

:hearts: Thank you!