### PR TITLE
Backport 'Fix duplicate ActiveSupport notifications' to v0.28

### DIFF
--- a/decidim-core/app/services/decidim/events_manager.rb
+++ b/decidim-core/app/services/decidim/events_manager.rb
@@ -46,5 +46,11 @@ module Decidim
     def self.subscribe(event, &)
       ActiveSupport::Notifications.subscribe(event, &)
     end
+
+    def self.subscribe_events!
+      subscribe(/^decidim\.events\./) do |event_name, data|
+        EventPublisherJob.perform_later(event_name, data)
+      end
+    end
   end
 end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -383,9 +383,13 @@ module Decidim
       end
 
       initializer "decidim_core.notifications" do
-        config.to_prepare do
-          Decidim::EventsManager.subscribe(/^decidim\.events\./) do |event_name, data|
-            EventPublisherJob.perform_later(event_name, data)
+        if Rails.autoloaders.zeitwerk_enabled?
+          config.after_initialize do
+            Decidim::EventsManager.subscribe_events!
+          end
+        else
+          config.to_prepare do
+            Decidim::EventsManager.subscribe_events!
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12485 to v0.28

:hearts: Thank you!