### PR TITLE
Redesign: HTML clean-up of the design module

### DIFF
--- a/decidim-design/app/views/decidim/design/components/activities/_static-activities.html.erb
+++ b/decidim-design/app/views/decidim/design/components/activities/_static-activities.html.erb
@@ -19,7 +19,7 @@
     </div>
     <div class="activity__author">
       <div class="author" data-author="">
-        <div class="author__container has-tip" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
+        <div class="author__container" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
           <div class=&quot;author__container&quot;>
           <span class=&quot;author__avatar-container&quot;>
           <a href=&quot;#&quot;>

--- a/decidim-design/app/views/decidim/design/components/activities/_static-activity.html.erb
+++ b/decidim-design/app/views/decidim/design/components/activities/_static-activity.html.erb
@@ -18,7 +18,7 @@
   </div>
   <div class="activity__author">
     <div class="author" data-author="">
-      <div class="author__container has-tip" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
+      <div class="author__container" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
         <div class=&quot;author__container&quot;>
         <span class=&quot;author__avatar-container&quot;>
         <a href=&quot;#&quot;>

--- a/decidim-design/app/views/decidim/design/components/author/_static-avatar.html.erb
+++ b/decidim-design/app/views/decidim/design/components/author/_static-avatar.html.erb
@@ -1,5 +1,5 @@
 <div class="author" data-author="">
-  <div class="author__container has-tip" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
+  <div class="author__container" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
     <div class=&quot;author__container&quot;>
     <span class=&quot;author__avatar-container&quot;>
     <a href=&quot;#&quot;>

--- a/decidim-design/app/views/decidim/design/components/author/_static-compact.html.erb
+++ b/decidim-design/app/views/decidim/design/components/author/_static-compact.html.erb
@@ -1,5 +1,5 @@
 <div class="author" data-author="">
-  <div class="author__container is-compact has-tip" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
+  <div class="author__container is-compact" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
     <div class=&quot;author__container&quot;>
     <span class=&quot;author__avatar-container&quot;>
     <a href=&quot;#&quot;>

--- a/decidim-design/app/views/decidim/design/components/author/_static-default.html.erb
+++ b/decidim-design/app/views/decidim/design/components/author/_static-default.html.erb
@@ -1,5 +1,5 @@
 <div class="author" data-author="">
-  <div class="author__container has-tip" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
+  <div class="author__container" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
     <div class=&quot;author__container&quot;>
     <span class=&quot;author__avatar-container&quot;>
     <img alt=&quot;Avatar: Clint Runolfsdottir 2 2 0&quot; class=&quot;author__avatar&quot; src=&quot;<%= asset_pack_path("media/images/default-avatar.svg") %>&quot; />

--- a/decidim-design/app/views/decidim/design/components/cards/_static-card-l-extra-data-2.html.erb
+++ b/decidim-design/app/views/decidim/design/components/cards/_static-card-l-extra-data-2.html.erb
@@ -20,7 +20,7 @@
       €15,233,687
       </span>
       <form class="button_to" method="post" action="/processes/corpse-curriculum/f/4/budgets/1/order/line_item?project_id=1&amp;show_only_added=false" data-remote="true">
-        <button class="button w-full hollow button__transparent-secondary button__sm budget-list__action" id="project-vote-button-1" data-add="true" data-disable="true" data-budget="15233687" data-allocation="15233687" data-redirect-url="/processes/corpse-curriculum/f/4/budgets/1/projects/1" title="Add project Sed harum. to your vote." type="submit">
+        <button class="button w-full button__transparent-secondary button__sm budget-list__action" id="project-vote-button-1" data-add="true" data-disable="true" data-budget="15233687" data-allocation="15233687" data-redirect-url="/processes/corpse-curriculum/f/4/budgets/1/projects/1" title="Add project Sed harum. to your vote." type="submit">
           Add
           <%= icon("add-fill") %>
         </button>

--- a/decidim-design/app/views/decidim/design/components/cards/_static-card-l-image.html.erb
+++ b/decidim-design/app/views/decidim/design/components/cards/_static-card-l-image.html.erb
@@ -13,7 +13,7 @@
       <span>
         <!-- linthtml-disable -->
         <div class="author" data-author="">
-          <div class="author__container has-tip" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
+          <div class="author__container" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
             <div class=&quot;author__container&quot;>
             <span class=&quot;author__avatar-container&quot;>
             <img alt=&quot;Avatar: Terica MacGyver Sr.&quot; class=&quot;author__avatar&quot; src=&quot;<%= asset_pack_path("media/images/default-avatar.svg") %>&quot; />

--- a/decidim-design/app/views/decidim/design/components/cards/_static-card-l.html.erb
+++ b/decidim-design/app/views/decidim/design/components/cards/_static-card-l.html.erb
@@ -7,7 +7,7 @@
       <span>
         <!-- linthtml-disable -->
         <div class="author" data-author="">
-          <div class="author__container has-tip" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
+          <div class="author__container" data-tooltip="<div class=&quot;author__tooltip bottom&quot; role=&quot;tooltip&quot;>
             <div class=&quot;author__container&quot;>
             <span class=&quot;author__avatar-container&quot;>
             <img alt=&quot;Avatar: Tammy Lesch VM&quot; class=&quot;author__avatar&quot; src=&quot;<%= asset_pack_path("media/images/default-avatar.svg") %>&quot; />


### PR DESCRIPTION
#### :tophat: What? Why?
Removal of unused classes in the design module. List of those untouched due to theirt usage in some JS event listener files. These are the following: 
- ```budget-list__action``` within ```decidim-design/app/views/decidim/design/components/cards/_static-card-l-extra-data-2.html.erb:23```
- ```secondary```within ```decidim-design/app/views/decidim/design/foundations/layout.html.erb:26```    &      ```decidim-design/app/views/decidim/design/foundations/layout.html.erb:38```     &      ```decidim-design/app/views/decidim/design/foundations/layout.html.erb:50```

#### :pushpin: Related Issues
- Related to #12178 

#### Testing
Run ```bundle exec erblint decidim-design/**/*.erb``` in your command line.

### :camera: Screenshots

:hearts: Thank you!
