### PR TITLE
Change unique key to icon instead of name

### DIFF
--- a/decidim-core/lib/decidim/icon_registry.rb
+++ b/decidim-core/lib/decidim/icon_registry.rb
@@ -18,7 +18,7 @@ module Decidim
     # @param description [String] The description of the icon. It will be used to show the purpose of the icon in DDG.
     # @param engine [String] The engine name. It is used internally to identify the module where the icon is being used.
     def register(name:, icon:, description:, category:, engine:)
-      ActiveSupport::Deprecation.warn("#{name} already registered. #{@icons[name].inspect}") if @icons[name]
+      ActiveSupport::Deprecation.warn("#{icon} already registered. #{@icons[icon].inspect}") if @icons[icon]
 
       @icons[name] = { name:, icon:, description:, category:, engine: }
     end

--- a/decidim-core/lib/decidim/icon_registry.rb
+++ b/decidim-core/lib/decidim/icon_registry.rb
@@ -18,7 +18,11 @@ module Decidim
     # @param description [String] The description of the icon. It will be used to show the purpose of the icon in DDG.
     # @param engine [String] The engine name. It is used internally to identify the module where the icon is being used.
     def register(name:, icon:, description:, category:, engine:)
-      ActiveSupport::Deprecation.warn("#{icon} already registered. #{@icons[icon].inspect}") if @icons[icon]
+     if @icons[icon]
+       message = "#{icon} already registered. #{@icons[icon].inspect}"
+       ActiveSupport::Deprecation.warn(message)
+       raise message if Rails.env.development? || Rails.env.test?
+     end
 
       @icons[name] = { name:, icon:, description:, category:, engine: }
     end


### PR DESCRIPTION
## :tophat: What? Why?

While reviewing #12247, I saw that 2 out of 4 icons defined in this same file (https://github.com/decidim/decidim/blob/develop/decidim-accountability/app/cells/decidim/accountability/project_cell.rb):

### `chat-new-line` 

```
# definition 
decidim-proposals/lib/decidim/proposals/engine.rb:47:        Decidim.icons.register(name: 
"Decidim::Proposals::Proposal", icon: "chat-new-line", category: "activity",
decidim-core/lib/decidim/core/engine.rb:156:        Decidim.icons.register(name: "chat-new-line", icon: "chat-new-line", category: "system", description: "", engine: :core)

# usage 
./decidim-accountability/app/cells/decidim/accountability/project_cell.rb:51:            icon: "chat-new-line",
./decidim-proposals/app/helpers/decidim/proposals/map_helper.rb:35:            icon: icon("chat-new-line", width: 40, height: 70, remove_icon_class: true)
./decidim-proposals/lib/decidim/proposals/engine.rb:47:        Decidim.icons.register(name: "Decidim::Proposals::Proposal", icon: "chat-new-line", category: "activity",
./decidim-proposals/lib/decidim/proposals/component.rb:10:  component.icon_key = "chat-new-line"
./decidim-core/lib/decidim/core/engine.rb:156:        Decidim.icons.register(name: "chat-new-line", icon: "chat-new-line", category: "system", description: "", engine: :core)
./decidim-sortitions/app/cells/decidim/sortitions/sortition_metadata_cell.rb:24:          icon: "chat-new-line"
./decidim-design/app/views/decidim/design/components/activities/_static-activity.html.erb:8:        <%= icon("chat-new-line") %>
``` 

### `treasure-map-line` 

```
# definition 
decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb:50:        Decidim.icons.register(name: "Decidim::ParticipatoryProcess", icon: "treasure-map-line", description: "Participatory Process", category: "activity",
decidim-core/lib/decidim/core/engine.rb:155:        Decidim.icons.register(name: "treasure-map-line", icon: "treasure-map-line", category: "system", description: "", engine: :core)

# usage
./decidim-accountability/app/cells/decidim/accountability/project_cell.rb:67:            icon: "treasure-map-line",
./decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb:50:        Decidim.icons.register(name: "Decidim::ParticipatoryProcess", icon: "treasure-map-line", description: "Participatory Process", category: "activity",
./decidim-participatory_processes/lib/decidim/participatory_processes/menu.rb:33:                        icon_name: "treasure-map-line",
./decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb:12:          <%= icon "treasure-map-line", class: "fill-gray-2" %>
./decidim-core/lib/decidim/core/engine.rb:155:        Decidim.icons.register(name: "treasure-map-line", icon: "treasure-map-line", category: "system", description: "", engine: :core)
./decidim-core/app/cells/decidim/activity_cell.rb:155:      icon "treasure-map-line"
./decidim-core/app/cells/decidim/card_cell.rb:16:      participatory_space: "treasure-map-line"
```

So, depending on how we think the registry should work, we could have two bugs:

1. We should have one registry entry for each usage in different modules. So, in `chat-new-line`, we have missing entries for `decidim-accountability` and `decidim-sortitions`. I'm excluding `decidim-design` as that's for internal usage. This would mean that we will have hundreds of icons in the registry.
2. We should have only one registry entry for each icon. 

I'm opening this PR for a quick exploration of the second strategy, but while I'm writing this I think @alecslupu mentioned me that the idea of the "name" key is to actually be able to override the icons in installations that have this need, so yeah, maybe we should instead find a solution for the first bug? (missing entries for each module)

## :pushpin: Related Issues
 
- Related to #12247 
- Related to #11982 

## Testing

All the CI should be green 

:hearts: Thank you!
