### PR TITLE
Lock axe-core-api to 4.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ PATH
       decidim-comments (= 0.26.8)
       decidim-core (= 0.26.8)
     decidim-dev (0.26.8)
+      axe-core-api (~> 4.7.0)
       axe-core-rspec (~> 4.1.0)
       byebug (~> 11.0)
       capybara (~> 3.24)

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim", Decidim::Dev.version
   s.add_dependency "factory_bot_rails", "~> 4.8"
 
+  s.add_dependency "axe-core-api", "~> 4.7.0"
   s.add_dependency "axe-core-rspec", "~> 4.1.0"
   s.add_dependency "byebug", "~> 11.0"
   s.add_dependency "db-query-matchers", "~> 0.10.0"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -112,6 +112,7 @@ PATH
       decidim-comments (= 0.26.8)
       decidim-core (= 0.26.8)
     decidim-dev (0.26.8)
+      axe-core-api (~> 4.7.0)
       axe-core-rspec (~> 4.1.0)
       byebug (~> 11.0)
       capybara (~> 3.24)
@@ -263,7 +264,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    axe-core-api (4.8.0)
+    axe-core-api (4.7.0)
       dumb_delegator
       virtus
     axe-core-rspec (4.1.0)

--- a/decidim_app-design/Gemfile.lock
+++ b/decidim_app-design/Gemfile.lock
@@ -122,6 +122,7 @@ PATH
       decidim-comments (= 0.26.8)
       decidim-core (= 0.26.8)
     decidim-dev (0.26.8)
+      axe-core-api (~> 4.7.0)
       axe-core-rspec (~> 4.1.0)
       byebug (~> 11.0)
       capybara (~> 3.24)
@@ -273,7 +274,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    axe-core-api (4.8.0)
+    axe-core-api (4.7.0)
       dumb_delegator
       virtus
     axe-core-rspec (4.1.0)


### PR DESCRIPTION
#### :tophat: What? Why?
During the release process of Decidim 0.26.9 we have noticed that the PR #12216 failed with: 

```
 NoMethodError:
       undefined method `page_load' for #<Selenium::WebDriver::Timeouts:0x00005616c48e3420>
       Did you mean?  page_load=
```

![image](https://github.com/decidim/decidim/assets/105683/56f41e8d-010a-4b11-b04c-e23bc0539f5a)

During investigation, i have seen that axe-core-api version 4.7.0 is being on local while working, yet 4.8.0 is being used on pipeline. As I have further chased the error, I have noticed that `page_load` is a method of Selenium-Webdriver. Decidim 0.26 is using 3.142.7, yet the `page_load` method has been added in version 4.0-rc3 ( commit https://github.com/SeleniumHQ/selenium/commit/22638e01b1fcf6911ef81f8fdc78b9b3f47bd11f)

To avoid further issues caused by a selenium webdriver upgrade on a Decidim version we will stop supporting, I just locked the `axe-core-api` to the latest working version.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12216

#### Testing
Make sure the pipeline is green
