### PR TITLE
Update Browserslist DB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7005,9 +7005,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001515",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
+      "version": "1.0.30001572",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001572.tgz",
+      "integrity": "sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw==",
       "funding": [
         {
           "type": "opencollective",
@@ -26357,9 +26357,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001515",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA=="
+      "version": "1.0.30001572",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001572.tgz",
+      "integrity": "sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw=="
     },
     "case-anything": {
       "version": "2.1.13",

--- a/packages/webpacker/package-lock.json
+++ b/packages/webpacker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@decidim/webpacker",
-  "version": "0.28.0-dev",
+  "version": "0.29.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@decidim/webpacker",
-      "version": "0.28.0-dev",
+      "version": "0.29.0-dev",
       "license": "AGPL-3.0",
       "dependencies": {
         "@babel/core": "^7.22.9",
@@ -22,6 +22,7 @@
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "compression-webpack-plugin": "^10.0.0",
+        "core-js": "~3.33.1",
         "css-loader": "^6.8.1",
         "expose-loader": "^4.1.0",
         "glob": "^10.3.3",
@@ -36,7 +37,7 @@
         "postcss-preset-env": "^9.0.0",
         "postcss-scss": "^4.0.6",
         "sass-embedded": "^1.63.6",
-        "shakapacker": "~6.6.0",
+        "shakapacker": "~7.1.0",
         "source-map-loader": "^4.0.1",
         "style-loader": "^3.3.3",
         "tailwindcss": "^3.3.2",
@@ -3790,9 +3791,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001515",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
+      "version": "1.0.30001572",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001572.tgz",
+      "integrity": "sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4046,6 +4047,16 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/core-js": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.3.tgz",
+      "integrity": "sha512-lo0kOocUlLKmm6kv/FswQL8zbkH7mVsLJ/FULClOhv8WRVmKLVcs6XPNQAzstfeJTCHMyButEwG+z1kHxHoDZw==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.31.1",
@@ -9021,9 +9032,9 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/shakapacker": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/shakapacker/-/shakapacker-6.6.0.tgz",
-      "integrity": "sha512-7sNnv8PXMlgm2Ob7vZOayLKu0+PPMN3q0HEyAlkFIJtHJt7wA3p1rObhlk0/OrNeBa4dio/9HiBUeEU7bZsHvw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/shakapacker/-/shakapacker-7.1.0.tgz",
+      "integrity": "sha512-xKfF4LKrFQdMLYeIi/uBV6pfkPTO4lgCAIMx3W5+MHW61ENOXu4WeQ50qVR9u5hV6XXzi7AiS7C6dWO2GFnYAg==",
       "dependencies": {
         "glob": "^7.2.0",
         "js-yaml": "^4.1.0",
@@ -9038,6 +9049,8 @@
         "@babel/plugin-transform-runtime": "^7.17.0",
         "@babel/preset-env": "^7.16.11",
         "@babel/runtime": "^7.17.9",
+        "@types/babel__core": "^7.0.0",
+        "@types/webpack": "^5.0.0",
         "babel-loader": "^8.2.4 || ^9.0.0",
         "compression-webpack-plugin": "^9.0.0 || ^10.0.0",
         "terser-webpack-plugin": "^5.3.1",
@@ -9046,6 +9059,14 @@
         "webpack-cli": "^4.9.2 || ^5.0.0",
         "webpack-dev-server": "^4.9.0",
         "webpack-merge": "^5.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/babel__core": {
+          "optional": true
+        },
+        "@types/webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/shakapacker/node_modules/glob": {
@@ -13268,9 +13289,9 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001515",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA=="
+      "version": "1.0.30001572",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001572.tgz",
+      "integrity": "sha512-1Pbh5FLmn5y4+QhNyJE9j3/7dK44dGB83/ZMjv/qJk86TvDbjk0LosiZo0i0WB0Vx607qMX9jYrn1VLHCkN4rw=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -13448,6 +13469,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "core-js": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.3.tgz",
+      "integrity": "sha512-lo0kOocUlLKmm6kv/FswQL8zbkH7mVsLJ/FULClOhv8WRVmKLVcs6XPNQAzstfeJTCHMyButEwG+z1kHxHoDZw=="
     },
     "core-js-compat": {
       "version": "3.31.1",
@@ -16721,9 +16747,9 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "shakapacker": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/shakapacker/-/shakapacker-6.6.0.tgz",
-      "integrity": "sha512-7sNnv8PXMlgm2Ob7vZOayLKu0+PPMN3q0HEyAlkFIJtHJt7wA3p1rObhlk0/OrNeBa4dio/9HiBUeEU7bZsHvw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/shakapacker/-/shakapacker-7.1.0.tgz",
+      "integrity": "sha512-xKfF4LKrFQdMLYeIi/uBV6pfkPTO4lgCAIMx3W5+MHW61ENOXu4WeQ50qVR9u5hV6XXzi7AiS7C6dWO2GFnYAg==",
       "requires": {
         "glob": "^7.2.0",
         "js-yaml": "^4.1.0",


### PR DESCRIPTION
#### :tophat: What? Why?
while working on #12243, i have noticed that my console stated to display a lot of deprecation warnings like : 

```
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```

It can also be found in Github pipelines like https://github.com/decidim/decidim/actions/runs/7377815931/job/20072237235: 
![image](https://github.com/decidim/decidim/assets/105683/8871af5d-ac5b-46f1-b90c-c73f6803e113)


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12243

#### Testing
Make sure the javascript test pipeline is not displaying the message

:hearts: Thank you!
