### PR TITLE
Fix flaky spec on Content Security Policy

### DIFF
--- a/decidim-core/spec/lib/content_security_policy_spec.rb
+++ b/decidim-core/spec/lib/content_security_policy_spec.rb
@@ -12,13 +12,13 @@ module Decidim
     describe "output_policy" do
       it { is_expected.to respond_to(:output_policy) }
       it { expect(subject.output_policy).to be_a(String) }
-      it { expect(subject.output_policy).to include("default-src 'self' 'unsafe-inline'; ") }
-      it { expect(subject.output_policy).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval';") }
-      it { expect(subject.output_policy).to include("style-src 'self' 'unsafe-inline';") }
-      it { expect(subject.output_policy).to include("img-src 'self' *.hereapi.com data:;") }
-      it { expect(subject.output_policy).to include("connect-src 'self' *.hereapi.com *.jsdelivr.net data:;") }
-      it { expect(subject.output_policy).to include("font-src 'self';") }
-      it { expect(subject.output_policy).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com;") }
+      it { expect(subject.output_policy).to include("default-src 'self' 'unsafe-inline'") }
+      it { expect(subject.output_policy).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval'") }
+      it { expect(subject.output_policy).to include("style-src 'self' 'unsafe-inline'") }
+      it { expect(subject.output_policy).to include("img-src 'self' *.hereapi.com data:") }
+      it { expect(subject.output_policy).to include("connect-src 'self' *.hereapi.com *.jsdelivr.net data:") }
+      it { expect(subject.output_policy).to include("font-src 'self'") }
+      it { expect(subject.output_policy).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com") }
       it { expect(subject.output_policy).to include("media-src 'self'") }
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #12410 I have introduced a flacky test. This PR fixes that. 
Depending the running order of the specs, sometimes we have an organization specs, and sometimes we don't. This PR tries to relax the spec, so that we partially match the CSPs. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12410 

:hearts: Thank you!
