### PR TITLE
Backport 'Use git instead of filesystem for releases files' to v0.27

### DIFF
--- a/decidim-accountability/decidim-accountability.gemspec
+++ b/decidim-accountability/decidim-accountability.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim accountability module"
   s.description = "An accountability component for decidim's participatory spaces."
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-comments", Decidim::Accountability.version
   s.add_dependency "decidim-core", Decidim::Accountability.version

--- a/decidim-admin/decidim-admin.gemspec
+++ b/decidim-admin/decidim-admin.gemspec
@@ -17,7 +17,13 @@ Gem::Specification.new do |s|
   s.name = "decidim-admin"
   s.summary = "Decidim organization administration"
   s.description = "Organization administration to manage a single organization."
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "active_link_to", "~> 1.0"
   s.add_dependency "decidim-core", Decidim::Admin.version

--- a/decidim-api/decidim-api.gemspec
+++ b/decidim-api/decidim-api.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim API module"
   s.description = "API engine for decidim"
 
-  s.files = Dir["{app,config,db,lib,vendor,docs}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ docs/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "graphql", "~> 1.12", "< 1.13"
   s.add_dependency "graphql-docs", "~> 2.1.0"

--- a/decidim-assemblies/decidim-assemblies.gemspec
+++ b/decidim-assemblies/decidim-assemblies.gemspec
@@ -16,7 +16,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim assemblies module"
   s.description = "Assemblies component for decidim."
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Assemblies.version
 

--- a/decidim-blogs/decidim-blogs.gemspec
+++ b/decidim-blogs/decidim-blogs.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim blogs module"
   s.description = "A Blog component for decidim's participatory spaces."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-admin", Decidim::Blogs.version
   s.add_dependency "decidim-comments", Decidim::Blogs.version

--- a/decidim-budgets/decidim-budgets.gemspec
+++ b/decidim-budgets/decidim-budgets.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim budgets module"
   s.description = "A budgets component for decidim's participatory spaces."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-comments", Decidim::Budgets.version
   s.add_dependency "decidim-core", Decidim::Budgets.version

--- a/decidim-comments/decidim-comments.gemspec
+++ b/decidim-comments/decidim-comments.gemspec
@@ -17,7 +17,13 @@ Gem::Specification.new do |s|
   s.name = "decidim-comments"
   s.summary = "Decidim comments module"
   s.description = "Pluggable comments system for some components."
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Comments.version
   s.add_dependency "redcarpet", "~> 3.5", ">= 3.5.1"

--- a/decidim-conferences/decidim-conferences.gemspec
+++ b/decidim-conferences/decidim-conferences.gemspec
@@ -16,7 +16,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim conferences module"
   s.description = "Conferences component for decidim."
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Conferences.version
   s.add_dependency "decidim-meetings", Decidim::Conferences.version

--- a/decidim-consultations/decidim-consultations.gemspec
+++ b/decidim-consultations/decidim-consultations.gemspec
@@ -17,7 +17,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim consultations module"
   s.description = "Extends Decidim adding a first level public consultation component"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-admin", Decidim::Consultations.version
   s.add_dependency "decidim-comments", Decidim::Consultations.version

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -17,7 +17,12 @@ Gem::Specification.new do |s|
   s.license = "AGPL-3.0"
   s.required_ruby_version = ">= 3.0"
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "active_link_to", "~> 1.0"
   s.add_dependency "acts_as_list", "~> 0.9"

--- a/decidim-debates/decidim-debates.gemspec
+++ b/decidim-debates/decidim-debates.gemspec
@@ -16,7 +16,13 @@ Gem::Specification.new do |s|
   s.name = "decidim-debates"
   s.summary = "Decidim debates module"
   s.description = "A debates component for decidim's participatory spaces."
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-comments", Decidim::Debates.version
   s.add_dependency "decidim-core", Decidim::Debates.version

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim dev tools"
   s.description = "Utilities and tools we need to develop Decidim"
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "capybara", "~> 3.24"
   s.add_dependency "decidim", Decidim::Dev.version

--- a/decidim-elections/decidim-elections.gemspec
+++ b/decidim-elections/decidim-elections.gemspec
@@ -16,7 +16,12 @@ Gem::Specification.new do |s|
   s.summary = "A decidim elections module (votings space and elections component)"
   s.description = "The Elections module adds elections to any participatory space."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-bulletin_board", "0.23"
   s.add_dependency "voting_schemes-dummy", "0.23"

--- a/decidim-forms/decidim-forms.gemspec
+++ b/decidim-forms/decidim-forms.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim forms"
   s.description = "A forms gem for decidim."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Forms.version
   s.add_dependency "wicked_pdf", "~> 2.1"

--- a/decidim-generators/decidim-generators.gemspec
+++ b/decidim-generators/decidim-generators.gemspec
@@ -18,13 +18,12 @@ Gem::Specification.new do |s|
   s.summary = "Citizen participation framework for Ruby on Rails."
   s.description = "A generator and multiple gems made with Ruby on Rails."
 
-  s.files = Dir[
-    "lib/**/*",
-    "Gemfile",
-    "Gemfile.lock",
-    "Rakefile",
-    "README.md"
-  ]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(lib/ Gemfile Gemfile.lock Rakefile README.md))
+    end
+  end
 
   s.bindir = "exe"
   s.executables = ["decidim"]

--- a/decidim-generators/lib/decidim/generators/component_templates/decidim-component.gemspec.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/decidim-component.gemspec.erb
@@ -16,7 +16,12 @@ Gem::Specification.new do |s|
   s.summary = "A decidim <%= component_name %> module"
   s.description = "<%= component_description %>."
 
-  s.files = Dir["{app,config,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ LICENSE-AGPLv3.txt Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::<%= component_module_name %>.version
 end

--- a/decidim-initiatives/decidim-initiatives.gemspec
+++ b/decidim-initiatives/decidim-initiatives.gemspec
@@ -16,7 +16,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim initiatives module"
   s.description = "Participants initiatives plugin for decidim."
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-admin", Decidim::Initiatives.version
   s.add_dependency "decidim-comments", Decidim::Initiatives.version

--- a/decidim-meetings/decidim-meetings.gemspec
+++ b/decidim-meetings/decidim-meetings.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim meetings module"
   s.description = "A meetings component for decidim's participatory spaces."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Meetings.version
   s.add_dependency "decidim-forms", Decidim::Meetings.version

--- a/decidim-pages/decidim-pages.gemspec
+++ b/decidim-pages/decidim-pages.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim pages module"
   s.description = "A pages component for decidim's participatory processes."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Pages.version
 

--- a/decidim-participatory_processes/decidim-participatory_processes.gemspec
+++ b/decidim-participatory_processes/decidim-participatory_processes.gemspec
@@ -16,7 +16,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim participatory processes module"
   s.description = "Participatory processes component for decidim."
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::ParticipatoryProcesses.version
 

--- a/decidim-proposals/decidim-proposals.gemspec
+++ b/decidim-proposals/decidim-proposals.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim proposals module"
   s.description = "A proposals component for decidim's participatory spaces."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-comments", Decidim::Proposals.version
   s.add_dependency "decidim-core", Decidim::Proposals.version

--- a/decidim-sortitions/decidim-sortitions.gemspec
+++ b/decidim-sortitions/decidim-sortitions.gemspec
@@ -16,7 +16,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim sortitions module"
   s.description = "This module makes possible to select amont a set of proposal by sortition"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-admin", Decidim::Sortitions.version
   s.add_dependency "decidim-comments", Decidim::Sortitions.version

--- a/decidim-surveys/decidim-surveys.gemspec
+++ b/decidim-surveys/decidim-surveys.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim surveys module"
   s.description = "A surveys component for decidim's participatory spaces."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Surveys.version
   s.add_dependency "decidim-forms", Decidim::Surveys.version

--- a/decidim-system/decidim-system.gemspec
+++ b/decidim-system/decidim-system.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |s|
   s.summary = "Decidim system administration"
   s.description = "System administration to create new organization in an installation."
 
-  s.files = Dir["{app,config,db,lib,vendor}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "active_link_to", "~> 1.0"
   s.add_dependency "decidim-core", Decidim::System.version

--- a/decidim-templates/decidim-templates.gemspec
+++ b/decidim-templates/decidim-templates.gemspec
@@ -16,7 +16,12 @@ Gem::Specification.new do |s|
   s.summary = "A decidim templates module"
   s.description = "This module provides a solution to create templates for different Decidim models, such as Proposals and Questionnaires.."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Templates.version
   s.add_dependency "decidim-forms", Decidim::Templates.version

--- a/decidim-verifications/decidim-verifications.gemspec
+++ b/decidim-verifications/decidim-verifications.gemspec
@@ -16,7 +16,12 @@ Gem::Specification.new do |s|
   s.description = "Several verification methods for your decidim instance"
   s.license = "AGPL-3.0"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(app/ config/ db/ lib/ Rakefile README.md))
+    end
+  end
 
   s.add_dependency "decidim-core", Decidim::Verifications.version
 

--- a/decidim.gemspec
+++ b/decidim.gemspec
@@ -18,17 +18,23 @@ Gem::Specification.new do |s|
   s.summary = "Citizen participation framework for Ruby on Rails."
   s.description = "A generator and multiple gems made with Ruby on Rails."
 
-  s.files = Dir[
-    "{docs,lib}/**/*",
-    "LICENSE-AGPLv3.txt",
-    "Rakefile",
-    "README.md",
-    "package.json",
-    "package-lock.json",
-    "packages/**/*",
-    "babel.config.json",
-    "decidim-core/lib/decidim/webpacker/**/*"
-  ]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w(
+                        docs/
+                        lib/
+                        LICENSE-AGPLv3.txt
+                        Rakefile
+                        README.md
+                        package.json
+                        package-lock.json
+                        packages/
+                        babel.config.json
+                        decidim-core/lib/decidim/webpacker/
+                      ))
+    end
+  end
 
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12188 to v0.27

:hearts: Thank you!