### PR TITLE
Remove `tabindex="-1"` from the SVG icons

### DIFF
--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -62,7 +62,7 @@ module Decidim
       href = Decidim.cors_enabled ? "" : asset_pack_path("media/images/remixicon.symbol.svg")
 
       content_tag :svg, html_properties do
-        content_tag :use, nil, "href" => "#{href}#ri-#{name}", :tabindex => -1
+        content_tag :use, nil, "href" => "#{href}#ri-#{name}"
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This seems unnecessary and is considered incorrect by some a11y evaluation tools when these icons are placed within interactive elements, such as buttons or links.

Even if the `tabindex="-1"` is set to indicate that the element cannot be focused within, some accessibility evaluation tools consider this an error when the element is placed within an interactive element

I don't know the original reason why this was added but the user should not be able to focus within the `<use>` element of an `<svg>` by default in the first place, which would make this attribute unnecessary.

This was originally introduced by #9852.

#### :pushpin: Related Issues
- Related to #9852

#### Testing
Test that the buttons and links which have icons within them are working correctly after this change.

One example is the language selector at the footer:

![Footer language selector](https://github.com/decidim/decidim/assets/864340/cff30397-d59b-4309-878f-a7d72d0c6a14)