### PR TITLE
Fix missing namespaces and icon

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/last_activity_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/last_activity_cell.rb
@@ -56,7 +56,7 @@ module Decidim
       end
 
       def activities
-        @activities ||= LastActivity.new(current_organization, current_user:).query.limit(activities_to_show * 6)
+        @activities ||= Decidim::LastActivity.new(current_organization, current_user:).query.limit(activities_to_show * 6)
       end
 
       def activities_to_show

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -144,6 +144,7 @@ module Decidim
         Decidim.icons.register(name: "calendar-line", icon: "calendar-line", category: "system", description: "", engine: :core)
         Decidim.icons.register(name: "question-mark", icon: "question-mark", category: "system", description: "", engine: :core)
         Decidim.icons.register(name: "arrow-left-s-line", icon: "arrow-left-s-line", category: "system", description: "", engine: :core)
+        Decidim.icons.register(name: "phone", icon: "phone", category: "system", description: "", engine: :core)
 
         Decidim.icons.register(name: "user-line", icon: "user-line", category: "system", description: "", engine: :core)
         Decidim.icons.register(name: "mic-line", icon: "mic-line", category: "system", description: "", engine: :core)

--- a/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component_cell.rb
@@ -8,7 +8,7 @@ module Decidim
     # It is intended to be used in the `participatory_space_highlighted_elements`
     # view hook.
     class HighlightedMeetingsForComponentCell < Decidim::ViewModel
-      include ApplicationHelper
+      include Decidim::Meetings::ApplicationHelper
       include Decidim::ComponentPathHelper
       include Decidim::CardHelper
       include Decidim::LayoutHelper


### PR DESCRIPTION
#### :tophat: What? Why?

While working in the v0.28.0.rc2 release, I found a couple exceptions in the Metadecidim app:

- A missing icon from the registry
- Some missing namespaces that appeared when loading the homepage

#### Testing

You should see these exceptions in the Metadecidim app  https://github.com/decidim/metadecidim/pull/120 (Mind that I've added an initiatlizer with the icon as a workaround, you'd need to remove that if you want to try that out)
To test the fixes, do so in your local gem paths (`bundle show decidim-core` and then modified it manually)

:hearts: Thank you!
