### PR TITLE
Backport 'Redesign: fix grid in the partners section of the conferences' to v0.28

### DIFF
--- a/decidim-conferences/app/packs/stylesheets/decidim/conferences/_conference.scss
+++ b/decidim-conferences/app/packs/stylesheets/decidim/conferences/_conference.scss
@@ -53,7 +53,7 @@
   }
 
   &__grid {
-    @apply grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-x-6 gap-y-10;
+    @apply grid grid-cols-2 md:grid-cols-4 auto-rows-fr gap-3 md:gap-x-6 gap-y-10;
 
     &-item {
       @apply space-y-4;


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12155 to v0.28

:hearts: Thank you!