### PR TITLE
Exclude participatory text example file from markdownlint

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -4,3 +4,5 @@ decidim_dummy_app/
 dev/assets/iso-8859-15.md
 vendor/bundle
 development_app/
+decidim-dev/lib/decidim/dev/assets/participatory_text.md
+decidim-proposals/app/packs/documents/decidim/proposals/participatory_texts/participatory_text.md

--- a/decidim-dev/lib/decidim/dev/assets/participatory_text.md
+++ b/decidim-dev/lib/decidim/dev/assets/participatory_text.md
@@ -1,5 +1,3 @@
-<!-- markdown-lint-disable-file single-h1 -->
-
 # The great title for a new law
 
 ## A co-creation process to create creative creations

--- a/decidim-proposals/app/packs/documents/decidim/proposals/participatory_texts/participatory_text.md
+++ b/decidim-proposals/app/packs/documents/decidim/proposals/participatory_texts/participatory_text.md
@@ -54,4 +54,4 @@ Ordered lists will be parsed too:
 
 A link to Decidim's web site uses [this format](https://decidim.org).
 
-![Important image for Decidim](https://meta.decidim.org/assets/decidim/decidim-logo-1f39092fb3e41d23936dc8aeadd054e2119807dccf3c395de88637e4187f0a3f.svg)
+![Important image for Decidim](https://raw.githubusercontent.com/decidim/decidim/develop/logo.svg)

--- a/decidim-proposals/app/packs/documents/decidim/proposals/participatory_texts/participatory_text.md
+++ b/decidim-proposals/app/packs/documents/decidim/proposals/participatory_texts/participatory_text.md
@@ -1,5 +1,3 @@
-<!-- markdownlint-disable-file single-h1 strong-style emphasis-style -->
-
 # Section title 1: grouping content
 
 Participatory texts relay on the parsing of Markdown texts to produce a structured document.

--- a/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
+++ b/decidim-proposals/lib/decidim/proposals/markdown_to_proposals.rb
@@ -41,12 +41,6 @@ module Decidim
 
       # Block-level calls ######################
 
-      # Recarpet callback to preprocess the document.
-      # Removes the HTML comment from the markdown file
-      def preprocess(document)
-        document.gsub(/<!--.*-->/, "")
-      end
-
       # Recarpet callback to process headers.
       # Creates Paricipatory Text Proposals at Section and Subsection levels.
       def header(title, level)

--- a/decidim-proposals/spec/lib/decidim/proposals/markdown_to_proposals_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/markdown_to_proposals_spec.rb
@@ -225,23 +225,6 @@ module Decidim
           end
         end
       end
-
-      describe "HTML comments are ignored" do
-        let(:paragraph) { "<!-- This should be ignored --> \nThis should be kept." }
-
-        before do
-          items << "#{paragraph}\n"
-        end
-
-        it "ignores the comment" do
-          should_parse_and_produce_proposals(1)
-
-          proposal = Proposal.last
-          # proposal titled with its numbering (position)
-          expect(translated(proposal.title)).to eq("1")
-          expect(translated(proposal.body)).to eq("This should be kept.")
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

There are some security alerts from a bad regexp on the markdown lint, so I want to fix it.

The problem is that actually using the markdownlint comments in this file is just a bad idea, as when the admin downloads this example file is the first thing that they see. 

This PR excludes this file as there are just too many wrong things here to fix, and we should change this whole feature altogether. As that's planned to do in the near future (i.e. its in the roadmap for 2024), I will not fix it, and just exclude it from the linter. 

#### :pushpin: Related Issues
 
- Related to #9446
- Related to #11967 (this was my attempt to fix the file)
 
#### Testing

All the linters should pass
All the specs should pass too 

:hearts: Thank you!
