### PR TITLE
Fix selection of polls with two answers and single options questions

### DIFF
--- a/decidim-meetings/app/packs/src/decidim/meetings/poll.component.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/poll.component.js
@@ -1,5 +1,8 @@
 /* eslint id-length: ["error", { "exceptions": ["$"] }] */
 
+import createOptionAttachedInputs from "src/decidim/forms/option_attached_inputs.component"
+import createMaxChoicesAlertComponent from "src/decidim/forms/max_choices_alert.component"
+
 /**
  * A plain Javascript component that handles questions from polls in meetings:
  *   - fetches them via Ajax
@@ -75,6 +78,7 @@ export default class PollComponent {
       this._updateCounter();
       this._setQuestionsState(this.$element);
       this._pollQuestions();
+      this._addValidations();
     });
   }
 
@@ -162,5 +166,30 @@ export default class PollComponent {
       const questionsCount = this.$element.find("details").length;
       this.$counter.html(`(${questionsCount})`);
     }
+  }
+
+  _addValidations() {
+    console.log("KEEP ME ASFSL")
+    $(".js-radio-button-collection, .js-check-box-collection").each((idx, el) => {
+      createOptionAttachedInputs({
+        wrapperField: $(el),
+        controllerFieldSelector: "input[type=radio], input[type=checkbox]",
+        dependentInputSelector: "input[type=text], input[type=hidden]"
+      });
+    });
+
+    $.unique($(".js-check-box-collection").parents(".answer")).each((idx, el) => {
+      console.log("CHECKIE")
+      const maxChoices = $(el).data("max-choices");
+      if (maxChoices) {
+        createMaxChoicesAlertComponent({
+          wrapperField: $(el),
+          controllerFieldSelector: "input[type=checkbox]",
+          controllerCollectionSelector: ".js-check-box-collection",
+          alertElement: $(el).find(".max-choices-alert"),
+          maxChoices: maxChoices
+        });
+      }
+    });
   }
 }

--- a/decidim-meetings/app/packs/src/decidim/meetings/poll.component.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/poll.component.js
@@ -169,7 +169,6 @@ export default class PollComponent {
   }
 
   _addValidations() {
-    console.log("KEEP ME ASFSL")
     $(".js-radio-button-collection, .js-check-box-collection").each((idx, el) => {
       createOptionAttachedInputs({
         wrapperField: $(el),
@@ -179,7 +178,6 @@ export default class PollComponent {
     });
 
     $.unique($(".js-check-box-collection").parents(".answer")).each((idx, el) => {
-      console.log("CHECKIE")
       const maxChoices = $(el).data("max-choices");
       if (maxChoices) {
         createMaxChoicesAlertComponent({

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/_multiple_option.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/_multiple_option.html.erb
@@ -1,13 +1,17 @@
-<% question.answer_options.each_with_index do |answer_option, idx| %>
-  <% choice = answer.choices.find { |choice| choice.decidim_answer_option_id == answer_option.id } if answer %>
+<div class="answer-questionnaire__single-option js-check-box-collection">
+  <% question.answer_options.each_with_index do |answer_option, idx| %>
+    <% choice = answer.choices.find { |choice| choice.decidim_answer_option_id == answer_option.id } if answer %>
 
-  <%= label_tag do %>
-    <%= check_box_tag "answer[choices][#{idx}][body]",
-                      translated_attribute(answer_option.body),
-                      choice.present?, disabled: %>
+    <div class="js-collection-input">
+      <%= label_tag do %>
+        <%= check_box_tag "answer[choices][#{idx}][body]",
+                          translated_attribute(answer_option.body),
+                          choice.present?, disabled: %>
 
-    <%= translated_attribute(answer_option.body) %>
+        <%= translated_attribute(answer_option.body) %>
 
-    <%= hidden_field_tag "answer[choices][#{idx}][answer_option_id]", answer_option.id, disabled: %>
+        <%= hidden_field_tag "answer[choices][#{idx}][answer_option_id]", answer_option.id, disabled: %>
+      <% end %>
+    </div>
   <% end %>
-<% end %>
+</div>

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/_single_option.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/_single_option.html.erb
@@ -4,14 +4,14 @@
   <% choice_id = "#{field_id}_choices_#{idx}" %>
 
   <%= label_tag "#{choice_id}_body" do %>
-    <%= radio_button_tag "answer[choices][#{idx}][body]",
+    <%= radio_button_tag "answer[choices][#{question.id}][body]",
                          translated_attribute(answer_option.body),
                          answer_option.id == choice.try(:decidim_answer_option_id),
                          id: "#{choice_id}_body", disabled: %>
 
     <%= translated_attribute(answer_option.body) %>
 
-    <%= hidden_field_tag "answer[choices][#{idx}][answer_option_id]",
+    <%= hidden_field_tag "answer[choices][#{question.id}][answer_option_id]",
                          answer_option.id,
                          id: "#{choice_id}_answer_option",
                          disabled: %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_published_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_published_question.html.erb
@@ -6,11 +6,11 @@
   <% @form = form || Decidim::Meetings::AnswerForm.new(question_id: question.id, current_user:) %>
   <%= decidim_form_for(@form, url: meeting_polls_answers_path(meeting), method: :post, remote: true, html: { class: "form-defaults mt-4" }, data: { "safe-path" => meeting_live_event_path(meeting) }) do |form| %>
     <div class="answer question" data-max-choices="<%= question.max_choices %>">
+      <p class="form-error max-choices-alert mt-0 mb-4"><%= t(".max_choices_alert") %></p>
+
       <%= render partial: "decidim/meetings/polls/answers/#{question.question_type}", locals: { answer: @form.answer, question:, answer_form: form, disabled: question.answered_by?(current_user), field_id: question.id } %>
 
       <%= form.hidden_field :question_id %>
-
-      <small class="form-error max-choices-alert"><%= t(".max_choices_alert") %></small>
 
       <% @form.errors.full_messages.each do |msg| %>
         <small class="form-error is-visible mt-1"><%= msg %></small>

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -17,6 +17,7 @@ module Decidim
 
         2.times do
           create_meeting!(component:, type: :online)
+          create_meeting!(component:, type: :online_live_event)
           create_meeting!(component:, type: :hybrid)
           meeting = create_meeting!(component:, type: :in_person)
 
@@ -104,6 +105,18 @@ module Decidim
                      iframe_access_level: :all,
                      iframe_embed_type: [:embed_in_meeting_page, :open_in_live_event_page, :open_in_new_tab].sample
                    )
+                 when :online_live_event
+                   params.merge(
+                     end_time: Time.zone.now + [rand(1..4).hours, rand(1..20).days].sample,
+                     location: nil,
+                     location_hints: nil,
+                     latitude: nil,
+                     longitude: nil,
+                     type_of_meeting: :online,
+                     online_meeting_url: "https://www.youtube.com/watch?v=f6JMgJAQ2tc",
+                     iframe_access_level: :all,
+                     iframe_embed_type: :open_in_live_event_page
+                   )
                  else
                    params # :in_person
                  end
@@ -129,7 +142,7 @@ module Decidim
       # Create a meeting
       #
       # @param component [Decidim::Component] The component where this class will be created
-      # @param type [:in_person, :hybrid, :online] The meeting type
+      # @param type [:in_person, :hybrid, :online, :online_live_event] The meeting type
       # @param author_type [:official, :user, :user_group] Which type the author of the meeting will be
       #
       # @return [Decidim::Meeting]

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -86,19 +86,23 @@ module Decidim
         params = case type
                  when :hybrid
                    params.merge(
-                     title: Decidim::Faker::Localized.sentence(word_count: 2),
+                     end_time: Time.zone.now + [rand(1..4).hours, rand(1..20).days].sample,
                      type_of_meeting: :hybrid,
-                     online_meeting_url: "https://www.youtube.com/watch?v=f6JMgJAQ2tc"
+                     online_meeting_url: "https://www.youtube.com/watch?v=f6JMgJAQ2tc",
+                     iframe_access_level: :all,
+                     iframe_embed_type: [:embed_in_meeting_page, :open_in_live_event_page, :open_in_new_tab].sample
                    )
                  when :online
                    params.merge(
+                     end_time: Time.zone.now + [rand(1..4).hours, rand(1..20).days].sample,
                      location: nil,
                      location_hints: nil,
                      latitude: nil,
                      longitude: nil,
-                     title: Decidim::Faker::Localized.sentence(word_count: 2),
                      type_of_meeting: :online,
-                     online_meeting_url: "https://www.youtube.com/watch?v=f6JMgJAQ2tc"
+                     online_meeting_url: "https://www.youtube.com/watch?v=f6JMgJAQ2tc",
+                     iframe_access_level: :all,
+                     iframe_embed_type: [:embed_in_meeting_page, :open_in_live_event_page, :open_in_new_tab].sample
                    )
                  else
                    params # :in_person

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -88,7 +88,7 @@ module Decidim
                    params.merge(
                      title: Decidim::Faker::Localized.sentence(word_count: 2),
                      type_of_meeting: :hybrid,
-                     online_meeting_url: "http://example.org"
+                     online_meeting_url: "https://www.youtube.com/watch?v=f6JMgJAQ2tc"
                    )
                  when :online
                    params.merge(
@@ -98,7 +98,7 @@ module Decidim
                      longitude: nil,
                      title: Decidim::Faker::Localized.sentence(word_count: 2),
                      type_of_meeting: :online,
-                     online_meeting_url: "http://example.org"
+                     online_meeting_url: "https://www.youtube.com/watch?v=f6JMgJAQ2tc"
                    )
                  else
                    params # :in_person

--- a/decidim-meetings/spec/system/live_meeting_answer_questions_spec.rb
+++ b/decidim-meetings/spec/system/live_meeting_answer_questions_spec.rb
@@ -62,7 +62,7 @@ describe "Meeting live event poll answer" do
   end
 
   context "when questions are published" do
-    let!(:question_multiple_option) { create(:meetings_poll_question, :published, questionnaire:, body: body_multiple_option_question, question_type: "multiple_option") }
+    let!(:question_multiple_option) { create(:meetings_poll_question, :published, questionnaire:, body: body_multiple_option_question, question_type: "multiple_option", max_choices: 2) }
     let!(:question_single_option) { create(:meetings_poll_question, :published, questionnaire:, body: body_single_option_question, question_type: "single_option") }
 
     before do
@@ -90,6 +90,17 @@ describe "Meeting live event poll answer" do
       expect(answers[0]["checked"]).to be_falsy
       expect(answers[1]["checked"]).to be_truthy
       expect(answers[2]["checked"]).to be_falsy
+    end
+
+    it "does not allow selecting more than the maximum choices for multiple options" do
+      click_button "Questions (2)"
+      open_first_question
+
+      check question_multiple_option.answer_options.first.body["en"]
+      check question_multiple_option.answer_options.second.body["en"]
+      check question_multiple_option.answer_options.third.body["en"]
+
+      expect(page).to have_content("There are too many choices selected")
     end
   end
 

--- a/decidim-meetings/spec/system/live_meeting_answer_questions_spec.rb
+++ b/decidim-meetings/spec/system/live_meeting_answer_questions_spec.rb
@@ -78,6 +78,19 @@ describe "Meeting live event poll answer" do
 
       expect(page).to have_content("Question replied")
     end
+
+    it "does not allow selecting two single options" do
+      click_button "Questions (2)"
+      find("details[data-question='#{question_single_option.id}']").click
+
+      choose question_single_option.answer_options.first.body["en"]
+      choose question_single_option.answer_options.second.body["en"]
+      answers = all("details[data-question='#{question_single_option.id}'] input[type='radio']")
+
+      expect(answers[0]["checked"]).to be_falsy
+      expect(answers[1]["checked"]).to be_truthy
+      expect(answers[2]["checked"]).to be_falsy
+    end
   end
 
   context "when questions are closed" do


### PR DESCRIPTION
#### :tophat: What? Why?

On online meetings with live events and polls, there are a couple of bugs:

- If you have a question of type "single option" you can select more than one single option (!!)
- If you have a question of type "multiple option" and you have a max choice configured (for instance of 2) and you have more options (for instance 4) and you pass the max choice, then you don't see any error message

I've also added some seeds for the online meetings with events. I didn't have the way to actually add the poll questions to the seeds, but that's like a nice to have 😄 

#### :pushpin: Related Issues
 
- Fixes #12025 

#### Testing

##### Without the patch 

1. Sign in as admin
2. Create an online meeting with an embeded iframe with a live event page
3. Create a new poll with two type of answers:
3.1. A "single option" answer with two options
3.2. A "multiple option" answer with four options and two max choices
4. Go to the live event page
5. Click in the "Administrate" button
6. Click in the "Send" question button
7. Click in the "Questions" button
8. Click in the first question
9. See that you can click more than one single option
10. Click in the second question
11. See that you can click more than three options and you don't see any error

##### With the patch 

1. Run the seeds
2. Sign in as admin
3. See that you have already at least one online meeting with live event page
4. Create a new poll with two type of answers:
4.1. A "single option" answer with two options
4.2. A "multiple option" answer with four options and two max choices
5. Go to the live event page
6. Click in the "Administrate" button
7. Click in each question and click in their "Send" question button
8. Click in the "Questions" button
9. Click in the first question
10. See that you **can not** click more than one single option
11. Click in the second question
12. See that you can click more than three options and you **do see** an error

### :camera: Screenshots

#### Before

![Screenshot of the live event page with the bugs](https://github.com/decidim/decidim/assets/717367/b28b71e9-e11b-4892-9425-d2d5c320dfd2)

#### After

![Screenshot of the live event page with the fixes](https://github.com/decidim/decidim/assets/717367/7817fad6-26df-4d0e-b432-e1033810593a)

:hearts: Thank you!
