### PR TITLE
Backport 'Remove `tabindex="-1"` from the SVG icons' to v0.28

### DIFF
--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -62,7 +62,7 @@ module Decidim
       href = Decidim.cors_enabled ? "" : asset_pack_path("media/images/remixicon.symbol.svg")
 
       content_tag :svg, html_properties do
-        content_tag :use, nil, "href" => "#{href}#ri-#{name}", tabindex: -1
+        content_tag :use, nil, "href" => "#{href}#ri-#{name}"
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12515 to v0.28

:hearts: Thank you!