### PR TITLE
Redesign: fix `layout-2col` height on Safari

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_layout.scss
@@ -31,7 +31,7 @@
 }
 
 .layout-2col {
-  @apply md:grid grid-cols-12 container grow auto-rows-fr;
+  @apply md:grid grid-cols-12 container grow min-h-[60vh];
 
   &__aside {
     @apply col-span-4 lg:col-span-3 md:pr-16 py-6 md:py-12 gap-6 md:gap-12 flex flex-col justify-between items-start md:justify-start before:content-[''] before:absolute before:top-0 before:left-0 before:h-full before:w-1/2 before:-z-10 md:before:bg-background;

--- a/decidim-core/app/packs/stylesheets/decidim/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_layout.scss
@@ -31,7 +31,7 @@
 }
 
 .layout-2col {
-  @apply md:grid grid-cols-12 container grow;
+  @apply md:grid grid-cols-12 container grow auto-rows-fr;
 
   &__aside {
     @apply col-span-4 lg:col-span-3 md:pr-16 py-6 md:py-12 gap-6 md:gap-12 flex flex-col justify-between items-start md:justify-start before:content-[''] before:absolute before:top-0 before:left-0 before:h-full before:w-1/2 before:-z-10 md:before:bg-background;


### PR DESCRIPTION
#### :tophat: What? Why?

Fix `layout2-col` height on Safari (tested on Firefox and Chrome too)

#### :pushpin: Related Issues

- Fixes #12154

#### Testing

1. Use Safari
2. Log in to a freshly seeded development app with user@example.org
3. Visit http://localhost:3000/conversations
4. See how it's rendered properly

### :camera: Screenshots

![Screenshot 2023-12-12 at 15 07 57](https://github.com/decidim/decidim/assets/6973564/d8dfc686-428c-483b-8839-f6883916c434)

:hearts: Thank you!
