### PR TITLE
Fix flaky scope creation in Seeds

### DIFF
--- a/decidim-core/lib/decidim/core/seeds.rb
+++ b/decidim-core/lib/decidim/core/seeds.rb
@@ -177,6 +177,8 @@ module Decidim
           organization:,
           parent:
         )
+      rescue ActiveRecord::RecordInvalid
+        retry
       end
 
       def create_area_type!(name:, plural:)

--- a/decidim-core/lib/decidim/core/seeds.rb
+++ b/decidim-core/lib/decidim/core/seeds.rb
@@ -166,11 +166,12 @@ module Decidim
       end
 
       def create_scope!(scope_type:, parent:)
-        n = rand(3)
-        code = parent.nil? ? "#{::Faker::Address.country_code}_#{n}" : "#{parent.code}-#{::Faker::Address.unique.state_abbr}"
+        n = rand(99_999)
+        code = parent.nil? ? "#{::Faker::Address.country_code}_#{n}" : "#{parent.code}-#{::Faker::Address.postcode}_#{n}"
+        name = [::Faker::Address.state, ::Faker::Address.city].sample
 
         Decidim::Scope.create!(
-          name: Decidim::Faker::Localized.literal(::Faker::Address.unique.state),
+          name: Decidim::Faker::Localized.literal(name),
           code:,
           scope_type:,
           organization:,


### PR DESCRIPTION
#### :tophat: What? Why?

There's flaky seed regarding the Scopes code generation, where we arrive to a point where the code is repeated, and we have a uniqueness validation. 

This PR fixes it by introducing more entropy and retrying if there's an invalid record. 

Link to the build error: https://github.com/decidim/decidim/actions/runs/8372192728/job/22922674897?pr=12633 - as it will be gone in a few days I also add the screenshot and traceback:

       Creating seeds for decidim-core...
       rails aborted!
       ActiveRecord::RecordInvalid: Validation failed: Code has already been taken (ActiveRecord::RecordInvalid)
       /home/runner/work/decidim/decidim/decidim-generators/spec/generator_test_app/db/seeds.rb:9:in `<top (required)>'
       Tasks: TOP => db:seed
       (See full trace by running task with --trace)
       Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
       Coverage report generated for (1/2) to /home/runner/work/decidim/decidim/coverage/coverage.xml. 243 / 288 LOC (84.38%) covered
     Shared Example Group: "a new development application" called from ./spec/runtime/path_flag_spec.rb:24
     # ./lib/decidim/generators/test/generator_examples.rb:52:in `block (2 levels) in <top (required)>'

#### Testing

Run this with and without the patch (mind that you'll have to regenerate your DB afterwards, as you'll have lots of Scopes)

`bin/rails runner 'require "decidim/core/seeds"; scope_type = Decidim::Core::Seeds.new.create_scope_type!(name: "municipality", plural: "municipalities"); 99999.times.each { Decidim::Core::Seeds.new.create_scope!(scope_type:, parent: nil) }'`

### :camera: Screenshots
 
![Build with the error](https://github.com/decidim/decidim/assets/717367/7a642878-26ed-40c1-81fb-a0e79e44b532)

:hearts: Thank you!
