### PR TITLE
Have only one h1 in the authorizations workflow page

### DIFF
--- a/decidim-admin/app/views/decidim/admin/authorization_workflows/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/authorization_workflows/index.html.erb
@@ -9,9 +9,9 @@
 <div class="card">
   <%= cell("decidim/verifications/revocations", @authorizations) %>
   <div class="card-divider">
-    <h1 class="card-title">
+    <h2 class="card-title">
       <%= t("decidim.admin.titles.authorization_workflows") %>
-    </h1>
+    </h2>
   </div>
   <div class="card-section">
     <table class="table-list table-list--lastleft">


### PR DESCRIPTION
#### :tophat: What? Why?

As I mentioned in a comment:

https://github.com/decidim/decidim/pull/12324#discussion_r1467550729

We should only have on h1 in each page, so this PR fixes that.   

:hearts: Thank you!
