### PR TITLE
Backport 'Fix documentation format in models.adoc' to v0.28

### DIFF
--- a/docs/modules/develop/pages/classes/models.adoc
+++ b/docs/modules/develop/pages/classes/models.adoc
@@ -39,7 +39,7 @@ The concerns are used to share code between models. They are located in `app/mod
 
 Most commonly used concerns are:
 
-- xref:`Decidim::ActsAsAuthor`
+- `Decidim::ActsAsAuthor`
 - `Decidim::ActsAsTree`
 - `Decidim::Amendable`
 - `xref:develop:authorable.adoc[Decidim::Authorable]`


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12168 to v0.28

:hearts: Thank you!