### PR TITLE
Fix a typo on decidim-design Home

### DIFF
--- a/decidim-design/config/locales/en.yml
+++ b/decidim-design/config/locales/en.yml
@@ -70,7 +70,7 @@ en:
         value: Value
       home:
         index:
-          by_sharing_principles: By sharing the principles, philsophy, and rationale behind design decisions we want to empower the community to contribute with consistency so we reach the best participant experience.
+          by_sharing_principles: By sharing the principles, philosophy, and rationale behind design decisions we want to empower the community to contribute with consistency so we reach the best participant experience.
           decidim_guide: The guide to design all things Decidim
           different_ui_components: At the same time, we document the different UI components and patterns in use, that should be reused or extended.
           github_source: Source code on GitHub


### PR DESCRIPTION
#### :tophat: What? Why?

Fix a typo in decidim-design Home page, added in e975173c596163903d94e233fabad9a64b6cc964

#### :pushpin: Related Issues

- (none)

#### Testing

open http://localhost:3000/design and see in development_app

### :camera: Screenshots

**Before:**

<img width="880" alt="decidim-before" src="https://github.com/decidim/decidim/assets/10401/7709a0d3-b02e-434d-9c76-0d215769d742">

**After:**

<img width="871" alt="decidim-after" src="https://github.com/decidim/decidim/assets/10401/1ca555f1-008f-423b-a613-8f0d4cf7b9da">
