### PR TITLE
Fix graphiql initial query escaping

### DIFF
--- a/decidim-api/lib/decidim/api/engine.rb
+++ b/decidim-api/lib/decidim/api/engine.rb
@@ -35,9 +35,9 @@ module Decidim
       initializer "decidim_api.graphiql" do
         Decidim::GraphiQL::Rails.config.tap do |config|
           config.query_params = true
-          config.initial_query = File.read(
-            File.join(__dir__, "graphiql-initial-query.txt")
-          ).html_safe
+          config.initial_query = ERB::Util.html_escape(
+            File.read(File.join(__dir__, "graphiql-initial-query.txt"))
+          )
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Fix a warning related to a stored XSS in this file. Mind that this file is already provided by Decidim and can't be changed by users/administrators, so it is a false positive. Even though, we fix it so we don't have the alert. 

#### Testing

Everything should be green
Going to http://localhost:3000/api/graphiql with a clean session should work with the initial query 

### :camera: Screenshots

![GraphiQL api with the initial query](https://github.com/decidim/decidim/assets/717367/ef81b670-b2d2-419e-b1f0-32657b7ceff4)

:hearts: Thank you!
