### PR TITLE
Fix styles for steps checklist in elections

### DIFF
--- a/decidim-elections/app/views/decidim/elections/admin/steps/_create_election.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_create_election.html.erb
@@ -12,13 +12,13 @@
           <% if form.errors.include?(key) %>
             <% Array(form.errors[key]).each do |error| %>
               <li class="flex justify-between mb-2">
-                <span><%= icon "close-line", class: "text-alert", role: "img", "aria-hidden": true %>&nbsp;<%= error.html_safe %></span>
+                <span><%= icon "close-line", class: "inline-block text-alert", role: "img", "aria-hidden": true %>&nbsp;<%= error.html_safe %></span>
                 <% method = key == :published ? :put : :get %>
                 <span><%= fix_it_button_with_icon(value[:link], "pencil-line", method) %></span>
               </li>
             <% end %>
           <% else %>
-            <li class="mb-2"><%= icon "check-line", class: "text-success", role: "img", "aria-hidden": true %>&nbsp;<%= value[:message].html_safe %></li>
+            <li class="mb-2"><%= icon "check-line", class: "inline-block text-success", role: "img", "aria-hidden": true %>&nbsp;<%= value[:message].html_safe %></li>
           <% end %>
         <% end %>
       </ul>
@@ -28,9 +28,9 @@
         <ul>
           <% form.census_messages.each do |key, value| %>
             <% if form.errors.include?(key) %>
-              <li class="mb-2"><%= icon "close-line", class: "text-alert", role: "img", "aria-hidden": true %>&nbsp;<%= form.errors.messages[key][0].html_safe %></li>
+              <li class="mb-2"><%= icon "close-line", class: "inline-block text-alert", role: "img", "aria-hidden": true %>&nbsp;<%= form.errors.messages[key][0].html_safe %></li>
             <% else %>
-              <li class="mb-2"><%= icon "check-line", class: "text-success", role: "img", "aria-hidden": true %>&nbsp;<%= value.html_safe %></li>
+              <li class="mb-2"><%= icon "check-line", class: "inline-block text-success", role: "img", "aria-hidden": true %>&nbsp;<%= value.html_safe %></li>
             <% end %>
           <% end %>
         </ul>
@@ -39,7 +39,7 @@
       <h4 class="mb-2"><%= t(".trustees") %></h4>
       <ul>
         <% if form.participatory_space_trustees.none? %>
-          <li><%= icon "close-line", class: "text-alert", role: "img", "aria-hidden": true %>&nbsp;<%= t(".no_trustees") %></li>
+          <li><%= icon "close-line", class: "inline-block text-alert", role: "img", "aria-hidden": true %>&nbsp;<%= t(".no_trustees") %></li>
         <% end %>
 
         <% form.participatory_space_trustees
@@ -47,7 +47,7 @@
                .sort_by { |_trustee, used| used ? 0 : 1 }
                .each do |trustee, used| %>
           <li <%= "class=text-muted" if !used %>>
-            <%= icon trustee.public_key ? "check-line" : "close-line", class: "text-#{trustee.public_key ? "success" : "alert"}", role: "img", "aria-hidden": true %>
+            <%= icon trustee.public_key ? "check-line" : "close-line", class: "inline-block text-#{trustee.public_key ? "success" : "alert"}", role: "img", "aria-hidden": true %>
             <%= trustee.user.name || trustee.name %> <%= t(".public_key.#{used}").html_safe %>
             <% if used %>
               <%= f.hidden_field :trustee_ids, multiple: true, value: trustee.id %>


### PR DESCRIPTION
#### :tophat: What? Why?
The upgrade to the version 28 left some styles wrongly configured in the steps page of elections. This should fix it.
wrong:
![image](https://github.com/decidim/decidim/assets/1401520/3875b666-e2cf-40e0-a688-e85533ae896d)
fixed:
![image](https://github.com/decidim/decidim/assets/1401520/381ce49e-340e-4f64-bf6e-65248675c220)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
not much to test, just open the "steps" section of an elections component.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![image](https://github.com/decidim/decidim/assets/1401520/9f3d1950-6511-4cc1-9bd6-b02cb62b5663)

:hearts: Thank you!
