### PR TITLE
Fix documentation format in models.adoc

### DIFF
--- a/docs/modules/develop/pages/classes/models.adoc
+++ b/docs/modules/develop/pages/classes/models.adoc
@@ -39,7 +39,7 @@ The concerns are used to share code between models. They are located in `app/mod
 
 Most commonly used concerns are:
 
-- xref:`Decidim::ActsAsAuthor`
+- `Decidim::ActsAsAuthor`
 - `Decidim::ActsAsTree`
 - `Decidim::Amendable`
 - `xref:develop:authorable.adoc[Decidim::Authorable]`


### PR DESCRIPTION
A small detail that I've found while reading the documentation
 
This should be backported to v0.28 only 

:hearts: Thank you!
