### PR TITLE
Resolve icon usage in projects

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/_project-tr.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/_project-tr.html.erb
@@ -25,7 +25,7 @@
     <% if project.selected? %>
       <%= content_tag :strong, t("projects.index.selected", scope: "decidim.budgets.admin"), class: "text-success" %>
     <% else %>
-      <%= content_tag :span, "close-line", class: "text-muted" %>
+      <%= content_tag :span, icon("close-line"), class: "text-muted" %>
     <% end %>
   </td>
   <td class="table-list__actions">


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing  #12206, i have noticed that a project had a value of `close-line` in selected field. 
The PR converts that text to an icon. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12206

#### Testing
1. Login as admin in nightly
2. Navigate to Processes -> first process -> Components -> budgets -> First budget 
3. Click on projects 
4. See that "Selected" column is displaying `close-line`
5. Apply locally the patch 
6. Repeat 1,2,3 
7. See that Selected has a cross. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
Before: 
![image](https://github.com/decidim/decidim/assets/105683/9dd6e362-5230-4de0-8283-352d0b05cd25)

After 
![image](https://github.com/decidim/decidim/assets/105683/b3480f58-02e9-42e4-a5c5-edbf5fa77019)


:hearts: Thank you!
