### PR TITLE
Use git instead of filesystem for releases files

### DIFF
--- a/decidim-accountability/decidim-accountability.gemspec
+++ b/decidim-accountability/decidim-accountability.gemspec
@@ -25,7 +25,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim accountability module"
   s.description = "An accountability component for decidim's participatory spaces."
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-comments", Decidim::Accountability.version
   s.add_dependency "decidim-core", Decidim::Accountability.version

--- a/decidim-admin/decidim-admin.gemspec
+++ b/decidim-admin/decidim-admin.gemspec
@@ -24,7 +24,13 @@ Gem::Specification.new do |s|
   s.name = "decidim-admin"
   s.summary = "Decidim organization administration"
   s.description = "Organization administration to manage a single organization."
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "active_link_to", "~> 1.0"
   s.add_dependency "decidim-core", Decidim::Admin.version

--- a/decidim-api/decidim-api.gemspec
+++ b/decidim-api/decidim-api.gemspec
@@ -25,7 +25,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim API module"
   s.description = "API engine for decidim"
 
-  s.files = Dir["{app,config,db,lib,vendor,docs}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ docs/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "commonmarker", "~> 0.23.0", ">= 0.23.9"
   # Graphql version 2.1 breaks graphql-client compatibility See https://github.com/github/graphql-client/pull/310

--- a/decidim-assemblies/decidim-assemblies.gemspec
+++ b/decidim-assemblies/decidim-assemblies.gemspec
@@ -23,7 +23,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim assemblies module"
   s.description = "Assemblies component for decidim."
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Assemblies.version
 

--- a/decidim-blogs/decidim-blogs.gemspec
+++ b/decidim-blogs/decidim-blogs.gemspec
@@ -25,7 +25,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim blogs module"
   s.description = "A Blog component for decidim's participatory spaces."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-admin", Decidim::Blogs.version
   s.add_dependency "decidim-comments", Decidim::Blogs.version

--- a/decidim-budgets/decidim-budgets.gemspec
+++ b/decidim-budgets/decidim-budgets.gemspec
@@ -25,7 +25,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim budgets module"
   s.description = "A budgets component for decidim's participatory spaces."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-comments", Decidim::Budgets.version
   s.add_dependency "decidim-core", Decidim::Budgets.version

--- a/decidim-comments/decidim-comments.gemspec
+++ b/decidim-comments/decidim-comments.gemspec
@@ -24,7 +24,13 @@ Gem::Specification.new do |s|
   s.name = "decidim-comments"
   s.summary = "Decidim comments module"
   s.description = "Pluggable comments system for some components."
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Comments.version
   s.add_dependency "redcarpet", "~> 3.5", ">= 3.5.1"

--- a/decidim-conferences/decidim-conferences.gemspec
+++ b/decidim-conferences/decidim-conferences.gemspec
@@ -23,7 +23,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim conferences module"
   s.description = "Conferences component for decidim."
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Conferences.version
   s.add_dependency "decidim-meetings", Decidim::Conferences.version

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -24,7 +24,12 @@ Gem::Specification.new do |s|
   s.license = "AGPL-3.0"
   s.required_ruby_version = ">= 3.1"
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "active_link_to", "~> 1.0"
   s.add_dependency "acts_as_list", "~> 1.0"

--- a/decidim-debates/decidim-debates.gemspec
+++ b/decidim-debates/decidim-debates.gemspec
@@ -23,7 +23,13 @@ Gem::Specification.new do |s|
   s.name = "decidim-debates"
   s.summary = "Decidim debates module"
   s.description = "A debates component for decidim's participatory spaces."
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-comments", Decidim::Debates.version
   s.add_dependency "decidim-core", Decidim::Debates.version

--- a/decidim-design/decidim-design.gemspec
+++ b/decidim-design/decidim-design.gemspec
@@ -25,7 +25,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim Design Guide (DDG) module"
   s.description = "The design guide module for Decidim."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Design.version
   s.add_development_dependency "decidim-dev", Decidim::Design.version

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -25,7 +25,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim dev tools"
   s.description = "Utilities and tools we need to develop Decidim"
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md", "rubocop-decidim.yml"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md rubocop-decidim.yml))
+    end
+  end
 
   s.add_dependency "capybara", "~> 3.39"
   s.add_dependency "decidim", Decidim::Dev.version

--- a/decidim-elections/decidim-elections.gemspec
+++ b/decidim-elections/decidim-elections.gemspec
@@ -23,7 +23,12 @@ Gem::Specification.new do |s|
   s.summary = "A decidim elections module (votings space and elections component)"
   s.description = "The Elections module adds elections to any participatory space."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-bulletin_board", "~> 0.24.4"
   s.add_dependency "voting_schemes-dummy", "~> 0.24.4"

--- a/decidim-forms/decidim-forms.gemspec
+++ b/decidim-forms/decidim-forms.gemspec
@@ -25,7 +25,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim forms"
   s.description = "A forms gem for decidim."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Forms.version
   s.add_dependency "wicked_pdf", "~> 2.1"

--- a/decidim-generators/decidim-generators.gemspec
+++ b/decidim-generators/decidim-generators.gemspec
@@ -25,14 +25,12 @@ Gem::Specification.new do |s|
   s.summary = "Citizen participation framework for Ruby on Rails."
   s.description = "A generator and multiple gems made with Ruby on Rails."
 
-  s.files = Dir[
-    "lib/**/*",
-    "lib/decidim/generators/{app,component}_templates/{*,.*}",
-    "Gemfile",
-    "Gemfile.lock",
-    "Rakefile",
-    "README.md"
-  ]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(lib/ Gemfile Gemfile.lock Rakefile README.md))
+    end
+  end
 
   s.bindir = "exe"
   s.executables = ["decidim"]

--- a/decidim-generators/lib/decidim/generators/component_templates/decidim-component.gemspec.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/decidim-component.gemspec.erb
@@ -23,7 +23,12 @@ Gem::Specification.new do |s|
   s.summary = "A decidim <%= component_name %> module"
   s.description = "<%= component_description %>."
 
-  s.files = Dir["{app,config,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ LICENSE-AGPLv3.txt Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::<%= component_module_name %>.version
 end

--- a/decidim-initiatives/decidim-initiatives.gemspec
+++ b/decidim-initiatives/decidim-initiatives.gemspec
@@ -23,7 +23,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim initiatives module"
   s.description = "Participants initiatives plugin for decidim."
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-admin", Decidim::Initiatives.version
   s.add_dependency "decidim-comments", Decidim::Initiatives.version

--- a/decidim-meetings/decidim-meetings.gemspec
+++ b/decidim-meetings/decidim-meetings.gemspec
@@ -25,7 +25,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim meetings module"
   s.description = "A meetings component for decidim's participatory spaces."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Meetings.version
   s.add_dependency "decidim-forms", Decidim::Meetings.version

--- a/decidim-pages/decidim-pages.gemspec
+++ b/decidim-pages/decidim-pages.gemspec
@@ -25,7 +25,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim pages module"
   s.description = "A pages component for decidim's participatory processes."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Pages.version
 

--- a/decidim-participatory_processes/decidim-participatory_processes.gemspec
+++ b/decidim-participatory_processes/decidim-participatory_processes.gemspec
@@ -23,7 +23,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim participatory processes module"
   s.description = "Participatory processes component for decidim."
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::ParticipatoryProcesses.version
 

--- a/decidim-proposals/decidim-proposals.gemspec
+++ b/decidim-proposals/decidim-proposals.gemspec
@@ -25,7 +25,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim proposals module"
   s.description = "A proposals component for decidim's participatory spaces."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w[app/ config/ db/ lib/ Rakefile README.md])
+    end
+  end
 
   s.add_dependency "decidim-comments", Decidim::Proposals.version
   s.add_dependency "decidim-core", Decidim::Proposals.version

--- a/decidim-proposals/decidim-proposals.gemspec
+++ b/decidim-proposals/decidim-proposals.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").select do |f|
       (File.expand_path(f) == __FILE__) ||
-        f.start_with?(*%w[app/ config/ db/ lib/ Rakefile README.md])
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
     end
   end
 

--- a/decidim-sortitions/decidim-sortitions.gemspec
+++ b/decidim-sortitions/decidim-sortitions.gemspec
@@ -23,7 +23,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim sortitions module"
   s.description = "This module makes possible to select amont a set of proposal by sortition"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-admin", Decidim::Sortitions.version
   s.add_dependency "decidim-comments", Decidim::Sortitions.version

--- a/decidim-surveys/decidim-surveys.gemspec
+++ b/decidim-surveys/decidim-surveys.gemspec
@@ -25,7 +25,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim surveys module"
   s.description = "A surveys component for decidim's participatory spaces."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Surveys.version
   s.add_dependency "decidim-forms", Decidim::Surveys.version

--- a/decidim-system/decidim-system.gemspec
+++ b/decidim-system/decidim-system.gemspec
@@ -25,7 +25,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim system administration"
   s.description = "System administration to create new organization in an installation."
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "active_link_to", "~> 1.0"
   s.add_dependency "decidim-core", Decidim::System.version

--- a/decidim-templates/decidim-templates.gemspec
+++ b/decidim-templates/decidim-templates.gemspec
@@ -23,7 +23,12 @@ Gem::Specification.new do |s|
   s.summary = "A decidim templates module"
   s.description = "This module provides a solution to create templates for different Decidim models, such as Proposals and Questionnaires.."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Templates.version
   s.add_dependency "decidim-forms", Decidim::Templates.version

--- a/decidim-verifications/decidim-verifications.gemspec
+++ b/decidim-verifications/decidim-verifications.gemspec
@@ -23,7 +23,12 @@ Gem::Specification.new do |s|
   s.description = "Several verification methods for your decidim instance"
   s.license = "AGPL-3.0"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Verifications.version
 

--- a/decidim.gemspec
+++ b/decidim.gemspec
@@ -32,7 +32,8 @@ Gem::Specification.new do |s|
                         docs/
                         lib/
                         LICENSE-AGPLv3.txt
-                        Rakefile README.md
+                        Rakefile
+                        README.md
                         package.json
                         package-lock.json
                         packages/

--- a/decidim.gemspec
+++ b/decidim.gemspec
@@ -25,17 +25,22 @@ Gem::Specification.new do |s|
   s.summary = "Citizen participation framework for Ruby on Rails."
   s.description = "A generator and multiple gems made with Ruby on Rails."
 
-  s.files = Dir[
-    "{docs,lib}/**/*",
-    "LICENSE-AGPLv3.txt",
-    "Rakefile",
-    "README.md",
-    "package.json",
-    "package-lock.json",
-    "packages/**/*",
-    "babel.config.json",
-    "decidim-core/lib/decidim/webpacker/**/*"
-  ]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(
+                        docs/
+                        lib/
+                        LICENSE-AGPLv3.txt
+                        Rakefile README.md
+                        package.json
+                        package-lock.json
+                        packages/
+                        babel.config.json
+                        decidim-core/lib/decidim/webpacker/
+                      ))
+    end
+  end
 
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
#### :tophat: What? Why?

I don't want to point fingers, but someone [0] has messed-up the release process of the first RCs of v0.28 by having untracked files locally while doing the release. 

This PR fixes that by implementing the solution that bundler does by default one new gems: using `git ls-files` to get the files list. Apart from that, I decided to use an allow list (i.e. which files and directories we want) vs the reject list (i.e. which files and directories we don't want), as that makes more sense for me and seems more secure. 

I'm only doing it with `decidim-proposals` to get an OK with this approach and then go forward with the rest of the gemspecs.

#### Testing

Until we do a release (we can do rc6 for this) is tricky to check this out, but what I did was trying this out with ruby:

```ruby
#!/bin/env ruby

old_files_list = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
new_files_list = Dir.chdir(__dir__) do
  `git ls-files -z`.split("\x0").select do |f|
    (File.expand_path(f) == __FILE__) ||
      f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
  end
end

puts old_files_list.sort - new_files_list.sort
```

The only files that I could see are directories. As far as I know this makes sense as git doesn't track directories and it should not be a problem)

### :camera: Screenshots

[0] Okey okey, this someone was me! 

![Meme of pointing fingers](https://github.com/decidim/decidim/assets/717367/1cc30038-ed4e-4b47-831b-2e3ebeebabfa)

:hearts: Thank you!
