### PR TITLE
Backport 'Add missing creation date on the proposals page' to v0.28

### DIFF
--- a/decidim-core/app/cells/decidim/card_metadata_cell.rb
+++ b/decidim-core/app/cells/decidim/card_metadata_cell.rb
@@ -75,7 +75,7 @@ module Decidim
 
       {
         cell: "decidim/coauthorships",
-        args: [resource, { stack: true }]
+        args: [resource, { stack: true, context_actions: [] }]
       }
     end
 

--- a/decidim-core/app/cells/decidim/coauthorships_cell.rb
+++ b/decidim-core/app/cells/decidim/coauthorships_cell.rb
@@ -16,7 +16,7 @@ module Decidim
         cell(
           "decidim/collapsible_authors",
           presenters_for_identities(model),
-          options
+          options.merge(from: model)
         )
       end
     end

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
@@ -26,7 +26,7 @@
     <% end %>
 
     <div class="layout-author">
-      <%= cell "decidim/coauthorships", @collaborative_draft %>
+      <%= cell "decidim/coauthorships", @collaborative_draft, context_actions: [] %>
 
       <% if @collaborative_draft.state %>
         <span class="<%= collaborative_drafts_state_class(@collaborative_draft.state) %> label">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -47,7 +47,7 @@ extra_admin_link(
 
     <% unless component_settings.participatory_texts_enabled? %>
       <div class="layout-author">
-        <%= cell "decidim/coauthorships", @proposal %>
+        <%= cell "decidim/coauthorships", @proposal, context_actions: [:date] %>
 
         <% if not ["section","subsection"].include? @proposal.participatory_text_level %>
           <%== cell("decidim/proposals/proposal_metadata", @proposal).state_item&.dig(:text)&.html_safe %>

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -70,6 +70,7 @@ describe "Proposals" do
       expect(page).to have_content(strip_tags(translated(proposal.body)).strip)
       expect(page).to have_author(proposal.creator_author.name)
       expect(page).to have_content(proposal.reference)
+      expect(page).to have_content(proposal.published_at.strftime("%d/%m/%Y %H:%M"))
     end
 
     context "when process is not related to any scope" do


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12237 to v0.28

:hearts: Thank you!