### PR TITLE
Protect participatory text buttons under authorization

### DIFF
--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal/buttons.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal/buttons.erb
@@ -1,5 +1,5 @@
 <% if amendmendment_creation_enabled? || visible_emendations.any? %>
-  <%= link_to amend_resource_path, disabled: amend_button_disabled?, class: "proposal-participatory__button" do %>
+  <%= action_authorized_link_to :amend, amend_resource_path, resource: model, disabled: amend_button_disabled?, class: "proposal-participatory__button" do %>
     <%= icon "chat-1-line" %>
     <span><%= t("amend", scope: "decidim.proposals.participatory_text_proposal.buttons") %></span>
     <div class="label"><%= visible_emendations.count %></div>
@@ -14,7 +14,7 @@
       <div class="label"><%= model.comments_count %></div>
     <% end %>
   <% else %>
-    <%= link_to resource_comments_path, class: "proposal-participatory__button" do %>
+    <%= action_authorized_link_to :comment, resource_comments_path, resource: model, class: "proposal-participatory__button" do %>
       <%= icon "chat-1-line" %>
       <span><%= t("comment", scope: "decidim.proposals.participatory_text_proposal.buttons") %></span>
       <div class="label"><%= model.comments_count %></div>

--- a/decidim-proposals/spec/system/participatory_texts_spec.rb
+++ b/decidim-proposals/spec/system/participatory_texts_spec.rb
@@ -89,6 +89,62 @@ describe "Participatory texts" do
     end
   end
 
+  shared_examples "the Amend button is protected under authorization" do
+    shared_context "when clicking on the amend button" do
+      before do
+        visit_component
+        within "#proposals section[id='proposal_#{proposal.id}']" do
+          click_link "Amend"
+        end
+      end
+    end
+
+    let(:proposal) { proposals.first }
+    let(:user) { create(:user, :confirmed, organization:) }
+
+    before do
+      proposal.create_resource_permission(
+        permissions: {
+          "amend" => {
+            "authorization_handlers" => {
+              "dummy_authorization_handler" => { "options" => {} }
+            }
+          }
+        }
+      )
+    end
+
+    context "when the user is not logged in" do
+      include_context "when clicking on the amend button"
+
+      it "needs to login" do
+        expect(page).to have_content("Please log in")
+      end
+    end
+
+    context "when the user is logged in" do
+      before { login_as user, scope: :user }
+
+      context "when the user is not authorized" do
+        include_context "when clicking on the amend button"
+
+        it "cannot perform the action" do
+          expect(page).to have_content("Authorization required")
+        end
+      end
+
+      context "when the user is authorized" do
+        let!(:authorization) { create(:authorization, name: "dummy_authorization_handler", user:) }
+
+        include_context "when clicking on the amend button"
+
+        it "can perform the action" do
+          expect(page).to have_content("Create Amendment Draft")
+        end
+      end
+    end
+  end
+
   context "when listing proposals in a participatory process as participatory texts" do
     context "when admin has not yet published a participatory text" do
       let!(:component) do
@@ -133,6 +189,8 @@ describe "Participatory texts" do
             let(:amendments_count) { 0 }
             let(:disabled_value) { false }
           end
+
+          it_behaves_like "the Amend button is protected under authorization"
         end
 
         context "when amendment CREATION is disabled" do
@@ -191,6 +249,8 @@ describe "Participatory texts" do
               end
             end
           end
+
+          it_behaves_like "the Amend button is protected under authorization"
         end
 
         context "when amendment CREATION is disabled" do


### PR DESCRIPTION
#### :tophat: What? Why?

Protect links to amend and comment proposals from a participatory text under authorization.

#### :pushpin: Related Issues

- Fixes #12226

#### Testing

1. Configure a proposal component with participatory texts and amendments enabled
2. Import participatory texts
3. Configure one of them requiring a verification you know a user doesn't have for amendments
4. Login with the user and navigate to the component with the participatory texts
5. Go to the proposal with the restricted action and click on "Amend"
6. See a modal specifying you are not authorized to perform the action

### :camera: Screenshots

In the video below, the proposal with title "1" needs permission to amend and comment, and the proposal with title "1. Etiam ornare tincidunt nulla" doesn't. So the user will be able to perform the actions of the buttons only for the second one.

https://github.com/decidim/decidim/assets/6973564/f6d5f926-ae1e-4adc-aa54-9ff2f5515029

:hearts: Thank you!
