### PR TITLE
Change the buttons UI for removing answers in forms

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_cards.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_cards.scss
@@ -104,10 +104,6 @@
 
 .card-section {
   @apply pb-4 bg-white;
-
-  svg {
-    @apply w-4 h-4 inline-block fill-secondary;
-  }
 }
 
 .fcell .label {

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_answer_option.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_answer_option.html.erb
@@ -5,7 +5,8 @@
     <h2 class="card-title">
     <span><%= t(".answer_option") %></span>
     <% if editable %>
-      <button class="button button__sm button__secondary small alert hollow remove-answer-option button--title">
+      <button class="button button__sm button__transparent button__transparent-secondary small alert hollow remove-answer-option button--title mb-2">
+        <%= icon("delete-bin-line") %>
         <%= t(".remove") %>
       </button>
     <% end %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_answer_option.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_answer_option.html.erb
@@ -5,7 +5,7 @@
     <h2 class="card-title">
     <span><%= t(".answer_option") %></span>
     <% if editable %>
-      <button class="button button__sm button__transparent button__transparent-secondary small alert hollow remove-answer-option button--title mb-2">
+      <button class="button button__sm button__transparent-secondary small alert hollow remove-answer-option button--title mb-2">
         <%= icon("delete-bin-line") %>
         <%= t(".remove") %>
       </button>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_display_condition.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_display_condition.html.erb
@@ -5,7 +5,8 @@
     <h2 class="card-title">
     <span><%= t(".display_condition") %></span>
     <% if editable %>
-      <button class="button button__sm button__secondary small alert hollow remove-display-condition button--title">
+      <button class="button button__sm button__transparent button__transparent-secondary small alert hollow remove-display-condition button--title">
+        <%= icon("delete-bin-line") %>
         <%= t(".remove") %>
       </button>
     <% end %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_display_condition.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_display_condition.html.erb
@@ -5,7 +5,7 @@
     <h2 class="card-title">
     <span><%= t(".display_condition") %></span>
     <% if editable %>
-      <button class="button button__sm button__transparent button__transparent-secondary small alert hollow remove-display-condition button--title">
+      <button class="button button__sm button__transparent-secondary small alert hollow remove-display-condition button--title">
         <%= icon("delete-bin-line") %>
         <%= t(".remove") %>
       </button>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_matrix_row.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_matrix_row.html.erb
@@ -5,7 +5,7 @@
     <h2 class="card-title">
     <span><%= t(".matrix_row") %></span>
     <% if editable %>
-      <button class="button button__sm button__transparent button__transparent-secondary small alert hollow remove-matrix-row button--title mb-2">
+      <button class="button button__sm button__transparent-secondary small alert hollow remove-matrix-row button--title mb-2">
         <%= icon("delete-bin-line") %>
         <%= t(".remove") %>
       </button>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_matrix_row.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_matrix_row.html.erb
@@ -5,7 +5,8 @@
     <h2 class="card-title">
     <span><%= t(".matrix_row") %></span>
     <% if editable %>
-      <button class="button button__sm button__secondary small alert hollow remove-matrix-row button--title">
+      <button class="button button__sm button__transparent button__transparent-secondary small alert hollow remove-matrix-row button--title mb-2">
+        <%= icon("delete-bin-line") %>
         <%= t(".remove") %>
       </button>
     <% end %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_question.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_question.html.erb
@@ -134,7 +134,7 @@
 
         <% if editable %>
           <div class="row column">
-            <button type="button" class="button button__sm button__secondary add-answer-option"><%= t(".add_answer_option") %></button>
+            <button type="button" class="button button__sm button__secondary mt-4 add-answer-option"><%= t(".add_answer_option") %></button>
           </div>
         <% end %>
       </div>
@@ -162,7 +162,7 @@
         <% if editable %>
           <% disabled = !question.persisted? %>
           <div class="row column">
-            <button <%= "disabled" if disabled %> title="<%= disabled ? t(".add_display_condition_info") : t(".add_display_condition_info") %>" class="button button__sm button__secondary add-display-condition"><%= t(".add_display_condition") %></button>
+            <button <%= "disabled" if disabled %> title="<%= disabled ? t(".add_display_condition_info") : t(".add_display_condition_info") %>" class="button button__sm button__secondary mt-4 add-display-condition"><%= t(".add_display_condition") %></button>
           </div>
         <% end %>
       </div>

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_answer_option.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_answer_option.html.erb
@@ -5,7 +5,8 @@
     <h2 class="card-title">
     <span><%= t("answer_option", scope: "decidim.forms.admin.questionnaires.answer_option") %></span>
     <% if editable %>
-      <button class="button button__sm button__secondary small alert hollow remove-answer-option button--title">
+      <button class="button button__sm button__transparent button__transparent-secondary small alert hollow remove-answer-option button--title mb-2">
+        <%= icon("delete-bin-line") %>
         <%= t("remove", scope: "decidim.forms.admin.questionnaires.answer_option") %>
       </button>
     <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_answer_option.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_answer_option.html.erb
@@ -5,7 +5,7 @@
     <h2 class="card-title">
     <span><%= t("answer_option", scope: "decidim.forms.admin.questionnaires.answer_option") %></span>
     <% if editable %>
-      <button class="button button__sm button__transparent button__transparent-secondary small alert hollow remove-answer-option button--title mb-2">
+      <button class="button button__sm button__transparent-secondary small alert hollow remove-answer-option button--title mb-2">
         <%= icon("delete-bin-line") %>
         <%= t("remove", scope: "decidim.forms.admin.questionnaires.answer_option") %>
       </button>

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
@@ -82,7 +82,7 @@
         </div>
         <% if editable %>
           <div class="row column">
-            <button type="button" class="button button__sm button__secondary add-answer-option"><%= t("add_answer_option", scope: "decidim.forms.admin.questionnaires.question") %></button>
+            <button type="button" class="button button__sm button__secondary mt-4 add-answer-option"><%= t("add_answer_option", scope: "decidim.forms.admin.questionnaires.question") %></button>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing the new design, it has been detected that there are some buttons in Surveys and Polls that aren't consistent with the others: the "Remove" an answer question is a CTA (i.e. with full colors). It should be a transparent button with a "trash" icon. 

This PR fixes that, both in surveys and in polls. 
 
#### Testing

1. Sign in as admin
2. Go to a survey component
3. Find questions of "Multiple options" and "Matrix"
4. See that the "Remove" buttons are transparent with an icon

And also

1. Sign in as admin
2. Go to a poll in the meetings component 
3. Create new questions of both types with multiple answers
4. See that the "Remove" buttons are transparent with an icon

### :camera: Screenshots

#### Before

![Screenshot of the surveys' answers](https://github.com/decidim/decidim/assets/717367/60734cf7-24ba-4e33-8ce7-38b928ac6775)

#### After 

![Screenshot of the surveys' answers](https://github.com/decidim/decidim/assets/717367/ed18f79f-7e56-43d0-b20a-27ca7057bb01)

:hearts: Thank you!
