### PR TITLE
Backport 'Lock ChromeDriver to 119.0.6045.105' to v0.28

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -84,6 +84,8 @@ jobs:
           ruby-version: ${{ inputs.ruby_version }}
           bundler-cache: true
       - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: 119.0.6045.105
       - uses: actions/cache@v3
         id: app-cache
         with:


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12159 to v0.28

:hearts: Thank you!