### PR TITLE
Fix impersonnating users

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/impersonations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/impersonations_controller.rb
@@ -82,6 +82,7 @@ module Decidim
         return nil unless handler.unique_id
 
         existing_authorization = Authorization.find_by(
+          user: User.where(organization: current_organization),
           name: handler_name,
           unique_id: handler.unique_id
         )

--- a/decidim-admin/spec/controllers/impersonations_controller_spec.rb
+++ b/decidim-admin/spec/controllers/impersonations_controller_spec.rb
@@ -158,6 +158,46 @@ module Decidim
           end
         end
 
+        context "with existing managed user with the same identity in another organization" do
+          let(:other_organization) do
+            create(
+              :organization,
+              available_authorizations: ["dummy_authorization_handler"]
+            )
+          end
+
+          before do
+            user = create(
+              :user,
+              :managed,
+              organization: other_organization,
+              name: managed_user_name
+            )
+            Decidim::Authorization.create!(
+              user:,
+              name: authorization_params[:handler_name],
+              unique_id: authorization_params[:document_number],
+              metadata: {
+                document_number: "9999X",
+                postal_code: "99999"
+              }
+            )
+          end
+
+          it_behaves_like "successful authorization"
+
+          it "creates a new managed user" do
+            post(:create, params:)
+
+            expect(
+              Decidim::User.where(
+                name: managed_user_name,
+                managed: true
+              ).count
+            ).to eq(2)
+          end
+        end
+
         context "with existing non-managed user with the same identity" do
           before do
             user = create(
@@ -188,6 +228,53 @@ module Decidim
 
             expect(flash[:alert]).to be_present
             expect(subject).to render_template(:new)
+          end
+        end
+
+        context "with existing non-managed user with the same identity in another organization" do
+          let(:other_organization) do
+            create(
+              :organization,
+              available_authorizations: ["dummy_authorization_handler"]
+            )
+          end
+
+          before do
+            user = create(
+              :user,
+              organization: other_organization,
+              name: managed_user_name
+            )
+            Decidim::Authorization.create!(
+              user:,
+              name: authorization_params[:handler_name],
+              unique_id: authorization_params[:document_number],
+              metadata: {
+                document_number: authorization_params[:document_number],
+                postal_code: "99999"
+              }
+            )
+          end
+
+          it_behaves_like "successful authorization"
+
+          it "creates a new managed user" do
+            post(:create, params:)
+
+            expect(
+              Decidim::User.where(
+                organization:,
+                name: managed_user_name,
+                managed: true
+              ).count
+            ).to eq(1)
+
+            expect(
+              Decidim::User.where(
+                organization: other_organization,
+                name: managed_user_name
+              ).count
+            ).to eq(1)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

This pull request aims to allow impersonating users that already exist in another sister organization.

#### :pushpin: Related Issues

- Fixes #12382 

#### Testing

1. Create a decidim app using `decidim  0.29.0.dev` (`develop` branch)
2. Create a system admin
3. Create two organizations A & B
4. [Set up a Decidim Authorization of the “Form authorizations” type](https://github.com/decidim/decidim/blob/develop/decidim-verifications/README.md#types-of-authorization-methods). See below for our impersonation authorization handler implementation
5. For each of the two organizations, create an admin
6. Access organization A and log in as an administrator
7. Access "Admin panel" > "Participants" > "Impersonations" and click on "Manage new participant"
8. Fill the form and click on "Impersonate"
9. Close impersonation session
10. Access organization B and log in as an administrator
11. Access "Admin panel" > "Participants" > "Impersonations" and click on "Manage new participant"
12. Fill the form (using the same document number as the one in step 7. !) and click on "Impersonate"

Impersonation handler implementation :

```ruby
# frozen_string_literal: true

class ParticipantImpersonationHandler < Decidim::AuthorizationHandler
  attribute :name_and_surname, String
  attribute :document_number, String
  attribute :postal_code, String
  attribute :birthday, Decidim::Attributes::LocalizedDate
  attribute :scope_id, Integer

  validates :document_number, presence: true
  validate :valid_document_number
  validate :valid_scope_id

  def unique_id
    document_number
  end

  def scope
    user.organization.scopes.find_by(id: scope_id) if scope_id
  end
  
  def metadata
    super.merge(document_number: document_number, postal_code: postal_code, scope_id: scope_id)
  end

  private

  def valid_document_number
    errors.add(:document_number, :invalid) unless document_number =~ /\A[a-zA-Z0-9]+\z/
  end

  def valid_scope_id
    errors.add(:scope_id, :invalid) if scope_id && !scope
  end
end
```

Note: the bug has been discovered on Decidim 0.27.5.
