### PR TITLE
Declare permissions for lint_pr_labels

### DIFF
--- a/.github/workflows/lint_pr_labels.yml
+++ b/.github/workflows/lint_pr_labels.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  pull-requests: write
+
 jobs:
   check_label:
     name: Check PR labels


### PR DESCRIPTION
#### :tophat: What? Why?
Without this, this workflow fails for PRs in forks

#### :pushpin: Related Issues
- Fixes #12407

#### Testing
Create a PR in a fork to a branch with this workflow fixed:
https://github.com/check-spelling-sandbox/decidim/pull/2#pullrequestreview-1874924478

### :camera: Screenshots
<img width="919" alt="image" src="https://github.com/decidim/decidim/assets/2119212/9495eabd-0d88-40c0-a047-48c8deec3962">
