### PR TITLE
Backport 'Redesign: fix `layout-2col` height on Safari' to v0.28

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_layout.scss
@@ -31,7 +31,7 @@
 }
 
 .layout-2col {
-  @apply md:grid grid-cols-12 container grow;
+  @apply md:grid grid-cols-12 container grow min-h-[60vh];
 
   &__aside {
     @apply col-span-4 lg:col-span-3 md:pr-16 py-6 md:py-12 gap-6 md:gap-12 flex flex-col justify-between items-start md:justify-start before:content-[''] before:absolute before:top-0 before:left-0 before:h-full before:w-1/2 before:-z-10 md:before:bg-background;


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12156 to v0.28

:hearts: Thank you!