### PR TITLE
Remove duplicated chromedriver setting in v0.26

### DIFF
--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -50,7 +50,6 @@ runs:
     - run: mkdir -p ./spec/decidim_dummy_app/tmp/screenshots
       name: Create the screenshots folder
       shell: "bash"
-    - uses: nanasess/setup-chromedriver@v2
     - run: RAILS_ENV=test bundle exec rails assets:precompile
       name: Precompile assets
       working-directory: ./spec/decidim_dummy_app/


### PR DESCRIPTION
#### :tophat: What? Why?

As in #12182: 

> Back in https://github.com/decidim/decidim/pull/12162, we have back ported a ChromeDriver lock to 0.27. Unfortunately, we have not taken into account the old setting. So when we merged https://github.com/decidim/decidim/pull/12050, all the pipelines started to fail.

This PR brings that same change to v0.26

#### :pushpin: Related Issues

Related to https://github.com/decidim/decidim/pull/12162

#### Testing

Make sure the pipeline is green.
 
:hearts: Thank you!
