### PR TITLE
Backport 'Allow apps to configure the document types in the verifications module' to v0.28

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -445,6 +445,52 @@ sed -i -e "/rackup      DefaultRackup/d" config/puma.rb
 
 You can see more details about this change in issue [puma/puma#2989](https://github.com/puma/puma/issues/2989#issuecomment-1279331520)
 
+### 3.15. Verifications documents configurations
+
+Until now we have hard-coded the document types for verifications with types from Spain legislation ("DNI, NIE and passport"). We have change it to "Identification number and passport", and allow installations to adapt them to their own needs.
+
+If you want to go back to the old setting, you need to follow these steps:
+
+#### 3.2.1. Add to your config/secrets.yml the `decidim.verifications.document_types` key
+
+```erb
+decidim_default: &decidim_default
+  application_name: <%%= Decidim::Env.new("DECIDIM_APPLICATION_NAME", "My Application Name").to_json %>
+  (...)
+  verifications:
+    document_types: <%%= Decidim::Env.new("VERIFICATIONS_DOCUMENT_TYPES", %w(identification_number passport)).to_array %>
+```
+
+#### 3.2.2. Add to your `config/initializers/decidim.rb` the following snippet in the bottom of the file
+
+```ruby
+if Decidim.module_installed? :verifications
+  Decidim::Verifications.configure do |config|
+    config.document_types = Rails.application.secrets.dig(:verifications, :document_types).presence || %w(identification_number passport)
+  end
+end
+```
+
+#### 3.2.3. Add the values that you want to define using the environmnet variable `VERIFICATIONS_DOCUMENT_TYPES`
+
+```env
+VERIFICATIONS_DOCUMENT_TYPES="dni,nie,passport"
+```
+
+#### 3.2.4. Add the translation of these values to your i18n files (i.e. `config/locales/en.yml`)
+
+```yaml
+en:
+  decidim:
+    verifications:
+        id_documents:
+          dni: DNI
+          nie: NIE
+          passport: Passport
+```
+
+You can read more about this change on PR [\#12306](https://github.com/decidim/decidim/pull/12306)
+
 ## 4. Scheduled tasks
 
 Implementers need to configure these changes it in your scheduler task system in the production server. We give the examples

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -172,7 +172,7 @@ ignore_unused:
   - decidim.resource_links.*
   - decidim.system.default_pages.placeholders.*
   - decidim.system.organizations.omniauth_settings.*
-  - decidim.verifications.id_documents.{dni,nie,passport}
+  - decidim.verifications.id_documents.{identification_number,passport}
   - decidim.verifications.dummy_authorization.extra_explanation.user_postal_codes.{one,other}
   - decidim.verifications.dummy_authorization.extra_explanation.user_scope
   - errors.messages.*

--- a/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
@@ -79,6 +79,8 @@ decidim_default: &decidim_default
     max_time_in_validating_state: <%%= Decidim::Env.new("INITIATIVES_MAX_TIME_IN_VALIDATING_STATE", 60).to_i %>
     print_enabled: <%%= Decidim::Env.new("INITIATIVES_PRINT_ENABLED", "auto").default_or_present_if_exists.to_s %>
     do_not_require_authorization: <%%= Decidim::Env.new("INITIATIVES_DO_NOT_REQUIRE_AUTHORIZATION").to_boolean_string %>
+  verifications:
+    document_types: <%%= Decidim::Env.new("VERIFICATIONS_DOCUMENT_TYPES", "identification_number,passport").to_array %>
 
 elections_default: &elections_default
   bulletin_board_server: <%%= Decidim::Env.new("ELECTIONS_BULLETIN_BOARD_SERVER", 'http://bulletin-board.lvh.me:8000/api').to_s %>

--- a/decidim-verifications/README.md
+++ b/decidim-verifications/README.md
@@ -113,6 +113,28 @@ Decidim implements two type of authorization methods:
   end
   ```
 
+### Identification numbers
+
+For the verification of the participants' data in Verifications, you can configure which type of documents a participant can have. By default these documents are `identification_number` and `passport`, but in some countries you may need to adapt these to your region or governmental specific needs. For instance, in Spain there are `dni`, `nie` and `passport`.
+
+For configuring these you can do so with the Environment Variable `VERIFICATIONS_DOCUMENT_TYPES`.
+
+```env
+VERIFICATIONS_DOCUMENT_TYPES="dni,nie,passport"
+```
+
+You need to also add the following keys in your i18n files (i.e. `config/locales/en.yml`). By default in the verifications, `indentification_number` is currently being used as a universal example. Below are examples of adding `dni`, `nie` and `passport` locally used in Spain.
+
+```yaml
+en:
+  decidim:
+    verifications:
+        id_documents:
+          dni: DNI
+          nie: NIE
+          passport: Passport
+```
+
 ### SMS verification
 
 Decidim comes with a verification workflow designed to verify users by sending

--- a/decidim-verifications/app/forms/decidim/verifications/id_documents/information_form.rb
+++ b/decidim-verifications/app/forms/decidim/verifications/id_documents/information_form.rb
@@ -7,14 +7,12 @@ module Decidim
       class InformationForm < AuthorizationHandler
         mimic :id_document_information
 
-        DOCUMENT_TYPES = %w(DNI NIE passport).freeze
-
         attribute :document_number, String
         attribute :document_type, String
         attribute :verification_type, String
 
         validates :document_type,
-                  inclusion: { in: DOCUMENT_TYPES },
+                  inclusion: { in: :document_types },
                   presence: true
 
         validates :document_number,
@@ -44,7 +42,7 @@ module Decidim
         end
 
         def document_types_for_select
-          DOCUMENT_TYPES.map do |type|
+          document_types.map do |type|
             [
               I18n.t(type.downcase, scope: "decidim.verifications.id_documents"),
               type
@@ -54,6 +52,12 @@ module Decidim
 
         def uses_online_method?
           verification_type == "online"
+        end
+
+        private
+
+        def document_types
+          Decidim::Verifications.document_types
         end
       end
     end

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -232,8 +232,7 @@ en:
           update:
             error: There was a problem reuploading your document.
             success: Document successfully reuploaded.
-        dni: DNI
-        nie: NIE
+        identification_number: Identification number
         passport: Passport
       postal_letter:
         admin:

--- a/decidim-verifications/lib/decidim/verifications.rb
+++ b/decidim-verifications/lib/decidim/verifications.rb
@@ -25,4 +25,11 @@ module Decidim
   def self.authorization_handlers
     Decidim::Verifications.workflows.select(&:form)
   end
+
+  module Verifications
+    include ActiveSupport::Configurable
+    config_accessor :document_types do
+      %w(identification_number passport)
+    end
+  end
 end

--- a/decidim-verifications/spec/forms/decidim/verifications/id_documents/information_form_spec.rb
+++ b/decidim-verifications/spec/forms/decidim/verifications/id_documents/information_form_spec.rb
@@ -15,7 +15,7 @@ module Decidim::Verifications::IdDocuments
     let(:user) { create(:user) }
 
     let(:verification_type) { "online" }
-    let(:document_type) { "DNI" }
+    let(:document_type) { "identification_number" }
     let(:document_number) { "XXXXXXXXY" }
 
     context "when the information is valid" do

--- a/decidim-verifications/spec/system/id_documents/id_document_offline_request_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_offline_request_spec.rb
@@ -27,7 +27,7 @@ describe "Identity document offline request" do
 
   it "allows the user fill in their identity document" do
     submit_upload_form(
-      doc_type: "DNI",
+      doc_type: "Identification number",
       doc_number: "XXXXXXXX"
     )
 

--- a/decidim-verifications/spec/system/id_documents/id_document_offline_review_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_offline_review_spec.rb
@@ -23,7 +23,7 @@ describe "Identity document offline review" do
       user:,
       verification_metadata: {
         "verification_type" => "offline",
-        "document_type" => "DNI",
+        "document_type" => "identification_number",
         "document_number" => "XXXXXXXX"
       }
     )
@@ -39,20 +39,20 @@ describe "Identity document offline review" do
   end
 
   it "allows the user to verify an identity document" do
-    submit_verification_form(doc_type: "DNI", doc_number: "XXXXXXXX")
+    submit_verification_form(doc_type: "Identification number", doc_number: "XXXXXXXX")
 
     expect(page).to have_content("Participant successfully verified")
   end
 
   it "shows an error when there is no authorization for the given email" do
-    submit_verification_form(doc_type: "DNI", doc_number: "XXXXXXXX", user_email: "this@doesnot.exist")
+    submit_verification_form(doc_type: "Identification number", doc_number: "XXXXXXXX", user_email: "this@doesnot.exist")
 
     expect(page).to have_content("Verification does not match")
     expect(page).to have_content("Introduce the participant email and the document data")
   end
 
   it "shows an error when information does not match" do
-    submit_verification_form(doc_type: "NIE", doc_number: "XXXXXXXY")
+    submit_verification_form(doc_type: "Identification number", doc_number: "XXXXXXXY")
 
     expect(page).to have_content("Verification does not match")
     expect(page).to have_content("Introduce the participant email and the document data")

--- a/decidim-verifications/spec/system/id_documents/id_document_online_review_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_online_review_spec.rb
@@ -18,7 +18,7 @@ describe "Identity document online review" do
       user:,
       verification_metadata: {
         "verification_type" => "online",
-        "document_type" => "DNI",
+        "document_type" => "identification_number",
         "document_number" => "XXXXXXXX"
       },
       verification_attachment: Decidim::Dev.test_file("id.jpg", "image/jpeg")
@@ -35,14 +35,14 @@ describe "Identity document online review" do
   end
 
   it "allows the user to verify an identity document" do
-    submit_verification_form(doc_type: "DNI", doc_number: "XXXXXXXX")
+    submit_verification_form(doc_type: "Identification number", doc_number: "XXXXXXXX")
 
     expect(page).to have_content("Participant successfully verified")
     expect(page).not_to have_content("Verification #")
   end
 
   it "shows an error when information does not match" do
-    submit_verification_form(doc_type: "NIE", doc_number: "XXXXXXXY")
+    submit_verification_form(doc_type: "Identification number", doc_number: "XXXXXXXY")
 
     expect(page).to have_content("Verification does not match")
     expect(page).to have_content("Introduce the data in the picture")
@@ -69,7 +69,7 @@ describe "Identity document online review" do
 
       it "allows the verificator to review the amended request" do
         submit_reupload_form(
-          doc_type: "DNI",
+          doc_type: "Identification number",
           doc_number: "XXXXXXXY",
           file_name: "dni.jpg"
         )
@@ -79,7 +79,7 @@ describe "Identity document online review" do
         visit decidim_admin_id_documents.root_path
         click_link "Verification #1"
         expect(page).to have_css("img[src*='dni.jpg']")
-        submit_verification_form(doc_type: "DNI", doc_number: "XXXXXXXY")
+        submit_verification_form(doc_type: "Identification number", doc_number: "XXXXXXXY")
         expect(page).to have_content("Participant successfully verified")
       end
 

--- a/decidim-verifications/spec/system/id_documents/id_document_online_upload_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_online_upload_spec.rb
@@ -21,7 +21,7 @@ describe "Identity document online upload" do
 
   it "allows the user to upload their identity document" do
     submit_upload_form(
-      doc_type: "DNI",
+      doc_type: "Identification number",
       doc_number: "XXXXXXXX",
       file_name: "id.jpg"
     )
@@ -31,7 +31,7 @@ describe "Identity document online upload" do
 
   it "does not allow to upload an invalid file" do
     submit_upload_form(
-      doc_type: "DNI",
+      doc_type: "Identification number",
       doc_number: "XXXXXXXX",
       file_name: "Exampledocument.pdf",
       keep_modal_open: true

--- a/decidim-verifications/spec/system/id_documents/id_document_request_edition_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_request_edition_spec.rb
@@ -20,7 +20,7 @@ describe "Identity document request edition" do
       user:,
       verification_metadata: {
         "verification_type" => verification_method,
-        "document_type" => "DNI",
+        "document_type" => "identification_number",
         "document_number" => "XXXXXXXX"
       },
       verification_attachment: Decidim::Dev.test_file("id.jpg", "image/jpeg")
@@ -41,7 +41,7 @@ describe "Identity document request edition" do
       expect(page).to have_selector("form", text: "Request verification again")
 
       submit_upload_form(
-        doc_type: "DNI",
+        doc_type: "Identification number",
         doc_number: "XXXXXXXY",
         file_name: "dni.jpg",
         remove_before: true
@@ -70,7 +70,7 @@ describe "Identity document request edition" do
       expect(page).to have_content("This is my explanation text")
 
       submit_upload_form(
-        doc_type: "DNI",
+        doc_type: "Identification number",
         doc_number: "XXXXXXXY"
       )
       expect(page).to have_content("Document successfully reuploaded")
@@ -99,7 +99,7 @@ describe "Identity document request edition" do
         click_link "Use online verification"
 
         submit_upload_form(
-          doc_type: "DNI",
+          doc_type: "Identification number",
           doc_number: "XXXXXXXY",
           file_name: "dni.jpg",
           remove_before: true
@@ -122,7 +122,7 @@ describe "Identity document request edition" do
         expect(page).not_to have_content("Scanned copy of your document")
 
         submit_upload_form(
-          doc_type: "DNI",
+          doc_type: "Identification number",
           doc_number: "XXXXXXXY"
         )
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12306 to v0.28

:hearts: Thank you!