### PR TITLE
Fix Capybara deprecation warning

### DIFF
--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -294,7 +294,7 @@ shared_examples "manage proposals" do
 
         it "cannot create a new proposal from the admin site" do
           visit_component_admin
-          expect(page).not_to have_link(/New/)
+          expect(page).not_to have_link("New proposal")
         end
       end
     end
@@ -311,7 +311,7 @@ shared_examples "manage proposals" do
 
       it "cannot create a new proposal from the admin site" do
         visit_component_admin
-        expect(page).not_to have_link(/New/)
+        expect(page).not_to have_link("New proposal")
       end
     end
   end

--- a/decidim-proposals/spec/system/participatory_texts_spec.rb
+++ b/decidim-proposals/spec/system/participatory_texts_spec.rb
@@ -73,7 +73,7 @@ describe "Participatory texts" do
       within all("#proposals section[id^='proposal']").first, visible: :visible do
         expect(page).to have_link("Amend")
         expect(amend_button_disabled?).to eq(disabled_value)
-        expect(page).to have_link(amendments_count)
+        expect(page).to have_link(amendments_count.to_s)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing #12230 , i have noticed the following deprecation error:

```
/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.1.0/gems/capybara-3.39.0/lib/capybara/selector/selector.rb:69: warning: Locator Integer:2 for selector :link must be an instance of String or Symbol. This will raise an error in a future version of Capybara. Called from: /home/runner/work/decidim/decidim/decidim-proposals/spec/system/participatory_texts_spec.rb:76
/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.1.0/gems/capybara-3.39.0/lib/capybara/selector/selector.rb:69: warning: Locator Integer:2 for selector :link must be an instance of String or Symbol. This will raise an error in a future version of Capybara. Called from: /home/runner/work/decidim/decidim/decidim-proposals/spec/system/participatory_texts_spec.rb:76
/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.1.0/gems/capybara-3.39.0/lib/capybara/selector/selector.rb:69: warning: Locator Integer:0 for selector :link must be an instance of String or Symbol. This will raise an error in a future version of Capybara. Called from: /home/runner/work/decidim/decidim/decidim-proposals/spec/system/participatory_texts_spec.rb:76
/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.1.0/gems/capybara-3.39.0/lib/capybara/selector/selector.rb:69: warning: Locator Integer:1 for selector :link must be an instance of String or Symbol. This will raise an error in a future version of Capybara. Called from: /home/runner/work/decidim/decidim/decidim-proposals/spec/system/participatory_texts_spec.rb:76
/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.1.0/gems/capybara-3.39.0/lib/capybara/selector/selector.rb:69: warning: Locator Integer:2 for selector :link must be an instance of String or Symbol. This will raise an error in a future version of Capybara. Called from: /home/runner/work/decidim/decidim/decidim-proposals/spec/system/participatory_texts_spec.rb:76
/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.1.0/gems/capybara-3.39.0/lib/capybara/selector/selector.rb:69: warning: Locator Integer:2 for selector :link must be an instance of String or Symbol. This will raise an error in a future version of Capybara. Called from: /home/runner/work/decidim/decidim/decidim-proposals/spec/system/participatory_texts_spec.rb:76
/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.1.0/gems/capybara-3.39.0/lib/capybara/selector/selector.rb:69: warning: Locator Integer:1 for selector :link must be an instance of String or Symbol. This will raise an error in a future version of Capybara. Called from: /home/runner/work/decidim/decidim/decidim-proposals/spec/system/participatory_texts_spec.rb:76
/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.1.0/gems/capybara-3.39.0/lib/capybara/selector/selector.rb:69: warning: Locator Integer:0 for selector :link must be an instance of String or Symbol. This will raise an error in a future version of Capybara. Called from: /home/runner/work/decidim/decidim/decidim-proposals/spec/system/participatory_texts_spec.rb:76
````

Additionally, we fix also the following: 
```
/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.1.0/gems/capybara-3.39.0/lib/capybara/selector/selector.rb:69: warning: Locator Regexp:/New/ for selector :link must be an instance of String or Symbol. This will raise an error in a future version of Capybara. Called from: /home/runner/work/decidim/decidim/decidim-proposals/spec/shared/manage_proposals_examples.rb:297
/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.1.0/gems/capybara-3.39.0/lib/capybara/selector/selector.rb:69: warning: Locator Regexp:/New/ for selector :link must be an instance of String or Symbol. This will raise an error in a future version of Capybara. Called from: /home/runner/work/decidim/decidim/decidim-proposals/spec/shared/manage_proposals_examples.rb:314
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12230

#### Testing
- make sure there is no deprecation warning regarding the above error on the proposal pipeline.

### :camera: Screenshots
![image](https://github.com/decidim/decidim/assets/105683/e78ea438-fd0d-4d83-b0b0-545590a049f6)

:hearts: Thank you!
