### PR TITLE
Fix flaky spec on date_picker with single digit days

### DIFF
--- a/decidim-core/spec/system/date_picker/date_picker_spec.rb
+++ b/decidim-core/spec/system/date_picker/date_picker_spec.rb
@@ -152,7 +152,7 @@ describe "Datepicker" do
           context "when choosing a date" do
             it "enables the select button" do
               find(".datepicker__calendar-button").click
-              yesterday = Date.yesterday.strftime("%d")
+              yesterday = Date.yesterday.strftime("%-d")
               find("td > span", text: yesterday, match: :first).click
               expect(page).to have_button("Select", disabled: false)
             end


### PR DESCRIPTION
#### :tophat: What? Why?

After we fixed #12486, we introduced another bug in single digit days (i.e. 5) as we're using the zero padded version (05) and it isn't found in the calendar

>   %d - Day of the month, zero-padded (01..31)
>           %-d  no-padded (1..31)

#### :pushpin: Related Issues
 
- Related to #12486 
- https://apidock.com/ruby/DateTime/strftime 
 
#### Testing

Run the spec with and without the pach
`
bin/rspec decidim-core/spec/system/date_picker/date_picker_spec.rb:153
` 

:hearts: Thank you!
