### PR TITLE
Backport 'Fix a11y errors with organizations seeds colors' to v0.28

### DIFF
--- a/decidim-core/lib/decidim/core/seeds.rb
+++ b/decidim-core/lib/decidim/core/seeds.rb
@@ -25,11 +25,11 @@ module Decidim
         smtp_email = ENV.fetch("SMTP_FROM_EMAIL", ::Faker::Internet.email)
 
         primary_color, secondary_color, tertiary_color = [
-          ["#e02d2d", "#155abf", "#ebc34b"],
-          ["#4caf50", "#a0309e", "#a8753e"],
-          ["#e91e63", "#1ee9a5", "#e9b61e"],
-          ["#009688", "#d12c26", "#b4a110"],
-          ["#ff9800", "#00bcd4", "#ea0094"]
+          ["#bf4044", "#09780e", "#3584e4"],
+          ["#09780e", "#4448bb", "#da565b"],
+          ["#bf4086", "#487511", "#5384ac"],
+          ["#086263", "#811380", "#abac53"],
+          ["#5340bf", "#a82c2c", "#40bf53"]
         ].sample
 
         colors = {


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12399 to v0.28

:hearts: Thank you!