### PR TITLE
Fix flaky with accessibility errors in Direct Uploads

### DIFF
--- a/decidim-core/app/cells/decidim/upload_modal/modal.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/modal.erb
@@ -37,10 +37,10 @@
             <%= icon "upload-cloud-2-line", class: "w-8 h-8 text-gray fill-current" %>
             <%= t("decidim.forms.upload_help.dropzone") %>
           </span>
-          <label class="button button__sm button__secondary" for="files-<%= modal_id %>">
+          <button class="button button__sm button__secondary" data-select-file-button>
             <span><%= t("decidim.forms.upload.select_file") %></span>
             <%= icon "arrow-right-line", class: "fill-current" %>
-          </label>
+          </button>
         </div>
       </div>
     </div>

--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_field.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_field.js
@@ -66,7 +66,7 @@ const updateActiveUploads = (modal) => {
 
     const template = `
       <div ${attachmentIdOrHiddenField} data-filename="${escapeQuotes(file.name)}" data-title="${escapeQuotes(title)}">
-        ${(/image/).test(file.type) && `<div><img src="" alt="${escapeQuotes(file.name)}" /></div>` || ""}
+        ${(/image/).test(file.type) && `<div><img src="data:," alt="${escapeQuotes(file.name)}" /></div>` || ""}
         <span>${escapeHtml(title)} (${escapeHtml(truncateFilename(file.name))})</span>
         ${hidden}
       </div>

--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
@@ -172,7 +172,7 @@ export default class UploadModal {
 
   createUploadItem(file, errors, opts = {}) {
     const okTemplate = `
-      <img src="" alt="${escapeQuotes(file.name)}" />
+      <img src="data:," alt="${escapeQuotes(file.name)}" />
       <span>${escapeHtml(truncateFilename(file.name))}</span>
     `
 
@@ -186,7 +186,7 @@ export default class UploadModal {
     `
 
     const titleTemplate = `
-      <img src="" alt="${escapeQuotes(file.name)}" />
+      <img src="data:," alt="${escapeQuotes(file.name)}" />
       <div>
         <div>
           <label>${this.locales.filename}</label>

--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
@@ -122,8 +122,8 @@ export default class UploadModal {
     if (src) {
       buffer = await fetch(src).then((res) => res.arrayBuffer())
       // since we cannot know the exact mime-type of the file,
-      // we assume as "image" if it has the src attribute in order to load the preview
-      type = "image"
+      // we assume as "image/*" if it has the src attribute in order to load the preview
+      type = "image/*"
     }
 
     const file = new File([buffer], element.dataset.filename, { type })

--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
@@ -154,16 +154,20 @@ export default class UploadModal {
     // Disabled save button when any children have data-state="error"
     this.saveButton.disabled = Array.from(files).filter(({ dataset: { state } }) => state === STATUS.ERROR).length > 0;
 
+    const dataSelectFileButton = this.emptyItems.querySelector("[data-select-file-button]");
+
     // Only allow to continue the upload when the multiple option is true (default: false)
     const continueUpload = !files.length || this.options.multiple
     this.input.disabled = !continueUpload
     if (continueUpload) {
       this.emptyItems.classList.remove("is-disabled");
-      this.emptyItems.querySelector("label").removeAttribute("disabled");
+      dataSelectFileButton.removeAttribute("disabled");
     } else {
       this.emptyItems.classList.add("is-disabled");
-      this.emptyItems.querySelector("label").setAttribute("disabled", true);
+      dataSelectFileButton.disabled = true;
     }
+
+    dataSelectFileButton.addEventListener("click", () => this.input.click());
   }
 
   createUploadItem(file, errors, opts = {}) {


### PR DESCRIPTION
#### :tophat: What? Why?

We have some flaky validations regarding the accessbility of this feature. This PR solves them. 

[Example failure run](https://github.com/decidim/decidim/actions/runs/8374164084/job/22928894538?pr=12635) (mind that it'll be gone in a couple of days) 

The errors are:

##### 1. Bad value  for attribute “src”

      line 912: Bad value  for attribute “src” on element “img”: Expected a token character or “/” but saw “;” instead.
      <ul class="upload-modal__dropzone" data-dropzone-items="" data-locales="{&quot;error&quot;:&quot;Error!&quot;,&quot;title_required&quot;:&quot;Title is required!&quot;,&quot;filename&quot;:&quot;Filename&quot;,&quot;file_size_too_large&quot;:&quot;File size is too large! Maximun file size: 5MB&quot;,&quot;remove&quot;:&quot;Remove&quot;,&quot;title&quot;:&quot;Title&quot;,&quot;uploaded&quot;:&quot;Uploaded&quot;,&quot;validating&quot;:&quot;Validating...&quot;,&quot;validation_error&quot;:&quot;Validation error!&quot;}"><li data-attachment-id="580" data-filename="avatar.jpg" data-state="validated">
        <div data-template="ok">
          >> <img src="data:image;base64,/9j/4QAYRXhpZg..." alt="avatar.jpg">
      <span>avatar.jpg</span>
          <button>Remove</button>
        </div>

##### 2. Attribute “disabled” not allowed

    line 925: Attribute “disabled” not allowed on element “label” at this point.
            Drop files here or click the button to upload
          </span>
            >> <label class="button button__sm button__secondary" for="files-upload_26a3dd45-2737-42ad-a6e5-986070895d78" disabled="true">
            <span>Select file</span>
            <svg width="1em" height="1em" role="img" aria-hidden="true" class="fill-current"><use href="/packs-test/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-arrow-right-line"></use></svg>
          </label>

##### 3. Bad value “” for attribute “src” on element “img”

      line 912: Bad value “” for attribute “src” on element “img”: Must be non-empty.
             <ul class="upload-modal__dropzone" data-dropzone-items="" data-locales="{&quot;error&quot;:&quot;Error!&quot;,&quot;title_required&quot;:&quot;Title is required!&quot;,&quot;filename&quot;:&quot;Filename&quot;,&quot;file_size_too_large&quot;:&quot;File size is too large! Maximun file size: 5MB&quot;,&quot;remove&quot;:&quot;Remove&quot;,&quot;title&quot;:&quot;Title&quot;,&quot;uploaded&quot;:&quot;Uploaded&quot;,&quot;validating&quot;:&quot;Validating...&quot;,&quot;validation_error&quot;:&quot;Validation error!&quot;}"><li data-attachment-id="585" data-filename="avatar.jpg" data-state="validated">
               <div data-template="ok">
       >>          <img src="" alt="avatar.jpg">
             <span>avatar.jpg</span>
                 <button>Remove</button>
               </div>

#### Testing

There were two approaches to reproduce these flakies: 

```console
bin/rspec decidim-core/spec/system/account_spec.rb -e "passes HTML validation"  --bisect
for i in $(seq 1 100); do echo $i ; bin/rspec decidim-core/spec/system/account_spec.rb -e "passes HTML validation" || break; done
```

So running those commands before this patch it fails, and afterwards it passes


:hearts: Thank you!
