### PR TITLE
Remove uuid NPM package as a core dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21707,7 +21707,6 @@
         "tom-select": "2.2.2",
         "tributejs": "5.1.3",
         "unfetch": "^3.0.0",
-        "uuid": "^9.0.0",
         "wc-datepicker": "^0.5.2"
       }
     },
@@ -21716,17 +21715,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "packages/core/node_modules/uuid": {
-      "version": "9.0.1",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "packages/dev": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,7 +73,6 @@
     "tom-select": "2.2.2",
     "tributejs": "5.1.3",
     "unfetch": "^3.0.0",
-    "uuid": "^9.0.0",
     "wc-datepicker": "^0.5.2"
   }
 }


### PR DESCRIPTION
#### :tophat: What? Why?
The `uuid` package does not seem to be used, so it should not be shipped with the core dependencies either.

Note that this is still as a dependency to some of the other dependencies but it ships automatically through those dependencies.

This originates from the old JS-based comments component. Introduced at #250.

Moved to root `package.json` by at #467.

Moved to `packages/core/package.json` at #8121.

#### :pushpin: Related Issues
- Related to #6498

#### Testing
To verify that the word `uuid` is nowhere to be found:
```bash
$ grep -rinw . --include=\*.js --exclude-dir=node_modules --exclude-dir=decidim_dummy_app --exclude-dir=development_app -e uuid
```

To verify it used to be part of and older version:
```bash
$ git checkout 5f3d15
$ grep -rinw . --include=\*.js --include=\*.ts --exclude=bundle.js --exclude-dir=node_modules --exclude-dir=decidim_dummy_app --exclude-dir=development_app -e uuid
./decidim-comments/app/frontend/support/generate_comments_data.js:13:      id: random.uuid(),
```
