### PR TITLE
Fix modal forms for editor

### DIFF
--- a/decidim-core/app/packs/src/decidim/editor/common/input_dialog.js
+++ b/decidim-core/app/packs/src/decidim/editor/common/input_dialog.js
@@ -38,7 +38,7 @@ export default class InputDialog {
       <div id="${uniq}-content">
         <button type="button" data-dialog-close="${uniq}" data-dialog-closable="" aria-label="${i18n.close}">&times</button>
         <div data-dialog-container>
-          <form>
+          <form class="form-defaults form">
             <div class="form__wrapper">
               ${inputsHTML}
             </div>

--- a/decidim-core/app/packs/src/decidim/editor/common/upload_dialog.js
+++ b/decidim-core/app/packs/src/decidim/editor/common/upload_dialog.js
@@ -134,10 +134,12 @@ export default class UploadDialog {
       }
 
       const titleInputHtml = `
-        <label>
-          ${options.inputLabel}
-          <input class="attachment-title" type="text" name="alt">
-        </label>
+        <form class="form-defaults form">
+          <label>
+            ${options.inputLabel}
+            <input class="attachment-title" type="text" name="alt">
+          </label>
+        </form>
       `;
 
       let titleSection = null;


### PR DESCRIPTION
#### :tophat: What? Why?
Link and Video layout in editor are broken. This PR fixes it.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #12076

#### Testing
1. Login as admin 
2. Enter organization [edit page](https://nightly.decidim.org/admin/organization/edit)
3. In the Terms of Service editor 
4. Any piece of text and press "link" icon
5. See the layout of pop-up
6. Close the pop-up
7. Click on Insert video button 
8. See the layout of pop-up
9. Apply patch 
10. Repeat 4,5,6,7,8

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

#### Before 
Link 
![image](https://github.com/decidim/decidim/assets/105683/81154b89-a1e0-43a0-964f-bee3ff225ba2)

Video
![image](https://github.com/decidim/decidim/assets/105683/933dc728-75db-4ea3-a538-6d2983de2626)

#### After 
LInk
![image](https://github.com/decidim/decidim/assets/105683/a8035083-98ac-4495-8151-dd1caeb8607b)

Video
![image](https://github.com/decidim/decidim/assets/105683/c684eedc-eff9-4a64-9cc3-da373ab8ef87)

:hearts: Thank you!
