### PR TITLE
Fix chromedriver headless syntax for v120

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -42,7 +42,7 @@ end
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.args << "--explicitly-allowed-ports=#{Capybara.server_port}"
-  options.args << "--headless"
+  options.args << "--headless=new"
   options.args << "--no-sandbox"
   options.args << if ENV["BIG_SCREEN_SIZE"].present?
                     "--window-size=1920,3000"
@@ -91,7 +91,7 @@ end
 
 Capybara.register_driver :iphone do |app|
   options = Selenium::WebDriver::Chrome::Options.new
-  options.args << "--headless"
+  options.args << "--headless=new"
   options.args << "--no-sandbox"
   options.add_emulation(device_name: "iPhone 6")
 


### PR DESCRIPTION
#### :tophat: What? Why?

Related to the failing spec from #12159, in [Selenium](https://github.com/SeleniumHQ/selenium/issues/13112) they mention that we should fix the syntax of the arguments.  

(Same as in #12159, I'm labeling as a fix so we can backport this)

#### Testing

All the test suite should be green 

:hearts: Thank you!
