### PR TITLE
Lock Ruby to Decidim supported version

### DIFF
--- a/decidim-accountability/decidim-accountability.gemspec
+++ b/decidim-accountability/decidim-accountability.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-accountability"
   s.summary = "Decidim accountability module"

--- a/decidim-admin/decidim-admin.gemspec
+++ b/decidim-admin/decidim-admin.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-admin"
   s.summary = "Decidim organization administration"

--- a/decidim-api/decidim-api.gemspec
+++ b/decidim-api/decidim-api.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-api"
   s.summary = "Decidim API module"

--- a/decidim-assemblies/decidim-assemblies.gemspec
+++ b/decidim-assemblies/decidim-assemblies.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-assemblies"
   s.summary = "Decidim assemblies module"

--- a/decidim-blogs/decidim-blogs.gemspec
+++ b/decidim-blogs/decidim-blogs.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-blogs"
   s.summary = "Decidim blogs module"

--- a/decidim-budgets/decidim-budgets.gemspec
+++ b/decidim-budgets/decidim-budgets.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-budgets"
   s.summary = "Decidim budgets module"

--- a/decidim-comments/decidim-comments.gemspec
+++ b/decidim-comments/decidim-comments.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-comments"
   s.summary = "Decidim comments module"

--- a/decidim-conferences/decidim-conferences.gemspec
+++ b/decidim-conferences/decidim-conferences.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-conferences"
   s.summary = "Decidim conferences module"

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.summary = "The core of the Decidim framework."
   s.description = "Adds core features so other engines can hook into the framework."
   s.license = "AGPL-3.0"
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
 

--- a/decidim-debates/decidim-debates.gemspec
+++ b/decidim-debates/decidim-debates.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-debates"
   s.summary = "Decidim debates module"

--- a/decidim-design/decidim-design.gemspec
+++ b/decidim-design/decidim-design.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-design"
   s.summary = "Decidim Design Guide (DDG) module"

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-dev"
   s.summary = "Decidim dev tools"

--- a/decidim-elections/decidim-elections.gemspec
+++ b/decidim-elections/decidim-elections.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-elections"
   s.summary = "A decidim elections module (votings space and elections component)"

--- a/decidim-forms/decidim-forms.gemspec
+++ b/decidim-forms/decidim-forms.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-forms"
   s.summary = "Decidim forms"

--- a/decidim-generators/decidim-generators.gemspec
+++ b/decidim-generators/decidim-generators.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-generators"
 

--- a/decidim-generators/lib/decidim/generators/component_templates/decidim-component.gemspec.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/decidim-component.gemspec.erb
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= <%= required_ruby_version %>"
+  s.required_ruby_version = "~> <%= required_ruby_version %>"
 
   s.name = "decidim-<%= component_name %>"
   s.summary = "A decidim <%= component_name %> module"

--- a/decidim-initiatives/decidim-initiatives.gemspec
+++ b/decidim-initiatives/decidim-initiatives.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-initiatives"
   s.summary = "Decidim initiatives module"

--- a/decidim-meetings/decidim-meetings.gemspec
+++ b/decidim-meetings/decidim-meetings.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-meetings"
   s.summary = "Decidim meetings module"

--- a/decidim-pages/decidim-pages.gemspec
+++ b/decidim-pages/decidim-pages.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-pages"
   s.summary = "Decidim pages module"

--- a/decidim-participatory_processes/decidim-participatory_processes.gemspec
+++ b/decidim-participatory_processes/decidim-participatory_processes.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-participatory_processes"
   s.summary = "Decidim participatory processes module"

--- a/decidim-proposals/decidim-proposals.gemspec
+++ b/decidim-proposals/decidim-proposals.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-proposals"
   s.summary = "Decidim proposals module"

--- a/decidim-sortitions/decidim-sortitions.gemspec
+++ b/decidim-sortitions/decidim-sortitions.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-sortitions"
   s.summary = "Decidim sortitions module"

--- a/decidim-surveys/decidim-surveys.gemspec
+++ b/decidim-surveys/decidim-surveys.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-surveys"
   s.summary = "Decidim surveys module"

--- a/decidim-system/decidim-system.gemspec
+++ b/decidim-system/decidim-system.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-system"
   s.summary = "Decidim system administration"

--- a/decidim-templates/decidim-templates.gemspec
+++ b/decidim-templates/decidim-templates.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim-templates"
   s.summary = "A decidim templates module"

--- a/decidim-verifications/decidim-verifications.gemspec
+++ b/decidim-verifications/decidim-verifications.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.summary = "Decidim verifications module"
   s.description = "Several verification methods for your decidim instance"

--- a/decidim.gemspec
+++ b/decidim.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     "homepage_uri" => "https://decidim.org",
     "source_code_uri" => "https://github.com/decidim/decidim"
   }
-  s.required_ruby_version = ">= 3.1"
+  s.required_ruby_version = "~> 3.1.0"
 
   s.name = "decidim"
 


### PR DESCRIPTION
#### :tophat: What? Why?
This pull request aims to lock required version of Ruby to the specific version. The goal is to prevent users to install Decidim on the unsupported versions of Ruby. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #10995
- Related to #12204

#### Testing
- make sure the pipelines green. 
- using rbenv, install other Ruby version ( 3.0, 3.2 or 3.3 :D ) then try to run bundle install from root
- The following output should be displayed ( for ruby 3.2 ) 
```
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies...
Could not find compatible versions

Because every version of decidim depends on Ruby ~> 3.2
  and Gemfile depends on decidim >= 0,
  Ruby ~> 3.2 is required.
So, because current Ruby version is = 3.1.1,
  version solving has failed.
```

:hearts: Thank you!
