### PR TITLE
Fix for upgrade taks not installing node packages

### DIFF
--- a/decidim-core/lib/tasks/decidim_webpacker_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_webpacker_tasks.rake
@@ -76,7 +76,7 @@ namespace :decidim do
       copy_folder_to_application "decidim-core/lib/decidim/webpacker/webpack", "config"
 
       system!("bin/rails shakapacker:binstubs") unless File.exist?(rails_app_path.join("bin/shakapacker"))
-      
+
       # Modify the webpack binstubs
       add_binstub_load_path "bin/shakapacker"
       add_binstub_load_path "bin/shakapacker-dev-server"


### PR DESCRIPTION
#### :tophat: What? Why?

While running decidim upgrade, i could see that sometimes the upgrade task is exiting without updating the npm packages. 

![image](https://github.com/decidim/decidim/assets/105683/2c03c019-865e-4979-8d13-bc9f4d0a6e2f)

:hearts: Thank you!
