### PR TITLE
Refactor meeting invites filters to use Filterable API

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -458,7 +458,6 @@ en:
           report_count_eq: Report count eq
           reported_id_string_or_reported_content_cont: Search %{collection} by reportable id or content.
           title_cont: Search %{collection} by title.
-          user_name_or_user_email_cont: Search %{collection} by name or email.
           user_name_or_user_nickname_or_user_email_cont: Search %{collection} by email, name or nickname.
         state_eq:
           label: State

--- a/decidim-meetings/app/controllers/concerns/decidim/meetings/admin/invites/filterable.rb
+++ b/decidim-meetings/app/controllers/concerns/decidim/meetings/admin/invites/filterable.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Meetings
+    module Admin
+      module Invites
+        module Filterable
+          extend ActiveSupport::Concern
+
+          included do
+            include Decidim::Admin::Filterable
+
+            private
+
+            def filters
+              [:accepted_at_not_null, :rejected_at_not_null, :sent_at_not_null]
+            end
+
+            def base_query
+              collection
+            end
+
+            def search_field_predicate
+              :user_name_or_user_email_cont
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/invites_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/invites_controller.rb
@@ -6,14 +6,14 @@ module Decidim
       # Controller that allows inviting users to join a meeting.
       #
       class InvitesController < Admin::ApplicationController
-        helper_method :invites
+        helper_method :collection
+
+        include Decidim::Meetings::Admin::Invites::Filterable
 
         def index
           enforce_permission_to(:read_invites, :meeting, meeting:)
 
-          @query = params[:q]
-          @status = params[:status]
-
+          @invites = filtered_collection
           @form = form(MeetingRegistrationInviteForm).instance
         end
 
@@ -41,8 +41,8 @@ module Decidim
           @meeting ||= Meeting.where(component: current_component).find(params[:meeting_id])
         end
 
-        def invites
-          @invites ||= Decidim::Admin::Invites.for(meeting.invites, @query, @status).page(params[:page]).per(15)
+        def collection
+          meeting.invites
         end
       end
     end

--- a/decidim-meetings/app/views/decidim/meetings/admin/invites/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/invites/index.html.erb
@@ -18,38 +18,8 @@
       <% end %>
     <% end %>
 
-    <%# NOTE: this old filters section should be refactorized in order to use the shared admin_filter_selector method
-    it would require the definition of concerns similar to decidim-conferences/app/controllers/concerns/decidim/conferences/admin/filterable.rb %>
-    <div class="filters__section mt-4">
-      <div class="fcell">
-        <ul class="dropdown menu" data-dropdown-menu data-click-open="true" data-close-on-click-inside="false">
-          <li class="is-dropdown-submenu-parent">
-            <a href="#" class="dropdown button">
-              <%= t("filter_label", scope: "decidim.admin.filters") %>
-              <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
-            </a>
-            <ul class="menu is-dropdown-submenu">
-              <li><%= link_to t(".filter.sent"), url_for(status: "sent", q: @query) %></li>
-              <li><%= link_to t(".filter.accepted"), url_for(status: "accepted", q: @query) %></li>
-              <li><%= link_to t(".filter.rejected"), url_for(status: "rejected", q: @query) %></li>
-              <li><%= link_to t(".filter.all"), url_for(q: @query) %></li>
-            </ul>
-          </li>
-        </ul>
-      </div>
-      <div class="fcell search">
-        <%= form_tag "", method: :get do %>
-          <div class="input-group">
-            <%= search_field_tag :q, @query,label: false, class: "input-group-field", placeholder: t(".search") %>
-            <%= hidden_field_tag :state, @state %>
-            <div class="input-group-button">
-              <button type="submit" class="text-secondary" aria-label="<%= t("decidim.search.term_input_placeholder") %>">
-                <%= icon "search-line", class: "fill-secondary w-4 h-4" %>
-              </button>
-            </div>
-          </div>
-        <% end %>
-      </div>
+    <div class="mt-4">
+      <%= admin_filter_selector %>
     </div>
 
     <div class="card" id="meeting-invites">
@@ -67,7 +37,7 @@
             </tr>
           </thead>
           <tbody>
-            <% invites.each do |invite| %>
+            <% @invites.each do |invite| %>
               <% presenter = Decidim::Meetings::InvitePresenter.new(invite) %>
               <tr data-id="<%= invite.id %>">
                 <td>
@@ -90,6 +60,6 @@
         </table>
       </div>
     </div>
-    <%= decidim_paginate invites %>
+    <%= decidim_paginate @invites %>
   </div>
 </div>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -91,6 +91,11 @@ en:
   decidim:
     admin:
       filters:
+        accepted_at_not_null:
+          label: Accepted
+          values:
+            'false': Not accepted
+            'true': Accepted
         meetings:
           category_id_eq:
             label: Category
@@ -118,6 +123,18 @@ en:
               hybrid: Hybrid
               in_person: In Person
               online: Online
+        rejected_at_not_null:
+          label: Rejected
+          values:
+            'false': Not rejected
+            'true': Rejected
+        search_placeholder:
+          user_name_or_user_email_cont: Search by name or email
+        sent_at_not_null:
+          label: Sent
+          values:
+            'false': Not sent
+            'true': Sent
       meeting_copies:
         create:
           error: There was a problem duplicating this meeting.
@@ -282,15 +299,9 @@ en:
             non_user: Non existing participant
             select_user: Select participant
           index:
-            filter:
-              accepted: Accepted
-              all: All
-              rejected: Rejected
-              sent: Sent
             invite_attendee: Invite attendee
             invites: Invites
             registrations_disabled: You cannot invite an attendee because the registrations are disabled.
-            search: Search
         meeting_closes:
           edit:
             close: Close

--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -58,6 +58,7 @@ module Decidim
       def meeting_params(component:, type:, author_type:)
         start_time = ::Faker::Date.between(from: 20.weeks.ago, to: 20.weeks.from_now)
         end_time = start_time + [rand(1..4).hours, rand(1..20).days].sample
+        registration_type = Decidim::Meetings::Meeting::REGISTRATION_TYPES.keys.sample
 
         params = {
           component:,
@@ -77,6 +78,7 @@ module Decidim
           registrations_enabled: [true, false].sample,
           available_slots: (10..50).step(10).to_a.sample,
           author: participatory_space.organization,
+          registration_type:,
           registration_terms: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
             Decidim::Faker::Localized.paragraph(sentence_count: 3)
           end,
@@ -102,6 +104,15 @@ module Decidim
                    )
                  else
                    params # :in_person
+                 end
+
+        params = case registration_type
+                 when :on_different_platform
+                   params.merge(registration_url: Faker::Internet.url)
+                 when :on_this_platform
+                   params.merge(registrations_enabled: true)
+                 else
+                   params # registration_disabled
                  end
 
         case author_type

--- a/decidim-meetings/spec/shared/manage_invites_examples.rb
+++ b/decidim-meetings/spec/shared/manage_invites_examples.rb
@@ -166,11 +166,13 @@ shared_examples "manage invites" do
     end
 
     context "when filtering" do
+      include_context "with filterable context"
+
       it "allows searching by text" do
         visit_meeting_invites_page
 
         within ".filters__section" do
-          fill_in :q, with: invites.first.user.email
+          fill_in :q_user_name_or_user_email_cont, with: invites.first.user.email
           click_button(type: "submit")
         end
 
@@ -184,12 +186,10 @@ shared_examples "manage invites" do
       it "allows filtering by status" do
         accepted_invite = create(:invite, :accepted, meeting:)
         rejected_invite = create(:invite, :rejected, meeting:)
+
         visit_meeting_invites_page
 
-        within ".filters__section" do
-          find("ul.dropdown > li > a").click # Open the dropdown-menu
-          find_link("Accepted", visible: false).click
-        end
+        apply_filter("Accepted", "Accepted")
 
         within "#meeting-invites table tbody" do
           expect(page).to have_css("tr", count: 1)
@@ -197,10 +197,8 @@ shared_examples "manage invites" do
           expect(page).not_to have_content(rejected_invite.user.name)
         end
 
-        within ".filters__section" do
-          find("ul.dropdown > li > a").click # Open the dropdown-menu
-          find_link("Rejected", visible: false).click
-        end
+        remove_applied_filter("Accepted")
+        apply_filter("Rejected", "Rejected")
 
         within "#meeting-invites table tbody" do
           expect(page).to have_css("tr", count: 1)

--- a/decidim-meetings/spec/system/admin/admin_filters_meeting_invites_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_filters_meeting_invites_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin filters invites" do
+  let(:meeting) { create(:meeting) }
+  let(:organization) { meeting.component.organization }
+  let(:admin) { create(:user, :admin, :confirmed, organization:) }
+
+  let(:resource_controller) { Decidim::Meetings::Admin::InvitesController }
+
+  let(:name) { "Dummy Name" }
+  let(:user1) { create(:user, name:, organization:) }
+  let!(:invited_user1) { create(:invite, :accepted, user: user1, meeting:) }
+
+  let(:email) { "dummy_email@example.org" }
+  let(:user2) { create(:user, email:, organization:) }
+  let!(:invited_user2) { create(:invite, user: user2, meeting:) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as admin, scope: :user
+    visit Decidim::EngineRouter.admin_proxy(meeting.component).meeting_registrations_invites_path(meeting)
+  end
+
+  include_context "with filterable context"
+
+  context "when filtering by accepted" do
+    context "when filtering Accepted" do
+      it_behaves_like "a filtered collection", options: "Accepted", filter: "Accepted" do
+        let(:in_filter) { user1.name }
+        let(:not_in_filter) { user2.name }
+      end
+    end
+
+    context "when filtering: Not accepted" do
+      it_behaves_like "a filtered collection", options: "Accepted", filter: "Not accepted" do
+        let(:in_filter) { user2.name }
+        let(:not_in_filter) { user1.name }
+      end
+    end
+  end
+
+  it_behaves_like "paginating a collection" do
+    let!(:collection) { create_list(:invite, 50, meeting:) }
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

There is a filter that uses the old way of filtering, and the HTML has this comment:
```erb
 <%# NOTE: this old filters section should be refactorized in order to use the shared admin_filter_selector method
    it would require the definition of concerns similar to decidim-conferences/app/controllers/concerns/decidim/conferences/admin/filterable.rb %>
```

This PR fixes it by migrating to the Filterable API

I've also changed the seeds so we have different kind of registrations in the meetings to ease-up the testing

#### :pushpin: Related Issues
 
- Related to #12059
- Fixes #11695

#### Testing

0. Seed a new database
1. Sign in as admin
2. Go to a meeting with registrations enabled in the admin
3. Go to the invites page
4. Invite some participants to the conference
5. Filter by its values and search

### :camera: Screenshots

![Screenshot of the meetings invitation page](https://github.com/decidim/decidim/assets/717367/e330d356-f173-4ef7-a0ce-30424516e9ed)

:hearts: Thank you!
