### PR TITLE
Add participatory text missing attribute

### DIFF
--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -12,6 +12,8 @@ en:
         state: State
         title: Title
         user_group_id: Create collaborative draft as
+      import_participatory_text:
+        document: Participatory text document
       proposal:
         address: Address
         answer: Answer


### PR DESCRIPTION
#### :tophat: What? Why?

There's a missing attribute in the participatory text import of v0.27. This PR fixes it. 

#### :pushpin: Related Issues
 
- Fixes #12312

#### Testing

1. Create a new Proposals component with Participatory texts enabled
2. Add a new document in this component 
3. See that there isn't anymore the "Translation missing" error
 
### :camera: Screenshots
 
![Screenshot of the fix in the button](https://github.com/decidim/decidim/assets/717367/4edb74f8-7ae6-4a65-a24e-6d311bede508)

![Screenshot of the fix in the modal](https://github.com/decidim/decidim/assets/717367/23103f0b-ccd9-4804-830a-adc3965693e8)

:hearts: Thank you!
