### PR TITLE
Fix potential unsafe external link in initiatives

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_result.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_result.html.erb
@@ -3,9 +3,9 @@
   <h5><%= t("decidim.initiatives.initiatives.result.answer_title") %>:</h5>
   <p>
     <% if initiative.answer_url.present? %>
-      <a href="<%= initiative.answer_url %>" target="_blank">
+      <%= link_to initiative.answer_url, target: "_blank", rel: "noopener noreferrer" do %>
         <%= decidim_sanitize_editor translated_attribute initiative.answer %>
-      </a>
+      <% end %>
     <% else %>
       <%= decidim_sanitize_editor translated_attribute initiative.answer %>
     <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

We're missing a `rel: "noopener noreferrer"` in a link in Initiatives. This PR fixes it. 
 
#### Testing

Everything should be green. 

:hearts: Thank you!
