### PR TITLE
Fix context on proposal preview

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
@@ -11,7 +11,7 @@
     <h2 class="h3 text-secondary"><%= present(@proposal).title(links: true, html_escape: true) %></h2>
 
     <% unless component_settings.participatory_texts_enabled? %>
-      <%= cell "decidim/coauthorships", @proposal %>
+      <%= cell "decidim/coauthorships", @proposal, context_actions: [] %>
     <% end %>
 
     <div class="editor-content">


### PR DESCRIPTION
#### :tophat: What? Why?
While I was working on #12289, i have noticed the resource context is being set for the proposal author, and that is not a good thing, as it breaks the layout. 
Please refer to below screenshots. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. login as administrator 
2. Go to a Space and create a Proposal 
3. Check the "preview" page
4. Apply patch 
5. Refresh

### :camera: Screenshots

![image](https://github.com/decidim/decidim/assets/105683/9375f1dc-eb07-43ba-bd6e-669f1c039e59)
===========
![image](https://github.com/decidim/decidim/assets/105683/80638ff1-ff1e-4938-a6e2-61ead39c108f)


:hearts: Thank you!
