### PR TITLE
Bump ruby version in gitpod configuration

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -29,7 +29,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh |
     && echo ". ~/.nvm/nvm.sh"  >> ~/.bashrc.d/50-node
 
 # Install rbenv and Ruby
-ENV RUBY_VERSION=3.1.1
+ENV RUBY_VERSION=3.2.2
 ENV WORKSPACE_GEM_HOME=/workspace/.gem
 RUN sudo apt-get install -y build-essential curl git zlib1g-dev libssl-dev \
   libreadline-dev libyaml-dev libxml2-dev libxslt-dev


### PR DESCRIPTION
#### :tophat: What? Why?

On #12199 we forgot to change the version in the gitpod dockerfile. This PR changes it. 
 
#### Testing

Launch this branch with gitpod (with the URL https://gitpod.io/new#https://github.com/decidim/decidim/tree/chore/bump-ruby-version-gitpod )

### :camera: Screenshots

The screenshot of the error: 
![Screenshot of the error in gitpod](https://github.com/decidim/decidim/assets/717367/63fd1578-680f-4ffb-96af-53b51a1734f0)

:hearts: Thank you!
