### PR TITLE
Fix favicons in admin panel

### DIFF
--- a/decidim-admin/app/views/layouts/decidim/admin/_header.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_header.html.erb
@@ -1,5 +1,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <%= csrf_meta_tags %>
+<%= legacy_favicon %>
+<%= favicon %>
+<%= apple_favicon %>
 <%= stylesheet_pack_tag "decidim_core", "decidim_admin", media: "all" %>
 <%= javascript_pack_tag "decidim_core", "decidim_admin", defer: false %>
 <%= snippets.display(:head) %>


### PR DESCRIPTION
#### :tophat: What? Why?

I noticed that even after an admin uploads a favicon in the admin panel, this isn't shown in the admin panel itself. 

This PR fixes that.

#### Testing

1. Sign in as admin
2. Go to http://localhost:3000/admin/organization/appearance/edit
3. Upload an icon 
4. See the tab in your browser for the favicon

Mind that depending on how aggressive the caching mechanism of your browser is, it **may** be available even though is not accesses in the HTML. This is just how browsers works with favicons. 🤷🏽 

### :camera: Screenshots

![Screenshot of the browser with a favicon in the admin panel](https://github.com/decidim/decidim/assets/717367/1bea90f7-7cea-4ad1-83b8-bebb6ceb4de3)

:hearts: Thank you!
