### PR TITLE
Backport 'Fix missing icon error in production environment' to v0.28

### DIFF
--- a/decidim-core/lib/decidim/icon_registry.rb
+++ b/decidim-core/lib/decidim/icon_registry.rb
@@ -49,6 +49,8 @@ module Decidim
 
       ActiveSupport::Deprecation.warn(message)
       raise message if Rails.env.development? || Rails.env.test?
+
+      @icons["other"]
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12150 to v0.28

:hearts: Thank you!