### PR TITLE
Fix Polling station icons needed for maps

### DIFF
--- a/decidim-elections/lib/decidim/votings/engine.rb
+++ b/decidim-elections/lib/decidim/votings/engine.rb
@@ -44,6 +44,7 @@ module Decidim
       end
 
       initializer "decidim_votings.register_icons" do
+        Decidim.icons.register(name: "map-line", icon: "map-line", category: "system", description: "Icon used to display Polling Stations on maps", engine: :votings)
         Decidim.icons.register(name: "Decidim::Votings::Voting", icon: "check-double-fill", description: "Voting", category: "activity", engine: :votings)
         Decidim.icons.register(name: "lock-unlock-line", icon: "lock-unlock-line", category: "system", description: "", engine: :votings)
       end


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing  #12198, i have visited a votings page, that threw an error like the one below. 

```
 ActionView::Template::Error (Icon map-line not found. Register it with 

        Decidim.icons.register(name: "map-line", icon: "map-line", category: "system", description: "", engine: :core)
      ):
```
#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12198
- Related to #11982

#### Testing
1. On develop branch , visit the votings index page 
2. From there navigate to a voting that is currently in progress 
3. You should see the error 
4. Apply patch 
5. Restart and refresh page

:hearts: Thank you!
