### PR TITLE
Fix voting data migration for AddFollowableCounterCacheToVotings

### DIFF
--- a/decidim-elections/db/migrate/20210310120708_add_followable_counter_cache_to_votings.rb
+++ b/decidim-elections/db/migrate/20210310120708_add_followable_counter_cache_to_votings.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 class AddFollowableCounterCacheToVotings < ActiveRecord::Migration[5.2]
+  class Voting < ApplicationRecord
+    self.table_name = :decidim_votings_votings
+  end
+
   def change
     add_column :decidim_votings_votings, :follows_count, :integer, null: false, default: 0, index: true
 
     reversible do |dir|
       dir.up do
-        Decidim::Votings::Voting.reset_column_information
-        Decidim::Votings::Voting.find_each do |record|
+        Voting.reset_column_information
+        Voting.find_each do |record|
           record.class.reset_counters(record.id, :follows)
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

While working with an app and disabling the `decidim-elections` module, I found a data migration that doesn't work. This PR fixes it by following the strategy 3 from https://github.com/decidim/decidim/discussions/8068 (**Define ad-hoc model classe**) 

#### Testing

To check the failure:

1. Comment `decidim-elections` gem from `development_app/Gemfile`
2. Run `bundle install` 
3. Regenerate and migrate the DB: `bin/rails db:drop db:create db:migrate`

> See the exception:
> == 20240125096051 AddFollowableCounterCacheToVotings: migrating ===============
> -- add_column(:decidim_votings_votings, :follows_count, :integer, {:null=>false, :default=>0, :index=>true})
>    -> 0.0011s
> rails aborted!
> StandardError: An error has occurred, this and all later migrations canceled: (StandardError)
> 
> uninitialized constant Decidim::Votings
> /home/apereira/Work/decidim/decidim/development_app/db/migrate/20240125096051_add_followable_counter_cache_to_votings.decidim_elections.rb:10:in `block (2 levels) in change'
> /home/apereira/Work/decidim/decidim/development_app/db/migrate/20240125096051_add_followable_counter_cache_to_votings.decidim_elections.rb:9:in `block in change'
> /home/apereira/Work/decidim/decidim/development_app/db/migrate/20240125096051_add_followable_counter_cache_to_votings.decidim_elections.rb:8:in `change'
> /home/apereira/Work/decidim/decidim/development_app/bin/rails:5:in `<top (required)>'
> /home/apereira/Work/decidim/decidim/development_app/bin/spring:10:in `block in <top (required)>'
> /home/apereira/Work/decidim/decidim/development_app/bin/spring:7:in `<top (required)>'
> 
> Caused by:
> NameError: uninitialized constant Decidim::Votings (NameError)
> 
>         Decidim::Votings::Voting.reset_column_information
>                         ^^^^^^^^
> /home/apereira/Work/decidim/decidim/development_app/db/migrate/20240125096051_add_followable_counter_cache_to_votings.decidim_elections.rb:10:in `block (2 levels) in change'
> /home/apereira/Work/decidim/decidim/development_app/db/migrate/20240125096051_add_followable_counter_cache_to_votings.decidim_elections.rb:9:in `block in change'
> /home/apereira/Work/decidim/decidim/development_app/db/migrate/20240125096051_add_followable_counter_cache_to_votings.decidim_elections.rb:8:in `change'
> /home/apereira/Work/decidim/decidim/development_app/bin/rails:5:in `<top (required)>'
> /home/apereira/Work/decidim/decidim/development_app/bin/spring:10:in `block in <top (required)>'
> /home/apereira/Work/decidim/decidim/development_app/bin/spring:7:in `<top (required)>'
> Tasks: TOP => db:migrate
> (See full trace by running task with --trace)

To fix it: 

1. Apply this patch
2. Remove the migration ` rm development_app/db/migrate/*_add_followable_counter_cache_to_votings.decidim_elections.rb` 
3. Copy the new migration `bin/rails decidim:update` 
4. Migrate `bin/rails db:migrate` 
 

:hearts: Thank you!
