### PR TITLE
Lock ChromeDriver to 119.0.6045.105

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -84,6 +84,8 @@ jobs:
           ruby-version: ${{ inputs.ruby_version }}
           bundler-cache: true
       - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: 119.0.6045.105
       - uses: actions/cache@v3
         id: app-cache
         with:


### PR DESCRIPTION
#### :tophat: What? Why?
I have noticed that the develop pipeline has started to fail with Chrome related issues. Upon investigation, i have noticed the that there is a new GoogleChrome version. 

Last successful pipeline used version:  119.0.6045.105
Last Failing pipleine is using version:  120.0.6099.71 

#### Testing
Make sure there is a green piepline.

### :camera: Screenshots
![image](https://github.com/decidim/decidim/assets/105683/f647ae28-5e71-4116-af41-3d77388c7bcb)

:hearts: Thank you!
