### PR TITLE
Remove axios NPM package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6099,6 +6099,7 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -6163,15 +6164,6 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.6.7",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.4",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -7224,6 +7216,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -8422,6 +8415,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -10461,6 +10455,7 @@
     },
     "node_modules/form-data": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -17100,10 +17095,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
     "node_modules/psl": {
       "version": "1.9.0",
       "dev": true,
@@ -21687,7 +21678,6 @@
         "a11y-accordion-component": "^1.2.6",
         "a11y-dialog-component": "^5.5.1",
         "a11y-dropdown-component": "^1.2.0",
-        "axios": "^1.4.0",
         "classnames": "^2.2.5",
         "d3": "^7.8.5",
         "dayjs": "^1.11.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,6 @@
     "a11y-accordion-component": "^1.2.6",
     "a11y-dialog-component": "^5.5.1",
     "a11y-dropdown-component": "^1.2.0",
-    "axios": "^1.4.0",
     "classnames": "^2.2.5",
     "d3": "^7.8.5",
     "dayjs": "^1.11.0",


### PR DESCRIPTION
#### :tophat: What? Why?
The `axios` package is no longer used, so it should not be shipped with the core dependencies either.

This used to be a dependency for the admin autocomplete component:
https://github.com/decidim/decidim/blob/5a4f4de67e18273df6888b91a26a5da1300d3a46/decidim-admin/app/packs/src/decidim/admin/autocomplete.component.js#L4

But it was removed at #8524 which became part of 0.27.0:
https://github.com/decidim/decidim/releases/tag/v0.27.0

#### :pushpin: Related Issues
- Related to #8524

#### Testing
To verify that the word `axios` is nowhere to be found:
```bash
$ grep -rinw . --include=\*.js --exclude-dir=node_modules -e axios
```

To verify it used to be part of 0.26:
```bash
$ git checkout release/0.26-stable
$ grep -rinw . --include=\*.js --exclude-dir=node_modules -e axios
./decidim-admin/app/packs/src/decidim/admin/autocomplete.component.js:4:import axios from "axios";
./decidim-admin/app/packs/src/decidim/admin/autocomplete.component.js:32:            if (axios.isCancel(error)) {
./decidim-admin/app/packs/src/decidim/admin/autocomplete.component.js:69:      this.cancelTokenSource = axios.CancelToken.source();
./decidim-admin/app/packs/src/decidim/admin/autocomplete.component.js:70:      axios.get(this.props.searchURL, {
./decidim-admin/app/packs/src/decidim/admin/autocomplete.component.js:86:          if (!axios.isCancel(error)) {
```