### PR TITLE
Update WickedPdf configuration syntax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -471,7 +471,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
-    minitest (5.21.2)
+    minitest (5.22.2)
     msgpack (1.4.5)
     multi_xml (0.6.0)
     net-http (0.4.1)
@@ -772,14 +772,14 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wicked_pdf (2.7.0)
+    wicked_pdf (2.8.0)
       activesupport
     wisper (2.0.1)
     wisper-rspec (1.1.0)
     wkhtmltopdf-binary (0.12.6.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.13)
 
 PLATFORMS
   ruby

--- a/decidim-conferences/config/initializers/wicked_pdf.rb
+++ b/decidim-conferences/config/initializers/wicked_pdf.rb
@@ -10,14 +10,14 @@
 #
 # https://github.com/mileszs/wicked_pdf/blob/master/README.md
 
-WickedPdf.config = {
+WickedPdf.configure do |config|
   # Path to the wkhtmltopdf executable: This usually is not needed if using
   # one of the wkhtmltopdf-binary family of gems.
-  # exe_path: '/usr/local/bin/wkhtmltopdf',
   #   or
-  exe_path: Gem.bin_path("wkhtmltopdf-binary", "wkhtmltopdf")
+  # config.exe_path = '/usr/local/bin/wkhtmltopdf',
+  config.exe_path = Gem.bin_path("wkhtmltopdf-binary", "wkhtmltopdf")
 
   # Layout file to be used for all PDFs
   # (but can be overridden in `render :pdf` calls)
-  # layout: 'pdf.html',
-}
+  # config.layout = 'pdf.html'
+end

--- a/decidim-forms/config/initializers/wicked_pdf.rb
+++ b/decidim-forms/config/initializers/wicked_pdf.rb
@@ -14,14 +14,14 @@ require "wicked_pdf"
 #
 # https://github.com/mileszs/wicked_pdf/blob/master/README.md
 
-WickedPdf.config = {
+WickedPdf.configure do |config|
   # Path to the wkhtmltopdf executable: This usually is not needed if using
   # one of the wkhtmltopdf-binary family of gems.
-  # exe_path: '/usr/local/bin/wkhtmltopdf',
   #   or
-  exe_path: Gem.bin_path("wkhtmltopdf-binary", "wkhtmltopdf")
+  # config.exe_path = '/usr/local/bin/wkhtmltopdf',
+  config.exe_path = Gem.bin_path("wkhtmltopdf-binary", "wkhtmltopdf")
 
   # Layout file to be used for all PDFs
   # (but can be overridden in `render :pdf` calls)
-  # layout: 'pdf.html',
-}
+  # config.layout = 'pdf.html'
+end

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -471,7 +471,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
-    minitest (5.21.2)
+    minitest (5.22.2)
     msgpack (1.4.5)
     multi_xml (0.6.0)
     net-http (0.4.1)
@@ -772,14 +772,14 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wicked_pdf (2.7.0)
+    wicked_pdf (2.8.0)
       activesupport
     wisper (2.0.1)
     wisper-rspec (1.1.0)
     wkhtmltopdf-binary (0.12.6.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.13)
 
 PLATFORMS
   ruby

--- a/decidim-initiatives/config/initializers/wicked_pdf.rb
+++ b/decidim-initiatives/config/initializers/wicked_pdf.rb
@@ -10,14 +10,14 @@
 #
 # https://github.com/mileszs/wicked_pdf/blob/master/README.md
 
-WickedPdf.config = {
+WickedPdf.configure do |config|
   # Path to the wkhtmltopdf executable: This usually is not needed if using
   # one of the wkhtmltopdf-binary family of gems.
-  # exe_path: '/usr/local/bin/wkhtmltopdf',
   #   or
-  exe_path: Gem.bin_path("wkhtmltopdf-binary", "wkhtmltopdf")
+  # config.exe_path = '/usr/local/bin/wkhtmltopdf',
+  config.exe_path = Gem.bin_path("wkhtmltopdf-binary", "wkhtmltopdf")
 
   # Layout file to be used for all PDFs
   # (but can be overridden in `render :pdf` calls)
-  # layout: 'pdf.html',
-}
+  # config.layout = 'pdf.html'
+end


### PR DESCRIPTION
#### :tophat: What? Why?

There's a deprecation warning while creating the `development_app`, saying that the syntax that we're using in the initializers is going to be removed. This PR updates them.


#### Testing

1. (Without this patch) Run `bundle exec rake development_app` 
2. See in the output 
```
(...)
Using decidim-surveys 0.29.0.dev from source at `..`
Using decidim 0.29.0.dev from source at `..`
Using decidim-dev 0.29.0.dev from source at `..`
Bundle complete! 19 Gemfile dependencies, 256 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
6 installed gems you directly depend on are looking for funding.
  Run `bundle fund` for details
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
Copying binstubs
       exist  bin
      create  bin/shakapacker
      create  bin/shakapacker-dev-server
      create  bin/yarn
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.

```
3. Cancel the command (Ctrl + C)
4. Switch to this branch
5. Run `bundle exec rake development_app` 
6. See in the output 
```
(...)
Using decidim-surveys 0.29.0.dev from source at `..`
Using decidim-conferences 0.29.0.dev from source at `..`
Using decidim 0.29.0.dev from source at `..`
Using decidim-dev 0.29.0.dev from source at `..`
Bundle complete! 19 Gemfile dependencies, 256 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
6 installed gems you directly depend on are looking for funding.
  Run `bundle fund` for details
Copying binstubs
       exist  bin
      create  bin/shakapacker
      create  bin/shakapacker-dev-server
      create  bin/yarn

```

:hearts: Thank you!
