### PR TITLE
Add initial implementation of the bin/releaser script

### DIFF
--- a/bin/releaser
+++ b/bin/releaser
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "thor"
+
+require "./lib/decidim/releaser"
+
+class ReleaserCLI < Thor
+  desc "", "Make the branch for preparing a release"
+  option :github_token, required: true, desc: <<~HELP
+    Required. Github Personal Access Token (PAT). It can be obtained from https://github.com/settings/tokens/new. You will need to create one with `public_repo` access.
+    Alternatively, you can use the `gh` CLI tool to authenticate with `gh auth token` (i.e. --github-token=$(gh auth token))
+  HELP
+  option :exit_with_unstaged_changes, type: :boolean, default: true, desc: <<~HELP
+    Optional. Whether the script should exit with an error if there are unstaged changes in the current project.
+  HELP
+  default_task :releaser
+
+  def releaser
+    Decidim::Releaser.new(
+      token: options[:github_token],
+      exit_with_unstaged_changes: options[:exit_with_unstaged_changes]
+    ).call
+  rescue Decidim::Releaser::InvalidMetadataError
+    puts "Metadata was not returned from the server. Please check that the GitHub token is correct."
+  end
+
+  def help
+    super("releaser")
+  end
+
+  def self.exit_on_failure?
+    true
+  end
+end
+
+ReleaserCLI.start(ARGV)

--- a/bin/releaser
+++ b/bin/releaser
@@ -11,6 +11,9 @@ class ReleaserCLI < Thor
     Required. Github Personal Access Token (PAT). It can be obtained from https://github.com/settings/tokens/new. You will need to create one with `public_repo` access.
     Alternatively, you can use the `gh` CLI tool to authenticate with `gh auth token` (i.e. --github-token=$(gh auth token))
   HELP
+  option :version_type, enum: %w(rc minor patch), required: true, desc: <<~HELP
+    Required. The kind of release that you want to prepare.
+  HELP
   option :exit_with_unstaged_changes, type: :boolean, default: true, desc: <<~HELP
     Optional. Whether the script should exit with an error if there are unstaged changes in the current project.
   HELP
@@ -19,6 +22,7 @@ class ReleaserCLI < Thor
   def releaser
     Decidim::Releaser.new(
       token: options[:github_token],
+      version_type: options[:version_type],
       exit_with_unstaged_changes: options[:exit_with_unstaged_changes]
     ).call
   rescue Decidim::Releaser::InvalidMetadataError

--- a/lib/decidim/releaser.rb
+++ b/lib/decidim/releaser.rb
@@ -187,7 +187,7 @@ module Decidim
       run("bin/changelog_generator #{@token} #{sha_version}")
       temporary_changelog = File.read("./temporary_changelog.md")
       legacy_changelog = File.read("./CHANGELOG.md")
-      version_changelog = "##[#{version_number}](https://github.com/decidim/decidim/tree/#{version_number})\n\n#{temporary_changelog}\n"
+      version_changelog = "## [#{version_number}](https://github.com/decidim/decidim/tree/#{version_number})\n\n#{temporary_changelog}\n"
       changelog = legacy_changelog.gsub("# Changelog\n\n", "# Changelog\n\n#{version_changelog}")
       File.write("./CHANGELOG.md", changelog)
     end

--- a/lib/decidim/releaser.rb
+++ b/lib/decidim/releaser.rb
@@ -40,7 +40,7 @@ module Decidim
         run("git commit -a -m 'Prepare #{version_number} release'")
         run("git push origin chore/prepare/#{version_number}")
 
-        # create_pull_request
+        create_pull_request
       end
     end
 
@@ -180,11 +180,8 @@ module Decidim
       base_branch = release_branch
       head_branch = "chore/prepare/#{version_number}"
 
-      run("git branch #{head_branch}")
-      run("git swtich --quiet #{head_branch}")
-
       params = {
-        title: "Bump to #{version_number} version",
+        title: "Bump to v#{version_number} version",
         body: "#### :tophat: What? Why?
 
 This PR changes the version of the #{release_branch} branch, so we can publish the release once this is approved and merged.
@@ -199,7 +196,7 @@ Everything should be green.
         head: head_branch,
         base: base_branch
       }
-      Decidim::GitHubManager::Poster.new(token: @token, params:)
+      Decidim::GithubManager::Poster.new(token: @token, params:).call
     end
 
     # Captures to output of a command

--- a/lib/decidim/releaser.rb
+++ b/lib/decidim/releaser.rb
@@ -36,12 +36,6 @@ module Decidim
         run("npm install")
         generate_changelog
 
-        # rubocop:disable Rails/Output
-        puts "Check all the changes before making the PR"
-        puts "After you finish leave the change staged and exit the shell with the `exit` command"
-        system ENV.fetch("SHELL")
-        # rubocop:enable Rails/Output
-
         run("git checkout -b chore/prepare/#{version_number}")
         run("git commit -a -m 'Prepare #{version_number} release'")
         run("git push origin chore/prepare/#{version_number}")
@@ -174,7 +168,8 @@ module Decidim
       run("bin/changelog_generator #{@token} #{sha_version}")
       temporary_changelog = File.read("./temporary_changelog.md")
       legacy_changelog = File.read("./CHANGELOG.md")
-      changelog = legacy_changelog.gsub("# Changelog\r", "# Changelog\r #{temporary_changelog}")
+      version_changelog = "##[#{version_number}](https://github.com/decidim/decidim/tree/#{version_number})\n\n#{temporary_changelog}\n"
+      changelog = legacy_changelog.gsub("# Changelog\n\n", "# Changelog\n\n#{version_changelog}")
       File.write("./CHANGELOG.md", changelog)
     end
 

--- a/lib/decidim/releaser.rb
+++ b/lib/decidim/releaser.rb
@@ -34,6 +34,9 @@ module Decidim
         run("bin/rake update_versions")
         run("bin/rake bundle")
         run("npm install")
+
+        check_tests
+
         generate_changelog
 
         run("git checkout -b chore/prepare/#{version_number}")
@@ -158,6 +161,22 @@ module Decidim
     # @return [String] the version number
     def old_version_number
       File.read(DECIDIM_VERSION_FILE).strip
+    end
+
+    # Run the tests and if fails restore the changes using git and exit with an error
+    #
+    # @return [void]
+    def check_tests
+      # rubocop:disable Rails/Output
+      puts "Running specs"
+      output, status = capture("bin/rspec")
+
+      unless status.sucess?
+        run("git restore .")
+        puts output
+        exit_with_errors("Tests execution failed. Fix the errors and run again.")
+      end
+      # rubocop:enable Rails/Output
     end
 
     # Generates the changelog taking into account the last time the version changed

--- a/lib/decidim/releaser.rb
+++ b/lib/decidim/releaser.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "open3"
+require "decidim/github_manager/poster"
+
+module Decidim
+  class Releaser
+    class InvalidMetadataError < StandardError; end
+
+    class InvalidBranchError < StandardError; end
+
+    DECIDIM_VERSION_FILE = ".decidim-version"
+
+    # @param token [String] token for GitHub authentication
+    # @param working_dir [String] current working directory. Useful for testing purposes
+    # @param exit_with_unstaged_changes [Boolean] wheter we should exit cowardly if there is any unstaged change
+    def initialize(token:, working_dir: Dir.pwd, exit_with_unstaged_changes: false)
+      @token = token
+      @working_dir = working_dir
+      @exit_with_unstaged_changes = exit_with_unstaged_changes
+    end
+
+    def call
+      Dir.chdir(@working_dir) do
+        exit_if_unstaged_changes if @exit_with_unstaged_changes
+
+        run("git checkout #{release_branch}")
+        run("git pull origin #{release_branch}")
+        bump_decidim_version
+        run("bin/rake update_versions")
+        run("bin/rake bundle")
+        run("npm install")
+        generate_changelog
+
+        # rubocop:disable Rails/Output
+        puts "Check all the changes before making the PR"
+        puts "After you finish leave the change staged and exit the shell with the `exit` command"
+        system ENV.fetch("SHELL")
+        # rubocop:enable Rails/Output
+
+        run("git checkout -b chore/prepare/#{version_number}")
+        run("git commit -a -m 'Prepare #{version_number} release'")
+        run("git push origin chore/prepare/#{version_number}")
+
+        # create_pull_request
+      end
+    end
+
+    private
+
+    # The git branch
+    #
+    # @return [String]
+    def branch
+      @branch ||= capture("git rev-parse --abbrev-ref HEAD")[0].strip
+    end
+
+    # Raise an error if the branch does not start with the preffix "release/"
+    # or returns the branch name
+    #
+    # @raise [Exception]
+    #
+    # @return [String]
+    def release_branch
+      raise InvalidBranchError, "This is not a release branch, aborting" unless branch.start_with?("release/")
+
+      branch
+    end
+
+    # Changes the decidim version in the file
+    #
+    # @return [void]
+    def bump_decidim_version
+      File.write(DECIDIM_VERSION_FILE, version_number)
+    end
+
+    # The version number for the release that we are preparing
+    #
+    # @return [String] the version number
+    def version_number
+      @version_number ||= if old_version_number.include? "rc"
+                            next_version_number_for_release_candidate(old_version_number)
+                          else
+                            next_version_number_for_patch_release(old_version_number)
+                          end
+    end
+
+    # Given a version number, returns the next release candidate
+    #
+    # @return [String]
+    def next_version_number_for_release_candidate(version_number)
+      new_rc_number = version_number.match(/rc(\d)/)[1].to_i + 1
+      version_number.gsub(/rc\d/, "rc#{new_rc_number}")
+    end
+
+    # Given a version number, returns the next patch release
+    #
+    # @return [String]
+    def next_version_number_for_patch_release(version_number)
+      /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/ =~ version_number
+
+      "#{major}.#{minor}.#{patch.to_i + 1}"
+    end
+
+    # The version number from the file
+    #
+    # @return [String] the version number
+    def old_version_number
+      File.read(DECIDIM_VERSION_FILE).strip
+    end
+
+    # Generates the changelog taking into account the last time the version changed
+    #
+    # @return [void]
+    def generate_changelog
+      sha_version = capture("git log -n 1 --pretty=format:%h -- .decidim-version")[0]
+      run("bin/changelog_generator #{@token} #{sha_version}")
+      temporary_changelog = File.read("./temporary_changelog.md")
+      legacy_changelog = File.read("./CHANGELOG.md")
+      changelog = legacy_changelog.gsub("# Changelog\r", "# Changelog\r #{temporary_changelog}")
+      File.write("./CHANGELOG.md", changelog)
+    end
+
+    # Creates the pull request for bumping the version
+    #
+    # @return [void]
+    def create_pull_request
+      base_branch = release_branch
+      head_branch = "chore/prepare/#{version_number}"
+
+      run("git branch #{head_branch}")
+      run("git swtich --quiet #{head_branch}")
+
+      params = {
+        title: "Bump to #{version_number} version",
+        body: "#### :tophat: What? Why?
+
+This PR changes the version of the #{release_branch} branch, so we can publish the release once this is approved and merged.
+
+#### Testing
+
+Everything should be green.
+
+:hearts: Thank you!
+        ",
+        labels: ["type: internal"],
+        head: head_branch,
+        base: base_branch
+      }
+      Decidim::GitHubManager::Poster.new(token: @token, params:)
+    end
+
+    # Captures to output of a command
+    #
+    # @return [Array<String, Process::Status>] The stdout and stderr of the command and its status (aka error code)
+    def capture(cmd, env: {})
+      Open3.capture2e(env, cmd)
+    end
+
+    # Runs a command
+    #
+    # @return [void]
+    def run(cmd, out: $stdout)
+      system(cmd, out:)
+    end
+
+    # Exit the script execution if there are any unstaged changes
+    #
+    # @return [void]
+    def exit_if_unstaged_changes
+      return if `git diff`.empty?
+
+      error_message = <<-EOERROR
+  There are changes not staged in your project.
+  Please commit your changes or stash them.
+      EOERROR
+      exit_with_errors(error_message)
+    end
+
+    # Exit the script execution with a message
+    #
+    # @return [void]
+    def exit_with_errors(message)
+      # rubocop:disable Rails/Output, Rails/Exit
+      puts message
+      exit 1
+      # rubocop:enable Rails/Output, Rails/Exit
+    end
+  end
+end

--- a/lib/decidim/releaser.rb
+++ b/lib/decidim/releaser.rb
@@ -207,7 +207,9 @@ This PR changes the version of the #{release_branch} branch, so we can publish t
 
 #### Testing
 
-Everything should be green.
+All the tests should pass, except for some generators tests, that will fail because the gems and NPM packages have not
+been actually published yet (as in sent to rubygems/npm).
+You will see errors such as `No matching version found for @decidim/browserslist-config@~0.xx.y` in the CI logs.
 
 :hearts: Thank you!
         ",

--- a/lib/decidim/releaser.rb
+++ b/lib/decidim/releaser.rb
@@ -171,7 +171,7 @@ module Decidim
       puts "Running specs"
       output, status = capture("bin/rspec")
 
-      unless status.sucess?
+      unless status.success?
         run("git restore .")
         puts output
         exit_with_errors("Tests execution failed. Fix the errors and run again.")

--- a/spec/lib/decidim/releaser_spec.rb
+++ b/spec/lib/decidim/releaser_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "decidim/releaser"
+
+describe Decidim::Releaser do
+  subject { described_class.new(token:, exit_with_unstaged_changes:, working_dir: tmp_repository_dir) }
+
+  let(:token) { "1234" }
+  let(:release_branch) { "release/0.99-stable" }
+  let(:tmp_repository_dir) { "/tmp/decidim-releaser-test-#{rand(1_000)}" }
+  let(:working_dir) { File.expand_path("../../..", __dir__) }
+  let(:exit_with_unstaged_changes) { true }
+  let(:decidim_version) { "0.99.0.rc1" }
+
+  before do
+    FileUtils.mkdir_p("#{tmp_repository_dir}/code")
+    Dir.chdir("#{tmp_repository_dir}/code")
+    `
+      git init --initial-branch=develop .
+      git config user.email "decidim_releaser@example.com"
+      git config user.name "Decidim::Releaser test"
+
+      touch a_file.txt && git add a_file.txt
+      echo #{decidim_version} > .decidim-version && git add .decidim-version
+      git commit -m "Initial commit (#1234)"
+
+      git branch #{release_branch}
+      git switch --quiet #{release_branch}
+    `
+  end
+
+  after do
+    Dir.chdir(working_dir)
+    FileUtils.rm_r(Dir.glob(tmp_repository_dir))
+  end
+
+  describe "#branch" do
+    it "returns the correct branch" do
+      expect(subject.send(:branch)).to eq release_branch
+    end
+  end
+
+  describe "#release_branch" do
+    it "returns the correct branch" do
+      expect(subject.send(:release_branch)).to eq release_branch
+    end
+
+    context "when we are not in a release branch" do
+      it "raises an error" do
+        `git switch --quiet develop`
+        expect { subject.send(:release_branch) }.to raise_error(Decidim::Releaser::InvalidBranchError)
+      end
+    end
+  end
+
+  describe "#bump_decidim_version" do
+    context "when it is a release candidate" do
+      let(:decidim_version) { "0.99.0.rc1" }
+
+      it "changes the version number in the decidim version file" do
+        subject.send(:bump_decidim_version)
+        new_version_number = File.read(".decidim-version")
+
+        expect(new_version_number).to eq("0.99.0.rc2")
+      end
+    end
+
+    context "when it is a patch release" do
+      let(:decidim_version) { "0.99.0" }
+
+      it "changes the version number in the decidim version file" do
+        subject.send(:bump_decidim_version)
+        new_version_number = File.read(".decidim-version")
+
+        expect(new_version_number).to eq("0.99.1")
+      end
+    end
+  end
+
+  describe "#next_version_number_for_release_candidate" do
+    let(:version_number) { "0.1.0.rc1" }
+
+    it "returns the correct next version number" do
+      expect(subject.send(:next_version_number_for_release_candidate, version_number)).to eq "0.1.0.rc2"
+    end
+  end
+
+  describe "#next_version_number_for_patch_release" do
+    let(:version_number) { "0.1.0" }
+
+    it "returns the correct next version number" do
+      expect(subject.send(:next_version_number_for_patch_release, version_number)).to eq "0.1.1"
+    end
+  end
+
+  describe "#old_version_number" do
+    let(:decidim_version) { "0.1.0" }
+
+    it "returns the correct version number" do
+      expect(subject.send(:old_version_number)).to eq "0.1.0"
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

With the last two release candidates, I made a script that allows maintainers to automate much of the tasks of the release process. 

This is the first iteration. 

#### :pushpin: Related Issues
 
- Related to #12129 
 

#### Testing

It's called with `./bin/releaser --github-token=(gh auth token) --version-type=rc`. 

I didn't try it for the patch release (yet) but it should work too for that case. For the minor release (i.e. the next v0.29.0.rc1) I'd need to make a few changes, but it should be easy to do so.  

:hearts: Thank you!
