### PR TITLE
Extract methods from budgets seeds

### DIFF
--- a/decidim-budgets/lib/decidim/budgets/seeds.rb
+++ b/decidim-budgets/lib/decidim/budgets/seeds.rb
@@ -16,14 +16,7 @@ module Decidim
         component = create_component!
 
         rand(1...3).times do
-          Decidim::Budgets::Budget.create!(
-            component:,
-            title: Decidim::Faker::Localized.sentence(word_count: 2),
-            description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-              Decidim::Faker::Localized.paragraph(sentence_count: 3)
-            end,
-            total_budget: ::Faker::Number.number(digits: 8)
-          )
+          create_budget!(component:)
         end
 
         Decidim::Budgets::Budget.where(component:).each do |budget|
@@ -66,6 +59,17 @@ module Decidim
             more_information_modal: Decidim::Faker::Localized.paragraph(sentence_count: 4),
             workflow: Decidim::Budgets.workflows.keys.sample
           }
+        )
+      end
+
+      def create_budget!(component:)
+        Decidim::Budgets::Budget.create!(
+          component:,
+          title: Decidim::Faker::Localized.sentence(word_count: 2),
+          description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.paragraph(sentence_count: 3)
+          end,
+          total_budget: ::Faker::Number.number(digits: 8)
         )
       end
     end

--- a/decidim-budgets/lib/decidim/budgets/seeds.rb
+++ b/decidim-budgets/lib/decidim/budgets/seeds.rb
@@ -23,10 +23,7 @@ module Decidim
           rand(2...4).times do
             project = create_project!(budget:)
 
-            attachment_collection = create_attachment_collection(collection_for: project)
-            create_attachment(attached_to: project, filename: "Exampledocument.pdf", attachment_collection:)
-            create_attachment(attached_to: project, filename: "city.jpeg")
-            create_attachment(attached_to: project, filename: "Exampledocument.pdf")
+            create_attachments!(attached_to: project)
 
             Decidim::Comments::Seed.comments_for(project)
           end

--- a/decidim-budgets/lib/decidim/budgets/seeds.rb
+++ b/decidim-budgets/lib/decidim/budgets/seeds.rb
@@ -21,16 +21,7 @@ module Decidim
 
         Decidim::Budgets::Budget.where(component:).each do |budget|
           rand(2...4).times do
-            project = Decidim::Budgets::Project.create!(
-              budget:,
-              scope: participatory_space.organization.scopes.sample,
-              category: participatory_space.categories.sample,
-              title: Decidim::Faker::Localized.sentence(word_count: 2),
-              description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-                Decidim::Faker::Localized.paragraph(sentence_count: 3)
-              end,
-              budget_amount: ::Faker::Number.between(from: Integer(budget.total_budget * 0.7), to: budget.total_budget)
-            )
+            project = create_project!(budget:)
 
             attachment_collection = create_attachment_collection(collection_for: project)
             create_attachment(attached_to: project, filename: "Exampledocument.pdf", attachment_collection:)
@@ -70,6 +61,19 @@ module Decidim
             Decidim::Faker::Localized.paragraph(sentence_count: 3)
           end,
           total_budget: ::Faker::Number.number(digits: 8)
+        )
+      end
+
+      def create_project!(budget:)
+        Decidim::Budgets::Project.create!(
+          budget:,
+          scope: participatory_space.organization.scopes.sample,
+          category: participatory_space.categories.sample,
+          title: Decidim::Faker::Localized.sentence(word_count: 2),
+          description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+            Decidim::Faker::Localized.paragraph(sentence_count: 3)
+          end,
+          budget_amount: ::Faker::Number.between(from: Integer(budget.total_budget * 0.7), to: budget.total_budget)
         )
       end
     end

--- a/decidim-budgets/lib/decidim/budgets/seeds.rb
+++ b/decidim-budgets/lib/decidim/budgets/seeds.rb
@@ -43,6 +43,7 @@ module Decidim
           published_at: Time.current,
           participatory_space:,
           settings: {
+            geocoding_enabled: [true, false].sample,
             landing_page_content:,
             more_information_modal: Decidim::Faker::Localized.paragraph(sentence_count: 4),
             workflow: Decidim::Budgets.workflows.keys.sample
@@ -62,7 +63,7 @@ module Decidim
       end
 
       def create_project!(budget:)
-        Decidim::Budgets::Project.create!(
+        params = {
           budget:,
           scope: participatory_space.organization.scopes.sample,
           category: participatory_space.categories.sample,
@@ -71,7 +72,17 @@ module Decidim
             Decidim::Faker::Localized.paragraph(sentence_count: 3)
           end,
           budget_amount: ::Faker::Number.between(from: Integer(budget.total_budget * 0.7), to: budget.total_budget)
-        )
+        }
+
+        if budget.component.settings.geocoding_enabled?
+          params = params.merge(
+            address: "#{::Faker::Address.street_address} #{::Faker::Address.zip} #{::Faker::Address.city}",
+            latitude: ::Faker::Address.latitude,
+            longitude: ::Faker::Address.longitude
+          )
+        end
+
+        Decidim::Budgets::Project.create!(params)
       end
     end
   end

--- a/decidim-budgets/lib/decidim/budgets/seeds.rb
+++ b/decidim-budgets/lib/decidim/budgets/seeds.rb
@@ -37,7 +37,7 @@ module Decidim
             "<p>#{::Faker::Lorem.paragraph}</p>"
         end
 
-        Decidim::Component.create!(
+        params = {
           name: Decidim::Components::Namer.new(participatory_space.organization.available_locales, :budgets).i18n_name,
           manifest_name: :budgets,
           published_at: Time.current,
@@ -48,18 +48,33 @@ module Decidim
             more_information_modal: Decidim::Faker::Localized.paragraph(sentence_count: 4),
             workflow: Decidim::Budgets.workflows.keys.sample
           }
-        )
+        }
+
+        Decidim.traceability.perform_action!(
+          "publish",
+          Decidim::Component,
+          admin_user,
+          visibility: "all"
+        ) do
+          Decidim::Component.create!(params)
+        end
       end
 
       def create_budget!(component:)
-        Decidim::Budgets::Budget.create!(
-          component:,
-          title: Decidim::Faker::Localized.sentence(word_count: 2),
-          description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-            Decidim::Faker::Localized.paragraph(sentence_count: 3)
-          end,
-          total_budget: ::Faker::Number.number(digits: 8)
-        )
+        Decidim.traceability.perform_action!(
+          "create",
+          Decidim::Budgets::Budget,
+          admin_user
+        ) do
+          Decidim::Budgets::Budget.create!(
+            component:,
+            title: Decidim::Faker::Localized.sentence(word_count: 2),
+            description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+              Decidim::Faker::Localized.paragraph(sentence_count: 3)
+            end,
+            total_budget: ::Faker::Number.number(digits: 8)
+          )
+        end
       end
 
       def create_project!(budget:)
@@ -82,7 +97,13 @@ module Decidim
           )
         end
 
-        Decidim::Budgets::Project.create!(params)
+        Decidim.traceability.perform_action!(
+          "create",
+          Decidim::Budgets::Project,
+          admin_user
+        ) do
+          Decidim::Budgets::Project.create!(params)
+        end
       end
     end
   end

--- a/decidim-budgets/lib/decidim/budgets/seeds.rb
+++ b/decidim-budgets/lib/decidim/budgets/seeds.rb
@@ -13,23 +13,7 @@ module Decidim
       end
 
       def call
-        landing_page_content = Decidim::Faker::Localized.localized do
-          "<h2>#{::Faker::Lorem.sentence}</h2>" \
-            "<p>#{::Faker::Lorem.paragraph}</p>" \
-            "<p>#{::Faker::Lorem.paragraph}</p>"
-        end
-
-        component = Decidim::Component.create!(
-          name: Decidim::Components::Namer.new(participatory_space.organization.available_locales, :budgets).i18n_name,
-          manifest_name: :budgets,
-          published_at: Time.current,
-          participatory_space:,
-          settings: {
-            landing_page_content:,
-            more_information_modal: Decidim::Faker::Localized.paragraph(sentence_count: 4),
-            workflow: Decidim::Budgets.workflows.keys.sample
-          }
-        )
+        component = create_component!
 
         rand(1...3).times do
           Decidim::Budgets::Budget.create!(
@@ -63,6 +47,26 @@ module Decidim
             Decidim::Comments::Seed.comments_for(project)
           end
         end
+      end
+
+      def create_component!
+        landing_page_content = Decidim::Faker::Localized.localized do
+          "<h2>#{::Faker::Lorem.sentence}</h2>" \
+            "<p>#{::Faker::Lorem.paragraph}</p>" \
+            "<p>#{::Faker::Lorem.paragraph}</p>"
+        end
+
+        Decidim::Component.create!(
+          name: Decidim::Components::Namer.new(participatory_space.organization.available_locales, :budgets).i18n_name,
+          manifest_name: :budgets,
+          published_at: Time.current,
+          participatory_space:,
+          settings: {
+            landing_page_content:,
+            more_information_modal: Decidim::Faker::Localized.paragraph(sentence_count: 4),
+            workflow: Decidim::Budgets.workflows.keys.sample
+          }
+        )
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Refactors the budgets seeds to individual methods.

This is following the same methodology and reasoning from #12005, so refer to that issue for the explanations.

To ease-up the review process, I was disciplined and made the changes in a commit by commit basis 😎

I've also added some logic for the geolocation feature, as that's what I need for closing an issue. 

#### Testing

Regenerating the development_app database should have different kind of budgets (almost the same as before + some projects with geolocation):

$ bin/rails db:drop db:create db:migrate db:seed

:hearts: Thank you!
