### PR TITLE
Add "Processes groups" to filter in admin

### DIFF
--- a/decidim-participatory_processes/app/controllers/concerns/decidim/participatory_processes/admin/filterable.rb
+++ b/decidim-participatory_processes/app/controllers/concerns/decidim/participatory_processes/admin/filterable.rb
@@ -17,8 +17,28 @@ module Decidim
             collection
           end
 
-          def extra_filters
+          def filters
+            [
+              :private_space_eq,
+              :published_at_null,
+              :decidim_participatory_process_group_id_eq
+            ]
+          end
+
+          def filters_with_values
+            {
+              private_space_eq: [true, false],
+              published_at_null: [true, false],
+              decidim_participatory_process_group_id_eq: OrganizationParticipatoryProcessGroups.new(current_organization).pluck(:id)
+            }
+          end
+
+          def dynamically_translated_filters
             [:decidim_participatory_process_group_id_eq]
+          end
+
+          def translated_decidim_participatory_process_group_id_eq(id)
+            translated_attribute(Decidim::ParticipatoryProcessGroup.find(id).title)
           end
         end
       end

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
@@ -2,31 +2,6 @@
 <%= admin_tabs(:admin_participatory_processes_menu).render %>
 
 <div class="card" id="processes">
-  <div class="flex justify-end" data-group-filter>
-    <button data-toggle="process_groups" class="button button__sm button__secondary">
-      <%= t("actions.filter.process_groups", scope: "decidim.admin") %>
-      <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
-    </button>
-    <div id="process_groups" class="dropdown-pane" data-position="bottom" data-dropdown data-auto-focus="true">
-      <ul>
-        <%= link_to query_params_with(decidim_participatory_process_group_id_eq: nil) do %>
-          <li><%= t("actions.filter.all_processes", scope: "decidim.admin") %></li>
-        <% end %>
-        <% process_groups_for_select.each do |group_title, group_id| %>
-          <%= link_to query_params_with(decidim_participatory_process_group_id_eq: group_id) do %>
-            <li><%= group_title %></li>
-          <% end %>
-        <% end %>
-      </ul>
-    </div>
-  </div>
-  <% if process_group %>
-    <div>
-      <%= link_to translated_attribute(process_group.title),
-                  edit_participatory_process_group_path(process_group) %>
-    </div>
-  <% end %>
-  <br>
   <%= admin_filter_selector %>
 </div>
 <div class="table-scroll">

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -114,6 +114,9 @@ en:
         resend_invitation: Resend invitation
         see_process: See process
         unpublish: Unpublish
+      filters:
+        decidim_participatory_process_group_id_eq:
+          label: By process group
       menu:
         participatory_process_groups: Process groups
         participatory_process_groups_submenu:

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -99,9 +99,6 @@ en:
         destroy: Delete
         duplicate: Duplicate
         edit: Edit
-        filter:
-          all_processes: Show all processes
-          process_groups: Filter processes in groups
         import_process: Import
         moderate: Moderate
         new_process: New process

--- a/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
@@ -8,12 +8,11 @@ shared_examples "manage processes examples" do
     let(:model_name) { participatory_process.class.model_name }
     let(:resource_controller) { Decidim::ParticipatoryProcesses::Admin::ParticipatoryProcessesController }
 
+    include_context "with filterable context"
+
     def filter_by_group(group_title)
       visit current_path
-      within("[data-group-filter]") do
-        click_button("Filter processes in groups")
-        click_link(group_title)
-      end
+      apply_filter("By process group", group_title)
     end
 
     it "allows the user to filter processes by process_group" do
@@ -30,12 +29,6 @@ shared_examples "manage processes examples" do
 
     context "when processes are filtered by process_group" do
       before { filter_by_group(translated(process_group.title)) }
-
-      it "allows the user to edit the process_group" do
-        click_link translated(process_group.title)
-
-        expect(page).to have_content("Edit process group")
-      end
 
       describe "listing processes filtered by group" do
         it_behaves_like "filtering collection by published/unpublished" do


### PR DESCRIPTION
#### :tophat: What? Why?

We have an explicit filter for process groups in admin, and another filter for publish processes. 

This PR moves the process groups filters to the main filters.

#### Testing

1. Sign in as admin 
2. Go to http://localhost:3000/admin/participatory_processes

### :camera: Screenshots

![Screenshot of the processes filters by process group](https://github.com/decidim/decidim/assets/717367/88c88477-b265-4d88-b3b8-7a9ef3a4d745)

:hearts: Thank you!
