### PR TITLE
Add answered_at field in proposals' export

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -40,6 +40,7 @@ module Decidim
           state: proposal.state.to_s,
           reference: proposal.reference,
           answer: ensure_translatable(proposal.answer),
+          answered_at: proposal.answered_at,
           supports: proposal.proposal_votes_count,
           endorsements: {
             total_count: proposal.endorsements.size,

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -119,6 +119,10 @@ module Decidim
           expect(serialized).to include(answer: expected_answer)
         end
 
+        it "serializes the date of the answer" do
+          expect(serialized).to include(answered_at: proposal.answered_at)
+        end
+
         it "serializes the amount of attachments" do
           expect(serialized).to include(attachments: proposal.attachments.count)
         end


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing a proposals export from Metadecidim, I saw that the `answered_at` field isn't available in them. This PR adds this field.

#### Testing

1. Sign in as admin
2. Go to a proposals component
3. Export to CSV
4. See that you have the `answered_at` column 

:hearts: Thank you!
