### PR TITLE
Hide wrongly unsupported browser message

### DIFF
--- a/decidim-elections/app/packs/src/decidim/elections/election_log.js
+++ b/decidim-elections/app/packs/src/decidim/elections/election_log.js
@@ -5,6 +5,11 @@
 import { Client, MessageParser } from "@decidim/decidim-bulletin_board";
 
 $(async () => {
+  // Check safari browser
+  if(/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
+    $("#not_supported_safari_browser").removeClass("hidden");
+  }
+
   // UI Elements
   const $electionLog = $("#election-log");
 

--- a/decidim-elections/app/packs/src/decidim/elections/election_log.js
+++ b/decidim-elections/app/packs/src/decidim/elections/election_log.js
@@ -5,7 +5,7 @@
 import { Client, MessageParser } from "@decidim/decidim-bulletin_board";
 
 $(async () => {
-  const isSafariBrowser = (/^((?!chrome|android).)*safari/i).test(navigator.userAgent); 
+  const isSafariBrowser = (/^((?!chrome|android).)*safari/i).test(navigator.userAgent);
   if (isSafariBrowser) {
     $("#not_supported_safari_browser").removeClass("hidden");
   }

--- a/decidim-elections/app/packs/src/decidim/elections/election_log.js
+++ b/decidim-elections/app/packs/src/decidim/elections/election_log.js
@@ -6,7 +6,7 @@ import { Client, MessageParser } from "@decidim/decidim-bulletin_board";
 
 $(async () => {
   // Check safari browser
-  if(/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
+  if ((/^((?!chrome|android).)*safari/i).test(navigator.userAgent)) {
     $("#not_supported_safari_browser").removeClass("hidden");
   }
 

--- a/decidim-elections/app/packs/src/decidim/elections/election_log.js
+++ b/decidim-elections/app/packs/src/decidim/elections/election_log.js
@@ -5,8 +5,8 @@
 import { Client, MessageParser } from "@decidim/decidim-bulletin_board";
 
 $(async () => {
-  // Check safari browser
-  if ((/^((?!chrome|android).)*safari/i).test(navigator.userAgent)) {
+  const isSafariBrowser = (/^((?!chrome|android).)*safari/i).test(navigator.userAgent); 
+  if (isSafariBrowser) {
     $("#not_supported_safari_browser").removeClass("hidden");
   }
 

--- a/decidim-elections/app/packs/src/decidim/elections/trustee/trustee_zone.js
+++ b/decidim-elections/app/packs/src/decidim/elections/trustee/trustee_zone.js
@@ -14,7 +14,7 @@ $(() => {
     );
 
     if (!window.trusteeIdentificationKeys.browserSupport) {
-      $("#not_supported_browser").attr("hidden", false);
+      $("#not_supported_browser").removeClass("hidden");
       return;
     }
 

--- a/decidim-elections/app/views/decidim/elections/trustee_zone/trustees/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/trustee_zone/trustees/show.html.erb
@@ -6,7 +6,11 @@
   <%= cell("decidim/announcement", {
              title: t("not_supported_browser_title", scope: "decidim.elections.trustee_zone.trustees.show"),
              body: t("not_supported_browser_description", scope: "decidim.elections.trustee_zone.trustees.show")
-           }, callout_class: "alert", id: "not_supported_browser", hidden: true ) %>
+           }, callout_class: "alert hidden", id: "not_supported_browser") %>
+  <%= cell("decidim/announcement", {
+             title: t("safari_warning_title", scope: "decidim.elections.trustee_zone.trustees.show"),
+             body: t("safari_warning_description", scope: "decidim.elections.trustee_zone.trustees.show")
+           }, callout_class: "alert hidden", id: "not_supported_safari_browser") %>
 
   <%
     # i18n-tasks-use t('decidim.elections.trustee_zone.trustees.show.trustee_role_description.without_keys')

--- a/decidim-elections/app/views/decidim/elections/votes/_new_ballot_decision_step.html.erb
+++ b/decidim-elections/app/views/decidim/elections/votes/_new_ballot_decision_step.html.erb
@@ -2,7 +2,7 @@
   <h2 class="h3">
     <%= t("decidim.elections.votes.ballot_decision.header") %>
   </h2>
-  <p class="election-question__description"><%= t("decidim.elections.votes.ballot_decision.description") %></p>
+  <p class="election-question__description"><%= t("decidim.elections.votes.ballot_decision.description_html") %></p>
 </div>
 
 <div class="election-question__ballot">

--- a/decidim-elections/app/views/decidim/elections/votes/new.html.erb
+++ b/decidim-elections/app/views/decidim/elections/votes/new.html.erb
@@ -29,6 +29,10 @@
     </div>
 
     <%= cell("decidim/announcement", t("decidim.elections.votes.new.preview_alert"), callout_class: "warning mb-4") if preview_mode? %>
+    <%= cell("decidim/announcement", {
+               title: t("safari_warning_title", scope: "decidim.elections.trustee_zone.trustees.show"),
+               body: t("safari_warning_description", scope: "decidim.elections.trustee_zone.trustees.show")
+             }, callout_class: "alert hidden", id: "not_supported_safari_browser") %>
 
     <% questions.each_with_index do |step_question, step_index| %>
       <div id="step-<%= step_index %>" <%= "hidden" unless step_index.zero? %>>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -672,7 +672,7 @@ en:
           back: Start voting process again
           ballot_hash: 'Your ballot identifier is:'
           cast: Cast ballot to finish your vote
-          description: Here, you have the options to cast your ballot so that it is properly counted or, alternatively, you can audit that your ballot was correctly encrypted. For security reasons, auditing your ballot will spoil it. That means, to cast your vote, you will need to restart the voting process.
+          description_html: Here, you have the options to cast your ballot so that it is properly counted or, you can audit that your ballot was correctly encrypted. If you want to audit the vote, please read the instructions on <a href="https://github.com/decidim/decidim-bulletin-board/blob/develop/verifier/README.md">how to proceed</a>.
           header: 'Ballot is encrypted: cast it or audit it'
         casting:
           header: Casting the vote...

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -659,6 +659,8 @@ en:
               upload_legend: The server has your public identification keys, but your browser still does not have it. You need to import the file with your identification keys to your computer from the backup you created after generating them.
             not_supported_browser_description: It looks like you are using a web browser that cannot be used to act as a Trustee. Make sure you are using the most recent version of your browser, or try using any of the most popular browsers to be able to complete your Trustee tasks.
             not_supported_browser_title: Upgrade browser to act as a Trustee
+            safari_warning_description: It looks like you are using Safari, which is not supported to act as a Trustee or to encrypt a Vote (this is due the memory restrictions that Apple impose in it). This might be solved in the future by a change of policy by Apple or future optimization of Decidim Elections. Please, use another browser meanwhile.
+            safari_warning_title: Safari browser detected
             trustee_role_description:
               with_keys: You have been assigned to act as a Trustee in some of the elections celebrated in this platform.
               without_keys: You have been assigned to act as a Trustee. Please, generate and upload your identification keys.


### PR DESCRIPTION
#### :tophat: What? Why?

Hides the announcement that you cannot act as a Trustee. The problem comes from the redesign which does not use the attribute "hidden" but instead a class.

This PR also shows a warning when voting or performing a trustee action if you are using Safari, which is known not to work with vote encryption:

![Screenshot from 2023-12-20 14-03-25](https://github.com/decidim/decidim/assets/1401520/287467ac-0be9-4888-bfba-3101c9f788f7)


#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/orgs/decidim/projects/23/views/1?pane=issue&itemId=40880905
- Fixes #9590

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
