### PR TITLE
Center modals using inset

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_modal.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_modal.scss
@@ -2,7 +2,7 @@
   @apply invisible opacity-0 fixed z-50 inset-0 bg-[rgba(0,0,0,0.25)] transition duration-300;
 
   & > * {
-    @apply absolute inset-1/2 ltr:-translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 w-[90%] lg:max-w-[900px] max-h-[95vh] h-fit overflow-y-auto p-6 bg-white z-50 rounded shadow-[0_4px_6px_rgba(211,211,211,0.25)];
+    @apply absolute inset-y-1/2 inset-x-1/4 ltr:-translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 w-[90%] lg:max-w-[900px] max-h-[95vh] h-fit overflow-y-auto p-6 bg-white z-50 rounded shadow-[0_4px_6px_rgba(211,211,211,0.25)];
 
     & > svg:only-child {
       @apply w-8 h-8 mx-auto text-gray-2 fill-current animate-spin;

--- a/decidim-core/app/packs/stylesheets/decidim/_modal.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_modal.scss
@@ -2,7 +2,7 @@
   @apply invisible opacity-0 fixed z-50 inset-0 bg-[rgba(0,0,0,0.25)] transition duration-300;
 
   & > * {
-    @apply absolute inset-y-1/2 inset-x-1/4 ltr:-translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 w-[90%] lg:max-w-[900px] max-h-[95vh] h-fit overflow-y-auto p-6 bg-white z-50 rounded shadow-[0_4px_6px_rgba(211,211,211,0.25)];
+    @apply absolute inset-1/2 -translate-x-1/2 -translate-y-1/2 w-[90%] lg:max-w-[900px] max-h-[95vh] h-fit overflow-y-auto p-6 bg-white z-50 rounded shadow-[0_4px_6px_rgba(211,211,211,0.25)];
 
     & > svg:only-child {
       @apply w-8 h-8 mx-auto text-gray-2 fill-current animate-spin;


### PR DESCRIPTION
#### :tophat: What? Why?

Looks like modals are not centering horizontally.
I don't know much about tailwind but I found that removing the `  rtl:-translate-x-1/2 rtl:translate-x-1/2` and using simply `-translate-x-1/2` solves it.

Note that this affects version 0.28 too.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing

Try to open a modal window (for instance the cookies modal):
![image](https://github.com/decidim/decidim/assets/1401520/625aacb6-2a74-4c58-97be-a20268d19330)

Apply patch, you should see it fixed:
![image](https://github.com/decidim/decidim/assets/1401520/aa94eacd-457a-499a-8f12-2f798c8096af)

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
