### PR TITLE
Fix using CTA image on promoted process group

### DIFF
--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process_group.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/_promoted_process_group.html.erb
@@ -14,7 +14,7 @@
       </div>
     </div>
     <div class="columns mediumlarge-8 large-6 card--process__column">
-      <div class="card--full__image" style="background-image:url('<%= cta_settings&.image_url || promoted_process_group.attached_uploader(:hero_image).path %>')">
+      <div class="card--full__image" style="background-image:url('<%= promoted_process_group.attached_uploader(:hero_image).path %>')">
         <% if cta_settings.present? %>
           <div class="card__content row collapse">
             <div class="large-6 large-offset-6 columns">


### PR DESCRIPTION
#### :tophat: What? Why?

On v0.27, when you have a process group with a CTA and the group is promoted, the promoted image uses the CTA image. 

This breaks the user expectation, as this doesn't work like that in processes. This PR changes it so it behaves the same. 

I could not reproduce it in v0.28 

#### :pushpin: Related Issues
 
- Fixes #9268

#### Testing

1. Sign in as admin
2. Create a process group
3. Add an image on it
4. Go to the processes list http://localhost:3000/processes - See that it's using the image in the card
6. Define an image in the landing page in the content block "Image, text and Call to Action button" 
4. Go to the processes list http://localhost:3000/processes - See that it's still using the same image in the card
5. Make the process group promoted and save it 
4. Go to the processes list http://localhost:3000/processes - See that it's using the CTA image

:hearts: Thank you!
