### PR TITLE
Attempt to fix flaky spec on proposals' ammends

### DIFF
--- a/decidim-proposals/spec/system/amendable/amend_proposal_spec.rb
+++ b/decidim-proposals/spec/system/amendable/amend_proposal_spec.rb
@@ -225,6 +225,10 @@ describe "Amend Proposal", versioning: true do
 
           context "when the form is filled correctly" do
             before do
+              login_as user, scope: :user
+              visit proposal_path
+              expect(page).to have_content(proposal_title)
+              click_link "Amend"
               within ".new_amendment" do
                 fill_in "amendment[emendation_params][title]", with: "More sidewalks and less roads"
                 fill_in "amendment[emendation_params][body]", with: "Cities need more people, not more cars"
@@ -240,6 +244,10 @@ describe "Amend Proposal", versioning: true do
 
           context "when the form is filled incorrectly" do
             before do
+              login_as user, scope: :user
+              visit proposal_path
+              expect(page).to have_content(proposal_title)
+              click_link "Amend"
               within ".new_amendment" do
                 fill_in "amendment[emendation_params][title]", with: "INVALID TITLE"
               end


### PR DESCRIPTION
#### :tophat: What? Why?
It seems that we have a flaky spec in proposals. which is caused by a glitch in the way hooks are working. It has been revealed many times while running the pipeline.  

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
![image](https://github.com/decidim/decidim/assets/105683/362a3dd5-6bf3-47a7-9974-54d230fc4706)

The tested interface here. Somehow, the authentication is not always happens. 

![failures_r_spec_example_groups_amend_proposal_with_amendments_enabled_when_amendment_creation_is_enabled_and_visits_an_amendable_proposal_when_the_user_is_logged_in_and_clicks_when_the_form_is_filled_incorrect_809](https://github.com/decidim/decidim/assets/105683/03963716-00fe-422d-9893-91bd3a48bd9f)

:hearts: Thank you!
