### PR TITLE
Fix the focus guard under redesign

### DIFF
--- a/decidim-core/app/packs/src/decidim/a11y.js
+++ b/decidim-core/app/packs/src/decidim/a11y.js
@@ -136,7 +136,7 @@ const createDialog = (component) => {
     enableAutoFocus: false,
     onOpen: (params, trigger) => {
       setFocusOnTitle(params);
-      window.focusGuard.trap(trigger);
+      window.focusGuard.trap(params, trigger);
       params.dispatchEvent(new CustomEvent("open.dialog"));
     },
     onClose: (params) => {

--- a/decidim-core/app/packs/src/decidim/focus_guard.js
+++ b/decidim-core/app/packs/src/decidim/focus_guard.js
@@ -1,5 +1,3 @@
-import { Keyboard } from "foundation-sites"
-
 const focusGuardClass = "focusguard";
 const focusableNodes = ["A", "IFRAME", "OBJECT", "EMBED"];
 const focusableDisableableNodes = ["BUTTON", "INPUT", "TEXTAREA", "SELECT"];
@@ -8,21 +6,13 @@ export default class FocusGuard {
   constructor(container) {
     this.container = container;
     this.guardedElement = null;
+    this.triggerElement = null;
   }
 
-  trap(element) {
-    if (this.guardedElement) {
-      Keyboard.releaseFocus($(this.guardedElement));
-    }
-
+  trap(element, trigger) {
     this.enable();
     this.guardedElement = element;
-
-    // Call the release focus first so that we do not accidentally add the
-    // keyboard trap twice. Note that the Foundation methods expect the elements
-    // to be jQuery elements which is why we pass them through jQuery.
-    Keyboard.releaseFocus($(element));
-    Keyboard.trapFocus($(element));
+    this.triggerElement = trigger;
   }
 
   enable() {
@@ -58,12 +48,11 @@ export default class FocusGuard {
     const guards = this.container.querySelectorAll(`:scope > .${focusGuardClass}`);
     guards.forEach((guard) => guard.remove());
 
-    if (this.guardedElement) {
-      // Note that the Foundation methods expect the elements to be jQuery
-      // elements which is why we pass them through jQuery.
-      Keyboard.releaseFocus($(this.guardedElement));
-      this.guardedElement.focus();
-      this.guardedElement = null;
+    this.guardedElement = null;
+
+    if (this.triggerElement) {
+      this.triggerElement.focus();
+      this.triggerElement = null;
     }
   }
 
@@ -89,7 +78,6 @@ export default class FocusGuard {
 
     let target = null;
     if (guard.dataset.position === "start") {
-
       // Focus at the start guard, so focus the first focusable element after that
       for (let ind = 0; ind < visibleNodes.length; ind += 1) {
         if (!this.isFocusGuard(visibleNodes[ind]) && this.isFocusable(visibleNodes[ind])) {

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -9,6 +9,9 @@ import "core-js/stable";
 import "regenerator-runtime/runtime";
 import "jquery"
 
+// REDESIGN_PENDING: deprecated
+import "foundation-sites";
+
 // external deps that require initialization
 import Rails from "@rails/ujs"
 import svg4everybody from "svg4everybody"


### PR DESCRIPTION
#### :tophat: What? Why?
The focus guard has been broken again under redesign.

See #11399 where the issue is explained further.

**NOTE:**

I actually noticed this as I was wondering why the foundation is still as a dependency and found it in this file. Then noticed the Keyboard class from foundation is not required by the focus guard as the `a11y-dialog-component` already handles the focus **WITHIN** the modal (but not outside of it, thus the focus guard).

So I removed the Foundation `Keyboard` dependency from the focus guard but then noticed JS errors appearing in the console (`$(...).foundation is not a function`). Therefore, added the import back to the `index.js` where it is more suitable.

#### :pushpin: Related Issues
- Related to
  * #11399
  * #11504

#### Testing
1. Go to a proposals component when not signed in
2. Click the "New proposal" button
3. Place focus in the browser's address bar
4. Enter the page again using only the `TAB` key
5. See that focus is placed within the modal instead of the elements beneath it
6. Place focus again in the browser's address bar
7. Enter the page again from the bottom using only the `SHIFT` + `TAB` key
8. See that focus is placed within the modal instead of the elements beneath it