### PR TITLE
Remove redundant block user link

### DIFF
--- a/decidim-admin/app/views/decidim/admin/block_user/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/block_user/new.html.erb
@@ -16,8 +16,7 @@
             </div>
 
             <% if @form.hide %>
-              <% announcement_message = t(".already_reported_html", link: new_user_block_path(user_id: user.id)) %>
-              <%= cell("decidim/announcement", announcement_message, callout_class: "alert" ) %>
+              <%= cell("decidim/announcement", t(".already_reported_html"), callout_class: "alert" ) %>
             <% end %>
 
             <% if defined?(Decidim::Templates) %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -288,7 +288,7 @@ en:
       block_user:
         new:
           action: Block account and send justification
-          already_reported_html: Continuing with this action you will also hide all the participants contents. <a href="%{link}">Block the account</a>.
+          already_reported_html: Continuing with this action you will also hide all the participants contents.
           description: Blocking a user will render their account unusable. You may provide in your justification any guidelines on ways you would consider unblocking the user.
           justification: Justification
           title: Block User %{name}


### PR DESCRIPTION
I didn't get assigned to this issue, so feel free to disregard if I've circumvented the process. 

#### :tophat: What? Why?
Removes the "block this account" link from internationalization, per #12406.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #12406

#### Testing
Block a user, view the message, and verify that no link to block the account appears in the message.

### :camera: Screenshots

:hearts: Thank you!
