### PR TITLE
Fix flash of admin inputs, panels and dropdowns

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/filterable_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/filterable_helper.rb
@@ -53,7 +53,7 @@ module Decidim
       # Produces the html for the dropdown submenu from the options tree.
       # Returns a ActiveSupport::SafeBuffer.
       def dropdown_submenu(options)
-        content_tag(:ul, class: "vertical menu") do
+        content_tag(:ul, class: "vertical menu", "aria-hidden": true) do
           options.map do |key, value|
             if value.nil?
               content_tag(:li, key)

--- a/decidim-admin/app/packs/src/decidim/admin/application.js
+++ b/decidim-admin/app/packs/src/decidim/admin/application.js
@@ -15,6 +15,14 @@ window.Decidim.InputCharacterCounter = InputCharacterCounter;
 $(() => {
   $(document).foundation();
 
+  $(document).on("show.zf.dropdownMenu", function(event, $element) {
+    $element.attr("aria-hidden", "false");
+  });
+
+  $(document).on("hide.zf.dropdownMenu", function(event, $element) {
+    $element.children(".is-dropdown-submenu").attr("aria-hidden", "true");
+  });
+
   toggleNav();
 
   createSortList("#steps tbody", {

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_filters.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_filters.scss
@@ -16,7 +16,7 @@
   }
 
   .dropdown {
-    @apply relative p-0 bg-transparent border-0;
+    @apply relative p-0 border-0;
   }
 
   .button,

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_legacy_foundation.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_legacy_foundation.scss
@@ -32,6 +32,16 @@ li.opens-left > .is-dropdown-submenu {
   display: none;
 }
 
+.dropdown.menu ul {
+  &[aria-hidden="true"] {
+    display: none;
+  }
+
+  &[aria-hidden="false"] {
+    display: block;
+  }
+}
+
 .dropdown.menu .nested.is-dropdown-submenu {
   margin-right: 0;
   margin-left: 0;

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -12,9 +12,10 @@
               <%= t(".social_handlers") %>
             </label>
             <ul class="tabs tabs--lang" data-tabs id="organization_social_handlers">
+              <% first_handler = Decidim::Organization::SOCIAL_HANDLERS.first %>
               <% Decidim::Organization::SOCIAL_HANDLERS.each do |handler| %>
-                <li class="tabs-title <% if handler == Decidim::Organization::SOCIAL_HANDLERS.first %> is-active <% end %>">
-                  <a href="#<%= handler %>" <% if handler == Decidim::Organization::SOCIAL_HANDLERS.first %> aria-selected="true" <% end %>>
+                <li class="tabs-title <% if handler == first_handler %> is-active <% end %>">
+                  <a href="#<%= handler %>" <% if handler == first_handler %> aria-selected="true" <% end %>>
                     <%= t(".#{handler}") %>
                   </a>
                 </li>
@@ -23,7 +24,8 @@
           </div>
           <div class="tabs-content" data-tabs-content="organization_social_handlers">
             <% Decidim::Organization::SOCIAL_HANDLERS.each do |handler| %>
-              <div class="tabs-panel <% if handler == Decidim::Organization::SOCIAL_HANDLERS.first %> is-active <% end %>" id="<%= handler %>">
+              <div class="tabs-panel <% if handler == first_handler %> is-active <% end %>" id="<%= handler %>"
+                aria-hidden="<% if handler == first_handler %>false<% else %>true<% end %>">
                 <%= form.text_field "#{handler}_handler", label: false %>
               </div>
             <% end %>

--- a/decidim-admin/app/views/decidim/admin/shared/_filters.html.erb
+++ b/decidim-admin/app/views/decidim/admin/shared/_filters.html.erb
@@ -2,7 +2,7 @@
   <div class="fcell">
     <ul class="dropdown menu" data-dropdown-menu data-close-on-click-inside="false">
       <li>
-        <a href="#" class="dropdown button">
+        <a href="#" class="dropdown button button__sm button__secondary">
           <%= t("filter_label", scope: "decidim.admin.filters") %>
           <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
         </a>

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -34,7 +34,7 @@
 }
 
 .dropdown {
-  @apply absolute bg-white border-2 border-gray-3 rounded min-w-max p-4 drop-shadow-md text-left z-10;
+  @apply absolute border-2 border-gray-3 rounded min-w-max p-4 drop-shadow-md text-left z-10;
 
   & > * {
     @apply relative z-10 p-3.5 first:pt-1.5 last:pb-1.5;

--- a/decidim-core/app/presenters/decidim/log/diff_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/diff_presenter.rb
@@ -42,7 +42,7 @@ module Decidim
       def present_diff
         return "".html_safe if changeset.blank?
 
-        h.content_tag(:div, class: "logs__log__diff", id: "panel-#{h.dom_id(action_log)}") do
+        h.content_tag(:div, class: "logs__log__diff", id: "panel-#{h.dom_id(action_log)}", "aria-hidden": true) do
           changeset.each do |attribute|
             h.concat(present_new_value(attribute[:label], attribute[:new_value], attribute[:type]))
             h.concat(present_previous_value(attribute[:previous_value], attribute[:type])) if options[:show_previous_value?]

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -164,7 +164,7 @@ module Decidim
       tabs_content = content_tag(:div, class: "tabs-content", data: { tabs_content: tabs_id }) do
         handlers.each_with_index.inject("".html_safe) do |string, (handler, index)|
           tab_content_id = sanitize_tabs_selector "#{tabs_id}-#{name}-panel-#{index}"
-          string + content_tag(:div, class: tab_element_class_for("panel", index), id: tab_content_id) do
+          string + content_tag(:div, class: tab_element_class_for("panel", index), id: tab_content_id, "aria-hidden": tab_attr_aria_hidden_for(index)) do
             send(type, "#{handler}_handler", options.merge(label: false))
           end
         end

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -79,7 +79,7 @@ module Decidim
       tabs_content = content_tag(:div, class: "tabs-content", data: { tabs_content: tabs_id }) do
         locales.each_with_index.inject("".html_safe) do |string, (locale, index)|
           tab_content_id = "#{tabs_id}-#{name}-panel-#{index}"
-          string + content_tag(:div, class: tab_element_class_for("panel", index), id: tab_content_id) do
+          string + content_tag(:div, class: tab_element_class_for("panel", index), id: tab_content_id, "aria-hidden": tab_attr_aria_hidden_for(index)) do
             if hashtaggable
               hashtaggable_text_field(type, name, locale, options.merge(label: false))
             elsif type.to_sym == :editor
@@ -744,6 +744,12 @@ module Decidim
       element_class = "tabs-#{type}"
       element_class += " is-active" if index.zero?
       element_class
+    end
+
+    def tab_attr_aria_hidden_for(index)
+      return "false" if index.zero?
+
+      "true"
     end
 
     def locales


### PR DESCRIPTION
#### :tophat: What? Why?

Fix the flash of unstyled content in some admin dropdowns:

- in the admin activity log in http://localhost:3000/admin/ 
- in an admin form with many translated fields like processes new page
- in the admin organization page in the social networks
- in an admin manage page with many fields like accountability index page
- in an admin form with social networks (assemblies new/edit page is the only place that I could find) 

#### :pushpin: Related Issues

- Related to #12011
- Fixes #11783 - I could not find any other flash to be honest

#### Testing

Load the page and see that the lists inside these dropdowns are shown and then hidden (before)
Load the page and see that the lists inside these dropdowns aren't shown and then hidden (after)

:hearts: Thank you!
