### PR TITLE
Fix authorization handler in OmniauthRegistrations

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/devise_authentication_methods.rb
+++ b/decidim-core/app/controllers/concerns/decidim/devise_authentication_methods.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module DeviseAuthenticationMethods
+    extend ActiveSupport::Concern
+    include Decidim::UserBlockedChecker
+
+    included do
+      def after_sign_in_path_for(user)
+        if user.present? && user.blocked?
+          check_user_block_status(user)
+        elsif user.needs_password_update?
+          change_password_path
+        elsif first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user)
+          decidim_verifications.first_login_authorizations_path
+        else
+          super
+        end
+      end
+
+      # Calling the `stored_location_for` method removes the key, so in order
+      # to check if there is any pending redirect after login I need to call
+      # this method and use the value to set a pending redirect. This is the
+      # only way to do this without checking the session directly.
+      def pending_redirect?(user)
+        store_location_for(user, stored_location_for(user))
+      end
+
+      def first_login_and_not_authorized?(user)
+        user.is_a?(User) && user.sign_in_count == 1 && current_organization.available_authorizations.any? && user.verifiable?
+      end
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -64,7 +64,7 @@ module Decidim
       end
 
       def first_login_and_not_authorized?(user)
-        user.is_a?(User) && user.sign_in_count == 1 && Decidim::Verifications.workflows.any? && user.verifiable?
+        user.is_a?(User) && user.sign_in_count == 1 && current_organization.available_authorizations.any? && user.verifiable?
       end
 
       def action_missing(action_name)

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -6,6 +6,7 @@ module Decidim
     class OmniauthRegistrationsController < ::Devise::OmniauthCallbacksController
       include FormFactory
       include Decidim::DeviseControllers
+      include Decidim::DeviseAuthenticationMethods
 
       def new
         @form = form(OmniauthRegistrationForm).from_params(params[:user])
@@ -43,28 +44,6 @@ module Decidim
             render :new
           end
         end
-      end
-
-      def after_sign_in_path_for(user)
-        if user.present? && user.blocked?
-          check_user_block_status(user)
-        elsif !pending_redirect?(user) && first_login_and_not_authorized?(user)
-          decidim_verifications.authorizations_path
-        else
-          super
-        end
-      end
-
-      # Calling the `stored_location_for` method removes the key, so in order
-      # to check if there is any pending redirect after login I need to call
-      # this method and use the value to set a pending redirect. This is the
-      # only way to do this without checking the session directly.
-      def pending_redirect?(user)
-        store_location_for(user, stored_location_for(user))
-      end
-
-      def first_login_and_not_authorized?(user)
-        user.is_a?(User) && user.sign_in_count == 1 && current_organization.available_authorizations.any? && user.verifiable?
       end
 
       def action_missing(action_name)

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -5,6 +5,7 @@ module Decidim
     # Custom Devise SessionsController to avoid namespace problems.
     class SessionsController < ::Devise::SessionsController
       include Decidim::DeviseControllers
+      include Decidim::DeviseAuthenticationMethods
 
       before_action :check_sign_in_enabled, only: :create
 
@@ -33,30 +34,6 @@ module Decidim
         else
           super
         end
-      end
-
-      def after_sign_in_path_for(user)
-        if user.present? && user.blocked?
-          check_user_block_status(user)
-        elsif user.needs_password_update?
-          change_password_path
-        elsif first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user)
-          decidim_verifications.first_login_authorizations_path
-        else
-          super
-        end
-      end
-
-      # Calling the `stored_location_for` method removes the key, so in order
-      # to check if there is any pending redirect after login I need to call
-      # this method and use the value to set a pending redirect. This is the
-      # only way to do this without checking the session directly.
-      def pending_redirect?(user)
-        store_location_for(user, stored_location_for(user))
-      end
-
-      def first_login_and_not_authorized?(user)
-        user.is_a?(User) && user.sign_in_count == 1 && current_organization.available_authorizations.any? && user.verifiable?
       end
 
       def after_sign_out_path_for(user)

--- a/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
@@ -31,46 +31,84 @@ module Decidim
         }
       end
 
-      context "when the organization does have a valid authorization handler" do
-        let!(:user) { create(:user, :confirmed, organization:, sign_in_count: 1) }
+      describe "after_sign_in_path_for" do
+        subject { controller.after_sign_in_path_for(user) }
 
-        context "when there are authorization handlers" do
-          before do
-            allow(user.organization).to receive(:available_authorizations)
-              .and_return(["dummy_authorization_handler"])
-            post :create
-          end
-
-          it { expect(controller).to redirect_to("/authorizations") }
-
-          context "when there is a pending redirection" do
-            before do
-              controller.store_location_for(user, account_path)
-              post :create
-            end
-
-            it { expect(controller).to redirect_to(account_path) }
-          end
-
-          context "when the user has not confirmed their email" do
-            before do
-              allow(user.organization).to receive(:available_authorizations)
-                .and_return([])
-              user.confirmed_at = nil
-              post :create
-            end
-
-            it { expect(controller).to redirect_to(root_path) }
-          end
+        before do
+          request.env["decidim.current_organization"] = user.organization
         end
 
-        context "and otherwise", with_authorization_workflows: [] do
-          before do
-            allow(user.organization).to receive(:available_authorizations).and_return([])
-            post :create
+        context "when the given resource is a user" do
+          context "and is an admin" do
+            let(:user) { build(:user, :admin, sign_in_count: 1) }
+
+            before do
+              controller.store_location_for(user, account_path)
+            end
+
+            it { is_expected.to eq account_path }
           end
 
-          it { expect(controller).to redirect_to(root_path) }
+          context "and is not an admin" do
+            context "when it is the first time to log in" do
+              let(:user) { build(:user, :confirmed, sign_in_count: 1) }
+
+              context "when there are authorization handlers" do
+                before do
+                  allow(user.organization).to receive(:available_authorizations)
+                    .and_return(["dummy_authorization_handler"])
+                end
+
+                it { is_expected.to eq("/authorizations/first_login") }
+
+                context "when there is a pending redirection" do
+                  before do
+                    controller.store_location_for(user, account_path)
+                  end
+
+                  it { is_expected.to eq account_path }
+                end
+
+                context "when the user has not confirmed their email" do
+                  before do
+                    user.confirmed_at = nil
+                  end
+
+                  it { is_expected.to eq("/") }
+                end
+
+                context "when the user is blocked" do
+                  before do
+                    user.blocked = true
+                  end
+
+                  it { is_expected.to eq("/") }
+                end
+
+                context "when the user is not blocked" do
+                  before do
+                    user.blocked = false
+                  end
+
+                  it { is_expected.to eq("/authorizations/first_login") }
+                end
+              end
+
+              context "and otherwise", with_authorization_workflows: [] do
+                before do
+                  allow(user.organization).to receive(:available_authorizations).and_return([])
+                end
+
+                it { is_expected.to eq("/") }
+              end
+            end
+
+            context "and it is not the first time to log in" do
+              let(:user) { build(:user, sign_in_count: 2) }
+
+              it { is_expected.to eq("/") }
+            end
+          end
         end
       end
 

--- a/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
@@ -32,12 +32,12 @@ module Decidim
       end
 
       context "when the organization does have a valid authorization handler" do
-        let!(:user) { create(:user, :confirmed, organization: , sign_in_count: 1) }
+        let!(:user) { create(:user, :confirmed, organization:, sign_in_count: 1) }
 
         context "when there are authorization handlers" do
           before do
             allow(user.organization).to receive(:available_authorizations)
-                                          .and_return(["dummy_authorization_handler"])
+              .and_return(["dummy_authorization_handler"])
             post :create
           end
 
@@ -55,7 +55,7 @@ module Decidim
           context "when the user has not confirmed their email" do
             before do
               allow(user.organization).to receive(:available_authorizations)
-                                            .and_return([])
+                .and_return([])
               user.confirmed_at = nil
               post :create
             end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR is trying to fix an edge case in the OmniauthRegistrations, where the use is trying to register with a new Omniauth account into an organization that does not have any authorization handlers set  

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Closes #12395 

#### Testing
1. Go to a Decidim inststance in the system panel
2. Make sure you do not have any authorizations enabled.
3. Make sure you have oimniauth
4. Try to login using a new Omniauth account
5. On the omniauth provider screen, create a new account ( so that u receive the verification link from Service provider )
6. Open the verification link in a new private window ( to simulate outlook or other desktop email client )
7. See that you are being redirected on Oauth provider pages, then TOS, then Authorizations screen.
8. Apply patch, and repeat steps 4-7, and see that you are redirected to Root path. 

:hearts: Thank you!
