### PR TITLE
Backport 'Lock ChromeDriver to 119.0.6045.105' to v0.26

### DIFF
--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -27,6 +27,9 @@ runs:
       with:
         ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: true
+    - uses: nanasess/setup-chromedriver@v2
+      with:
+        chromedriver-version: 119.0.6045.105
     - uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12159 to v0.26

:hearts: Thank you!