### PR TITLE
Fix exception when presenting oauth application in admin log

### DIFF
--- a/decidim-core/app/presenters/decidim/admin_log/oauth_application_resource_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/oauth_application_resource_presenter.rb
@@ -11,7 +11,7 @@ module Decidim
       #
       # Returns an HTML-safe String.
       def resource_path
-        @resource_path ||= h.decidim_admin.oauth_application_path(resource)
+        @resource_path ||= h.decidim_system.oauth_application_path(resource)
       end
     end
   end

--- a/decidim-core/spec/presenters/decidim/admin_log/oauth_application_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/admin_log/oauth_application_presenter_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::AdminLog::OAuthApplicationPresenter, type: :helper do
+  include_examples "present admin log entry" do
+    let(:admin_log_resource) { create(:oauth_application, organization:) }
+    let(:action) { "update" }
+  end
+end

--- a/decidim-dev/config/rubocop/rspec.yml
+++ b/decidim-dev/config/rubocop/rspec.yml
@@ -5,6 +5,14 @@ require: rubocop-rspec
 #      - "(?:^|/)spec/"
 #      - "(?:^|/)test/"
 
+RSpec/FilePath:
+  CustomTransform:
+    OAuthApplicationPresenter: oauth_application_presenter
+
+RSpec/SpecFilePathFormat:
+  CustomTransform:
+    OAuthApplicationPresenter: oauth_application_presenter
+
 RSpec/BeforeAfterAll:
   Enabled: true
 


### PR DESCRIPTION
#### :tophat: What? Why?

When creating or updating an OAuth application and then going to the admin dashboard, you see an exception. This PR fixes that. 

The exception error:

```ruby
ActionView::Template::Error (undefined method `oauth_application_path' for #<Module:0x00007a9437580ca0>):
     9:     <% if logs.any? %>
    10:       <div class="logs table">
    11:         <% logs.each do |log| %>
    12:           <%= render_log(log) %>
    13:         <% end %>
    14:       </div>
    15:     <% else %>

actionpack (6.1.7.6) lib/action_dispatch/routing/routes_proxy.rb:45:in `oauth_application_path'
/home/apereira/Work/decidim/decidim/decidim-core/app/presenters/decidim/admin_log/oauth_application_resource_presenter.rb:14:
in `resource_path'
/home/apereira/Work/decidim/decidim/decidim-core/app/presenters/decidim/log/resource_presenter.rb:45:in `present_resource'
/home/apereira/Work/decidim/decidim/decidim-core/app/presenters/decidim/log/resource_presenter.rb:31:in `present'
```

#### :pushpin: Related Issues
 
- Fixes #12087

#### Testing

(Without this patch) 
1. Sign in at system panel http://localhost:3000/system
2. Go to edit an oauth application (http://localhost:3000/system/oauth_applications/1/edit)
3. Sign in at admin panel  http://localhost:3000/admin
4. See an exception

(With this patch) 
1. Sign in at system panel http://localhost:3000/system
2. Go to edit an oauth application (http://localhost:3000/system/oauth_applications/1/edit)
3. Sign in at admin panel  http://localhost:3000/admin
4. See the log for the action 

### :camera: Screenshots
 
![Screenshot of the admin log with the logs from OAuth applications](https://github.com/decidim/decidim/assets/717367/f82d1fc6-f590-4306-83dd-716976a6b7fa)

:hearts: Thank you!
