### PR TITLE
Fix performance issue with attribute encryption/decryption

### DIFF
--- a/decidim-core/lib/decidim/attribute_encryptor.rb
+++ b/decidim-core/lib/decidim/attribute_encryptor.rb
@@ -19,10 +19,12 @@ module Decidim
     end
 
     def self.cryptor
-      key = ActiveSupport::KeyGenerator.new("attribute").generate_key(
-        Rails.application.secrets.secret_key_base, ActiveSupport::MessageEncryptor.key_len
-      )
-      ActiveSupport::MessageEncryptor.new(key)
+      @cryptor ||= begin
+        key = ActiveSupport::KeyGenerator.new("attribute").generate_key(
+          Rails.application.secrets.secret_key_base, ActiveSupport::MessageEncryptor.key_len
+        )
+        ActiveSupport::MessageEncryptor.new(key)
+      end
     end
   end
 end

--- a/decidim-core/spec/lib/attribute_encryptor_spec.rb
+++ b/decidim-core/spec/lib/attribute_encryptor_spec.rb
@@ -75,6 +75,15 @@ module Decidim
         it "returns the decrypted value" do
           expect(described_class.decrypt(value)).to eq("Decidim")
         end
+
+        it "runs in a performant way when called multiple times concecutively" do
+          start = Time.current
+          1000.times { described_class.decrypt(value) }
+
+          # This actually takes a lot less time but the idea of the spec is to
+          # check that this runs in a performant way.
+          expect(Time.current - start).to be < 1
+        end
       end
     end
   end

--- a/decidim-core/spec/lib/attribute_encryptor_spec.rb
+++ b/decidim-core/spec/lib/attribute_encryptor_spec.rb
@@ -4,6 +4,13 @@ require "spec_helper"
 
 module Decidim
   describe AttributeEncryptor do
+    after do
+      # Clear the cached cryptor instance because the specs are testing the
+      # utility under different configurations which can affect the
+      # `ActiveSupport::MessageEncryptor` instance.
+      described_class.remove_instance_variable(:@cryptor) if described_class.instance_variable_defined?(:@cryptor)
+    end
+
     describe ".decrypt" do
       context "when the passed value is blank" do
         let(:value) { "" }

--- a/decidim-core/spec/lib/attribute_encryptor_spec.rb
+++ b/decidim-core/spec/lib/attribute_encryptor_spec.rb
@@ -4,10 +4,12 @@ require "spec_helper"
 
 module Decidim
   describe AttributeEncryptor do
-    after do
+    around do |example|
       # Clear the cached cryptor instance because the specs are testing the
       # utility under different configurations which can affect the
       # `ActiveSupport::MessageEncryptor` instance.
+      described_class.remove_instance_variable(:@cryptor) if described_class.instance_variable_defined?(:@cryptor)
+      example.run
       described_class.remove_instance_variable(:@cryptor) if described_class.instance_variable_defined?(:@cryptor)
     end
 

--- a/decidim-core/spec/models/decidim/authorization_spec.rb
+++ b/decidim-core/spec/models/decidim/authorization_spec.rb
@@ -144,12 +144,6 @@ module Decidim
     end
 
     describe "#metadata" do
-      # metadata: {
-      #   date_of_birth: "1972-02-29",
-      #   municipality: "091",
-      #   postal_code: "00200",
-      #   gender: "f"
-      # }
       let!(:authorization) { create(:authorization, :granted, metadata: authorization_metadata) }
       let(:authorization_metadata) do
         {

--- a/decidim-core/spec/models/decidim/authorization_spec.rb
+++ b/decidim-core/spec/models/decidim/authorization_spec.rb
@@ -142,5 +142,39 @@ module Decidim
         end
       end
     end
+
+    describe "#metadata" do
+      # metadata: {
+      #   date_of_birth: "1972-02-29",
+      #   municipality: "091",
+      #   postal_code: "00200",
+      #   gender: "f"
+      # }
+      let!(:authorization) { create(:authorization, :granted, metadata: authorization_metadata) }
+      let(:authorization_metadata) do
+        {
+          uid: SecureRandom.hex(256),
+          foo: "bar",
+          baz: "biz",
+          dob: "2016-09-16",
+          postal_code: "00000",
+          municipality: "Babylon"
+        }
+      end
+
+      it "runs the decryption in a timely manner" do
+        start = Time.current
+        100.times { Decidim::Authorization.find(authorization.id).metadata }
+
+        # This should actually take ~0.05 seconds during normal performance but
+        # the idea of this test is to check that there is no unnecessary delay
+        # when running the decryption multiple times.
+        #
+        # There used to be a performance problem at the
+        # `Decidim::AttributeEncryptor` class which caused unnecessary delay
+        # when called multiple times.
+        expect(Time.current - start).to be < 1
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Creating new instances of the `ActiveSupport::MessageEncryptor` causes delay every time an attribute value is decrypted. We are using exactly the same key and options for all attributes, so we can cache this variable and by doing so highly improve the performance.

This causes unnecessary load and delays under high load situations when there are a lot of people trying to access some component that has authorization rules that needs to decrypt this information potentially multiple times.

As a sidenote, this also highly improves the performance of this v0.24.0 migration if run for large databases:

https://github.com/decidim/decidim/blob/develop/decidim-core/db/migrate/20201127114444_encrypt_authorization_metadatas.rb

#### :pushpin: Related Issues
- Related to
  * #4698
  * #6947

#### Testing
- See the added performance specs in this PR
- Run these specs without the fix
- See the specs fail
- Re-run the specs with the fix 
- See the specs pass