### PR TITLE
Add matrix for Decidim/Ruby/Node versions in manual guide

### DIFF
--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -12,14 +12,7 @@ In order to develop on decidim, you will need:
 
 The compatibility between the different versions of the components is the following:
 
-|===
-|Decidim version |Ruby version |Node version
-
-|v0.28 | 3.1.1 | 18.17.x
-
-|v0.27 | 3.0.2 | 16.18.x
-
-|===
+include::install:partial$version_matrix.adoc[]
 
 We are starting with an Ubuntu 22.04.3 LTS. This is an opinionated guide, so you are free to use the technology that you are most comfortable. If you have any doubts and you are blocked you can go and ask on https://matrix.to/#/#decidimdevs:matrix.org[our Matrix.org chat room for developers].
 

--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -10,6 +10,17 @@ In order to develop on decidim, you will need:
 * *ImageMagick*
 * *Chrome* browser and https://sites.google.com/a/chromium.org/chromedriver/[chromedriver].
 
+The compatibility between the different versions of the components is the following:
+
+|===
+|Decidim version |Ruby version |Node version
+
+|v0.28 | 3.1.1 | 18.17.x
+
+|v0.27 | 3.0.2 | 16.18.x
+
+|===
+
 We are starting with an Ubuntu 22.04.3 LTS. This is an opinionated guide, so you are free to use the technology that you are most comfortable. If you have any doubts and you are blocked you can go and ask on https://matrix.to/#/#decidimdevs:matrix.org[our Matrix.org chat room for developers].
 
 We recommend to have at least some basic proficiency in GNU/Linux (i.e. how to use the command-line, packages, etc), networking knowledge, server administration, development in general, and some basic knowledge about software package managers. It would be great to have Ruby on Rails development basics (a good starting point is http://guides.rubyonrails.org/getting_started.html[Getting Started with Ruby on Rails]) and have some knowledge on how package libraries are working (we use `bundler` for handling ruby packages, and `npm`/`yarn` for handling javascript).

--- a/docs/modules/install/pages/update.adoc
+++ b/docs/modules/install/pages/update.adoc
@@ -80,6 +80,11 @@ gem "decidim-initiatives", DECIDIM_VERSION
 gem "decidim-dev", DECIDIM_VERSION
 ----
 
+== Compatiblity versions matrix
+
+There are different versions of Decidim that are compatible with different versions of Ruby and Node. You can check the following table to see which versions are compatible with each other:
+
+include::install:partial$version_matrix.adoc[]
 
 [discrete]
 == Recommendations

--- a/docs/modules/install/partials/version_matrix.adoc
+++ b/docs/modules/install/partials/version_matrix.adoc
@@ -1,0 +1,9 @@
+
+|===
+|Decidim version |Ruby version |Node version
+
+|v0.28 | 3.1.1 | 18.17.x
+
+|v0.27 | 3.0.2 | 16.18.x
+
+|===

--- a/docs/modules/install/partials/version_matrix.adoc
+++ b/docs/modules/install/partials/version_matrix.adoc
@@ -1,9 +1,13 @@
 
 |===
-|Decidim version |Ruby version |Node version
+|Decidim version |Ruby version |Node version | Status
 
-|v0.28 | 3.1.1 | 18.17.x
+|develop | 3.2.2 | 18.17.x | Unreleased
 
-|v0.27 | 3.0.2 | 16.18.x
+|v0.28 | 3.1.1 | 18.17.x | Bug fixes and security updates
+
+|v0.27 | 3.0.2 | 16.18.x | Bug fixes and security updates
+
+|v0.26 | 2.7.5+ | 16.9.x | Not maintained
 
 |===


### PR DESCRIPTION
#### :tophat: What? Why?

In #10473, it was suggested that we clarify which versions of Decidim are compatible with which versions of Ruby/Node. This PR implements that, both in the Installation and the Update pages of the doc. 

#### :pushpin: Related Issues

- Fixes #10473 

#### Testing

It's a mess to work locally with antora and this repostiory, so yeah, check out the screenshot 😇 

### :camera: Screenshots

![Screenshot of the documentation in the Installations page](https://github.com/decidim/decidim/assets/717367/6fc3c592-3d59-4045-9eaa-3adda674adf1)

![Screenshot of the documentation in the Update page](https://github.com/decidim/decidim/assets/717367/b37ea6ce-17d4-40d9-b51e-51c2fe8d9668)

:hearts: Thank you!
