### PR TITLE
Backport 'Allow passing a blob object to `AssetRouter::Storage`' to v0.27

### DIFF
--- a/decidim-core/lib/decidim/asset_router/storage.rb
+++ b/decidim-core/lib/decidim/asset_router/storage.rb
@@ -26,7 +26,7 @@ module Decidim
         elsif asset.is_a? ActiveStorage::Blob
           routes.rails_blob_url(asset, **default_options.merge(options))
         else
-          representation_url(**options)
+          routes.rails_representation_url(asset, **default_options.merge(options))
         end
       end
       # rubocop:enable Style/CaseLikeIf

--- a/decidim-core/lib/decidim/asset_router/storage.rb
+++ b/decidim-core/lib/decidim/asset_router/storage.rb
@@ -22,6 +22,8 @@ module Decidim
       def url(**options)
         if asset.is_a? ActiveStorage::Attached
           routes.rails_blob_url(asset.blob, **default_options.merge(options))
+        elsif asset.is_a? ActiveStorage::Blob
+          routes.rails_blob_url(asset, **default_options.merge(options))
         else
           routes.rails_representation_url(asset, **default_options.merge(options))
         end

--- a/decidim-core/lib/decidim/asset_router/storage.rb
+++ b/decidim-core/lib/decidim/asset_router/storage.rb
@@ -20,9 +20,10 @@ module Decidim
       # @param options The options for the URL that are the normal route options
       #   Rails route helpers accept
       def url(**options)
-        if asset.is_a? ActiveStorage::Attached
+        case asset
+        when is_a?(ActiveStorage::Attached)
           routes.rails_blob_url(asset.blob, **default_options.merge(options))
-        elsif asset.is_a? ActiveStorage::Blob
+        when is_a?(ActiveStorage::Blob)
           routes.rails_blob_url(asset, **default_options.merge(options))
         else
           routes.rails_representation_url(asset, **default_options.merge(options))

--- a/decidim-core/lib/decidim/asset_router/storage.rb
+++ b/decidim-core/lib/decidim/asset_router/storage.rb
@@ -19,16 +19,17 @@ module Decidim
       #
       # @param options The options for the URL that are the normal route options
       #   Rails route helpers accept
+      # rubocop:disable Style/CaseLikeIf
       def url(**options)
-        case asset
-        when is_a?(ActiveStorage::Attached)
+        if asset.is_a? ActiveStorage::Attached
           routes.rails_blob_url(asset.blob, **default_options.merge(options))
-        when is_a?(ActiveStorage::Blob)
+        elsif asset.is_a? ActiveStorage::Blob
           routes.rails_blob_url(asset, **default_options.merge(options))
         else
-          routes.rails_representation_url(asset, **default_options.merge(options))
+          representation_url(**options)
         end
       end
+      # rubocop:enable Style/CaseLikeIf
 
       private
 

--- a/decidim-core/spec/lib/asset_router/storage_spec.rb
+++ b/decidim-core/spec/lib/asset_router/storage_spec.rb
@@ -30,6 +30,22 @@ module Decidim::AssetRouter
         end
       end
 
+      context "with an ActiveStorage::Blob" do
+        let(:asset) { organization.official_img_footer.blob }
+
+        it "creates the route to the blob" do
+          expect(subject).to match(%r{^http://localhost:#{default_port}/rails/active_storage/blobs/redirect/.*/avatar.jpg$})
+        end
+
+        context "with extra URL options" do
+          let(:options) { { port: nil, host: "custom.host", utm_source: "website", utm_medium: "email", utm_campaign: "testing" } }
+
+          it "handles the extra URL options correctly" do
+            expect(subject).to match(%r{^http://custom.host/rails/active_storage/blobs/redirect/.*/avatar.jpg\?utm_campaign=testing&utm_medium=email&utm_source=website$})
+          end
+        end
+      end
+
       context "with a variant" do
         let(:asset) { organization.official_img_header.variant(resize_to_fit: [160, 160]) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12122 to v0.27

:hearts: Thank you!