### PR TITLE
Change the selected column in budgets' projects

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/_project-tr.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/_project-tr.html.erb
@@ -23,9 +23,9 @@
   </td>
   <td>
     <% if project.selected? %>
-      <%= content_tag :strong, t("projects.index.selected", scope: "decidim.budgets.admin"), class: "text-success" %>
+      <%= content_tag :strong, t("yes", scope: "decidim.budgets.admin.projects.index.selected_options"), class: "label success" %>
     <% else %>
-      <%= content_tag :span, icon("close-line"), class: "text-muted" %>
+      <%= content_tag :strong, t("no", scope: "decidim.budgets.admin.projects.index.selected_options"), class: "label" %>
     <% end %>
   </td>
   <% if maps_enabled? && Decidim::Map.available?(:static, :geocoding) %>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -105,6 +105,9 @@ en:
             pending_orders: Pending votes
             select_for_implementation: Select for implementation
             selected: Selected
+            selected_options:
+              'no': 'No'
+              'yes': 'Yes'
             title: Projects
             update: Update
             update_budget_button: Update project's budget

--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -65,6 +65,13 @@ describe "Admin manages projects" do
     end
 
     it "selects projects to implementation" do
+      within "tr[data-id='#{project.id}']" do
+        expect(page).to have_content("No")
+      end
+      within "tr[data-id='#{project2.id}']" do
+        expect(page).to have_content("No")
+      end
+
       find_by_id("projects_bulk").set(true)
       find_by_id("js-bulk-actions-button").click
       click_button "Change selected"
@@ -73,10 +80,10 @@ describe "Admin manages projects" do
 
       expect(page).to have_admin_callout "These projects were successfully selected for implementation"
       within "tr[data-id='#{project.id}']" do
-        expect(page).to have_content("Selected")
+        expect(page).to have_content("Yes")
       end
       within "tr[data-id='#{project2.id}']" do
-        expect(page).to have_content("Selected")
+        expect(page).to have_content("Yes")
       end
       expect(Decidim::Budgets::Project.find(project.id).selected_at).to eq(Time.zone.today)
       expect(Decidim::Budgets::Project.find(project2.id).selected_at).to eq(Time.zone.today)


### PR DESCRIPTION
#### :tophat: What? Why?

Related to #12246, we're using a cross icon ("X") to show that a project wasn't selected in `decidim-budgets`. IMO this isn't clear, so I've asked to @carolromero if we can change this, and she asked to have the "yes/no" words to show if a project was selected (or not). This PR implements that.
 

#### Testing

1. Sign in as admin
2. Go to projects in a budgets component in a space in the admin panel 
3. Edit a project and check the "Selected" checkbox

### :camera: Screenshots

#### Before

![Screenshot of the projects in the budgets' admin with one selected and two not selected (before)](https://github.com/decidim/decidim/assets/717367/303427eb-18f3-42c2-9bad-090e1c7e3d8c)

#### After

![Screenshot of the projects in the budgets' admin with one selected and two not selected (before)](https://github.com/decidim/decidim/assets/717367/6012675d-ae81-42f5-a7e7-c1772e22b24f)

:hearts: Thank you!
