### PR TITLE
Allow passing a blob object to `AssetRouter::Storage`

### DIFF
--- a/decidim-core/lib/decidim/asset_router/storage.rb
+++ b/decidim-core/lib/decidim/asset_router/storage.rb
@@ -22,6 +22,8 @@ module Decidim
       def url(**options)
         if asset.is_a? ActiveStorage::Attached
           routes.rails_blob_url(asset.blob, **default_options.merge(options))
+        elsif asset.is_a? ActiveStorage::Blob
+          routes.rails_blob_url(asset, **default_options.merge(options))
         else
           representation_url(**options)
         end

--- a/decidim-core/spec/lib/asset_router/storage_spec.rb
+++ b/decidim-core/spec/lib/asset_router/storage_spec.rb
@@ -30,6 +30,22 @@ module Decidim::AssetRouter
         end
       end
 
+      context "with an ActiveStorage::Blob" do
+        let(:asset) { organization.official_img_footer.blob }
+
+        it "creates the route to the blob" do
+          expect(subject).to match(%r{^http://localhost:#{default_port}/rails/active_storage/blobs/redirect/.*/avatar.jpg$})
+        end
+
+        context "with extra URL options" do
+          let(:options) { { port: nil, host: "custom.host", utm_source: "website", utm_medium: "email", utm_campaign: "testing" } }
+
+          it "handles the extra URL options correctly" do
+            expect(subject).to match(%r{^http://custom.host/rails/active_storage/blobs/redirect/.*/avatar.jpg\?utm_campaign=testing&utm_medium=email&utm_source=website$})
+          end
+        end
+      end
+
       context "with a variant" do
         let(:asset) { organization.official_img_footer.variant(resize_to_fit: [160, 160]) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
I was developing [a module](https://github.com/mainio/decidim-module-apifiles) that allows managing files through the APIs.

There I defined the [`BlobType`](https://github.com/mainio/decidim-module-apifiles/blob/57efc84dcc93420e35f6c43eecd0c48b4c38e20c/lib/decidim/api/blob_type.rb) for the API and I was missing an easy way to get the URL for the blob.

I noticed it's been an oversight with the `AssetRouter::Storage` implementation that it does not allow passing a direct blob objects as the asset objects. This led to duplicating a lot of the functionality already built into this class.

This fixes the issue by allowing passing blob objects directly to this class.

#### :pushpin: Related Issues
- Related to #9597

#### Testing
```ruby
$ cd /path/to/decidim
$ bundle exec rails c
> blob = ActiveStorage::Blob.last
> router = Decidim::AssetRouter::Storage.new(blob)
> puts router.url(host: "foobar.host")
```