### PR TITLE
Fix a11y errors with organizations seeds colors

### DIFF
--- a/decidim-core/lib/decidim/core/seeds.rb
+++ b/decidim-core/lib/decidim/core/seeds.rb
@@ -105,11 +105,11 @@ module Decidim
         smtp_email = ENV.fetch("SMTP_FROM_EMAIL", ::Faker::Internet.email)
 
         primary_color, secondary_color, tertiary_color = [
-          ["#e02d2d", "#155abf", "#ebc34b"],
-          ["#4caf50", "#a0309e", "#a8753e"],
-          ["#e91e63", "#1ee9a5", "#e9b61e"],
-          ["#009688", "#d12c26", "#b4a110"],
-          ["#ff9800", "#00bcd4", "#ea0094"]
+          ["#bf4044", "#09780e", "#3584e4"],
+          ["#09780e", "#4448bb", "#da565b"],
+          ["#bf4086", "#487511", "#5384ac"],
+          ["#086263", "#811380", "#abac53"],
+          ["#5340bf", "#a82c2c", "#40bf53"]
         ].sample
 
         colors = {


### PR DESCRIPTION
#### :tophat: What? Why?

Starting with the redesign, the colors that we have for seeds have a really bad a11y contrast, so they are always making errors in the WCAG checker that we use for develop. 

This PR changes those colors so we don't have these a11y errors

#### :pushpin: Related Issues
 
- Related to #10974 
 
#### Testing

1. Sign in as admin
2. Go to http://localhost:3000/admin/organization/appearance/edit 
3. Edit the colors in the bottom of the page for the ones from this PR 
4. Go to the frontend (i.e. http://localhost:3000/) 
5. See that you don't have errors in the top left WAI WCAG checker

### :camera: Screenshots

![Screenshot of the homepage without WAI WCAG errors](https://github.com/decidim/decidim/assets/717367/ac7ad760-ba92-498f-a736-769032146b33)

:hearts: Thank you!
