### PR TITLE
Fix the email subject in elections

### DIFF
--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -761,7 +761,7 @@ en:
           new_election:
             email_intro: You got added as a trustee for the %{resource_title} election.
             email_outro: You have received this notification because you have been added as trustee for the %{resource_title} election.
-            email_subject: You are a trustee for the %{resource_title} election..
+            email_subject: You are a trustee for the %{resource_title} election.
             notification_title: You have been selected as a Trustee in Election <a href="%{resource_path}">%{resource_title}.</a> Please, do the key ceremony to set up the election.
           new_trustee:
             email_intro: An admin has added you as trustee for %{resource_name}. You should create your public key <a href='%{trustee_zone_url}'>in your trustee zone</a>

--- a/decidim-elections/spec/events/decidim/elections/trustees/notify_trustee_new_election_event_spec.rb
+++ b/decidim-elections/spec/events/decidim/elections/trustees/notify_trustee_new_election_event_spec.rb
@@ -8,7 +8,7 @@ describe Decidim::Elections::Trustees::NotifyTrusteeNewElectionEvent do
   let(:event_name) { "decidim.events.elections.trustees.new_election" }
   let(:resource) { create(:election) }
   let(:resource_title) { resource.title["en"] }
-  let(:email_subject) { "You are a trustee for the #{resource_title} election.." }
+  let(:email_subject) { "You are a trustee for the #{resource_title} election." }
   let(:email_intro) { "You got added as a trustee for the #{resource_title} election." }
   let(:email_outro) { "You have received this notification because you have been added as trustee for the #{resource_title} election." }
   let(:notification_title) { "You have been selected as a Trustee in Election <a href=\"#{resource_path}\">#{resource_title}.</a> Please, do the key ceremony to set up the election." }


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing #12147, i noticed there is a small typo on email subject. This PR fixes it. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12147

#### Testing
1. Make sure the pipeline is green 
2. Generate a notification by adding someone as trustee to an election
3. Check the generated email subject. 

:hearts: Thank you!
