### PR TITLE
Extract methods from votings seeds

### DIFF
--- a/decidim-elections/lib/decidim/votings/seeds.rb
+++ b/decidim-elections/lib/decidim/votings/seeds.rb
@@ -21,13 +21,7 @@ module Decidim
           create_landing_page!(voting:)
 
           2.times do
-            Decidim::Category.create!(
-              name: Decidim::Faker::Localized.sentence(word_count: 5),
-              description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-                Decidim::Faker::Localized.paragraph(sentence_count: 3)
-              end,
-              participatory_space: voting
-            )
+            create_category!(participatory_space: voting)
           end
 
           Decidim.component_manifests.each do |manifest|

--- a/decidim-elections/lib/decidim/votings/seeds.rb
+++ b/decidim-elections/lib/decidim/votings/seeds.rb
@@ -12,22 +12,7 @@ module Decidim
 
           unless voting.online_voting?
             3.times do
-              params = {
-                voting:,
-                title: Decidim::Faker::Localized.sentence(word_count: 5),
-                address: ::Faker::Address.full_address,
-                latitude: ::Faker::Address.latitude,
-                longitude: ::Faker::Address.longitude,
-                location: Decidim::Faker::Localized.sentence,
-                location_hints: Decidim::Faker::Localized.sentence
-              }
-
-              polling_station = Decidim.traceability.create!(
-                Decidim::Votings::PollingStation,
-                organization.users.first,
-                params,
-                visibility: "all"
-              )
+              polling_station = create_polling_station!(voting:)
 
               email = "voting_#{voting.id}_president_#{polling_station.id}@example.org"
 
@@ -196,6 +181,25 @@ module Decidim
         voting.add_to_index_as_search_resource
 
         voting
+      end
+
+      def create_polling_station!(voting:)
+        params = {
+          voting:,
+          title: Decidim::Faker::Localized.sentence(word_count: 5),
+          address: ::Faker::Address.full_address,
+          latitude: ::Faker::Address.latitude,
+          longitude: ::Faker::Address.longitude,
+          location: Decidim::Faker::Localized.sentence,
+          location_hints: Decidim::Faker::Localized.sentence
+        }
+
+        Decidim.traceability.create!(
+          Decidim::Votings::PollingStation,
+          organization.users.first,
+          params,
+          visibility: "all"
+        )
       end
     end
   end

--- a/decidim-elections/lib/decidim/votings/seeds.rb
+++ b/decidim-elections/lib/decidim/votings/seeds.rb
@@ -18,18 +18,7 @@ module Decidim
             end
           end
 
-          landing_page_content_blocks = [:hero, :title, :related_elections, :polling_stations, :related_documents, :related_images, :stats, :metrics]
-
-          landing_page_content_blocks.each.with_index(1) do |manifest_name, index|
-            Decidim::ContentBlock.create(
-              organization:,
-              scope_name: :voting_landing_page,
-              manifest_name:,
-              weight: index,
-              scoped_resource_id: voting.id,
-              published_at: Time.current
-            )
-          end
+          create_landing_page!(voting:)
 
           2.times do
             Decidim::Category.create!(
@@ -204,6 +193,21 @@ module Decidim
           },
           visibility: "all"
         )
+      end
+
+      def create_landing_page!(voting:)
+        landing_page_content_blocks = [:hero, :title, :related_elections, :polling_stations, :related_documents, :related_images, :stats, :metrics]
+
+        landing_page_content_blocks.each.with_index(1) do |manifest_name, index|
+          Decidim::ContentBlock.create(
+            organization:,
+            scope_name: :voting_landing_page,
+            manifest_name:,
+            weight: index,
+            scoped_resource_id: voting.id,
+            published_at: Time.current
+          )
+        end
       end
     end
   end

--- a/decidim-elections/lib/decidim/votings/seeds.rb
+++ b/decidim-elections/lib/decidim/votings/seeds.rb
@@ -14,29 +14,7 @@ module Decidim
             3.times do
               polling_station = create_polling_station!(voting:)
 
-              email = "voting_#{voting.id}_president_#{polling_station.id}@example.org"
-
-              user = Decidim::User.find_or_initialize_by(email:)
-              user.update!(
-                name: ::Faker::Name.name,
-                nickname: ::Faker::Twitter.unique.screen_name,
-                password: "decidim123456789",
-                organization:,
-                confirmed_at: Time.current,
-                locale: I18n.default_locale,
-                tos_agreement: true
-              )
-
-              Decidim.traceability.create!(
-                Decidim::Votings::PollingOfficer,
-                organization.users.first,
-                {
-                  voting:,
-                  user:,
-                  presided_polling_station: polling_station
-                },
-                visibility: "all"
-              )
+              create_polling_officer!(voting:, polling_station:)
             end
           end
 
@@ -198,6 +176,32 @@ module Decidim
           Decidim::Votings::PollingStation,
           organization.users.first,
           params,
+          visibility: "all"
+        )
+      end
+
+      def create_polling_officer!(voting:, polling_station:)
+        email = "voting_#{voting.id}_president_#{polling_station.id}@example.org"
+
+        user = Decidim::User.find_or_initialize_by(email:)
+        user.update!(
+          name: ::Faker::Name.name,
+          nickname: ::Faker::Twitter.unique.screen_name,
+          password: "decidim123456789",
+          organization:,
+          confirmed_at: Time.current,
+          locale: I18n.default_locale,
+          tos_agreement: true
+        )
+
+        Decidim.traceability.create!(
+          Decidim::Votings::PollingOfficer,
+          organization.users.first,
+          {
+            voting:,
+            user:,
+            presided_polling_station: polling_station
+          },
           visibility: "all"
         )
       end

--- a/decidim-elections/lib/decidim/votings/seeds.rb
+++ b/decidim-elections/lib/decidim/votings/seeds.rb
@@ -7,8 +7,6 @@ module Decidim
     class Seeds < Decidim::Seeds
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def call
-        organization = Decidim::Organization.first
-
         3.times do |n|
           params = {
             organization:,


### PR DESCRIPTION
#### :tophat: What? Why?

Refactors the votings seeds to individual methods.

This is following the same methodology and reasoning from #12005, so refer to that issue for the explanations.   

To ease-up the review process, I was disciplined and made the changes in a commit by commit basis 😎 
 
#### Testing

Regenerating the `development_app` database should have different kind of votings (almost the same as before):

```console
$ bin/rails db:drop db:create db:migrate db:seed
``` 

:hearts: Thank you!
