### PR TITLE
Restrict comments replies tree including polymorphism

### DIFF
--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -29,6 +29,7 @@ module Decidim
       translatable_fields :body
 
       parent_item_foreign_key :decidim_commentable_id
+      parent_item_polymorphic_type_key :decidim_commentable_type
 
       belongs_to :commentable, foreign_key: "decidim_commentable_id", foreign_type: "decidim_commentable_type", polymorphic: true
       belongs_to :root_commentable, foreign_key: "decidim_root_commentable_id", foreign_type: "decidim_root_commentable_type", polymorphic: true, touch: true

--- a/decidim-core/lib/decidim/acts_as_tree.rb
+++ b/decidim-core/lib/decidim/acts_as_tree.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Adapted from https://hashrocket.com/blog/posts/recursive-sql-in-activerecord
+
 module Decidim
   module ActsAsTree
     extend ActiveSupport::Concern

--- a/decidim-core/lib/decidim/acts_as_tree.rb
+++ b/decidim-core/lib/decidim/acts_as_tree.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# Adapted from https://hashrocket.com/blog/posts/recursive-sql-in-activerecord
-
 module Decidim
+  # Adapted from https://hashrocket.com/blog/posts/recursive-sql-in-activerecord
   module ActsAsTree
     extend ActiveSupport::Concern
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -44,6 +44,38 @@ shared_examples "comments" do
     expect(page).to have_css(".comments > div:nth-child(2)", text: "Most Rated Comment")
   end
 
+  context "when there are comments and replies" do
+    let!(:single_comment) { create(:comment, commentable:) }
+    let!(:reply) { create(:comment, commentable: single_comment, root_commentable: commentable) }
+
+    it "displays the show replies link on comment with reply" do
+      visit resource_path
+      expect(page).not_to have_content("Comments are disabled at this time")
+      expect(page).to have_css(".comment", minimum: 1)
+
+      within("#accordion-#{single_comment.id}") do
+        expect(page).to have_content "Hide replies"
+      end
+    end
+
+    context "when there is a comment with the same parent id but different type with replies" do
+      let!(:component) { create(:component, manifest_name: :dummy, organization:) }
+      let!(:other_commentable) { create(:dummy_resource, component:, author: user, id: single_comment.id) }
+      let!(:reply) { create(:comment, commentable: other_commentable, root_commentable: other_commentable) }
+      let!(:other_reply) { create(:comment, commentable: reply, root_commentable: other_commentable) }
+
+      it "displays the show replies link on comment with reply" do
+        visit resource_path
+        expect(page).not_to have_content("Comments are disabled at this time")
+        expect(page).to have_css(".comment", minimum: 1)
+
+        within("#accordion-#{single_comment.id}") do
+          expect(page).not_to have_content "Hide replies"
+        end
+      end
+    end
+  end
+
   context "when there are deleted comments" do
     let(:deleted_comment) { comments[0] }
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -59,8 +59,8 @@ shared_examples "comments" do
     end
 
     context "when there is a comment with the same parent id but different type with replies" do
-      let!(:component) { create(:component, manifest_name: :dummy, organization:) }
-      let!(:other_commentable) { create(:dummy_resource, component:, author: user, id: single_comment.id) }
+      let!(:other_component) { create(:component, manifest_name: :dummy, organization:) }
+      let!(:other_commentable) { create(:dummy_resource, component: other_component, author: user, id: single_comment.id) }
       let!(:reply) { create(:comment, commentable: other_commentable, root_commentable: other_commentable) }
       let!(:other_reply) { create(:comment, commentable: reply, root_commentable: other_commentable) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR:
* Adds an option to ActsAsTree concern to calculate tree taking into account the polymorphic relation between comments and commentables. This restriction only consider comments related with parent comment with the correct `decidim_commentable_type` and `decidim_commentable_id`
* Adds tests to verify that the conditions described by the related issue are fixed

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11990

#### Testing
Automatic tests have been added. To find a comment which reproduces the error fixed by this PR using seeds find a comment without replies and with comments with replies to different type of resources but the same id of the initial comment:

```ruby
comments_list = Decidim::Comments::Comment
                        .where(
                          decidim_commentable_id: Decidim::Comments::Comment.where(
                            decidim_commentable_type: "Decidim::Comments::Comment"
                          ).select(:id)
                        )
                        .where.not(decidim_commentable_type: "Decidim::Comments::Comment").select do |c|
                          Decidim::Comments::Comment.where(commentable: c).count.positive?
                        end.map do |c|
                          Decidim::Comments::Comment.find(c.decidim_commentable_id)
                        end.select do |c|
                          Decidim::Comments::Comment.where(commentable: c).blank?
                        end.uniq

```
Find the path of the commentable of one of those comments and the "Hide replies" element should not appear

* To find the path of the space the comments belongs to use:
```ruby
Decidim::ResourceLocatorPresenter.new(comment.participatory_space).url 
```
* Then navigate to the component by its name `comment.component.name`
* And find the resource by `comment.commentable`

### :camera: Screenshots

#### Before

![Screenshot from 2023-11-29 19-32-32](https://github.com/decidim/decidim/assets/446459/3c13084a-1170-4fb0-8aaa-04c121b68ac8)


#### After

![Screenshot from 2023-11-29 19-40-13](https://github.com/decidim/decidim/assets/446459/57a8eef3-3ee5-4b9a-b5d7-95ea3bbd2274)



:hearts: Thank you!
