### PR TITLE
Fix authorization required screen design

### DIFF
--- a/decidim-core/app/cells/decidim/authorization_modal/show.erb
+++ b/decidim-core/app/cells/decidim/authorization_modal/show.erb
@@ -1,6 +1,8 @@
-<div data-dialog-container>
-  <%= icon "lock-line" %>
-  <h2 id="dialog-title-authorizationModal" tabindex="-1" data-dialog-title><%= title %></h2>
+<div data-dialog-container class="text-center mt-8">
+  <div class="flex justify-center">
+    <%= icon "lock-line", class: "w-20 h-20" %>
+  </div>
+  <h1 tabindex="-1" class="h1" data-dialog-title><%= title %></h1>
   <div>
     <div class="authorization-modal__verification-container">
       <% verifications.each do |verification| %>

--- a/decidim-core/app/cells/decidim/authorization_modal/show.erb
+++ b/decidim-core/app/cells/decidim/authorization_modal/show.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(title) %>
+
 <div data-dialog-container class="text-center mt-8">
   <div class="flex justify-center">
     <%= icon "lock-line", class: "w-20 h-20" %>

--- a/decidim-core/app/cells/decidim/authorization_modal/show.erb
+++ b/decidim-core/app/cells/decidim/authorization_modal/show.erb
@@ -1,6 +1,6 @@
 <% add_decidim_page_title(title) %>
 
-<div data-dialog-container class="text-center mt-8">
+<main data-dialog-container class="text-center mt-8">
   <div class="flex justify-center">
     <%= icon "lock-line", class: "w-20 h-20" %>
   </div>
@@ -29,4 +29,4 @@
       <% end %>
     </div>
   </div>
-</div>
+</main>

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -62,7 +62,9 @@ describe "Answer a survey" do
       visit_component
     end
 
-    it "shows a modal dialog" do
+    it_behaves_like "accessible page"
+
+    it "shows a page" do
       expect(page).to have_content("Authorization required")
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

The "Authorization required" page design is broken. This PR fixes it. 


#### Testing

1. Sign in as admin
2. Configure permissions in a component to use an authorization
3. In the frontend, go to this component
4. See the page without design (without this patch)
5. Apply this patch
6. See the page with design

### :camera: Screenshots

#### Before

![Screenshot of the page](https://github.com/decidim/decidim/assets/717367/7a4c4d5e-1027-4c8d-ae4f-1e657d673b2c)

#### After

![Screenshot of the page](https://github.com/decidim/decidim/assets/717367/03816051-2186-412c-a256-ebbe10a33891)

:hearts: Thank you!
