### PR TITLE
Backport 'Use relative JS imports to allow overrides' to v0.28

### DIFF
--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
@@ -18,8 +18,8 @@ window.Rails = Rails;
 // Fake timers for testing polling
 jest.useFakeTimers();
 
-import { createCharacterCounter } from "../../../../../../decidim-core/app/packs/src/decidim/input_character_counter";
-import Configuration from "../../../../../../decidim-core/app/packs/src/decidim/configuration";
+import { createCharacterCounter } from "src/decidim/input_character_counter";
+import Configuration from "src/decidim/configuration";
 // Component is loaded with require because using import loads it before $ has been mocked
 // so tests are not able to check the spied behaviours
 const CommentsComponent = require("./comments.component_for_testing.js");

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component_for_testing.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component_for_testing.js
@@ -1,4 +1,5 @@
 /* eslint no-undef: 0 */
+/* eslint-disable no-relative-import-paths/no-relative-import-paths */
 
 import CommentsComponent from "./comments.component"
 

--- a/decidim-core/app/packs/src/decidim/account_form.js
+++ b/decidim-core/app/packs/src/decidim/account_form.js
@@ -1,4 +1,4 @@
-import PasswordToggler from "./password_toggler";
+import PasswordToggler from "src/decidim/password_toggler";
 
 const initializeAccountForm = () => {
   const newPasswordPanel = document.getElementById("panel-password");

--- a/decidim-core/app/packs/src/decidim/data_consent/consent_manager.test.js
+++ b/decidim-core/app/packs/src/decidim/data_consent/consent_manager.test.js
@@ -1,7 +1,7 @@
 /* global global, jest */
 
 import Cookies from "js-cookie";
-import ConsentManager from "./consent_manager";
+import ConsentManager from "src/decidim/data_consent/consent_manager";
 
 // Mock js-cookie so that we can store the return values from the "set" method
 // in order to inspect their flags.

--- a/decidim-core/app/packs/src/decidim/data_consent/index.js
+++ b/decidim-core/app/packs/src/decidim/data_consent/index.js
@@ -1,4 +1,4 @@
-import ConsentManager from "./consent_manager";
+import ConsentManager from "src/decidim/data_consent/consent_manager";
 
 const initDialog = (manager) => {
   if (Object.keys(manager.state).length > 0) {

--- a/decidim-core/app/packs/src/decidim/editor/test/editor/create.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/editor/create.test.js
@@ -1,6 +1,6 @@
 import { Editor } from "@tiptap/core";
 
-import { createEditorContainer, updateContent } from "../helpers";
+import { createEditorContainer, updateContent } from "src/decidim/editor/test/helpers";
 
 describe("createEditor", () => {
   const ctx = {

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/bold.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/bold.test.js
@@ -6,10 +6,9 @@ import OrderedList from "@tiptap/extension-ordered-list";
 import ListItem from "@tiptap/extension-list-item";
 import Text from "@tiptap/extension-text";
 
-import Bold from "../../extensions/bold";
-// import OrderedList from "../../extensions/ordered_list";
+import Bold from "src/decidim/editor/extensions/bold";
 
-import { updateContent } from "../helpers";
+import { updateContent } from "src/decidim/editor/test/helpers";
 
 const createBasicEditor = () => {
   const element = document.createElement("div");

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/character_count.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/character_count.test.js
@@ -1,6 +1,6 @@
-import { createBasicEditor, updateContent } from "../helpers";
+import { createBasicEditor, updateContent } from "src/decidim/editor/test/helpers";
 
-import CharacterCount from "../../extensions/character_count";
+import CharacterCount from "src/decidim/editor/extensions/character_count";
 
 describe("CharacterCount", () => {
   let editor = null;

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/decidim_kit.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/decidim_kit.test.js
@@ -1,11 +1,10 @@
 /* global jest */
 
-// import { createBasicEditor } from "../helpers";
 import { Editor } from "@tiptap/core";
 
-import DecidimKit from "../../extensions/decidim_kit";
+import DecidimKit from "src/decidim/editor/extensions/decidim_kit";
 
-import { createEditorContainer } from "../helpers";
+import { createEditorContainer } from "src/decidim/editor/test/helpers";
 
 // Mock picmo as it is distributed as an ES6 module that is not fully compatible
 // with Jest without configuration changes.

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/dialog.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/dialog.test.js
@@ -1,6 +1,6 @@
-import { createBasicEditor } from "../helpers";
+import { createBasicEditor } from "src/decidim/editor/test/helpers";
 
-import Dialog from "../../extensions/dialog";
+import Dialog from "src/decidim/editor/extensions/dialog";
 
 describe("Dialog", () => {
   let editor = null;

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/emoji.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/emoji.test.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-undef */
 
-import { createBasicEditor, sleep } from "../helpers";
+import { createBasicEditor, sleep } from "src/decidim/editor/test/helpers";
 
-import Emoji from "../../extensions/emoji";
+import Emoji from "src/decidim/editor/extensions/emoji";
 
 Reflect.defineProperty(window, "matchMedia", {
   writable: true,

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/hashtag.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/hashtag.test.js
@@ -1,8 +1,8 @@
 /* global jest, global */
 
-import { createBasicEditor, updateContent } from "../helpers";
+import { createBasicEditor, updateContent } from "src/decidim/editor/test/helpers";
 
-import Hashtag from "../../extensions/hashtag";
+import Hashtag from "src/decidim/editor/extensions/hashtag";
 
 const hashtagsResponse = [
   { name: "apples" },

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/heading.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/heading.test.js
@@ -6,9 +6,9 @@ import OrderedList from "@tiptap/extension-ordered-list";
 import ListItem from "@tiptap/extension-list-item";
 import Text from "@tiptap/extension-text";
 
-import { updateContent } from "../helpers";
+import { updateContent } from "src/decidim/editor/test/helpers";
 
-import Heading from "../../extensions/heading";
+import Heading from "src/decidim/editor/extensions/heading";
 
 const createBasicEditor = () => {
   const element = document.createElement("div");

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/image.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/image.test.js
@@ -1,10 +1,10 @@
 /* global jest, global */
 
-import { createBasicEditor, updateContent, sleep, pasteFixtureFile, dropFixtureFile } from "../helpers";
+import { createBasicEditor, updateContent, sleep, pasteFixtureFile, dropFixtureFile } from "src/decidim/editor/test/helpers";
 
-import Dialog from "../../extensions/dialog";
-import Image from "../../extensions/image";
-import uploadTemplates from "../fixtures/upload_templates";
+import Dialog from "src/decidim/editor/extensions/dialog";
+import Image from "src/decidim/editor/extensions/image";
+import uploadTemplates from "src/decidim/editor/test/fixtures/upload_templates";
 
 class DummyDialog {
   constructor(element) { this.element = element; }

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/indent.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/indent.test.js
@@ -1,6 +1,6 @@
-import { createBasicEditor, updateContent, selectRange } from "../helpers";
+import { createBasicEditor, updateContent, selectRange } from "src/decidim/editor/test/helpers";
 
-import Indent from "../../extensions/indent";
+import Indent from "src/decidim/editor/extensions/indent";
 
 describe("Indent", () => {
   let editor = null;

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/link.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/link.test.js
@@ -1,7 +1,7 @@
-import { createBasicEditor, updateContent, selectRange, sleep } from "../helpers";
+import { createBasicEditor, updateContent, selectRange, sleep } from "src/decidim/editor/test/helpers";
 
-import Dialog from "../../extensions/dialog";
-import Link from "../../extensions/link";
+import Dialog from "src/decidim/editor/extensions/dialog";
+import Link from "src/decidim/editor/extensions/link";
 
 describe("Link", () => {
   let editor = null;

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/mention.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/mention.test.js
@@ -1,8 +1,8 @@
 /* global jest, global */
 
-import { createBasicEditor, updateContent } from "../helpers";
+import { createBasicEditor, updateContent } from "src/decidim/editor/test/helpers";
 
-import Mention from "../../extensions/mention";
+import Mention from "src/decidim/editor/extensions/mention";
 
 const mentionsResponse = [
   {

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/ordered_list.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/ordered_list.test.js
@@ -5,9 +5,9 @@ import BulletList from "@tiptap/extension-bullet-list";
 import ListItem from "@tiptap/extension-list-item";
 import Text from "@tiptap/extension-text";
 
-import { updateContent, pasteContent } from "../helpers";
+import { updateContent, pasteContent } from "src/decidim/editor/test/helpers";
 
-import OrderedList from "../../extensions/ordered_list";
+import OrderedList from "src/decidim/editor/extensions/ordered_list";
 
 const createBasicEditor = () => {
   const element = document.createElement("div");

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/video_embed.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/video_embed.test.js
@@ -1,9 +1,9 @@
 /* global jest */
 
-import { createBasicEditor, updateContent, sleep, pasteContent } from "../helpers";
+import { createBasicEditor, updateContent, sleep, pasteContent } from "src/decidim/editor/test/helpers";
 
-import Dialog from "../../extensions/dialog";
-import VideoEmbed from "../../extensions/video_embed";
+import Dialog from "src/decidim/editor/extensions/dialog";
+import VideoEmbed from "src/decidim/editor/extensions/video_embed";
 
 describe("VideoEmbed", () => {
   let editor = null;

--- a/decidim-core/app/packs/src/decidim/editor/test/helpers.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/helpers.js
@@ -21,10 +21,10 @@ import OrderedList from "@tiptap/extension-ordered-list";
 import ListItem from "@tiptap/extension-list-item";
 import Text from "@tiptap/extension-text";
 
-import createEditor from "../index";
+import createEditor from "src/decidim/editor/index";
 
-import editorMessages from "./fixtures/editor_messages";
-import uploadTemplates from "./fixtures/upload_templates";
+import editorMessages from "src/decidim/editor/test/fixtures/editor_messages";
+import uploadTemplates from "src/decidim/editor/test/fixtures/upload_templates";
 
 const config = { messages: { editor: editorMessages } };
 window.Decidim = { config: { get: (key) => config[key] } };

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/basic.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/basic.test.js
@@ -1,5 +1,5 @@
-import { createEditorContainer } from "../helpers";
-import itBehavesLikeBasicToolbar from "./shared/behaves_like_basic";
+import { createEditorContainer } from "src/decidim/editor/test/helpers";
+import itBehavesLikeBasicToolbar from "src/decidim/editor/test/toolbar/shared/behaves_like_basic";
 
 describe("basic toolbar", () => {
   const ctx = {

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/content.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/content.test.js
@@ -1,5 +1,5 @@
-import { createEditorContainer } from "../helpers";
-import itBehavesLikeContentToolbar from "./shared/behaves_like_content";
+import { createEditorContainer } from "src/decidim/editor/test/helpers";
+import itBehavesLikeContentToolbar from "src/decidim/editor/test/toolbar/shared/behaves_like_content";
 
 describe("content toolbar", () => {
   const ctx = {

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/full.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/full.test.js
@@ -2,9 +2,9 @@
 
 import Dialog from "a11y-dialog-component";
 
-import { createEditorContainer, sleep, updateContent, selectContent, dropFixtureFile } from "../helpers";
-import contextHelpers from "./shared/context";
-import itBehavesLikeContentToolbar from "./shared/behaves_like_content";
+import { createEditorContainer, sleep, updateContent, selectContent, dropFixtureFile } from "src/decidim/editor/test/helpers";
+import contextHelpers from "src/decidim/editor/test/toolbar/shared/context";
+import itBehavesLikeContentToolbar from "src/decidim/editor/test/toolbar/shared/behaves_like_content";
 
 describe("full toolbar", () => {
   const ctx = {

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic.js
@@ -1,9 +1,9 @@
-import itBehavesLikeBasicToolbarStyling from "./behaves_like_basic_styling";
-import itBehavesLikeBasicToolbarFormatting from "./behaves_like_basic_formatting";
-import itBehavesLikeBasicToolbarList from "./behaves_like_basic_list";
-import itBehavesLikeBasicToolbarBlock from "./behaves_like_basic_block";
-import itBehavesLikeBasicToolbarLink from "./behaves_like_basic_link";
-import itBehavesLikeBasicToolbarIndent from "./behaves_like_basic_indent";
+import itBehavesLikeBasicToolbarStyling from "src/decidim/editor/test/toolbar/shared/behaves_like_basic_styling";
+import itBehavesLikeBasicToolbarFormatting from "src/decidim/editor/test/toolbar/shared/behaves_like_basic_formatting";
+import itBehavesLikeBasicToolbarList from "src/decidim/editor/test/toolbar/shared/behaves_like_basic_list";
+import itBehavesLikeBasicToolbarBlock from "src/decidim/editor/test/toolbar/shared/behaves_like_basic_block";
+import itBehavesLikeBasicToolbarLink from "src/decidim/editor/test/toolbar/shared/behaves_like_basic_link";
+import itBehavesLikeBasicToolbarIndent from "src/decidim/editor/test/toolbar/shared/behaves_like_basic_indent";
 
 export default (ctx) => {
   ctx.prosemirror = null;

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_block.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_block.js
@@ -1,6 +1,6 @@
-import { selectContent } from "../../helpers";
+import { selectContent } from "src/decidim/editor/test/helpers";
 
-import contextHelpers from "./context";
+import contextHelpers from "src/decidim/editor/test/toolbar/shared/context";
 
 export default (ctx) => {
   const { getControl, setContent } = contextHelpers(ctx);

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_formatting.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_formatting.js
@@ -1,4 +1,4 @@
-import contextHelpers from "./context";
+import contextHelpers from "src/decidim/editor/test/toolbar/shared/context";
 
 export default (ctx) => {
   const { getControl, setContent } = contextHelpers(ctx);

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_indent.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_indent.js
@@ -1,6 +1,6 @@
-import { selectContent, selectRange } from "../../helpers";
+import { selectContent, selectRange } from "src/decidim/editor/test/helpers";
 
-import contextHelpers from "./context";
+import contextHelpers from "src/decidim/editor/test/toolbar/shared/context";
 
 export default (ctx) => {
   const { getControl, setContent } = contextHelpers(ctx);

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_link.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_link.js
@@ -1,6 +1,6 @@
-import { sleep, selectRange } from "../../helpers";
+import { sleep, selectRange } from "src/decidim/editor/test/helpers";
 
-import contextHelpers from "./context";
+import contextHelpers from "src/decidim/editor/test/toolbar/shared/context";
 
 export default (ctx) => {
   const { getControl, setContent } = contextHelpers(ctx);

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_list.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_list.js
@@ -1,6 +1,6 @@
-import { selectContent } from "../../helpers";
+import { selectContent } from "src/decidim/editor/test/helpers";
 
-import contextHelpers from "./context";
+import contextHelpers from "src/decidim/editor/test/toolbar/shared/context";
 
 export default (ctx) => {
   const { getControl, setContent } = contextHelpers(ctx);

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_styling.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_styling.js
@@ -1,6 +1,6 @@
-import { selectContent } from "../../helpers";
+import { selectContent } from "src/decidim/editor/test/helpers";
 
-import contextHelpers from "./context";
+import contextHelpers from "src/decidim/editor/test/toolbar/shared/context";
 
 export default (ctx) => {
   const { getControl, setContent } = contextHelpers(ctx);

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_content.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_content.js
@@ -1,10 +1,10 @@
-import itBehavesLikeBasicToolbarStyling from "./behaves_like_basic_styling";
-import itBehavesLikeContentToolbarStyling from "./behaves_like_content_styling";
-import itBehavesLikeBasicToolbarFormatting from "./behaves_like_basic_formatting";
-import itBehavesLikeBasicToolbarList from "./behaves_like_basic_list";
-import itBehavesLikeBasicToolbarBlock from "./behaves_like_basic_block";
-import itBehavesLikeBasicToolbarLink from "./behaves_like_basic_link";
-import itBehavesLikeBasicToolbarIndent from "./behaves_like_basic_indent";
+import itBehavesLikeBasicToolbarStyling from "src/decidim/editor/test/toolbar/shared/behaves_like_basic_styling";
+import itBehavesLikeContentToolbarStyling from "src/decidim/editor/test/toolbar/shared/behaves_like_content_styling";
+import itBehavesLikeBasicToolbarFormatting from "src/decidim/editor/test/toolbar/shared/behaves_like_basic_formatting";
+import itBehavesLikeBasicToolbarList from "src/decidim/editor/test/toolbar/shared/behaves_like_basic_list";
+import itBehavesLikeBasicToolbarBlock from "src/decidim/editor/test/toolbar/shared/behaves_like_basic_block";
+import itBehavesLikeBasicToolbarLink from "src/decidim/editor/test/toolbar/shared/behaves_like_basic_link";
+import itBehavesLikeBasicToolbarIndent from "src/decidim/editor/test/toolbar/shared/behaves_like_basic_indent";
 
 export default (ctx) => {
   ctx.prosemirror = null;

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_content_styling.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_content_styling.js
@@ -1,6 +1,6 @@
-import { selectContent } from "../../helpers";
+import { selectContent } from "src/decidim/editor/test/helpers";
 
-import contextHelpers from "./context";
+import contextHelpers from "src/decidim/editor/test/toolbar/shared/context";
 
 export default (ctx) => {
   const { getControl, setContent } = contextHelpers(ctx);

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/context.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/context.js
@@ -1,4 +1,4 @@
-import { updateContent } from "../../helpers";
+import { updateContent } from "src/decidim/editor/test/helpers";
 
 export default (ctx) => {
   return {

--- a/decidim-core/app/packs/src/decidim/editor/test/utilities/paste_transform.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/utilities/paste_transform.test.js
@@ -1,6 +1,6 @@
-import { transformMsDesktop, transformMsCould } from "../../utilities/paste_transform";
+import { transformMsDesktop, transformMsCould } from "src/decidim/editor/utilities/paste_transform";
 
-import "../helpers";
+import "src/decidim/editor/test/helpers";
 
 const uglifyHtml = (html) => html.replace(/[\r\n]+\s+/g, " ").replace(/>\s+</g, "><").trim();
 

--- a/decidim-core/app/packs/src/decidim/external_domain_warning.test.js
+++ b/decidim-core/app/packs/src/decidim/external_domain_warning.test.js
@@ -1,4 +1,4 @@
-import ExternalDomainLink from "./external_domain_warning";
+import ExternalDomainLink from "src/decidim/external_domain_warning";
 
 describe("ExternalDomainLink", () => {
   const content = `

--- a/decidim-core/app/packs/src/decidim/external_link.test.js
+++ b/decidim-core/app/packs/src/decidim/external_link.test.js
@@ -1,6 +1,6 @@
 import $ from "jquery"; // eslint-disable-line id-length
 
-import ExternalLink from "./external_link";
+import ExternalLink from "src/decidim/external_link";
 
 describe("ExternalLink", () => {
   const content = `

--- a/decidim-core/app/packs/src/decidim/form_filter.component_for_testing.js
+++ b/decidim-core/app/packs/src/decidim/form_filter.component_for_testing.js
@@ -1,6 +1,6 @@
 /* eslint no-undef: 0 */
 
-import FormFilterComponent from "./form_filter"
+import FormFilterComponent from "src/decidim/form_filter"
 
 // This module.exports is necessary for the tests to load
 // does not conflict with import/export

--- a/decidim-core/app/packs/src/decidim/form_filter.js
+++ b/decidim-core/app/packs/src/decidim/form_filter.js
@@ -7,9 +7,9 @@
  * @augments Component
  */
 
-import delayed from "./delayed"
-import CheckBoxesTree from "./check_boxes_tree"
-import { registerCallback, unregisterCallback, pushState, replaceState, state } from "./history"
+import delayed from "src/decidim/delayed"
+import CheckBoxesTree from "src/decidim/check_boxes_tree"
+import { registerCallback, unregisterCallback, pushState, replaceState, state } from "src/decidim/history"
 
 export default class FormFilterComponent {
   constructor($form) {

--- a/decidim-core/app/packs/src/decidim/geocoding/attach_input.js
+++ b/decidim-core/app/packs/src/decidim/geocoding/attach_input.js
@@ -1,5 +1,5 @@
 /* eslint-disable require-jsdoc */
-import getCoordinateInputName from "./coordinate_input"
+import getCoordinateInputName from "src/decidim/geocoding/coordinate_input"
 
 /**
  * You can use this method to "attach" front-end geocoding to any forms in the

--- a/decidim-core/app/packs/src/decidim/i18n.test.js
+++ b/decidim-core/app/packs/src/decidim/i18n.test.js
@@ -1,4 +1,4 @@
-import * as i18n from "./i18n";
+import * as i18n from "src/decidim/i18n";
 
 const config = {
   messages: {

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -15,7 +15,7 @@ import svg4everybody from "svg4everybody"
 import morphdom from "morphdom"
 
 // vendor customizated scripts (bad practice: these ones should be removed eventually)
-import "./vendor/modernizr"
+import "src/decidim/vendor/modernizr"
 
 /**
  * Local dependencies

--- a/decidim-core/app/packs/src/decidim/sw/index.js
+++ b/decidim-core/app/packs/src/decidim/sw/index.js
@@ -1,3 +1,3 @@
-import "./loader"
-import "./a2hs"
-import "./push-permissions"
+import "src/decidim/sw/loader"
+import "src/decidim/sw/a2hs"
+import "src/decidim/sw/push-permissions"

--- a/decidim-core/app/packs/src/decidim/user_registrations.js
+++ b/decidim-core/app/packs/src/decidim/user_registrations.js
@@ -1,4 +1,4 @@
-import PasswordToggler from "./password_toggler";
+import PasswordToggler from "src/decidim/password_toggler";
 
 $(() => {
   const $userRegistrationForm = $("#register-form");

--- a/decidim-forms/app/packs/entrypoints/decidim_forms_admin.js
+++ b/decidim-forms/app/packs/entrypoints/decidim_forms_admin.js
@@ -1,4 +1,4 @@
 import "src/decidim/forms/admin/collapsible_questions"
 
-import createEditableForm from "../src/decidim/forms/admin/forms"
+import createEditableForm from "src/decidim/forms/admin/forms"
 window.Decidim.createEditableForm = createEditableForm

--- a/package-lock.json
+++ b/package-lock.json
@@ -9496,6 +9496,13 @@
       "license": "ISC",
       "peer": true
     },
+    "node_modules/eslint-plugin-no-relative-import-paths": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.5.3.tgz",
+      "integrity": "sha512-z7c7Km1U0zdLyPziWeRKSsN2mPaGaBHDjfXn98B8XjRIhFi2bPqduRYcxWih1kI5al5tQtiChXVmspLkB0wNsQ==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/eslint-plugin-node": {
       "version": "11.1.0",
       "dev": true,
@@ -21446,6 +21453,7 @@
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-no-relative-import-paths": "^1.5.3",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-react": "^7.32.2"
@@ -28166,6 +28174,13 @@
           "peer": true
         }
       }
+    },
+    "eslint-plugin-no-relative-import-paths": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.5.3.tgz",
+      "integrity": "sha512-z7c7Km1U0zdLyPziWeRKSsN2mPaGaBHDjfXn98B8XjRIhFi2bPqduRYcxWih1kI5al5tQtiChXVmspLkB0wNsQ==",
+      "dev": true,
+      "peer": true
     },
     "eslint-plugin-node": {
       "version": "11.1.0",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -13,7 +13,8 @@ module.exports = { // eslint-disable-line
     "sourceType": "module"
   },
   "plugins": [
-    "react"
+    "react",
+    "no-relative-import-paths"
   ],
   "globals": {
     "$": false,
@@ -175,6 +176,10 @@ module.exports = { // eslint-disable-line
     "no-process-exit": "error",
     "no-proto": "error",
     "no-prototype-builtins": "error",
+    "no-relative-import-paths/no-relative-import-paths": [
+      "warn",
+      { "allowSameFolder": false, "rootDir": "decidim-core/app/packs/" }
+    ],
     "no-restricted-globals": "error",
     "no-restricted-imports": "error",
     "no-restricted-modules": "error",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -17,6 +17,7 @@
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-plugin-no-relative-import-paths": "^1.5.3",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.32.2"


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12211 to v0.28

:hearts: Thank you!