### PR TITLE
Exit if there are open Crowdin PRs during the release process

### DIFF
--- a/lib/decidim/github_manager/querier.rb
+++ b/lib/decidim/github_manager/querier.rb
@@ -14,6 +14,7 @@ module Decidim
     module Querier
       autoload :ByIssueId, "decidim/github_manager/querier/by_issue_id"
       autoload :ByLabel, "decidim/github_manager/querier/by_label"
+      autoload :ByTitle, "decidim/github_manager/querier/by_title"
       autoload :RelatedIssues, "decidim/github_manager/querier/related_issues"
     end
   end

--- a/lib/decidim/github_manager/querier/by_title.rb
+++ b/lib/decidim/github_manager/querier/by_title.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module Decidim
+  module GithubManager
+    module Querier
+      # Makes a GET request for the list of Issues or Pull Requests in GitHub.
+      #
+      # @param token [String] token for GitHub authentication
+      # @param title [String] the title that we want to search by
+      # @param state [String] the state of the issue. By default is "open"
+      #
+      # @see https://docs.github.com/en/rest/issues/issues#list-repository-issues GitHub API documentation
+      class ByTitle < Decidim::GithubManager::Querier::Base
+        def initialize(title:, token:, state: "open")
+          @title = title
+          @token = token
+          @state = state
+        end
+
+        # Makes the GET request and parses the response of an Issue or Pull Request in GitHub
+        #
+        # @return [Hash]
+        def call
+          data = json_response("https://api.github.com/repos/decidim/decidim/issues")
+
+          parse(data)
+        end
+
+        private
+
+        attr_reader :title, :state
+
+        def headers
+          {
+            title:,
+            state:,
+            per_page: 100
+          }
+        end
+
+        # Parses the response of an Issue or Pull Request in GitHub
+        #
+        # @return [Hash]
+        def parse(metadata)
+          metadata.map do |item|
+            {
+              id: item["number"],
+              title: item["title"]
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/decidim/releaser.rb
+++ b/lib/decidim/releaser.rb
@@ -172,16 +172,14 @@ module Decidim
     #
     # @return [void]
     def check_tests
-      # rubocop:disable Rails/Output
-      puts "Running specs"
+      puts "Running specs" # rubocop:disable Rails/Output
       output, status = capture("bin/rspec")
 
       unless status.success?
         run("git restore .")
-        puts output
+        puts output # rubocop:disable Rails/Output
         exit_with_errors("Tests execution failed. Fix the errors and run again.")
       end
-      # rubocop:enable Rails/Output
     end
 
     # Generates the changelog taking into account the last time the version changed
@@ -278,10 +276,8 @@ You will see errors such as `No matching version found for @decidim/browserslist
     #
     # @return [void]
     def exit_with_errors(message)
-      # rubocop:disable Rails/Output, Rails/Exit
-      puts message
-      exit 1
-      # rubocop:enable Rails/Output, Rails/Exit
+      puts message # rubocop:disable Rails/Output
+      exit 1 # rubocop:disable Rails/Exit
     end
   end
 end

--- a/spec/lib/decidim/github_manager/querier/by_title_spec.rb
+++ b/spec/lib/decidim/github_manager/querier/by_title_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "decidim/github_manager/querier"
+require "webmock/rspec"
+
+describe Decidim::GithubManager::Querier::ByTitle do
+  let(:querier) { described_class.new(token: "abc", title:, state:) }
+  let(:title) { "Fix whatever" }
+  let(:state) { "open" }
+
+  let(:stubbed_url) { "https://api.github.com/repos/decidim/decidim/issues?per_page=100&state=open&title=Fix%20whatever" }
+  let(:stubbed_headers) { {} }
+
+  before do
+    stub_request(:get, stubbed_url).to_return(status: 200, body: stubbed_body, headers: stubbed_headers)
+  end
+
+  describe ".call" do
+    let(:stubbed_body) do
+      <<~RESPONSE
+        [
+          {"number": 12345, "title": "Fix whatever", "pull_request": { "merged_at": "2020-01-01T01:01:01Z" }},
+          {"number": 98765, "title": "Fix whatever (part 2)", "pull_request": { "merged_at": "2020-01-01T01:01:01Z" }}
+        ]
+      RESPONSE
+    end
+    let(:result) do
+      [
+        { id: 12_345, title: "Fix whatever" },
+        { id: 98_765, title: "Fix whatever (part 2)" }
+      ]
+    end
+
+    it "returns a valid result" do
+      expect(querier.call).to eq result
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

On the last release I forgot about the first step in the [release candidate process according to our doc](https://docs.decidim.org/en/develop/develop/maintainers/releases.html): 

> Merge all the [Crowdin pull requests created by the user decidim-bot](https://github.com/decidim/decidim/pulls?q=is%3Apr+is%3Aopen+author%3Adecidim-bot+sort%3Aupdated-desc), specially the one that is going to be marged against the release branch release/x.y-stable that should be returned by the provided example search (pick the correct pull request for the release from the results). 

So, this PR introduces the automation to make that check  

#### Testing

Run the command for a release (`./bin/releaser --github-token=(gh auth token) --version-type=rc`)
You should see an error as there are some PRs from Crowdin not merged (#12118, #12119, #12124 and #12125)

:hearts: Thank you!
