### PR TITLE
Do not display dates for upcoming moderated meetings

### DIFF
--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -57,7 +57,7 @@ module Decidim
         # meeting for the given participatory space.
         Decidim.view_hooks.register(:upcoming_meeting_for_card, priority: Decidim::ViewHooks::LOW_PRIORITY) do |view_context|
           published_components = Decidim::Component.where(participatory_space: view_context.current_participatory_space).published
-          upcoming_meeting = Decidim::Meetings::Meeting.where(component: published_components).published.upcoming.order(:start_time, :end_time).first
+          upcoming_meeting = Decidim::Meetings::Meeting.where(component: published_components).not_hidden.published.upcoming.order(:start_time, :end_time).first
 
           next unless upcoming_meeting
 

--- a/decidim-meetings/spec/system/upcoming_meeting_for_card_view_hooks_spec.rb
+++ b/decidim-meetings/spec/system/upcoming_meeting_for_card_view_hooks_spec.rb
@@ -45,5 +45,25 @@ describe "Upcoming meeting for card view hook", type: :system do
         end
       end
     end
+
+    context "when the meeting is moderated" do
+      let!(:upcoming_meeting1) do
+        create(:meeting, :published, :moderated, :upcoming, start_time: start_time, end_time: start_time + 1.hour, component: component)
+      end
+
+      it "hides upcoming moderated meetings" do
+        visit decidim_assemblies.assemblies_path
+
+        within "#assembly_#{assembly.id}" do
+          expect(page).to have_selector(".card__icondata")
+
+          within ".card__icondata" do
+            expect(page).to have_text("31 MAY 2100")
+            expect(page).to have_text("12:34")
+            expect(page).to have_text("13:34")
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR hides the moderated upcoming meeting date from assembly and conferences cards. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #11541

#### Testing

1. Visit the website, and click find , select Assemblies 
2. In the Assembly cards, you should be able to see a text labeled " Upcoming meeting " 
3. Visit the assembly, and hide (moderate) all meetings 
4. Refresh the search results. 
5. See the " Upcoming meeting " is still present 
6. Apply patch 
7. See the meeting date is not being shown

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
