### PR TITLE
Increase newsletter preview dimensions

### DIFF
--- a/decidim-admin/app/views/decidim/admin/newsletters/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/show.html.erb
@@ -15,13 +15,13 @@
           <dd><%= selective_newsletter_to newsletter %></dd>
         </dl>
 
-        <iframe src="<%= preview_newsletter_path(@newsletter) %>" class="w-full" data-email-preview>
+        <iframe src="<%= preview_newsletter_path(@newsletter) %>" class="w-full h-96" data-email-preview>
         </iframe>
       </div>
     </div>
   </div>
 </div>
-<div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
+<div class="form__wrapper flex-col-reverse md:flex-row justify-between">
   <% if allowed_to?(:update, :newsletter, newsletter: @newsletter) %>
     <% unless @newsletter.sent? %>
       <%= link_to t("actions.edit", scope: "decidim.admin"), [:edit, @newsletter], class: "button button__sm button__secondary" %>

--- a/decidim-admin/app/views/decidim/admin/newsletters/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/show.html.erb
@@ -15,7 +15,7 @@
           <dd><%= selective_newsletter_to newsletter %></dd>
         </dl>
 
-        <iframe src="<%= preview_newsletter_path(@newsletter) %>" class="w-full h-96" data-email-preview>
+        <iframe src="<%= preview_newsletter_path(@newsletter) %>" class="w-full h-lvh h-full" data-email-preview>
         </iframe>
       </div>
     </div>


### PR DESCRIPTION
#### :tophat: What? Why?
A previewed Newsletter created within the Decidim system did not provide users with the desirable size to see their work before sending to registered users. 

#### :pushpin: Related Issues
- Fixes #12403 

#### Testing
1. Login and head over to edit.
2. Click on Newsletters 
3. Create one and you'll be taken over to Preview it before sending it.
4. See the sizing more appropriate for the user to view and scroll before sending. 

### :camera: Screenshots

<img width="1424" alt="Screenshot 2024-02-27 at 12 48 19" src="https://github.com/decidim/decidim/assets/101816158/51508aec-6e49-4a5a-a844-fcc866f89f51">


:hearts: Thank you!
