### PR TITLE
Ensure that there is always a hybrid voting in the seeds

### DIFF
--- a/decidim-elections/lib/decidim/votings/seeds.rb
+++ b/decidim-elections/lib/decidim/votings/seeds.rb
@@ -6,8 +6,7 @@ module Decidim
   module Votings
     class Seeds < Decidim::Seeds
       def call
-        3.times do |n|
-          voting_type = :hybrid if n == 1
+        Decidim::Votings::Voting.voting_types.values.each do |voting_type|
           voting = create_voting!(voting_type:)
 
           unless voting.online_voting?

--- a/decidim-elections/lib/decidim/votings/seeds.rb
+++ b/decidim-elections/lib/decidim/votings/seeds.rb
@@ -6,8 +6,9 @@ module Decidim
   module Votings
     class Seeds < Decidim::Seeds
       def call
-        3.times do |_n|
-          voting = create_voting!
+        3.times do |n|
+          voting_type = :hybrid if n == 1
+          voting = create_voting!(voting_type:)
 
           unless voting.online_voting?
             3.times do
@@ -44,7 +45,7 @@ module Decidim
         end
       end
 
-      def create_voting!
+      def create_voting!(voting_type: Decidim::Votings::Voting.voting_types.values.sample)
         n = rand(3)
         params = {
           organization:,
@@ -58,7 +59,7 @@ module Decidim
           published_at: 2.weeks.ago,
           start_time: n.weeks.from_now,
           end_time: (n + 1).weeks.from_now + 4.hours,
-          voting_type: Decidim::Votings::Voting.voting_types.values.sample,
+          voting_type:,
           promoted: n.odd?
         }
 


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing #9628, I needed to have a Hybrid or In Person voting in the seeds, but I didn't have any, as it was random. I re-run my seeds, but once again I only had Online Votings.

This PR changes the seeds to ensure that we have at least one Hybrid Voting.
 
#### Testing

1. Run the seeds
2. Go to http://localhost:3000/votings/ 
3. Check that there's at least one Hybrid voting
 
:hearts: Thank you!
