### PR TITLE
Make the comments deleted and moderated less prominent

### DIFF
--- a/decidim-comments/app/packs/stylesheets/comments.scss
+++ b/decidim-comments/app/packs/stylesheets/comments.scss
@@ -318,7 +318,7 @@
 
   &__deleted,
   &__moderated {
-    @apply font-bold;
+    @apply text-gray;
   }
 
   .comment__content > * {


### PR DESCRIPTION
#### :tophat: What? Why?

Deleted and moderated comments are too prominent (with text bold) and we actually like to make them not that visible. 

This PR fixes that.

#### :pushpin: Related Issues
 
- Fixes  #12170

#### Testing

1. Sign in as admin
2. Moderate a comment
3. Create a new comment and delete it 

### :camera: Screenshots

#### Before

![Screenshot of the comment section with a deleted and a moderated comment](https://github.com/decidim/decidim/assets/717367/ba58d698-3cbd-41b1-9527-e62c466aee8f)

#### After 

![Screenshot of the comment section with a deleted and a moderated comment](https://github.com/decidim/decidim/assets/717367/bb91a9a0-63e5-48d5-b581-5d9fd6767690)

:hearts: Thank you!
