### PR TITLE
Don't add the slug of the space in some links

### DIFF
--- a/decidim-core/lib/decidim/engine_router.rb
+++ b/decidim-core/lib/decidim/engine_router.rb
@@ -16,7 +16,7 @@ module Decidim
     #
     # @return [EngineRouter] The new engine router
     def self.main_proxy(target)
-      new(target.mounted_engine, target.mounted_params)
+      new(target.mounted_engine, filter_spaces_slug_on_mounted_params(target))
     end
 
     # Instantiates a router to the backend engine for an object.
@@ -25,7 +25,7 @@ module Decidim
     #
     # @return [EngineRouter] The new engine router
     def self.admin_proxy(target)
-      new(target.mounted_admin_engine, target.mounted_params)
+      new(target.mounted_admin_engine, filter_spaces_slug_on_mounted_params(target))
     end
 
     def initialize(engine, default_url_options)
@@ -46,6 +46,15 @@ module Decidim
 
       send(@engine).send(method_name, *args)
     end
+
+    # Prevent adding two times the slug in the URL
+    def self.filter_spaces_slug_on_mounted_params(target)
+      return target.mounted_params unless target.class.include?(Decidim::Participable)
+
+      target.mounted_params.reject { |key, _val| key.ends_with?("_slug") }
+    end
+
+    private_class_method :filter_spaces_slug_on_mounted_params
 
     private
 

--- a/decidim-core/spec/lib/engine_router_spec.rb
+++ b/decidim-core/spec/lib/engine_router_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe EngineRouter do
+    let(:organization) do
+      build(:organization)
+    end
+
+    let(:participatory_process) do
+      build(:participatory_process, slug: "my-process", organization:)
+    end
+
+    describe ".admin_proxy" do
+      describe "#components_path" do
+        subject { described_class.admin_proxy(participatory_process).components_path }
+
+        it { is_expected.to eq("/admin/participatory_processes/my-process/components") }
+      end
+    end
+  end
+end

--- a/decidim-core/spec/presenters/decidim/resource_locator_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/resource_locator_presenter_spec.rb
@@ -44,13 +44,13 @@ module Decidim
       describe "#show" do
         subject { described_class.new(participatory_process).show }
 
-        it { is_expected.to start_with("/admin/participatory_processes/my-process") }
+        it { is_expected.to eq("/admin/participatory_processes/my-process") }
       end
 
       describe "#edit" do
         subject { described_class.new(participatory_process).edit }
 
-        it { is_expected.to start_with("/admin/participatory_processes/my-process/edit") }
+        it { is_expected.to eq("/admin/participatory_processes/my-process/edit") }
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This one has been bothering me for some time: on some links we had the slug of the space two times in the URL. Things like this:

- https://nightly.decidim.org/processes/compete-corpse?participatory_process_slug=compete-corpse
- https://nightly.decidim.org/admin/participatory_processes/compete-corpse/edit?participatory_process_slug=compete-corpse 

This makes these URL ugly and also the second time (in a query string) isn't necessary.

This PR fixes that.  

#### :pushpin: Related Issues
 
- Fixes  #11176

#### Testing

All the specs should be green

1. Sign in as admin
2. Go to a space
3. Click in the "edit" button  

:hearts: Thank you!
