### PR TITLE
Redesign: fix grid in the partners section of the conferences

### DIFF
--- a/decidim-conferences/app/packs/stylesheets/decidim/conferences/_conference.scss
+++ b/decidim-conferences/app/packs/stylesheets/decidim/conferences/_conference.scss
@@ -53,7 +53,7 @@
   }
 
   &__grid {
-    @apply grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-x-6 gap-y-10;
+    @apply grid grid-cols-2 md:grid-cols-4 auto-rows-fr gap-3 md:gap-x-6 gap-y-10;
 
     &-item {
       @apply space-y-4;


### PR DESCRIPTION
#### :tophat: What? Why?

Fix weird behavior on Safari in the partners section of the conferences when there are more than one row.

#### :pushpin: Related Issues

- Fixes #12149 

#### Testing

1. In a fresh installation of decidim with the seeds go to any of the conferences
2. Navigate down to the partners section
3. Make the page width smaller so there are more than one row in the partners section
4. See they are rendered properly

### :camera: Screenshots

![Screenshot 2023-12-12 at 13 22 15](https://github.com/decidim/decidim/assets/6973564/ce962cd3-4515-48a6-a524-227679f93d60)

:hearts: Thank you!
