### PR TITLE
Add map and export address in projects with address on budgets

### DIFF
--- a/decidim-budgets/app/controllers/decidim/budgets/admin/application_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/application_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       # Note that it inherits from `Decidim::Components::BaseController`, which
       # override its layout and provide all kinds of useful methods.
       class ApplicationController < Decidim::Admin::Components::BaseController
-        helper_method :budget, :projects, :project
+        helper_method :budget, :projects, :project, :maps_enabled?
 
         def budget
           @budget ||= Budget.where(component: current_component).includes(:projects).find_by(id: params[:budget_id])
@@ -23,6 +23,10 @@ module Decidim
 
         def project
           @project ||= projects.find(params[:id])
+        end
+
+        def maps_enabled?
+          @maps_enabled ||= current_component.settings.geocoding_enabled?
         end
       end
     end

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/_project-tr.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/_project-tr.html.erb
@@ -28,6 +28,11 @@
       <%= content_tag :span, "close-line", class: "text-muted" %>
     <% end %>
   </td>
+  <% if maps_enabled? && Decidim::Map.available?(:static, :geocoding) %>
+    <td>
+      <%= static_map_link(project, {}, { class: "static-map__admin" }) %>
+    </td>
+  <% end %>
   <td class="table-list__actions">
     <% if allowed_to? :update, :project, project: project %>
       <%= icon_link_to "pencil-line", resource_locator([budget, project]).edit, t("actions.edit", scope: "decidim.budgets"), class: "action-icon--edit" %>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
@@ -22,6 +22,9 @@
           <%= th_scope_sort_link %>
           <th><%= sort_link(query, :confirmed_orders_count, t("index.confirmed_orders_count")) %></th>
           <th><%= sort_link(query, :selected, t(".selected")) %></th>
+          <% if maps_enabled? && Decidim::Map.available?(:static, :geocoding) %>
+            <th><%= t("models.project.fields.map", scope: "decidim.budgets") %></th>
+          <% end %>
           <th class="actions"><%= t("actions.title", scope: "decidim.budgets") %></th>
         </tr>
       </thead>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -203,6 +203,7 @@ en:
           fields:
             category: Category
             id: ID
+            map: Map
             title: Title
       order_summary_mailer:
         order_summary:

--- a/decidim-budgets/lib/decidim/budgets/project_serializer.rb
+++ b/decidim-budgets/lib/decidim/budgets/project_serializer.rb
@@ -37,6 +37,7 @@ module Decidim
           comments: project.comments_count,
           created_at: project.created_at,
           url: project.polymorphic_resource_url({}),
+          address: project.address,
           related_proposals:,
           related_proposal_titles:,
           related_proposal_urls:

--- a/decidim-budgets/spec/serializers/project_serializer_spec.rb
+++ b/decidim-budgets/spec/serializers/project_serializer_spec.rb
@@ -73,6 +73,10 @@ module Decidim::Budgets
         expect(serialized[:url]).to eq(project.polymorphic_resource_url({}))
       end
 
+      it "serializes the address" do
+        expect(serialized).to include(address: project.address)
+      end
+
       it "includes related proposal ids" do
         expect(serialized[:related_proposals]).to match_array(project.linked_resources(:proposals, "included_proposals").map(&:id))
       end


### PR DESCRIPTION
#### :tophat: What? Why?

We've added geocoding to budgets but there are some missing touches to close that issue. See on :

> So tracking this, the main functionality was already implemented at #9280 but there are still some missing features:
> 
> - [x] Add a "Map" column to display the map preview on projects index in BO 
> - [x] Add an address field column in the projects export
> 
> (...)
> 
> Because of the missing features, I will still leave this issue open.

This PR implements both of these missing features.

To ease up the review, I've also modified the seeds to have some budgets with geocoding (see #12205) 

#### :pushpin: Related Issues
 
- Fixes #9109 

#### Testing

1. Run the seeds from #12205 
2. Sign in as admin and fin a budget with geocoding
3. See that the index table has a map
4. Export to CSV
5. Go to /letter_opener
6. Download the zip and open the CSV inside of it
7. See that you have the address field there

### :camera: Screenshots

![Screenshot of the budgets screen with map](https://github.com/decidim/decidim/assets/717367/7f4feab2-0cb0-4b94-9c16-8cd2c5fe2b4c)

:hearts: Thank you!
