### PR TITLE
Fix a11y "page-has-heading-one" warning for some pages in the admin panel

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/admin/import_results/new.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/import_results/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-accountability/app/views/decidim/accountability/admin/projects_import/new.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/projects_import/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/edit.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <% if parent_result %>
         <%= "#{translated_attribute(parent_result.title)} > " %>
       <% end %>
@@ -19,7 +19,7 @@
       <%= render partial: "decidim/accountability/admin/shared/subnav" unless parent_result %>
       <%= link_to t("actions.new_result", scope: "decidim.accountability"), new_result_path(parent_id: parent_result), class: "button button__sm button__secondary" if allowed_to? :create, :result %>
       <%= render partial: "decidim/admin/components/resource_action" %>
-    </h2>
+    </h1>
   </div>
 
   <%= admin_filter_selector(:results) %>

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/new.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-accountability/app/views/decidim/accountability/admin/statuses/edit.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/statuses/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-accountability/app/views/decidim/accountability/admin/statuses/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/statuses/index.html.erb
@@ -1,10 +1,10 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <%= link_to t("actions.new_status", scope: "decidim.accountability"), new_status_path, class: "button button__sm button__secondary" if allowed_to? :create, :status %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-accountability/app/views/decidim/accountability/admin/statuses/new.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/statuses/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/edit.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/index.html.erb
@@ -2,13 +2,13 @@
 <% add_decidim_page_title(translated_attribute(result.title)) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <div>
         <%= link_to "#{translated_attribute(result.title)} > ", edit_result_path(result) %>
         <%= t(".title") %>
       </div>
       <%= link_to t("actions.new_timeline_entry", scope: "decidim.accountability"), new_result_timeline_entry_path(result), class: "button button__sm button__secondary button--title" if allowed_to? :create, :timeline_entry %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/new.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/timeline_entries/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/admin_terms/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/admin_terms/show.html.erb
@@ -1,9 +1,9 @@
 <%= cell("decidim/announcement", announcement_body, callout_class: current_user.admin_terms_accepted? ? "success" : "warning" ) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("title", scope: "decidim.admin.admin_terms_of_service") %>
-  </h2>
+  </h1>
 </div>
 
 <article class="card">

--- a/decidim-admin/app/views/decidim/admin/area_types/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/area_types/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit-form">
   <%= decidim_form_for(@form, html: { class: "form-defaults form edit_area_type" }) do |f| %>

--- a/decidim-admin/app/views/decidim/admin/area_types/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/area_types/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t("decidim.admin.titles.area_types")) %>
 <div class="card" id="area-types">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t "decidim.admin.titles.area_types" %>
       <% if allowed_to? :create, :area_type %>
         <%= link_to t("actions.add", scope: "decidim.admin"), [:new, :area_type], class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
       <table class="table-list">

--- a/decidim-admin/app/views/decidim/admin/area_types/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/area_types/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit-form">
   <%= decidim_form_for(@form, html: { class: "form-defaults form new_area_type" }) do |f| %>

--- a/decidim-admin/app/views/decidim/admin/areas/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/areas/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit-form">
   <%= decidim_form_for(@form, html: { class: "form-defaults form edit_area_" }) do |f| %>

--- a/decidim-admin/app/views/decidim/admin/areas/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/areas/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t("areas", scope: "decidim.admin.titles")) %>
 <div class="card" id="areas">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t "decidim.admin.titles.areas" %>
       <% if allowed_to? :create, :area %>
         <%= link_to t("actions.add", scope: "decidim.admin"), new_area_path, class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <% if @areas.any? %>
     <div class="table-scroll">

--- a/decidim-admin/app/views/decidim/admin/areas/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/areas/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit-form">
   <%= decidim_form_for(@form, url: areas_path, html: { class: "form-defaults form new_area_" }) do |f| %>

--- a/decidim-admin/app/views/decidim/admin/attachment_collections/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/attachment_collections/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("attachment_collections.edit.title", scope: "decidim.admin")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("attachment_collections.edit.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-admin/app/views/decidim/admin/attachment_collections/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/attachment_collections/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t("attachment_collections.index.attachment_collections_title", scope: "decidim.admin")) %>
 <div class="card" id="attachment_collections">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("attachment_collections.index.attachment_collections_title", scope: "decidim.admin") %>
       <% if allowed_to? :create, :attachment_collection %>
         <%= link_to t("actions.attachment_collection.new", scope: "decidim.admin"), url_for(action: :new), class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <% if collection_for.attachment_collections.any? %>
     <div class="table-scroll">

--- a/decidim-admin/app/views/decidim/admin/attachment_collections/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/attachment_collections/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("attachment_collections.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("attachment_collections.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-admin/app/views/decidim/admin/attachments/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/attachments/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-admin/app/views/decidim/admin/attachments/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/attachments/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t(".attachments_title")) %>
 <div class="card" id="attachments">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".attachments_title") %>
       <% if allowed_to? :create, :attachment %>
         <%= link_to t("actions.attachment.new", scope: "decidim.admin"), url_for(action: :new), class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <%= cell("decidim/admin/attachments_privacy_warning", attached_to.attachments) %>
   <% if attached_to.attachments.any? %>

--- a/decidim-admin/app/views/decidim/admin/attachments/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/attachments/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-admin/app/views/decidim/admin/authorization_workflows/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/authorization_workflows/index.html.erb
@@ -1,17 +1,17 @@
 <% add_decidim_page_title(t("authorization_workflows", scope: "decidim.admin.titles")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("authorization_workflows", scope: "decidim.admin.titles") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="card">
   <%= cell("decidim/verifications/revocations", @authorizations) %>
   <div class="card-divider">
-    <h2 class="card-title">
+    <h1 class="card-title">
       <%= t("decidim.admin.titles.authorization_workflows") %>
-    </h2>
+    </h1>
   </div>
   <div class="card-section">
     <table class="table-list table-list--lastleft">

--- a/decidim-admin/app/views/decidim/admin/block_user/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/block_user/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title", name: user.name)) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title", name: user.name) %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-admin/app/views/decidim/admin/categories/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("categories.edit.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-admin/app/views/decidim/admin/categories/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t("categories.index.categories_title", scope: "decidim.admin")) %>
 <div class="card" id="categories">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("categories.index.categories_title", scope: "decidim.admin") %>
       <% if allowed_to? :create, :category %>
         <%= link_to t("actions.category.new", scope: "decidim.admin"), new_category_path(current_participatory_space), class: "button button__sm button__secondary new ml-auto" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
    <% if current_participatory_space.categories.any? %>
     <div class="table-scroll">

--- a/decidim-admin/app/views/decidim/admin/categories/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("categories.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("categories.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-admin/app/views/decidim/admin/components/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title", name: t("#{@component.manifest.name}.name", scope: "decidim.components"))) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title", name: t("#{manifest.name}.name", scope: "decidim.components")) %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-admin/app/views/decidim/admin/components/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("components.title", scope: "decidim.admin") %>
 
       <% if allowed_to?(:create, :component) %>
@@ -20,7 +20,7 @@
         </div>
       </div>
       <% end %>
-    </h2>
+    </h1>
   </div>
 
   <div class="table-scroll">

--- a/decidim-admin/app/views/decidim/admin/components/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title", name: t("#{manifest.name}.name", scope: "decidim.components"))) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title", name: t("#{manifest.name}.name", scope: "decidim.components")) %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-admin/app/views/decidim/admin/conflicts/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/conflicts/index.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("title", scope: "decidim.admin.conflicts")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("title", scope: "decidim.admin.conflicts") %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-admin/app/views/decidim/admin/dashboard/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/dashboard/show.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("decidim.admin.titles.dashboard")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
   <%= t "decidim.admin.titles.dashboard" %> <%= current_organization.name %>
-  </h2>
+  </h1>
 </div>
 
 <div class="content">

--- a/decidim-admin/app/views/decidim/admin/help_sections/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/help_sections/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t "decidim.admin.menu.help_sections" %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit-form">
@@ -13,9 +13,9 @@
             <div class="card-divider">
               <button class="card-divider-button" data-open="true" data-controls="panel-<%= translated_attribute section.name %>" type="button">
                 <%= icon "arrow-right-s-line" %>
-                <h2 class="card-title" id="<%= translated_attribute section.name %>">
+                <h1 class="card-title" id="<%= translated_attribute section.name %>">
                   <%= translated_attribute section.name %>
-                </h2>
+                </h1>
               </button>
             </div>
             <div id="panel-<%= translated_attribute section.name %>" class="card-section">

--- a/decidim-admin/app/views/decidim/admin/impersonatable_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/impersonatable_users/index.html.erb
@@ -6,12 +6,12 @@
 <% end %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t "decidim.admin.titles.impersonatable_users" %>
     <% if allowed_to? :impersonate, :impersonatable_user, user: new_managed_user %>
       <%= link_to t(".impersonate_new_managed_user"), new_impersonatable_user_impersonation_path(:new_managed_user), class: "button button__sm button__secondary #{"disabled" if current_organization.available_authorizations.empty?}" %>
     <% end %>
-  </h2>
+  </h1>
 </div>
 
 <div class="filters__section">

--- a/decidim-admin/app/views/decidim/admin/impersonations/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/impersonations/new.html.erb
@@ -1,6 +1,6 @@
 <% add_decidim_page_title(t("impersonate_new_managed_user", scope: "decidim.admin.impersonations.new")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <% if creating_managed_user? %>
       <%= t(".impersonate_new_managed_user") %>
     <% else %>
@@ -10,7 +10,7 @@
         <%= t(".impersonate_existing_user", name: @form.user.name) %>
       <% end %>
     <% end %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/imports/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/imports/new.html.erb
@@ -1,6 +1,6 @@
 <% add_decidim_page_title(import_manifest.message(:title, self)) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= import_manifest.message(:title, self) %>
 
     <div id="js-other-actions-wrapper">
@@ -23,7 +23,7 @@
 
       <%= link_to t(".actions.back"), manage_component_path(@current_component), class: "button button__sm button__secondary hollow tiny button--simple" %>
     </div>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-admin/app/views/decidim/admin/managed_users/impersonation_logs/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/managed_users/impersonation_logs/index.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("decidim.admin.titles.impersonations")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t "decidim.admin.titles.impersonations" %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-admin/app/views/decidim/admin/managed_users/promotions/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/managed_users/promotions/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".new_managed_user_promotion")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".new_managed_user_promotion") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="section">

--- a/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
@@ -1,6 +1,6 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
 
     <div class="card__filter">
@@ -8,7 +8,7 @@
       |
       <%= link_to t("decidim.admin.moderated_users.tabs.blocked"), moderated_users_path(blocked: true) %>
     </div>
-  </h2>
+  </h1>
 </div>
 
 <%= admin_filter_selector(:moderated_users) %>

--- a/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/index.html.erb
@@ -1,6 +1,6 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
 
     <div class="card__filter">
@@ -8,7 +8,7 @@
       |
       <%= link_to t("actions.hidden", scope: "decidim.moderations"), moderations_path(hidden: true) %>
     </div>
-  </h2>
+  </h1>
 </div>
 <%= admin_filter_selector(:moderations) %>
 <div class="table-scroll">

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/index.html.erb
@@ -1,11 +1,11 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <div>
       <%= link_to "#{t("title", scope: "decidim.admin.moderations.index")} > ", moderations_path %>
       <%= t(".title") %>
     </div>
-  </h2>
+  </h1>
 </div>
 
 <div class="card-section moderation-details">

--- a/decidim-admin/app/views/decidim/admin/moderations/reports/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/reports/show.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <div>
       <%= link_to "#{t("title", scope: "decidim.admin.moderations.index")} > ", moderations_path %>
       <%= link_to "#{t("title", scope: "decidim.admin.moderations.reports.index")} > ", moderation_reports_path %>
       <%= t(".title") %>
     </div>
-  </h2>
+  </h1>
 </div>
 
 <div class="card-section moderation-details">

--- a/decidim-admin/app/views/decidim/admin/newsletter_templates/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletter_templates/index.html.erb
@@ -1,10 +1,10 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t ".title" %>
       <%= link_to t("actions.newsletter.new", scope: "decidim.admin"), [:newsletter_templates], class: "button button__sm button__secondary expanded small new" %>
-    </h2>
+    </h1>
   </div>
 
   <div class="card-section">
@@ -15,13 +15,13 @@
           </iframe>
 
           <div class="card-footer">
-            <h2 class="card-title flex items-center">
+            <h1 class="card-title flex items-center">
               <%= t newsletter_template.public_name_key %>
               <div class="ml-auto">
                 <%= link_to(t(".preview_template"), newsletter_template_path(newsletter_template.name), class: "button button__sm button__secondary") %>
                 <%= link_to(t(".use_template"), new_newsletter_template_newsletter_path(newsletter_template.name), class: "button button__sm button__secondary") %>
               </div>
-            </h2>
+            </h1>
           </div>
         </div>
       <% end %>

--- a/decidim-admin/app/views/decidim/admin/newsletter_templates/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletter_templates/show.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".preview", template_name: t(template_manifest.public_name_key))) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t ".preview", template_name: t(template_manifest.public_name_key) %>
-    </h2>
+    </h1>
   </div>
   <div class="card-section p-4">
     <iframe src="<%= preview_newsletter_template_path(template_manifest.name) %>" class="email-preview newsletter-template-preview w-full h-96">

--- a/decidim-admin/app/views/decidim/admin/newsletters/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/newsletters/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/index.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t ".title" %>
       <div class="flex ml-auto items-center gap-x-4">
         <strong class="font-bold text-md text-gray-2"><%= t("newsletters.index.subscribed_count", scope: "decidim.admin") %></strong>
@@ -10,7 +10,7 @@
           <%= link_to t("actions.newsletter.new", scope: "decidim.admin"), [:newsletter_templates], class: "button button__sm button__secondary new" %>
         <% end %>
       </div>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-admin/app/views/decidim/admin/newsletters/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/newsletters/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/show.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".preview")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".preview" %>
-  </h2>
+  </h1>
 </div>
 <div class="form__wrapper">
   <div class="card">

--- a/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_page_title(t("decidim.admin.titles.participants")) %>
 <div class="card" id="user-groups">
   <div class="item_show__header">
-    <h2 class="item_show__header-title"><%= t "decidim.admin.titles.participants" %></h2>
+    <h1 class="item_show__header-title"><%= t "decidim.admin.titles.participants" %></h1>
   </div>
   <%= admin_filter_selector %>
   <div class="table-scroll">

--- a/decidim-admin/app/views/decidim/admin/officializations/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title", name: user.name)) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title", name: user.name) %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("edit_organization_appearance", scope: "decidim.admin.titles")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("edit_organization_appearance", scope: "decidim.admin.titles") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/organization_external_domain_allowlist/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_external_domain_allowlist/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("edit_external_domains", scope: "decidim.admin.titles")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("title", scope: "decidim.admin.organization_external_domain_allowlist.form") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
@@ -1,13 +1,13 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card" id="private_users">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <% if allowed_to? :create, :space_private_user %>
         <%= link_to t(".import_via_csv"), new_participatory_space_private_users_csv_imports_path, class: "button button__sm button__secondary import" %>
         <%= link_to t("actions.participatory_space_private_user.new", scope: "decidim.admin"), url_for(action: :new), class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <%= admin_filter_selector(:participatory_space_private_users) %>
   <% if participatory_space_private_users.any? %>

--- a/decidim-admin/app/views/decidim/admin/participatory_space_private_users/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_space_private_users/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-admin/app/views/decidim/admin/resource_permissions/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/resource_permissions/edit.html.erb
@@ -2,9 +2,9 @@
 
 <section id="components">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
-    </h2>
+    </h1>
   </div>
 
   <%= form_for @permissions_form, url: url_for(action: :update, **resource_params), html: { class: "form form-defaults" }, method: "put" do |permissions_form| %>

--- a/decidim-admin/app/views/decidim/admin/scope_types/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scope_types/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit-form">
   <%= decidim_form_for(@form, html: { class: "form-defaults form scope_types_edit" }) do |f| %>

--- a/decidim-admin/app/views/decidim/admin/scope_types/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scope_types/index.html.erb
@@ -1,13 +1,13 @@
 <% add_decidim_page_title(t("decidim.admin.titles.scope_types")) %>
 <div class="card" id="scope-types">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t "decidim.admin.titles.scope_types" %>
 
       <% if allowed_to? :create, :scope_type %>
         <%= link_to t("actions.add", scope: "decidim.admin"), [:new, :scope_type], class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-admin/app/views/decidim/admin/scope_types/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scope_types/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit-form">
   <%= decidim_form_for(@form, html: { class: "form-defaults form scope_types_new" }) do |f| %>

--- a/decidim-admin/app/views/decidim/admin/scopes/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scopes/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit-form">
   <%= decidim_form_for(@form, html: { class: "form-defaults form edit_scope" }) do |f| %>

--- a/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
@@ -1,13 +1,13 @@
 <% add_decidim_page_title(t("decidim.admin.titles.scopes")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <% if parent_scope %>
         <%= scope_breadcrumbs(parent_scope).join(" - ").html_safe %> <%= link_to t("actions.add", scope: "decidim.admin"), new_scope_scope_path(parent_scope), class: "button button__sm button__secondary" if allowed_to? :create, :scope %><%= link_to t("actions.edit", scope: "decidim.admin"), edit_scope_path(parent_scope), class: "button button__sm button__secondary" if allowed_to? :edit, :scope, scope: parent_scope %>
       <% else %>
         <%= t "decidim.admin.titles.scopes" %> <%= link_to t("actions.add", scope: "decidim.admin"), new_scope_path, class: "button button__sm button__secondary" if allowed_to? :create, :scope %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <% if @scopes.any? %>
     <div class="table-scroll">

--- a/decidim-admin/app/views/decidim/admin/scopes/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scopes/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit-form">
   <%= decidim_form_for(@form, url: current_scopes_path, html: { class: " form form-defaults new_scope" }) do |f| %>

--- a/decidim-admin/app/views/decidim/admin/shared/landing_page/_content_blocks.html.erb
+++ b/decidim-admin/app/views/decidim/admin/shared/landing_page/_content_blocks.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_page_title(t("edit_landing_page", scope: "decidim.admin.titles")) %>
 <div class="card edit_content_blocks">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= content_blocks_title %>
 
       <div>
@@ -17,7 +17,7 @@
           </ul>
         </div>
       </div>
-    </h2>
+    </h1>
   </div>
 
   <div class="card-section-draggable-list">

--- a/decidim-admin/app/views/decidim/admin/shared/landing_page_content_blocks/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/shared/landing_page_content_blocks/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(content_block.public_name_key)) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t content_block.public_name_key %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/static_page_topics/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_page_topics/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/static_page_topics/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_page_topics/index.html.erb
@@ -2,12 +2,12 @@
 
 <div class="card" id="page_topics">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("page_topics", scope: "decidim.admin.titles") %>
       <% if allowed_to? :create, :attachment_collection %>
         <%= link_to t("static_page_topics.new.create", scope: "decidim.admin"), [:new, :static_page_topic], class: "button button__sm button__secondary expanded small new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <% if topics.any? %>
     <div class="table-scroll">

--- a/decidim-admin/app/views/decidim/admin/static_page_topics/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_page_topics/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/static_pages/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title t(".title") %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t("pages", scope: "decidim.admin.titles")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("pages", scope: "decidim.admin.titles") %>
     <% if allowed_to? :create, :static_page %>
       <%= link_to t("static_pages.new.create", scope: "decidim.admin"), [:new, :static_page], class: "button button__sm button__secondary expanded small new" %>
     <% end %>
-  </h2>
+  </h1>
 </div>
 
 <% @topics.each do |topic| %>

--- a/decidim-admin/app/views/decidim/admin/static_pages/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
@@ -1,10 +1,10 @@
 <% add_decidim_page_title(t("decidim.admin.titles.user_groups")) %>
 <div class="card" id="user-groups">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t "decidim.admin.titles.user_groups" %>
       <%= link_to t(".verify_via_csv"), new_user_groups_csv_verification_path, class: "button button__sm button__secondary" %>
-    </h2>
+    </h1>
   </div>
   <%= admin_filter_selector %>
   <div class="table-scroll">

--- a/decidim-admin/app/views/decidim/admin/user_groups_csv_verifications/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/user_groups_csv_verifications/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-admin/app/views/decidim/admin/users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t("decidim.admin.titles.users")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t "decidim.admin.titles.users" %>
       <% if allowed_to? :create, :admin_user %>
         <%= link_to t("actions.user.new", scope: "decidim.admin"), [:new, :user], class: "button button__sm button__secondary" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <%= admin_filter_selector %>
   <div class="table-scroll">

--- a/decidim-admin/app/views/decidim/admin/users/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/edit.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("info", scope: "decidim.admin.menu.assemblies_submenu")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("info", scope: "decidim.admin.menu.assemblies_submenu") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -3,14 +3,14 @@
 
   <% if parent_assembly && parent_assembly.self_and_ancestors.length %>
     <div class="item_show__header">
-      <h2 class="item_show__header-title">
+      <h1 class="item_show__header-title">
         <% parent_assembly.self_and_ancestors.each_with_index do |assembly, ix| %>
           <%= translated_attribute(assembly.title) %>
           <% unless ix == parent_assembly.self_and_ancestors.length - 1 %>
             &gt;
           <% end %>
         <% end if parent_assembly %>
-      </h2>
+      </h1>
     </div>
   <% end %>
 

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/new.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/new.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("assemblies.new.title", scope: "decidim.admin")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t "assemblies.new.title", scope: "decidim.admin" %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies_types/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies_types/index.html.erb
@@ -2,12 +2,12 @@
 
 <div class="card" id="assembly-types">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t "decidim.admin.titles.assemblies_types" %>
       <%= link_to t("actions.new_assembly_type", scope: "decidim.admin"),
                   [:new, :assemblies_type],
                   class: "button button__sm button__secondary" if allowed_to? :create, :assembly_type %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies_types/new.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies_types/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("assemblies_types.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("assemblies_types.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_copies/new.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_copies/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("assembly_copies.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("assembly_copies.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_imports/new.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_imports/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("assembly_imports.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("assembly_imports.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/edit.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("assembly_members.edit.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("assembly_members.edit.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/index.html.erb
@@ -1,11 +1,11 @@
 <% add_decidim_page_title(t("assembly_members_title", scope: "decidim.admin.assembly_members.index")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("assembly_members_title", scope: "decidim.admin.assembly_members.index") %>
     <% if allowed_to? :create, :assembly_member %>
       <%= link_to t("actions.new_assembly_member", scope: "decidim.admin"), new_assembly_member_path(current_assembly), class: "button button__sm button__secondary new" %>
     <% end %>
-  </h2>
+  </h1>
 </div>
 
 <div class="card" id="assembly_members">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/new.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_members/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("assembly_members.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("assembly_members.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/edit.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("assembly_user_roles.edit.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("assembly_user_roles.edit.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t("assembly_user_roles.index.assembly_admins_title", scope: "decidim.admin")) %>
 <div class="card" id="assembly_admins">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("assembly_user_roles.index.assembly_admins_title", scope: "decidim.admin") %>
       <% if allowed_to? :create, :assembly_user_role %>
          <%= link_to t("actions.new_assembly_user_role", scope: "decidim.admin"), new_assembly_user_role_path(current_assembly), class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <%= admin_filter_selector %>
   <div class="table-scroll">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/new.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("assembly_user_roles.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("assembly_user_roles.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/edit.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/index.html.erb
@@ -1,11 +1,11 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <%= link_to t("actions.new", scope: "decidim.blogs"), new_post_path, class: "button button__sm button__secondary ml-auto" if allowed_to? :create, :blogpost %>
       <%= render partial: "decidim/admin/components/resource_action" %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/new.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-budgets/app/views/decidim/budgets/admin/budgets/edit.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/budgets/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <% if allowed_to? :export, :budget %>
         <%= export_dropdown %>
@@ -13,7 +13,7 @@
         <%= link_to t("actions.new_budget", scope: "decidim.budgets"), new_budget_path, class: "button button__sm button__secondary" if allowed_to? :create, :budget %>
       </div>
       <%= render partial: "decidim/admin/components/resource_action" %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-budgets/app/views/decidim/budgets/admin/budgets/new.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/budgets/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/edit.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title("#{translated_attribute(budget.title)} - #{t(".title")}") %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= "#{translated_attribute(budget.title)} #{t(".title")}" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
@@ -1,14 +1,14 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <div>
         <%= link_to translated_attribute(budget.title), budgets_path %> &gt;
         <%= t(".title") %>
         <span id="js-selected-resources-count" class="component-counter component-counter--inline" title="<%= t("decidim.budgets.admin.projects.index.selected") %>"></span>
       </div>
       <%= render partial: "bulk-actions" %>
-    </h2>
+    </h1>
   </div>
   <%= admin_filter_selector(:projects) %>
   <div class="table-scroll">

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/new.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title("#{translated_attribute(budget.title)} - #{t(".title")}") %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= "#{translated_attribute(budget.title)} &gt; #{t(".title")}".html_safe %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/proposals_imports/new.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_copies/new.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_copies/new.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("conference_copies.new.title", scope: "decidim.admin")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("conference_copies.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_invites/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_invites/index.html.erb
@@ -2,10 +2,10 @@
 
 <div class="card" id="conference-invites">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".invites") %>
       <%= link_to t(".invite_attendee"), conference.registrations_enabled ? new_conference_conference_invite_path(conference) : "#", class: "button button__sm button__secondary #{"disabled" unless conference.registrations_enabled && allowed_to?(:invite_attendee, :conference, conference:)}" %>
-    </h2>
+    </h1>
   </div>
 
   <%= admin_filter_selector %>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_invites/new.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_invites/new.html.erb
@@ -3,9 +3,9 @@
 <%= cell("decidim/announcement", t(".explanation"), callout_class: "warning") %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".new_invite") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_registrations/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_registrations/index.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_page_title(t(".registrations")) %>
 <div class="card" id="conference-registrations">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".registrations") %>
       <% if allowed_to? :export_conference_registrations, :conference, conference: conference %>
         <span class="exports button button__sm button__secondary button--simple button--title" data-toggle="export-dropdown">
@@ -16,7 +16,7 @@
           </ul>
         </div>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/edit.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("conference_speakers.edit.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("conference_speakers.edit.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
@@ -2,12 +2,12 @@
 
 <div class="card" id="conference_speakers">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("conference_speakers.index.conference_speakers_title", scope: "decidim.admin") %>
       <% if allowed_to? :create, :conference_speaker %>
          <%= link_to t("actions.new_speaker", scope: "decidim.admin"), new_conference_speaker_path(current_conference), class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
 
   <div class="filters__section">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/new.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("conference_speakers.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("conference_speakers.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/edit.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("conference_user_roles.edit.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("conference_user_roles.edit.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t("conference_user_roles.index.conference_admins_title", scope: "decidim.admin")) %>
 <div class="card" id="conference_admins">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("conference_user_roles.index.conference_admins_title", scope: "decidim.admin") %>
       <% if allowed_to? :create, :conference_user_role %>
          <%= link_to t("actions.new_conference_user_role", scope: "decidim.admin"), new_conference_user_role_path(current_conference), class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <%= admin_filter_selector %>
   <div class="table-scroll">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/new.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("conference_user_roles.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("conference_user_roles.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/edit.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("info", scope: "decidim.admin.menu.conferences_submenu")) %>
 <% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("info", scope: "decidim.admin.menu.conferences_submenu") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/new.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("conferences.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t "conferences.new.title", scope: "decidim.admin" %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-conferences/app/views/decidim/conferences/admin/diplomas/edit.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/diplomas/edit.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t("diplomas.edit.title", scope: "decidim.conferences.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("diplomas.edit.title", scope: "decidim.conferences.admin") %>
 
     <% if allowed_to?(:send_diplomas, :conference, conference: current_participatory_space ) && current_participatory_space.sign_date.present? && current_participatory_space.conference_registrations.confirmed.any? %>
       <%= link_to t("actions.send_diplomas", scope: "decidim.admin"), send_conference_diploma_path(current_conference), method: :post, id: "send-diplomas", class: "button button__sm button__secondary new #{"disabled" if current_participatory_space.diploma_sent?}" %>
     <% end %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-conferences/app/views/decidim/conferences/admin/media_links/edit.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/media_links/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("media_links.edit.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("media_links.edit.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-conferences/app/views/decidim/conferences/admin/media_links/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/media_links/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t("media_links.index.media_links_title", scope: "decidim.admin")) %>
 <div class="card" id="media_links">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("media_links.index.media_links_title", scope: "decidim.admin") %>
       <% if allowed_to? :create, :media_link %>
          <%= link_to t("actions.new_media_link", scope: "decidim.admin"), new_conference_media_link_path(current_conference), class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-conferences/app/views/decidim/conferences/admin/media_links/new.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/media_links/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("media_links.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("conference_speakers.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-conferences/app/views/decidim/conferences/admin/partners/edit.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/partners/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("partners.edit.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("partners.edit.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-conferences/app/views/decidim/conferences/admin/partners/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/partners/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card" id="partners">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <% if allowed_to? :create, :partner %>
          <%= link_to t("actions.new_partner", scope: "decidim.admin"), new_conference_partner_path(current_conference), class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-conferences/app/views/decidim/conferences/admin/partners/new.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/partners/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("partners.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("partners.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-conferences/app/views/decidim/conferences/admin/registration_types/edit.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/registration_types/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("registration_types.edit.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("registration_types.edit.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-conferences/app/views/decidim/conferences/admin/registration_types/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/registration_types/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card" id="registration_types">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <% if allowed_to? :create, :registration_type %>
          <%= link_to t("actions.new_registration_type", scope: "decidim.admin"), new_conference_registration_type_path(current_conference), class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-conferences/app/views/decidim/conferences/admin/registration_types/new.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/registration_types/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("registration_types.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("registration_types.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-debates/app/views/decidim/debates/admin/debate_closes/edit.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debate_closes/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-debates/app/views/decidim/debates/admin/debates/edit.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-debates/app/views/decidim/debates/admin/debates/index.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <%= export_dropdown if allowed_to? :export, :comments %>
       <%= link_to t("actions.new", scope: "decidim.debates"), new_debate_path, class: "button button__sm button__secondary" if allowed_to? :create, :debate %>
       <%= render partial: "decidim/admin/components/resource_action" %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-debates/app/views/decidim/debates/admin/debates/new.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-elections/app/views/decidim/elections/admin/answers/edit.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/answers/edit.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <div>
       <%= link_to translated_attribute(election.title), elections_path %> &gt;
       <%= link_to translated_attribute(question.title), election_questions_path(election) %> &gt;
       <%= t(".title") %>
     </div>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/answers/index.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <div>
         <%= link_to translated_attribute(election.title), elections_path %> &gt;
         <%= link_to translated_attribute(question.title), election_questions_path(election) %> &gt;
@@ -18,7 +18,7 @@
         <% end %>
         <%= link_to t("actions.new_answer", scope: "decidim.elections"), new_election_question_answer_path(election, question), class: "button button__sm button__secondary" if allowed_to? :create, :answer, election: election, question: question %>
       </div>
-    </h2>
+    </h1>
   </div>
 
   <div class="card-section">

--- a/decidim-elections/app/views/decidim/elections/admin/answers/new.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/answers/new.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <div>
       <%= link_to translated_attribute(election.title), elections_path %> &gt;
       <%= link_to translated_attribute(question.title), election_questions_path(election) %> &gt;
       <%= t(".title") %>
     </div>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-elections/app/views/decidim/elections/admin/elections/edit.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-elections/app/views/decidim/elections/admin/elections/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
 
       <%= link_to t("actions.new_election", scope: "decidim.elections"), new_election_path, class: "button button__sm button__secondary" if allowed_to? :create, :election %>
       <%= render partial: "decidim/admin/components/resource_action" %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-elections/app/views/decidim/elections/admin/elections/new.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-elections/app/views/decidim/elections/admin/proposals_imports/new.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/proposals_imports/new.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <div>
       <%= link_to translated_attribute(election.title), elections_path %> &gt;
       <%= link_to translated_attribute(question.title), election_questions_path(election) %> &gt;
       <%= t(".title") %>
     </div>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-elections/app/views/decidim/elections/admin/questions/edit.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/edit.html.erb
@@ -1,11 +1,11 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <div>
       <%= link_to translated_attribute(election.title), elections_path %> &gt;
       <%= t(".title") %>
     </div>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-elections/app/views/decidim/elections/admin/questions/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/index.html.erb
@@ -1,11 +1,11 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
 
       <%= link_to t("actions.new_question", scope: "decidim.elections"), new_election_question_path(election), class: "button button__sm button__secondary" if allowed_to? :create, :question, election: election %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-elections/app/views/decidim/elections/admin/questions/new.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/new.html.erb
@@ -1,11 +1,11 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <div>
       <%= link_to translated_attribute(election.title), elections_path %> &gt;
       <%= t(".title") %>
     </div>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_created.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_created.html.erb
@@ -1,6 +1,6 @@
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title"><%= t(".title") %></h2>
+    <h1 class="item_show__header-title"><%= t(".title") %></h1>
   </div>
 
   <div class="card-section">

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_key_ceremony.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_key_ceremony.html.erb
@@ -1,6 +1,6 @@
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title"><%= t(".title") %></h2>
+    <h1 class="item_show__header-title"><%= t(".title") %></h1>
   </div>
 
   <div id="trustees_process" class="card-section"

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_key_ceremony_ended.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_key_ceremony_ended.html.erb
@@ -1,6 +1,6 @@
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title"><%= t(".title") %></h2>
+    <h1 class="item_show__header-title"><%= t(".title") %></h1>
   </div>
 
   <div class="card-section">

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_results_published.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_results_published.html.erb
@@ -1,8 +1,8 @@
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <ul class="accordion mb-m evote__preview"

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_tally_ended.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_tally_ended.html.erb
@@ -1,8 +1,8 @@
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <ul class="accordion mb-m evote__preview"

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_tally_started.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_tally_started.html.erb
@@ -1,6 +1,6 @@
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title"><%= t(".title") %></h2>
+    <h1 class="item_show__header-title"><%= t(".title") %></h1>
   </div>
 
   <div id="trustees_process" class="card-section"

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_vote.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_vote.html.erb
@@ -4,7 +4,7 @@
 
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title"><%= t(".title") %></h2>
+    <h1 class="item_show__header-title"><%= t(".title") %></h1>
   </div>
 
   <div class="card-section">

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_vote_ended.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_vote_ended.html.erb
@@ -1,6 +1,6 @@
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title"><%= t(".title") %></h2>
+    <h1 class="item_show__header-title"><%= t(".title") %></h1>
   </div>
 
   <div class="card-section">

--- a/decidim-elections/app/views/decidim/elections/admin/steps/_vote_stats.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/_vote_stats.html.erb
@@ -1,8 +1,8 @@
 <div class="card" data-vote-status="<%= election.bb_status %>">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <% if vote_stats.values.sum == 0 %>

--- a/decidim-elections/app/views/decidim/elections/admin/steps/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/steps/index.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("title", scope: "decidim.elections.trustee_zone.elections.key_ceremony_steps", election: translated_attribute(election.title))) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("title", scope: "decidim.elections.trustee_zone.elections.key_ceremony_steps", election: translated_attribute(election.title)) %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-elections/app/views/decidim/elections/admin/trustees_participatory_spaces/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/trustees_participatory_spaces/index.html.erb
@@ -1,10 +1,10 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card" id="trustees">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <%= link_to t("actions.new_trustee", scope: "decidim.elections"), new_trustee_path, class: "button button__sm button__secondary new ml-auto" %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-elections/app/views/decidim/elections/admin/trustees_participatory_spaces/new.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/trustees_participatory_spaces/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-elections/app/views/decidim/votings/admin/ballot_styles/edit.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/ballot_styles/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-elections/app/views/decidim/votings/admin/ballot_styles/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/ballot_styles/index.html.erb
@@ -3,10 +3,10 @@
 <%= cell("decidim/announcement", t("explanation_callout", scope: "decidim.votings.admin.ballot_styles.index"), callout_class: "warning" ) %>
 <div class="card" id="ballot_styles">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <%= link_to t("actions.new", scope: "decidim.votings.admin.ballot_styles.index"), new_voting_ballot_style_path(current_voting), class: "button button__sm button__secondary" if allowed_to? :create, :ballot_style, voting: current_voting %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-elections/app/views/decidim/votings/admin/ballot_styles/new.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/ballot_styles/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_election_results/_results.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_election_results/_results.html.erb
@@ -1,9 +1,9 @@
 
 <div class="card" id="monitoring_committee_polling_station_closures">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title", election_title: translated_attribute(election.title)).html_safe %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_election_results/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_election_results/index.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card" id="monitoring_committee_election_results">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_members/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_members/index.html.erb
@@ -1,10 +1,10 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card" id="monitoring_committee_members">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <%= link_to t("actions.new", scope: "decidim.votings.monitoring_committee_members"), new_voting_monitoring_committee_member_path(current_voting), class: "button button__sm button__secondary" if allowed_to? :create, :monitoring_committee_member, voting: current_voting %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_members/new.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_members/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_polling_station_closures/_closures.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_polling_station_closures/_closures.html.erb
@@ -6,9 +6,9 @@
 
 <div class="card" id="monitoring_committee_polling_station_closures">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title", election_title: translated_attribute(election.title)).html_safe %>
-    </h2>
+    </h1>
   </div>
 
   <%= admin_filter_selector %>

--- a/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_polling_station_closures/_elections.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_polling_station_closures/_elections.html.erb
@@ -1,8 +1,8 @@
 <div class="card" id="monitoring_committee_polling_station_closures">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_polling_station_closures/edit.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_polling_station_closures/edit.html.erb
@@ -5,9 +5,9 @@
 
 <div class="card" id="monitoring_committee_polling_station_closures">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title", polling_station_title: translated_attribute(closure.polling_station.title), election_title: translated_attribute(closure.election.title)).html_safe %>
-    </h2>
+    </h1>
   </div>
 
   <%= render partial: "closure_certificate_results" %>

--- a/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_verify_elections/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/monitoring_committee_verify_elections/index.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card" id="monitoring_committee_verify_elections">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">
@@ -43,9 +43,9 @@
 
 <div class="card" id="monitoring_committee_verify_elections_instructions">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".how_to_title") %>
-    </h2>
+    </h1>
   </div>
   <div class="card-section">
     <%= content_tag :p, sanitize(t(".how_to_download")) %>

--- a/decidim-elections/app/views/decidim/votings/admin/polling_officers/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_officers/index.html.erb
@@ -1,10 +1,10 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card" id="polling_officers">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <%= link_to t("actions.new", scope: "decidim.votings.polling_officers"), new_voting_polling_officer_path(current_voting), class: "button button__sm button__secondary" if allowed_to? :create, :polling_officer, voting: current_voting %>
-    </h2>
+    </h1>
   </div>
 
   <%= admin_filter_selector %>

--- a/decidim-elections/app/views/decidim/votings/admin/polling_officers/new.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_officers/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-elections/app/views/decidim/votings/admin/polling_stations/edit.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_stations/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-elections/app/views/decidim/votings/admin/polling_stations/index.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_stations/index.html.erb
@@ -1,10 +1,10 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card" id="polling_stations">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <%= link_to t("actions.new", scope: "decidim.votings.polling_stations"), new_voting_polling_station_path(current_voting), class: "button button__sm button__secondary" if allowed_to? :create, :polling_station, voting: current_voting %>
-    </h2>
+    </h1>
   </div>
   <%= admin_filter_selector %>
   <div class="table-scroll">

--- a/decidim-elections/app/views/decidim/votings/admin/polling_stations/new.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/polling_stations/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-elections/app/views/decidim/votings/admin/votings/edit.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/votings/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("info", scope: "decidim.votings.admin.menu.votings_submenu")) %>
 <% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
 <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
     <%= t("info", scope: "decidim.votings.admin.menu.votings_submenu") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-elections/app/views/decidim/votings/admin/votings/new.html.erb
+++ b/decidim-elections/app/views/decidim/votings/admin/votings/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("votings.new.title", scope: "decidim.votings.admin")) %>
 <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
     <%= t("votings.new.title", scope: "decidim.votings.admin") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-elections/app/views/decidim/votings/census/admin/census/show.html.erb
+++ b/decidim-elections/app/views/decidim/votings/census/admin/census/show.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_page_title(t("show.heading", scope: "decidim.votings.census.admin.census")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("show.heading", scope: "decidim.votings.census.admin.census") %>
 
       <% if current_census.data_created? %>
@@ -11,7 +11,7 @@
                     method: :delete,
                     data: { confirm: t("delete.confirm", scope: "decidim.votings.census.admin.census") } %>
       <% end %>
-    </h2>
+    </h1>
   </div>
 
   <div id="wrapper-action-view">

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/index.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/index.html.erb
@@ -1,9 +1,9 @@
 <div class="card" id="answers">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t ".title", total: @total %>
       <%= link_to t("actions.back", scope: "decidim.forms.admin.questionnaires"), questionnaire_url, class: "button button__sm button__secondary new" %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/show.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/answers/show.html.erb
@@ -1,13 +1,13 @@
 <div class="card" id="answers">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t ".title", number: current_idx %>
 
       <%= link_to t("actions.next", scope: "decidim.forms.admin.questionnaires.answers").html_safe, next_url, rel: "next", class: "button button__sm button__secondary next" unless last? %>
       <%= link_to t("actions.previous", scope: "decidim.forms.admin.questionnaires.answers").html_safe, prev_url, rel: "prev", class: "button button__sm button__secondary prev" unless first? %>
       <%= link_to t("actions.export", scope: "decidim.forms.admin.questionnaires.answers"), questionnaire_export_response_url(@participant.session_token), class: "button button__sm button__secondary export" %>
       <%= link_to t("actions.back", scope: "decidim.forms.admin.questionnaires.answers"), questionnaire_participants_url, class: "button button__sm button__secondary back" %>
-    </h2>
+    </h1>
   </div>
   <div class="card-section">
      <div class="table">

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit.html.erb
@@ -5,7 +5,7 @@
 <% else %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= edit_questionnaire_title %>
 
     <% unless template? questionnaire.questionnaire_for %>
@@ -21,7 +21,7 @@
         <button class="button button__sm button__secondary whitespace-nowrap" disabled><%= t("empty", scope: "decidim.forms.admin.questionnaires.answers") %></button>
       <% end %>
     <% end %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/answers/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("decidim.admin_log.helpers.answers") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">
@@ -13,7 +13,7 @@
       <div class="form__wrapper">
         <div class="card">
           <div class="card-divider">
-            <h2 class="card-title"><%= t ".title", title: translated_attribute(current_initiative.title) %></h2>
+            <h1 class="card-title"><%= t ".title", title: translated_attribute(current_initiative.title) %></h1>
           </div>
 
           <div class="card-section">

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/committee_requests/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/committee_requests/index.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card" id="committee_members">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t ".title" %>
-    </h2>
+    </h1>
   </div>
 
   <div class="card-section p-4">

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("info", scope: "decidim.admin.menu.initiatives_submenu")) %>
 <% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("info", scope: "decidim.admin.menu.initiatives_submenu") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -1,13 +1,13 @@
 <% add_decidim_page_title(t("decidim.admin.titles.initiatives")) %>
 <div class="card" id="initiatives">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("decidim.admin.titles.initiatives") %>
 
       <% if allowed_to? :export, :initiatives %>
         <%= export_dropdowns(query) %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <%= admin_filter_selector(:initiatives) %>
   <div class="table-scroll">

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_settings/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_settings/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("decidim.initiatives.admin.initiatives_settings.form.title")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t "title", scope: "decidim.initiatives.admin.initiatives_settings.form" %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_type_scopes/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_type_scopes/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 
 <div>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_type_scopes/new.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_type_scopes/new.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 
 <div>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(translated_attribute(current_initiative_type.title)) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t "decidim.admin.titles.initiatives_types" %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/index.html.erb
@@ -2,12 +2,12 @@
 
 <div class="card" id="initiative-types">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t "decidim.admin.titles.initiatives_types" %>
       <%= link_to t("actions.new_initiative_type", scope: "decidim.admin"),
                   [:new, :initiatives_type],
                   class: "button button__sm button__secondary" if allowed_to? :create, :initiative_type %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/new.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-meetings/app/views/decidim/meetings/admin/agenda/edit.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/agenda/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-meetings/app/views/decidim/meetings/admin/agenda/new.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/agenda/new.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-meetings/app/views/decidim/meetings/admin/invites/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/invites/index.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".invite_attendee")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".invite_attendee") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">
@@ -24,7 +24,7 @@
 
     <div class="card" id="meeting-invites">
       <div class="card-divider">
-        <h2 class="card-title"><%= t(".invites") %></h2>
+        <h1 class="card-title"><%= t(".invites") %></h1>
       </div>
       <div class="table-scroll">
         <table class="table-list">

--- a/decidim-meetings/app/views/decidim/meetings/admin/meeting_closes/edit.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meeting_closes/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-meetings/app/views/decidim/meetings/admin/meeting_copies/new.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meeting_copies/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("meeting_copies.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("meeting_copies.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/edit.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <%= export_dropdowns(query) %>
       <%= link_to t("actions.new_meeting", scope: "decidim.meetings"), new_meeting_path, class: "button button__sm button__secondary" if allowed_to? :create, :meeting %>
       <%= render partial: "decidim/admin/components/resource_action" %>
-    </h2>
+    </h1>
   </div>
 
   <%= admin_filter_selector(:meetings) %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/new.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/edit.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/edit.html.erb
@@ -1,6 +1,6 @@
 <% add_decidim_page_title(edit_questionnaire_title) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= edit_questionnaire_title %>
     <% if questionnaire.answers.any? %>
       <div class="button--title">
@@ -9,7 +9,7 @@
     <% else %>
       <button class="button button__sm button__secondary" disabled><%= t("empty", scope: "decidim.forms.admin.questionnaires.answers") %></button>
     <% end %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-meetings/app/views/decidim/meetings/admin/registrations/edit.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <% add_decidim_page_title(t("title", scope: "decidim.meetings.admin.registrations.form")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("title", scope: "decidim.meetings.admin.registrations.form") %>
     <div class="flex items-center gap-x-4 ml-auto">
       <%= link_to t("invites", scope: "decidim.meetings.admin.registrations.form"), meeting_registrations_invites_path(meeting), class: "button button__sm button__secondary #{"disabled" unless allowed_to? :read_invites, :meeting, meeting: meeting}" %>
@@ -19,7 +19,7 @@
       <% end %>
       <%= link_to t("registration_form" , scope: "decidim.meetings.admin.registrations.form"), edit_meeting_registrations_form_path(meeting_id: meeting.id), class: "button button__sm button__secondary" %>
     </div>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">
@@ -27,9 +27,9 @@
     <% if meeting.component.settings.registration_code_enabled %>
       <div class="card mb-4">
         <div class="card-divider">
-          <h2 class="card-title">
+          <h1 class="card-title">
             <%= t(".validate_registration_code") %>
-          </h2>
+          </h1>
         </div>
         <div class="card-section">
           <%= decidim_form_for(@validation_form, url: validate_registration_code_meeting_registrations_path, html: { class: "form form-defaults validate_meeting_registration_code" })  do |f| %>

--- a/decidim-pages/app/views/decidim/pages/admin/pages/edit.html.erb
+++ b/decidim-pages/app/views/decidim/pages/admin/pages/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
     <%= render partial: "decidim/admin/components/resource_action" %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_copies/new.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_copies/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("participatory_process_copies.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("participatory_process_copies.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/edit.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title t("participatory_process_groups.edit.title", scope: "decidim.admin") %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t "participatory_process_groups.edit.title", scope: "decidim.admin" %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/new.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/new.html.erb
@@ -12,9 +12,9 @@
   </div>
 <% end %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t "participatory_process_groups.new.title", scope: "decidim.admin" %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_imports/new.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_imports/new.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("participatory_process_imports.new.title", scope: "decidim.admin")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("participatory_process_imports.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/edit.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("participatory_process_steps.edit.title", scope: "decidim.admin")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("participatory_process_steps.edit.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t("participatory_process_steps.index.steps_title", scope: "decidim.admin")) %>
 <div class="card" id="steps">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("participatory_process_steps.index.steps_title", scope: "decidim.admin") %>
       <% if allowed_to? :create, :process_step %>
         <%= link_to t("actions.new_process_step", scope: "decidim.admin"), new_participatory_process_step_path(current_participatory_process), class: "button button__sm button__secondary ml-auto" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <% if current_participatory_process.steps.any? %>
     <div class="table-scroll">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/new.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("participatory_process_steps.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("participatory_process_steps.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_types/edit.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_types/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title t("participatory_process_types.edit.title", scope: "decidim.admin") %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("participatory_process_types.edit.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_types/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_types/index.html.erb
@@ -1,14 +1,14 @@
 <% add_decidim_page_title(t("titles.participatory_process_types", scope: "decidim.admin")) %>
 <div class="card" id="participatory-process-types">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("titles.participatory_process_types", scope: "decidim.admin") %>
       <%= link_to(
             t("actions.new_process_type", scope: "decidim.admin"),
             [:new, :participatory_process_type],
             class: "button button__sm button__secondary"
           ) if allowed_to? :create, :participatory_process_type %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_types/new.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_types/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("participatory_process_types.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("participatory_process_types.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/edit.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("participatory_process_user_roles.edit.title", scope: "decidim.admin")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("participatory_process_user_roles.edit.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/index.html.erb
@@ -2,12 +2,12 @@
 
 <div class="card" id="process_admins">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("participatory_process_user_roles.index.process_admins_title", scope: "decidim.admin") %>
       <% if allowed_to? :create, :process_user_role %>
          <%= link_to t("actions.new_process_user_role", scope: "decidim.admin"), new_participatory_process_user_role_path(current_participatory_process), class: "button button__sm button__secondary new ml-auto" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <%= admin_filter_selector %>
   <div class="table-scroll">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/new.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/new.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("participatory_process_user_roles.new.title", scope: "decidim.admin")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("participatory_process_user_roles.new.title", scope: "decidim.admin") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/edit.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("info", scope: "decidim.admin.menu.participatory_processes_submenu")) %>
 <% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("info", scope: "decidim.admin.menu.participatory_processes_submenu") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/new.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t("participatory_processes.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("title", scope: "decidim.admin.participatory_processes.new") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/index.html.erb
@@ -1,10 +1,10 @@
 <% add_decidim_page_title(t(".title")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
     <%= render partial: "bulk-actions" %>
-  </h2>
+  </h1>
 </div>
 <% if @drafts.any? %>
   <div class="item__edit item__edit-1col">

--- a/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/new_import.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/new_import.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/edit.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -1,14 +1,14 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <div>
         <%= t(".title") %>
         <span id="js-selected-proposals-count" class="component-counter component-counter--inline" title="<%= t("decidim.proposals.admin.proposals.index.selected") %>"></span>
       </div>
         <%= render partial: "bulk-actions" %>
         <%= render partial: "decidim/admin/components/resource_action" %>
-    </h2>
+    </h1>
   </div>
   <%= admin_filter_selector(:proposals) %>
   <div class="table-scroll mt-16">

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/confirm_destroy.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/confirm_destroy.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/edit.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(translated_attribute(sortition.title)) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
@@ -1,13 +1,13 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
       <% if allowed_to? :create, :sortition %>
         <%= link_to t("actions.new_sortition", scope: "decidim.sortitions.admin"), new_sortition_path, class: "button button__sm button__secondary" %>
       <% end %>
       <%= render partial: "decidim/admin/components/resource_action" %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/new.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t ".title" %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/show.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/show.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(translated_attribute(sortition.title)) %>
 <div class="card" id="sortition">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= decidim_html_escape(translated_attribute(sortition.title)) %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list sortition">

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/edit.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/edit.html.erb
@@ -5,7 +5,7 @@
 <% else %>
 
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= edit_questionnaire_title %>
 
       <% if allowed_to? :preview, :questionnaire %>
@@ -21,7 +21,7 @@
       <% end %>
       <%= render partial: "decidim/admin/components/resource_action" %>
 
-    </h2>
+    </h1>
   </div>
 
   <div class="item__edit item__edit-1col">

--- a/decidim-templates/app/views/decidim/templates/admin/block_user_templates/edit.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/block_user_templates/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-templates/app/views/decidim/templates/admin/block_user_templates/index.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/block_user_templates/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t ".title" %>
       <% if allowed_to?(:create, :template) %>
         <%= link_to t("actions.new_template", scope: "decidim.admin.templates"), [:new, :block_user_template], class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <% if @templates.any? %>
     <div class="table-scroll">

--- a/decidim-templates/app/views/decidim/templates/admin/block_user_templates/new.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/block_user_templates/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-templates/app/views/decidim/templates/admin/proposal_answer_templates/edit.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/proposal_answer_templates/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-templates/app/views/decidim/templates/admin/proposal_answer_templates/index.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/proposal_answer_templates/index.html.erb
@@ -2,12 +2,12 @@
 
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t ".title" %>
       <% if allowed_to?(:create, :template) %>
         <%= link_to t("actions.new_template", scope: "decidim.admin.templates"), [:new, :proposal_answer_template], class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <% if @templates.any? %>
     <div class="table-scroll">

--- a/decidim-templates/app/views/decidim/templates/admin/proposal_answer_templates/new.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/proposal_answer_templates/new.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/_choose.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/_choose.html.erb
@@ -1,10 +1,10 @@
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= form_title %>
     <div class="ml-auto">
       <%= link_to t(".skip_template"), decidim_admin_templates.skip_questionnaire_templates_path(questionnaire_id: questionnaire, url: request.url), class: "button button__sm button__secondary", method: :post %>
     </div>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/edit.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/edit.html.erb
@@ -1,8 +1,8 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">
@@ -17,9 +17,9 @@
 
     <div class="card mt-4">
       <div class="card-divider">
-        <h2 class="card-title"><%= t(".questionnaire") %>
+        <h1 class="card-title"><%= t(".questionnaire") %>
           <%= link_to t(".edit"), edit_questionnaire_path(template), class: "button button__sm button__secondary" %>
-        </h2>
+        </h1>
       </div>
 
       <div class="card-section questionnaire-template-preview">

--- a/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/index.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/index.html.erb
@@ -1,12 +1,12 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t ".title" %>
       <% if allowed_to?(:create, :template) %>
         <%= link_to t("actions.new_template", scope: "decidim.admin.templates"), [:new, :questionnaire_template], class: "button button__sm button__secondary new" %>
       <% end %>
-    </h2>
+    </h1>
   </div>
   <% if @templates.any? %>
     <div class="table-scroll">

--- a/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/new.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/new.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 <% add_decidim_page_title(t("templates", scope: "decidim.admin.titles")) %>
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-verifications/app/views/decidim/verifications/csv_census/admin/census/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/csv_census/admin/census/index.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("admin.index.title", scope: "decidim.verifications.csv_census")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t("admin.index.title", scope: "decidim.verifications.csv_census") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-verifications/app/views/decidim/verifications/csv_census/admin/census/instructions.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/csv_census/admin/census/instructions.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t("admin.instructions.title", scope: "decidim.verifications.csv_census") ) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t("admin.instructions.title", scope: "decidim.verifications.csv_census") %>
-    </h2>
+    </h1>
   </div>
   <div class="card-section">
     <p><%= t("admin.instructions.body", scope: "decidim.verifications.csv_census") %></p>

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/config/edit.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/config/edit.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".title")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".title") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/confirmations/new.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/confirmations/new.html.erb
@@ -1,10 +1,10 @@
 <% add_decidim_page_title(t(".introduce_user_data")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".introduce_user_data") %>
     <%= link_to t(".reject"), pending_authorization_rejection_path(@pending_authorization), method: :post, class: "button button__sm button__secondary alert tiny button--title destroy" %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/offline_confirmations/new.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/offline_confirmations/new.html.erb
@@ -1,9 +1,9 @@
 <% add_decidim_page_title(t(".introduce_user_data")) %>
 
 <div class="item_show__header">
-  <h2 class="item_show__header-title">
+  <h1 class="item_show__header-title">
     <%= t(".introduce_user_data") %>
-  </h2>
+  </h1>
 </div>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/pending_authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/pending_authorizations/index.html.erb
@@ -1,11 +1,11 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
         <%= link_to t(".config"), edit_config_path, class: "button button__sm button__secondary" %>
         <%= link_to t(".offline_verification"), new_offline_confirmation_path, class: "button button__sm button__secondary" if has_offline_method? %>
-    </h2>
+    </h1>
   </div>
   <div class="table-scroll">
     <table class="table-list">

--- a/decidim-verifications/app/views/decidim/verifications/postal_letter/admin/pending_authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/postal_letter/admin/pending_authorizations/index.html.erb
@@ -2,9 +2,9 @@
 <div class="card">
 
   <div class="item_show__header">
-    <h2 class="item_show__header-title">
+    <h1 class="item_show__header-title">
       <%= t(".title") %>
-    </h2>
+    </h1>
   </div>
 
   <div class="table-scroll">


### PR DESCRIPTION
#### :tophat: What? Why?

Lots of pages in the admin panel have the same error in the WAI WCAG checker 

> page-has-heading-one - Page should contain a level-one heading
> Impact: moderate
> Ensure that the page, or at least one of its frames contains a level-one heading

This PR fixes that error in the pages with the item_show__header-title class, as `h1` is what it should be used for titles instead of `h2` 

#### Testing

1. Go to any of these pages
2. Click in the WAI WCAG checker in the left side
3. See that don't see this error anymore 

:hearts: Thank you!
