### PR TITLE
Fix regression on password change for seeds

### DIFF
--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -31,7 +31,8 @@ module Decidim
         avatar: random_avatar,
         accepted_tos_version: organization.tos_version + 1.hour,
         newsletter_notifications_at: Time.current,
-        tos_agreement: true
+        tos_agreement: true,
+        password_updated_at: Time.current
       )
 
       user


### PR DESCRIPTION
#### :tophat: What? Why?
After we merged #12091 i have noticed that the admin user is prompted to change its password right after first login. This is a regression of #9482. 

This PR restores the functionality added by https://github.com/decidim/decidim/pull/9482.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12091

#### Testing
1. Create new app 
2. Login with admin 
3. See the password change screen 
4. Apply patch 
5. Repeat step 1 + 2 
6. See there is no password change screen. 

:hearts: Thank you!
