### PR TITLE
Design: Do not translate `text_types` items in forms

### DIFF
--- a/decidim-design/app/views/decidim/design/components/forms.html.erb
+++ b/decidim-design/app/views/decidim/design/components/forms.html.erb
@@ -14,15 +14,15 @@
 
 <%
   text_types = [
-                t(".date"),
-                t(".datetime_local"),
+                "date",
+                "datetime_local",
                 # "email",
                 # "month",
-                t(".number"),
-                t(".password"),
+                "number",
+                "password",
                 # "search",
                 # "tel",
-                t(".text")
+                "text"
                 # "time",
                 # "url",
                 # "week"

--- a/decidim-design/config/locales/en.yml
+++ b/decidim-design/config/locales/en.yml
@@ -45,8 +45,6 @@ en:
         follow:
           title: Follow
         forms:
-          date: date
-          datetime_local: datetime-local
           disabled: Disabled
           emojis: Emojis
           emojis_description: Only works for textarea
@@ -57,10 +55,7 @@ en:
           html_regular_inputs: HTML regular inputs
           min_max_length: Min/Max length
           min_max_length_description: Only works for input type='text' and textarea
-          number: number
-          password: password
           regular_inputs_description: 'Only displays common types, full available list: date, datetime-local, email, month, number, password, search, tel, text, time, url, week'
-          text: text
           textarea_required: textarea required
           title: Forms
         report:


### PR DESCRIPTION
#### :tophat: What? Why?

In `decidim-design/app/views/decidim/design/components/forms.html.erb`, some elements of `text_types` are translated using `t()`, but since these are used as the type attribute values for `<input>` tags, they should not be translated.

#### :pushpin: Related Issues
- Related to #12622

#### Testing

open http://localhost:3000/design/components/forms with local development instance

### :camera: Screenshots

Before (in Japanese):

<img width="736" alt="form-before" src="https://github.com/decidim/decidim/assets/10401/ea5a53a3-eb7e-4645-93fd-1028d2ca19f0">

After:

<img width="702" alt="form-after" src="https://github.com/decidim/decidim/assets/10401/f843838f-e470-4256-b04d-7d0df50aa2fc">


:hearts: Thank you!
