### PR TITLE
Redesign: HTML-clean up on comments module

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comment/actions.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/actions.erb
@@ -1,8 +1,8 @@
 <div class="comment__actions">
   <% if depth.zero? && has_replies_in_children? %>
-    <button class="button button__sm button__text-secondary" data-controls="comment-<%= model.id %>-replies">
+    <button class="button button__sm button__text-secondary comment__hide" data-controls="comment-<%= model.id %>-replies">
       <%= icon "arrow-up-s-line" %>
-      <span class="font-normal"><%= t("decidim.components.comment.hide_replies") %></span>
+      <span class="hide-comment-replies font-normal"><%= t("decidim.components.comment.hide_replies") %></span>
       <%= icon "arrow-down-s-line" %>
       <span class="show-comment-replies font-normal"><%= t("decidim.components.comment.show_replies", count: replies.size, replies_count: replies.size ) %></span>
     </button>

--- a/decidim-comments/app/cells/decidim/comments/comment/actions.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/actions.erb
@@ -4,7 +4,7 @@
       <%= icon "arrow-up-s-line" %>
       <span class="font-normal"><%= t("decidim.components.comment.hide_replies") %></span>
       <%= icon "arrow-down-s-line" %>
-      <span class="font-normal"><%= t("decidim.components.comment.show_replies", count: replies.size, replies_count: replies.size ) %></span>
+      <span class="show-comment-replies font-normal"><%= t("decidim.components.comment.show_replies", count: replies.size, replies_count: replies.size ) %></span>
     </button>
   <% end %>
   <% if can_reply? %>

--- a/decidim-comments/app/cells/decidim/comments/comment/actions.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/actions.erb
@@ -1,10 +1,10 @@
 <div class="comment__actions">
   <% if depth.zero? && has_replies_in_children? %>
-    <button class="button button__sm button__text-secondary comment__hide" data-controls="comment-<%= model.id %>-replies">
+    <button class="button button__sm button__text-secondary" data-controls="comment-<%= model.id %>-replies">
       <%= icon "arrow-up-s-line" %>
-      <span class="hide-comment-replies font-normal"><%= t("decidim.components.comment.hide_replies") %></span>
+      <span class="font-normal"><%= t("decidim.components.comment.hide_replies") %></span>
       <%= icon "arrow-down-s-line" %>
-      <span class="show-comment-replies font-normal"><%= t("decidim.components.comment.show_replies", count: replies.size, replies_count: replies.size ) %></span>
+      <span class="font-normal"><%= t("decidim.components.comment.show_replies", count: replies.size, replies_count: replies.size ) %></span>
     </button>
   <% end %>
   <% if can_reply? %>

--- a/decidim-comments/app/cells/decidim/comments/comment/actions.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/actions.erb
@@ -2,7 +2,7 @@
   <% if depth.zero? && has_replies_in_children? %>
     <button class="button button__sm button__text-secondary comment__hide" data-controls="comment-<%= model.id %>-replies">
       <%= icon "arrow-up-s-line" %>
-      <span class="hide-comment-replies font-normal"><%= t("decidim.components.comment.hide_replies") %></span>
+      <span class="font-normal"><%= t("decidim.components.comment.hide_replies") %></span>
       <%= icon "arrow-down-s-line" %>
       <span class="show-comment-replies font-normal"><%= t("decidim.components.comment.show_replies", count: replies.size, replies_count: replies.size ) %></span>
     </button>

--- a/decidim-comments/app/cells/decidim/comments/comment/actions.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/actions.erb
@@ -1,10 +1,10 @@
 <div class="comment__actions">
   <% if depth.zero? && has_replies_in_children? %>
-    <button class="button button__sm button__text-secondary comment__hide" data-controls="comment-<%= model.id %>-replies">
+    <button class="button button__sm button__text-secondary" data-comment-hide data-controls="comment-<%= model.id %>-replies">
       <%= icon "arrow-up-s-line" %>
       <span class="font-normal"><%= t("decidim.components.comment.hide_replies") %></span>
       <%= icon "arrow-down-s-line" %>
-      <span class="show-comment-replies font-normal"><%= t("decidim.components.comment.show_replies", count: replies.size, replies_count: replies.size ) %></span>
+      <span class="font-normal" data-show-comment-replies><%= t("decidim.components.comment.show_replies", count: replies.size, replies_count: replies.size ) %></span>
     </button>
   <% end %>
   <% if can_reply? %>

--- a/decidim-comments/app/cells/decidim/comments/comment/deletion_data.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/deletion_data.erb
@@ -1,6 +1,6 @@
 <%= render partial: "decidim/comments/comments/delete", formats: [:html], locals: { comment: model } %>
 
-<div data-component="accordion" id="accordion-<%= model.id %>">
+<div class="comment__footer" data-component="accordion" id="accordion-<%= model.id %>">
   <div id="comment-<%= model.id %>-replies" class="<%= "comment-reply" if has_replies_in_children? %>">
     <% if has_replies_in_children? %>
       <%= render :replies %>

--- a/decidim-comments/app/cells/decidim/comments/comment/deletion_data.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/deletion_data.erb
@@ -1,6 +1,6 @@
 <%= render partial: "decidim/comments/comments/delete", formats: [:html], locals: { comment: model } %>
 
-<div class="comment__footer" data-component="accordion" id="accordion-<%= model.id %>">
+<div data-component="accordion" id="accordion-<%= model.id %>">
   <div id="comment-<%= model.id %>-replies" class="<%= "comment-reply" if has_replies_in_children? %>">
     <% if has_replies_in_children? %>
       <%= render :replies %>

--- a/decidim-comments/app/cells/decidim/comments/comment/deletion_data.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/deletion_data.erb
@@ -1,6 +1,6 @@
 <%= render partial: "decidim/comments/comments/delete", formats: [:html], locals: { comment: model } %>
 
-<div class="comment__footer" data-component="accordion" id="accordion-<%= model.id %>">
+<div data-comment-footer data-component="accordion" id="accordion-<%= model.id %>">
   <div id="comment-<%= model.id %>-replies" class="<%= "comment-reply" if has_replies_in_children? %>">
     <% if has_replies_in_children? %>
       <%= render :replies %>

--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -61,13 +61,13 @@
       </div>
     </div>
 
-    <div class="comment__footer" data-component="accordion" id="accordion-<%= model.id %>">
+    <div data-component="accordion" id="accordion-<%= model.id %>">
       <div class="comment__footer-grid">
         <%= render :actions %>
         <%= votes %>
       </div>
       <% if can_reply? %>
-        <div id="panel-<%= reply_id %>" class="add-comment comment__additionalreply">
+        <div id="panel-<%= reply_id %>" class="add-comment">
           <%== cell("decidim/comments/comment_form", model, root_depth:, order:) %>
         </div>
       <% end %>

--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -61,7 +61,7 @@
       </div>
     </div>
 
-    <div data-component="accordion" id="accordion-<%= model.id %>">
+    <div class="comment__footer" data-component="accordion" id="accordion-<%= model.id %>">
       <div class="comment__footer-grid">
         <%= render :actions %>
         <%= votes %>

--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -61,7 +61,7 @@
       </div>
     </div>
 
-    <div class="comment__footer" data-component="accordion" id="accordion-<%= model.id %>">
+    <div data-comment-footer data-component="accordion" id="accordion-<%= model.id %>">
       <div class="comment__footer-grid">
         <%= render :actions %>
         <%= votes %>

--- a/decidim-comments/app/cells/decidim/comments/comment_form/opinion.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment_form/opinion.erb
@@ -1,15 +1,15 @@
 <div>
   <span class="comment__opinion-label"><%= t("decidim.components.add_comment_form.opinion.label") %></span>
-  <div class="opinion-toggle comment__opinion-container">
-    <button type="button" aria-pressed="false" class="opinion-toggle--ok" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.positive_selected") %>">
+  <div class="comment__opinion-container">
+    <button type="button" aria-pressed="false" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.positive_selected") %>">
       <span><%= t("decidim.components.comment.alignment.in_favor") %></span>
       <%= icon "thumb-up-line" %>
     </button>
-    <button type="button" aria-pressed="true" class="opinion-toggle--meh is-active" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.neutral_selected") %>">
+    <button type="button" aria-pressed="true" class="is-active" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.neutral_selected") %>">
       <span><%= t("decidim.components.add_comment_form.opinion.neutral") %></span>
       <%= icon "loader-3-line" %>
     </button>
-    <button type="button" aria-pressed="false" class="opinion-toggle--ko" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.negative_selected") %>">
+    <button type="button" aria-pressed="false" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.negative_selected") %>">
       <span><%= t("decidim.components.comment.alignment.against") %></span>
       <%= icon "thumb-down-line" %>
     </button>

--- a/decidim-comments/app/cells/decidim/comments/comment_form/opinion.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment_form/opinion.erb
@@ -1,15 +1,15 @@
 <div>
   <span class="comment__opinion-label"><%= t("decidim.components.add_comment_form.opinion.label") %></span>
-  <div class="comment__opinion-container">
-    <button type="button" aria-pressed="false" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.positive_selected") %>">
+  <div class="opinion-toggle comment__opinion-container">
+    <button type="button" aria-pressed="false" class="opinion-toggle--ok" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.positive_selected") %>">
       <span><%= t("decidim.components.comment.alignment.in_favor") %></span>
       <%= icon "thumb-up-line" %>
     </button>
-    <button type="button" aria-pressed="true" class="is-active" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.neutral_selected") %>">
+    <button type="button" aria-pressed="true" class="opinion-toggle--meh is-active" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.neutral_selected") %>">
       <span><%= t("decidim.components.add_comment_form.opinion.neutral") %></span>
       <%= icon "loader-3-line" %>
     </button>
-    <button type="button" aria-pressed="false" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.negative_selected") %>">
+    <button type="button" aria-pressed="false" class="opinion-toggle--ko" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.negative_selected") %>">
       <span><%= t("decidim.components.comment.alignment.against") %></span>
       <%= icon "thumb-down-line" %>
     </button>

--- a/decidim-comments/app/cells/decidim/comments/comment_form/opinion.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment_form/opinion.erb
@@ -1,15 +1,15 @@
 <div>
   <span class="comment__opinion-label"><%= t("decidim.components.add_comment_form.opinion.label") %></span>
-  <div class="opinion-toggle comment__opinion-container">
-    <button type="button" aria-pressed="false" class="opinion-toggle--ok" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.positive_selected") %>">
+  <div class="comment__opinion-container" data-opinion-toggle>
+    <button type="button" aria-pressed="false" data-opinion-toggle-ok data-selected-label="<%= t("decidim.components.add_comment_form.opinion.positive_selected") %>">
       <span><%= t("decidim.components.comment.alignment.in_favor") %></span>
       <%= icon "thumb-up-line" %>
     </button>
-    <button type="button" aria-pressed="true" class="opinion-toggle--meh is-active" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.neutral_selected") %>">
+    <button type="button" aria-pressed="true" class="is-active" opinion-toggle-meh data-selected-label="<%= t("decidim.components.add_comment_form.opinion.neutral_selected") %>">
       <span><%= t("decidim.components.add_comment_form.opinion.neutral") %></span>
       <%= icon "loader-3-line" %>
     </button>
-    <button type="button" aria-pressed="false" class="opinion-toggle--ko" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.negative_selected") %>">
+    <button type="button" aria-pressed="false" opinion-toggle-ko data-selected-label="<%= t("decidim.components.add_comment_form.opinion.negative_selected") %>">
       <span><%= t("decidim.components.comment.alignment.against") %></span>
       <%= icon "thumb-down-line" %>
     </button>

--- a/decidim-comments/app/cells/decidim/comments/comment_form/opinion.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment_form/opinion.erb
@@ -5,11 +5,11 @@
       <span><%= t("decidim.components.comment.alignment.in_favor") %></span>
       <%= icon "thumb-up-line" %>
     </button>
-    <button type="button" aria-pressed="true" class="is-active" opinion-toggle-meh data-selected-label="<%= t("decidim.components.add_comment_form.opinion.neutral_selected") %>">
+    <button type="button" aria-pressed="true" class="is-active" data-opinion-toggle-meh data-selected-label="<%= t("decidim.components.add_comment_form.opinion.neutral_selected") %>">
       <span><%= t("decidim.components.add_comment_form.opinion.neutral") %></span>
       <%= icon "loader-3-line" %>
     </button>
-    <button type="button" aria-pressed="false" opinion-toggle-ko data-selected-label="<%= t("decidim.components.add_comment_form.opinion.negative_selected") %>">
+    <button type="button" aria-pressed="false" data-opinion-toggle-ko data-selected-label="<%= t("decidim.components.add_comment_form.opinion.negative_selected") %>">
       <span><%= t("decidim.components.comment.alignment.against") %></span>
       <%= icon "thumb-down-line" %>
     </button>

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -287,11 +287,11 @@ export default class CommentsComponent {
     $opinionButtons.removeClass("is-active").attr("aria-pressed", "false");
     $btn.addClass("is-active").attr("aria-pressed", "true");
 
-    if ($btn.is("[opinion-toggle-ok]")) {
+    if ($btn.is("[data-opinion-toggle-ok]")) {
       $alignment.val(1);
-    } else if ($btn.is("[opinion-toggle-meh]")) {
+    } else if ($btn.is("[data-opinion-toggle-meh]")) {
       $alignment.val(0);
-    } else if ($btn.is("[opinion-toggle-ko]")) {
+    } else if ($btn.is("[data-opinion-toggle-ko]")) {
       $alignment.val(-1);
     }
 

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -56,7 +56,7 @@ export default class CommentsComponent {
       this.mounted = false;
       this._stopPolling();
 
-      $(".add-comment .opinion-toggle button", this.$element).off("click.decidim-comments");
+      $(".add-comment [data-opinion-toggle] button", this.$element).off("click.decidim-comments");
       $(".add-comment textarea", this.$element).off("input.decidim-comments");
       $(".add-comment form", this.$element).off("submit.decidim-comments");
       $(".add-comment textarea", this.$element).each((_i, el) => el.removeEventListener("emoji.added", this._onTextInput));
@@ -117,7 +117,7 @@ export default class CommentsComponent {
     $(".add-comment", $parent).each((_i, el) => {
       const $add = $(el);
       const $form = $("form", $add);
-      const $opinionButtons = $(".opinion-toggle button", $add);
+      const $opinionButtons = $("[data-opinion-toggle] button", $add);
       const $text = $("textarea", $form);
 
       $opinionButtons.on("click.decidim-comments", this._onToggleOpinion);
@@ -280,18 +280,18 @@ export default class CommentsComponent {
 
     const $add = $btn.closest(".add-comment");
     const $form = $("form", $add);
-    const $opinionButtons = $(".opinion-toggle button", $add);
-    const $selectedState = $(".opinion-toggle .selected-state", $add);
+    const $opinionButtons = $("[data-opinion-toggle] button", $add);
+    const $selectedState = $("[data-opinion-toggle] .selected-state", $add);
     const $alignment = $(".alignment-input", $form);
 
     $opinionButtons.removeClass("is-active").attr("aria-pressed", "false");
     $btn.addClass("is-active").attr("aria-pressed", "true");
 
-    if ($btn.is(".opinion-toggle--ok")) {
+    if ($btn.is("[opinion-toggle-ok]")) {
       $alignment.val(1);
-    } else if ($btn.is(".opinion-toggle--meh")) {
+    } else if ($btn.is("[opinion-toggle-meh]")) {
       $alignment.val(0);
-    } else if ($btn.is(".opinion-toggle--ko")) {
+    } else if ($btn.is("[opinion-toggle-ko]")) {
       $alignment.val(-1);
     }
 

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
@@ -233,7 +233,7 @@ describe("CommentsComponent", () => {
         <div class="comment__content">
           <div><p>${content}</p></div>
         </div>
-        <div data-comment-footer data-component="accordion" role="presentation">
+        <div class="comment__footer" data-component="accordion" role="presentation">
           <div class="comment__footer-grid">
             <div class="comment__actions">
               <button class="button button__sm button__text-secondary" data-controls="panel-comment${commentId}-reply" role="button" tabindex="0" aria-controls="panel-comment${commentId}-reply" aria-expanded="false" aria-disabled="false">

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
@@ -45,7 +45,7 @@ describe("CommentsComponent", () => {
   const spyOnAddComment = (methodToSpy) => {
     addComment.each((i) => {
       addComment[i].$ = $(addComment[i]);
-      addComment[i].opinionToggles = $(".opinion-toggle button", addComment[i].$);
+      addComment[i].opinionToggles = $("[data-opinion-toggle] button", addComment[i].$);
       addComment[i].commentForm = $("form", addComment[i].$);
       addComment[i].commentTextarea = $("textarea", addComment[i].commentForm);
 
@@ -66,7 +66,7 @@ describe("CommentsComponent", () => {
         return orderLinks;
       } else if (jqSelector === ".add-comment" && parent.is(subject.$element)) {
         return addComment;
-      } else if (jqSelector === ".add-comment .opinion-toggle button" && parent.is(subject.$element)) {
+      } else if (jqSelector === ".add-comment [data-opinion-toggle] button" && parent.is(subject.$element)) {
         return allToggles;
       } else if (jqSelector === ".add-comment textarea" && parent.is(subject.$element)) {
         return allTextareas;
@@ -75,7 +75,7 @@ describe("CommentsComponent", () => {
       }
       const addCommentsArray = addComment.toArray();
       for (let i = 0; i < addCommentsArray.length; i += 1) {
-        if (jqSelector === ".opinion-toggle button" && parent.is(addCommentsArray[i].$)) {
+        if (jqSelector === "[data-opinion-toggle] button" && parent.is(addCommentsArray[i].$)) {
           return addCommentsArray[i].opinionToggles;
         } else if (jqSelector === "form" && parent.is(addCommentsArray[i].$)) {
           return addCommentsArray[i].commentForm;
@@ -371,7 +371,7 @@ describe("CommentsComponent", () => {
     addComment = $(".add-comment", subject.$element);
     orderLinks = $(".comment-order-by a.comment-order-by__item", subject.$element);
 
-    allToggles = $(".add-comment .opinion-toggle .button", subject.$element);
+    allToggles = $(".add-comment [data-opinion-toggle] .button", subject.$element);
     allTextareas = $(".add-comment textarea", subject.$element);
     allForms = $(".add-comment form", subject.$element);
   });

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
@@ -233,7 +233,7 @@ describe("CommentsComponent", () => {
         <div class="comment__content">
           <div><p>${content}</p></div>
         </div>
-        <div class="comment__footer" data-component="accordion" role="presentation">
+        <div data-comment-footer data-component="accordion" role="presentation">
           <div class="comment__footer-grid">
             <div class="comment__actions">
               <button class="button button__sm button__text-secondary" data-controls="panel-comment${commentId}-reply" role="button" tabindex="0" aria-controls="panel-comment${commentId}-reply" aria-expanded="false" aria-disabled="false">

--- a/decidim-comments/app/views/decidim/comments/comments/create.js.erb
+++ b/decidim-comments/app/views/decidim/comments/comments/create.js.erb
@@ -8,8 +8,8 @@
   if (inReplyTo) {
     component.addReply(inReplyTo, commentHtml, true);
 
-    var hideButton = $("#comment_" + <%= root_comment.id %>).find(".comment__hide").first();
-    hideButton.find(".show-comment-replies").first().html('<%= t("decidim.components.comment.show_replies", count: Decidim::Comments::SortedComments.for(root_comment.reload).size) %>');
+    var hideButton = $("#comment_" + <%= root_comment.id %>).find("[data-comment-hide]").first();
+    hideButton.find("[data-show-comment-replies]").first().html('<%= t("decidim.components.comment.show_replies", count: Decidim::Comments::SortedComments.for(root_comment.reload).size) %>');
 
   } else {
     component.addThread(commentHtml, true);

--- a/decidim-comments/app/views/decidim/comments/comments/create.js.erb
+++ b/decidim-comments/app/views/decidim/comments/comments/create.js.erb
@@ -9,7 +9,7 @@
     component.addReply(inReplyTo, commentHtml, true);
 
     var hideButton = $("#comment_" + <%= root_comment.id %>).find("[data-comment-hide]").first();
-    hideButton.find("[data-show-comment-replies]").first().html('<%= t("decidim.components.comment.show_replies", count: Decidim::Comments::SortedComments.for(root_comment.reload).size) %>');
+    hideButton.find("div[data-show-comment-replies]").first().html('<%= t("decidim.components.comment.show_replies", count: Decidim::Comments::SortedComments.for(root_comment.reload).size) %>');
 
   } else {
     component.addThread(commentHtml, true);

--- a/decidim-comments/app/views/decidim/comments/votes/create.js.erb
+++ b/decidim-comments/app/views/decidim/comments/votes/create.js.erb
@@ -3,7 +3,7 @@
   var upVotes = <%= comment.up_votes.count.to_json %>;
   var downVotes = <%= comment.down_votes.count.to_json %>;
   var $comment = $("#comment_" + commentId);
-  var $votes = $("> .comment__footer > .comment__footer-grid .comment__votes", $comment);
+  var $votes = $("> [data-comment-footer] > .comment__footer-grid .comment__votes", $comment);
   var $upVote = $(".js-comment__votes--up", $votes);
   var $downVote = $(".js-comment__votes--down", $votes);
 

--- a/decidim-comments/app/views/decidim/comments/votes/create.js.erb
+++ b/decidim-comments/app/views/decidim/comments/votes/create.js.erb
@@ -3,7 +3,7 @@
   var upVotes = <%= comment.up_votes.count.to_json %>;
   var downVotes = <%= comment.down_votes.count.to_json %>;
   var $comment = $("#comment_" + commentId);
-  var $votes = $("> "[data-comment-footer]" > .comment__footer-grid .comment__votes", $comment);
+  var $votes = $("> [data-comment-footer] > .comment__footer-grid .comment__votes", $comment);
   var $upVote = $(".js-comment__votes--up", $votes);
   var $downVote = $(".js-comment__votes--down", $votes);
 

--- a/decidim-comments/app/views/decidim/comments/votes/create.js.erb
+++ b/decidim-comments/app/views/decidim/comments/votes/create.js.erb
@@ -3,9 +3,10 @@
   var upVotes = <%= comment.up_votes.count.to_json %>;
   var downVotes = <%= comment.down_votes.count.to_json %>;
   var $comment = $("#comment_" + commentId);
-  var $votes = $("> [data-comment-footer] > .comment__footer-grid .comment__votes", $comment);
+  var $votes = $("> div[data-comment-footer] > .comment__footer-grid .comment__votes", $comment);
   var $upVote = $(".js-comment__votes--up", $votes);
   var $downVote = $(".js-comment__votes--down", $votes);
+  console.log($votes)
 
   $("span", $upVote).text(upVotes);
   $("span", $downVote).text(downVotes);

--- a/decidim-comments/app/views/decidim/comments/votes/create.js.erb
+++ b/decidim-comments/app/views/decidim/comments/votes/create.js.erb
@@ -3,7 +3,7 @@
   var upVotes = <%= comment.up_votes.count.to_json %>;
   var downVotes = <%= comment.down_votes.count.to_json %>;
   var $comment = $("#comment_" + commentId);
-  var $votes = $("> [data-comment-footer] > .comment__footer-grid .comment__votes", $comment);
+  var $votes = $("> "[data-comment-footer]" > .comment__footer-grid .comment__votes", $comment);
   var $upVote = $(".js-comment__votes--up", $votes);
   var $downVote = $(".js-comment__votes--down", $votes);
 

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -85,12 +85,6 @@ module Decidim::Comments
           expect(subject).to have_css(".add-comment #new_comment_for_DummyResource_#{commentable.id}")
         end
 
-        context "when alignment is enabled" do
-          before do
-            allow(commentable).to receive(:comments_have_alignment?).and_return(true)
-          end
-        end
-
         context "when comments are blocked" do
           before do
             comment # Create the comment before disabling comments

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -89,12 +89,6 @@ module Decidim::Comments
           before do
             allow(commentable).to receive(:comments_have_alignment?).and_return(true)
           end
-
-          it "renders the alignment buttons" do
-            expect(subject).to have_css(".opinion-toggle--ok")
-            expect(subject).to have_css(".opinion-toggle--meh")
-            expect(subject).to have_css(".opinion-toggle--ko")
-          end
         end
 
         context "when comments are blocked" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -91,7 +91,7 @@ shared_examples "comments" do
       expect(page).not_to have_content(translated(deleted_comment.body))
       within "#comment_#{deleted_comment.id}" do
         expect(page).to have_content("Comment deleted on")
-        expect(page).not_to have_selector("comment__footer")
+        expect(page).not_to have_selector("[data-comment-footer]")
       end
     end
 
@@ -641,7 +641,7 @@ shared_examples "comments" do
           within "#comment_#{comment.id}" do
             expect(page).to have_content("Comment deleted on")
             expect(page).not_to have_content comment_author.name
-            expect(page).not_to have_selector("comment__footer")
+            expect(page).not_to have_selector("[data-comment-footer]")
           end
           expect(page).to have_selector("span.comments-count", text: "3 comments")
 
@@ -809,10 +809,10 @@ shared_examples "comments" do
             skip "Commentable comments has no votes" unless commentable.comments_have_votes?
 
             visit current_path
-            expect(page).to have_selector("#comment_#{comments[0].id} > .comment__footer > .comment__footer-grid .comment__votes .js-comment__votes--up", text: /0/)
-            page.find("#comment_#{comments[0].id} > .comment__footer > .comment__footer-grid .comment__votes .js-comment__votes--up").click
-            expect(page).to have_selector("#comment_#{comments[0].id} > .comment__footer > .comment__footer-grid .comment__votes .js-comment__votes--up", text: /1/)
-            expect(page).to have_selector("#comment_#{comment_on_comment.id} > .comment__footer > .comment__footer-grid .comment__votes .js-comment__votes--up", text: /0/)
+            expect(page).to have_selector("#comment_#{comments[0].id} > [data-comment-footer] > .comment__footer-grid .comment__votes .js-comment__votes--up", text: /0/)
+            page.find("#comment_#{comments[0].id} > [data-comment-footer] > .comment__footer-grid .comment__votes .js-comment__votes--up").click
+            expect(page).to have_selector("#comment_#{comments[0].id} > [data-comment-footer] > .comment__footer-grid .comment__votes .js-comment__votes--up", text: /1/)
+            expect(page).to have_selector("#comment_#{comment_on_comment.id} > [data-comment-footer] > .comment__footer-grid .comment__votes .js-comment__votes--up", text: /0/)
           end
         end
       end

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -91,7 +91,7 @@ shared_examples "comments" do
       expect(page).not_to have_content(translated(deleted_comment.body))
       within "#comment_#{deleted_comment.id}" do
         expect(page).to have_content("Comment deleted on")
-        expect(page).not_to have_selector("[data-comment-footer]")
+        expect(page).not_to have_selector("data-comment-footer")
       end
     end
 
@@ -641,7 +641,7 @@ shared_examples "comments" do
           within "#comment_#{comment.id}" do
             expect(page).to have_content("Comment deleted on")
             expect(page).not_to have_content comment_author.name
-            expect(page).not_to have_selector("[data-comment-footer]")
+            expect(page).not_to have_selector("data-comment-footer")
           end
           expect(page).to have_selector("span.comments-count", text: "3 comments")
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -91,7 +91,7 @@ shared_examples "comments" do
       expect(page).not_to have_content(translated(deleted_comment.body))
       within "#comment_#{deleted_comment.id}" do
         expect(page).to have_content("Comment deleted on")
-        expect(page).not_to have_selector([data-comment-footer])
+        expect(page).not_to have_selector("div[data-comment-footer]")
       end
     end
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -761,11 +761,11 @@ shared_examples "comments" do
 
         it "works according to the setting in the commentable" do
           if commentable.comments_have_alignment?
-            page.find(".opinion-toggle--ok").click
-            expect(page.find(".opinion-toggle--ok")["aria-pressed"]).to eq("true")
-            expect(page.find(".opinion-toggle--meh")["aria-pressed"]).to eq("false")
-            expect(page.find(".opinion-toggle--ko")["aria-pressed"]).to eq("false")
-            expect(page.find(".opinion-toggle .selected-state", visible: false)).to have_content("Your opinion about this topic is positive")
+            page.find("[opinion-toggle-ok]").click
+            expect(page.find("[opinion-toggle-ok]")["aria-pressed"]).to eq("true")
+            expect(page.find("[opinion-toggle-meh]")["aria-pressed"]).to eq("false")
+            expect(page.find("[opinion-toggle-ko]")["aria-pressed"]).to eq("false")
+            expect(page.find("[opinion-toggle] .selected-state", visible: false)).to have_content("Your opinion about this topic is positive")
 
             within "form#new_comment_for_#{commentable.commentable_type.demodulize}_#{commentable.id}" do
               field = find("#add-comment-#{commentable.commentable_type.demodulize}-#{commentable.id}")
@@ -778,7 +778,7 @@ shared_examples "comments" do
               expect(page).to have_selector "span.success.label", text: "In favor", wait: 20
             end
           else
-            expect(page).not_to have_selector(".opinion-toggle--ok")
+            expect(page).not_to have_selector("[opinion-toggle-ok]")
           end
         end
       end

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -91,7 +91,7 @@ shared_examples "comments" do
       expect(page).not_to have_content(translated(deleted_comment.body))
       within "#comment_#{deleted_comment.id}" do
         expect(page).to have_content("Comment deleted on")
-        expect(page).not_to have_selector("[data-comment-footer]")
+        expect(page).not_to have_selector([data-comment-footer])
       end
     end
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -761,11 +761,11 @@ shared_examples "comments" do
 
         it "works according to the setting in the commentable" do
           if commentable.comments_have_alignment?
-            page.find("[opinion-toggle-ok]").click
-            expect(page.find("[opinion-toggle-ok]")["aria-pressed"]).to eq("true")
-            expect(page.find("[opinion-toggle-meh]")["aria-pressed"]).to eq("false")
-            expect(page.find("[opinion-toggle-ko]")["aria-pressed"]).to eq("false")
-            expect(page.find("[opinion-toggle] .selected-state", visible: false)).to have_content("Your opinion about this topic is positive")
+            page.find("[data-opinion-toggle-ok]").click
+            expect(page.find("[data-opinion-toggle-ok]")["aria-pressed"]).to eq("true")
+            expect(page.find("[data-opinion-toggle-meh]")["aria-pressed"]).to eq("false")
+            expect(page.find("[data-opinion-toggle-ko]")["aria-pressed"]).to eq("false")
+            expect(page.find("[data-opinion-toggle] .selected-state", visible: false)).to have_content("Your opinion about this topic is positive")
 
             within "form#new_comment_for_#{commentable.commentable_type.demodulize}_#{commentable.id}" do
               field = find("#add-comment-#{commentable.commentable_type.demodulize}-#{commentable.id}")
@@ -778,7 +778,7 @@ shared_examples "comments" do
               expect(page).to have_selector "span.success.label", text: "In favor", wait: 20
             end
           else
-            expect(page).not_to have_selector("[opinion-toggle-ok]")
+            expect(page).not_to have_selector("[data-opinion-toggle-ok]")
           end
         end
       end

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -91,7 +91,7 @@ shared_examples "comments" do
       expect(page).not_to have_content(translated(deleted_comment.body))
       within "#comment_#{deleted_comment.id}" do
         expect(page).to have_content("Comment deleted on")
-        expect(page).not_to have_selector("data-comment-footer")
+        expect(page).not_to have_selector("[data-comment-footer]")
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR relates to the clean up of depreciated HTML classes within the comments module and over develop application. 

#### :pushpin: Related Issues
- Related to #12178 

#### Testing
Run ```bundle exec erblint decidim-comments/**/*.erb``` to  check if any unused classes still exist in the module.

### :camera: Screenshots

:hearts: Thank you!
