### PR TITLE
Fix bug in welcome notifications when the organization has weird characters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,6 @@ PATH
       loofah (~> 2.19, >= 2.19.1)
       mime-types (>= 1.16, < 4.0)
       mini_magick (~> 4.9)
-      mustache (~> 1.1.0)
       net-smtp (~> 0.3.1)
       omniauth (~> 2.0)
       omniauth-facebook (~> 5.0)
@@ -512,7 +511,6 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.2.3)
-    mustache (1.1.1)
     net-imap (0.2.3)
       digest
       net-protocol

--- a/decidim-core/app/events/decidim/welcome_notification_event.rb
+++ b/decidim-core/app/events/decidim/welcome_notification_event.rb
@@ -49,6 +49,7 @@ module Decidim
         .gsub("{{organization}}", organization.name)
         .gsub("{{help_url}}", url_helpers.pages_url(host: organization.host))
         .gsub("{{badges_url}}", url_helpers.gamification_badges_url(host: organization.host))
+        .html_safe
     end
   end
 end

--- a/decidim-core/app/events/decidim/welcome_notification_event.rb
+++ b/decidim-core/app/events/decidim/welcome_notification_event.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "mustache"
-
 module Decidim
   class WelcomeNotificationEvent < Decidim::Events::BaseEvent
     include Decidim::Events::EmailEvent
@@ -46,13 +44,11 @@ module Decidim
     private
 
     def interpolate(template)
-      Mustache.render(
-        template.to_s,
-        organization: organization.name,
-        name: user.name,
-        help_url: url_helpers.pages_url(host: organization.host),
-        badges_url: url_helpers.gamification_badges_url(host: organization.host)
-      ).html_safe
+      template
+        .gsub("{{name}}", user.name)
+        .gsub("{{organization}}", organization.name)
+        .gsub("{{help_url}}", url_helpers.pages_url(host: organization.host))
+        .gsub("{{badges_url}}", url_helpers.gamification_badges_url(host: organization.host))
     end
   end
 end

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -55,7 +55,6 @@ Gem::Specification.new do |s|
   s.add_dependency "loofah", "~> 2.19", ">= 2.19.1"
   s.add_dependency "mime-types", ">= 1.16", "< 4.0"
   s.add_dependency "mini_magick", "~> 4.9"
-  s.add_dependency "mustache", "~> 1.1.0"
   s.add_dependency "net-smtp", "~> 0.3.1"
   s.add_dependency "omniauth", "~> 2.0"
   s.add_dependency "omniauth-facebook", "~> 5.0"

--- a/decidim-core/spec/events/decidim/welcome_notification_event_spec.rb
+++ b/decidim-core/spec/events/decidim/welcome_notification_event_spec.rb
@@ -13,17 +13,38 @@ describe Decidim::WelcomeNotificationEvent do
     )
   end
   let(:event_name) { "decidim.events.core.welcome_notification" }
-  let(:user) { create(:user) }
+  let(:user) { create(:user, organization:) }
+  let(:organization) { create(:organization, name: organization_name) }
 
-  describe "#email_subject" do
-    subject { event_instance.email_subject }
+  context "with a normal organization name" do
+    let(:organization_name) { "My Organization" }
 
-    it { is_expected.to eq("Thanks for joining #{user.organization.name}!") }
+    describe "#email_subject" do
+      subject { event_instance.email_subject }
+
+      it { is_expected.to eq("Thanks for joining My Organization!") }
+    end
+
+    describe "#email_intro" do
+      subject { event_instance.email_intro }
+
+      it { is_expected.to match(%r{^<p>Hi #{CGI.escapeHTML(user.name)}, thanks for joining My Organization and welcome!</p>}) }
+    end
   end
 
-  describe "#email_intro" do
-    subject { event_instance.email_intro }
+  context "with an organization with an apostrophe" do
+    let(:organization_name) { "My ol'Organization" }
 
-    it { is_expected.to match(%r{^<p>Hi #{CGI.escapeHTML(user.name)}, thanks for joining #{CGI.escapeHTML(user.organization.name)} and welcome!</p>}) }
+    describe "#email_subject" do
+      subject { event_instance.email_subject }
+
+      it { is_expected.to eq("Thanks for joining My ol'Organization!") }
+    end
+
+    describe "#email_intro" do
+      subject { event_instance.email_intro }
+
+      it { is_expected.to match(%r{^<p>Hi #{CGI.escapeHTML(user.name)}, thanks for joining My ol'Organization and welcome!</p>}) }
+    end
   end
 end

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -79,7 +79,6 @@ PATH
       loofah (~> 2.19, >= 2.19.1)
       mime-types (>= 1.16, < 4.0)
       mini_magick (~> 4.9)
-      mustache (~> 1.1.0)
       net-smtp (~> 0.3.1)
       omniauth (~> 2.0)
       omniauth-facebook (~> 5.0)
@@ -512,7 +511,6 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.2.3)
-    mustache (1.1.1)
     net-imap (0.2.3)
       digest
       net-protocol


### PR DESCRIPTION
#### :tophat: What? Why?

While working in #12323, I [had a flaky spec](https://github.com/decidim/decidim/actions/runs/7638394834/job/20809357819?pr=12323): 

```
  1) Decidim::User#after_confirmation sends the email
     Failure/Error: expect(last_email.subject).to eq("Thanks for joining #{organization.name}!")

       expected: "Thanks for joining Block, Fadel and O'Kon!"
            got: "Thanks for joining Block, Fadel and O&#39;Kon!"

       (compared using ==)
     # ./spec/models/decidim/user_spec.rb:331:in `block (3 levels) in <module:Decidim>'

```

This PR fixes it, and also removes a dependency that was only used here (`mustache` gem)

#### :pushpin: Related Issues

- Related to #4432 

#### Testing

CI should be green. You can copy the spec and see that it currently fails in develop without the fix. 

### :camera: Screenshots

![Screenshot of the failing flaky spec](https://github.com/decidim/decidim/assets/717367/de0d18d9-d781-4044-90d8-63bfa42fb5ea)


:hearts: Thank you!
