### PR TITLE
Show message when there are no questions in survey

### DIFF
--- a/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
@@ -34,7 +34,11 @@
         <% if visitor_already_answered? %>
           <%= cell("decidim/announcement", { title: t("decidim.forms.questionnaires.show.questionnaire_answered.title"), body: t("decidim.forms.questionnaires.show.questionnaire_answered.body") }) %>
         <% else %>
-          <%= render partial: "decidim/forms/questionnaires/questionnaire" %>
+          <% if @form.responses_by_step.flatten.empty? %>
+            <%= cell("decidim/announcement", t("decidim.forms.questionnaires.show.empty")) %>
+          <% else %>
+            <%= render partial: "decidim/forms/questionnaires/questionnaire" %>
+          <% end %>
         <% end %>
       <% else %>
         <%= render partial: "decidim/forms/questionnaires/questionnaire_readonly" %>

--- a/decidim-forms/config/locales/en.yml
+++ b/decidim-forms/config/locales/en.yml
@@ -162,6 +162,7 @@ en:
             sign_up_description: Create a participant account to take the survey
             title: Answer the form
           current_step: Step %{step}
+          empty: No questions configured for this form yet.
           of_total_steps: of %{total_steps}
           questionnaire_answered:
             body: You have already answered this form.

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -23,6 +23,18 @@ shared_examples_for "has questionnaire" do
       login_as user, scope: :user
     end
 
+    context "and there are no questions" do
+      before do
+        questionnaire.questions.delete_all
+      end
+
+      it "shows an empty page with a message" do
+        visit questionnaire_public_path
+
+        expect(page).to have_content("No questions configured for this form yet.")
+      end
+    end
+
     it "allows answering the questionnaire" do
       visit questionnaire_public_path
 

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -287,17 +287,10 @@ describe "Meeting registrations" do
           login_as user, scope: :user
         end
 
-        it "shows the registration form without questions" do
+        it "shows an empty page with a message" do
           visit questionnaire_public_path
 
-          expect(page).to have_i18n_content(questionnaire.title)
-          expect(page).to have_i18n_content(questionnaire.description)
-          expect(page).to have_content "Show my attendance publicly"
-          expect(page).to have_field("public_participation", checked: false)
-
-          expect(page).to have_no_i18n_content(question.body)
-
-          expect(page).to have_button("Submit")
+          expect(page).to have_content("No questions configured for this form yet.")
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When there are no questions in a survey, we don't show any message, just a blank page.

This PR changes it to show a message.

I've found about this error while reviewing #11480. 

#### :pushpin: Related Issues
 
- Related to #11875

#### Testing

1. Create a new process 
2. Create a survey component
3. Allow answers for this survey
4. Click in the "Preview" icon in the admin's component page
5. See the page

### :camera: Screenshots

![Screenshot of the no content page in surveys module](https://github.com/decidim/decidim/assets/717367/f7e6ffa6-9d25-44a9-8e73-71459277586d)
 
:hearts: Thank you!