### PR TITLE
Extract methods from initiatives seeds

### DIFF
--- a/decidim-initiatives/lib/decidim/initiatives/seeds.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/seeds.rb
@@ -10,12 +10,7 @@ module Decidim
         create_content_block!
 
         3.times do |n|
-          type = Decidim::InitiativesType.create!(
-            title: Decidim::Faker::Localized.sentence(word_count: 5),
-            description: Decidim::Faker::Localized.sentence(word_count: 25),
-            organization:,
-            banner_image: ::Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil # Keep after organization
-          )
+          type = create_initiative_type!
 
           organization.top_scopes.each do |scope|
             Decidim::InitiativesTypeScope.create(
@@ -90,6 +85,15 @@ module Decidim
           scope_name: :homepage,
           manifest_name: :highlighted_initiatives,
           published_at: Time.current
+        )
+      end
+
+      def create_initiative_type!
+        Decidim::InitiativesType.create!(
+          title: Decidim::Faker::Localized.sentence(word_count: 5),
+          description: Decidim::Faker::Localized.sentence(word_count: 25),
+          organization:,
+          banner_image: ::Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil # Keep after organization
         )
       end
     end

--- a/decidim-initiatives/lib/decidim/initiatives/seeds.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/seeds.rb
@@ -7,13 +7,7 @@ module Decidim
   module Initiatives
     class Seeds < Decidim::Seeds
       def call
-        Decidim::ContentBlock.create(
-          organization:,
-          weight: 33,
-          scope_name: :homepage,
-          manifest_name: :highlighted_initiatives,
-          published_at: Time.current
-        )
+        create_content_block!
 
         3.times do |n|
           type = Decidim::InitiativesType.create!(
@@ -87,6 +81,16 @@ module Decidim
             end
           end
         end
+      end
+
+      def create_content_block!
+        Decidim::ContentBlock.create(
+          organization:,
+          weight: 33,
+          scope_name: :homepage,
+          manifest_name: :highlighted_initiatives,
+          published_at: Time.current
+        )
       end
     end
   end

--- a/decidim-initiatives/lib/decidim/initiatives/seeds.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/seeds.rb
@@ -23,14 +23,7 @@ module Decidim
 
           initiative = create_initiative!(state:)
 
-          if %w(published rejected accepted).include? state
-            users = []
-            rand(50).times do
-              author = (Decidim::User.all - users).sample
-              initiative.votes.create!(author:, scope: initiative.scope, hash_id: SecureRandom.hex)
-              users << author
-            end
-          end
+          create_initiative_votes!(initiative:) if %w(published rejected accepted).include? state
 
           Decidim::Comments::Seed.comments_for(initiative)
 
@@ -106,6 +99,15 @@ module Decidim
         initiative.add_to_index_as_search_resource
 
         initiative
+      end
+
+      def create_initiative_votes!(initiative:)
+        users = []
+        rand(50).times do
+          author = (Decidim::User.all - users).sample
+          initiative.votes.create!(author:, scope: initiative.scope, hash_id: SecureRandom.hex)
+          users << author
+        end
       end
     end
   end

--- a/decidim-initiatives/lib/decidim/initiatives/seeds.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/seeds.rb
@@ -7,8 +7,6 @@ module Decidim
   module Initiatives
     class Seeds < Decidim::Seeds
       def call
-        organization = Decidim::Organization.first
-
         Decidim::ContentBlock.create(
           organization:,
           weight: 33,

--- a/decidim-initiatives/lib/decidim/initiatives/seeds.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/seeds.rb
@@ -21,28 +21,7 @@ module Decidim
           Decidim::Initiative.skip_callback(:save, :after, :notify_state_change, raise: false)
           Decidim::Initiative.skip_callback(:create, :after, :notify_creation, raise: false)
 
-          params = {
-            title: Decidim::Faker::Localized.sentence(word_count: 3),
-            description: Decidim::Faker::Localized.sentence(word_count: 25),
-            scoped_type: Decidim::InitiativesTypeScope.all.sample,
-            state:,
-            signature_type: "online",
-            signature_start_date: Date.current - 7.days,
-            signature_end_date: Date.current + 7.days,
-            published_at: 7.days.ago,
-            author: Decidim::User.all.sample,
-            organization:
-          }
-
-          initiative = Decidim.traceability.perform_action!(
-            "publish",
-            Decidim::Initiative,
-            organization.users.first,
-            visibility: "all"
-          ) do
-            Decidim::Initiative.create!(params)
-          end
-          initiative.add_to_index_as_search_resource
+          initiative = create_initiative!(state:)
 
           if %w(published rejected accepted).include? state
             users = []
@@ -100,6 +79,33 @@ module Decidim
           scope:,
           supports_required: (n + 1) * 1000
         )
+      end
+
+      def create_initiative!(state:)
+        params = {
+          title: Decidim::Faker::Localized.sentence(word_count: 3),
+          description: Decidim::Faker::Localized.sentence(word_count: 25),
+          scoped_type: Decidim::InitiativesTypeScope.all.sample,
+          state:,
+          signature_type: "online",
+          signature_start_date: Date.current - 7.days,
+          signature_end_date: Date.current + 7.days,
+          published_at: 7.days.ago,
+          author: Decidim::User.all.sample,
+          organization:
+        }
+
+        initiative = Decidim.traceability.perform_action!(
+          "publish",
+          Decidim::Initiative,
+          organization.users.first,
+          visibility: "all"
+        ) do
+          Decidim::Initiative.create!(params)
+        end
+        initiative.add_to_index_as_search_resource
+
+        initiative
       end
     end
   end

--- a/decidim-initiatives/lib/decidim/initiatives/seeds.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/seeds.rb
@@ -30,18 +30,7 @@ module Decidim
           create_attachment(attached_to: initiative, filename: "city.jpeg")
 
           Decidim::Initiatives.default_components.each do |component_name|
-            component = Decidim::Component.create!(
-              name: Decidim::Components::Namer.new(initiative.organization.available_locales, component_name).i18n_name,
-              manifest_name: component_name,
-              published_at: Time.current,
-              participatory_space: initiative
-            )
-
-            next unless component_name.in? ["pages", :pages]
-
-            Decidim::Pages::CreatePage.call(component) do
-              on(:invalid) { raise "Cannot create page" }
-            end
+            create_component!(initiative:, component_name:)
           end
         end
       end
@@ -107,6 +96,21 @@ module Decidim
           author = (Decidim::User.all - users).sample
           initiative.votes.create!(author:, scope: initiative.scope, hash_id: SecureRandom.hex)
           users << author
+        end
+      end
+
+      def create_component!(initiative:, component_name:)
+        component = Decidim::Component.create!(
+          name: Decidim::Components::Namer.new(initiative.organization.available_locales, component_name).i18n_name,
+          manifest_name: component_name,
+          published_at: Time.current,
+          participatory_space: initiative
+        )
+
+        return unless component_name.in? ["pages", :pages]
+
+        Decidim::Pages::CreatePage.call(component) do
+          on(:invalid) { raise "Cannot create page" }
         end
       end
     end

--- a/decidim-initiatives/lib/decidim/initiatives/seeds.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/seeds.rb
@@ -9,15 +9,11 @@ module Decidim
       def call
         create_content_block!
 
-        3.times do |n|
+        3.times do |_n|
           type = create_initiative_type!
 
           organization.top_scopes.each do |scope|
-            Decidim::InitiativesTypeScope.create(
-              type:,
-              scope:,
-              supports_required: (n + 1) * 1000
-            )
+            create_initiative_type_scope!(scope:, type:)
           end
         end
 
@@ -94,6 +90,15 @@ module Decidim
           description: Decidim::Faker::Localized.sentence(word_count: 25),
           organization:,
           banner_image: ::Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil # Keep after organization
+        )
+      end
+
+      def create_initiative_type_scope!(scope:, type:)
+        n = rand(3)
+        Decidim::InitiativesTypeScope.create(
+          type:,
+          scope:,
+          supports_required: (n + 1) * 1000
         )
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Refactors the initiatives seeds to individual methods.

This is following the same methodology and reasoning from #12005, so refer to that issue for the explanations.   

To ease-up the review process, I was disciplined and made the changes in a commit by commit basis 😎 
 
#### Testing

Regenerating the `development_app` database should have different kind of initiatives (almost the same as before):

```console
$ bin/rails db:drop db:create db:migrate db:seed
``` 

:hearts: Thank you!
