### PR TITLE
Fix flaky spec on join user group command spec

### DIFF
--- a/decidim-core/spec/commands/decidim/join_user_group_spec.rb
+++ b/decidim-core/spec/commands/decidim/join_user_group_spec.rb
@@ -55,7 +55,7 @@ module Decidim
                 event: "decidim.events.groups.join_request_created",
                 event_class: JoinRequestCreatedEvent,
                 resource: user_group,
-                affected_users:,
+                affected_users: match_array(affected_users),
                 extra: {
                   user_group_name: user_group.name,
                   user_group_nickname: user_group.nickname


### PR DESCRIPTION
#### :tophat: What? Why?

We have another flaky in the test suite, this time related to a matcher in an array. 

The bug is that sometimes Rails might return the same ActiveRecord result but with another order and this makes the `eq` rspec matcher to fail. 

As the order here is not important, we can use the `match_array` matcher.

#### :pushpin: Related Issues
 
- Related to https://medium.com/beambenefits/array-matchers-in-rspec-42b370e3983e  
- Related to #12641 (as its the same kind of bug)

#### Testing

This can be reproduced locally in less than 10 tries (at least in my machine 😄) with this command:

```console
for i in $(seq 1 100); do echo $i ; bin/rspec decidim-core/spec/commands/decidim/join_user_group_spec.rb || break; done
```
Link to the failure: https://github.com/decidim/decidim/actions/runs/8387717166/job/22979498365?pr=12639 (mind that will dissapear in a couple days)

    1st Try error in ./spec/commands/decidim/join_user_group_spec.rb:46:
    #<Decidim::EventsManager (class)> received :publish with unexpected arguments
    expected: (hash_including(:event=>"decidim.events.groups.join_request_created", :event_class=>Decidim::JoinReque...ccepted_at: nil>], :extra=>{:user_group_name=>"Spencer-Waelchi 69", :user_group_nickname=>"3o_820"}))
       got: ({:affected_users=>#<ActiveRecord::Associations::CollectionProxy [#<Decidim::User id: 797, email: "use..., previous_passwords: [], officialized_at: nil, officialized_as: nil, admin_terms_accepted_at: nil>})
     Diff:
     @@ -1,8 +1,15 @@
     -["hash_including(:event=>\"decidim.events.groups.join_request_created\", :event_class=>Decidim::JoinRequestCreatedEvent, :resource=>#<Decidim::UserGroup id: 795, email: \"usergroup69@example.org\", created_at: \"2024-03-22 13:06:32.593815395 +0000\", updated_at: \"2024-03-22 13:06:32.613517911 +0000\", decidim_organization_id: 498, name: \"Spencer-Waelchi 69\", locale: nil, avatar: nil, delete_reason: nil, deleted_at: nil, admin: false, managed: false, roles: [], nickname: \"3o_820\", personal_url: nil, about: \"{\\\"en\\\"=>\\\"<script>alert(\\\\\\\"user_group_about\\\\\\\");</scri...\", accepted_tos_version: nil, newsletter_token: \"\", newsletter_notifications_at: nil, extended_data: {\"document_number\"=>\"68946586X\", \"phone\"=>\"(118) 091-6539 x825\", \"rejected_at\"=>nil, \"verified_at\"=>nil}, following_count: 0, followers_count: 0, notification_types: \"all\", session_token: nil, direct_message_types: \"all\", blocked: false, blocked_at: nil, block_id: nil, email_on_moderations: true, follows_count: 0, notification_settings: {}, notifications_sending_frequency: \"daily\", digest_sent_at: nil, password_updated_at: nil, previous_passwords: [], officialized_at: nil, officialized_as: nil, admin_terms_accepted_at: nil>, :affected_users=>[#<Decidim::User id: 796, email: \"user789@example.org\", created_at: \"2024-03-22 13:06:32.772164641 +0000\", updated_at: \"2024-03-22 13:06:32.793170799 +0000\", decidim_organization_id: 498, name: \"The Hon. Raphael Wyman\", locale: \"en\", avatar: nil, delete_reason: nil, deleted_at: nil, admin: false, managed: false, roles: [], nickname: \"7ekv_821\", personal_url: \"[http://kunde.example/harland.prosacco\](http://kunde.example/harland.prosacco/)", about: \"{\\\"en\\\"=>\\\"<script>alert(\\\\\\\"user_about\\\\\\\");</script> Re...\", accepted_tos_version: \"2024-03-22 13:06:32.508940857 +0000\", newsletter_token: \"\", newsletter_notifications_at: nil, extended_data: {}, following_count: 0, followers_count: 0, notification_types: \"all\", session_token: nil, direct_message_types: \"all\", blocked: false, blocked_at: nil, block_id: nil, email_on_moderations: true, follows_count: 0, notification_settings: {}, notifications_sending_frequency: \"real_time\", digest_sent_at: nil, password_updated_at: \"2024-03-22 13:06:32.765374882 +0000\", previous_passwords: [], officialized_at: nil, officialized_as: nil, admin_terms_accepted_at: nil>, #<Decidim::User id: 797, email: \"user790@example.org\", created_at: \"2024-03-22 13:06:32.807146582 +0000\", updated_at: \"2024-03-22 13:06:32.827766816 +0000\", decidim_organization_id: 498, name: \"Everett Kassulke\", locale: \"en\", avatar: nil, delete_reason: nil, deleted_at: nil, admin: false, managed: false, roles: [], nickname: \"jibi_822\", personal_url: \"[http://oberbrunner-fisher.test/sandy.swaniawski\](http://oberbrunner-fisher.test/sandy.swaniawski/)", about: \"{\\\"en\\\"=>\\\"<script>alert(\\\\\\\"user_about\\\\\\\");</script> Ad...\", accepted_tos_version: \"2024-03-22 13:06:32.508940857 +0000\", newsletter_token: \"\", newsletter_notifications_at: nil, extended_data: {}, following_count: 0, followers_count: 0, notification_types: \"all\", session_token: nil, direct_message_types: \"all\", blocked: false, blocked_at: nil, block_id: nil, email_on_moderations: true, follows_count: 0, notification_settings: {}, notifications_sending_frequency: \"real_time\", digest_sent_at: nil, password_updated_at: \"2024-03-22 13:06:32.801148422 +0000\", previous_passwords: [], officialized_at: nil, officialized_as: nil, admin_terms_accepted_at: nil>], :extra=>{:user_group_name=>\"Spencer-Waelchi 69\", :user_group_nickname=>\"3o_820\"})"]
    +[{:affected_users=>
    +   #<ActiveRecord::Associations::CollectionProxy [#<Decidim::User id: 797, email: "user790@example.org", created_at: "2024-03-22 13:06:32.807146000 +0000", updated_at: "2024-03-22 13:06:32.827766000 +0000", decidim_organization_id: 498, name: "Everett Kassulke", locale: "en", avatar: nil, delete_reason: nil, deleted_at: nil, admin: false, managed: false, roles: [], nickname: "jibi_822", personal_url: "http://oberbrunner-fisher.test/sandy.swaniawski", about: "{\"en\"=>\"<script>alert(\\\"user_about\\\");</script> Ad...", accepted_tos_version: "2024-03-22 13:06:32.508940000 +0000", newsletter_token: "", newsletter_notifications_at: nil, extended_data: {}, following_count: 0, followers_count: 0, notification_types: "all", session_token: nil, direct_message_types: "all", blocked: false, blocked_at: nil, block_id: nil, email_on_moderations: true, follows_count: 0, notification_settings: {}, notifications_sending_frequency: "real_time", digest_sent_at: nil, password_updated_at: "2024-03-22 13:06:32.801148000 +0000", previous_passwords: [], officialized_at: nil, officialized_as: nil, admin_terms_accepted_at: nil>, #<Decidim::User id: 796, email: "user789@example.org", created_at: "2024-03-22 13:06:32.772164000 +0000", updated_at: "2024-03-22 13:06:32.793170000 +0000", decidim_organization_id: 498, name: "The Hon. Raphael Wyman", locale: "en", avatar: nil, delete_reason: nil, deleted_at: nil, admin: false, managed: false, roles: [], nickname: "7ekv_821", personal_url: "http://kunde.example/harland.prosacco", about: "{\"en\"=>\"<script>alert(\\\"user_about\\\");</script> Re...", accepted_tos_version: "2024-03-22 13:06:32.508940000 +0000", newsletter_token: "", newsletter_notifications_at: nil, extended_data: {}, following_count: 0, followers_count: 0, notification_types: "all", session_token: nil, direct_message_types: "all", blocked: false, blocked_at: nil, block_id: nil, email_on_moderations: true, follows_count: 0, notification_settings: {}, notifications_sending_frequency: "real_time", digest_sent_at: nil, password_updated_at: "2024-03-22 13:06:32.765374000 +0000", previous_passwords: [], officialized_at: nil, officialized_as: nil, admin_terms_accepted_at: nil>]>,
     +  :event=>"decidim.events.groups.join_request_created",
    +  :event_class=>Decidim::JoinRequestCreatedEvent,
    +  :extra=>
    +   {:user_group_name=>"Spencer-Waelchi 69", :user_group_nickname=>"3o_820"},
    +  :resource=>
    +    #<Decidim::UserGroup id: 795, email: "usergroup69@example.org", created_at: "2024-03-22 13:06:32.593815395 +0000", updated_at: "2024-03-22 13:06:32.613517911 +0000", decidim_organization_id: 498, name: "Spencer-Waelchi 69", locale: nil, avatar: nil, delete_reason: nil, deleted_at: nil, admin: false, managed: false, roles: [], nickname: "3o_820", personal_url: nil, about: "{\"en\"=>\"<script>alert(\\\"user_group_about\\\");</scri...", accepted_tos_version: nil, newsletter_token: "", newsletter_notifications_at: nil, extended_data: {"document_number"=>"68946586X", "phone"=>"(118) 091-6539 x825", "rejected_at"=>nil, "verified_at"=>nil}, following_count: 0, followers_count: 0, notification_types: "all", session_token: nil, direct_message_types: "all", blocked: false, blocked_at: nil, block_id: nil, email_on_moderations: true, follows_count: 0, notification_settings: {}, notifications_sending_frequency: "daily", digest_sent_at: nil, password_updated_at: nil, previous_passwords: [], officialized_at: nil, officialized_as: nil, admin_terms_accepted_at: nil>}]
 
### :camera: Screenshots
  
![Screenshot of the failing run](https://github.com/decidim/decidim/assets/717367/06c4f49e-fb33-483e-8056-f75f245d881f)

:hearts: Thank you!
