### PR TITLE
Fix the markup for verifications

### DIFF
--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/pending_authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/pending_authorizations/index.html.erb
@@ -7,7 +7,7 @@
         <%= link_to t(".offline_verification"), new_offline_confirmation_path, class: "button button__sm button__secondary" if has_offline_method? %>
     </h2>
   </div>
-  <div class="card-section">
+  <div class="table-scroll">
     <table class="table-list">
       <thead>
         <tr>

--- a/decidim-verifications/app/views/decidim/verifications/postal_letter/admin/pending_authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/postal_letter/admin/pending_authorizations/index.html.erb
@@ -1,56 +1,53 @@
 <% add_decidim_page_title(t(".title")) %>
-<div class="item_show__header">
-  <h2 class="item_show__header-title">
-    <%= t(".title") %>
-  </h2>
-</div>
+<div class="card">
 
-<div class="item__edit item__edit-1col">
-  <div class="item__edit-form">
-    <div class="card">
-      <div class="card-section">
-        <table class="table-list">
-          <thead>
-            <tr>
-              <th><%= t(".username") %></th>
-              <th><%= t(".address") %></th>
-              <th><%= t(".verification_code") %></th>
-              <th><%= t(".letter_sent_at") %></th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            <% @pending_authorizations.each do |authorization| %>
-              <tr>
-                <td>
-                  <%= authorization.user.name %>
-                </td>
-                <td>
-                  <%= authorization.verification_address %>
-                </td>
-                <td>
-                  <%= authorization.verification_code %>
-                </td>
-                <td>
-                  <%= authorization.letter_sent_at %>
-                </td>
-                <td>
-                  <% if authorization.letter_sent? %>
-                    <%= icon "checkbox-circle-line",
-                             class: "action-icon action-icon--disabled" %>
-                  <% else %>
-                    <%= icon_link_to "checkbox-circle-line",
-                                     pending_authorization_postage_path(authorization.id),
-                                     t(".mark_as_sent"),
-                                     method: :post,
-                                     class: "action-icon--verify" %>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-    </div>
+  <div class="item_show__header">
+    <h2 class="item_show__header-title">
+      <%= t(".title") %>
+    </h2>
+  </div>
+
+  <div class="table-scroll">
+    <table class="table-list">
+      <thead>
+        <tr>
+          <th><%= t(".username") %></th>
+          <th><%= t(".address") %></th>
+          <th><%= t(".verification_code") %></th>
+          <th><%= t(".letter_sent_at") %></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @pending_authorizations.each do |authorization| %>
+          <tr>
+            <td>
+              <%= authorization.user.name %>
+            </td>
+            <td>
+              <%= authorization.verification_address %>
+            </td>
+            <td>
+              <%= authorization.verification_code %>
+            </td>
+            <td>
+              <%= authorization.letter_sent_at %>
+            </td>
+            <td>
+              <% if authorization.letter_sent? %>
+                <%= icon "checkbox-circle-line",
+                         class: "action-icon action-icon--disabled" %>
+              <% else %>
+                <%= icon_link_to "checkbox-circle-line",
+                                 pending_authorization_postage_path(authorization.id),
+                                 t(".mark_as_sent"),
+                                 method: :post,
+                                 class: "action-icon--verify" %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
   </div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
While i was browsing the admin, i have noticed that some of the views have the wrong mark-up, as the table does not have the full required width. 

Before: 
![image](https://github.com/decidim/decidim/assets/105683/9bb6e57f-41df-45f0-8b5b-ebcd6d623832)

After: 
![image](https://github.com/decidim/decidim/assets/105683/a38f81c9-33c9-4ec8-b845-ba0a7d944c66)

= 
Before: 
![image](https://github.com/decidim/decidim/assets/105683/a006eb12-3f0c-4f9b-ab2b-e33eb8c407cb)

After:
![image](https://github.com/decidim/decidim/assets/105683/13b3f8f2-c98e-4d76-be80-6fe5d0ca49b7)


#### Testing
Make sure that the empty tables in the verification module do have the required length in page. by visiting

- http://localhost:3000/admin/postal_letter/
- http://localhost:3000/admin/id_documents/

:hearts: Thank you!
