### PR TITLE
Standardize the way resources are being listed in application

### DIFF
--- a/decidim-accountability/app/cells/decidim/accountability/highlighted_results_for_component/show.erb
+++ b/decidim-accountability/app/cells/decidim/accountability/highlighted_results_for_component/show.erb
@@ -3,7 +3,7 @@
 
 <div class="content-block__title">
   <h2 class="h2 decorator">
-    <%= single_component? ? escape_translated(model.name) : t("decidim.accountability.content_blocks.highlighted_results.results") %>
+    <%= single_component? ? decidim_escape_translated(model.name) : t("decidim.accountability.content_blocks.highlighted_results.results") %>
   </h2>
   <div class="label text-lg"><%= results_count %></div>
   <% if single_component? %>

--- a/decidim-accountability/app/cells/decidim/accountability/highlighted_results_for_component/show.erb
+++ b/decidim-accountability/app/cells/decidim/accountability/highlighted_results_for_component/show.erb
@@ -3,7 +3,7 @@
 
 <div class="content-block__title">
   <h2 class="h2 decorator">
-    <%= single_component? ? translated_attribute(model.name) : t("decidim.accountability.content_blocks.highlighted_results.results") %>
+    <%= single_component? ? escape_translated(model.name) : t("decidim.accountability.content_blocks.highlighted_results.results") %>
   </h2>
   <div class="label text-lg"><%= results_count %></div>
   <% if single_component? %>

--- a/decidim-accountability/spec/mailers/import_projects_mailer_spec.rb
+++ b/decidim-accountability/spec/mailers/import_projects_mailer_spec.rb
@@ -24,7 +24,7 @@ module Decidim
         let(:mail) { described_class.import(user, current_component, some_amount) }
 
         it "emails success message to the user" do
-          expect(mail.body).to include("Successful imported projects to results in the #{current_component.name["en"]} component. You can review the results in the administration interface.")
+          expect(mail.body).to include("Successful imported projects to results in the #{escape_translated(current_component.name)} component. You can review the results in the administration interface.")
           expect(mail.body).to include("#{some_amount} results were imported from projects.")
         end
       end

--- a/decidim-accountability/spec/mailers/import_projects_mailer_spec.rb
+++ b/decidim-accountability/spec/mailers/import_projects_mailer_spec.rb
@@ -24,7 +24,7 @@ module Decidim
         let(:mail) { described_class.import(user, current_component, some_amount) }
 
         it "emails success message to the user" do
-          expect(mail.body).to include("Successful imported projects to results in the #{escape_translated(current_component.name)} component. You can review the results in the administration interface.")
+          expect(mail.body).to include("Successful imported projects to results in the #{decidim_escape_translated(current_component.name)} component. You can review the results in the administration interface.")
           expect(mail.body).to include("#{some_amount} results were imported from projects.")
         end
       end

--- a/decidim-admin/app/helpers/decidim/admin/admin_terms_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/admin_terms_helper.rb
@@ -5,7 +5,7 @@ module Decidim
     # This module includes helpers to show admin terms of service
     module AdminTermsHelper
       def admin_terms_of_service_body
-        current_organization.admin_terms_of_service_body.symbolize_keys[I18n.locale].html_safe
+        decidim_sanitize_admin(translated_attribute(current_organization.admin_terms_of_service_body)).html_safe
       end
 
       def announcement_body

--- a/decidim-admin/spec/events/decidim/component_published_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/component_published_event_spec.rb
@@ -11,10 +11,12 @@ describe Decidim::ComponentPublishedEvent do
   let(:resource) { create(:component) }
   let(:participatory_space) { resource.participatory_space }
   let(:resource_path) { main_component_path(resource) }
-  let(:email_subject) { "An update to #{participatory_space.title["en"]}" }
-  let(:email_intro) { "The #{resource.name["en"]} component is now active for #{participatory_space.title["en"]}. You can see it from this page:" }
-  let(:email_outro) { "You have received this notification because you are following #{participatory_space.title["en"]}. You can stop receiving notifications following the previous link." }
-  let(:notification_title) { "The #{resource.name["en"]} component is now active for <a href=\"#{resource_path}\">#{participatory_space.title["en"]}</a>" }
+  let(:email_subject) { "An update to #{participatory_space_title}" }
+  let(:resource_title) { sanitize_translated(resource.name) }
+  let(:participatory_space_title) { sanitize_translated(participatory_space.title) }
+  let(:email_intro) { "The #{resource_title} component is now active for #{participatory_space_title}. You can see it from this page:" }
+  let(:email_outro) { "You have received this notification because you are following #{participatory_space_title}. You can stop receiving notifications following the previous link." }
+  let(:notification_title) { "The #{resource_title} component is now active for <a href=\"#{resource_path}\">#{participatory_space_title}</a>" }
 
   it_behaves_like "a simple event"
   it_behaves_like "a simple event email"

--- a/decidim-admin/spec/events/decidim/component_published_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/component_published_event_spec.rb
@@ -14,9 +14,9 @@ describe Decidim::ComponentPublishedEvent do
   let(:email_subject) { "An update to #{participatory_space_title}" }
   let(:resource_title) { sanitize_translated(resource.name) }
   let(:participatory_space_title) { sanitize_translated(participatory_space.title) }
-  let(:email_intro) { "The #{resource_title} component is now active for #{participatory_space_title}. You can see it from this page:" }
+  let(:email_intro) { "The #{escape_translated(resource.name)} component is now active for #{participatory_space_title}. You can see it from this page:" }
   let(:email_outro) { "You have received this notification because you are following #{participatory_space_title}. You can stop receiving notifications following the previous link." }
-  let(:notification_title) { "The #{resource_title} component is now active for <a href=\"#{resource_path}\">#{participatory_space_title}</a>" }
+  let(:notification_title) { "The #{escape_translated(resource.name)} component is now active for <a href=\"#{resource_path}\">#{participatory_space_title}</a>" }
 
   it_behaves_like "a simple event"
   it_behaves_like "a simple event email"

--- a/decidim-admin/spec/events/decidim/component_published_event_spec.rb
+++ b/decidim-admin/spec/events/decidim/component_published_event_spec.rb
@@ -12,11 +12,11 @@ describe Decidim::ComponentPublishedEvent do
   let(:participatory_space) { resource.participatory_space }
   let(:resource_path) { main_component_path(resource) }
   let(:email_subject) { "An update to #{participatory_space_title}" }
-  let(:resource_title) { sanitize_translated(resource.name) }
-  let(:participatory_space_title) { sanitize_translated(participatory_space.title) }
-  let(:email_intro) { "The #{escape_translated(resource.name)} component is now active for #{participatory_space_title}. You can see it from this page:" }
+  let(:resource_title) { decidim_sanitize_translated(resource.name) }
+  let(:participatory_space_title) { decidim_sanitize_translated(participatory_space.title) }
+  let(:email_intro) { "The #{decidim_escape_translated(resource.name)} component is now active for #{participatory_space_title}. You can see it from this page:" }
   let(:email_outro) { "You have received this notification because you are following #{participatory_space_title}. You can stop receiving notifications following the previous link." }
-  let(:notification_title) { "The #{escape_translated(resource.name)} component is now active for <a href=\"#{resource_path}\">#{participatory_space_title}</a>" }
+  let(:notification_title) { "The #{decidim_escape_translated(resource.name)} component is now active for <a href=\"#{resource_path}\">#{participatory_space_title}</a>" }
 
   it_behaves_like "a simple event"
   it_behaves_like "a simple event email"

--- a/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
+++ b/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
@@ -53,7 +53,7 @@ module Decidim
            )
         ] + components.map do |component|
           {
-            name: escape_translated(component.name),
+            name: decidim_escape_translated(component.name),
             url: main_component_path(component),
             active: is_active_link?(main_component_path(component), :inclusive)
           }

--- a/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
+++ b/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
@@ -53,7 +53,7 @@ module Decidim
            )
         ] + components.map do |component|
           {
-            name: translated_attribute(component.name),
+            name: escape_translated(component.name),
             url: main_component_path(component),
             active: is_active_link?(main_component_path(component), :inclusive)
           }

--- a/decidim-assemblies/lib/decidim/assemblies/menu.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/menu.rb
@@ -58,7 +58,7 @@ module Decidim
       def self.register_admin_assemblies_components_menu!
         Decidim.menu :admin_assemblies_components_menu do |menu|
           current_participatory_space.components.each do |component|
-            caption = escape_translated(component.name)
+            caption = decidim_escape_translated(component.name)
             caption += content_tag(:span, component.primary_stat, class: "component-counter") if component.primary_stat.present?
 
             menu.add_item [component.manifest_name, component.id].join("_"),

--- a/decidim-assemblies/lib/decidim/assemblies/menu.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/menu.rb
@@ -58,7 +58,7 @@ module Decidim
       def self.register_admin_assemblies_components_menu!
         Decidim.menu :admin_assemblies_components_menu do |menu|
           current_participatory_space.components.each do |component|
-            caption = translated_attribute(component.name)
+            caption = escape_translated(component.name)
             caption += content_tag(:span, component.primary_stat, class: "component-counter") if component.primary_stat.present?
 
             menu.add_item [component.manifest_name, component.id].join("_"),

--- a/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
@@ -14,6 +14,9 @@ FactoryBot.define do
   end
 
   factory :assembly, class: "Decidim::Assembly" do
+    transient do
+      skip_injection { false }
+    end
     title { generate_localized_title }
     slug { generate(:assembly_slug) }
     subtitle { generate_localized_title }

--- a/decidim-budgets/spec/mailers/decidim/budgets/order_summary_mailer_spec.rb
+++ b/decidim-budgets/spec/mailers/decidim/budgets/order_summary_mailer_spec.rb
@@ -23,16 +23,16 @@ module Decidim::Budgets
         end
 
         it "includes the budget title" do
-          expect(mail.body.encoded).to include(translated(budget.title))
+          expect(mail.body.encoded).to include(escape_translated(budget.title))
         end
 
         it "includes the participatory space title" do
-          expect(mail.body).to include(translated(space.title))
+          expect(mail.body).to include(escape_translated(space.title))
         end
 
         it "includes the projects names" do
           order.projects.each do |project|
-            expect(mail.body).to include(translated(project.title))
+            expect(mail.body).to include(escape_translated(project.title))
           end
         end
       end
@@ -51,7 +51,7 @@ module Decidim::Budgets
 
         it "includes the scope name and scope type name" do
           expect(mail.body.encoded).to include(translated(scope.name))
-          expect(mail.body.encoded).to include(translated(scope.scope_type.name))
+          expect(mail.body.encoded).to include(escape_translated(scope.scope_type.name))
         end
       end
     end

--- a/decidim-budgets/spec/mailers/decidim/budgets/order_summary_mailer_spec.rb
+++ b/decidim-budgets/spec/mailers/decidim/budgets/order_summary_mailer_spec.rb
@@ -23,16 +23,16 @@ module Decidim::Budgets
         end
 
         it "includes the budget title" do
-          expect(mail.body.encoded).to include(escape_translated(budget.title))
+          expect(mail.body.encoded).to include(decidim_escape_translated(budget.title))
         end
 
         it "includes the participatory space title" do
-          expect(mail.body).to include(escape_translated(space.title))
+          expect(mail.body).to include(decidim_escape_translated(space.title))
         end
 
         it "includes the projects names" do
           order.projects.each do |project|
-            expect(mail.body).to include(escape_translated(project.title))
+            expect(mail.body).to include(decidim_escape_translated(project.title))
           end
         end
       end
@@ -51,7 +51,7 @@ module Decidim::Budgets
 
         it "includes the scope name and scope type name" do
           expect(mail.body.encoded).to include(translated(scope.name))
-          expect(mail.body.encoded).to include(escape_translated(scope.scope_type.name))
+          expect(mail.body.encoded).to include(decidim_escape_translated(scope.scope_type.name))
         end
       end
     end

--- a/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
+++ b/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
@@ -32,7 +32,7 @@ module Decidim
             next unless Decidim::Meetings::Meeting.where(component:).published.not_hidden.visible_for(current_user).exists?
 
             items << {
-              name: escape_translated(component.name),
+              name: decidim_escape_translated(component.name),
               url: decidim_conferences.conference_conference_program_path(participatory_space, id: component.id)
             }
           end
@@ -53,7 +53,7 @@ module Decidim
 
           other_components.each do |component|
             items << {
-              name: escape_translated(component.name),
+              name: decidim_escape_translated(component.name),
               url: main_component_path(component)
             }
           end

--- a/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
+++ b/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
@@ -32,7 +32,7 @@ module Decidim
             next unless Decidim::Meetings::Meeting.where(component:).published.not_hidden.visible_for(current_user).exists?
 
             items << {
-              name: translated_attribute(component.name),
+              name: escape_translated(component.name),
               url: decidim_conferences.conference_conference_program_path(participatory_space, id: component.id)
             }
           end
@@ -53,7 +53,7 @@ module Decidim
 
           other_components.each do |component|
             items << {
-              name: translated_attribute(component.name),
+              name: escape_translated(component.name),
               url: main_component_path(component)
             }
           end

--- a/decidim-conferences/lib/decidim/conferences/menu.rb
+++ b/decidim-conferences/lib/decidim/conferences/menu.rb
@@ -28,7 +28,7 @@ module Decidim
       def self.register_admin_conferences_components_menu!
         Decidim.menu :admin_conferences_components_menu do |menu|
           current_participatory_space.components.each do |component|
-            caption = translated_attribute(component.name)
+            caption = escape_translated(component.name)
             caption += content_tag(:span, component.primary_stat, class: "component-counter") if component.primary_stat.present?
 
             menu.add_item [component.manifest_name, component.id].join("_"),

--- a/decidim-conferences/lib/decidim/conferences/menu.rb
+++ b/decidim-conferences/lib/decidim/conferences/menu.rb
@@ -28,7 +28,7 @@ module Decidim
       def self.register_admin_conferences_components_menu!
         Decidim.menu :admin_conferences_components_menu do |menu|
           current_participatory_space.components.each do |component|
-            caption = escape_translated(component.name)
+            caption = decidim_escape_translated(component.name)
             caption += content_tag(:span, component.primary_stat, class: "component-counter") if component.primary_stat.present?
 
             menu.add_item [component.manifest_name, component.id].join("_"),

--- a/decidim-conferences/spec/system/conference_program_spec.rb
+++ b/decidim-conferences/spec/system/conference_program_spec.rb
@@ -50,8 +50,8 @@ describe "Conference program" do
           visit decidim_conferences.conference_path(conference)
 
           within "aside .conference__nav-container" do
-            expect(page).to have_content(escape_translated(component.name))
-            click_link escape_translated(component.name)
+            expect(page).to have_content(decidim_escape_translated(component.name))
+            click_link decidim_escape_translated(component.name)
           end
 
           expect(page).to have_current_path decidim_conferences.conference_conference_program_path(conference, component)

--- a/decidim-conferences/spec/system/conference_program_spec.rb
+++ b/decidim-conferences/spec/system/conference_program_spec.rb
@@ -50,8 +50,8 @@ describe "Conference program" do
           visit decidim_conferences.conference_path(conference)
 
           within "aside .conference__nav-container" do
-            expect(page).to have_content(translated_attribute(component.name))
-            click_link translated_attribute(component.name)
+            expect(page).to have_content(escape_translated(component.name))
+            click_link escape_translated(component.name)
           end
 
           expect(page).to have_current_path decidim_conferences.conference_conference_program_path(conference, component)

--- a/decidim-conferences/spec/system/conferences_spec.rb
+++ b/decidim-conferences/spec/system/conferences_spec.rb
@@ -228,8 +228,8 @@ describe "Conferences" do
     context "when the conference has some components" do
       it "shows the components" do
         within ".conference__nav" do
-          expect(page).to have_content(escape_translated(proposals_component.name))
-          expect(page).not_to have_content(escape_translated(meetings_component.name))
+          expect(page).to have_content(decidim_escape_translated(proposals_component.name))
+          expect(page).not_to have_content(decidim_escape_translated(meetings_component.name))
         end
       end
 

--- a/decidim-conferences/spec/system/conferences_spec.rb
+++ b/decidim-conferences/spec/system/conferences_spec.rb
@@ -228,8 +228,8 @@ describe "Conferences" do
     context "when the conference has some components" do
       it "shows the components" do
         within ".conference__nav" do
-          expect(page).to have_content(translated(proposals_component.name, locale: :en))
-          expect(page).not_to have_content(translated(meetings_component.name, locale: :en))
+          expect(page).to have_content(escape_translated(proposals_component.name))
+          expect(page).not_to have_content(escape_translated(meetings_component.name))
         end
       end
 

--- a/decidim-conferences/spec/system/media_spec.rb
+++ b/decidim-conferences/spec/system/media_spec.rb
@@ -86,11 +86,11 @@ describe "Conferences" do
 
     it "shows them ordered" do
       within "#conference-media-documents" do
-        expect(escape_translated(first_document.title).gsub("&quot;", "\"")).to appear_before(escape_translated(last_document.title).gsub("&quot;", "\""))
+        expect(decidim_escape_translated(first_document.title).gsub("&quot;", "\"")).to appear_before(decidim_escape_translated(last_document.title).gsub("&quot;", "\""))
       end
 
       within "#conference-media-photos" do
-        expect(escape_translated(fist_image.title).gsub("&quot;", "\"")).to appear_before(escape_translated(last_image.title).gsub("&quot;", "\""))
+        expect(decidim_escape_translated(fist_image.title).gsub("&quot;", "\"")).to appear_before(decidim_escape_translated(last_image.title).gsub("&quot;", "\""))
       end
     end
   end

--- a/decidim-conferences/spec/system/media_spec.rb
+++ b/decidim-conferences/spec/system/media_spec.rb
@@ -48,7 +48,7 @@ describe "Conferences" do
     it "shows them" do
       within "#conference-media-links" do
         expect(page).to have_content("Media and Links")
-        expect(page).to have_content(/#{translated(media_link.title, locale: :en)}/i)
+        expect(page).to have_content(translated(media_link.title))
         expect(page).to have_css("[data-conference-media-links] a")
       end
     end
@@ -65,7 +65,7 @@ describe "Conferences" do
 
     it "shows them" do
       within "#conference-media-documents" do
-        expect(page).to have_content(/#{translated(document.title, locale: :en)}/i)
+        expect(page).to have_content(translated(document.title))
       end
 
       within "#conference-media-photos" do
@@ -86,11 +86,11 @@ describe "Conferences" do
 
     it "shows them ordered" do
       within "#conference-media-documents" do
-        expect(translated(first_document.title, locale: :en)).to appear_before(translated(last_document.title, locale: :en))
+        expect(escape_translated(first_document.title).gsub("&quot;", "\"")).to appear_before(escape_translated(last_document.title).gsub("&quot;", "\""))
       end
 
       within "#conference-media-photos" do
-        expect(strip_tags(translated(fist_image.description, locale: :en))).to appear_before(strip_tags(translated(last_image.description, locale: :en)))
+        expect(escape_translated(fist_image.title).gsub("&quot;", "\"")).to appear_before(escape_translated(last_image.title).gsub("&quot;", "\""))
       end
     end
   end

--- a/decidim-core/app/cells/decidim/footer_pages_cell.rb
+++ b/decidim-core/app/cells/decidim/footer_pages_cell.rb
@@ -42,7 +42,7 @@ module Decidim
         .static_pages_accessible_for(current_user)
         .where(show_in_footer: true, topic_id: nil)
         .where.not(slug: "terms-and-conditions").map do |page|
-        { title: translated_attribute(page.title), path: decidim.page_path(page) }
+        { title: escape_translated(page.title), path: decidim.page_path(page) }
       end
     end
 
@@ -51,9 +51,9 @@ module Decidim
         next if (topic_pages = topic.accessible_pages_for(current_user).where(show_in_footer: true)).blank?
 
         {
-          title: translated_attribute(topic.title),
+          title: escape_translated(topic.title),
           pages: topic_pages.map do |page|
-            { title: translated_attribute(page.title), path: decidim.page_path(page) }
+            { title: escape_translated(page.title), path: decidim.page_path(page) }
           end
         }
       end.compact

--- a/decidim-core/app/cells/decidim/footer_pages_cell.rb
+++ b/decidim-core/app/cells/decidim/footer_pages_cell.rb
@@ -42,7 +42,7 @@ module Decidim
         .static_pages_accessible_for(current_user)
         .where(show_in_footer: true, topic_id: nil)
         .where.not(slug: "terms-and-conditions").map do |page|
-        { title: escape_translated(page.title), path: decidim.page_path(page) }
+        { title: decidim_escape_translated(page.title), path: decidim.page_path(page) }
       end
     end
 
@@ -51,9 +51,9 @@ module Decidim
         next if (topic_pages = topic.accessible_pages_for(current_user).where(show_in_footer: true)).blank?
 
         {
-          title: escape_translated(topic.title),
+          title: decidim_escape_translated(topic.title),
           pages: topic_pages.map do |page|
-            { title: escape_translated(page.title), path: decidim.page_path(page) }
+            { title: decidim_escape_translated(page.title), path: decidim.page_path(page) }
           end
         }
       end.compact

--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -54,11 +54,11 @@ module Decidim
       decidim_html_escape(text).sub(/^javascript:/, "")
     end
 
-    def sanitize_translated(text)
+    def decidim_sanitize_translated(text)
       decidim_sanitize(translated_attribute(text))
     end
 
-    def escape_translated(text)
+    def decidim_escape_translated(text)
       decidim_html_escape(translated_attribute(text))
     end
 

--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -6,6 +6,7 @@ module Decidim
     def self.included(base)
       base.include ActionView::Helpers::SanitizeHelper
       base.include ActionView::Helpers::TagHelper
+      base.include Decidim::TranslatableAttributes
     end
 
     # Public: It sanitizes a user-inputted string with the
@@ -51,6 +52,14 @@ module Decidim
 
     def decidim_url_escape(text)
       decidim_html_escape(text).sub(/^javascript:/, "")
+    end
+
+    def sanitize_translated(text)
+      decidim_sanitize(translated_attribute(text))
+    end
+
+    def escape_translated(text)
+      decidim_html_escape(translated_attribute(text))
     end
 
     private

--- a/decidim-core/app/views/decidim/application/_collection.html.erb
+++ b/decidim-core/app/views/decidim/application/_collection.html.erb
@@ -5,14 +5,14 @@
       <%= icon "folder-line" %>
       <%= icon "folder-open-line" %>
     </span>
-    <%= escape_translated(attachment_collection.name) %>
+    <%= decidim_escape_translated(attachment_collection.name) %>
   </span>
   <%= icon "arrow-down-s-fill" %>
   <%= icon "arrow-up-s-fill" %>
 </button>
 
 <div id="dropdown-menu-documents-<%= attachment_collection.id %>" class="documents__collection-content" aria-hidden="true">
-  <p><%= escape_translated(attachment_collection.description) %></p>
+  <p><%= decidim_escape_translated(attachment_collection.description) %></p>
 
   <div class="documents__container">
     <% documents.each do |document| %>

--- a/decidim-core/app/views/decidim/application/_collection.html.erb
+++ b/decidim-core/app/views/decidim/application/_collection.html.erb
@@ -5,14 +5,14 @@
       <%= icon "folder-line" %>
       <%= icon "folder-open-line" %>
     </span>
-    <%= translated_attribute(attachment_collection.name) %>
+    <%= escape_translated(attachment_collection.name) %>
   </span>
   <%= icon "arrow-down-s-fill" %>
   <%= icon "arrow-up-s-fill" %>
 </button>
 
 <div id="dropdown-menu-documents-<%= attachment_collection.id %>" class="documents__collection-content" aria-hidden="true">
-  <p><%= translated_attribute(attachment_collection.description) %></p>
+  <p><%= escape_translated(attachment_collection.description) %></p>
 
   <div class="documents__container">
     <% documents.each do |document| %>

--- a/decidim-core/app/views/decidim/application/_document.html.erb
+++ b/decidim-core/app/views/decidim/application/_document.html.erb
@@ -4,7 +4,7 @@
       <%= h attachment_title(document) %>
     <% end %>
     <% if document.description.present? %>
-      <div class="card__list-text"><%= escape_translated(document.description) %></div>
+      <div class="card__list-text"><%= decidim_escape_translated(document.description) %></div>
     <% end %>
     <div class="card__list-metadata">
       <span><%= icon "file-text-line" %><%= document.file_type %></span>

--- a/decidim-core/app/views/decidim/application/_document.html.erb
+++ b/decidim-core/app/views/decidim/application/_document.html.erb
@@ -4,7 +4,7 @@
       <%= h attachment_title(document) %>
     <% end %>
     <% if document.description.present? %>
-      <div class="card__list-text"><%= translated_attribute(document.description) %></div>
+      <div class="card__list-text"><%= escape_translated(document.description) %></div>
     <% end %>
     <div class="card__list-metadata">
       <span><%= icon "file-text-line" %><%= document.file_type %></span>

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -9,10 +9,6 @@ require "decidim/participatory_processes/test/factories"
 require "decidim/assemblies/test/factories"
 require "decidim/comments/test/factories"
 
-#
-# TODO: Add skip_injection to all factories in this file
-#
-
 def generate_component_name(locales, manifest_name, skip_injection: false)
   prepend = skip_injection ? "" : "<script>alert(\"#{manifest_name}\");</script>"
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -9,8 +9,43 @@ require "decidim/participatory_processes/test/factories"
 require "decidim/assemblies/test/factories"
 require "decidim/comments/test/factories"
 
-def generate_localized_title
-  Decidim::Faker::Localized.localized { generate(:title) }
+#
+# TODO: Add skip_injection to all factories in this file
+#
+
+def generate_component_name(locales, manifest_name, skip_injection: false)
+  prepend = skip_injection ? "" : "<script>alert(\"#{manifest_name}\");</script>"
+
+  Decidim::Components::Namer.new(locales, manifest_name).i18n_name.transform_values { |v| [prepend, v].compact_blank.join(" ") }
+end
+
+def generate_localized_description(field = nil, skip_injection: false, before: "<p>", after: "</p>")
+  Decidim::Faker::Localized.wrapped(before, after) do
+    generate_localized_title(field, skip_injection:)
+  end
+end
+
+def generate_localized_word(field = nil, skip_injection: false)
+  skip_injection = true if field.nil?
+  Decidim::Faker::Localized.localized do
+    if skip_injection
+      Faker::Lorem.word
+    else
+      "<script>alert(\"#{field}\");</script> #{Faker::Lorem.word}"
+    end
+  end
+end
+
+def generate_localized_title(field = nil, skip_injection: false)
+  skip_injection = true if field.nil?
+
+  Decidim::Faker::Localized.localized do
+    if skip_injection
+      generate(:title)
+    else
+      "<script>alert(\"#{field}\");</script> #{generate(:title)}"
+    end
+  end
 end
 
 FactoryBot.define do
@@ -59,27 +94,25 @@ FactoryBot.define do
       skip_injection { false }
     end
 
-    name do
-      if skip_injection
-        Decidim::Faker::Localized.localized { generate(:title) }
-      else
-        Decidim::Faker::Localized.localized { "<script>alert(\"category name\");</script> #{generate(:title)}" }
-      end
-    end
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    name { generate_localized_title(:category_name, skip_injection:) }
+    description { generate_localized_description(:category_description, skip_injection:) }
     weight { 0 }
 
     association :participatory_space, factory: :participatory_process
   end
 
   factory :subcategory, parent: :category do
-    parent { build(:category) }
+    transient do
+      skip_injection { false }
+    end
+    parent { build(:category, skip_injection:) }
 
     participatory_space { parent.participatory_space }
   end
 
   factory :organization, class: "Decidim::Organization" do
     transient do
+      skip_injection { false }
       create_static_pages { true }
     end
 
@@ -92,7 +125,7 @@ FactoryBot.define do
     youtube_handler { Faker::Hipster.word }
     github_handler { Faker::Hipster.word }
     sequence(:host) { |n| "#{n}.lvh.me" }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    description { generate_localized_description(:organization_description, skip_injection:) }
     favicon { Decidim::Dev.test_file("icon.png", "image/png") }
     default_locale { Decidim.default_locale }
     available_locales { Decidim.available_locales }
@@ -105,7 +138,7 @@ FactoryBot.define do
     user_groups_enabled { true }
     send_welcome_notification { true }
     comments_max_length { 1000 }
-    admin_terms_of_service_body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    admin_terms_of_service_body { generate_localized_description(:admin_terms_of_service_body, skip_injection:) }
     force_users_to_authenticate_before_access_organization { false }
     machine_translation_display_priority { "original" }
     external_domain_allowlist { ["example.org", "twitter.com", "facebook.com", "youtube.com", "github.com", "mytesturl.me"] }
@@ -136,12 +169,15 @@ FactoryBot.define do
     after(:create) do |organization, evaluator|
       if evaluator.create_static_pages
         tos_page = Decidim::StaticPage.find_by(slug: "terms-of-service", organization:)
-        create(:static_page, :tos, organization:) if tos_page.nil?
+        create(:static_page, :tos, organization:, skip_injection: evaluator.skip_injection) if tos_page.nil?
       end
     end
   end
 
   factory :user, class: "Decidim::User" do
+    transient do
+      skip_injection { false }
+    end
     email { generate(:email) }
     name { generate(:name) }
     nickname { generate(:nickname) }
@@ -150,7 +186,7 @@ FactoryBot.define do
     tos_agreement { "1" }
     avatar { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
     personal_url { Faker::Internet.url }
-    about { "<script>alert(\"ABOUT\");</script>#{Faker::Lorem.paragraph(sentence_count: 2)}" }
+    about { generate_localized_title(:user_about, skip_injection:) }
     confirmation_sent_at { Time.current }
     accepted_tos_version { organization.tos_version }
     notifications_sending_frequency { "real_time" }
@@ -198,7 +234,7 @@ FactoryBot.define do
 
     trait :officialized do
       officialized_at { Time.current }
-      officialized_as { generate_localized_title }
+      officialized_as { generate_localized_title(:officialized_as, skip_injection:) }
     end
 
     after(:build) do |user, evaluator|
@@ -210,17 +246,24 @@ FactoryBot.define do
   end
 
   factory :participatory_space_private_user, class: "Decidim::ParticipatorySpacePrivateUser" do
+    transient do
+      skip_injection { false }
+    end
     user
-    privatable_to { create(:participatory_process, organization: user.organization) }
+    privatable_to { create(:participatory_process, organization: user.organization, skip_injection:) }
   end
 
   factory :assembly_private_user, class: "Decidim::ParticipatorySpacePrivateUser" do
+    transient do
+      skip_injection { false }
+    end
     user
-    privatable_to { create(:assembly, organization: user.organization) }
+    privatable_to { create(:assembly, organization: user.organization, skip_injection:) }
   end
 
   factory :user_group, class: "Decidim::UserGroup" do
     transient do
+      skip_injection { false }
       document_number { "#{Faker::Number.number(digits: 8)}X" }
       phone { Faker::PhoneNumber.phone_number }
       rejected_at { nil }
@@ -230,7 +273,7 @@ FactoryBot.define do
     sequence(:name) { |n| "#{Faker::Company.name} #{n}" }
     email { generate(:user_group_email) }
     nickname { generate(:nickname) }
-    about { "<script>alert(\"ABOUT\");</script>#{Faker::Lorem.paragraph(sentence_count: 2)}" }
+    about { generate_localized_title(:user_group_about, skip_injection:) }
     organization
     avatar { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") } # Keep after organization
 
@@ -271,21 +314,27 @@ FactoryBot.define do
       next if users.empty?
 
       creator = users.shift
-      create(:user_group_membership, user: creator, user_group:, role: :creator)
+      create(:user_group_membership, user: creator, user_group:, role: :creator, skip_injection: evaluator.skip_injection)
 
       users.each do |user|
-        create(:user_group_membership, user:, user_group:, role: :admin)
+        create(:user_group_membership, user:, user_group:, role: :admin, skip_injection: evaluator.skip_injection)
       end
     end
   end
 
   factory :user_group_membership, class: "Decidim::UserGroupMembership" do
-    user { create(:user, :confirmed, organization: user_group.organization) }
+    transient do
+      skip_injection { false }
+    end
+    user { create(:user, :confirmed, organization: user_group.organization, skip_injection:) }
     role { :creator }
     user_group
   end
 
   factory :identity, class: "Decidim::Identity" do
+    transient do
+      skip_injection { false }
+    end
     provider { "facebook" }
     sequence(:uid)
     user
@@ -293,6 +342,9 @@ FactoryBot.define do
   end
 
   factory :authorization, class: "Decidim::Authorization" do
+    transient do
+      skip_injection { false }
+    end
     sequence(:name) { |n| "dummy_authorization_#{n}" }
     user
     metadata { {} }
@@ -309,37 +361,42 @@ FactoryBot.define do
 
   factory :authorization_transfer, class: "Decidim::AuthorizationTransfer" do
     transient do
-      organization { create(:organization) }
+      skip_injection { false }
+      organization { create(:organization, skip_injection:) }
     end
 
-    user { create(:user, :confirmed, organization:) }
-    source_user { create(:user, :confirmed, :deleted, organization: user.try(:organization) || organization) }
+    user { create(:user, :confirmed, organization:, skip_injection:) }
+    source_user { create(:user, :confirmed, :deleted, organization: user.try(:organization) || organization, skip_injection:) }
     authorization do
       create(
         :authorization,
-        user: source_user || create(:user, :confirmed, :deleted, organization: user.try(:organization) || organization)
+        user: source_user || create(:user, :confirmed, :deleted, organization: user.try(:organization) || organization, skip_injection:)
       )
     end
 
     trait :transferred do
-      authorization { create(:authorization, user:) }
+      authorization { create(:authorization, user:, skip_injection:) }
     end
   end
 
   factory :authorization_transfer_record, class: "Decidim::AuthorizationTransferRecord" do
     transient do
-      organization { resource.try(:organization) || create(:organization) }
+      skip_injection { false }
+      organization { resource.try(:organization) || create(:organization, skip_injection:) }
     end
 
-    transfer { create(:authorization_transfer, organization:) }
-    resource { create(:dummy_resource) }
+    transfer { create(:authorization_transfer, organization:, skip_injection:) }
+    resource { create(:dummy_resource, skip_injection:) }
   end
 
   factory :static_page, class: "Decidim::StaticPage" do
+    transient do
+      skip_injection { false }
+    end
     slug { generate(:slug) }
-    title { generate_localized_title }
-    content { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
-    organization { build(:organization) }
+    title { generate_localized_title(:static_page_title, skip_injection:) }
+    content { generate_localized_description(:static_page_content, skip_injection:) }
+    organization { build(:organization, skip_injection:) }
     allow_public_access { false }
 
     trait :default do
@@ -355,8 +412,8 @@ FactoryBot.define do
     end
 
     trait :with_topic do
-      after(:create) do |static_page|
-        topic = create(:static_page_topic, organization: static_page.organization)
+      after(:create) do |static_page, evaluator|
+        topic = create(:static_page_topic, organization: static_page.organization, skip_injection: evaluator.skip_injection)
         static_page.topic = topic
         static_page.save
       end
@@ -364,24 +421,33 @@ FactoryBot.define do
   end
 
   factory :static_page_topic, class: "Decidim::StaticPageTopic" do
-    title { generate_localized_title }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    transient do
+      skip_injection { false }
+    end
+    title { generate_localized_title(:static_page_topic_title, skip_injection:) }
+    description { generate_localized_description(:static_page_topic_description, skip_injection:) }
     organization
   end
 
   factory :attachment_collection, class: "Decidim::AttachmentCollection" do
-    name { generate_localized_title }
-    description { generate_localized_title }
+    transient do
+      skip_injection { false }
+    end
+    name { generate_localized_title(:attachment_collection_name, skip_injection:) }
+    description { generate_localized_title(:attachment_collection_description, skip_injection:) }
     weight { Faker::Number.number(digits: 1) }
 
     association :collection_for, factory: :participatory_process
   end
 
   factory :attachment, class: "Decidim::Attachment" do
-    title { generate_localized_title }
-    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    transient do
+      skip_injection { false }
+    end
+    title { generate_localized_title(:attachment_title, skip_injection:) }
+    description { generate_localized_description(:attachment_description, skip_injection:) }
     weight { Faker::Number.number(digits: 1) }
-    attached_to { build(:participatory_process) }
+    attached_to { build(:participatory_process, skip_injection:) }
     content_type { "image/jpeg" }
     file { Decidim::Dev.test_file("city.jpeg", "image/jpeg") } # Keep after attached_to
     file_size { 108_908 }
@@ -399,23 +465,24 @@ FactoryBot.define do
 
   factory :component, class: "Decidim::Component" do
     transient do
-      organization { create(:organization) }
+      skip_injection { false }
+      organization { create(:organization, skip_injection:) }
     end
 
-    name { generate_localized_title }
-    participatory_space { create(:participatory_process, organization:) }
+    name { generate_localized_title(:component_name, skip_injection:) }
+    participatory_space { create(:participatory_process, organization:, skip_injection:) }
     manifest_name { "dummy" }
     published_at { Time.current }
     settings do
       {
-        dummy_global_translatable_text: generate_localized_title,
+        dummy_global_translatable_text: generate_localized_title(:dummy_global_translatable_text, skip_injection:),
         comments_max_length: participatory_space.organization.comments_max_length || organization.comments_max_length
       }
     end
 
     default_step_settings do
       {
-        dummy_step_translatable_text: generate_localized_title
+        dummy_step_translatable_text: generate_localized_title(:dummy_step_translatable_text, skip_injection:)
       }
     end
 
@@ -453,7 +520,8 @@ FactoryBot.define do
         create(:participatory_process_step,
                active: true,
                end_date: 1.month.from_now,
-               participatory_process: participatory_space)
+               participatory_process: participatory_space,
+               skip_injection:)
         participatory_space.reload
         participatory_space.steps.reload
       end
@@ -496,20 +564,29 @@ FactoryBot.define do
   end
 
   factory :scope_type, class: "Decidim::ScopeType" do
-    name { Decidim::Faker::Localized.word }
+    transient do
+      skip_injection { false }
+    end
+    name { generate_localized_word(:scope_type_name, skip_injection:) }
     plural { Decidim::Faker::Localized.literal(name.values.first.pluralize) }
     organization
   end
 
   factory :scope, class: "Decidim::Scope" do
+    transient do
+      skip_injection { false }
+    end
     name { Decidim::Faker::Localized.literal(generate(:scope_name)) }
     code { generate(:scope_code) }
-    scope_type { create(:scope_type, organization:) }
-    organization { parent ? parent.organization : build(:organization) }
+    scope_type { create(:scope_type, organization:, skip_injection:) }
+    organization { parent ? parent.organization : build(:organization, skip_injection:) }
   end
 
   factory :subscope, parent: :scope do
-    parent { build(:scope) }
+    transient do
+      skip_injection { false }
+    end
+    parent { build(:scope, skip_injection:) }
 
     before(:create) do |object|
       object.parent.save unless object.parent.persisted?
@@ -517,36 +594,49 @@ FactoryBot.define do
   end
 
   factory :area_type, class: "Decidim::AreaType" do
-    name { Decidim::Faker::Localized.word }
+    transient do
+      skip_injection { false }
+    end
+    name { generate_localized_word(:area_type_name, skip_injection:) }
     plural { Decidim::Faker::Localized.literal(name.values.first.pluralize) }
     organization
   end
 
   factory :area, class: "Decidim::Area" do
+    transient do
+      skip_injection { false }
+    end
     name { Decidim::Faker::Localized.literal(generate(:area_name)) }
     organization
   end
 
   factory :coauthorship, class: "Decidim::Coauthorship" do
-    coauthorable { create(:dummy_resource) }
+    transient do
+      skip_injection { false }
+    end
+    coauthorable { create(:dummy_resource, skip_injection:) }
     transient do
       organization { coauthorable.component.participatory_space.organization }
     end
-    author { create(:user, :confirmed, organization:) }
+    author { create(:user, :confirmed, organization:, skip_injection:) }
   end
 
   factory :resource_link, class: "Decidim::ResourceLink" do
+    transient do
+      skip_injection { false }
+    end
     name { generate(:slug) }
-    to { build(:dummy_resource) }
-    from { build(:dummy_resource, component: to.component) }
+    to { build(:dummy_resource, skip_injection:) }
+    from { build(:dummy_resource, component: to.component, skip_injection:) }
   end
 
   factory :newsletter, class: "Decidim::Newsletter" do
     transient do
-      body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+      skip_injection { false }
+      body { generate_localized_description(:newsletter_body, skip_injection:) }
     end
 
-    author { build(:user, :confirmed, organization:) }
+    author { build(:user, :confirmed, organization:, skip_injection:) }
     organization
 
     subject { generate_localized_title }
@@ -558,7 +648,8 @@ FactoryBot.define do
         organization: evaluator.organization,
         scoped_resource_id: newsletter.id,
         manifest_name: "basic_only_text",
-        settings: evaluator.body.transform_keys { |key| "body_#{key}" }
+        settings: evaluator.body.transform_keys { |key| "body_#{key}" },
+        skip_injection: evaluator.skip_injection
       )
     end
 
@@ -568,7 +659,10 @@ FactoryBot.define do
   end
 
   factory :moderation, class: "Decidim::Moderation" do
-    reportable { build(:dummy_resource) }
+    transient do
+      skip_injection { false }
+    end
+    reportable { build(:dummy_resource, skip_injection:) }
     participatory_space { reportable.component.participatory_space }
 
     trait :hidden do
@@ -577,35 +671,47 @@ FactoryBot.define do
   end
 
   factory :report, class: "Decidim::Report" do
+    transient do
+      skip_injection { false }
+    end
     moderation
-    user { build(:user, organization: moderation.reportable.organization) }
+    user { build(:user, organization: moderation.reportable.organization, skip_injection:) }
     reason { "spam" }
   end
 
   factory :impersonation_log, class: "Decidim::ImpersonationLog" do
-    admin { build(:user, :admin) }
-    user { build(:user, :managed, organization: admin.organization) }
+    transient do
+      skip_injection { false }
+    end
+    admin { build(:user, :admin, skip_injection:) }
+    user { build(:user, :managed, organization: admin.organization, skip_injection:) }
     started_at { 10.minutes.ago }
   end
 
   factory :follow, class: "Decidim::Follow" do
+    transient do
+      skip_injection { false }
+    end
     user do
       build(
         :user,
-        organization: followable.try(:organization) || build(:organization)
+        organization: followable.try(:organization) || build(:organization, skip_injection:)
       )
     end
-    followable { build(:dummy_resource) }
+    followable { build(:dummy_resource, skip_injection:) }
   end
 
   factory :notification, class: "Decidim::Notification" do
+    transient do
+      skip_injection { false }
+    end
     user do
       build(
         :user,
-        organization: resource.try(:organization) || build(:organization)
+        organization: resource.try(:organization) || build(:organization, skip_injection:)
       )
     end
-    resource { build(:dummy_resource) }
+    resource { build(:dummy_resource, skip_injection:) }
     event_name { resource.class.name.underscore.tr("/", ".") }
     event_class { "Decidim::Dev::DummyResourceEvent" }
     extra do
@@ -617,14 +723,15 @@ FactoryBot.define do
 
   factory :action_log, class: "Decidim::ActionLog" do
     transient do
+      skip_injection { false }
       extra_data { {} }
     end
 
     organization { user.organization }
     user
-    participatory_space { build(:participatory_process, organization:) }
-    component { build(:component, participatory_space:) }
-    resource { build(:dummy_resource, component:) }
+    participatory_space { build(:participatory_process, organization:, skip_injection:) }
+    component { build(:component, participatory_space:, skip_injection:) }
+    resource { build(:dummy_resource, component:, skip_injection:) }
     action { "create" }
     visibility { "admin-only" }
     extra do
@@ -650,6 +757,9 @@ FactoryBot.define do
   end
 
   factory :oauth_application, class: "Decidim::OAuthApplication" do
+    transient do
+      skip_injection { false }
+    end
     organization
     sequence(:name) { |n| "OAuth application #{n}" }
     sequence(:organization_name) { |n| "OAuth application owner #{n}" }
@@ -660,8 +770,11 @@ FactoryBot.define do
   end
 
   factory :oauth_access_token, class: "Doorkeeper::AccessToken" do
-    resource_owner_id { create(:user, organization: application.organization).id }
-    application { build(:oauth_application) }
+    transient do
+      skip_injection { false }
+    end
+    resource_owner_id { create(:user, organization: application.organization, skip_injection:).id }
+    application { build(:oauth_application, skip_injection:) }
     token { SecureRandom.hex(32) }
     expires_in { 1.month.from_now }
     created_at { Time.current }
@@ -669,7 +782,10 @@ FactoryBot.define do
   end
 
   factory :searchable_resource, class: "Decidim::SearchableResource" do
-    resource { build(:dummy_resource) }
+    transient do
+      skip_injection { false }
+    end
+    resource { build(:dummy_resource, skip_injection:) }
     resource_id { resource.id }
     resource_type { resource.class.name }
     organization { resource.component.organization }
@@ -681,6 +797,9 @@ FactoryBot.define do
   end
 
   factory :content_block, class: "Decidim::ContentBlock" do
+    transient do
+      skip_injection { false }
+    end
     organization
     scope_name { :homepage }
     manifest_name { :hero }
@@ -694,24 +813,33 @@ FactoryBot.define do
   end
 
   factory :hashtag, class: "Decidim::Hashtag" do
+    transient do
+      skip_injection { false }
+    end
     name { generate(:hashtag_name) }
     organization
   end
 
   factory :metric, class: "Decidim::Metric" do
+    transient do
+      skip_injection { false }
+    end
     organization
     day { Time.zone.today }
     metric_type { "random_metric" }
     cumulative { 2 }
     quantity { 1 }
     category { create(:category) }
-    participatory_space { create(:participatory_process, organization:) }
-    related_object { create(:component, participatory_space:) }
+    participatory_space { create(:participatory_process, organization:, skip_injection:) }
+    related_object { create(:component, participatory_space:, skip_injection:) }
   end
 
   factory :amendment, class: "Decidim::Amendment" do
-    amendable { build(:dummy_resource) }
-    emendation { build(:dummy_resource) }
+    transient do
+      skip_injection { false }
+    end
+    amendable { build(:dummy_resource, skip_injection:) }
+    emendation { build(:dummy_resource, skip_injection:) }
     amender { emendation.try(:creator_author) || emendation.try(:author) }
     state { "evaluating" }
 
@@ -723,29 +851,44 @@ FactoryBot.define do
   end
 
   factory :user_report, class: "Decidim::UserReport" do
+    transient do
+      skip_injection { false }
+    end
     reason { "spam" }
-    moderation { create(:user_moderation, user:) }
+    moderation { create(:user_moderation, user:, skip_injection:) }
     user { build(:user) }
   end
 
   factory :user_moderation, class: "Decidim::UserModeration" do
+    transient do
+      skip_injection { false }
+    end
     user { build(:user) }
   end
 
   factory :endorsement, class: "Decidim::Endorsement" do
-    resource { build(:dummy_resource) }
-    author { resource.try(:creator_author) || resource.try(:author) || build(:user, organization: resource.organization) }
+    transient do
+      skip_injection { false }
+    end
+    resource { build(:dummy_resource, skip_injection:) }
+    author { resource.try(:creator_author) || resource.try(:author) || build(:user, organization: resource.organization, skip_injection:) }
   end
 
   factory :user_group_endorsement, class: "Decidim::Endorsement" do
-    resource { build(:dummy_resource) }
-    author { build(:user, organization: resource.organization) }
-    user_group { create(:user_group, verified_at: Time.current, organization: resource.organization, users: [author]) }
+    transient do
+      skip_injection { false }
+    end
+    resource { build(:dummy_resource, skip_injection:) }
+    author { build(:user, organization: resource.organization, skip_injection:) }
+    user_group { create(:user_group, verified_at: Time.current, organization: resource.organization, users: [author], skip_injection:) }
   end
 
   factory :share_token, class: "Decidim::ShareToken" do
-    token_for { build(:component) }
-    user { build(:user, organization: token_for.organization) }
+    transient do
+      skip_injection { false }
+    end
+    token_for { build(:component, skip_injection:) }
+    user { build(:user, organization: token_for.organization, skip_injection:) }
 
     before(:create) do |object|
       object.organization ||= object.token_for.organization
@@ -762,19 +905,28 @@ FactoryBot.define do
   end
 
   factory :editor_image, class: "Decidim::EditorImage" do
+    transient do
+      skip_injection { false }
+    end
     organization
-    author { create(:user, :admin, :confirmed, organization:) }
+    author { create(:user, :admin, :confirmed, organization:, skip_injection:) }
     file { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
   end
 
   factory :reminder, class: "Decidim::Reminder" do
-    user { build(:user) }
-    component { build(:dummy_component, organization: user.organization) }
+    transient do
+      skip_injection { false }
+    end
+    user { build(:user, skip_injection:) }
+    component { build(:dummy_component, organization: user.organization, skip_injection:) }
   end
 
   factory :reminder_record, class: "Decidim::ReminderRecord" do
-    reminder { create(:reminder) }
-    remindable { build(:dummy_resource) }
+    transient do
+      skip_injection { false }
+    end
+    reminder { create(:reminder, skip_injection:) }
+    remindable { build(:dummy_resource, skip_injection:) }
 
     Decidim::ReminderRecord::STATES.keys.each do |defined_state|
       trait defined_state do
@@ -784,17 +936,23 @@ FactoryBot.define do
   end
 
   factory :reminder_delivery, class: "Decidim::ReminderDelivery" do
-    reminder { create(:reminder) }
+    transient do
+      skip_injection { false }
+    end
+    reminder { create(:reminder, skip_injection:) }
   end
 
   factory :short_link, class: "Decidim::ShortLink" do
-    target { create(:component, manifest_name: "dummy") }
+    transient do
+      skip_injection { false }
+    end
+    target { create(:component, manifest_name: "dummy", skip_injection:) }
     route_name { nil }
     params { {} }
 
-    before(:create) do |object|
+    before(:create) do |object, evaluator|
       object.organization ||= object.target if object.target.is_a?(Decidim::Organization)
-      object.organization ||= object.target.try(:organization) || create(:organization)
+      object.organization ||= object.target.try(:organization) || create(:organization, skip_injection: evaluator.skip_injection)
       object.identifier ||= Decidim::ShortLink.unique_identifier_within(object.organization)
       object.mounted_engine_name ||=
         if object.target.respond_to?(:participatory_space)

--- a/decidim-core/lib/decidim/core/test/shared_examples/has_attachment_collections.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/has_attachment_collections.rb
@@ -13,13 +13,13 @@ shared_examples_for "has attachment collections" do
     end
 
     it "shows them" do
-      expect(page).to have_content(/#{translated(attachment_collection.name, locale: :en)}/i)
+      expect(page).to have_content(translated(attachment_collection.name))
     end
 
     it "show their documents" do
       within "[id*=documents-#{attachment_collection.id}]", visible: false do
-        expect(page).to have_content(:all, /#{translated(document.title, locale: :en)}/i)
-        expect(page).not_to have_content(:all, /#{translated(other_document.title, locale: :en)}/i)
+        expect(page).to have_content(:all, translated(document.title))
+        expect(page).not_to have_content(:all, translated(other_document.title))
       end
     end
   end
@@ -36,7 +36,7 @@ shared_examples_for "has attachment collections" do
     end
 
     it "shows them ordered" do
-      expect(translated(first_attachment_collection.name, locale: :en)).to appear_before(translated(last_attachment_collection.name, locale: :en))
+      expect(escape_translated(first_attachment_collection.name).gsub("&quot;", "\"")).to appear_before(escape_translated(last_attachment_collection.name).gsub("&quot;", "\""))
     end
   end
 
@@ -50,8 +50,8 @@ shared_examples_for "has attachment collections" do
     end
 
     it "is not present" do
-      expect(page).to have_content(/#{translated(attachment_collection.name, locale: :en)}/i)
-      expect(page).not_to have_content(/#{translated(empty_attachment_collection.name, locale: :en)}/i)
+      expect(page).to have_content(translated(attachment_collection.name))
+      expect(page).not_to have_content(translated(empty_attachment_collection.name))
     end
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/has_attachment_collections.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/has_attachment_collections.rb
@@ -36,7 +36,9 @@ shared_examples_for "has attachment collections" do
     end
 
     it "shows them ordered" do
-      expect(escape_translated(first_attachment_collection.name).gsub("&quot;", "\"")).to appear_before(escape_translated(last_attachment_collection.name).gsub("&quot;", "\""))
+      expect(decidim_escape_translated(first_attachment_collection.name).gsub("&quot;",
+                                                                              "\"")).to appear_before(decidim_escape_translated(last_attachment_collection.name).gsub("&quot;",
+                                                                                                                                                                      "\""))
     end
   end
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/has_attachments.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/has_attachments.rb
@@ -35,7 +35,7 @@ shared_examples_for "has attachments content blocks" do
 
     it "shows them ordered" do
       within "[data-content] .documents__container" do
-        expect(escape_translated(first_document.title).gsub("&quot;", "\"")).to appear_before(escape_translated(last_document.title).gsub("&quot;", "\""))
+        expect(decidim_escape_translated(first_document.title).gsub("&quot;", "\"")).to appear_before(decidim_escape_translated(last_document.title).gsub("&quot;", "\""))
       end
 
       within "[data-content] [data-gallery]" do
@@ -81,7 +81,7 @@ shared_examples_for "has attachments tabs" do
     it "shows them ordered" do
       find("li [data-controls='panel-documents']").click
       within "#panel-documents" do
-        expect(escape_translated(first_document.title).gsub("&quot;", "\"")).to appear_before(escape_translated(last_document.title).gsub("&quot;", "\""))
+        expect(decidim_escape_translated(first_document.title).gsub("&quot;", "\"")).to appear_before(decidim_escape_translated(last_document.title).gsub("&quot;", "\""))
       end
 
       find("li [data-controls='panel-images']").click

--- a/decidim-core/lib/decidim/core/test/shared_examples/has_attachments.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/has_attachments.rb
@@ -14,7 +14,7 @@ shared_examples_for "has attachments content blocks" do
 
     it "shows them" do
       within "[data-content] .documents__container" do
-        expect(page).to have_content(/#{translated(document.title, locale: :en)}/i)
+        expect(page).to have_content(translated(document.title))
       end
 
       within "[data-content] [data-gallery]" do
@@ -27,7 +27,7 @@ shared_examples_for "has attachments content blocks" do
     let!(:last_document) { create(:attachment, :with_pdf, attached_to:, weight: 2) }
     let!(:first_document) { create(:attachment, :with_pdf, attached_to:, weight: 1) }
     let!(:last_image) { create(:attachment, attached_to:, weight: 2) }
-    let!(:fist_image) { create(:attachment, attached_to:, weight: 1) }
+    let!(:first_image) { create(:attachment, attached_to:, weight: 1) }
 
     before do
       visit current_path
@@ -35,11 +35,11 @@ shared_examples_for "has attachments content blocks" do
 
     it "shows them ordered" do
       within "[data-content] .documents__container" do
-        expect(translated(first_document.title, locale: :en)).to appear_before(translated(last_document.title, locale: :en))
+        expect(escape_translated(first_document.title).gsub("&quot;", "\"")).to appear_before(escape_translated(last_document.title).gsub("&quot;", "\""))
       end
 
       within "[data-content] [data-gallery]" do
-        expect(strip_tags(translated(fist_image.title, locale: :en))).to appear_before(strip_tags(translated(last_image.title, locale: :en)))
+        expect(strip_tags(translated(first_image.title, locale: :en))).to appear_before(strip_tags(translated(last_image.title, locale: :en)))
       end
     end
   end
@@ -58,7 +58,7 @@ shared_examples_for "has attachments tabs" do
     it "shows them" do
       find("li [data-controls='panel-documents']").click
       within "#panel-documents" do
-        expect(page).to have_content(/#{translated(document.title, locale: :en)}/i)
+        expect(page).to have_content(translated(document.title))
       end
 
       find("li [data-controls='panel-images']").click
@@ -81,7 +81,7 @@ shared_examples_for "has attachments tabs" do
     it "shows them ordered" do
       find("li [data-controls='panel-documents']").click
       within "#panel-documents" do
-        expect(translated(first_document.title, locale: :en)).to appear_before(translated(last_document.title, locale: :en))
+        expect(escape_translated(first_document.title).gsub("&quot;", "\"")).to appear_before(escape_translated(last_document.title).gsub("&quot;", "\""))
       end
 
       find("li [data-controls='panel-images']").click

--- a/decidim-core/lib/decidim/view_model.rb
+++ b/decidim-core/lib/decidim/view_model.rb
@@ -16,6 +16,7 @@ module Decidim
     include Cell::Caching::Notifications
     include Decidim::MarkupHelper
     include Decidim::LayoutHelper
+    include Decidim::SanitizeHelper
 
     delegate :current_organization, to: :controller
 

--- a/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
@@ -102,7 +102,7 @@ describe Decidim::UploadModalCell, type: :cell do
         expect(subject).to have_selector("[data-filename='#{filename}']")
 
         details = subject.find(".attachment-details")
-        expect(details).to have_content("#{attachments[0].title["en"]} (#{filename})")
+        expect(details).to have_content("#{sanitize_translated(attachments[0].title)} (#{filename})")
       end
     end
 
@@ -165,7 +165,7 @@ describe Decidim::UploadModalCell, type: :cell do
         expect(subject).to have_selector("[data-filename='#{filename1}']")
 
         details = subject.find(".attachment-details", match: :first)
-        expect(details).to have_content("#{attachments[0].title["en"]} (#{filename1})")
+        expect(details).to have_content("#{sanitize_translated(attachments[0].title)} (#{filename1})")
       end
     end
 

--- a/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
@@ -102,7 +102,7 @@ describe Decidim::UploadModalCell, type: :cell do
         expect(subject).to have_selector("[data-filename='#{filename}']")
 
         details = subject.find(".attachment-details")
-        expect(details).to have_content("#{sanitize_translated(attachments[0].title)} (#{filename})")
+        expect(details).to have_content("#{decidim_sanitize_translated(attachments[0].title)} (#{filename})")
       end
     end
 
@@ -165,7 +165,7 @@ describe Decidim::UploadModalCell, type: :cell do
         expect(subject).to have_selector("[data-filename='#{filename1}']")
 
         details = subject.find(".attachment-details", match: :first)
-        expect(details).to have_content("#{sanitize_translated(attachments[0].title)} (#{filename1})")
+        expect(details).to have_content("#{decidim_sanitize_translated(attachments[0].title)} (#{filename1})")
       end
     end
 

--- a/decidim-core/spec/controllers/pages_controller_spec.rb
+++ b/decidim-core/spec/controllers/pages_controller_spec.rb
@@ -21,7 +21,7 @@ module Decidim
 
           expect(response).to render_template(:show)
 
-          expect(response.body).to include(escape_translated(page.title))
+          expect(response.body).to include(decidim_escape_translated(page.title))
           expect(response.body).to include(decidim_sanitize_admin(translated(page.content)))
         end
       end

--- a/decidim-core/spec/controllers/pages_controller_spec.rb
+++ b/decidim-core/spec/controllers/pages_controller_spec.rb
@@ -21,8 +21,8 @@ module Decidim
 
           expect(response).to render_template(:show)
 
-          expect(response.body).to include(page.title[I18n.locale.to_s])
-          expect(response.body).to include(page.content[I18n.locale.to_s])
+          expect(response.body).to include(escape_translated(page.title))
+          expect(response.body).to include(decidim_sanitize_admin(translated(page.content)))
         end
       end
 

--- a/decidim-core/spec/serializers/decidim/importers/participatory_space_components_importer_spec.rb
+++ b/decidim-core/spec/serializers/decidim/importers/participatory_space_components_importer_spec.rb
@@ -16,38 +16,39 @@ module Decidim::Importers
       let!(:component2) { create(:component, :with_one_step, :unpublished, :with_permissions, participatory_space:, weight: 2) }
 
       let(:json_as_text) do
-        <<~EOJSON
-          [{
-            "manifest_name": "#{component1.manifest_name}",
-            "id": #{component1.id},
-            "name": {
-              "ca": "#{component1.name["ca"]}",
-              "en": "#{component1.name["en"]}",
-              "es": "#{component1.name["es"]}"
+        json = [
+          {
+            manifest_name: component1.manifest_name,
+            id: component1.id,
+            name: {
+              ca: component1.name["ca"],
+              en: component1.name["en"],
+              es: component1.name["es"]
             },
-            "participatory_space_id": #{previous_participatory_space.id},
-            "participatory_space_type": "#{component1.participatory_space.class.name}",
-            "settings": #{component1.attributes["settings"].to_json},
-            "weight": #{component1.weight},
-            "permissions": #{component1.permissions.to_json},
-            "published_at": "#{component1.published_at&.iso8601 || "null"}"
+            participatory_space_id: previous_participatory_space.id,
+            participatory_space_type: component1.participatory_space.class.name,
+            settings: component1.attributes["settings"],
+            weight: component1.weight,
+            permissions: component1.permissions,
+            published_at: component1.published_at&.iso8601
           }, {
-            "manifest_name": "#{component2.manifest_name}",
-            "id": #{component2.id},
-            "name": {
-              "ca": "#{component2.name["ca"]}",
-              "en": "#{component2.name["en"]}",
-              "es": "#{component2.name["es"]}"
+            manifest_name: component2.manifest_name,
+            id: component2.id,
+            name: {
+              ca: component2.name["ca"],
+              en: component2.name["en"],
+              es: component2.name["es"]
             },
-            "participatory_space_id": #{previous_participatory_space.id},
-            "participatory_space_type": "#{component2.participatory_space.class.name}",
-            "settings": #{component2.attributes["settings"].to_json},
-            "weight": #{component2.weight},
-            "permissions": #{component2.permissions.to_json},
-            "published_at": "#{component2.published_at&.iso8601 || "null"}"
+            participatory_space_id: previous_participatory_space.id,
+            participatory_space_type: component2.participatory_space.class.name,
+            settings: component2.attributes["settings"],
+            weight: component2.weight,
+            permissions: component2.permissions,
+            published_at: component2.published_at&.iso8601
           }
-          ]
-        EOJSON
+        ]
+
+        JSON.generate(json)
       end
 
       describe "#import" do

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -172,7 +172,7 @@ describe "Homepage" do
           click_link static_page1.title["en"]
           expect(page).to have_i18n_content(static_page1.title)
 
-          expect(page).to have_i18n_content(static_page1.content)
+          expect(page).to have_i18n_content(static_page1.content, strip_tags: true)
         end
 
         it "includes the footer sub_hero with the current organization name" do

--- a/decidim-core/spec/types/component_input_sort_spec.rb
+++ b/decidim-core/spec/types/component_input_sort_spec.rb
@@ -13,7 +13,7 @@ module Decidim
 
       let(:model) { create(:participatory_process, organization: current_organization) }
       let(:models) { model.components }
-      let!(:proposal) { create(:proposal_component, :published, participatory_space: model, name: generate_component_name(current_organization.available_locales, :proposals) ) }
+      let!(:proposal) { create(:proposal_component, :published, participatory_space: model, name: generate_component_name(current_organization.available_locales, :proposals)) }
       let!(:dummy) { create(:component, :published, participatory_space: model) }
 
       context "when sorting by component id" do

--- a/decidim-core/spec/types/component_input_sort_spec.rb
+++ b/decidim-core/spec/types/component_input_sort_spec.rb
@@ -13,7 +13,7 @@ module Decidim
 
       let(:model) { create(:participatory_process, organization: current_organization) }
       let(:models) { model.components }
-      let!(:proposal) { create(:proposal_component, :published, participatory_space: model) }
+      let!(:proposal) { create(:proposal_component, :published, participatory_space: model, name: generate_component_name(current_organization.available_locales, :proposals) ) }
       let!(:dummy) { create(:component, :published, participatory_space: model) }
 
       context "when sorting by component id" do

--- a/decidim-dev/lib/decidim/dev/test/factories.rb
+++ b/decidim-dev/lib/decidim/dev/test/factories.rb
@@ -4,12 +4,16 @@ require "decidim/components/namer"
 
 FactoryBot.define do
   factory :dummy_component, parent: :component do
+    transient do
+      skip_injection { false }
+    end
     name { Decidim::Components::Namer.new(participatory_space.organization.available_locales, :surveys).i18n_name }
     manifest_name { :dummy }
   end
 
   factory :dummy_resource, class: "Decidim::Dev::DummyResource" do
     transient do
+      skip_injection { false }
       users { nil }
       # user_groups correspondence to users is by sorting order
       user_groups { [] }
@@ -33,6 +37,9 @@ FactoryBot.define do
   end
 
   factory :nested_dummy_resource, class: "Decidim::Dev::NestedDummyResource" do
+    transient do
+      skip_injection { false }
+    end
     title { generate(:name) }
     dummy_resource { create(:dummy_resource) }
   end
@@ -42,6 +49,7 @@ FactoryBot.define do
     component { create(:component, manifest_name: "dummy") }
 
     transient do
+      skip_injection { false }
       authors_list { [create(:user, organization: component.organization)] }
     end
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/decidim_sanitization.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/decidim_sanitization.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.include Decidim::SanitizeHelper
+end

--- a/decidim-elections/app/cells/decidim/elections/highlighted_elections_for_component/show.erb
+++ b/decidim-elections/app/cells/decidim/elections/highlighted_elections_for_component/show.erb
@@ -1,6 +1,6 @@
 <div class="content-block__title">
   <h2 class="h2 decorator">
-    <%= single_component? ? translated_attribute(model.name) : t("decidim.components.elections.name") %>
+    <%= single_component? ? escape_translated(model.name) : t("decidim.components.elections.name") %>
   </h2>
   <div class="label text-lg"><%= elections_count %></div>
   <% if see_all_path.present? %>

--- a/decidim-elections/app/cells/decidim/elections/highlighted_elections_for_component/show.erb
+++ b/decidim-elections/app/cells/decidim/elections/highlighted_elections_for_component/show.erb
@@ -1,6 +1,6 @@
 <div class="content-block__title">
   <h2 class="h2 decorator">
-    <%= single_component? ? escape_translated(model.name) : t("decidim.components.elections.name") %>
+    <%= single_component? ? decidim_escape_translated(model.name) : t("decidim.components.elections.name") %>
   </h2>
   <div class="label text-lg"><%= elections_count %></div>
   <% if see_all_path.present? %>

--- a/decidim-elections/app/helpers/decidim/votings/votings_helper.rb
+++ b/decidim-elections/app/helpers/decidim/votings/votings_helper.rb
@@ -34,7 +34,7 @@ module Decidim
             end
           ] + components.map do |component|
             {
-              name: escape_translated(component.name),
+              name: decidim_escape_translated(component.name),
               url: main_component_path(component),
               active: is_active_link?(main_component_path(component), :inclusive) && !is_active_link?("election_log", /election_log$/)
             }

--- a/decidim-elections/app/helpers/decidim/votings/votings_helper.rb
+++ b/decidim-elections/app/helpers/decidim/votings/votings_helper.rb
@@ -34,7 +34,7 @@ module Decidim
             end
           ] + components.map do |component|
             {
-              name: translated_attribute(component.name),
+              name: escape_translated(component.name),
               url: main_component_path(component),
               active: is_active_link?(main_component_path(component), :inclusive) && !is_active_link?("election_log", /election_log$/)
             }

--- a/decidim-elections/lib/decidim/votings/menu.rb
+++ b/decidim-elections/lib/decidim/votings/menu.rb
@@ -40,7 +40,7 @@ module Decidim
       def self.register_admin_votings_components_menu!
         Decidim.menu :admin_votings_components_menu do |menu|
           current_participatory_space.components.each do |component|
-            caption = escape_translated(component.name)
+            caption = decidim_escape_translated(component.name)
             caption += content_tag(:span, component.primary_stat, class: "component-counter") if component.primary_stat.present?
 
             menu.add_item [component.manifest_name, component.id].join("_"),

--- a/decidim-elections/lib/decidim/votings/menu.rb
+++ b/decidim-elections/lib/decidim/votings/menu.rb
@@ -40,7 +40,7 @@ module Decidim
       def self.register_admin_votings_components_menu!
         Decidim.menu :admin_votings_components_menu do |menu|
           current_participatory_space.components.each do |component|
-            caption = translated_attribute(component.name)
+            caption = escape_translated(component.name)
             caption += content_tag(:span, component.primary_stat, class: "component-counter") if component.primary_stat.present?
 
             menu.add_item [component.manifest_name, component.id].join("_"),

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
@@ -79,7 +79,7 @@ module Decidim
         let!(:attachment) { create(:attachment, :with_image, attached_to: answer) }
 
         it "returns the download attachment link" do
-          expect(subject.body).to eq(%(<ul><li><a target="_blank" rel="noopener noreferrer" href="#{attachment.url}"><span>#{escape_translated(attachment.title)}</span> <small>jpeg 105 KB</small></a></li></ul>))
+          expect(subject.body).to eq(%(<ul><li><a target="_blank" rel="noopener noreferrer" href="#{attachment.url}"><span>#{decidim_escape_translated(attachment.title)}</span> <small>jpeg 105 KB</small></a></li></ul>))
         end
 
         context "when the attachment does not have a title" do

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_answer_presenter_spec.rb
@@ -79,7 +79,7 @@ module Decidim
         let!(:attachment) { create(:attachment, :with_image, attached_to: answer) }
 
         it "returns the download attachment link" do
-          expect(subject.body).to eq(%(<ul><li><a target="_blank" rel="noopener noreferrer" href="#{attachment.url}"><span>#{translated(attachment.title)}</span> <small>jpeg 105 KB</small></a></li></ul>))
+          expect(subject.body).to eq(%(<ul><li><a target="_blank" rel="noopener noreferrer" href="#{attachment.url}"><span>#{escape_translated(attachment.title)}</span> <small>jpeg 105 KB</small></a></li></ul>))
         end
 
         context "when the attachment does not have a title" do

--- a/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
@@ -10,7 +10,7 @@ module Decidim
 
         components.map do |component|
           {
-            name: translated_attribute(component.name),
+            name: escape_translated(component.name),
             url: main_component_path(component),
             active: is_active_link?(main_component_path(component), :inclusive)
           }

--- a/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
@@ -10,7 +10,7 @@ module Decidim
 
         components.map do |component|
           {
-            name: escape_translated(component.name),
+            name: decidim_escape_translated(component.name),
             url: main_component_path(component),
             active: is_active_link?(main_component_path(component), :inclusive)
           }

--- a/decidim-initiatives/lib/decidim/initiatives/menu.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/menu.rb
@@ -46,7 +46,7 @@ module Decidim
       def self.register_admin_initiatives_components_menu!
         Decidim.menu :admin_initiatives_components_menu do |menu|
           current_participatory_space.components.each do |component|
-            caption = translated_attribute(component.name)
+            caption = escape_translated(component.name)
             caption += content_tag(:span, component.primary_stat, class: "component-counter") if component.primary_stat.present?
 
             menu.add_item [component.manifest_name, component.id].join("_"),

--- a/decidim-initiatives/lib/decidim/initiatives/menu.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/menu.rb
@@ -46,7 +46,7 @@ module Decidim
       def self.register_admin_initiatives_components_menu!
         Decidim.menu :admin_initiatives_components_menu do |menu|
           current_participatory_space.components.each do |component|
-            caption = escape_translated(component.name)
+            caption = decidim_escape_translated(component.name)
             caption += content_tag(:span, component.primary_stat, class: "component-counter") if component.primary_stat.present?
 
             menu.add_item [component.manifest_name, component.id].join("_"),

--- a/decidim-initiatives/spec/system/filter_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/filter_initiatives_spec.rb
@@ -196,7 +196,6 @@ describe "Filter Initiatives", :slow do
       end
 
       it "does not display TYPE filter" do
-        expect(page).not_to have_content(/Type/i)
         expect(page).not_to have_css("#panel-dropdown-menu-type")
       end
 

--- a/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component/show.erb
@@ -4,7 +4,7 @@
 
 <div class="content-block__title">
   <h2 class="h2 decorator">
-    <%= single_component? ? translated_attribute(model.name) : t("decidim.components.meetings.name") %>
+    <%= single_component? ? escape_translated(model.name) : t("decidim.components.meetings.name") %>
   </h2>
   <div class="label text-lg"><%= meetings_count %></div>
   <% if see_all_path.present? %>

--- a/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/highlighted_meetings_for_component/show.erb
@@ -4,7 +4,7 @@
 
 <div class="content-block__title">
   <h2 class="h2 decorator">
-    <%= single_component? ? escape_translated(model.name) : t("decidim.components.meetings.name") %>
+    <%= single_component? ? decidim_escape_translated(model.name) : t("decidim.components.meetings.name") %>
   </h2>
   <div class="label text-lg"><%= meetings_count %></div>
   <% if see_all_path.present? %>

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -63,7 +63,7 @@ module Decidim
 
         components.map do |component|
           {
-            name: escape_translated(component.name),
+            name: decidim_escape_translated(component.name),
             url: main_component_path(component),
             active: is_active_link?(main_component_path(component), :inclusive)
           }

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -63,7 +63,7 @@ module Decidim
 
         components.map do |component|
           {
-            name: translated_attribute(component.name),
+            name: escape_translated(component.name),
             url: main_component_path(component),
             active: is_active_link?(main_component_path(component), :inclusive)
           }

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/menu.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/menu.rb
@@ -80,7 +80,7 @@ module Decidim
       def self.register_admin_participatory_process_components_menu!
         Decidim.menu :admin_participatory_process_components_menu do |menu|
           current_participatory_space.components.each do |component|
-            caption = escape_translated(component.name)
+            caption = decidim_escape_translated(component.name)
             caption += content_tag(:span, component.primary_stat, class: "component-counter") if component.primary_stat.present?
 
             menu.add_item [component.manifest_name, component.id].join("_"),

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/menu.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/menu.rb
@@ -80,7 +80,7 @@ module Decidim
       def self.register_admin_participatory_process_components_menu!
         Decidim.menu :admin_participatory_process_components_menu do |menu|
           current_participatory_space.components.each do |component|
-            caption = translated_attribute(component.name)
+            caption = escape_translated(component.name)
             caption += content_tag(:span, component.primary_stat, class: "component-counter") if component.primary_stat.present?
 
             menu.add_item [component.manifest_name, component.id].join("_"),

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -130,6 +130,10 @@ FactoryBot.define do
   end
 
   factory :participatory_process_step, class: "Decidim::ParticipatoryProcessStep" do
+    transient do
+      skip_injection { false }
+    end
+
     title { generate_localized_title }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     start_date { 1.month.ago }

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -11,6 +11,9 @@ FactoryBot.define do
   end
 
   factory :participatory_process, class: "Decidim::ParticipatoryProcess" do
+    transient do
+      skip_injection { false }
+    end
     title { generate_localized_title }
     slug { generate(:participatory_process_slug) }
     subtitle { generate_localized_title }

--- a/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
@@ -1,6 +1,6 @@
 <div class="content-block__title">
   <h2 class="h2 decorator">
-    <%= single_component? ? escape_translated(model.name) : t("decidim.components.proposals.name") %>
+    <%= single_component? ? decidim_escape_translated(model.name) : t("decidim.components.proposals.name") %>
   </h2>
   <div class="label text-lg"><%= proposals_count %></div>
   <% if single_component? %>

--- a/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
@@ -1,6 +1,6 @@
 <div class="content-block__title">
   <h2 class="h2 decorator">
-    <%= single_component? ? translated_attribute(model.name) : t("decidim.components.proposals.name") %>
+    <%= single_component? ? escape_translated(model.name) : t("decidim.components.proposals.name") %>
   </h2>
   <div class="label text-lg"><%= proposals_count %></div>
   <% if single_component? %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR aims to standardize the way the texts on factories are being used. 
Also, We simplify the frontend by adding 2 helper methods `sanitize_translated` and `escape_translated`, which will allow us to avoid using `decidim_sanitize(translated_attribute(model.name))` 

#### :pushpin: Related Issues

#### Testing
1. make sure the pipelines are green. 

:hearts: Thank you!
