### PR TITLE
Backport 'Disable shm usage in Capybara' to v0.28

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -32,6 +32,7 @@ end
   port = rand(5000..6999)
   begin
     Socket.tcp("127.0.0.1", port, connect_timeout: 5).close
+    warn "Port #{port} is already in use, trying another one."
   rescue Errno::ECONNREFUSED
     # When connection is refused, the port is available for use.
     Capybara.server_port = port
@@ -43,6 +44,8 @@ Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.args << "--explicitly-allowed-ports=#{Capybara.server_port}"
   options.args << "--headless=new"
+  # Do not limit browser resources
+  options.args << "--disable-dev-shm-usage"
   options.args << "--no-sandbox"
   options.args << if ENV["BIG_SCREEN_SIZE"].present?
                     "--window-size=1920,3000"
@@ -93,6 +96,8 @@ Capybara.register_driver :iphone do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.args << "--headless=new"
   options.args << "--no-sandbox"
+  # Do not limit browser resources
+  options.args << "--disable-dev-shm-usage"
   options.add_emulation(device_name: "iPhone 6")
 
   Capybara::Selenium::Driver.new(


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12462 to v0.28

:hearts: Thank you!