### PR TITLE
Accessibility fixes regarding links that open in new tabs

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -30,7 +30,7 @@
               </li>
             <% end %>
             <li>
-              <%= link_to "#{commentable_path("commentId" => model.id)}#comment_#{model.id}", target: "_blank", data: { "external-link": "false" }, class: "dropdown__item", title: t("decidim.components.comment.single_comment_link_title") do %>
+              <%= link_to "#{commentable_path("commentId" => model.id)}#comment_#{model.id}", target: "_blank", data: { "external-link": "text-only" }, class: "dropdown__item", title: t("decidim.components.comment.single_comment_link_title") do %>
                 <%= icon "share-line" %>
                 <span><%= t("decidim.components.comment.single_comment_link_title") %></span>
               <% end %>

--- a/decidim-conferences/app/cells/decidim/conferences/partner/show.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/partner/show.erb
@@ -1,5 +1,5 @@
 <% if model.link.present? %>
-  <%= link_to model.link, target: "_blank", class: "conference__grid-item", data: { "external-link": "false" } do %>
+  <%= link_to model.link, target: "_blank", class: "conference__grid-item", data: { "external-link": "text-only" } do %>
     <%= render :image %>
     <%= render :text %>
   <% end %>

--- a/decidim-core/app/helpers/decidim/map_helper.rb
+++ b/decidim-core/app/helpers/decidim/map_helper.rb
@@ -32,7 +32,7 @@ module Decidim
             class: "static-map",
             target: "_blank",
             rel: "noopener",
-            data: { "external-link": false }
+            data: { "external-link": "text-only" }
           }.merge(map_html_options)
           return link_to(map_url, html_options) do
             image_tag decidim.static_map_path(sgid: resource.to_sgid.to_s), alt: "#{map_service_brand} - #{address_text}"

--- a/decidim-core/app/helpers/decidim/social_share_button_helper.rb
+++ b/decidim-core/app/helpers/decidim/social_share_button_helper.rb
@@ -27,7 +27,7 @@ module Decidim
         target: "_blank",
         data: {
           "site" => service.name.downcase,
-          "external-link" => false,
+          "external-link" => "text-only",
           "external-domain-link" => false
         },
         title: t("decidim.shared.share_modal.share_to", service: service.name)

--- a/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
@@ -26,7 +26,8 @@ character_messages = {
   }
 }
 external_link_messages = {
-  "externalLink": t("decidim.accessibility.external_link")
+  "externalLink": t("decidim.accessibility.external_link"),
+  "opensInNewTab": t("decidim.accessibility.opens_in_new_tab")
 }
 validator_messages = {
   "correctErrors": t("forms.correct_errors")

--- a/decidim-core/app/views/layouts/decidim/footer/_main_social_media_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_social_media_links.html.erb
@@ -1,7 +1,7 @@
 <ul class="flex justify-between md:justify-start gap-6 text-sm text-white hover:[&_a]:opacity-50">
   <% if current_organization.twitter_handler.present? %>
     <li>
-      <a target="_blank" data-external-link="false" rel="noopener noreferrer" href="https://twitter.com/<%= current_organization.twitter_handler %>">
+      <a target="_blank" data-external-link="text-only" rel="noopener noreferrer" href="https://twitter.com/<%= current_organization.twitter_handler %>">
         <span class="sr-only"><%= t("layouts.decidim.social_media_links.x", organization: translated_attribute(current_organization.name)) %></span>
         <%= icon "twitter-x-line", class: "w-8 h-8 fill-current", "aria-label": "X" %>
       </a>
@@ -9,7 +9,7 @@
   <% end %>
   <% if current_organization.facebook_handler.present? %>
     <li>
-      <a target="_blank" data-external-link="false" rel="noopener noreferrer" href="https://www.facebook.com/<%= current_organization.facebook_handler %>">
+      <a target="_blank" data-external-link="text-only" rel="noopener noreferrer" href="https://www.facebook.com/<%= current_organization.facebook_handler %>">
         <span class="sr-only"><%= t("layouts.decidim.social_media_links.facebook", organization: translated_attribute(current_organization.name)) %></span>
         <%= icon "facebook-fill", class: "w-8 h-8 fill-current", "aria-label": "Facebook" %>
       </a>
@@ -17,7 +17,7 @@
   <% end %>
   <% if current_organization.instagram_handler.present? %>
     <li>
-      <a target="_blank" data-external-link="false" rel="noopener noreferrer" href="https://www.instagram.com/<%= current_organization.instagram_handler %>">
+      <a target="_blank" data-external-link="text-only" rel="noopener noreferrer" href="https://www.instagram.com/<%= current_organization.instagram_handler %>">
         <span class="sr-only"><%= t("layouts.decidim.social_media_links.instagram", organization: translated_attribute(current_organization.name)) %></span>
         <%= icon "instagram-line", class: "w-8 h-8 fill-current", "aria-label": "Instagram" %>
       </a>
@@ -25,7 +25,7 @@
   <% end %>
   <% if current_organization.youtube_handler.present? %>
     <li>
-      <a target="_blank" data-external-link="false" rel="noopener noreferrer" href="https://www.youtube.com/<%= current_organization.youtube_handler %>">
+      <a target="_blank" data-external-link="text-only" rel="noopener noreferrer" href="https://www.youtube.com/<%= current_organization.youtube_handler %>">
         <span class="sr-only"><%= t("layouts.decidim.social_media_links.youtube", organization: translated_attribute(current_organization.name)) %></span>
         <%= icon "youtube-line", class: "w-8 h-8 fill-current", "aria-label": "YouTube" %>
       </a>
@@ -33,7 +33,7 @@
   <% end %>
   <% if current_organization.github_handler.present? %>
     <li>
-      <a target="_blank" data-external-link="false" rel="noopener noreferrer" href="https://www.github.com/<%= current_organization.github_handler %>">
+      <a target="_blank" data-external-link="text-only" rel="noopener noreferrer" href="https://www.github.com/<%= current_organization.github_handler %>">
         <span class="sr-only"><%= t("layouts.decidim.social_media_links.github", organization: translated_attribute(current_organization.name)) %></span>
         <%= icon "github-fill", class: "w-8 h-8 fill-current", "aria-label": "GitHub" %>
       </a>

--- a/decidim-core/app/views/layouts/decidim/footer/_mini.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_mini.html.erb
@@ -1,14 +1,14 @@
 <div class="mini-footer">
   <div class="mini-footer__content">
     <div>
-      <a rel="decidim noopener noreferrer" href="https://decidim.org/" target="_blank" data-external-link="false">
+      <a rel="decidim noopener noreferrer" href="https://decidim.org/" target="_blank" data-external-link="text-only">
         <%= image_pack_tag("media/images/decidim-logo.svg", alt: t("layouts.decidim.footer.decidim_logo"), class: "max-h-8 block") %>
       </a>
       <div class="text-xs mt-2 [&_a]:underline">
         <%= t("layouts.decidim.footer.made_with_open_source").html_safe %>
       </div>
     </div>
-    <a class="flex gap-1 hover:opacity-50" rel="license noopener noreferrer" href="http://creativecommons.org/licenses/by-sa/4.0/" target="_blank" data-external-link="false">
+    <a class="flex gap-1 hover:opacity-50" rel="license noopener noreferrer" href="http://creativecommons.org/licenses/by-sa/4.0/" target="_blank" data-external-link="text-only">
       <span class="sr-only"><%= t("layouts.decidim.footer.cc_by_license") %></span>
       <%= icon "creative-commons-line", class: "w-6 h-6 fill-current" %>
       <%= icon "creative-commons-by-line", class: "w-6 h-6 fill-current" %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -145,6 +145,7 @@ en:
       external_link: External link
       front_page_link: Go to front page
       logo: "%{organization}'s official logo"
+      opens_in_new_tab: Opens in new tab
       skip_button: Skip to main content
     account:
       blocked: This account has been blocked due to terms of service violation

--- a/decidim-design/app/views/decidim/design/home/index.html.erb
+++ b/decidim-design/app/views/decidim/design/home/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :right_aside do %>
-  <%= link_to "https://github.com/decidim/decidim", target: "_blank", data: { "external-link": false }, class: "flex items-center justify-end gap-1 font-semibold text-secondary" do %>
+  <%= link_to "https://github.com/decidim/decidim", target: "_blank", data: { "external-link": "text-only" }, class: "flex items-center justify-end gap-1 font-semibold text-secondary" do %>
     <span class="whitespace-nowrap"><%= t(".github_source") %></span>
     <%= icon "github-fill", class: "flex-none w-3.5 h-3.5 fill-current" %>
   <% end %>

--- a/decidim-meetings/app/cells/decidim/meetings/online_meeting_link/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/online_meeting_link/show.erb
@@ -16,6 +16,6 @@
       <p><%= t("micro_camera_permissions_warning", scope: "decidim.meetings.meetings.show") %></p>
     <% end %>
 
-     <%= link_to t("join_meeting", scope: "decidim.meetings.meetings.meeting"), live_event_url, target: "_blank", class: "button button__xl button__secondary", data: { "external-link": false } %>
+     <%= link_to t("join_meeting", scope: "decidim.meetings.meetings.meeting"), live_event_url, target: "_blank", class: "button button__xl button__secondary", data: { "external-link": "text-only" } %>
   <% end %>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/layouts/live_event.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/layouts/live_event.html.erb
@@ -32,7 +32,7 @@
 
       <div class="flex gap-10">
         <% if current_user %>
-          <%= link_to current_user.name, decidim.account_path, target: "_blank", class: "button button__sm button__text-secondary", data: { "external-link": false }, "aria-label": t("layouts.decidim.user_menu.account", name: current_user.name) %>
+          <%= link_to current_user.name, decidim.account_path, target: "_blank", class: "button button__sm button__text-secondary", data: { "external-link": "text-only" }, "aria-label": t("layouts.decidim.user_menu.account", name: current_user.name) %>
         <% end %>
 
         <%= link_to meeting_path(meeting), class: "button button__sm button__text-secondary", "aria-label": t("close", scope: "decidim.meetings.layouts.live_event") do %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_add_to_calendar_modal.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_add_to_calendar_modal.html.erb
@@ -10,7 +10,7 @@
         <%= link_to t("apple", scope: "decidim.meetings.meetings.calendar_modal"), ics_url, class: "text-secondary underline" %>
       </li>
       <li>
-        <%= link_to t("google", scope: "decidim.meetings.meetings.calendar_modal"), google_url, target: "_blank", class: "text-secondary underline", data: { "external-link": false } %>
+        <%= link_to t("google", scope: "decidim.meetings.meetings.calendar_modal"), google_url, target: "_blank", class: "text-secondary underline", data: { "external-link": "text-only" } %>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
#### :tophat: What? Why?
- Add external link text to the external links that were missing it
- Add a new text "Opens in a new tab" to the internal links that open a new tab
- Fix the translations on the external links (were only in English)

Some links are incorrectly marked as `data-external-link="false"` because the implementer wanted to avoid showing the external link icon. Even when the visual indicator is not present or it is seen obvious that the link targets an external source, this should be still indicated to the screen readers.

This also implements a new feature "Opens in a new tab" for links that have `target="_blank"` but point to the same website. This is also required to indicate for screen readers.

#### Testing
- Test the footer links (e.g. Decidim GitHub, social medias, Creative Commons license, etc.) with a screen reader and you should now hear "External link" when placing the focus in those links
- Create a text page and add an internal link to that page pointing either to an internal URL `/pages/internal-url` or to the same domain `http://localhost:3000/pages/internal-url` and make that link open in a new tab
- Go to that page at the participant side and test it with a screen reader, you should now hear "Opens in a new tab" when placing focus to this link