### PR TITLE
Add note about the unescaped contents of the GraphQL API

### DIFF
--- a/decidim-api/docs/usage.md
+++ b/decidim-api/docs/usage.md
@@ -16,6 +16,8 @@ Typically (although some particular installations may change that) you will find
 
 The GraphQL format is a JSON formatted text that is specified in a query. Response is a JSON object as well. For details about specification check the official [GraphQL site](https://graphql.org/learn/).
 
+Exercise caution when utilizing the output of this API, as it may include HTML that has not been escaped. Take particular care in handling this data, specially if you intend to render it on a webpage.
+
 For instance, you can check the version of a Decidim installation by using `curl` in the terminal:
 
 ```bash


### PR DESCRIPTION
#### :tophat: What? Why?

Add a clarification message about the security of the public API. 
 
#### Testing

1. Regenerate the API docs with `bin/rails decidim:upgrade` 
2. Go to http://localhost:3000/api/docs and see the message

### :camera: Screenshots

![Screenshot of the change in the docs page](https://github.com/decidim/decidim/assets/717367/d892b43c-d4d9-49ff-85ae-a7d6aa90d799)

:hearts: Thank you!
