### PR TITLE
Register forgotten icon in Accountability

### DIFF
--- a/decidim-accountability/lib/decidim/accountability/engine.rb
+++ b/decidim-accountability/lib/decidim/accountability/engine.rb
@@ -21,6 +21,8 @@ module Decidim
         Decidim.icons.register(name: "Decidim::Accountability::Result", icon: "briefcase-2-line", description: "Result / project (Accountability)", category: "activity",
                                engine: :accountability)
 
+        Decidim.icons.register(name: "route-line", icon: "route-line", category: "system", description: "", engine: :accountability)
+
         Decidim.icons.register(name: "focus-2-line", icon: "focus-2-line", category: "system", description: "", engine: :accountability)
         Decidim.icons.register(name: "briefcase-2-line", icon: "briefcase-2-line", category: "system", description: "", engine: :accountability)
       end


### PR DESCRIPTION
#### :tophat: What? Why?
While working on #12236, i have discovered a missing icon, which this PR fixes. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12236

#### Testing
*Describe the best way to test or validate your PR.*
- The icon is being used in the accountability result page. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
