### PR TITLE
Rename permission_resource to authorization_scope

### DIFF
--- a/decidim-admin/app/controllers/concerns/decidim/admin/global_moderation_context.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/global_moderation_context.rb
@@ -10,7 +10,7 @@ module Decidim
       included do
         # Private: Overwrites the method from the parent controller so that the
         # permission system does not overwrite permissions.
-        def permission_resource
+        def authorization_scope
           :global_moderation
         end
 

--- a/decidim-admin/app/controllers/decidim/admin/moderations/reports_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderations/reports_controller.rb
@@ -5,14 +5,14 @@ module Decidim
     module Moderations
       # This controller allows admins to manage reports in a moderation.
       class ReportsController < Decidim::Admin::ApplicationController
-        helper_method :moderation, :reports, :permission_resource
+        helper_method :moderation, :reports, :authorization_scope
 
         def index
-          enforce_permission_to :read, permission_resource
+          enforce_permission_to :read, authorization_scope
         end
 
         def show
-          enforce_permission_to :read, permission_resource
+          enforce_permission_to :read, authorization_scope
           @report = reports.find(params[:id])
         end
 
@@ -30,7 +30,7 @@ module Decidim
           @participatory_space_moderations ||= Decidim::Moderation.where(participatory_space: current_participatory_space)
         end
 
-        def permission_resource
+        def authorization_scope
           :moderation
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb
@@ -6,19 +6,19 @@ module Decidim
     class ModerationsController < Decidim::Admin::ApplicationController
       include Decidim::Moderations::Admin::Filterable
 
-      helper_method :moderations, :allowed_to?, :query, :permission_resource
+      helper_method :moderations, :allowed_to?, :query, :authorization_scope
 
       def index
-        enforce_permission_to :read, permission_resource
+        enforce_permission_to :read, authorization_scope
       end
 
       def show
-        enforce_permission_to :read, permission_resource
+        enforce_permission_to :read, authorization_scope
         @moderation = collection.find(params[:id])
       end
 
       def unreport
-        enforce_permission_to :unreport, permission_resource
+        enforce_permission_to :unreport, authorization_scope
 
         Admin::UnreportResource.call(reportable, current_user) do
           on(:ok) do
@@ -34,7 +34,7 @@ module Decidim
       end
 
       def hide
-        enforce_permission_to :hide, permission_resource
+        enforce_permission_to :hide, authorization_scope
 
         Admin::HideResource.call(reportable, current_user) do
           on(:ok) do
@@ -50,7 +50,7 @@ module Decidim
       end
 
       def unhide
-        enforce_permission_to :unhide, permission_resource
+        enforce_permission_to :unhide, authorization_scope
 
         Admin::UnhideResource.call(reportable, current_user) do
           on(:ok) do
@@ -100,7 +100,7 @@ module Decidim
       # added so that the `GlobalModerationController` can overwrite this method
       # and define the custom permission resource, so that the permission system
       # is not overridden.
-      def permission_resource
+      def authorization_scope
         :moderation
       end
     end

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -74,17 +74,17 @@
                              moderation_reports_path(moderation_id: moderation),
                              t("actions.expand", scope: "decidim.moderations"),
                              class: "action-icon--expand" %>
-            <% if !moderation.reportable.hidden? && allowed_to?(:unreport, permission_resource) %>
+            <% if !moderation.reportable.hidden? && allowed_to?(:unreport, authorization_scope) %>
               <%= icon_link_to "arrow-go-back-line",
                                unreport_moderation_path(id: moderation),
                                t("actions.unreport", scope: "decidim.moderations"),
                                class: "action-icon--unreport",
                                method: :put %>
             <% end %>
-            <% if !moderation.reportable.hidden? && allowed_to?(:hide, permission_resource) %>
+            <% if !moderation.reportable.hidden? && allowed_to?(:hide, authorization_scope) %>
               <%= icon_link_to "eye-line", hide_moderation_path(id: moderation), t("actions.hide", scope: "decidim.moderations"), class: "action-icon--hide", method: :put %>
             <% end %>
-            <% if moderation.reportable.hidden? && allowed_to?(:unhide, permission_resource) %>
+            <% if moderation.reportable.hidden? && allowed_to?(:unhide, authorization_scope) %>
               <%= icon_link_to "eye-line", unhide_moderation_path(id: moderation), t("actions.unhide", scope: "decidim.moderations"), method: :put %>
             <% end %>
           </td>

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
@@ -92,13 +92,13 @@
 </div>
 <div class="item__edit-sticky">
   <div class="item__edit-sticky-container">
-    <% if !moderation.reportable.hidden? && allowed_to?(:unreport, permission_resource) %>
+    <% if !moderation.reportable.hidden? && allowed_to?(:unreport, authorization_scope) %>
       <%= link_to t("actions.unreport", scope: "decidim.moderations"), unreport_moderation_path(id: moderation), method: :put, class: "button button__sm button__secondary" %>
     <% end %>
-    <% if !moderation.reportable.hidden? && allowed_to?(:hide, permission_resource) %>
+    <% if !moderation.reportable.hidden? && allowed_to?(:hide, authorization_scope) %>
       <%= link_to t("actions.hide", scope: "decidim.moderations"), hide_moderation_path(id: moderation), method: :put, class: "button button__sm button__secondary alert" %>
     <% end %>
-    <% if moderation.reportable.hidden? && allowed_to?(:unhide, permission_resource) %>
+    <% if moderation.reportable.hidden? && allowed_to?(:unhide, authorization_scope) %>
       <%= link_to t("actions.unhide", scope: "decidim.moderations"), unhide_moderation_path(id: moderation), method: :put, class: "button button__sm button__secondary alert" %>
     <% end %>
   </div>

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/show.html.erb
@@ -51,13 +51,13 @@
 
 <div class="item__edit-sticky">
   <div class="item__edit-sticky-container">
-    <% if !moderation.reportable.hidden? && allowed_to?(:unreport, permission_resource) %>
+    <% if !moderation.reportable.hidden? && allowed_to?(:unreport, authorization_scope) %>
       <%= link_to t("actions.unreport", scope: "decidim.moderations"), unreport_moderation_path(id: moderation), method: :put, class: "button button__sm button__secondary" %>
     <% end %>
-    <% if !moderation.reportable.hidden? && allowed_to?(:hide, permission_resource) %>
+    <% if !moderation.reportable.hidden? && allowed_to?(:hide, authorization_scope) %>
       <%= link_to t("actions.hide", scope: "decidim.moderations"), hide_moderation_path(id: moderation), method: :put, class: "button button__sm button__secondary alert" %>
     <% end %>
-    <% if moderation.reportable.hidden? && allowed_to?(:unhide, permission_resource) %>
+    <% if moderation.reportable.hidden? && allowed_to?(:unhide, authorization_scope) %>
       <%= link_to t("actions.unhide", scope: "decidim.moderations"), unhide_moderation_path(id: moderation), method: :put, class: "button button__sm button__secondary alert" %>
     <% end %>
   </div>


### PR DESCRIPTION
#### :tophat: What? Why?
While digging through admin module, i noticed there are at least 2 different methods that are being used to determine permission subject. 

We have : `permission_resource` and `authorization_scope`

for example:
- https://github.com/decidim/decidim/blob/1392c91d0707f05f01a0b1af6b3691f40051a133/decidim-admin/app/controllers/decidim/admin/participatory_space/user_role_controller.rb#L14
- https://github.com/decidim/decidim/blob/1392c91d0707f05f01a0b1af6b3691f40051a133/decidim-admin/app/controllers/decidim/admin/moderations_controller.rb#L12

This PR tries to standardize this method name. 

#### Testing
Pipelines should be green, Moderation admin panel should be accessible for admin

:hearts: Thank you!
