### PR TITLE
Backport 'Lock ChromeDriver to 119.0.6045.105' to v0.27

### DIFF
--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -31,6 +31,9 @@ runs:
       with:
         ruby-version: ${{ inputs.ruby_version }}
         bundler-cache: true
+    - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: 119.0.6045.105
     - uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node_version }}

--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -32,8 +32,8 @@ runs:
         ruby-version: ${{ inputs.ruby_version }}
         bundler-cache: true
     - uses: nanasess/setup-chromedriver@v2
-        with:
-          chromedriver-version: 119.0.6045.105
+      with:
+        chromedriver-version: 119.0.6045.105
     - uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node_version }}


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12159 to v0.27

:hearts: Thank you!