### PR TITLE
Backport 'Protect participatory text buttons under authorization' to v0.28

### DIFF
--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal/buttons.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal/buttons.erb
@@ -1,5 +1,5 @@
 <% if amendmendment_creation_enabled? || visible_emendations.any? %>
-  <%= link_to amend_resource_path, disabled: amend_button_disabled?, class: "proposal-participatory__button" do %>
+  <%= action_authorized_link_to :amend, amend_resource_path, resource: model, disabled: amend_button_disabled?, class: "proposal-participatory__button" do %>
     <%= icon "chat-1-line" %>
     <span><%= t("amend", scope: "decidim.proposals.participatory_text_proposal.buttons") %></span>
     <div class="label"><%= visible_emendations.count %></div>
@@ -14,7 +14,7 @@
       <div class="label"><%= model.comments_count %></div>
     <% end %>
   <% else %>
-    <%= link_to resource_comments_path, class: "proposal-participatory__button" do %>
+    <%= action_authorized_link_to :comment, resource_comments_path, resource: model, class: "proposal-participatory__button" do %>
       <%= icon "chat-1-line" %>
       <span><%= t("comment", scope: "decidim.proposals.participatory_text_proposal.buttons") %></span>
       <div class="label"><%= model.comments_count %></div>

--- a/decidim-proposals/spec/system/participatory_texts_spec.rb
+++ b/decidim-proposals/spec/system/participatory_texts_spec.rb
@@ -89,6 +89,62 @@ describe "Participatory texts" do
     end
   end
 
+  shared_examples "the Amend button is protected under authorization" do
+    shared_context "when clicking on the amend button" do
+      before do
+        visit_component
+        within "#proposals section[id='proposal_#{proposal.id}']" do
+          click_link "Amend"
+        end
+      end
+    end
+
+    let(:proposal) { proposals.first }
+    let(:user) { create(:user, :confirmed, organization:) }
+
+    before do
+      proposal.create_resource_permission(
+        permissions: {
+          "amend" => {
+            "authorization_handlers" => {
+              "dummy_authorization_handler" => { "options" => {} }
+            }
+          }
+        }
+      )
+    end
+
+    context "when the user is not logged in" do
+      include_context "when clicking on the amend button"
+
+      it "needs to login" do
+        expect(page).to have_content("Please log in")
+      end
+    end
+
+    context "when the user is logged in" do
+      before { login_as user, scope: :user }
+
+      context "when the user is not authorized" do
+        include_context "when clicking on the amend button"
+
+        it "cannot perform the action" do
+          expect(page).to have_content("Authorization required")
+        end
+      end
+
+      context "when the user is authorized" do
+        let!(:authorization) { create(:authorization, name: "dummy_authorization_handler", user:) }
+
+        include_context "when clicking on the amend button"
+
+        it "can perform the action" do
+          expect(page).to have_content("Create Amendment Draft")
+        end
+      end
+    end
+  end
+
   context "when listing proposals in a participatory process as participatory texts" do
     context "when admin has not yet published a participatory text" do
       let!(:component) do
@@ -133,6 +189,8 @@ describe "Participatory texts" do
             let(:amendments_count) { 0 }
             let(:disabled_value) { false }
           end
+
+          it_behaves_like "the Amend button is protected under authorization"
         end
 
         context "when amendment CREATION is disabled" do
@@ -191,6 +249,8 @@ describe "Participatory texts" do
               end
             end
           end
+
+          it_behaves_like "the Amend button is protected under authorization"
         end
 
         context "when amendment CREATION is disabled" do


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12232 to v0.28

:hearts: Thank you!
