### PR TITLE
Fix icons on flash alerts

### DIFF
--- a/decidim-core/app/cells/decidim/announcement/show.erb
+++ b/decidim-core/app/cells/decidim/announcement/show.erb
@@ -1,4 +1,4 @@
-<%= content_tag :div, id: options[:id], class: "flash #{css_class}", data: { announcement: "" }.compact, hidden: options[:hidden] do %>
+<%= content_tag :div, id: options[:id], class: "flash flex-col #{css_class}", data: { announcement: "" }.compact, hidden: options[:hidden] do %>
   <% if has_title? %>
     <div class="flash__title">
       <%= clean_title %>

--- a/decidim-core/app/packs/stylesheets/decidim/_flash.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_flash.scss
@@ -1,5 +1,5 @@
 .flash {
-  @apply flex flex-col justify-start items-center gap-4 rounded border-2 border-secondary my-4 p-4 bg-secondary/5;
+  @apply flex justify-start items-center gap-4 rounded border-2 border-secondary my-4 p-4 bg-secondary/5;
 
   &__icon {
     svg {

--- a/decidim-core/app/packs/stylesheets/decidim/_flash.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_flash.scss
@@ -33,13 +33,25 @@
 
   &.success {
     @apply border-success bg-success/5;
+
+    svg {
+      @apply text-success;
+    }
   }
 
   &.alert {
     @apply border-alert bg-alert/5;
+
+    svg {
+      @apply text-alert;
+    }
   }
 
   &.warning {
     @apply border-warning bg-warning/5;
+
+    svg {
+      @apply text-warning;
+    }
   }
 }


### PR DESCRIPTION
#### :tophat: What? Why?

After merging #12067, I realized that I messed up the CSS for the flash alerts, that use the same CSS than announcements.

This PR fixes that. 

#### :pushpin: Related Issues

- Related to #12067

#### Testing

1. Log in and see a flash alert

### :camera: Screenshots

#### Before 

![Flash alert broken](https://github.com/decidim/decidim/assets/717367/ca163ec3-0480-462a-af79-3f903a011bc8)

#### After

![Flash alert fixed](https://github.com/decidim/decidim/assets/717367/01e42703-51d6-4e9e-8a56-2bd81956531c)

:hearts: Thank you!
