### PR TITLE
Fix flaky specs in proposals

### DIFF
--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -354,8 +354,8 @@ shared_examples "manage proposals" do
         end
 
         proposal.reload
-        expect(proposal.answered_at).to be_within(2.seconds).of Time.zone.now
-        expect(proposal.state_published_at).to be_within(2.seconds).of Time.zone.now
+        expect(proposal.answered_at).to be_within(5.seconds).of Time.zone.now
+        expect(proposal.state_published_at).to be_within(5.seconds).of Time.zone.now
       end
 
       it "can accept a proposal" do
@@ -373,8 +373,8 @@ shared_examples "manage proposals" do
         end
 
         proposal.reload
-        expect(proposal.answered_at).to be_within(2.seconds).of Time.zone.now
-        expect(proposal.state_published_at).to be_within(2.seconds).of Time.zone.now
+        expect(proposal.answered_at).to be_within(5.seconds).of Time.zone.now
+        expect(proposal.state_published_at).to be_within(5.seconds).of Time.zone.now
       end
 
       it "can mark a proposal as evaluating" do
@@ -392,8 +392,8 @@ shared_examples "manage proposals" do
         end
 
         proposal.reload
-        expect(proposal.answered_at).to be_within(2.seconds).of Time.zone.now
-        expect(proposal.state_published_at).to be_within(2.seconds).of Time.zone.now
+        expect(proposal.answered_at).to be_within(5.seconds).of Time.zone.now
+        expect(proposal.state_published_at).to be_within(5.seconds).of Time.zone.now
       end
 
       it "can mark a proposal as 'not answered'" do
@@ -452,7 +452,7 @@ shared_examples "manage proposals" do
         end
 
         proposal.reload
-        expect(proposal.answered_at).to be_within(2.seconds).of Time.zone.now
+        expect(proposal.answered_at).to be_within(5.seconds).of Time.zone.now
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR tries to fix a flacky scenario within Proposals, where the specs are failing as the tested time interval is just a bit outside of the specified time interval. 
This PR increases the time check to 5 seconds, so that we can make sure there are no further issues.

```
 1) Admin manages proposals behaves like manage proposals when the proposal_answering component setting is enabled when the proposal_answering step setting is enabled can edit a proposal answer
     Failure/Error: expect(proposal.answered_at).to be_within(2.seconds).of Time.zone.now
       expected 2024-02-08 18:40:42.241625000 +0000 to be within 2 of 2024-02-08 18:40:44.628330802 +0000

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_proposals_behaves_like_manage_proposals_when_the_proposal_answering_component_setting_is_enabled_when_the_proposal_answering_step_setting_is_enabled_can_edit_a_prop_439.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_proposals_behaves_like_manage_proposals_when_the_proposal_answering_component_setting_is_enabled_when_the_proposal_answering_step_setting_is_enabled_can_edit_a_prop_439.html


     Shared Example Group: "manage proposals" called from ./spec/system/admin/admin_manages_proposals_spec.rb:16
     # ./spec/shared/manage_proposals_examples.rb:455:in `block (4 levels) in <top (required)>'

```

#### Testing
1. Pipelines should be green. 

### :camera: Screenshots
![image](https://github.com/decidim/decidim/assets/105683/75f59605-60ac-472d-b623-b55306c3f4a9)

:hearts: Thank you!
