### PR TITLE
Fix broken links in debates index

### DIFF
--- a/decidim-debates/app/cells/decidim/debates/debate_l_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/debate_l_cell.rb
@@ -32,7 +32,7 @@ module Decidim
         attribute = model.try(:short_description) || model.try(:body) || model.description
         text = translated_attribute(attribute)
 
-        decidim_sanitize(html_truncate(text, length: 240))
+        decidim_sanitize(html_truncate(text, length: 240), strip_tags: true)
       end
 
       private

--- a/decidim-debates/spec/cells/decidim/debates/debate_l_cell_spec.rb
+++ b/decidim-debates/spec/cells/decidim/debates/debate_l_cell_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Debates
+  describe DebateLCell, type: :cell do
+    controller Decidim::Debates::DebatesController
+
+    subject { cell_html }
+
+    let(:my_cell) { cell("decidim/debates/debate_l", debate, context: { show_space: }) }
+    let(:cell_html) { my_cell.call }
+    let(:created_at) { 1.month.ago }
+    let(:component) { create(:debates_component) }
+    let!(:debate) { create(:debate, component:, created_at:) }
+    let(:model) { debate }
+    let(:user) { create(:user, organization: debate.participatory_space.organization) }
+
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+    end
+
+    it_behaves_like "has space in m-cell"
+
+    context "when rendering" do
+      let(:show_space) { false }
+
+      it_behaves_like "m-cell", :debate
+
+      it "renders the card" do
+        expect(subject).to have_css("[id^='debates__debate']")
+      end
+
+      it "renders the comments count" do
+        expect(subject).to have_css(".card__list-metadata [data-comments-count]")
+      end
+
+      it "renders the title" do
+        expect(subject).to have_content(translated_attribute(debate.title))
+        expect(subject).to have_css(".card__list-title")
+      end
+
+      it "renders the description" do
+        expect(subject).to have_content(decidim_sanitize(translated_attribute(debate.description), strip_tags: true))
+        expect(subject).to have_css(".card__list-text")
+      end
+
+      context "when the description has a link" do
+        let!(:debate) { create(:debate, description:, component:, created_at:) }
+        let(:description) { { en: "This is a description with a link to <a href='http://example.org'>example.org</a>" } }
+
+        it "renders the description" do
+          expect(subject).to have_content("This is a description with a link to example.org")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

It was detected that if a debates description has a link in the first line, the design gets broken. This PR fixes that. 

#### :pushpin: Related Issues
 
- Fixes #12293

#### Testing

1. Go to a debates component
2. Create a new debate with a link in the first line of the description
3. See the design broken (without the patch)
4. Apply the patch
5. See the design well

### :camera: Screenshots
 
Debate with link: 

![Screenshot of the debate with link](https://github.com/decidim/decidim/assets/717367/48e10ecc-c603-4777-9fae-cc4cf8ba5fd8)

#### Without this patch

![Screenshot of the bug](https://github.com/decidim/decidim/assets/717367/d90de195-d7a2-473d-9d75-950886475841)

#### With this patch

![Screenshot of the fix](https://github.com/decidim/decidim/assets/717367/469d7439-c38b-442f-b1d0-2503ca2b6cc4)

:hearts: Thank you!
