### PR TITLE
Prevent multiple requests from creating multiple orders for the same user at budgets

### DIFF
--- a/decidim-budgets/spec/requests/line_items_spec.rb
+++ b/decidim-budgets/spec/requests/line_items_spec.rb
@@ -45,20 +45,9 @@ RSpec.describe "Project search" do
     context "with concurrent requests" do
       include_context "with concurrency"
 
-      let(:warden_authenticate) { ->(proxy) { proxy.set_user(user, event: :authentication, scope: :user) } }
-
       before do
-        # Note that we cannot use login_as as that would be cleared due to the
-        # concurrency and the other requests than the first one would not have
-        # the user logged in.
-        Warden::Manager.on_request(&warden_authenticate)
-      end
-
-      after do
-        # Clear the custom on_request block so that it does not stick for other
-        # tests.
-        item = Warden::Manager._on_request.find { |defn| defn[0] == warden_authenticate }
-        Warden::Manager._on_request.delete(item)
+        # Persist the session cookie before the concurrent requests.
+        get(Decidim::Core::Engine.routes.url_helpers.root_path, headers:)
       end
 
       it "only creates a single order" do

--- a/decidim-budgets/spec/requests/line_items_spec.rb
+++ b/decidim-budgets/spec/requests/line_items_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Project search" do
+  include Decidim::ComponentPathHelper
+
+  let(:user) { create(:user, :confirmed) }
+  let(:participatory_space) { create :participatory_process, :with_steps, organization: user.organization }
+  let(:component) { create(:budgets_component, participatory_space:, settings:) }
+  let(:settings) { { vote_threshold_percent: 50 } }
+  let(:budget) { create(:budget, component:, total_budget: 100_000) }
+  let(:project) { create(:project, budget:, budget_amount: 60_000) }
+
+  let(:headers) { { "HOST" => participatory_space.organization.host } }
+
+  before do
+    login_as user, scope: :user
+  end
+
+  describe "POST create" do
+    let(:request_path) { Decidim::EngineRouter.main_proxy(component).budget_order_line_item_path(budget) }
+
+    it "creates the order" do
+      expect do
+        post(request_path, xhr: true, params: { project_id: project.id }, headers:)
+      end.to change(Decidim::Budgets::Order, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    context "when trying to add the same project twice" do
+      it "adds it only once" do
+        post(request_path, xhr: true, params: { project_id: project.id }, headers:)
+        expect(response).to have_http_status(:ok)
+
+        post(request_path, xhr: true, params: { project_id: project.id }, headers:)
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        expect(Decidim::Budgets::Order.count).to eq(1)
+        expect(Decidim::Budgets::LineItem.count).to eq(1)
+      end
+    end
+
+    context "with concurrent requests" do
+      include_context "with concurrency"
+
+      let(:warden_authenticate) { ->(proxy) { proxy.set_user(user, event: :authentication, scope: :user) } }
+
+      before do
+        # Note that we cannot use login_as as that would be cleared due to the
+        # concurrency and the other requests than the first one would not have
+        # the user logged in.
+        Warden::Manager.on_request(&warden_authenticate)
+      end
+
+      after do
+        # Clear the custom on_request block so that it does not stick for other
+        # tests.
+        item = Warden::Manager._on_request.find { |defn| defn[0] == warden_authenticate }
+        Warden::Manager._on_request.delete(item)
+      end
+
+      it "only creates a single order" do
+        expect do
+          threads = 10.times.map do
+            Thread.new do
+              sleep(rand(0.05..0.5))
+
+              post(request_path, xhr: true, params: { project_id: project.id }, headers:)
+            end
+          end
+          # Wait for each thread to finish
+          threads.each(&:join)
+        end.not_to raise_error
+
+        expect(Decidim::Budgets::Order.count).to eq(1)
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/concurrency.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/concurrency.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
-# Note that RSpec also provides `uses_transaction "doesn't run in transaction"`
-# but it doesn't work the same way. We want the same database to be used without
-# transactions during the tests so that we can test concurrency correctly.
+# Note that RSpec also provides `uses_transaction` but it needs to be specific
+# with the name of the method which can easily break and the concurrency tests
+# will anyways pass when run with the transactional mode. We want the same
+# database to be used without transactions during the tests so that we can test
+# concurrency correctly.
 RSpec.shared_context "with concurrency" do
   self.use_transactional_tests = false
+
   after do
     # Because the transactional tests are disabled, we need to manually clear
     # the tables after the test.

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/concurrency.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/concurrency.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Note that RSpec also provides `uses_transaction "doesn't run in transaction"`
+# but it doesn't work the same way. We want the same database to be used without
+# transactions during the tests so that we can test concurrency correctly.
+RSpec.shared_context "with concurrency" do
+  self.use_transactional_tests = false
+  after do
+    # Because the transactional tests are disabled, we need to manually clear
+    # the tables after the test.
+    connection = ActiveRecord::Base.connection
+    connection.disable_referential_integrity do
+      connection.tables.each do |table_name|
+        next if connection.select_value("SELECT COUNT(*) FROM #{table_name}").zero?
+
+        connection.execute("TRUNCATE #{table_name} CASCADE")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
We ran into an edge case where multiple orders were created for the user in case they managed to add items to their order two times simultaneously and these requests were served from different machines.

We are using a different module for the budgets which works a bit differently but the core module behaves the same under high concurrency.

In order to fix this I decided to lock the user record for updates to ensure only one process is creating the order at a time. I cannot lock the order record because it might not yet exist, so the only thing I came up with is to lock the user record which does not receive any other updates simultaneously from different processes (and if it does, it will wait until this request completes).

#### Testing
It's hard to test but I managed to create the test case in this PR which fails pretty consistently without this fix. So try to run this spec multiple times with and without the fix.

To test this properly, you need to run 10+ machines at production to increase the chance of this happening. And you also need to manage to create the same situation from the UI, so using `curl` for testing would be advisable.

You can also setup multiple Decidim servers running in different ports and add a load balancer in front of them if you want to try to replicate this situation locally. But it might be hard, so it might be easier to trust the added spec.