### PR TITLE
Fix flaky spec on CommentVote model spec

### DIFF
--- a/decidim-comments/spec/models/comment_vote_spec.rb
+++ b/decidim-comments/spec/models/comment_vote_spec.rb
@@ -43,8 +43,22 @@ module Decidim
         expect(comment_vote).to be_invalid
       end
 
-      it "updates the comment votes count after creation" do
-        expect(comment_vote.comment.up_votes_count).to eq(1)
+      context "when it is a downvote" do
+        let!(:comment_vote) { create(:comment_vote, comment:, author:, weight: -1) }
+
+        it "updates the comment votes count after creation" do
+          expect(comment.up_votes_count).to eq(0)
+          expect(comment.down_votes_count).to eq(1)
+        end
+      end
+
+      context "when it is an upvote" do
+        let!(:comment_vote) { create(:comment_vote, comment:, author:, weight: 1) }
+
+        it "updates the comment votes count after creation" do
+          expect(comment.up_votes_count).to eq(1)
+          expect(comment.down_votes_count).to eq(0)
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

After we merged #12551 there are some flaky specs in the CommentVote model spec. 

The problem is that in the factory we have a `[1, -1]` sample for the weight, and in the spec we try to always check for upvotes (`weight: 1`):

https://github.com/decidim/decidim/blob/c877810a8ee903e264fbb81bbaf9389b2a049514/decidim-comments/lib/decidim/comments/test/factories.rb#L51

This PR fixes the flaky spec. 

#### Testing

Run before and after this change:
`for i in $(seq 1 100); do echo $i ; bin/rspec decidim-comments/spec/models/comment_vote_spec.rb || break; done `

:hearts: Thank you!
