### PR TITLE
Fix Content Security Policy errors in pipeline

### DIFF
--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -149,7 +149,18 @@ FactoryBot.define do
     end
     file_upload_settings { Decidim::OrganizationSettings.default(:upload) }
     enable_participatory_space_filters { true }
-    content_security_policy { {} }
+    content_security_policy do
+      {
+        "default-src" => "localhost:* #{host}:*",
+        "script-src" => "localhost:* #{host}:*",
+        "style-src" => "localhost:* #{host}:*",
+        "img-src" => "localhost:* #{host}:*",
+        "font-src" => "localhost:* #{host}:*",
+        "connect-src" => "localhost:* #{host}:*",
+        "frame-src" => "localhost:* #{host}:* www.example.org",
+        "media-src" => "localhost:* #{host}:*"
+      }
+    end
     colors do
       {
         primary: "#e02d2d",

--- a/decidim-core/spec/controllers/concerns/content_security_policy_spec.rb
+++ b/decidim-core/spec/controllers/concerns/content_security_policy_spec.rb
@@ -40,14 +40,14 @@ module Decidim
 
       it "sets the appropiate headers" do
         get :show
-        expect(response.headers["Content-Security-Policy"]).to include("default-src 'self' 'unsafe-inline'; ")
-        expect(response.headers["Content-Security-Policy"]).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval';")
-        expect(response.headers["Content-Security-Policy"]).to include("style-src 'self' 'unsafe-inline';")
-        expect(response.headers["Content-Security-Policy"]).to include("img-src 'self' *.hereapi.com data: https://via.placeholder.com;")
-        expect(response.headers["Content-Security-Policy"]).to include("connect-src 'self' *.hereapi.com *.jsdelivr.net data:;")
-        expect(response.headers["Content-Security-Policy"]).to include("font-src 'self';")
-        expect(response.headers["Content-Security-Policy"]).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com;")
-        expect(response.headers["Content-Security-Policy"]).to include("media-src 'self'")
+        expect(response.headers["Content-Security-Policy"]).to include("default-src 'self' 'unsafe-inline' localhost:* #{organization.host}:*; ")
+        expect(response.headers["Content-Security-Policy"]).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval' localhost:* #{organization.host}:*; ")
+        expect(response.headers["Content-Security-Policy"]).to include("style-src 'self' 'unsafe-inline' localhost:* #{organization.host}:*;")
+        expect(response.headers["Content-Security-Policy"]).to include("img-src 'self' *.hereapi.com data: https://via.placeholder.com localhost:* #{organization.host}:*;")
+        expect(response.headers["Content-Security-Policy"]).to include("connect-src 'self' *.hereapi.com *.jsdelivr.net data: localhost:* #{organization.host}:*; ")
+        expect(response.headers["Content-Security-Policy"]).to include("font-src 'self' localhost:* #{organization.host}:*; ")
+        expect(response.headers["Content-Security-Policy"]).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com localhost:* #{organization.host}:* www.example.org;")
+        expect(response.headers["Content-Security-Policy"]).to include("media-src 'self' localhost:* #{organization.host}:*")
       end
 
       context "when content policy is added by organization" do
@@ -70,14 +70,14 @@ module Decidim
         it "sets the appropiate headers" do
           allow(Decidim).to receive(:content_security_policies_extra).and_return(additional_content_security_policies)
           get :show
-          expect(response.headers["Content-Security-Policy"]).to include("default-src 'self' 'unsafe-inline' https://example.org; ")
-          expect(response.headers["Content-Security-Policy"]).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval' https://script.example.org;")
-          expect(response.headers["Content-Security-Policy"]).to include("style-src 'self' 'unsafe-inline' https://style.example.org;")
-          expect(response.headers["Content-Security-Policy"]).to include("img-src 'self' *.hereapi.com data: https://img.example.org;")
-          expect(response.headers["Content-Security-Policy"]).to include("connect-src 'self' *.hereapi.com *.jsdelivr.net data: https://connect.example.org;")
-          expect(response.headers["Content-Security-Policy"]).to include("font-src 'self' https://font.example.org;")
-          expect(response.headers["Content-Security-Policy"]).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com https://frame.example.org;")
-          expect(response.headers["Content-Security-Policy"]).to include("media-src 'self' https://example.org")
+          expect(response.headers["Content-Security-Policy"]).to include("default-src 'self' 'unsafe-inline' https://example.org localhost:* #{organization.host}:*; ")
+          expect(response.headers["Content-Security-Policy"]).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval' https://script.example.org localhost:* #{organization.host}:*; ")
+          expect(response.headers["Content-Security-Policy"]).to include("style-src 'self' 'unsafe-inline' https://style.example.org localhost:* #{organization.host}:*;")
+          expect(response.headers["Content-Security-Policy"]).to include("img-src 'self' *.hereapi.com data: https://img.example.org localhost:* #{organization.host}:*;")
+          expect(response.headers["Content-Security-Policy"]).to include("connect-src 'self' *.hereapi.com *.jsdelivr.net data: https://connect.example.org localhost:* #{organization.host}:*; ")
+          expect(response.headers["Content-Security-Policy"]).to include("font-src 'self' https://font.example.org localhost:* #{organization.host}:*; ")
+          expect(response.headers["Content-Security-Policy"]).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com https://frame.example.org localhost:* #{organization.host}:* www.example.org;")
+          expect(response.headers["Content-Security-Policy"]).to include("media-src 'self' https://example.org localhost:* #{organization.host}:*")
         end
       end
 
@@ -116,14 +116,14 @@ module Decidim
 
         it "sets the appropiate headers" do
           get :show
-          expect(response.headers["Content-Security-Policy"]).to include("default-src 'self' 'unsafe-inline' https://example.org; ")
-          expect(response.headers["Content-Security-Policy"]).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval' https://script.example.org;")
-          expect(response.headers["Content-Security-Policy"]).to include("style-src 'self' 'unsafe-inline' https://style.example.org;")
-          expect(response.headers["Content-Security-Policy"]).to include("img-src 'self' *.hereapi.com data: https://img.example.org https://via.placeholder.com;")
-          expect(response.headers["Content-Security-Policy"]).to include("connect-src 'self' *.hereapi.com *.jsdelivr.net data: https://connect.example.org;")
-          expect(response.headers["Content-Security-Policy"]).to include("font-src 'self' https://font.example.org;")
-          expect(response.headers["Content-Security-Policy"]).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com https://frame.example.org;")
-          expect(response.headers["Content-Security-Policy"]).to include("media-src 'self' https://example.org")
+          expect(response.headers["Content-Security-Policy"]).to include("default-src 'self' 'unsafe-inline' https://example.org localhost:* #{organization.host}:*; ")
+          expect(response.headers["Content-Security-Policy"]).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval' https://script.example.org localhost:* #{organization.host}:*; ")
+          expect(response.headers["Content-Security-Policy"]).to include("style-src 'self' 'unsafe-inline' https://style.example.org localhost:* #{organization.host}:*; ")
+          expect(response.headers["Content-Security-Policy"]).to include("img-src 'self' *.hereapi.com data: https://img.example.org https://via.placeholder.com localhost:* #{organization.host}:*;")
+          expect(response.headers["Content-Security-Policy"]).to include("connect-src 'self' *.hereapi.com *.jsdelivr.net data: https://connect.example.org localhost:* #{organization.host}:*;")
+          expect(response.headers["Content-Security-Policy"]).to include("font-src 'self' https://font.example.org localhost:* #{organization.host}:*;")
+          expect(response.headers["Content-Security-Policy"]).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com https://frame.example.org localhost:* #{organization.host}:* www.example.org;")
+          expect(response.headers["Content-Security-Policy"]).to include("media-src 'self' https://example.org localhost:* #{organization.host}:*")
         end
       end
     end

--- a/decidim-core/spec/lib/asset_router/pipeline_spec.rb
+++ b/decidim-core/spec/lib/asset_router/pipeline_spec.rb
@@ -12,6 +12,10 @@ module Decidim::AssetRouter
 
     let(:correct_asset_path) { ActionController::Base.helpers.asset_pack_path(asset) }
 
+    before do
+      Rails.application.config.action_controller.asset_host = nil
+    end
+
     describe "#url" do
       subject { router.url }
 

--- a/decidim-core/spec/lib/content_security_policy_spec.rb
+++ b/decidim-core/spec/lib/content_security_policy_spec.rb
@@ -13,22 +13,9 @@ module Decidim
       it { is_expected.to respond_to(:output_policy) }
       it { expect(subject.output_policy).to be_a(String) }
       it { expect(subject.output_policy).to include("default-src 'self' 'unsafe-inline'; ") }
-
-      it {
-        puts subject.output_policy
-        expect(subject.output_policy).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval';")
-      }
-
-      it {
-        puts subject.output_policy
-        expect(subject.output_policy).to include("style-src 'self' 'unsafe-inline';")
-      }
-
-      it {
-        puts subject.output_policy
-        expect(subject.output_policy).to include("img-src 'self' *.hereapi.com data:;")
-      }
-
+      it { expect(subject.output_policy).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval';") }
+      it { expect(subject.output_policy).to include("style-src 'self' 'unsafe-inline';") }
+      it { expect(subject.output_policy).to include("img-src 'self' *.hereapi.com data:;") }
       it { expect(subject.output_policy).to include("connect-src 'self' *.hereapi.com *.jsdelivr.net data:;") }
       it { expect(subject.output_policy).to include("font-src 'self';") }
       it { expect(subject.output_policy).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com;") }

--- a/decidim-core/spec/lib/content_security_policy_spec.rb
+++ b/decidim-core/spec/lib/content_security_policy_spec.rb
@@ -13,9 +13,22 @@ module Decidim
       it { is_expected.to respond_to(:output_policy) }
       it { expect(subject.output_policy).to be_a(String) }
       it { expect(subject.output_policy).to include("default-src 'self' 'unsafe-inline'; ") }
-      it { expect(subject.output_policy).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval';") }
-      it { expect(subject.output_policy).to include("style-src 'self' 'unsafe-inline';") }
-      it { expect(subject.output_policy).to include("img-src 'self' *.hereapi.com data:;") }
+
+      it {
+        puts subject.output_policy
+        expect(subject.output_policy).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval';")
+      }
+
+      it {
+        puts subject.output_policy
+        expect(subject.output_policy).to include("style-src 'self' 'unsafe-inline';")
+      }
+
+      it {
+        puts subject.output_policy
+        expect(subject.output_policy).to include("img-src 'self' *.hereapi.com data:;")
+      }
+
       it { expect(subject.output_policy).to include("connect-src 'self' *.hereapi.com *.jsdelivr.net data:;") }
       it { expect(subject.output_policy).to include("font-src 'self';") }
       it { expect(subject.output_policy).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com;") }

--- a/decidim-core/spec/lib/content_security_policy_spec.rb
+++ b/decidim-core/spec/lib/content_security_policy_spec.rb
@@ -28,18 +28,18 @@ module Decidim
       it { expect(subject.append_csp_directive("default-src", "https://example.org")).to include("https://example.org") }
 
       context "when policies as passed as hash" do
-        let(:additional_content_security_policies) { { "img-src": %w('self') } } # rubocop:disable Lint/PercentStringArray
+        let(:additional_content_security_policies) { { "img-src": ["'self'"] } }
 
         it "does not raise any errors" do
-          expect { subject.output_policy }.not_to raise_error(RuntimeError)
+          expect { subject.output_policy }.not_to raise_error
         end
       end
 
       context "when policies as passed as string" do
-        let(:additional_content_security_policies) { { "img-src" => %w('self') } } # rubocop:disable Lint/PercentStringArray
+        let(:additional_content_security_policies) { { "img-src" => ["'self'"] } }
 
         it "does not raise any errors" do
-          expect { subject.output_policy }.not_to raise_error(RuntimeError)
+          expect { subject.output_policy }.not_to raise_error
         end
       end
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -156,6 +156,19 @@ RSpec.configure do |config|
     warn page.driver.browser.logs.get(:browser) unless example.metadata[:driver].eql?(:rack_test)
   end
 
+  config.after(type: :system) do |example|
+    unless example.metadata[:driver].eql?(:rack_test)
+      errors = page.driver.browser.logs.get(:browser)
+      if errors.present?
+        aggregate_failures "javascript errors" do
+          errors.each do |error|
+            expect(error.message).not_to include("Content Security Policy"), error.message if error.level == "SEVERE"
+          end
+        end
+      end
+    end
+  end
+
   config.include Decidim::CapybaraTestHelpers, type: :system
   config.include Devise::Test::IntegrationHelpers, type: :system
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -10,6 +10,7 @@ module Decidim
 
       app_host = (host ? "#{protocol}://#{host}" : nil)
       Capybara.app_host = app_host
+      Rails.application.config.action_controller.asset_host = host
     end
 
     def switch_to_default_host

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -156,20 +156,7 @@ RSpec.configure do |config|
   config.after(type: :system) do |example|
     warn page.driver.browser.logs.get(:browser) unless example.metadata[:driver].eql?(:rack_test)
   end
-
-  config.after(type: :system) do |example|
-    unless example.metadata[:driver].eql?(:rack_test)
-      errors = page.driver.browser.logs.get(:browser)
-      if errors.present?
-        aggregate_failures "javascript errors" do
-          errors.each do |error|
-            expect(error.message).not_to include("Content Security Policy"), error.message if error.level == "SEVERE"
-          end
-        end
-      end
-    end
-  end
-
+  
   config.include Decidim::CapybaraTestHelpers, type: :system
   config.include Devise::Test::IntegrationHelpers, type: :system
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -156,7 +156,7 @@ RSpec.configure do |config|
   config.after(type: :system) do |example|
     warn page.driver.browser.logs.get(:browser) unless example.metadata[:driver].eql?(:rack_test)
   end
-  
+
   config.include Decidim::CapybaraTestHelpers, type: :system
   config.include Devise::Test::IntegrationHelpers, type: :system
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #10700 we have added the Content Security Policy rules to improve the overall Decidim Security. When we have implemented this, a lot of javascript error have started to be displayed in the console, making hard to spot any deprecations or errors for easing the debugging. 


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
CUrrent state in develop / core ( https://github.com/decidim/decidim/actions/runs/7843413922/job/21422645846 ) 
![image](https://github.com/decidim/decidim/assets/105683/79a42685-00ca-4215-8c80-c12887cf4c12)


:hearts: Thank you!
