### PR TITLE
Properly handle the category name in tags

### DIFF
--- a/decidim-core/app/cells/decidim/tags_cell.rb
+++ b/decidim-core/app/cells/decidim/tags_cell.rb
@@ -9,6 +9,8 @@ module Decidim
   #   <%= cell("decidim/category", model.category, context: {resource: model}) %>
   #
   class TagsCell < Decidim::ViewModel
+    include Decidim::SanitizeHelper
+
     def show
       render if category? || scope?
     end
@@ -69,7 +71,7 @@ module Decidim
     end
 
     def category_name
-      model.category.translated_name
+      decidim_html_escape model.category.translated_name
     end
 
     def category_path

--- a/decidim-core/spec/cells/decidim/tags_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/tags_cell_spec.rb
@@ -87,6 +87,15 @@ describe Decidim::TagsCell, type: :cell do
       expect(html).to have_content(translated(category.name))
     end
 
+    it "sanitizes the category" do
+      name = %(Category a<img src=x onerror=alert(8) >"a)
+      custom_category = create(:category, participatory_space:, name: { "en" => name })
+      proposal_categorized.category = custom_category
+      html = cell("decidim/tags", proposal_categorized, context: { extra_classes: ["tags--proposal"] }).call
+      expect(html).to have_css(".tag-container.tags--proposal")
+      expect(html).to have_content(name)
+    end
+
     it "renders the correct filtering link" do
       html = cell("decidim/tags", proposal_categorized, context: { extra_classes: ["tags--proposal"] }).call
       path = Decidim::ResourceLocatorPresenter.new(proposal_categorized).index


### PR DESCRIPTION
#### :tophat: What? Why?
There are some cases when Categroy name is not properly displayed. This PR attempts to fix this. 

#### Testing
1 Create a category with a strange name
2 Assign it to a meeting 
3 Check the meeting detail page in user frontend 
4 Apply patch 
5  Check the meeting detail page in user frontend 

:hearts: Thank you!
