### PR TITLE
Fix details in CSS from redesign

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
@@ -30,7 +30,7 @@
           <th>
             <%= sort_link(query, :id, t("models.result.fields.id", scope: "decidim.accountability"), default_order: :desc ) %>
           </th>
-          <th>
+          <th class="!text-left">
             <%= sort_link(query, :title, t("models.result.fields.title", scope: "decidim.accountability")) %>
           </th>
           <th>
@@ -59,7 +59,7 @@
             <td>
               <%= result.id %><br>
             </td>
-            <td>
+            <td class="!text-left">
               <% if result.parent_id.nil? %>
                 <%= link_to translated_attribute(result.title), results_path(parent_id: result.id) %><br>
               <% else %>

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_cards.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_cards.scss
@@ -140,6 +140,10 @@
       @apply cursor-move py-2;
     }
 
+    svg {
+      @apply inline-block fill-secondary;
+    }
+
     .draggable-content {
       @apply flex justify-between items-center font-semibold py-2 px-4 rounded bg-gray-3;
     }

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/_project-tr.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/_project-tr.html.erb
@@ -5,7 +5,7 @@
   <td>
     <%= project.id %><br>
   </td>
-  <td>
+  <td class="!text-left">
     <% if allowed_to? :update, :project, project: project %>
       <%= link_to translated_attribute(project.title), resource_locator([budget, project]).edit %><br>
     <% else %>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
@@ -16,7 +16,7 @@
       <thead>
         <tr>
           <th><%= check_box_tag "projects_bulk", "all", false, class: "js-check-all" %></th>
-          <th><%= sort_link(query, :id, t("models.project.fields.id", scope: "decidim.budgets"), default_order: :desc) %>
+          <th><%= sort_link(query, :id, t("models.project.fields.id", scope: "decidim.budgets"), default_order: :desc) %></th>
           <th class="!text-left"><%= sort_link(query, :title, t("models.project.fields.title", scope: "decidim.budgets")) %></th>
           <th><%= sort_link(query, :category_name, t("models.project.fields.category", scope: "decidim.budgets") ) %></th>
           <%= th_scope_sort_link %>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
@@ -17,7 +17,7 @@
         <tr>
           <th><%= check_box_tag "projects_bulk", "all", false, class: "js-check-all" %></th>
           <th><%= sort_link(query, :id, t("models.project.fields.id", scope: "decidim.budgets"), default_order: :desc) %>
-          <th><%= sort_link(query, :title, t("models.project.fields.title", scope: "decidim.budgets")) %></th>
+          <th class="!text-left"><%= sort_link(query, :title, t("models.project.fields.title", scope: "decidim.budgets")) %></th>
           <th><%= sort_link(query, :category_name, t("models.project.fields.category", scope: "decidim.budgets") ) %></th>
           <%= th_scope_sort_link %>
           <th><%= sort_link(query, :confirmed_orders_count, t("index.confirmed_orders_count")) %></th>

--- a/decidim-core/app/packs/stylesheets/decidim/_login.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_login.scss
@@ -41,7 +41,7 @@
 
   &__modal {
     &-links {
-      @apply flex flex-col md:flex-row justify-between items-start md:items-center [&>a]:text-secondary;
+      @apply flex flex-col md:flex-row gap-4 justify-between items-start md:items-center [&>a]:text-secondary;
     }
 
     [data-announcement] {

--- a/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
@@ -21,7 +21,7 @@
       <% if current_organization.sign_up_enabled? %>
         <li class="font-semibold underline"><%= link_to t("layouts.decidim.footer.sign_up"), decidim.new_user_registration_path %></li>
       <% end %>
-      <li class="font-semibold"><%= link_to t("layouts.decidim.footer.log_in"), decidim.new_user_session_path %></li>
+      <li class="font-semibold underline"><%= link_to t("layouts.decidim.footer.log_in"), decidim.new_user_session_path %></li>
     <% end %>
   </ul>
 </nav>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -15,7 +15,7 @@
       <thead>
       <tr>
         <th><%= t("models.initiatives.fields.id", scope: "decidim.admin") %></th>
-        <th class="table-list__left"><%= t("models.initiatives.fields.title", scope: "decidim.admin") %></th>
+        <th class="!text-left"><%= t("models.initiatives.fields.title", scope: "decidim.admin") %></th>
         <th><%= t("models.initiatives.fields.state", scope: "decidim.admin") %></th>
         <th><%= sort_link(query, :supports_count, t("models.initiatives.fields.supports_count", scope: "decidim.admin"), default_order: :desc) %></th>
         <th><%= sort_link(query, :created_at, t("models.initiatives.fields.created_at", scope: "decidim.admin"), default_order: :desc) %></th>
@@ -27,7 +27,7 @@
       <% @initiatives.each do |initiative| %>
         <tr>
           <td><%= initiative.id %></td>
-          <td class="table-list__left">
+          <td class="!text-left">
             <% if allowed_to? :edit, :initiative, initiative: initiative %>
               <%= link_to translated_attribute(initiative.title),
                           decidim_admin_initiatives.edit_initiative_path(initiative.to_param) %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -17,7 +17,7 @@
           <th>
             <%= sort_link(query, :id, t("models.meeting.fields.id", scope: "decidim.meetings"), default_order: :desc ) %>
           </th>
-          <th>
+          <th class="!text-left">
             <%= sort_link(query, :translated_title, t("models.meeting.fields.title", scope: "decidim.meetings"), default_order: :desc ) %>
           </th>
           <th>
@@ -46,7 +46,7 @@
             <td>
               <%= meeting.id %><br>
             </td>
-            <td>
+            <td class="!text-left">
               <% if allowed_to? :update, :meeting, meeting: meeting %>
                 <%= link_to present(meeting).title(html_escape: true), edit_meeting_path(meeting) %>
               <% else %>


### PR DESCRIPTION
## :tophat: What? Why?

There were multiple little details in found in the CSS. This PR fixes them: 

- [ ] 1. Fix icons in the content blocks configurations
- [ ] 2. Fix links separation in login modal
- [ ] 3. Add underline in footer's Login link 

### 1. Fix icons in the content blocks configurations

#### Testing

1. Sign in as admin
2. Go to the homepage configuration http://localhost:3000/admin/organization/homepage/edit 

####  :camera: Screenshots

#### Before

![Screenshot of the content blocks broken](https://github.com/decidim/decidim/assets/717367/3cf48055-b543-4a48-89a1-a470e4aa020b)

#### After

![Screenshot of the content blocks fixed](https://github.com/decidim/decidim/assets/717367/f7977389-6bc7-4e0e-8453-48dd723952d0)

---

### 2. Fix links separation in login modal

#### Testing

1. As a visitor (i.e. non logged in)
2. Go to a page that has a login modal, for instance an open initiative http://localhost:3000/initiatives/i-4 
3. Resize your browser to the small viewport
4. Click on "Verify your account to sign the initiative" 
5. See the modal links

####  :camera: Screenshots

#### Before

![Login modal with links too near](https://github.com/decidim/decidim/assets/717367/48e5d93f-3a73-48b4-8ef9-4742593685e7)

#### After

![Login modal with links fixed](https://github.com/decidim/decidim/assets/717367/640b11dc-88a7-46af-9d99-d5ef1477d316)

----

### 3. Add underline in footer's Login link 

#### Testing

1. As a visitor (i.e. non logged in)
2. Go to the footer. See the "Log in" link

####  :camera: Screenshots

#### Before

![Log in link without underline](https://github.com/decidim/decidim/assets/717367/e9423d06-be4b-4077-ab05-14c3f4f5f624)

#### After

![Log in link with underline](https://github.com/decidim/decidim/assets/717367/1315cd1d-3584-4e43-a54b-b501f2430c9b)

----

### 4. Make titles of components and spaces left aligned

#### Testing

1. Sign in as admin
2. Go to the admin page of Initiatives http://localhost:3000/admin/initiatives - also Proposals and Meetings

####  :camera: Screenshots

#### Before

![Initiatives admin page with titles centered](https://github.com/decidim/decidim/assets/717367/07e0e0d3-bbd9-4274-abe6-f20bef514c07)

#### After

![Initiatives admin page with titles left aligned](https://github.com/decidim/decidim/assets/717367/5d27c062-17ee-4029-95bf-5c500e15fd96)

:hearts: Thank you!

