### PR TITLE
Do not list hidden reported debates in the admin

### DIFF
--- a/decidim-debates/app/controllers/decidim/debates/admin/debates_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/admin/debates_controller.rb
@@ -77,7 +77,6 @@ module Decidim
           @debates ||= Debate.where(component: current_component).not_hidden
         end
 
-
         def debate
           @debate ||= debates.find(params[:id])
         end

--- a/decidim-debates/app/controllers/decidim/debates/admin/debates_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/admin/debates_controller.rb
@@ -7,7 +7,7 @@ module Decidim
       class DebatesController < Decidim::Debates::Admin::ApplicationController
         helper Decidim::ApplicationHelper
 
-        helper_method :debates
+        helper_method :debates, :debate
 
         def index
           enforce_permission_to :read, :debate
@@ -74,7 +74,7 @@ module Decidim
         private
 
         def debates
-          @debates ||= Debate.where(component: current_component)
+          @debates ||= Debate.where(component: current_component).not_hidden
         end
 
         def debate

--- a/decidim-debates/app/controllers/decidim/debates/admin/debates_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/admin/debates_controller.rb
@@ -77,6 +77,7 @@ module Decidim
           @debates ||= Debate.where(component: current_component).not_hidden
         end
 
+
         def debate
           @debate ||= debates.find(params[:id])
         end

--- a/decidim-debates/app/controllers/decidim/debates/admin/debates_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/admin/debates_controller.rb
@@ -7,7 +7,7 @@ module Decidim
       class DebatesController < Decidim::Debates::Admin::ApplicationController
         helper Decidim::ApplicationHelper
 
-        helper_method :debates, :debate
+        helper_method :debates
 
         def index
           enforce_permission_to :read, :debate

--- a/decidim-debates/spec/shared/manage_debates_examples.rb
+++ b/decidim-debates/spec/shared/manage_debates_examples.rb
@@ -6,6 +6,20 @@ RSpec.shared_examples "manage debates" do
   before { visit_component_admin }
 
   describe "listing" do
+    context "with hidden debates" do
+      let!(:my_other_debate) { create(:debate, category:, component: current_component) }
+
+      before do
+        my_other_debate.update!(title: { en: "Debate <strong>title</strong>" })
+        create(:moderation, :hidden, reportable: my_other_debate)
+      end
+
+      it "does not list the hidden debates" do
+        visit current_path
+        expect(page).to have_no_content(translated(my_other_debate.title))
+      end
+    end
+
     context "with enriched content" do
       before do
         debate.update!(title: { en: "Debate <strong>title</strong>" })


### PR DESCRIPTION
#### :tophat: What? Why?
Debates that would reported and moderated into the global list of reported processes, would then be assessed to be hidden (removed from view). Once **Hidden**, these Debates would still appear in the list of Debates within a process. 

This PR extracts the ```not_hidden``` scope from the ```reportable.rb``` concern to allow Hidden reported Debates to be removed from the view of the user.

#### :pushpin: Related Issues
- Fixes #12405

#### Testing
1. Login and find a Debate within a Process
2. Report it
3. Go to the admin panel (edit) and head over to Global Moderations
4. Find that Debate which was reported and press hide.
5. Head back to the process nesting the Debate you reported while in Admin
6. Click on Debates
7. See the Debate you reported and hidden is not accessible anymore.

### :camera: Screenshots

:hearts: Thank you!
