### PR TITLE
Improve election dashboard with "Fix it" buttons and election configuration summary

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -138,6 +138,7 @@ ignore_unused:
   - decidim.admin.models.assembly_member.positions.*
   - decidim.statistics.*
   - decidim.components.*
+  - decidim.elections.admin.steps.create_election.technical_configuration.*
   - decidim.filters.linked_classes.*
   - decidim.shared.participatory_space_filters.filters.*
   - decidim.follows.create.participatory_space

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -138,7 +138,6 @@ ignore_unused:
   - decidim.admin.models.assembly_member.positions.*
   - decidim.statistics.*
   - decidim.components.*
-  - decidim.elections.admin.steps.create_election.technical_configuration.*
   - decidim.filters.linked_classes.*
   - decidim.shared.participatory_space_filters.filters.*
   - decidim.follows.create.participatory_space

--- a/decidim-elections/app/controllers/decidim/elections/admin/elections_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/elections_controller.rb
@@ -77,7 +77,7 @@ module Decidim
           PublishElection.call(election, current_user) do
             on(:ok) do
               flash[:notice] = I18n.t("admin.elections.publish.success", scope: "decidim.elections")
-              redirect_to elections_path
+              redirect_back(fallback_location: root_path)
             end
           end
         end

--- a/decidim-elections/app/forms/decidim/elections/admin/setup_form.rb
+++ b/decidim-elections/app/forms/decidim/elections/admin/setup_form.rb
@@ -41,8 +41,12 @@ module Decidim
             [:max_selections, { link: router.election_questions_path(election) }, election.valid_questions?],
             [:published, { link: router.publish_election_path(election) }, election.published_at.present?],
             [:component_published, { link: EngineRouter.admin_proxy(election.participatory_space).components_path(election.participatory_space) }, election.component.published?],
-            [:time_before, { link: router.edit_election_path(election), hours: I18n.t("datetime.distance_in_words.x_hours", count: Decidim::Elections.setup_minimum_hours_before_start) }, election.minimum_hours_before_start?],
-            [:trustees_number, { link: router.trustees_path, number: bulletin_board.number_of_trustees }, participatory_space_trustees_with_public_key.size >= bulletin_board.number_of_trustees]].freeze
+            [:time_before,
+             { link: router.edit_election_path(election), hours: I18n.t("datetime.distance_in_words.x_hours",
+                                                                        count: Decidim::Elections.setup_minimum_hours_before_start) }, election.minimum_hours_before_start?],
+            [:trustees_number, { link: router.trustees_path, number: bulletin_board.number_of_trustees },
+             participatory_space_trustees_with_public_key.size >= bulletin_board.number_of_trustees]
+          ].freeze
         end
 
         def census_validations

--- a/decidim-elections/app/helpers/decidim/elections/admin/steps_helper.rb
+++ b/decidim-elections/app/helpers/decidim/elections/admin/steps_helper.rb
@@ -17,6 +17,12 @@ module Decidim
             end
           end
         end
+
+        def fix_it_button_with_icon(link, icon_name, method = :get)
+          link_to(link, class: "button tiny button__secondary px-2 py-0", method:) do
+            "#{icon(icon_name, class: "fix-icon")} #{I18n.t("decidim.elections.admin.steps.create_election.errors.fix_it_text")}".html_safe
+          end
+        end
       end
     end
   end

--- a/decidim-elections/app/helpers/decidim/elections/admin/steps_helper.rb
+++ b/decidim-elections/app/helpers/decidim/elections/admin/steps_helper.rb
@@ -26,7 +26,7 @@ module Decidim
 
         def technical_configuration_items
           [
-            { key: ".technical_configuration.bulletin_board_server", value: Rails.application.secrets.elections[:bulletin_board_server] },
+            { key: ".technical_configuration.bulletin_board_server", value: Decidim::BulletinBoard.config[:bulletin_board_server] },
             { key: ".technical_configuration.authority_name", value: Decidim::BulletinBoard.config[:authority_name] },
             { key: ".technical_configuration.scheme_name", value: Decidim::BulletinBoard.config[:scheme_name] }
           ]

--- a/decidim-elections/app/helpers/decidim/elections/admin/steps_helper.rb
+++ b/decidim-elections/app/helpers/decidim/elections/admin/steps_helper.rb
@@ -24,7 +24,9 @@ module Decidim
           end
         end
 
-        # i18n-tasks-use decidim.elections.admin.steps.create_election.technical_configuration.*
+        # i18n-tasks-use t("decidim.elections.admin.steps.create_election.technical_configuration.bulletin_board_server")
+        # i18n-tasks-use t("decidim.elections.admin.steps.create_election.technical_configuration.authority_name")
+        # i18n-tasks-use t("decidim.elections.admin.steps.create_election.technical_configuration.scheme_name")
         def technical_configuration_items
           [
             { key: ".technical_configuration.bulletin_board_server", value: Decidim::BulletinBoard.config[:bulletin_board_server] },

--- a/decidim-elections/app/helpers/decidim/elections/admin/steps_helper.rb
+++ b/decidim-elections/app/helpers/decidim/elections/admin/steps_helper.rb
@@ -24,6 +24,7 @@ module Decidim
           end
         end
 
+        # i18n-tasks-use decidim.elections.admin.steps.create_election.technical_configuration.*
         def technical_configuration_items
           [
             { key: ".technical_configuration.bulletin_board_server", value: Decidim::BulletinBoard.config[:bulletin_board_server] },

--- a/decidim-elections/app/helpers/decidim/elections/admin/steps_helper.rb
+++ b/decidim-elections/app/helpers/decidim/elections/admin/steps_helper.rb
@@ -23,6 +23,14 @@ module Decidim
             "#{icon(icon_name, class: "fix-icon")} #{I18n.t("decidim.elections.admin.steps.create_election.errors.fix_it_text")}".html_safe
           end
         end
+
+        def technical_configuration_items
+          [
+            { key: ".technical_configuration.bulletin_board_server", value: Rails.application.secrets.elections[:bulletin_board_server] },
+            { key: ".technical_configuration.authority_name", value: Decidim::BulletinBoard.config[:authority_name] },
+            { key: ".technical_configuration.scheme_name", value: Decidim::BulletinBoard.config[:scheme_name] }
+          ]
+        end
       end
     end
   end

--- a/decidim-elections/app/packs/entrypoints/decidim_elections_admin.js
+++ b/decidim-elections/app/packs/entrypoints/decidim_elections_admin.js
@@ -4,3 +4,6 @@ import "src/decidim/elections/admin/pending_action";
 
 // Images
 require.context("../images", true)
+
+// CSS
+import "stylesheets/decidim/elections/admin/elections.scss"

--- a/decidim-elections/app/packs/stylesheets/decidim/elections/admin/elections.scss
+++ b/decidim-elections/app/packs/stylesheets/decidim/elections/admin/elections.scss
@@ -1,0 +1,7 @@
+.create_election {
+  .card-section {
+    svg.fix-icon {
+      @apply fill-white mr-0.5;
+    }
+  }
+}

--- a/decidim-elections/app/packs/stylesheets/decidim/elections/admin/elections.scss
+++ b/decidim-elections/app/packs/stylesheets/decidim/elections/admin/elections.scss
@@ -5,3 +5,20 @@
     }
   }
 }
+
+.accordion {
+  &.technical-configuration {
+    .accordion-title {
+      &::before {
+        content: "\25B6";
+        font-size: 0.7em;
+        display: inline-block;
+        vertical-align: text-bottom;
+      }
+    }
+
+    .is-active > .accordion-title::before {
+      content: "\25BC";
+    }
+  }
+}

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_create_election.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_create_election.html.erb
@@ -10,9 +10,15 @@
       <ul>
         <% form.messages.each do |key, value| %>
           <% if form.errors.include?(key) %>
-            <li><%= icon "close-line", class: "text-alert", role: "img", "aria-hidden": true %>&nbsp;<%= form.errors.messages[key][0].html_safe %></li>
+            <% Array(form.errors[key]).each do |error| %>
+              <li class="flex justify-between">
+                <span><%= icon "close-line", class: "text-alert", role: "img", "aria-hidden": true %>&nbsp;<%= error.html_safe %></span>
+                <% method = key == :published ? :put : :get %>
+                <span><%= fix_it_button_with_icon(value[:link], "pencil-line", method) %></span>
+              </li>
+            <% end %>
           <% else %>
-            <li><%= icon "check-line", class: "text-success", role: "img", "aria-hidden": true %>&nbsp;<%= value.html_safe %></li>
+            <li><%= icon "check-line", class: "text-success", role: "img", "aria-hidden": true %>&nbsp;<%= value[:message].html_safe %></li>
           <% end %>
         <% end %>
       </ul>

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_create_election.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_create_election.html.erb
@@ -64,9 +64,8 @@
     <div class="row column">
       <div class="accordion technical-configuration" data-accordion data-allow-all-closed="true">
         <div class="accordion-item" data-accordion-item>
-          <a href="#" class="accordion-title flex">
-            <%= icon "arrow-down-s-fill", class: "icon-arrow-down w-5 h-5" %>
-            <h2 class="card-title tabs-title ml-1 mb-2"><%= t(".technical_configuration.title") %></h2>
+          <a href="#" class="accordion-title flex card-title tabs-title ml-1 mb-2">
+            <%= t(".technical_configuration.title") %>
           </a>
           <div class="accordion-content" data-tab-content style="display: none;">
             <ul>

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_create_election.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_create_election.html.erb
@@ -18,8 +18,7 @@
               </li>
             <% end %>
           <% else %>
-            <li class="mb-2"><%= icon "check-line", class: "text-success", role: "img", "aria-hidden": true %>&nbsp;<%=
-              value[:message].html_safe %></li>
+            <li class="mb-2"><%= icon "check-line", class: "text-success", role: "img", "aria-hidden": true %>&nbsp;<%= value[:message].html_safe %></li>
           <% end %>
         <% end %>
       </ul>

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_create_election.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_create_election.html.erb
@@ -11,14 +11,15 @@
         <% form.messages.each do |key, value| %>
           <% if form.errors.include?(key) %>
             <% Array(form.errors[key]).each do |error| %>
-              <li class="flex justify-between">
+              <li class="flex justify-between mb-2">
                 <span><%= icon "close-line", class: "text-alert", role: "img", "aria-hidden": true %>&nbsp;<%= error.html_safe %></span>
                 <% method = key == :published ? :put : :get %>
                 <span><%= fix_it_button_with_icon(value[:link], "pencil-line", method) %></span>
               </li>
             <% end %>
           <% else %>
-            <li><%= icon "check-line", class: "text-success", role: "img", "aria-hidden": true %>&nbsp;<%= value[:message].html_safe %></li>
+            <li class="mb-2"><%= icon "check-line", class: "text-success", role: "img", "aria-hidden": true %>&nbsp;<%=
+              value[:message].html_safe %></li>
           <% end %>
         <% end %>
       </ul>
@@ -28,15 +29,15 @@
         <ul>
           <% form.census_messages.each do |key, value| %>
             <% if form.errors.include?(key) %>
-              <li><%= icon "close-line", class: "text-alert", role: "img", "aria-hidden": true %>&nbsp;<%= form.errors.messages[key][0].html_safe %></li>
+              <li class="mb-2"><%= icon "close-line", class: "text-alert", role: "img", "aria-hidden": true %>&nbsp;<%= form.errors.messages[key][0].html_safe %></li>
             <% else %>
-              <li><%= icon "check-line", class: "text-success", role: "img", "aria-hidden": true %>&nbsp;<%= value.html_safe %></li>
+              <li class="mb-2"><%= icon "check-line", class: "text-success", role: "img", "aria-hidden": true %>&nbsp;<%= value.html_safe %></li>
             <% end %>
           <% end %>
         </ul>
       <% end %>
 
-      <h4><%= t(".trustees") %></h4>
+      <h4 class="mb-2"><%= t(".trustees") %></h4>
       <ul>
         <% if form.participatory_space_trustees.none? %>
           <li><%= icon "close-line", class: "text-alert", role: "img", "aria-hidden": true %>&nbsp;<%= t(".no_trustees") %></li>
@@ -57,6 +58,26 @@
           </li>
         <% end %>
       </ul>
+    </div>
+  </div>
+
+  <div>
+    <div class="row column">
+      <div class="accordion technical-configuration" data-accordion data-allow-all-closed="true">
+        <div class="accordion-item" data-accordion-item>
+          <a href="#" class="accordion-title flex">
+            <%= icon "arrow-down-s-fill", class: "icon-arrow-down w-5 h-5" %>
+            <h2 class="card-title tabs-title ml-1 mb-2"><%= t(".technical_configuration.title") %></h2>
+          </a>
+          <div class="accordion-content" data-tab-content style="display: none;">
+            <ul>
+              <% technical_configuration_items.each do |config_item| %>
+                <li class="mb-2"><%= t(config_item[:key], value: config_item[:value]).html_safe %></li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/decidim-elections/app/views/decidim/elections/admin/steps/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/index.html.erb
@@ -52,3 +52,5 @@
     <%= render "decidim/elections/shared/broken_promises_modal" %>
   </div>
 </div>
+
+<%= append_stylesheet_pack_tag "decidim_elections_admin" %>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -273,6 +273,7 @@ en:
               census_frozen: Access codes for the census are not exported.
               census_uploaded: There is no census uploaded for this election.
               component_published: The election component is <strong>not published</strong>.
+              fix_it_text: Fix it
               max_selections: The questions do not have a <strong>correct value for amount of answers</strong>
               minimum_answers: Questions must have <strong>at least two answers</strong>.
               minimum_questions: The election <strong>must have at least one question</strong>.

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -300,9 +300,9 @@ en:
             submit: Setup election
             success: Election successfully sent to the Bulletin Board.
             technical_configuration:
-              authority_name: "<strong>Authority name: </strong> %{value}"
-              bulletin_board_server: "<strong>Bulletin Board server: </strong> <a href='%{value}'>%{value}</a>"
-              scheme_name: "<strong>Scheme name: </strong> %{value}"
+              authority_name: "<strong>Authority name:</strong> %{value}"
+              bulletin_board_server: "<strong>Bulletin Board server:</strong> <a href='%{value}'>%{value}</a>"
+              scheme_name: "<strong>Scheme name:</strong> %{value}"
               title: View technical information
             title: Setup election
             trustees: Election Trustees

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -300,8 +300,8 @@ en:
             submit: Setup election
             success: Election successfully sent to the Bulletin Board.
             technical_configuration:
-              bulletin_board_server: "<strong>Bulletin Board server: </strong> <a href='%{value}'>%{value}</a>"
               authority_name: "<strong>Authority name: </strong> %{value}"
+              bulletin_board_server: "<strong>Bulletin Board server: </strong> <a href='%{value}'>%{value}</a>"
               scheme_name: "<strong>Scheme name: </strong> %{value}"
               title: View technical information
             title: Setup election

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -303,7 +303,7 @@ en:
               bulletin_board_server: "<strong>Bulletin Board server: </strong> <a href='%{value}'>%{value}</a>"
               authority_name: "<strong>Authority name: </strong> %{value}"
               scheme_name: "<strong>Scheme name: </strong> %{value}"
-              title: Technical configuration
+              title: View technical information
             title: Setup election
             trustees: Election Trustees
           created:

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -299,6 +299,11 @@ en:
               trustees_number: The participatory space has <strong>at least %{number} trustees with public key</strong>.
             submit: Setup election
             success: Election successfully sent to the Bulletin Board.
+            technical_configuration:
+              bulletin_board_server: "<strong>Bulletin Board server: </strong> <a href='%{value}'>%{value}</a>"
+              authority_name: "<strong>Authority name: </strong> %{value}"
+              scheme_name: "<strong>Scheme name: </strong> %{value}"
+              title: Technical configuration
             title: Setup election
             trustees: Election Trustees
           created:

--- a/decidim-elections/spec/forms/decidim/elections/admin/setup_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/setup_form_spec.rb
@@ -24,18 +24,19 @@ describe Decidim::Elections::Admin::SetupForm do
   end
   let!(:trustees) { create_list(:trustee, 5, :with_public_key, election:) }
   let(:trustee_ids) { trustees.pluck(:id) }
+  let(:router) { Decidim::EngineRouter.admin_proxy(component) }
 
   it { is_expected.to be_valid }
 
   it "shows messages" do
     expect(subject.messages).to match(
       hash_including({
-                       max_selections: "All the questions have a correct value for <strong>maximum of answers</strong>.",
-                       minimum_answers: "Each question has <strong>at least 2 answers</strong>.",
-                       minimum_questions: "The election has <strong>at least 1 question</strong>.",
-                       published: "The election is <strong>published</strong>.",
-                       time_before: "The setup is being done <strong>at least 1 hour</strong> before the election starts.",
-                       trustees_number: "The participatory space has <strong>at least 3 trustees with public key</strong>."
+                       max_selections: { link: router.election_questions_path(election), message: "All the questions have a correct value for <strong>maximum of answers</strong>." },
+                       minimum_answers: { link: router.election_questions_path(election), message: "Each question has <strong>at least 2 answers</strong>." },
+                       minimum_questions: { link: router.election_questions_path(election), message: "The election has <strong>at least 1 question</strong>." },
+                       published: { link: router.publish_election_path(election), message: "The election is <strong>published</strong>." },
+                       time_before: { link: router.edit_election_path(election), message: "The setup is being done <strong>at least 1 hour</strong> before the election starts." },
+                       trustees_number: { link: router.trustees_path, message: "The participatory space has <strong>at least 2 trustees with public key</strong>." }
                      })
     )
   end

--- a/decidim-elections/spec/forms/decidim/elections/admin/setup_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/setup_form_spec.rb
@@ -36,7 +36,7 @@ describe Decidim::Elections::Admin::SetupForm do
                        minimum_questions: { link: router.election_questions_path(election), message: "The election has <strong>at least 1 question</strong>." },
                        published: { link: router.publish_election_path(election), message: "The election is <strong>published</strong>." },
                        time_before: { link: router.edit_election_path(election), message: "The setup is being done <strong>at least 1 hour</strong> before the election starts." },
-                       trustees_number: { link: router.trustees_path, message: "The participatory space has <strong>at least 2 trustees with public key</strong>." }
+                       trustees_number: { link: router.trustees_path, message: "The participatory space has <strong>at least 3 trustees with public key</strong>." }
                      })
     )
   end

--- a/decidim-elections/spec/helpers/decidim/elections/steps_helper_spec.rb
+++ b/decidim-elections/spec/helpers/decidim/elections/steps_helper_spec.rb
@@ -61,6 +61,19 @@ module Decidim
             }
           end
         end
+
+        describe "#fix_it_button_with_icon" do
+          subject { helper.fix_it_button_with_icon(link, icon_name, method) }
+
+          let(:link) { "/path/to/fix" }
+          let(:icon_name) { "pencil-line" }
+          let(:method) { :get }
+
+          it "generates the fix it link with icon" do
+            expect(subject).to have_link("Fix it", href: link)
+            expect(subject).to have_selector("svg.fix-icon")
+          end
+        end
       end
     end
   end

--- a/decidim-elections/spec/helpers/decidim/elections/steps_helper_spec.rb
+++ b/decidim-elections/spec/helpers/decidim/elections/steps_helper_spec.rb
@@ -80,7 +80,7 @@ module Decidim
 
           let(:expected_items) do
             [
-              { key: ".technical_configuration.bulletin_board_server", value: Decidim::BulletinBoard.config[:bulletin_board_server]},
+              { key: ".technical_configuration.bulletin_board_server", value: Decidim::BulletinBoard.config[:bulletin_board_server] },
               { key: ".technical_configuration.authority_name", value: Decidim::BulletinBoard.config[:authority_name] },
               { key: ".technical_configuration.scheme_name", value: Decidim::BulletinBoard.config[:scheme_name] }
             ]

--- a/decidim-elections/spec/helpers/decidim/elections/steps_helper_spec.rb
+++ b/decidim-elections/spec/helpers/decidim/elections/steps_helper_spec.rb
@@ -74,6 +74,22 @@ module Decidim
             expect(subject).to have_selector("svg.fix-icon")
           end
         end
+
+        describe "#technical_configuration_items" do
+          subject { helper.technical_configuration_items }
+
+          let(:expected_items) do
+            [
+              { key: ".technical_configuration.bulletin_board_server", value: Rails.application.secrets.elections[:bulletin_board_server] },
+              { key: ".technical_configuration.authority_name", value: Decidim::BulletinBoard.config[:authority_name] },
+              { key: ".technical_configuration.scheme_name", value: Decidim::BulletinBoard.config[:scheme_name] }
+            ]
+          end
+
+          it "returns the technical configuration items" do
+            expect(subject).to eq(expected_items)
+          end
+        end
       end
     end
   end

--- a/decidim-elections/spec/helpers/decidim/elections/steps_helper_spec.rb
+++ b/decidim-elections/spec/helpers/decidim/elections/steps_helper_spec.rb
@@ -80,7 +80,7 @@ module Decidim
 
           let(:expected_items) do
             [
-              { key: ".technical_configuration.bulletin_board_server", value: Rails.application.secrets.elections[:bulletin_board_server] },
+              { key: ".technical_configuration.bulletin_board_server", value: Decidim::BulletinBoard.config[:bulletin_board_server]},
               { key: ".technical_configuration.authority_name", value: Decidim::BulletinBoard.config[:authority_name] },
               { key: ".technical_configuration.scheme_name", value: Decidim::BulletinBoard.config[:scheme_name] }
             ]

--- a/decidim-elections/spec/system/admin/admin_manages_election_steps_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_election_steps_spec.rb
@@ -9,6 +9,23 @@ describe "Admin manages election steps", :slow do
 
   describe "setup an election" do
     let(:election) { create(:election, :ready_for_setup, component: current_component, title: { en: "English title", es: "" }) }
+    let(:bulletin_board_server) { Decidim::BulletinBoard.config[:bulletin_board_server] }
+    let(:authority_name) { Decidim::BulletinBoard.config[:authority_name] }
+    let(:scheme_name) { Decidim::BulletinBoard.config[:scheme_name] }
+
+    it "shows the election technical information" do
+      visit_steps_page
+      click_link "View technical information"
+
+      within ".form.step.create_election" do
+        expect(page).to have_content("Bulletin Board server")
+        expect(page).to have_content(bulletin_board_server)
+        expect(page).to have_content("Authority name")
+        expect(page).to have_content(authority_name)
+        expect(page).to have_content("Scheme name")
+        expect(page).to have_content(scheme_name)
+      end
+    end
 
     it "performs the action successfully" do
       visit_steps_page


### PR DESCRIPTION
#### :tophat: What? Why?
- [x] "Fix it" button – a new button has been added to make it convenient to fix the election configuration
- [x] Summary of the election – added ability to see election summaries with all questions and configurations for participatory space administrator
#### :pushpin: Related Issues
- Fixes #6624

#### Testing

1. Login as admin
2. Go to Elections
3. Find an election with bb_status "Setup election"
4. Go to "Manage steps"
5. If one of the steps does not match the required election configuration, there will be a "Fix it" button next to it to proceed to the fix
6. Clicking on "Technical configuration" opens the list

### :camera: Screenshots
<img width="600" alt="sc" src="https://github.com/decidim/decidim/assets/60363870/49966c4a-ba0e-4298-9164-bea68156d6a2">

:hearts: Thank you!
