### PR TITLE
Fix missing icon error in production environment

### DIFF
--- a/decidim-core/lib/decidim/icon_registry.rb
+++ b/decidim-core/lib/decidim/icon_registry.rb
@@ -49,6 +49,8 @@ module Decidim
 
       ActiveSupport::Deprecation.warn(message)
       raise message if Rails.env.development? || Rails.env.test?
+
+      @icons["other"]
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When running in production, if there is a reference to a missing icon, then the page will render a 500. 

The error looks like: 

```
[7724a1cc-2e06-42bc-8dfb-abd7087e4b27] ActionView::Template::Error (undefined method `[]' for nil:NilClass

 name = Decidim.icons.find(name)["icon"] unless options[:ignore_missing]
                                ^^^^^^^^):
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/decidim/metadecidim/pull/120

#### Testing
1. Write a reference to an icon in a page / footer  like: `icon('some-missing-icon-that-went-foo-bar')`
2. Start the application in prod environment 
3. Access the page and see the 500 error 
4. Apply patch 
5. Restart app
6. See the image got replaced by "question-line"

:hearts: Thank you!
