### PR TITLE
Fix a11y violations and title layout on announcements

### DIFF
--- a/decidim-core/app/cells/decidim/announcement/show.erb
+++ b/decidim-core/app/cells/decidim/announcement/show.erb
@@ -1,6 +1,6 @@
 <%= content_tag :div, id: options[:id], class: "flash #{css_class}", data: { announcement: "" }.compact, hidden: options[:hidden] do %>
   <% if has_title? %>
-    <div class="h4">
+    <div class="flash__title">
       <%= clean_title %>
     </div>
   <% end %>

--- a/decidim-core/app/cells/decidim/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/announcement_cell.rb
@@ -44,8 +44,7 @@ module Decidim
     def css_class
       return unless options[:callout_class]
 
-      callout_class = options[:callout_class]
-      has_title? ? + "#{callout_class} flex-col" : callout_class
+      options[:callout_class]
     end
 
     def announcement

--- a/decidim-core/app/packs/stylesheets/decidim/_flash.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_flash.scss
@@ -1,5 +1,5 @@
 .flash {
-  @apply flex justify-start items-center gap-4 rounded border-2 border-secondary text-secondary my-4 p-4 bg-secondary/5;
+  @apply flex flex-col justify-start items-center gap-4 rounded border-2 border-secondary text-secondary my-4 p-4 bg-secondary/5;
 
   &__icon {
     svg {

--- a/decidim-core/app/packs/stylesheets/decidim/_flash.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_flash.scss
@@ -7,6 +7,10 @@
     }
   }
 
+  &__title {
+    @apply font-semibold text-2xl;
+  }
+
   &__message {
     @apply gap-2 text-black font-semibold text-lg;
 

--- a/decidim-core/app/packs/stylesheets/decidim/_flash.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_flash.scss
@@ -1,5 +1,5 @@
 .flash {
-  @apply flex flex-col justify-start items-center gap-4 rounded border-2 border-secondary text-secondary my-4 p-4 bg-secondary/5;
+  @apply flex flex-col justify-start items-center gap-4 rounded border-2 border-secondary my-4 p-4 bg-secondary/5;
 
   &__icon {
     svg {
@@ -28,14 +28,14 @@
   }
 
   &.success {
-    @apply border-success text-success bg-success/5;
+    @apply border-success bg-success/5;
   }
 
   &.alert {
-    @apply border-alert text-alert bg-alert/5;
+    @apply border-alert bg-alert/5;
   }
 
   &.warning {
-    @apply border-warning text-warning bg-warning/5;
+    @apply border-warning bg-warning/5;
   }
 }

--- a/decidim-design/app/helpers/decidim/design/announcement_helper.rb
+++ b/decidim-design/app/helpers/decidim/design/announcement_helper.rb
@@ -37,10 +37,17 @@ module Decidim
               },
               {
                 type: :table,
-                options: { headings: %w(Announcement Argument) },
+                options: { headings: ["Announcement", "Callout class", "Argument"] },
                 items: announcement_table(
-                  { text: "I am just plain text", argument: '"I am just plain text"' },
-                  { text: { title: "This is the title", body: "This is the body" }, argument: '{ title: "This is the title", body: "This is the body" }' }
+                  { text: "I am just plain text", callout_class: "secondary", argument: '"I am just plain text"' },
+                  { text: { title: "This is the title", body: "This is the body" }, callout_class: "secondary",
+                    argument: '{ title: "This is the title", body: "This is the body" }' },
+                  { text: { title: "This is the title", body: "This is the body" }, callout_class: "warning",
+                    argument: '{ text: { title: "This is the title", body: "This is the body" }, callout_class: "warning" }' },
+                  { text: { title: "This is the title", body: "This is the body" }, callout_class: "alert",
+                    argument: '{ text: { title: "This is the title", body: "This is the body" }, callout_class: "alert" }' },
+                  { text: { title: "This is the title", body: "This is the body" }, callout_class: "success",
+                    argument: '{ text: { title: "This is the title", body: "This is the body" }, callout_class: "success" }' }
                 ),
                 cell_snippet: {
                   cell: "decidim/announcement",


### PR DESCRIPTION
#### :tophat: What? Why?

While working with a "warning" announcement with a title, I could not read the title and I thought: "this should be an accessibility problem, right?". Seems like every announcement with title has this problem.

I've also found out that the announcement without a `callout_class` (i.e. `secondary`) has the title broken.

This PR fixes these two issues.  

I've also added these in the DDG (http://localhost:3000/design/components/announcement), but mind that there are a couple problems with the current approach of the DDG that makes it difficult to detect these errors:

1. The a11y violations would not be seen as we don't have the a11y badges there
2. The columns of the table are too narrow, so the difference between the secondary callout_class with title vs any other callout class with title can't be detected

#### Testing

Copy and paste the following snippet in a page:

```erb
<%= cell("decidim/announcement", { title: "This is the title", body: "This is the body" }) %>
<%= cell("decidim/announcement", { title: "This is the title", body: "This is the body" }, callout_class: "alert") %>
<%= cell("decidim/announcement", { title: "This is the title", body: "This is the body" }, callout_class: "warning") %>
<%= cell("decidim/announcement", { title: "This is the title", body: "This is the body" }, callout_class: "success") %>
``` 

### :camera: Screenshots

#### Before

![Announcements  with the bugs and a11y violations](https://github.com/decidim/decidim/assets/717367/4fab1912-accd-4db7-ab17-e16970dba8a8)

#### After 

![Announcements with everything OK](https://github.com/decidim/decidim/assets/717367/7954c47b-1120-443c-ba7a-1ff47a12af76)

![Announcements with titles and callout classes in DDG](https://github.com/decidim/decidim/assets/717367/a5443277-cc1e-45ac-a806-a28a2ae9acdf)

:hearts: Thank you!
