### PR TITLE
Fix embeds for resources and spaces that shouldn't be embedded

### DIFF
--- a/decidim-assemblies/app/controllers/decidim/assemblies/widgets_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/widgets_controller.rb
@@ -5,6 +5,12 @@ module Decidim
     class WidgetsController < Decidim::WidgetsController
       helper Decidim::SanitizeHelper
 
+      def show
+        enforce_permission_to :read, :participatory_space, current_participatory_space: model if model
+
+        super
+      end
+
       private
 
       def model
@@ -17,6 +23,10 @@ module Decidim
 
       def iframe_url
         @iframe_url ||= assembly_widget_url(model)
+      end
+
+      def permission_class_chain
+        ::Decidim.permissions_registry.chain_for(::Decidim::Assemblies::ApplicationController)
       end
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/widgets_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/widgets_controller.rb
@@ -6,7 +6,7 @@ module Decidim
       helper Decidim::SanitizeHelper
 
       def show
-        enforce_permission_to :read, :participatory_space, current_participatory_space: model if model
+        enforce_permission_to :embed, :participatory_space, current_participatory_space: model if model
 
         super
       end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/widgets_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/widgets_controller.rb
@@ -14,7 +14,7 @@ module Decidim
       private
 
       def model
-        @model ||= Assembly.where(organization: current_organization).published.find_by(slug: params[:assembly_slug])
+        @model ||= Assembly.where(organization: current_organization).public_spaces.find_by(slug: params[:assembly_slug])
       end
 
       def current_participatory_space

--- a/decidim-assemblies/app/controllers/decidim/assemblies/widgets_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/widgets_controller.rb
@@ -14,7 +14,7 @@ module Decidim
       private
 
       def model
-        @model ||= Assembly.published.find_by(slug: params[:assembly_slug])
+        @model ||= Assembly.where(organization: current_organization).published.find_by(slug: params[:assembly_slug])
       end
 
       def current_participatory_space

--- a/decidim-assemblies/app/controllers/decidim/assemblies/widgets_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/widgets_controller.rb
@@ -8,7 +8,7 @@ module Decidim
       private
 
       def model
-        @model ||= Assembly.find_by(slug: params[:assembly_slug])
+        @model ||= Assembly.published.find_by(slug: params[:assembly_slug])
       end
 
       def current_participatory_space

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -16,6 +16,7 @@ module Decidim
         if permission_action.scope == :public
           public_list_assemblies_action?
           public_read_assembly_action?
+          public_embed_assembly_action?
           public_list_members_action?
           return permission_action
         end
@@ -132,6 +133,17 @@ module Decidim
       def public_list_members_action?
         return unless permission_action.action == :list &&
                       permission_action.subject == :members
+
+        allow!
+      end
+
+      def public_embed_assembly_action?
+        return unless permission_action.action == :embed &&
+                      [:assembly, :participatory_space].include?(permission_action.subject) &&
+                      assembly
+
+        return disallow! unless assembly.published?
+        return disallow! unless can_view_private_space?
 
         allow!
       end

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -143,7 +143,7 @@ module Decidim
                       assembly
 
         return disallow! unless assembly.published?
-        return disallow! unless can_view_private_space?
+        return disallow! if assembly.private_space && !assembly.is_transparent?
 
         allow!
       end

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -127,6 +127,36 @@ describe Decidim::Assemblies::Permissions do
       end
     end
 
+    context "when embedding an assembly" do
+      let(:action) do
+        { scope: :public, action: :embed, subject: :assembly }
+      end
+      let(:context) { { assembly: assembly } }
+
+      context "when the assembly is published" do
+        let(:user) { create(:user, organization: organization) }
+
+        it { is_expected.to be true }
+      end
+
+      context "when the assembly is not published" do
+        let(:user) { create(:user, organization: organization) }
+        let(:assembly) { create(:assembly, :unpublished, organization: organization) }
+
+        context "when the user doesn't have access to it" do
+          it { is_expected.to be false }
+        end
+
+        context "when the user has access to it" do
+          before do
+            create(:assembly_user_role, user: user, assembly: assembly)
+          end
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+
     context "when listing assemblies" do
       let(:action) do
         { scope: :public, action: :list, subject: :assembly }

--- a/decidim-assemblies/spec/system/assembly_embeds_spec.rb
+++ b/decidim-assemblies/spec/system/assembly_embeds_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe "Assembly embeds", type: :system do
   let(:resource) { create(:assembly) }
+  let(:widget_path) { Decidim::EngineRouter.main_proxy(resource).assembly_widget_path }
 
   it_behaves_like "an embed resource", skip_space_checks: true
 end

--- a/decidim-assemblies/spec/system/assembly_embeds_spec.rb
+++ b/decidim-assemblies/spec/system/assembly_embeds_spec.rb
@@ -7,4 +7,6 @@ describe "Assembly embeds", type: :system do
   let(:widget_path) { Decidim::EngineRouter.main_proxy(resource).assembly_widget_path }
 
   it_behaves_like "an embed resource", skip_space_checks: true
+  it_behaves_like "a private embed resource"
+  it_behaves_like "a transparent private embed resource"
 end

--- a/decidim-conferences/app/controllers/decidim/conferences/conference_widgets_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conference_widgets_controller.rb
@@ -14,7 +14,7 @@ module Decidim
       private
 
       def model
-        @model ||= Conference.published.find_by(slug: params[:conference_slug])
+        @model ||= Conference.where(organization: current_organization).published.find_by(slug: params[:conference_slug])
       end
 
       def current_participatory_space

--- a/decidim-conferences/app/controllers/decidim/conferences/conference_widgets_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conference_widgets_controller.rb
@@ -8,7 +8,7 @@ module Decidim
       private
 
       def model
-        @model ||= Conference.find_by(slug: params[:conference_slug])
+        @model ||= Conference.published.find_by(slug: params[:conference_slug])
       end
 
       def current_participatory_space

--- a/decidim-conferences/app/controllers/decidim/conferences/conference_widgets_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conference_widgets_controller.rb
@@ -5,6 +5,12 @@ module Decidim
     class ConferenceWidgetsController < Decidim::WidgetsController
       helper Decidim::SanitizeHelper
 
+      def show
+        enforce_permission_to :embed, :question, question: model if model
+
+        super
+      end
+
       private
 
       def model
@@ -17,6 +23,10 @@ module Decidim
 
       def iframe_url
         @iframe_url ||= conference_conference_widget_url(model)
+      end
+
+      def permission_class_chain
+        ::Decidim.permissions_registry.chain_for(::Decidim::Conferences::ApplicationController)
       end
     end
   end

--- a/decidim-conferences/app/controllers/decidim/conferences/conference_widgets_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conference_widgets_controller.rb
@@ -6,7 +6,7 @@ module Decidim
       helper Decidim::SanitizeHelper
 
       def show
-        enforce_permission_to :embed, :question, question: model if model
+        enforce_permission_to :embed, :conference, conference: model if model
 
         super
       end

--- a/decidim-conferences/app/permissions/decidim/conferences/permissions.rb
+++ b/decidim-conferences/app/permissions/decidim/conferences/permissions.rb
@@ -16,6 +16,7 @@ module Decidim
         if permission_action.scope == :public
           public_list_conferences_action?
           public_read_conference_action?
+          public_embed_conference_action?
           public_list_speakers_action?
           public_list_program_action?
           public_list_media_links_action?
@@ -129,6 +130,16 @@ module Decidim
         return allow! if conference.published?
 
         toggle_allow(can_manage_conference?)
+      end
+
+      def public_embed_conference_action?
+        return unless permission_action.action == :embed &&
+                      [:conference, :participatory_space].include?(permission_action.subject) &&
+                      conference
+
+        return disallow! unless conference.published?
+
+        allow!
       end
 
       def public_list_speakers_action?

--- a/decidim-conferences/spec/permissions/decidim/conferences/permissions_spec.rb
+++ b/decidim-conferences/spec/permissions/decidim/conferences/permissions_spec.rb
@@ -125,6 +125,42 @@ describe Decidim::Conferences::Permissions do
       end
     end
 
+    context "when embedding a conference" do
+      let(:action) do
+        { scope: :public, action: :embed, subject: :conference }
+      end
+      let(:context) { { conference: conference } }
+
+      context "when the user is an admin" do
+        let(:user) { create :user, :admin }
+
+        it { is_expected.to be true }
+      end
+
+      context "when the conference is published" do
+        let(:user) { create :user, organization: organization }
+
+        it { is_expected.to be true }
+      end
+
+      context "when the conference is not published" do
+        let(:user) { create :user, organization: organization }
+        let(:conference) { create :conference, :unpublished, organization: organization }
+
+        context "when the user doesn't have access to it" do
+          it { is_expected.to be false }
+        end
+
+        context "when the user has access to it" do
+          before do
+            create :conference_user_role, user: user, conference: conference
+          end
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+
     context "when listing conferences" do
       let(:action) do
         { scope: :public, action: :list, subject: :conference }

--- a/decidim-conferences/spec/system/conference_embeds_spec.rb
+++ b/decidim-conferences/spec/system/conference_embeds_spec.rb
@@ -6,5 +6,5 @@ describe "Conference embeds", type: :system do
   let!(:resource) { create(:conference) }
   let(:widget_path) { Decidim::EngineRouter.main_proxy(resource).conference_conference_widget_path }
 
-  it_behaves_like "an embed resource", skip_space_checks: true
+  it_behaves_like "an embed resource", skip_space_checks: true, skip_link_checks: true
 end

--- a/decidim-conferences/spec/system/conference_embeds_spec.rb
+++ b/decidim-conferences/spec/system/conference_embeds_spec.rb
@@ -3,18 +3,8 @@
 require "spec_helper"
 
 describe "Conference embeds", type: :system do
-  let!(:conference) { create(:conference) }
+  let!(:resource) { create(:conference) }
+  let(:widget_path) { Decidim::EngineRouter.main_proxy(resource).conference_conference_widget_path }
 
-  context "when visiting the embed page for an conference" do
-    before do
-      switch_to_host(conference.organization.host)
-      visit resource_locator(conference).path
-      visit "#{current_path}/embed"
-    end
-
-    it "renders the page correctly" do
-      expect(page).to have_i18n_content(conference.title)
-      expect(page).to have_content(conference.organization.name)
-    end
-  end
+  it_behaves_like "an embed resource", skip_space_checks: true
 end

--- a/decidim-consultations/app/controllers/decidim/consultations/consultation_widgets_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/consultation_widgets_controller.rb
@@ -17,7 +17,7 @@ module Decidim
       private
 
       def model
-        @model ||= Consultation.published.find_by(slug: params[:consultation_slug])
+        @model ||= Consultation.where(organization: current_organization).published.find_by(slug: params[:consultation_slug])
       end
 
       def current_participatory_space

--- a/decidim-consultations/app/controllers/decidim/consultations/consultation_widgets_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/consultation_widgets_controller.rb
@@ -4,13 +4,20 @@ module Decidim
   module Consultations
     class ConsultationWidgetsController < Decidim::WidgetsController
       helper Decidim::SanitizeHelper
+      helper ConsultationsHelper
 
       layout false
+
+      def show
+        enforce_permission_to :embed, :participatory_space, current_participatory_space: model if model
+
+        super
+      end
 
       private
 
       def model
-        @model ||= Consultation.find_by(slug: params[:consultation_slug])
+        @model ||= Consultation.published.find_by(slug: params[:consultation_slug])
       end
 
       def current_participatory_space
@@ -19,6 +26,10 @@ module Decidim
 
       def iframe_url
         @iframe_url ||= consultation_consultation_widget_url(model)
+      end
+
+      def permission_class_chain
+        ::Decidim.permissions_registry.chain_for(::Decidim::Consultations::ApplicationController)
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/question_widgets_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/question_widgets_controller.rb
@@ -8,6 +8,12 @@ module Decidim
 
       helper Decidim::SanitizeHelper
 
+      def show
+        enforce_permission_to :embed, :participatory_space, current_participatory_space: model if model
+
+        super
+      end
+
       private
 
       def model
@@ -20,6 +26,10 @@ module Decidim
 
       def iframe_url
         @iframe_url ||= question_question_widget_url(model)
+      end
+
+      def permission_class_chain
+        ::Decidim.permissions_registry.chain_for(::Decidim::Consultations::ApplicationController)
       end
     end
   end

--- a/decidim-consultations/app/controllers/decidim/consultations/question_widgets_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/question_widgets_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       helper Decidim::SanitizeHelper
 
       def show
-        enforce_permission_to :embed, :participatory_space, current_participatory_space: model if model
+        enforce_permission_to :embed, :question, question: model if model
 
         super
       end

--- a/decidim-consultations/app/controllers/decidim/consultations/question_widgets_controller.rb
+++ b/decidim-consultations/app/controllers/decidim/consultations/question_widgets_controller.rb
@@ -11,7 +11,7 @@ module Decidim
       private
 
       def model
-        @model ||= current_question
+        @model ||= current_question if current_question.published?
       end
 
       def current_participatory_space

--- a/decidim-consultations/app/permissions/decidim/consultations/permissions.rb
+++ b/decidim-consultations/app/permissions/decidim/consultations/permissions.rb
@@ -5,6 +5,7 @@ module Decidim
     class Permissions < Decidim::DefaultPermissions
       def permissions
         allowed_public_anonymous_action?
+        allowed_public_embed_consultation_action?
         allowed_public_embed_question_action?
 
         return permission_action unless user
@@ -23,7 +24,7 @@ module Decidim
       end
 
       def consultation
-        @consultation ||= context.fetch(:consultation, nil)
+        @consultation ||= context.fetch(:current_participatory_space, nil) || context.fetch(:consultation, nil)
       end
 
       def authorized?(permission_action, resource: nil)
@@ -44,6 +45,16 @@ module Decidim
         when :question
           toggle_allow(question.published? || user&.admin?)
         end
+      end
+
+      def allowed_public_embed_consultation_action?
+        return unless permission_action.action == :embed &&
+                      [:consultation, :participatory_space].include?(permission_action.subject) &&
+                      consultation
+
+        return disallow! unless consultation.published?
+
+        allow!
       end
 
       def allowed_public_embed_question_action?

--- a/decidim-consultations/app/permissions/decidim/consultations/permissions.rb
+++ b/decidim-consultations/app/permissions/decidim/consultations/permissions.rb
@@ -5,6 +5,7 @@ module Decidim
     class Permissions < Decidim::DefaultPermissions
       def permissions
         allowed_public_anonymous_action?
+        allowed_public_embed_question_action?
 
         return permission_action unless user
 
@@ -43,6 +44,14 @@ module Decidim
         when :question
           toggle_allow(question.published? || user&.admin?)
         end
+      end
+
+      def allowed_public_embed_question_action?
+        return unless permission_action.action == :embed && permission_action.subject == :question && question
+
+        return disallow! unless question.published?
+
+        allow!
       end
 
       def allowed_public_action?

--- a/decidim-consultations/app/views/decidim/consultations/consultation_widgets/show.html.erb
+++ b/decidim-consultations/app/views/decidim/consultations/consultation_widgets/show.html.erb
@@ -1,3 +1,6 @@
+<p><%= translated_attribute(model.title) %></p>
+<p><%= current_organization.name %></p>
+
 <%= render partial: "decidim/consultations/consultations/consultation_details", locals: { consultation: model } %>
 <%= render partial: "decidim/consultations/consultations/highlighted_questions", locals: { consultation: model } %>
 <%= render partial: "decidim/consultations/consultations/regular_questions", locals: { consultation: model } %>

--- a/decidim-consultations/spec/permissions/decidim/consultations/permissions_spec.rb
+++ b/decidim-consultations/spec/permissions/decidim/consultations/permissions_spec.rb
@@ -52,6 +52,33 @@ describe Decidim::Consultations::Permissions do
       end
     end
 
+    context "when embedding a consultation" do
+      let(:action_name) { :embed }
+      let(:action_subject) { :consultation }
+
+      context "when the consultation is published" do
+        let(:consultation) { create :consultation, :published }
+
+        it { is_expected.to be true }
+      end
+
+      context "when the consultation is not published" do
+        let(:consultation) { create :consultation, :unpublished }
+
+        context "when the user is not an admin" do
+          let(:user) { nil }
+
+          it { is_expected.to be false }
+        end
+
+        context "when the user is an admin" do
+          let(:user) { create :user, :admin, organization: organization }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+
     context "when reading a question" do
       let(:action_subject) { :question }
 

--- a/decidim-consultations/spec/permissions/decidim/consultations/permissions_spec.rb
+++ b/decidim-consultations/spec/permissions/decidim/consultations/permissions_spec.rb
@@ -78,6 +78,33 @@ describe Decidim::Consultations::Permissions do
       end
     end
 
+    context "when embedding a question" do
+      let(:action_name) { :embed }
+      let(:action_subject) { :question }
+
+      context "when the question is published" do
+        let(:question) { create :question, :published, consultation: consultation }
+
+        it { is_expected.to be true }
+      end
+
+      context "when the question is not published" do
+        let(:question) { create :question, :unpublished, consultation: consultation }
+
+        context "when the user is not an admin" do
+          let(:user) { nil }
+
+          it { is_expected.to be false }
+        end
+
+        context "when the user is an admin" do
+          let(:user) { create :user, :admin, organization: organization }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+
     context "when voting a question" do
       let(:action_subject) { :question }
       let(:action_name) { :vote }

--- a/decidim-consultations/spec/system/consultation_embeds_spec.rb
+++ b/decidim-consultations/spec/system/consultation_embeds_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Consultation embeds", type: :system do
+  let(:resource) { create(:consultation) }
+  let(:widget_path) { Decidim::EngineRouter.main_proxy(resource).consultation_consultation_widget_path }
+
+  it_behaves_like "an embed resource", skip_space_checks: true, skip_link_checks: true
+end

--- a/decidim-consultations/spec/system/question_embeds_spec.rb
+++ b/decidim-consultations/spec/system/question_embeds_spec.rb
@@ -6,5 +6,5 @@ describe "Question embeds", type: :system do
   let(:resource) { create(:question) }
   let(:widget_path) { Decidim::EngineRouter.main_proxy(resource).question_question_widget_path }
 
-  it_behaves_like "an embed resource", skip_space_checks: true
+  it_behaves_like "an embed resource", skip_space_checks: true, skip_link_checks: true
 end

--- a/decidim-consultations/spec/system/question_embeds_spec.rb
+++ b/decidim-consultations/spec/system/question_embeds_spec.rb
@@ -3,17 +3,8 @@
 require "spec_helper"
 
 describe "Question embeds", type: :system do
-  let(:question) { create(:question) }
+  let(:resource) { create(:question) }
+  let(:widget_path) { Decidim::EngineRouter.main_proxy(resource).question_question_widget_path }
 
-  context "when visiting the embed page for a question" do
-    before do
-      switch_to_host(question.organization.host)
-      visit "#{decidim_consultations.question_path(question)}/embed"
-    end
-
-    it "renders the page correctly" do
-      expect(page).to have_i18n_content(question.title)
-      expect(page).to have_content(question.organization.name)
-    end
-  end
+  it_behaves_like "an embed resource", skip_space_checks: true
 end

--- a/decidim-core/app/controllers/decidim/widgets_controller.rb
+++ b/decidim-core/app/controllers/decidim/widgets_controller.rb
@@ -11,6 +11,8 @@ module Decidim
     helper_method :model, :iframe_url, :current_participatory_space
 
     def show
+      raise ActionController::RoutingError, "Not Found" if model.nil?
+
       respond_to do |format|
         format.js { render "decidim/widgets/show" }
         format.html

--- a/decidim-core/app/controllers/decidim/widgets_controller.rb
+++ b/decidim-core/app/controllers/decidim/widgets_controller.rb
@@ -21,6 +21,10 @@ module Decidim
 
     private
 
+    def current_component
+      @current_component ||= request.env["decidim.current_component"]
+    end
+
     def current_participatory_space
       @current_participatory_space ||= model.component.participatory_space
     end

--- a/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
@@ -119,7 +119,10 @@ shared_examples_for "a private embed resource" do
       let(:user) { nil }
 
       it_behaves_like "not rendering the embed link in the resource page"
-      it_behaves_like "showing the unauthorized message in the widget_path"
+
+      it_behaves_like "a 404 page" do
+        let(:target_path) { widget_path }
+      end
     end
 
     context "and user is a registered user" do
@@ -130,7 +133,10 @@ shared_examples_for "a private embed resource" do
       end
 
       it_behaves_like "not rendering the embed link in the resource page"
-      it_behaves_like "showing the unauthorized message in the widget_path"
+
+      it_behaves_like "a 404 page" do
+        let(:target_path) { widget_path }
+      end
     end
 
     context "and user is a private user" do
@@ -140,7 +146,9 @@ shared_examples_for "a private embed resource" do
         sign_in user, scope: :user
       end
 
-      it_behaves_like "showing the unauthorized message in the widget_path"
+      it_behaves_like "a 404 page" do
+        let(:target_path) { widget_path }
+      end
     end
   end
 end
@@ -209,6 +217,9 @@ shared_examples_for "a withdrawn embed resource" do
     end
 
     it_behaves_like "not rendering the embed link in the resource page"
-    it_behaves_like "showing the unauthorized message in the widget_path"
+
+    it_behaves_like "a 404 page" do
+      let(:target_path) { widget_path }
+    end
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
@@ -18,6 +18,23 @@ shared_examples "rendering the page correctly" do
   end
 end
 
+shared_examples "rendering the embed link in the resource page" do
+  before do
+    visit resource_locator(resource).path
+  end
+
+  it "has the embed link" do
+    expect(page).to have_button("Embed")
+  end
+end
+
+shared_examples "showing the unauthorized message" do
+  it do
+    visit widget_path
+    expect(page).to have_content "You are not authorized to perform this action"
+  end
+end
+
 shared_examples "not rendering the embed link in the resource page" do
   before do
     visit resource_locator(resource).path
@@ -53,15 +70,7 @@ shared_examples_for "an embed resource" do |options|
     end
   end
 
-  context "when visting the resource page" do
-    before do
-      visit resource_locator(resource).path
-    end
-
-    it "has the embed link" do
-      expect(page).to have_button("Embed")
-    end
-  end
+  it_behaves_like "rendering the embed link in the resource page"
 
   context "when visiting the embed page for a resource" do
     before do
@@ -110,12 +119,7 @@ shared_examples_for "a private embed resource" do
       let(:user) { nil }
 
       it_behaves_like "not rendering the embed link in the resource page"
-
-      it "shows the unauthorized message" do
-        visit widget_path
-
-        expect(page).to have_content "You are not authorized to perform this action"
-      end
+      it_behaves_like "showing the unauthorized message in the widget_path"
     end
 
     context "and user is a registered user" do
@@ -126,12 +130,7 @@ shared_examples_for "a private embed resource" do
       end
 
       it_behaves_like "not rendering the embed link in the resource page"
-
-      it "shows the unauthorized message" do
-        visit widget_path
-
-        expect(page).to have_content "You are not authorized to perform this action"
-      end
+      it_behaves_like "showing the unauthorized message"
     end
 
     context "and user is a private user" do
@@ -141,11 +140,7 @@ shared_examples_for "a private embed resource" do
         sign_in user, scope: :user
       end
 
-      it "shows the unauthorized message" do
-        visit widget_path
-
-        expect(page).to have_content "You are not authorized to perform this action"
-      end
+      it_behaves_like "showing the unauthorized message"
     end
   end
 end
@@ -214,11 +209,6 @@ shared_examples_for "a withdrawn embed resource" do
     end
 
     it_behaves_like "not rendering the embed link in the resource page"
-
-    it "shows the unauthorized message" do
-      visit widget_path
-
-      expect(page).to have_content "You are not authorized to perform this action"
-    end
+    it_behaves_like "showing the unauthorized message"
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
@@ -115,7 +115,11 @@ shared_examples_for "a private embed resource" do
         sign_in user, scope: :user
       end
 
-      it_behaves_like "rendering the page correctly"
+      it "shows the unauthorized message" do
+        visit widget_path
+
+        expect(page).to have_content "You are not authorized to perform this action"
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
@@ -204,3 +204,21 @@ shared_examples_for "a moderated embed resource" do
     end
   end
 end
+
+shared_examples_for "a withdrawn embed resource" do
+  include_context "with a component"
+
+  context "when the resource is withdrawn" do
+    before do
+      resource.update!(state: "withdrawn")
+    end
+
+    it_behaves_like "not rendering the embed link in the resource page"
+
+    it "shows the unauthorized message" do
+      visit widget_path
+
+      expect(page).to have_content "You are not authorized to perform this action"
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
@@ -11,10 +11,21 @@ shared_examples_for "an embed resource" do |options|
     include_context "with a component"
   end
 
+  unless options.is_a?(Hash) && options[:skip_unpublish_checks]
+    context "when the resource is not published" do
+      before do
+        resource.unpublish!
+      end
+
+      it_behaves_like "a 404 page" do
+        let(:target_path) { widget_path }
+      end
+    end
+  end
+
   context "when visiting the embed page for a resource" do
     before do
-      visit resource_locator(resource).path
-      visit "#{current_path}/embed"
+      visit widget_path
     end
 
     it "renders the page correctly" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
@@ -2,7 +2,7 @@
 
 require "decidim/admin/test/admin_participatory_space_access_examples"
 
-shared_examples "rendering the page correctly" do
+shared_examples "rendering the embed page correctly" do
   before do
     visit widget_path
   end
@@ -28,7 +28,7 @@ shared_examples "rendering the embed link in the resource page" do
   end
 end
 
-shared_examples "showing the unauthorized message" do
+shared_examples "showing the unauthorized message in the widget_path" do
   it do
     visit widget_path
     expect(page).to have_content "You are not authorized to perform this action"
@@ -77,7 +77,7 @@ shared_examples_for "an embed resource" do |options|
       visit widget_path
     end
 
-    it_behaves_like "rendering the page correctly"
+    it_behaves_like "rendering the embed page correctly"
 
     unless options.is_a?(Hash) && options[:skip_space_checks]
       context "when the participatory_space is a process" do
@@ -130,7 +130,7 @@ shared_examples_for "a private embed resource" do
       end
 
       it_behaves_like "not rendering the embed link in the resource page"
-      it_behaves_like "showing the unauthorized message"
+      it_behaves_like "showing the unauthorized message in the widget_path"
     end
 
     context "and user is a private user" do
@@ -140,7 +140,7 @@ shared_examples_for "a private embed resource" do
         sign_in user, scope: :user
       end
 
-      it_behaves_like "showing the unauthorized message"
+      it_behaves_like "showing the unauthorized message in the widget_path"
     end
   end
 end
@@ -163,7 +163,7 @@ shared_examples_for "a transparent private embed resource" do
     context "and user is a visitor" do
       let(:user) { nil }
 
-      it_behaves_like "rendering the page correctly"
+      it_behaves_like "rendering the embed page correctly"
     end
 
     context "and user is a registered user" do
@@ -173,7 +173,7 @@ shared_examples_for "a transparent private embed resource" do
         sign_in user, scope: :user
       end
 
-      it_behaves_like "rendering the page correctly"
+      it_behaves_like "rendering the embed page correctly"
     end
 
     context "and user is a private user" do
@@ -183,7 +183,7 @@ shared_examples_for "a transparent private embed resource" do
         sign_in user, scope: :user
       end
 
-      it_behaves_like "rendering the page correctly"
+      it_behaves_like "rendering the embed page correctly"
     end
   end
 end
@@ -209,6 +209,6 @@ shared_examples_for "a withdrawn embed resource" do
     end
 
     it_behaves_like "not rendering the embed link in the resource page"
-    it_behaves_like "showing the unauthorized message"
+    it_behaves_like "showing the unauthorized message in the widget_path"
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
@@ -70,9 +70,7 @@ shared_examples_for "an embed resource" do |options|
     end
   end
 
-  unless options.is_a?(Hash) && options[:skip_link_checks]
-    it_behaves_like "rendering the embed link in the resource page"
-  end
+  it_behaves_like "rendering the embed link in the resource page" unless options.is_a?(Hash) && options[:skip_link_checks]
 
   context "when visiting the embed page for a resource" do
     before do

--- a/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
@@ -18,6 +18,16 @@ shared_examples "rendering the page correctly" do
   end
 end
 
+shared_examples "not rendering the embed link in the resource page" do
+  before do
+    visit resource_locator(resource).path
+  end
+
+  it "does not have the embed link" do
+    expect(page).to have_no_button("Embed")
+  end
+end
+
 shared_examples_for "an embed resource" do |options|
   if options.is_a?(Hash) && options[:skip_space_checks]
     let(:organization) { resource.organization }
@@ -35,9 +45,21 @@ shared_examples_for "an embed resource" do |options|
         resource.unpublish!
       end
 
+      it_behaves_like "not rendering the embed link in the resource page"
+
       it_behaves_like "a 404 page" do
         let(:target_path) { widget_path }
       end
+    end
+  end
+
+  context "when visting the resource page" do
+    before do
+      visit resource_locator(resource).path
+    end
+
+    it "has the embed link" do
+      expect(page).to have_button("Embed")
     end
   end
 
@@ -87,6 +109,8 @@ shared_examples_for "a private embed resource" do
     context "and user is a visitor" do
       let(:user) { nil }
 
+      it_behaves_like "not rendering the embed link in the resource page"
+
       it "shows the unauthorized message" do
         visit widget_path
 
@@ -100,6 +124,8 @@ shared_examples_for "a private embed resource" do
       before do
         sign_in user, scope: :user
       end
+
+      it_behaves_like "not rendering the embed link in the resource page"
 
       it "shows the unauthorized message" do
         visit widget_path

--- a/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
@@ -162,3 +162,15 @@ shared_examples_for "a transparent private embed resource" do
     end
   end
 end
+
+shared_examples_for "a moderated embed resource" do
+  include_context "with a component"
+
+  context "when the resource is moderated" do
+    let!(:moderation) { create(:moderation, reportable: resource, hidden_at: 2.days.ago) }
+
+    it_behaves_like "a 404 page" do
+      let(:target_path) { widget_path }
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
@@ -29,7 +29,7 @@ shared_examples_for "an embed resource" do |options|
     include_context "with a component"
   end
 
-  unless options.is_a?(Hash) && options[:skip_unpublish_checks]
+  unless options.is_a?(Hash) && options[:skip_publication_checks]
     context "when the resource is not published" do
       before do
         resource.unpublish!

--- a/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
@@ -70,7 +70,9 @@ shared_examples_for "an embed resource" do |options|
     end
   end
 
-  it_behaves_like "rendering the embed link in the resource page"
+  unless options.is_a?(Hash) && options[:skip_link_checks]
+    it_behaves_like "rendering the embed link in the resource page"
+  end
 
   context "when visiting the embed page for a resource" do
     before do

--- a/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/embed_resource_examples.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+require "decidim/admin/test/admin_participatory_space_access_examples"
+
+shared_examples "rendering the page correctly" do
+  before do
+    visit widget_path
+  end
+
+  it "renders" do
+    if resource.title.is_a?(Hash)
+      expect(page).to have_i18n_content(resource.title)
+    else
+      expect(page).to have_content(resource.title)
+    end
+
+    expect(page).to have_content(organization.name)
+  end
+end
+
 shared_examples_for "an embed resource" do |options|
   if options.is_a?(Hash) && options[:skip_space_checks]
     let(:organization) { resource.organization }
@@ -28,15 +46,7 @@ shared_examples_for "an embed resource" do |options|
       visit widget_path
     end
 
-    it "renders the page correctly" do
-      if resource.title.is_a?(Hash)
-        expect(page).to have_i18n_content(resource.title)
-      else
-        expect(page).to have_content(resource.title)
-      end
-
-      expect(page).to have_content(organization.name)
-    end
+    it_behaves_like "rendering the page correctly"
 
     unless options.is_a?(Hash) && options[:skip_space_checks]
       context "when the participatory_space is a process" do
@@ -55,6 +65,100 @@ shared_examples_for "an embed resource" do |options|
           expect(page).to have_i18n_content(assembly.title)
         end
       end
+    end
+  end
+end
+
+shared_examples_for "a private embed resource" do
+  let(:organization) { resource.organization }
+  let!(:other_user) { create(:user, :confirmed, organization: organization) }
+  let!(:participatory_space_private_user) { create(:participatory_space_private_user, user: other_user, privatable_to: resource) }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  context "when the resource is private" do
+    before do
+      resource.update!(private_space: true)
+      resource.update!(is_transparent: false) if resource.respond_to?(:is_transparent)
+    end
+
+    context "and user is a visitor" do
+      let(:user) { nil }
+
+      it "shows the unauthorized message" do
+        visit widget_path
+
+        expect(page).to have_content "You are not authorized to perform this action"
+      end
+    end
+
+    context "and user is a registered user" do
+      let(:user) { create(:user, :confirmed, organization: organization) }
+
+      before do
+        sign_in user, scope: :user
+      end
+
+      it "shows the unauthorized message" do
+        visit widget_path
+
+        expect(page).to have_content "You are not authorized to perform this action"
+      end
+    end
+
+    context "and user is a private user" do
+      let(:user) { other_user }
+
+      before do
+        sign_in user, scope: :user
+      end
+
+      it_behaves_like "rendering the page correctly"
+    end
+  end
+end
+
+shared_examples_for "a transparent private embed resource" do
+  let(:organization) { resource.organization }
+  let!(:other_user) { create(:user, :confirmed, organization: organization) }
+  let!(:participatory_space_private_user) { create(:participatory_space_private_user, user: other_user, privatable_to: resource) }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  context "when the resource is private" do
+    before do
+      resource.update!(private_space: true)
+      resource.update!(is_transparent: true) if resource.respond_to?(:is_transparent)
+    end
+
+    context "and user is a visitor" do
+      let(:user) { nil }
+
+      it_behaves_like "rendering the page correctly"
+    end
+
+    context "and user is a registered user" do
+      let(:user) { create(:user, :confirmed, organization: organization) }
+
+      before do
+        sign_in user, scope: :user
+      end
+
+      it_behaves_like "rendering the page correctly"
+    end
+
+    context "and user is a private user" do
+      let(:user) { other_user }
+
+      before do
+        sign_in user, scope: :user
+      end
+
+      it_behaves_like "rendering the page correctly"
     end
   end
 end

--- a/decidim-debates/app/controllers/decidim/debates/widgets_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/widgets_controller.rb
@@ -14,7 +14,7 @@ module Decidim
       private
 
       def model
-        @model ||= Debate.where(organization: current_organization).where(component: params[:component_id]).find(params[:debate_id])
+        @model ||= Debate.where(component: current_component).find(params[:debate_id])
       end
 
       def iframe_url

--- a/decidim-debates/app/controllers/decidim/debates/widgets_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/widgets_controller.rb
@@ -5,6 +5,12 @@ module Decidim
     class WidgetsController < Decidim::WidgetsController
       helper Debates::ApplicationHelper
 
+      def show
+        enforce_permission_to :embed, :debate, debate: model if model
+
+        super
+      end
+
       private
 
       def model
@@ -13,6 +19,10 @@ module Decidim
 
       def iframe_url
         @iframe_url ||= debate_widget_url(model)
+      end
+
+      def permission_class_chain
+        [Decidim::Debates::Permissions]
       end
     end
   end

--- a/decidim-debates/app/controllers/decidim/debates/widgets_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/widgets_controller.rb
@@ -14,7 +14,7 @@ module Decidim
       private
 
       def model
-        @model ||= Debate.where(component: params[:component_id]).find(params[:debate_id])
+        @model ||= Debate.where(organization: current_organization).where(component: params[:component_id]).find(params[:debate_id])
       end
 
       def iframe_url

--- a/decidim-debates/app/controllers/decidim/debates/widgets_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/widgets_controller.rb
@@ -14,7 +14,7 @@ module Decidim
       private
 
       def model
-        @model ||= Debate.where(component: current_component).find(params[:debate_id])
+        @model ||= Debate.not_hidden.where(component: current_component).find(params[:debate_id])
       end
 
       def iframe_url

--- a/decidim-debates/app/permissions/decidim/debates/permissions.rb
+++ b/decidim-debates/app/permissions/decidim/debates/permissions.rb
@@ -21,6 +21,8 @@ module Decidim
           can_endorse_debate?
         when :close
           can_close_debate?
+        when :embed
+          can_embed_debate?
         end
 
         permission_action
@@ -43,6 +45,10 @@ module Decidim
         return allow! if debate&.closeable_by?(user)
 
         disallow!
+      end
+
+      def can_embed_debate?
+        allow!
       end
 
       def can_endorse_debate?

--- a/decidim-debates/spec/permissions/decidim/debates/permissions_spec.rb
+++ b/decidim-debates/spec/permissions/decidim/debates/permissions_spec.rb
@@ -106,4 +106,18 @@ describe Decidim::Debates::Permissions do
       it { is_expected.to be false }
     end
   end
+
+  context "when embedding a debate" do
+    let(:action) do
+      { scope: :public, action: :embed, subject: :debate }
+    end
+
+    it { is_expected.to be true }
+
+    context "when the debate is closed" do
+      let(:debate) { create :debate, :closed, component: debates_component }
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/decidim-debates/spec/system/debate_embeds_spec.rb
+++ b/decidim-debates/spec/system/debate_embeds_spec.rb
@@ -4,8 +4,10 @@ require "spec_helper"
 
 describe "Debate embeds", type: :system do
   include_context "with a component"
+
   let(:manifest_name) { "debates" }
   let!(:resource) { create(:debate, component: component, skip_injection: true) }
+  let(:widget_path) { Decidim::EngineRouter.main_proxy(component).debate_widget_path(resource) }
 
-  it_behaves_like "an embed resource"
+  it_behaves_like "an embed resource", skip_unpublish_checks: true
 end

--- a/decidim-debates/spec/system/debate_embeds_spec.rb
+++ b/decidim-debates/spec/system/debate_embeds_spec.rb
@@ -9,5 +9,5 @@ describe "Debate embeds", type: :system do
   let!(:resource) { create(:debate, component: component, skip_injection: true) }
   let(:widget_path) { Decidim::EngineRouter.main_proxy(component).debate_widget_path(resource) }
 
-  it_behaves_like "an embed resource", skip_unpublish_checks: true
+  it_behaves_like "an embed resource", skip_publication_checks: true
 end

--- a/decidim-debates/spec/system/debate_embeds_spec.rb
+++ b/decidim-debates/spec/system/debate_embeds_spec.rb
@@ -10,4 +10,5 @@ describe "Debate embeds", type: :system do
   let(:widget_path) { Decidim::EngineRouter.main_proxy(component).debate_widget_path(resource) }
 
   it_behaves_like "an embed resource", skip_publication_checks: true
+  it_behaves_like "a moderated embed resource"
 end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/widgets_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/widgets_controller.rb
@@ -21,7 +21,11 @@ module Decidim
       private
 
       def model
-        @model ||= current_initiative
+        @model ||= if current_initiative.created? || current_initiative.validating? || current_initiative.discarded?
+                     nil
+                   else
+                     current_initiative
+                   end
       end
 
       def current_participatory_space

--- a/decidim-initiatives/app/controllers/decidim/initiatives/widgets_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/widgets_controller.rb
@@ -12,6 +12,12 @@ module Decidim
 
       include NeedsInitiative
 
+      def show
+        enforce_permission_to :embed, :participatory_space, current_participatory_space: model if model
+
+        super
+      end
+
       private
 
       def model
@@ -24,6 +30,10 @@ module Decidim
 
       def iframe_url
         @iframe_url ||= initiative_widget_url(model)
+      end
+
+      def permission_class_chain
+        ::Decidim.permissions_registry.chain_for(::Decidim::Initiatives::ApplicationController)
       end
     end
   end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/widgets_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/widgets_controller.rb
@@ -21,7 +21,7 @@ module Decidim
       private
 
       def model
-        @model ||= current_initiative if current_initiative.published?
+        @model ||= current_initiative
       end
 
       def current_participatory_space

--- a/decidim-initiatives/app/controllers/decidim/initiatives/widgets_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/widgets_controller.rb
@@ -15,7 +15,7 @@ module Decidim
       private
 
       def model
-        @model ||= current_initiative
+        @model ||= current_initiative if current_initiative.published?
       end
 
       def current_participatory_space

--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -11,6 +11,7 @@ module Decidim
         # Non-logged users permissions
         list_public_initiatives?
         read_public_initiative?
+        embed_public_initiative?
         search_initiative_types_and_scopes?
         request_membership?
 
@@ -55,6 +56,13 @@ module Decidim
         return allow! if user && authorship_or_admin?
 
         disallow!
+      end
+
+      def embed_public_initiative?
+        return unless [:initiative, :participatory_space].include?(permission_action.subject) &&
+                      permission_action.action == :embed
+
+        allow!
       end
 
       def search_initiative_types_and_scopes?

--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -62,6 +62,8 @@ module Decidim
         return unless [:initiative, :participatory_space].include?(permission_action.subject) &&
                       permission_action.action == :embed
 
+        return disallow! if initiative.created? || initiative.validating? || initiative.discarded?
+
         allow!
       end
 

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -65,7 +65,9 @@ edit_link(
       </div>
     <% end %>
     <%= render partial: "decidim/shared/share_modal" %>
-    <%= embed_modal_for initiative_widget_url(current_initiative, format: :js) %>
+    <% if allowed_to? :embed, :initiative, initiative: current_initiative %>
+      <%= embed_modal_for initiative_widget_url(current_initiative, format: :js) %>
+    <% end %>
     <%= resource_reference(current_initiative) %>
     <%= resource_version(current_initiative, versions_path: initiative_versions_path(current_initiative)) %>
   </div>

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
@@ -150,7 +150,7 @@ describe Decidim::Initiatives::Permissions do
   end
 
   context "when emeding an initiative" do
-    let(:initiative) { create(:initiative, :discarded, organization: organization) }
+    let(:initiative) { create(:initiative, :accepted, organization: organization) }
     let(:action) do
       { scope: :public, action: :embed, subject: :initiative }
     end

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
@@ -149,6 +149,58 @@ describe Decidim::Initiatives::Permissions do
     end
   end
 
+  context "when emeding an initiative" do
+    let(:initiative) { create(:initiative, :discarded, organization: organization) }
+    let(:action) do
+      { scope: :public, action: :embed, subject: :initiative }
+    end
+    let(:context) do
+      { initiative: initiative }
+    end
+
+    context "when initiative is published" do
+      let(:initiative) { create(:initiative, :published, organization: organization) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when initiative is rejected" do
+      let(:initiative) { create(:initiative, :rejected, organization: organization) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when initiative is accepted" do
+      let(:initiative) { create(:initiative, :accepted, organization: organization) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when user is admin" do
+      let(:user) { create(:user, :admin, organization: organization) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when user is author of the initiative" do
+      let(:initiative) { create(:initiative, author: user, organization: organization) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when user is committee member of the initiative" do
+      before do
+        create(:initiatives_committee_member, initiative: initiative, user: user)
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when any other condition" do
+      it { is_expected.to be true }
+    end
+  end
+
   context "when listing committee members of the initiative as author" do
     let(:initiative) { create(:initiative, organization: organization, author: user) }
     let(:action) do

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
@@ -158,6 +158,24 @@ describe Decidim::Initiatives::Permissions do
       { initiative: initiative }
     end
 
+    context "when initiative is created" do
+      let(:initiative) { create(:initiative, :created, organization: organization) }
+
+      it { is_expected.to be false }
+    end
+
+    context "when initiative is validating" do
+      let(:initiative) { create(:initiative, :validating, organization: organization) }
+
+      it { is_expected.to be false }
+    end
+
+    context "when initiative is discarded" do
+      let(:initiative) { create(:initiative, :discarded, organization: organization) }
+
+      it { is_expected.to be false }
+    end
+
     context "when initiative is published" do
       let(:initiative) { create(:initiative, :published, organization: organization) }
 

--- a/decidim-initiatives/spec/system/initiative_embeds_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_embeds_spec.rb
@@ -21,21 +21,30 @@ describe "Initiative embeds", type: :system do
       let(:state) { :created }
 
       it_behaves_like "not rendering the embed link in the resource page"
-      it_behaves_like "showing the unauthorized message in the widget_path"
+
+      it_behaves_like "a 404 page" do
+        let(:target_path) { widget_path }
+      end
     end
 
     context "when the state is validating" do
       let(:state) { :validating }
 
       it_behaves_like "not rendering the embed link in the resource page"
-      it_behaves_like "showing the unauthorized message in the widget_path"
+
+      it_behaves_like "a 404 page" do
+        let(:target_path) { widget_path }
+      end
     end
 
     context "when the state is discarded" do
       let(:state) { :discarded }
 
       # A discarded initiative is not available anymore to authors
-      it_behaves_like "showing the unauthorized message in the widget_path"
+
+      it_behaves_like "a 404 page" do
+        let(:target_path) { widget_path }
+      end
     end
 
     context "when the state is published" do

--- a/decidim-initiatives/spec/system/initiative_embeds_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_embeds_spec.rb
@@ -21,42 +21,42 @@ describe "Initiative embeds", type: :system do
       let(:state) { :created }
 
       it_behaves_like "not rendering the embed link in the resource page"
-      it_behaves_like "shows the unauthorized message"
+      it_behaves_like "showing the unauthorized message in the widget_path"
     end
 
     context "when the state is validating" do
       let(:state) { :validating }
 
       it_behaves_like "not rendering the embed link in the resource page"
-      it_behaves_like "shows the unauthorized message"
+      it_behaves_like "showing the unauthorized message in the widget_path"
     end
 
     context "when the state is discarded" do
       let(:state) { :discarded }
 
       # A discarded initiative is not available anymore to authors
-      it_behaves_like "shows the unauthorized message"
+      it_behaves_like "showing the unauthorized message in the widget_path"
     end
 
     context "when the state is published" do
       let(:state) { :published }
 
       it_behaves_like "rendering the embed link in the resource page"
-      it_behaves_like "rendering the page correctly"
+      it_behaves_like "rendering the embed page correctly"
     end
 
     context "when the state is rejected" do
       let(:state) { :rejected }
 
       it_behaves_like "rendering the embed link in the resource page"
-      it_behaves_like "rendering the page correctly"
+      it_behaves_like "rendering the embed page correctly"
     end
 
     context "when the state is accepted" do
       let(:state) { :accepted }
 
       it_behaves_like "rendering the embed link in the resource page"
-      it_behaves_like "rendering the page correctly"
+      it_behaves_like "rendering the embed page correctly"
     end
   end
 end

--- a/decidim-initiatives/spec/system/initiative_embeds_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_embeds_spec.rb
@@ -3,8 +3,60 @@
 require "spec_helper"
 
 describe "Initiative embeds", type: :system do
-  let(:resource) { create(:initiative) }
+  let(:state) { :published }
+  let(:resource) { create(:initiative, state: state) }
   let(:widget_path) { Decidim::EngineRouter.main_proxy(resource).initiative_widget_path }
 
-  it_behaves_like "an embed resource", skip_space_checks: true
+  it_behaves_like "an embed resource", skip_space_checks: true, skip_publication_checks: true
+
+  context "when the user is the initiative author" do
+    let(:organization) { resource.organization }
+    let(:user) { resource.author }
+
+    before do
+      switch_to_host(organization.host)
+    end
+
+    context "when the state is created" do
+      let(:state) { :created }
+
+      it_behaves_like "not rendering the embed link in the resource page"
+      it_behaves_like "shows the unauthorized message"
+    end
+
+    context "when the state is validating" do
+      let(:state) { :validating }
+
+      it_behaves_like "not rendering the embed link in the resource page"
+      it_behaves_like "shows the unauthorized message"
+    end
+
+    context "when the state is discarded" do
+      let(:state) { :discarded }
+
+      # A discarded initiative is not available anymore to authors
+      it_behaves_like "shows the unauthorized message"
+    end
+
+    context "when the state is published" do
+      let(:state) { :published }
+
+      it_behaves_like "rendering the embed link in the resource page"
+      it_behaves_like "rendering the page correctly"
+    end
+
+    context "when the state is rejected" do
+      let(:state) { :rejected }
+
+      it_behaves_like "rendering the embed link in the resource page"
+      it_behaves_like "rendering the page correctly"
+    end
+
+    context "when the state is accepted" do
+      let(:state) { :accepted }
+
+      it_behaves_like "rendering the embed link in the resource page"
+      it_behaves_like "rendering the page correctly"
+    end
+  end
 end

--- a/decidim-initiatives/spec/system/initiative_embeds_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_embeds_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe "Initiative embeds", type: :system do
   let(:resource) { create(:initiative) }
+  let(:widget_path) { Decidim::EngineRouter.main_proxy(resource).initiative_widget_path }
 
   it_behaves_like "an embed resource", skip_space_checks: true
 end

--- a/decidim-meetings/app/controllers/decidim/meetings/widgets_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/widgets_controller.rb
@@ -15,7 +15,7 @@ module Decidim
       private
 
       def model
-        @model ||= Meeting.published.not_hidden.where(component: current_component).find(params[:meeting_id])
+        @model ||= Meeting.except_withdrawn.published.not_hidden.where(component: current_component).find(params[:meeting_id])
       end
 
       def iframe_url

--- a/decidim-meetings/app/controllers/decidim/meetings/widgets_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/widgets_controller.rb
@@ -15,7 +15,7 @@ module Decidim
       private
 
       def model
-        @model ||= Meeting.where(organization: current_organization).published.where(component: params[:component_id]).find(params[:meeting_id])
+        @model ||= Meeting.published.where(component: current_component).find(params[:meeting_id])
       end
 
       def iframe_url

--- a/decidim-meetings/app/controllers/decidim/meetings/widgets_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/widgets_controller.rb
@@ -15,7 +15,7 @@ module Decidim
       private
 
       def model
-        @model ||= Meeting.published.where(component: params[:component_id]).find(params[:meeting_id])
+        @model ||= Meeting.where(organization: current_organization).published.where(component: params[:component_id]).find(params[:meeting_id])
       end
 
       def iframe_url

--- a/decidim-meetings/app/controllers/decidim/meetings/widgets_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/widgets_controller.rb
@@ -6,6 +6,12 @@ module Decidim
       helper MeetingsHelper
       helper Decidim::SanitizeHelper
 
+      def show
+        enforce_permission_to :embed, :meeting, meeting: model if model
+
+        super
+      end
+
       private
 
       def model
@@ -14,6 +20,10 @@ module Decidim
 
       def iframe_url
         @iframe_url ||= meeting_widget_url(model)
+      end
+
+      def permission_class_chain
+        [Decidim::Meetings::Permissions]
       end
     end
   end

--- a/decidim-meetings/app/controllers/decidim/meetings/widgets_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/widgets_controller.rb
@@ -15,7 +15,7 @@ module Decidim
       private
 
       def model
-        @model ||= Meeting.published.where(component: current_component).find(params[:meeting_id])
+        @model ||= Meeting.published.not_hidden.where(component: current_component).find(params[:meeting_id])
       end
 
       def iframe_url

--- a/decidim-meetings/app/controllers/decidim/meetings/widgets_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/widgets_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       private
 
       def model
-        @model ||= Meeting.where(component: params[:component_id]).find(params[:meeting_id])
+        @model ||= Meeting.published.where(component: params[:component_id]).find(params[:meeting_id])
       end
 
       def iframe_url

--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -61,6 +61,7 @@ module Decidim
       # As this is a public action, we need to run this before other checks
       def allow_embed_meeting?
         return unless permission_action.action == :embed && permission_action.subject == :meeting && meeting
+        return disallow! if meeting.withdrawn?
         return allow! if meeting.published?
 
         disallow!

--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -4,6 +4,7 @@ module Decidim
   module Meetings
     class Permissions < Decidim::DefaultPermissions
       def permissions
+        allow_embed_meeting?
         return permission_action unless user
 
         # Delegate the admin permission checks to the admin permissions class
@@ -55,6 +56,14 @@ module Decidim
 
       def question
         @question ||= context.fetch(:question, nil)
+      end
+
+      # As this is a public action, we need to run this before other checks
+      def allow_embed_meeting?
+        return unless permission_action.action == :embed && permission_action.subject == :meeting && meeting
+        return allow! if meeting.published?
+
+        disallow!
       end
 
       def can_join_meeting?

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -105,7 +105,9 @@ edit_link(
     <%= resource_version(meeting, versions_path: meeting_versions_path(meeting)) %>
     <%= cell "decidim/meetings/cancel_registration_meeting_button", meeting %>
     <%= render partial: "decidim/shared/share_modal" %>
-    <%= embed_modal_for meeting_widget_url(meeting, format: :js) %>
+    <% if allowed_to? :embed, :meeting, meeting: @meeting %>
+      <%= embed_modal_for meeting_widget_url(meeting, format: :js) %>
+    <% end %>
     <%= render partial: "calendar_modal", locals: { ics_url: calendar_meeting_url(meeting), google_url: google_calendar_event_url(meeting) } %>
   </div>
   <div class="columns mediumlarge-8 mediumlarge-pull-4">

--- a/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
+++ b/decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb
@@ -82,6 +82,28 @@ describe Decidim::Meetings::Permissions do
     end
   end
 
+  context "when embedding a meeting" do
+    let(:action) do
+      { scope: :public, action: :embed, subject: :meeting }
+    end
+
+    context "when meeting isn't published" do
+      before do
+        allow(meeting).to receive(:published?).and_return(false)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when meeting is published" do
+      before do
+        allow(meeting).to receive(:published?).and_return(true)
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
   context "when joining a meeting" do
     let(:action) do
       { scope: :public, action: :join, subject: :meeting }

--- a/decidim-meetings/spec/system/meeting_embeds_spec.rb
+++ b/decidim-meetings/spec/system/meeting_embeds_spec.rb
@@ -11,4 +11,5 @@ describe "Meeting embeds", type: :system do
 
   it_behaves_like "an embed resource"
   it_behaves_like "a moderated embed resource"
+  it_behaves_like "a withdrawn embed resource"
 end

--- a/decidim-meetings/spec/system/meeting_embeds_spec.rb
+++ b/decidim-meetings/spec/system/meeting_embeds_spec.rb
@@ -4,9 +4,10 @@ require "spec_helper"
 
 describe "Meeting embeds", type: :system do
   include_context "with a component"
-  let(:manifest_name) { "meetings" }
 
+  let(:manifest_name) { "meetings" }
   let!(:resource) { create(:meeting, :published, component: component) }
+  let(:widget_path) { Decidim::EngineRouter.main_proxy(component).meeting_widget_path(resource) }
 
   it_behaves_like "an embed resource"
 end

--- a/decidim-meetings/spec/system/meeting_embeds_spec.rb
+++ b/decidim-meetings/spec/system/meeting_embeds_spec.rb
@@ -10,4 +10,5 @@ describe "Meeting embeds", type: :system do
   let(:widget_path) { Decidim::EngineRouter.main_proxy(component).meeting_widget_path(resource) }
 
   it_behaves_like "an embed resource"
+  it_behaves_like "a moderated embed resource"
 end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/widgets_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/widgets_controller.rb
@@ -10,8 +10,8 @@ module Decidim
       def model
         return unless params[:participatory_process_slug]
 
-        @model ||= ParticipatoryProcess.where(slug: params[:participatory_process_slug]).or(
-          ParticipatoryProcess.where(id: params[:participatory_process_slug])
+        @model ||= ParticipatoryProcess.published.where(slug: params[:participatory_process_slug]).or(
+          ParticipatoryProcess.published.where(id: params[:participatory_process_slug])
         ).first!
       end
 

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/widgets_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/widgets_controller.rb
@@ -16,8 +16,8 @@ module Decidim
       def model
         return unless params[:participatory_process_slug]
 
-        @model ||= ParticipatoryProcess.published.where(slug: params[:participatory_process_slug]).or(
-          ParticipatoryProcess.published.where(id: params[:participatory_process_slug])
+        @model ||= ParticipatoryProcess.where(organization: current_organization).published.where(slug: params[:participatory_process_slug]).or(
+          ParticipatoryProcess.where(organization: current_organization).published.where(id: params[:participatory_process_slug])
         ).first!
       end
 

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/widgets_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/widgets_controller.rb
@@ -16,8 +16,8 @@ module Decidim
       def model
         return unless params[:participatory_process_slug]
 
-        @model ||= ParticipatoryProcess.where(organization: current_organization).published.where(slug: params[:participatory_process_slug]).or(
-          ParticipatoryProcess.where(organization: current_organization).published.where(id: params[:participatory_process_slug])
+        @model ||= ParticipatoryProcess.where(organization: current_organization).public_spaces.where(slug: params[:participatory_process_slug]).or(
+          ParticipatoryProcess.where(organization: current_organization).public_spaces.where(id: params[:participatory_process_slug])
         ).first!
       end
 

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/widgets_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/widgets_controller.rb
@@ -6,7 +6,7 @@ module Decidim
       helper Decidim::SanitizeHelper
 
       def show
-        enforce_permission_to :read, :participatory_space, current_participatory_space: model
+        enforce_permission_to :embed, :participatory_space, current_participatory_space: model
 
         super
       end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/widgets_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/widgets_controller.rb
@@ -5,6 +5,12 @@ module Decidim
     class WidgetsController < Decidim::WidgetsController
       helper Decidim::SanitizeHelper
 
+      def show
+        enforce_permission_to :read, :participatory_space, current_participatory_space: model
+
+        super
+      end
+
       private
 
       def model
@@ -21,6 +27,10 @@ module Decidim
 
       def iframe_url
         @iframe_url ||= participatory_process_widget_url(model)
+      end
+
+      def permission_class_chain
+        ::Decidim.permissions_registry.chain_for(::Decidim::ParticipatoryProcesses::ApplicationController)
       end
     end
   end

--- a/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
+++ b/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
@@ -119,7 +119,7 @@ module Decidim
                       process
 
         return disallow! unless process.published?
-        return disallow! unless can_view_private_space?
+        return disallow! if process.private_space
 
         allow!
       end

--- a/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
+++ b/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
@@ -19,6 +19,7 @@ module Decidim
           public_list_process_groups_action?
           public_read_process_group_action?
           public_read_process_action?
+          public_embed_process_action?
           return permission_action
         end
 
@@ -110,6 +111,17 @@ module Decidim
         return allow! if process.published?
 
         toggle_allow(can_manage_process?)
+      end
+
+      def public_embed_process_action?
+        return unless permission_action.action == :embed &&
+                      [:process, :participatory_space].include?(permission_action.subject) &&
+                      process
+
+        return disallow! unless process.published?
+        return disallow! unless can_view_private_space?
+
+        allow!
       end
 
       def can_view_private_space?

--- a/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
+++ b/decidim-participatory_processes/spec/permissions/decidim/participatory_processes/permissions_spec.rb
@@ -135,6 +135,36 @@ describe Decidim::ParticipatoryProcesses::Permissions do
       end
     end
 
+    context "when embedding an process" do
+      let(:action) do
+        { scope: :public, action: :embed, subject: :process }
+      end
+      let(:context) { { process: process } }
+
+      context "when the process is published" do
+        let(:user) { create(:user, organization: organization) }
+
+        it { is_expected.to be true }
+      end
+
+      context "when the process is not published" do
+        let(:user) { create(:user, organization: organization) }
+        let(:process) { create(:participatory_process, :unpublished, organization: organization) }
+
+        context "when the user doesn't have access to it" do
+          it { is_expected.to be false }
+        end
+
+        context "when the user has access to it" do
+          before do
+            create(:participatory_process_user_role, user: user, participatory_process: process)
+          end
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+
     context "when listing processes" do
       let(:action) do
         { scope: :public, action: :list, subject: :process }

--- a/decidim-participatory_processes/spec/system/process_embeds_spec.rb
+++ b/decidim-participatory_processes/spec/system/process_embeds_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe "Process embeds", type: :system do
   let(:resource) { create(:participatory_process) }
+  let(:widget_path) { Decidim::EngineRouter.main_proxy(resource).participatory_process_widget_path }
 
   it_behaves_like "an embed resource", skip_space_checks: true
 end

--- a/decidim-participatory_processes/spec/system/process_embeds_spec.rb
+++ b/decidim-participatory_processes/spec/system/process_embeds_spec.rb
@@ -7,4 +7,5 @@ describe "Process embeds", type: :system do
   let(:widget_path) { Decidim::EngineRouter.main_proxy(resource).participatory_process_widget_path }
 
   it_behaves_like "an embed resource", skip_space_checks: true
+  it_behaves_like "a private embed resource"
 end

--- a/decidim-proposals/app/controllers/decidim/proposals/widgets_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/widgets_controller.rb
@@ -5,6 +5,12 @@ module Decidim
     class WidgetsController < Decidim::WidgetsController
       helper Proposals::ApplicationHelper
 
+      def show
+        enforce_permission_to :embed, :proposal, proposal: model if model
+
+        super
+      end
+
       private
 
       def model
@@ -13,6 +19,10 @@ module Decidim
 
       def iframe_url
         @iframe_url ||= proposal_widget_url(model)
+      end
+
+      def permission_class_chain
+        [Decidim::Proposals::Permissions]
       end
     end
   end

--- a/decidim-proposals/app/controllers/decidim/proposals/widgets_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/widgets_controller.rb
@@ -14,7 +14,7 @@ module Decidim
       private
 
       def model
-        @model ||= Proposal.where(organization: current_organization).where(component: params[:component_id]).find(params[:proposal_id])
+        @model ||= Proposal.where(component: current_component).find(params[:proposal_id])
       end
 
       def iframe_url

--- a/decidim-proposals/app/controllers/decidim/proposals/widgets_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/widgets_controller.rb
@@ -14,7 +14,7 @@ module Decidim
       private
 
       def model
-        @model ||= Proposal.where(component: params[:component_id]).find(params[:proposal_id])
+        @model ||= Proposal.where(organization: current_organization).where(component: params[:component_id]).find(params[:proposal_id])
       end
 
       def iframe_url

--- a/decidim-proposals/app/controllers/decidim/proposals/widgets_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/widgets_controller.rb
@@ -14,7 +14,7 @@ module Decidim
       private
 
       def model
-        @model ||= Proposal.where(component: current_component).find(params[:proposal_id])
+        @model ||= Proposal.not_hidden.where(component: current_component).find(params[:proposal_id])
       end
 
       def iframe_url

--- a/decidim-proposals/app/controllers/decidim/proposals/widgets_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/widgets_controller.rb
@@ -14,7 +14,7 @@ module Decidim
       private
 
       def model
-        @model ||= Proposal.not_hidden.where(component: current_component).find(params[:proposal_id])
+        @model ||= Proposal.not_hidden.except_withdrawn.where(component: current_component).find(params[:proposal_id])
       end
 
       def iframe_url

--- a/decidim-proposals/app/permissions/decidim/proposals/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/permissions.rb
@@ -4,6 +4,7 @@ module Decidim
   module Proposals
     class Permissions < Decidim::DefaultPermissions
       def permissions
+        allow_embed_proposal?
         return permission_action unless user
 
         # Delegate the admin permission checks to the admin permissions class
@@ -45,6 +46,13 @@ module Decidim
 
       def proposal
         @proposal ||= context.fetch(:proposal, nil) || context.fetch(:resource, nil)
+      end
+
+      # As this is a public action, we need to run this before other checks
+      def allow_embed_proposal?
+        return unless permission_action.action == :embed && permission_action.subject == :proposal && proposal
+
+        allow!
       end
 
       def voting_enabled?

--- a/decidim-proposals/app/permissions/decidim/proposals/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/permissions.rb
@@ -51,6 +51,7 @@ module Decidim
       # As this is a public action, we need to run this before other checks
       def allow_embed_proposal?
         return unless permission_action.action == :embed && permission_action.subject == :proposal && proposal
+        return disallow! if proposal.withdrawn?
 
         allow!
       end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -129,7 +129,9 @@ extra_admin_link(
     <%= resource_version(proposal_presenter, versions_path: proposal_versions_path(@proposal)) %>
     <%= cell("decidim/fingerprint", @proposal) %>
     <%= render partial: "decidim/shared/share_modal", locals: { resource: @proposal } %>
-    <%= embed_modal_for proposal_widget_url(@proposal, format: :js) %>
+    <% if allowed_to? :embed, :proposal, proposal: @proposal %>
+      <%= embed_modal_for proposal_widget_url(@proposal, format: :js) %>
+    <% end %>
     <%= cell "decidim/proposals/proposal_link_to_collaborative_draft", @proposal %>
     <%= cell "decidim/proposals/proposal_link_to_rejected_emendation", @proposal %>
   </div>

--- a/decidim-proposals/spec/permissions/decidim/proposals/permissions_spec.rb
+++ b/decidim-proposals/spec/permissions/decidim/proposals/permissions_spec.rb
@@ -110,6 +110,14 @@ describe Decidim::Proposals::Permissions do
     end
   end
 
+  context "when emebeding a proposal" do
+    let(:action) do
+      { scope: :public, action: :embed, subject: :proposal }
+    end
+
+    it { is_expected.to be true }
+  end
+
   describe "voting" do
     let(:action) do
       { scope: :public, action: :vote, subject: :proposal }

--- a/decidim-proposals/spec/system/proposal_embeds_spec.rb
+++ b/decidim-proposals/spec/system/proposal_embeds_spec.rb
@@ -11,4 +11,5 @@ describe "Proposal embeds", type: :system do
 
   it_behaves_like "an embed resource", skip_publication_checks: true
   it_behaves_like "a moderated embed resource"
+  it_behaves_like "a withdrawn embed resource"
 end

--- a/decidim-proposals/spec/system/proposal_embeds_spec.rb
+++ b/decidim-proposals/spec/system/proposal_embeds_spec.rb
@@ -9,5 +9,5 @@ describe "Proposal embeds", type: :system do
   let(:resource) { create(:proposal, component: component) }
   let(:widget_path) { Decidim::EngineRouter.main_proxy(component).proposal_widget_path(resource) }
 
-  it_behaves_like "an embed resource", skip_unpublish_checks: true
+  it_behaves_like "an embed resource", skip_publication_checks: true
 end

--- a/decidim-proposals/spec/system/proposal_embeds_spec.rb
+++ b/decidim-proposals/spec/system/proposal_embeds_spec.rb
@@ -10,4 +10,5 @@ describe "Proposal embeds", type: :system do
   let(:widget_path) { Decidim::EngineRouter.main_proxy(component).proposal_widget_path(resource) }
 
   it_behaves_like "an embed resource", skip_publication_checks: true
+  it_behaves_like "a moderated embed resource"
 end

--- a/decidim-proposals/spec/system/proposal_embeds_spec.rb
+++ b/decidim-proposals/spec/system/proposal_embeds_spec.rb
@@ -4,8 +4,10 @@ require "spec_helper"
 
 describe "Proposal embeds", type: :system do
   include_context "with a component"
+
   let(:manifest_name) { "proposals" }
   let(:resource) { create(:proposal, component: component) }
+  let(:widget_path) { Decidim::EngineRouter.main_proxy(component).proposal_widget_path(resource) }
 
-  it_behaves_like "an embed resource"
+  it_behaves_like "an embed resource", skip_unpublish_checks: true
 end

--- a/decidim-sortitions/app/controllers/decidim/sortitions/widgets_controller.rb
+++ b/decidim-sortitions/app/controllers/decidim/sortitions/widgets_controller.rb
@@ -15,7 +15,7 @@ module Decidim
       private
 
       def model
-        @model ||= Sortition.where(organization: current_organization).where(component: params[:component_id]).find(params[:sortition_id])
+        @model ||= Sortition.where(component: current_component).find(params[:sortition_id])
       end
 
       def iframe_url

--- a/decidim-sortitions/app/controllers/decidim/sortitions/widgets_controller.rb
+++ b/decidim-sortitions/app/controllers/decidim/sortitions/widgets_controller.rb
@@ -6,6 +6,12 @@ module Decidim
       helper Decidim::SanitizeHelper
       helper Sortitions::SortitionsHelper
 
+      def show
+        enforce_permission_to :embed, :sortition, sortition: model if model
+
+        super
+      end
+
       private
 
       def model
@@ -14,6 +20,10 @@ module Decidim
 
       def iframe_url
         @iframe_url ||= sortition_widget_url(model)
+      end
+
+      def permission_class_chain
+        [Decidim::Sortitions::Permissions]
       end
     end
   end

--- a/decidim-sortitions/app/controllers/decidim/sortitions/widgets_controller.rb
+++ b/decidim-sortitions/app/controllers/decidim/sortitions/widgets_controller.rb
@@ -15,7 +15,7 @@ module Decidim
       private
 
       def model
-        @model ||= Sortition.where(component: params[:component_id]).find(params[:sortition_id])
+        @model ||= Sortition.where(organization: current_organization).where(component: params[:component_id]).find(params[:sortition_id])
       end
 
       def iframe_url

--- a/decidim-sortitions/app/permissions/decidim/sortitions/permissions.rb
+++ b/decidim-sortitions/app/permissions/decidim/sortitions/permissions.rb
@@ -4,11 +4,25 @@ module Decidim
   module Sortitions
     class Permissions < Decidim::DefaultPermissions
       def permissions
+        allow_embed_sortition?
         return permission_action unless user
 
         return Decidim::Sortitions::Admin::Permissions.new(user, permission_action, context).permissions if permission_action.scope == :admin
 
         permission_action
+      end
+
+      private
+
+      def sortition
+        @sortition ||= context.fetch(:sortition, nil) || context.fetch(:resource, nil)
+      end
+
+      # As this is a public action, we need to run this before other checks
+      def allow_embed_sortition?
+        return unless permission_action.action == :embed && permission_action.subject == :sortition && sortition
+
+        allow!
       end
     end
   end

--- a/decidim-sortitions/spec/permissions/decidim/sortitions/permissions_spec.rb
+++ b/decidim-sortitions/spec/permissions/decidim/sortitions/permissions_spec.rb
@@ -25,6 +25,14 @@ describe Decidim::Sortitions::Permissions do
     it_behaves_like "delegates permissions to", Decidim::Sortitions::Admin::Permissions
   end
 
+  context "when emebedding a sortition" do
+    let(:action) do
+      { scope: :public, action: :embed, subject: :sortition }
+    end
+
+    it { is_expected.to be true }
+  end
+
   context "when any other condition" do
     let(:action) do
       { scope: :foo, action: :blah, subject: :sortition }

--- a/decidim-sortitions/spec/system/decidim/sortitions/sortition_embeds_spec.rb
+++ b/decidim-sortitions/spec/system/decidim/sortitions/sortition_embeds_spec.rb
@@ -9,5 +9,5 @@ describe "Sortition embeds", type: :system do
   let(:resource) { create(:sortition, component: component) }
   let(:widget_path) { Decidim::EngineRouter.main_proxy(component).sortition_widget_path(resource) }
 
-  it_behaves_like "an embed resource", skip_unpublish_checks: true
+  it_behaves_like "an embed resource", skip_publication_checks: true
 end

--- a/decidim-sortitions/spec/system/decidim/sortitions/sortition_embeds_spec.rb
+++ b/decidim-sortitions/spec/system/decidim/sortitions/sortition_embeds_spec.rb
@@ -4,8 +4,10 @@ require "spec_helper"
 
 describe "Sortition embeds", type: :system do
   include_context "with a component"
+
   let(:manifest_name) { "sortitions" }
   let(:resource) { create(:sortition, component: component) }
+  let(:widget_path) { Decidim::EngineRouter.main_proxy(component).sortition_widget_path(resource) }
 
-  it_behaves_like "an embed resource"
+  it_behaves_like "an embed resource", skip_unpublish_checks: true
 end


### PR DESCRIPTION
## :tophat: What? Why?

There's a bug in v0.27 where we don't have multiple checks to see if a space or resource should actually be embedded. This PR fixes those cases. These are:

- If a space or resource is unpublished
- If a space or resource is moderated and hidden
- If a space or resource is withdrawn. Even though is still visible, it should not be available
- If a space is private, with the exception being if the space is transparent
- In the case of Initiatives, as their visibility depends on their state, we take into account that for allowing access or not

This also prevents another bug where an embed page could be leaked between Organizations in the multitenant installation

As this feature isn't anymore in v0.28, I'm doing the PR directly against the version that has this feature (and this bug).

## Testing

The blueprint for all the checks is actually the same 2 steps in the end

### Publication

1. Copy the URL for embedding an Assembly
2. Unpublish it
3. See that you can access to this URL (without this patch)
4. See that you can't access to this URL and you can't see the button (with this patch)

### Moderation

1. Copy the URL for embedding a Proposal 
2. Report and hide it

### Withdraw

1. Copy the URL for embedding a Proposal that you've created
2. Withdraw it 

### Private

1. Copy the URL for embedding an Assembly
2. Make it private and not transparent
3. It should not be visible

### Private transparent

1. Copy the URL for embedding an Assembly
2. Make it private and transparent
3. It should be visible

### Initiatives

1. Create an initiative
2. See that you don't have the embed link
3. As an admin, validate it so it is in the "published"  state
4. See that you have the embed likn 

:hearts: Thank you!
