### PR TITLE
Remove postcss-loader config loader customization

### DIFF
--- a/packages/webpacker/src/override-config.js
+++ b/packages/webpacker/src/override-config.js
@@ -24,6 +24,13 @@ const overrideSassRule = (modifyConfig) => {
       baseLoader = miniCssExtractPlugin.loader;
     }
 
+    // eslint-disable-next-line no-undef
+    let postCssConfig = path.resolve(__dirname, "../../../postcss.config.js");
+    if (postCssConfig.includes("node_modules")) {
+      // eslint-disable-next-line no-undef
+      postCssConfig = path.resolve(__dirname, "../../../../postcss.config.js");
+    }
+
     modifyConfig.module.rules.push({
       test: /\.(scss|sass)(\.erb)?$/i,
       use: [
@@ -37,7 +44,12 @@ const overrideSassRule = (modifyConfig) => {
         },
         {
           loader: "postcss-loader",
-          options: { sourceMap: true }
+          options: {
+            sourceMap: true,
+            postcssOptions: {
+              config: postCssConfig
+            }
+          }
         },
         {
           loader: sassLoaderPath

--- a/packages/webpacker/src/override-config.js
+++ b/packages/webpacker/src/override-config.js
@@ -36,14 +36,7 @@ const overrideSassRule = (modifyConfig) => {
           }
         },
         {
-          loader: "postcss-loader",
-          options: {
-            sourceMap: true,
-            postcssOptions: {
-              // eslint-disable-next-line no-undef
-              config: path.resolve(__dirname, "../../../postcss.config.js")
-            }
-          }
+          loader: "postcss-loader"
         },
         {
           loader: sassLoaderPath

--- a/packages/webpacker/src/override-config.js
+++ b/packages/webpacker/src/override-config.js
@@ -36,7 +36,8 @@ const overrideSassRule = (modifyConfig) => {
           }
         },
         {
-          loader: "postcss-loader"
+          loader: "postcss-loader",
+          options: { sourceMap: true }
         },
         {
           loader: sassLoaderPath


### PR DESCRIPTION
#### :tophat: What? Why?

After installing decidim-0.28.0.rc1, the asset compilation path fails with the following error: 

```
ERROR in ../../../.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-accountability-0.28.0.rc1/app/packs/stylesheets/accountability.scss (../../../.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-accountability-0.28.0.rc1/app/packs/stylesheets/accountability.scss.webpack[javascript/auto]!=!./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[4].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[4].use[2]!./node_modules/@decidim/webpacker/src/loaders/decidim-sass-loader.js!../../../.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-accountability-0.28.0.rc1/app/packs/stylesheets/accountability.scss)
Module build failed (from ./node_modules/postcss-loader/dist/cjs.js):
Error: No PostCSS config found in: /Sites/decidim/metadecidim/node_modules/postcss.config.js
    at loadConfig (//Sites/decidim/metadecidim/node_modules/postcss-loader/dist/utils.js:51:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.loader (/Sites/decidim/metadecidim/node_modules/postcss-loader/dist/index.js:45:22)
 @ ../../../.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-accountability-0.28.0.rc1/app/packs/stylesheets/accountability.scss
 @ ../../../.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-accountability-0.28.0.rc1/app/packs/entrypoints/decidim_accountability.js 7:0-41

```
This happens due to fact the `postcss.config.js` file is being resolved in the '/node_modules' folder instead of root project.

This PR removed the customization added in #9229 that allowed duplicate config. It is being removed as if the packages are installed locally, the config will fail due to path being resolved outside the project. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #9229

:hearts: Thank you!
