### PR TITLE
Fix flaky for questionnaire drag and drop question

### DIFF
--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -536,6 +536,14 @@ shared_examples_for "has questionnaire" do
         )
       end
 
+      before do
+        # Workaround for flaky spec related to resolution change
+        #
+        # For some unknown reason, depending on the order run for these specs, the resolution is changed to
+        # 800x600, which breaks the drag and drop. This forces the resolution to be 1920x1080
+        current_window.resize_to(1920, 1080)
+      end
+
       it "renders the question answers as a collection of divs sortable on drag and drop" do
         visit questionnaire_public_path
 


### PR DESCRIPTION
#### :tophat: What? Why?

After merging the `chromedriver` update, we started  to see a flaky related to the quesitonnaire shared examples.

I debugged mostly by using `--bisect` and getting and order on why is it failing (`bin/rspec decidim-surveys/spec/system/survey_spec.rb --bisect`). The order that I have that always fail is this: 
```console
bin/rspec decidim-surveys/spec/system/survey_spec.rb[1:1:1:2:1:1,1:1:1:2:2:1,1:2:1,1:3:1,1:4:1:1,1:4:2:1:1:1,1:4:2:1:2:1:1,1:4:2:1:2:2,1:4:2:1:2:3:1,1:4:2:1:2:3:2,1:4:2:1:2:3:3,1:4:2:1:2:4,1:4:2:1:2:5:1,1:4:2:1:2:6:1:1,1:4:2:1:2:8:1,1:4:2:1:2:9:1,1:4:2:1:2:11:1,1:4:2:1:2:12:1:4:2:1,1:4:2:1:2:12:2:1,1:4:2:1:2:12:2:2,1:4:2:1:2:12:2:3,1:4:2:1:2:12:2:4:1:1,1:4:2:1:2:13:1,1:4:2:1:2:13:2:1:1,1:4:2:1:2:13:2:2:1,1:4:2:1:2:14:1,1:4:2:1:2:14:2:1:1,1:4:2:1:2:14:2:2:1,1:4:2:1:2:15:1,1:4:2:1:2:16:1,1:4:2:1:2:16:2,1:4:2:1:2:17:1,1:4:2:1:2:17:2,1:4:2:1:2:18:1,1:4:2:1:2:18:2,1:4:2:1:2:18:3:1,1:4:2:1:2:19:1,1:4:2:1:2:19:2:1,1:4:2:1:2:19:3:1,1:4:2:1:2:20:1:1:1:1,1:4:2:1:2:20:1:1:2:1,1:4:2:1:2:20:1:1:3:1,1:4:2:1:2:20:1:1:4:1,1:4:2:1:2:20:1:3:1:1,1:4:2:1:2:20:1:3:2:1,1:4:2:1:2:20:1:4:1:1,1:4:2:1:2:20:1:4:2:1,1:4:2:1:2:20:2:1:1,1:4:2:1:2:20:2:2:1,1:4:2:1:2:20:2:3:1,1:4:3:1:1:1:1,1:4:3:1:1:2:1,1:4:3:2:1:1:1,1:4:3:2:1:2:1,1:5:1] --fail-fast
``` 

Then, another snippet that allow me to see the resolution change is this:

```patch
diff --git a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
index 11178418d7..bebe7c09af 100644
--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -3,6 +3,11 @@
 require "spec_helper"

 shared_examples_for "has questionnaire" do
+  before do
+    puts current_window.size if defined? current_window
+  rescue
+  end
+
   context "when the user is not logged in" do
     it "does not allow answering the questionnaire" do
       visit questionnaire_public_path
```

I don't have time to actually understand why we're seeing this resolution change and if this happened in `chromedriver` before 120, but for now this workaround solves the flaky always. 

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/pull/12351

#### Testing

This command should fail in develop and should pass when applied this patch 

```console
bin/rspec decidim-surveys/spec/system/survey_spec.rb[1:1:1:2:1:1,1:1:1:2:2:1,1:2:1,1:3:1,1:4:1:1,1:4:2:1:1:1,1:4:2:1:2:1:1,1:4:2:1:2:2,1:4:2:1:2:3:1,1:4:2:1:2:3:2,1:4:2:1:2:3:3,1:4:2:1:2:4,1:4:2:1:2:5:1,1:4:2:1:2:6:1:1,1:4:2:1:2:8:1,1:4:2:1:2:9:1,1:4:2:1:2:11:1,1:4:2:1:2:12:1:4:2:1,1:4:2:1:2:12:2:1,1:4:2:1:2:12:2:2,1:4:2:1:2:12:2:3,1:4:2:1:2:12:2:4:1:1,1:4:2:1:2:13:1,1:4:2:1:2:13:2:1:1,1:4:2:1:2:13:2:2:1,1:4:2:1:2:14:1,1:4:2:1:2:14:2:1:1,1:4:2:1:2:14:2:2:1,1:4:2:1:2:15:1,1:4:2:1:2:16:1,1:4:2:1:2:16:2,1:4:2:1:2:17:1,1:4:2:1:2:17:2,1:4:2:1:2:18:1,1:4:2:1:2:18:2,1:4:2:1:2:18:3:1,1:4:2:1:2:19:1,1:4:2:1:2:19:2:1,1:4:2:1:2:19:3:1,1:4:2:1:2:20:1:1:1:1,1:4:2:1:2:20:1:1:2:1,1:4:2:1:2:20:1:1:3:1,1:4:2:1:2:20:1:1:4:1,1:4:2:1:2:20:1:3:1:1,1:4:2:1:2:20:1:3:2:1,1:4:2:1:2:20:1:4:1:1,1:4:2:1:2:20:1:4:2:1,1:4:2:1:2:20:2:1:1,1:4:2:1:2:20:2:2:1,1:4:2:1:2:20:2:3:1,1:4:3:1:1:1:1,1:4:3:1:1:2:1,1:4:3:2:1:1:1,1:4:3:2:1:2:1,1:5:1] --fail-fast
``` 
 
:hearts: Thank you!
