### PR TITLE
Fix flaky for AXE violations in breadcrumb menu for mobile and tablets

### DIFF
--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
@@ -17,7 +17,7 @@
   </span>
   <% if dropdown_item.present? %>
     <button id="secondary-dropdown-trigger-mobile" data-component="dropdown" data-hover="true" data-target="secondary-dropdown-menu-mobile">
-      <%= icon "arrow-down-s-line", class: "flex-none w-6 h-6 fill-current" %>
+      <%= icon "arrow-down-s-line", class: "flex-none w-6 h-6 fill-current" %><span class="sr-only"><%= t("layouts.decidim.header.main_menu") %></span>
     </button>
   <% end %>
   <% if content_for?(:participatory_space_mobile_actions) %>


### PR DESCRIPTION
#### :tophat: What? Why?

While working with #12349 and #12281 I saw the same [flaky spec](https://github.com/decidim/decidim/actions/runs/7783714980/job/21222870328#step:8:466)

```ruby
Failures:

  1) Explore versions when showing version behaves like accessible page passes accessibility tests
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }

       Found 1 accessibility violation:

       1) button-name: Buttons must have discernible text (critical)
           https://dequeuniversity.com/rules/axe/4.8/button-name?application=axeAPI
           The following 1 node violate this rule:

               Selector: #secondary-dropdown-trigger-mobile
               HTML: <button id="secondary-dropdown-trigger-mobile" data-component="dropdown" data-hover="true" data-target="secondary-dropdown-menu-mobile" aria-haspopup="true" aria-controls="secondary-dropdown-menu-mobile">
               Fix any of the following:
               - Element does not have inner text that is visible to screen readers
               - aria-label attribute does not exist or is empty
               - aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
               - Element has no title attribute
               - Element's default semantics were not overridden with role="none" or role="presentation"

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_explore_versions_when_showing_version_behaves_like_accessible_page_passes_accessibility_tests_566.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_explore_versions_when_showing_version_behaves_like_accessible_page_passes_accessibility_tests_566.html


     Shared Example Group: "accessible page" called from ./spec/system/explore_versions_spec.rb:54
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:123:in `block (2 levels) in <top (required)>'

(...)


Failed examples:

rspec './spec/system/explore_versions_spec.rb[1:2:1:1]' # Explore versions when showing version behaves like accessible page passes accessibility tests
```

This PR solves it by applying the same fix for the screen readers as we do in the desktop menu

#### Testing

I could not reproduce the flaky locally with the typical strategies (using the same seed, `--bisect`, running the spec 200 times, etc), so this is difficult to reproduce and check that's actually fixed. 

:hearts: Thank you!
