### PR TITLE
Remove ComponentInterface from the ResultType in the API

### DIFF
--- a/decidim-accountability/lib/decidim/api/result_type.rb
+++ b/decidim-accountability/lib/decidim/api/result_type.rb
@@ -3,7 +3,6 @@
 module Decidim
   module Accountability
     class ResultType < Decidim::Api::Types::BaseObject
-      implements Decidim::Core::ComponentInterface
       implements Decidim::Core::CategorizableInterface
       implements Decidim::Comments::CommentableInterface
       implements Decidim::Core::ScopableInterface


### PR DESCRIPTION
#### :tophat: What? Why?
I was doing some investigations on the API and noticed some weird columns at the `ResultType`.

Turned out the `ResultType` is set to implement the `ComponentInterface` which is incorrect. E.g. trying to query the `name` of the result would cause a server error because the results don't have such field available.

#### :pushpin: Related Issues
- Since 0.21.0: #5584

#### Testing
Try to run the following query at the API:

```graphql
{
  participatoryProcesses {
    components(filter: { type: "accountability" }) {
      ... on Accountability {
        results {
          edges {
            node {
              name { translations { locale text } }
            }
          }
        }
      }
    }
  }
}
```

-> See error.