### PR TITLE
Fix typo in remove admin event subscriber

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -113,8 +113,8 @@ module Decidim
       end
 
       initializer "decidim_proposals.remove_space_admins" do
-        ActiveSupport::Notifications.subscribe("decidim.admin.participatorty_space.destroy_admin:after") do |_event_name, klass, id|
-          Decidim::Proposals::ValuationAssignment.where(valuator_role_type: klass, valuator_role_id: id).destroy_all
+        ActiveSupport::Notifications.subscribe("decidim.admin.participatory_space.destroy_admin:after") do |_event_name, data|
+          Decidim::Proposals::ValuationAssignment.where(valuator_role_type: data.fetch(:class_name), valuator_role_id: data.fetch(:role)).destroy_all
         end
       end
 

--- a/decidim-proposals/spec/lib/decidim/proposals/engine_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/engine_spec.rb
@@ -17,7 +17,7 @@ describe Decidim::Proposals::Engine do
 
       it "removes the record" do
         expect do
-          ActiveSupport::Notifications.publish("decidim.admin.participatorty_space.destroy_admin:after", valuator_role.class.name, valuator_role.id)
+          ActiveSupport::Notifications.publish("decidim.admin.participatory_space.destroy_admin:after", class_name: valuator_role.class.name, role: valuator_role.id)
         end.to change(Decidim::Proposals::ValuationAssignment, :count).by(-1)
       end
     end
@@ -29,7 +29,7 @@ describe Decidim::Proposals::Engine do
 
       it "removes the record" do
         expect do
-          ActiveSupport::Notifications.publish("decidim.admin.participatorty_space.destroy_admin:after", valuator_role.class.name, valuator_role.id)
+          ActiveSupport::Notifications.publish("decidim.admin.participatory_space.destroy_admin:after", class_name: valuator_role.class.name, role: valuator_role.id)
         end.to change(Decidim::Proposals::ValuationAssignment, :count).by(-1)
       end
     end
@@ -41,7 +41,7 @@ describe Decidim::Proposals::Engine do
 
       it "removes the record" do
         expect do
-          ActiveSupport::Notifications.publish("decidim.admin.participatorty_space.destroy_admin:after", valuator_role.class.name, valuator_role.id)
+          ActiveSupport::Notifications.publish("decidim.admin.participatory_space.destroy_admin:after", class_name: valuator_role.class.name, role: valuator_role.id)
         end.to change(Decidim::Proposals::ValuationAssignment, :count).by(-1)
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*
While reviewing #12509 i have noticed that @jsoref actually found a typo in the proposal subscribers, feature delivered by #10607. When he fixed the typo, a new error occurred. This PR fixes the error. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12509
- Related to #10607

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
![image](https://github.com/decidim/decidim/assets/105683/e5f2a35d-25bd-4974-bcba-c0bbea7d427b)

:hearts: Thank you!
