### PR TITLE
Fix Decidim::DummyResources autoload path

### DIFF
--- a/decidim-dev/lib/decidim/dev.rb
+++ b/decidim-dev/lib/decidim/dev.rb
@@ -2,6 +2,15 @@
 
 require "decidim/dev/railtie"
 
+# The next 4 uncommented lines are used to register the Decidim::DummyResources namespace to the autoloader
+# We cannot rely on Rails autoloading because some of the classes that are required within that namespace
+# are needed before Rails is being available (e.g. FactoryBot)
+# After 1 day of various attempts, this is the only way I found to make it work.
+app_paths = %w(commands controllers events forms jobs mailers models presenters serializers)
+app_paths.each do |path|
+  ActiveSupport::Dependencies.autoload_paths += [File.absolute_path("#{__dir__}/../../app/#{path}")]
+end
+
 module Decidim
   # Decidim::Dev holds all the convenience logic and libraries to be able to
   # create external libraries that create test apps and test themselves against


### PR DESCRIPTION
#### :tophat: What? Why?
While working on https://github.com/decidim/metadecidim/pull/120, @andreslucena observed that `Decidim::DummyResources::DummyResource` is not being recognized. 

![image](https://github.com/decidim/decidim/assets/105683/55a59d96-7860-433f-b446-73926ea32d2e)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10682

#### Testing
The easiest way to test this PR is to apply the changes directly to the installed gem 
Then run the test suite. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

:hearts: Thank you!
