### PR TITLE
Add webp to content types in ActiveStorage

### DIFF
--- a/decidim-core/app/packs/src/decidim/editor/test/helpers.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/helpers.js
@@ -33,7 +33,7 @@ window.DragEvent = class DragEvent extends Event {};
 
 const defaultEditorConfig = {
   contentTypes: {
-    image: ["image/jpeg", "image/png"]
+    image: ["image/jpeg", "image/png", "image/webp"]
   },
   uploadImagesPath: "/editor_images",
   dragAndDropHelpText: "Add images by dragging & dropping or pasting them.",

--- a/decidim-core/app/uploaders/decidim/organization_favicon_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/organization_favicon_uploader.rb
@@ -26,7 +26,7 @@ module Decidim
     end
 
     def extension_allowlist
-      %w(png jpg jpeg ico)
+      %w(png jpg jpeg webp ico)
     end
   end
 end

--- a/decidim-core/app/uploaders/decidim/record_image_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/record_image_uploader.rb
@@ -5,11 +5,11 @@ module Decidim
   # limited content types than the defaults.
   class RecordImageUploader < ImageUploader
     def content_type_allowlist
-      %w(image/jpeg image/png)
+      %w(image/jpeg image/png image/webp)
     end
 
     def extension_allowlist
-      %w(jpeg jpg png)
+      %w(jpeg jpg png webp)
     end
   end
 end

--- a/decidim-core/config/initializers/active_storage.rb
+++ b/decidim-core/config/initializers/active_storage.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Rails.application.config.active_storage[:variable_content_types] << "image/webp"

--- a/decidim-core/lib/decidim/organization_settings.rb
+++ b/decidim-core/lib/decidim/organization_settings.rb
@@ -104,9 +104,9 @@ module Decidim
         {
           "upload" => {
             "allowed_file_extensions" => {
-              "default" => %w(jpg jpeg png pdf rtf txt),
-              "admin" => %w(jpg jpeg png pdf doc docx xls xlsx ppt pptx ppx rtf txt odt ott odf otg ods ots),
-              "image" => %w(jpg jpeg png)
+              "default" => %w(jpg jpeg png webp pdf rtf txt),
+              "admin" => %w(jpg jpeg png webp pdf doc docx xls xlsx ppt pptx ppx rtf txt odt ott odf otg ods ots),
+              "image" => %w(jpg jpeg png webp)
             },
             "allowed_content_types" => {
               "default" => %w(

--- a/decidim-core/spec/config/initializers/active_storage_spec.rb
+++ b/decidim-core/spec/config/initializers/active_storage_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ActiveStorage do
+  it "active storage has .webp in content types" do
+    expect(Rails.application.config.active_storage[:variable_content_types]).to include("image/webp")
+  end
+end

--- a/decidim-core/spec/lib/file_validator_humanizer_spec.rb
+++ b/decidim-core/spec/lib/file_validator_humanizer_spec.rb
@@ -9,7 +9,7 @@ module Decidim
     let(:uploader) do
       Class.new(Decidim::ApplicationUploader) do
         def extension_allowlist
-          %w(jpeg jpg png)
+          %w(jpeg jpg png webp)
         end
       end
     end
@@ -49,7 +49,7 @@ module Decidim
         expect(subject.messages).to eq(
           [
             "Maximum file size: 10MB",
-            "Allowed file extensions: jpeg jpg png"
+            "Allowed file extensions: jpeg jpg png webp"
           ]
         )
       end
@@ -71,7 +71,7 @@ module Decidim
 
     describe "#extension_allowlist" do
       it "returns the correct extensions" do
-        expect(subject.extension_allowlist).to eq(%w(jpeg jpg png))
+        expect(subject.extension_allowlist).to eq(%w(jpeg jpg png webp))
       end
     end
   end

--- a/decidim-core/spec/lib/organization_settings_spec.rb
+++ b/decidim-core/spec/lib/organization_settings_spec.rb
@@ -11,9 +11,9 @@ module Decidim
     let(:default_settings) do
       {
         "allowed_file_extensions" => {
-          "default" => %w(jpg jpeg png pdf rtf txt),
-          "admin" => %w(jpg jpeg png pdf doc docx xls xlsx ppt pptx ppx rtf txt odt ott odf otg ods ots),
-          "image" => %w(jpg jpeg png)
+          "default" => %w(jpg jpeg png webp pdf rtf txt),
+          "admin" => %w(jpg jpeg png webp pdf doc docx xls xlsx ppt pptx ppx rtf txt odt ott odf otg ods ots),
+          "image" => %w(jpg jpeg png webp)
         },
         "allowed_content_types" => {
           "default" => %w(
@@ -70,9 +70,9 @@ module Decidim
       let(:updated_settings) do
         {
           "allowed_file_extensions" => {
-            "default" => %w(jpg jpeg pdf),
-            "admin" => %w(jpg jpeg pdf docx),
-            "image" => %w(jpg jpeg)
+            "default" => %w(jpg jpeg webp pdf),
+            "admin" => %w(jpg jpeg webp pdf docx),
+            "image" => %w(jpg jpeg webp)
           },
           "allowed_content_types" => {
             "default" => %w(

--- a/decidim-core/spec/uploaders/organization_favicon_uploader_spec.rb
+++ b/decidim-core/spec/uploaders/organization_favicon_uploader_spec.rb
@@ -14,7 +14,7 @@ module Decidim
       subject { uploader.extension_allowlist }
 
       it "returns the custom allowed extensions" do
-        expect(subject).to eq(%w(png jpg jpeg ico))
+        expect(subject).to eq(%w(png jpg jpeg webp ico))
       end
     end
 
@@ -22,7 +22,7 @@ module Decidim
       subject { uploader.content_type_allowlist }
 
       it "returns the correct MIME types" do
-        expect(subject).to eq(%w(image/png image/jpeg image/vnd.microsoft.icon))
+        expect(subject).to eq(%w(image/png image/jpeg image/webp image/vnd.microsoft.icon))
       end
     end
   end

--- a/decidim-core/spec/validators/active_model/validations/file_content_type_validator_spec.rb
+++ b/decidim-core/spec/validators/active_model/validations/file_content_type_validator_spec.rb
@@ -14,7 +14,7 @@ describe ActiveModel::Validations::FileContentTypeValidator do
   let(:uploader) do
     Class.new(Decidim::ApplicationUploader) do
       def content_type_allowlist
-        %w(image/jpeg image/png)
+        %w(image/jpeg image/png image/webp)
       end
     end
   end
@@ -56,7 +56,7 @@ describe ActiveModel::Validations::FileContentTypeValidator do
     it "adds the content type error" do
       expect(subject.count).to eq(1)
       expect(subject[:file]).to eq(
-        ["only files with the following extensions are allowed: jpeg, jpg, png"]
+        ["only files with the following extensions are allowed: jpeg, jpg, png, webp"]
       )
     end
 

--- a/decidim-core/spec/validators/passthru_validator_spec.rb
+++ b/decidim-core/spec/validators/passthru_validator_spec.rb
@@ -10,7 +10,7 @@ describe PassthruValidator do
   let(:uploader) do
     Class.new(Decidim::ApplicationUploader) do
       def content_type_allowlist
-        %w(image/jpeg image/png)
+        %w(image/jpeg image/png image/webp)
       end
     end
   end
@@ -64,7 +64,7 @@ describe PassthruValidator do
       it "adds the passthrough record's validation errors on the field" do
         expect(subject).to be_invalid
         expect(subject.errors[:file]).to eq(
-          ["only files with the following extensions are allowed: jpeg, jpg, png"]
+          ["only files with the following extensions are allowed: jpeg, jpg, png, webp"]
         )
       end
     end

--- a/decidim-core/spec/validators/uploader_content_type_validator_spec.rb
+++ b/decidim-core/spec/validators/uploader_content_type_validator_spec.rb
@@ -18,7 +18,7 @@ describe UploaderContentTypeValidator do
   let(:uploader) do
     Class.new(Decidim::ApplicationUploader) do
       def content_type_allowlist
-        %w(image/jpeg image/png)
+        %w(image/jpeg image/png image/webp)
       end
     end
   end
@@ -58,7 +58,7 @@ describe UploaderContentTypeValidator do
     it "adds the content type error" do
       expect(subject.count).to eq(1)
       expect(subject[:file]).to eq(
-        ["only files with the following extensions are allowed: jpeg, jpg, png"]
+        ["only files with the following extensions are allowed: jpeg, jpg, png, webp"]
       )
     end
 
@@ -74,7 +74,7 @@ describe UploaderContentTypeValidator do
       it "adds the correct content type error with the allowed extensions" do
         expect(subject.count).to eq(1)
         expect(subject[:file]).to eq(
-          ["only files with the following extensions are allowed: jpeg, jpg, png"]
+          ["only files with the following extensions are allowed: jpeg, jpg, png, webp"]
         )
       end
     end
@@ -108,7 +108,7 @@ describe UploaderContentTypeValidator do
       it "adds the recognized extensions and content type to the error in correct order" do
         expect(subject.count).to eq(1)
         expect(subject[:file]).to eq(
-          ["only files with the following extensions are allowed: jpeg, jpg, png, foobar/*"]
+          ["only files with the following extensions are allowed: jpeg, jpg, png, webp, foobar/*"]
         )
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
The webp format is not accepted as a variant in ActiveStorage by default so, although the system does not break if you upload an image in .webp format, it is not accepted either.
ActiveStorage does not have this extension by default to be able to create variants with this content type.

In this PR, .webp format is added in an initializer.

#### :pushpin: Related Issues
-  Metadecidim: https://meta.decidim.org/processes/roadmap/f/122/proposals/17645

#### Testing
The .webp image (uploaded as a zip because github don't support the .webp type 😅 )
[lion_webp_10.zip](https://github.com/decidim/decidim/files/14179272/lion_webp_10.zip)

1. Create a proposal with a .webp image.
2. You can do it

### :camera: Screenshots

![Screenshot from 2024-02-06 10-20-27](https://github.com/decidim/decidim/assets/75725233/53694589-0714-4b4a-99dc-5957aa75f407)

![Screenshot from 2024-02-06 10-20-36](https://github.com/decidim/decidim/assets/75725233/141cfa66-28cf-4403-9783-b05054390acc)


:hearts: Thank you!
