### PR TITLE
Pass the budget context to the admin new and edit actions for projects

### DIFF
--- a/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
@@ -44,7 +44,7 @@ module Decidim
 
         def edit
           enforce_permission_to(:update, :project, project:)
-          @form = form(ProjectForm).from_model(project, budget: budget)
+          @form = form(ProjectForm).from_model(project, budget:)
           @form.attachment = form(AttachmentForm).instance
         end
 

--- a/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
@@ -19,7 +19,8 @@ module Decidim
         def new
           enforce_permission_to :create, :project
           @form = form(ProjectForm).from_params(
-            attachment: form(AttachmentForm).instance
+            { attachment: form(AttachmentForm).instance },
+            budget: budget
           )
         end
 
@@ -43,7 +44,7 @@ module Decidim
 
         def edit
           enforce_permission_to(:update, :project, project:)
-          @form = form(ProjectForm).from_model(project)
+          @form = form(ProjectForm).from_model(project, budget: budget)
           @form.attachment = form(AttachmentForm).instance
         end
 

--- a/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
@@ -20,7 +20,7 @@ module Decidim
           enforce_permission_to :create, :project
           @form = form(ProjectForm).from_params(
             { attachment: form(AttachmentForm).instance },
-            budget: budget
+            budget:
           )
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
In a [3rd party module](https://github.com/mainio/decidim-module-budgeting_pipeline) we have added the possibility to define a "main image" for the budgeting projects. This required adding the attached uploader to the project model and also adding the passthrough validation for the "main image" for the project management form which passes the `budget` context object through the form to the PassthruValidator.

This is needed for the PassthruValidator to properly assign the component and organization to the record to be validated because this is needed to get the context for the images (e.g. allowed extensions, content types, etc.).

Within the "new" and "edit" actions, the PassthruValidator is used to display the helping text for the file uploads which is why the context is needed also for these actions similarly as it is already defined for "create" and "update".

#### Testing
This cannot be tested in core. Only way to test this is to use the "budgeting pipeline" module in its `develop` branch (currently) and go to the admin editing form by commenting out this override:
https://github.com/mainio/decidim-module-budgeting_pipeline/blob/c9e78aa926cecd27ccdf3ee2b0f0a65d8ab3f3f0/app/controllers/concerns/decidim/budgeting_pipeline/admin/projects_controller_extensions.rb

This override should be unnecessary if the "budget" content was passed to these actions.

This is also why I didn't add any specs as this bug cannot be replicated in the core right now. In case images are added to the projects at some point in the future, it might become relevant (and this was a tricky one to debug as well).
