### PR TITLE
Improve procfile and add alias for decidim:update

### DIFF
--- a/decidim-core/lib/tasks/decidim_procfile.rake
+++ b/decidim-core/lib/tasks/decidim_procfile.rake
@@ -4,7 +4,7 @@ require "thor"
 
 namespace :decidim do
   namespace :procfile do
-    desc "Generates a dummy app for testing in external installations"
+    desc "Generates a script for starting the development app server"
     task :install do
       actions :create_file, "Procfile.dev", <<~RUBY
         web: bin/rails server -b 0.0.0.0 -p 3000

--- a/decidim-core/lib/tasks/decidim_procfile.rake
+++ b/decidim-core/lib/tasks/decidim_procfile.rake
@@ -13,6 +13,12 @@ namespace :decidim do
 
       actions :create_file, "bin/dev", %(#!/usr/bin/env sh
 
+set -e
+
+bundle check || bundle install --jobs 20 --retry 5
+
+bin/rails decidim:upgrade db:migrate
+
 if ! gem list foreman -i --silent; then
   echo "Installing foreman..."
   gem install foreman

--- a/decidim-core/lib/tasks/decidim_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_tasks.rake
@@ -10,6 +10,8 @@ namespace :decidim do
     :"decidim_api:generate_docs"
   ]
 
+  task update: [:upgrade]
+
   desc "Setup environment so that only decidim migrations are installed."
   task :choose_target_plugins do
     ENV["FROM"] = %w(


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds a few quality of life improvement to developers:

1. `bin/dev`: checks for new gems in the Gemfile, new packages in package.json, and also brings in new migrations and runs them.
2. As I'm always asking myself "was it decidim:update or decidim:upgrade?", I think it's good to have an alias so any of these work.

#### :pushpin: Related Issues

- Related to changes like the one in #12289

#### Testing

1. For bin/dev

```console
bin/rails decidim:procfile:install
bin/dev
``` 

3. For decidim:upgrade and decidim:update

```console
bin/rails decidim:update
bin/rails decidim:upgrade
``` 

### :camera: Screenshots

![why-not-both-why-not](https://github.com/decidim/decidim/assets/717367/eb607072-021c-4147-9161-72251e340137)

:hearts: Thank you!
