### PR TITLE
Backport 'Fix failure when generating an application (`Could not find ".rubocop.yml"`) ' to v0.28

### DIFF
--- a/decidim-generators/decidim-generators.gemspec
+++ b/decidim-generators/decidim-generators.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir[
     "lib/**/*",
+    "lib/decidim/generators/{app,component}_templates/{*,.*}",
     "Gemfile",
     "Gemfile.lock",
     "Rakefile",


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12104 to v0.28

:hearts: Thank you!