### PR TITLE
Fix webpack generation on cells specs

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb
@@ -7,4 +7,7 @@ RSpec.configure do |config|
   config.before(:all, type: :mailer) do
     Dir.chdir(Rails.root) { Webpacker.compile }
   end
+  config.before(:all, type: :cell) do
+    Dir.chdir(Rails.root) { Webpacker.compile }
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Allows running a cell spec as the first spec on a newly generated `test_app`. Without this you'd get a Shackapacker error:

> Shakapacker::Manifest::MissingEntryError

For the past hour we've been debugging with @greenwoodt this error 🙃  

I think this may be related to some flaky specs that we've seen, so I'd want to backport this to v0.28 at least. 

#### Testing

Without this patch:

```console 
bundle exec rake test_app
bin/rspec decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
```

See exceptions related to Shakapacker

With this patch:

```console 
bundle exec rake test_app
bin/rspec decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
```

See that it works well 

:hearts: Thank you!
