### PR TITLE
Fix showing announcement when comments are disabled 

### DIFF
--- a/decidim-accountability/spec/system/comments_spec.rb
+++ b/decidim-accountability/spec/system/comments_spec.rb
@@ -9,4 +9,11 @@ describe "Accountability result comments", versioning: true do
   let(:resource_path) { resource_locator(commentable).path }
 
   include_examples "comments"
+
+  context "with comments blocked" do
+    let!(:component) { create(:component, manifest_name: :accountability, participatory_space:, organization:) }
+    let(:participatory_space) { create(:participatory_process, :with_steps, organization:) }
+
+    include_examples "comments blocked"
+  end
 end

--- a/decidim-blogs/spec/system/comments_spec.rb
+++ b/decidim-blogs/spec/system/comments_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Comments", perform_enqueued: true do
+  let!(:component) { create(:post_component, organization:) }
+  let!(:commentable) { create(:post, component:) }
+
+  let(:resource_path) { resource_locator(commentable).path }
+
+  include_examples "comments"
+
+  context "with comments blocked" do
+    let!(:component) { create(:post_component, participatory_space:, organization:) }
+    let(:participatory_space) { create(:participatory_process, :with_steps, organization:) }
+
+    include_examples "comments blocked"
+  end
+end

--- a/decidim-budgets/spec/system/comments_spec.rb
+++ b/decidim-budgets/spec/system/comments_spec.rb
@@ -10,6 +10,13 @@ describe "Comments" do
 
   include_examples "comments"
 
+  context "with comments blocked" do
+    let!(:component) { create(:budgets_component, participatory_space:, organization:) }
+    let(:participatory_space) { create(:participatory_process, :with_steps, organization:) }
+
+    include_examples "comments blocked"
+  end
+
   context "when requesting the comments index with a non-XHR request" do
     it "redirects the user to the correct commentable path" do
       visit decidim_comments.comments_path(commentable_gid: commentable.to_signed_global_id.to_s)

--- a/decidim-comments/app/cells/decidim/comments/comments_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comments_cell.rb
@@ -27,7 +27,7 @@ module Decidim
 
       def blocked_comments_warning
         return unless comments_blocked?
-        return unless user_comments_blocked?
+        return if user_comments_blocked?
 
         render :blocked_comments_warning
       end

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -101,7 +101,7 @@ module Decidim::Comments
           before do
             comment # Create the comment before disabling comments
             allow(commentable).to receive(:accepts_new_comments?).and_return(false)
-            allow(commentable).to receive(:user_allowed_to_comment?).with(current_user).and_return(false)
+            allow(commentable).to receive(:user_allowed_to_comment?).with(current_user).and_return(true)
           end
 
           it "renders the comments blocked warning" do

--- a/decidim-comments/spec/system/comments_spec.rb
+++ b/decidim-comments/spec/system/comments_spec.rb
@@ -9,11 +9,4 @@ describe "Comments" do
   let(:resource_path) { resource_locator(commentable).path }
 
   include_examples "comments"
-
-  context "with comments blocked" do
-    let!(:component) { create(:component, manifest_name: :dummy, participatory_space:, organization:) }
-    let(:participatory_space) { create(:participatory_process, :with_steps, organization:) }
-
-    include_examples "comments blocked"
-  end
 end

--- a/decidim-comments/spec/system/comments_spec.rb
+++ b/decidim-comments/spec/system/comments_spec.rb
@@ -4,10 +4,16 @@ require "spec_helper"
 
 describe "Comments" do
   let!(:component) { create(:component, manifest_name: :dummy, organization:) }
-  let!(:author) { create(:user, :confirmed, organization:) }
-  let!(:commentable) { create(:dummy_resource, component:, author:) }
+  let!(:commentable) { create(:dummy_resource, component:) }
 
   let(:resource_path) { resource_locator(commentable).path }
 
   include_examples "comments"
+
+  context "with comments blocked" do
+    let!(:component) { create(:component, manifest_name: :dummy, participatory_space:, organization:) }
+    let(:participatory_space) { create(:participatory_process, :with_steps, organization:) }
+
+    include_examples "comments blocked"
+  end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -120,20 +120,6 @@ shared_examples "comments" do
       expect(page).not_to have_selector(".add-comment form")
       expect(page).to have_selector(".comment-thread")
     end
-
-    context "when comments are blocked" do
-      let(:active_step_id) { component.participatory_space.active_step.id }
-
-      before do
-        component.update!(step_settings: { active_step_id => { comments_blocked: true } })
-      end
-
-      it "shows a message indicating that comments are disabled" do
-        visit resource_path
-        expect(page).to have_content("Comments are disabled at this time")
-        expect(page).to have_no_content("You need to be verified to comment at this moment")
-      end
-    end
   end
 
   context "when authenticated" do
@@ -144,20 +130,6 @@ shared_examples "comments" do
 
     it "shows form to add comments to user" do
       expect(page).to have_css(".add-comment form")
-    end
-
-    context "when comments are blocked" do
-      let(:active_step_id) { component.participatory_space.active_step.id }
-
-      before do
-        component.update!(step_settings: { active_step_id => { comments_blocked: true } })
-      end
-
-      it "shows a message indicating that comments are disabled" do
-        visit resource_path
-        expect(page).to have_content("Comments are disabled at this time")
-        expect(page).to have_no_content("You need to be verified to comment at this moment")
-      end
     end
 
     context "when user is not authorized to comment" do
@@ -1026,6 +998,49 @@ shared_examples "comments" do
         it { is_expected.to have_key(:commentable_id) }
         it { is_expected.to have_key(:commentable_type) }
         it { is_expected.to have_key(:root_commentable_url) }
+      end
+    end
+  end
+end
+
+shared_examples "comments blocked" do
+  context "when not authenticated" do
+    context "when comments are blocked" do
+      let(:active_step_id) { component.participatory_space.active_step.id }
+
+      before do
+        component.update!(step_settings: { active_step_id => { comments_blocked: true } })
+      end
+
+      it "shows a message indicating that comments are disabled" do
+        visit resource_path
+        expect(page).to have_content("Comments are disabled at this time")
+        expect(page).to have_no_content("You need to be verified to comment at this moment")
+      end
+    end
+  end
+
+  context "when authenticated" do
+    let!(:organization) { create(:organization) }
+    let!(:user) { create(:user, :confirmed, organization:) }
+    let!(:comments) { create_list(:comment, 3, commentable:) }
+
+    before do
+      login_as user, scope: :user
+      visit resource_path
+    end
+
+    context "when comments are blocked" do
+      let(:active_step_id) { component.participatory_space.active_step.id }
+
+      before do
+        component.update!(step_settings: { active_step_id => { comments_blocked: true } })
+      end
+
+      it "shows a message indicating that comments are disabled" do
+        visit resource_path
+        expect(page).to have_content("Comments are disabled at this time")
+        expect(page).to have_no_content("You need to be verified to comment at this moment")
       end
     end
   end

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -119,6 +119,20 @@ shared_examples "comments" do
       visit resource_path
       expect(page).to have_no_css(".add-comment form")
     end
+
+    context "when comments are blocked" do
+      let(:active_step_id) { component.participatory_space.active_step.id }
+
+      before do
+        component.update!(step_settings: { active_step_id => { comments_blocked: true } })
+      end
+
+      it "shows a message indicating that comments are disabled" do
+        visit resource_path
+        expect(page).to have_content("Comments are disabled at this time")
+        expect(page).to have_no_content("You need to be verified to comment at this moment")
+      end
+    end
   end
 
   context "when authenticated" do
@@ -129,6 +143,20 @@ shared_examples "comments" do
 
     it "shows form to add comments to user" do
       expect(page).to have_css(".add-comment form")
+    end
+
+    context "when comments are blocked" do
+      let(:active_step_id) { component.participatory_space.active_step.id }
+
+      before do
+        component.update!(step_settings: { active_step_id => { comments_blocked: true } })
+      end
+
+      it "shows a message indicating that comments are disabled" do
+        visit resource_path
+        expect(page).to have_content("Comments are disabled at this time")
+        expect(page).to have_no_content("You need to be verified to comment at this moment")
+      end
     end
 
     describe "when using emojis" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -117,8 +117,8 @@ shared_examples "comments" do
   context "when not authenticated" do
     it "does not show form to add comments to user" do
       visit resource_path
-      expect(page).not_to have_selector(".add-comment form")
-      expect(page).to have_selector(".comment-thread")
+      expect(page).to have_no_css(".add-comment form")
+      expect(page).to have_css(".comment-thread")
     end
   end
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -160,6 +160,32 @@ shared_examples "comments" do
       end
     end
 
+    context "when user is not authorized to comment" do
+      let(:permissions) do
+        {
+          comment: {
+            authorization_handlers: {
+              "dummy_authorization_handler" => { "options" => {} }
+            }
+          }
+        }
+      end
+
+      before do
+        organization.available_authorizations = ["dummy_authorization_handler"]
+        organization.save!
+        commentable.create_resource_permission(permissions:)
+        allow(commentable).to receive(:user_allowed_to_comment?).with(user).and_return(false)
+        allow(commentable).to receive(:user_authorized_to_comment?).with(user).and_return(true)
+      end
+
+      it "shows a message indicating that comments are restricted" do
+        visit resource_path
+        expect(page).to have_no_content("Comments are disabled at this time")
+        expect(page).to have_content("You need to be verified to comment at this moment")
+      end
+    end
+
     describe "when using emojis" do
       before do
         within_language_menu do

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -117,7 +117,8 @@ shared_examples "comments" do
   context "when not authenticated" do
     it "does not show form to add comments to user" do
       visit resource_path
-      expect(page).to have_no_css(".add-comment form")
+      expect(page).not_to have_selector(".add-comment form")
+      expect(page).to have_selector(".comment-thread")
     end
 
     context "when comments are blocked" do

--- a/decidim-debates/spec/system/comments_spec.rb
+++ b/decidim-debates/spec/system/comments_spec.rb
@@ -9,4 +9,11 @@ describe "Comments", perform_enqueued: true do
   let(:resource_path) { resource_locator(commentable).path }
 
   include_examples "comments"
+
+  context "with comments blocked" do
+    let!(:component) { create(:debates_component, participatory_space:, organization:) }
+    let(:participatory_space) { create(:participatory_process, :with_steps, organization:) }
+
+    include_examples "comments blocked"
+  end
 end

--- a/decidim-dev/app/models/decidim/dev/dummy_resource.rb
+++ b/decidim-dev/app/models/decidim/dev/dummy_resource.rb
@@ -63,7 +63,9 @@ module Decidim
 
       # Public: Whether the object can have new comments or not.
       def user_allowed_to_comment?(user)
-        component.can_participate_in_space?(user)
+        return unless component.can_participate_in_space?(user)
+
+        ActionAuthorizer.new(user, "comment", component, self).authorize.ok?
       end
 
       # Public: Whether the object can have new comment votes or not.

--- a/decidim-meetings/spec/system/comments_spec.rb
+++ b/decidim-meetings/spec/system/comments_spec.rb
@@ -20,4 +20,11 @@ describe "Comments" do
   let(:resource_path) { resource_locator(commentable).path }
 
   include_examples "comments"
+
+  context "with comments blocked" do
+    let!(:component) { create(:component, manifest_name: :meetings, participatory_space:, organization:) }
+    let(:participatory_space) { create(:participatory_process, :with_steps, organization:) }
+
+    include_examples "comments blocked"
+  end
 end

--- a/decidim-proposals/spec/system/comments_spec.rb
+++ b/decidim-proposals/spec/system/comments_spec.rb
@@ -21,4 +21,11 @@ describe "Comments" do
   end
 
   include_examples "comments"
+
+  context "with comments blocked" do
+    let!(:component) { create(:proposal_component, participatory_space:, organization:) }
+    let(:participatory_space) { create(:participatory_process, :with_steps, organization:) }
+
+    include_examples "comments blocked"
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

There's no warning message for disabled comments in frontend. This PR adds it. 

#### :pushpin: Related Issues
 
- Fixes #12404

#### Testing

1. Log in as administrator.
2. Enter the admin panel and navigate to a process that have a proposals component with comments enabled.
3. Block comments in that component in the steps settings.
4. Navigate to a proposal on the frontend where comments have been blocked.
5. See that no comments can be submitted and there is a warning message indicating that comments have been disabled

### :camera: Screenshots
 
![Screenshot of the warning message](https://github.com/decidim/decidim/assets/717367/3552099b-f78d-4c89-aa5c-2580523c65ce)

:hearts: Thank you!
