### PR TITLE
Fix help text style in the participatory text upload

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/new_import.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/new_import.html.erb
@@ -19,7 +19,7 @@
             </div>
 
             <div class="row column">
-              <%= form.upload :document, label: t(".document_legend", valid_mime_types: mime_types_with_document_examples).html_safe, button_class: "button button__sm button__transparent-secondary" %>
+              <%= form.upload :document, help_text: t(".document_legend", valid_mime_types: mime_types_with_document_examples).html_safe, button_class: "button button__sm button__transparent-secondary" %>
             </div>
           </div>
         </div>


### PR DESCRIPTION
#### :tophat: What? Why?

The help text when uploading a participatory text file is broken. This PR fixes it. 

#### Testing

1. Sign in as admin
2. Enable Participatory texts in a new Proposal component
3. Go to upload a file in the Participatory text
4. See the help text 

### :camera: Screenshots

#### Before

![Screenshot of the help text broken](https://github.com/decidim/decidim/assets/717367/1215a77a-fa44-4bcc-b2bb-9a2460ef858d)

#### After

![Screenshot of the help text fixed](https://github.com/decidim/decidim/assets/717367/a9bbab55-b3be-4ba3-8ebe-c517691b713a)

:hearts: Thank you!
