### PR TITLE
Fix flaky shakapacker compilation

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb
@@ -2,6 +2,10 @@
 
 RSpec.configure do |config|
   config.before(:all) do
+    raise "Rails.root directory does not exist" unless Rails.root.exist?
+    raise "package.json file does not exist" unless Rails.root.join("package.json").exist?
+    raise "Node modules directory does not exist" unless Rails.root.join("node_modules").exist?
+
     Dir.chdir(Rails.root) { Webpacker.compile }
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  config.before(:all, type: :system) do
-    Dir.chdir(Rails.root) { Webpacker.compile }
-  end
-  config.before(:all, type: :mailer) do
-    Dir.chdir(Rails.root) { Webpacker.compile }
-  end
-  config.before(:all, type: :cell) do
+  config.before(:all) do
     Dir.chdir(Rails.root) { Webpacker.compile }
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb
@@ -7,5 +7,22 @@ RSpec.configure do |config|
     raise "Node modules directory does not exist" unless Rails.root.join("node_modules").exist?
 
     Dir.chdir(Rails.root) { Webpacker.compile }
+  rescue Errno::ENOENT
+    node_modules_contents = `ls #{Rails.root.join("node_modules")}`
+
+    message = <<~ERROR
+      There was an error during the Webpacker compilation
+      #{"=" * 80}
+      Node version: #{`node -v`}
+      #{"=" * 80}
+      NPM version: #{`npm -v`}
+      #{"=" * 80}
+      Node modules packages: #{`npm list`}
+      #{"=" * 80}
+      Node modules contents: #{node_modules_contents}
+      #{"=" * 80}
+    ERROR
+
+    raise message
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Same as #12323, I detected that there are some cases where if the spec type that's running need an asset and Shakapacker wasn't compiled yet, then it'll fail. 

Let's do the Shakapacker compilation for each spec type, just to be sure.

Also, I'm trying to debug what is exactly happening in [this flaky](https://github.com/decidim/decidim/actions/runs/8372486880/job/22923678687?pr=12525):

    1) Decidim::NotificationCell when resource exists Resource title is present
     Failure/Error:
       File.open(name, "rb") {|f|
         buf = ""
         while f.read(16384, buf)
           update buf
         end
       }

     Errno::ENOENT:
       No such file or directory @ rb_sysopen - /home/runner/work/decidim/decidim/spec/decidim_dummy_app/package.json
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb:11:in `block (3 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb:11:in `chdir'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb:11:in `block (2 levels) in <top (required)>'

    2) Decidim::NotificationCell when resource is missing Resource title is present
     Failure/Error:
       File.open(name, "rb") {|f|
         buf = ""
         while f.read(16384, buf)
           update buf
         end
       }

     Errno::ENOENT:
       No such file or directory @ rb_sysopen - /home/runner/work/decidim/decidim/spec/decidim_dummy_app/package.json
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb:11:in `block (3 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb:11:in `chdir'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/webpacker.rb:11:in `block (2 levels) in <top (required)>'


So I added some checks in this compilation and also a debugging message to have more information in what's happening.

#### :pushpin: Related Issues

- Related to https://github.com/decidim/decidim/pull/12323

#### Testing

For the bug with the types, you can check it out before and after this patch with these commands:

```console
bundle exec rake test_app
bin/rspec decidim-core/spec/models/decidim/ --fail-fast
```
 
:hearts: Thank you!
