### PR TITLE
Remove image resolver from decidim-verifications

### DIFF
--- a/decidim-verifications/app/packs/entrypoints/decidim_verifications.js
+++ b/decidim-verifications/app/packs/entrypoints/decidim_verifications.js
@@ -1,5 +1,2 @@
-// Images
-require.context("../images", true)
-
 // CSS
 import "stylesheets/verifications.scss"


### PR DESCRIPTION
#### :tophat: What? Why?
compiling assets in decidim-0.28.0.rc1 fails with the following error:

```
ERROR in ../../../.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-verifications-0.28.0.rc1/app/packs/entrypoints/decidim_verifications.js 2:0-34
Module not found: Error: Can't resolve '../images' in '/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-verifications-0.28.0.rc1/app/packs/entrypoints'
resolve '../images' in '/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-verifications-0.28.0.rc1/app/packs/entrypoints'
  No description file found in /.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-verifications-0.28.0.rc1/app/packs/entrypoints or above
  No description file found in /.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-verifications-0.28.0.rc1/app/packs or above
  /.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-verifications-0.28.0.rc1/app/packs/images doesn't exist
```
Upon investigation, i have seen there is no folder images in that path, as on develop branch we have only a `.gitkeep` file. 

I am removing the resolve, as I know that the `.gitkeep` file will be ignored by the release process, and the empty folders may be ignored during the same process.