### PR TITLE
Fix flacky spec on date_picker

### DIFF
--- a/decidim-core/spec/system/date_picker/date_picker_spec.rb
+++ b/decidim-core/spec/system/date_picker/date_picker_spec.rb
@@ -152,7 +152,8 @@ describe "Datepicker" do
           context "when choosing a date" do
             it "enables the select button" do
               find(".datepicker__calendar-button").click
-              find("td > span", text: "20", match: :first).click
+              yesterday = Date.yesterday.strftime("%d")
+              find("td > span", text: yesterday, match: :first).click
               expect(page).to have_button("Select", disabled: false)
             end
           end


### PR DESCRIPTION
#### :tophat: What? Why?
We have a hardcoded date in spec, and considering today is the same day as the one hardcoded, the date picker is behaving differntly. This PR changes the date to be always `yesterday` so that we have a green spec here. 

#### Testing
1. Visit the edited spec, and change the `yesterday = Date.yesterday.strftime("%d")` variable to `yesterday = Date.today.strftime("%d")` . 
2. Additionally, you can comment `options.args << "--headless=new"` within `decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:47` and see the behaviour while spec is running. 
3. To find the behavior i went above the yesterday variable and added a sleep(1000) and applied step 2, to actually click by myself in the spec. 

:hearts: Thank you!
