### PR TITLE
Revert "Backport 'Fix bugs in details of RTL' to v0.28 (#12495)"

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_forms.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_forms.scss
@@ -154,7 +154,7 @@
   }
 
   button {
-    @apply absolute ltr:right-2 rtl:left-2 top-8;
+    @apply absolute right-2 top-8;
   }
 }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -43,7 +43,7 @@ header {
       }
 
       button[type="submit"] {
-        @apply absolute ltr:right-2 rtl:left-2 inset-y-2 text-secondary;
+        @apply absolute right-2 inset-y-2 text-secondary;
       }
     }
 
@@ -235,10 +235,10 @@ header {
       }
 
       &__dropdown-content {
-        @apply absolute z-20 top-full cursor-auto;
+        @apply absolute z-20 top-full left-8 cursor-auto;
 
         &-secondary {
-          @apply absolute z-20 top-[calc(100%+12px)];
+          @apply absolute z-20 top-[calc(100%+12px)] left-0;
         }
       }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_home.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_home.scss
@@ -37,7 +37,7 @@
     @apply mb-6 md:mb-8 flex flex-col md:flex-row gap-y-6 md:gap-y-0 gap-x-1 items-start md:items-center;
 
     .button {
-      @apply ltr:md:ml-auto rtl:md:mr-auto;
+      @apply md:ml-auto;
     }
   }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_modal.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_modal.scss
@@ -2,7 +2,7 @@
   @apply invisible opacity-0 fixed z-50 inset-0 bg-[rgba(0,0,0,0.25)] transition duration-300;
 
   & > * {
-    @apply absolute inset-1/2 ltr:-translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 w-[90%] lg:max-w-[900px] max-h-[95vh] h-fit overflow-y-auto p-6 bg-white z-50 rounded shadow-[0_4px_6px_rgba(211,211,211,0.25)];
+    @apply absolute inset-1/2 -translate-x-1/2 -translate-y-1/2 w-[90%] lg:max-w-[900px] max-h-[95vh] h-fit overflow-y-auto p-6 bg-white z-50 rounded shadow-[0_4px_6px_rgba(211,211,211,0.25)];
 
     & > svg:only-child {
       @apply w-8 h-8 mx-auto text-gray-2 fill-current animate-spin;


### PR DESCRIPTION
#### :tophat: What? Why?

We've backported a fix for RTL but it's a new feature from Tailwind that isn't supported in the version that we're using in v0.28. 

This was detected by @microstudi:

https://github.com/decidim/decidim/pull/12495#issuecomment-1978848034

This PR reverts the backport that introduced the bug in v0.28

#### :pushpin: Related Issues
 
- Related to #12495
- Related to #12559

#### Testing

To check the bug:
1. Run these commands:
```console
git checkout release/0.28-stable
bundle exec rake development_app
```
2. Go to the footer and click in the "Cookie settings" to open the modal. See that's broken
3. Go to the login page http://localhost:3000/users/sign_in. See that the input button for showing the password is broken

### :camera: Screenshots

![Bug of the modal](https://github.com/decidim/decidim/assets/717367/fb8ff8b1-0c8e-486f-909d-327721b7965b)
![Bug of the link in the login page](https://github.com/decidim/decidim/assets/717367/38e7349b-4c94-43ca-badf-ba9be4c33aeb)

:hearts: Thank you!