### PR TITLE
Fix issues with the budgets proposals import

### DIFF
--- a/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/import_proposals_to_budgets.rb
@@ -75,7 +75,7 @@ module Decidim
         end
 
         def all_proposals
-          Decidim::Proposals::Proposal.where(component: origin_component).accepted
+          Decidim::Proposals::Proposal.where(component: origin_component).published.not_hidden.not_withdrawn.accepted.order(:published_at)
         end
 
         def origin_component
@@ -87,8 +87,12 @@ module Decidim
           # because otherwise duplicates could be created until the component is
           # published.
           original_proposal.linked_resources(:projects, "included_proposals", component_published: false).any? do |project|
-            project.budget == form.budget
+            component_budgets.exists?(project.decidim_budgets_budget_id)
           end
+        end
+
+        def component_budgets
+          @component_budgets ||= Decidim::Budgets::Budget.where(component: form.budget.component)
         end
       end
     end

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_import_proposals_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_import_proposals_form.rb
@@ -34,7 +34,7 @@ module Decidim
         end
 
         def scope
-          @scope ||= @scope_id ? current_component.scopes.find_by(id: @scope_id) : current_component.scope
+          @scope ||= @attributes["scope_id"].value ? current_component.scopes.find_by(id: @attributes["scope_id"].value) : current_component.scope
         end
 
         def scope_id

--- a/decidim-budgets/spec/forms/decidim/budgets/admin/project_import_proposals_form_spec.rb
+++ b/decidim-budgets/spec/forms/decidim/budgets/admin/project_import_proposals_form_spec.rb
@@ -12,12 +12,14 @@ module Decidim
         let(:component) { project.component }
         let(:origin_component) { create(:proposal_component, participatory_space: component.participatory_space) }
         let(:default_budget) { 1000 }
+        let(:scope_id) { nil }
         let(:import_all_accepted_proposals) { true }
         let(:params) do
           {
             origin_component_id: origin_component.try(:id),
             default_budget:,
-            import_all_accepted_proposals:
+            import_all_accepted_proposals:,
+            scope_id:
           }
         end
 
@@ -58,7 +60,7 @@ module Decidim
           end
         end
 
-        describe "origin_components" do
+        describe "#origin_components" do
           before do
             create(:component, participatory_space: component.participatory_space)
           end
@@ -66,6 +68,44 @@ module Decidim
           it "returns available target components" do
             expect(form.origin_components).to include(origin_component)
             expect(form.origin_components.length).to eq(1)
+          end
+        end
+
+        describe "#scope" do
+          subject { form.scope }
+
+          let(:space_scope) { create(:scope, organization: component.organization) }
+          let(:component_scope) { create(:scope, organization: component.organization, parent: space_scope) }
+          let(:project_scope) { create(:scope, organization: component.organization, parent: component_scope) }
+
+          context "when the scope is not defined" do
+            it "returns nil" do
+              expect(subject).to be_nil
+            end
+
+            context "and the component has a scope" do
+              before do
+                component.participatory_space.update!(scope: space_scope)
+
+                settings = component.settings
+                settings.scope_id = component_scope.id
+                settings.scopes_enabled = true
+                component.settings = settings
+                component.save!
+              end
+
+              it "returns the component's scope" do
+                expect(subject).to eq(component_scope)
+              end
+            end
+          end
+
+          context "when the scope is defined" do
+            let(:scope_id) { project_scope.id }
+
+            it "returns the scope" do
+              expect(subject).to eq(project_scope)
+            end
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
- Fix the scope selection with the proposals to projects import
- Do not import proposal if it is already imported to another budget within the same component
- Only import published and visible proposals

The issue was noticed when importing proposals to projects and using the scope selection. There has been an oversight with the migration done at #8669 as this case was not covered by the specs.

This issue can be seen when the following situation is applied:
- The participatory process has a scope defined
- Scopes are enabled for the budgets component and the default scope is the one defined for the process
- Importing proposals to projects will only import the proposals mapped to the default scope regardless of what was selected from the scopes selector

At the same time, I also noticed few other improvements that are implemented in this PR (see the list above).

#### :pushpin: Related Issues
- Related to #8669

#### Testing
- Create a top scope and some sub-scopes under it
- Create a participatory process and enable the top scope for the process
- Create proposals component and enable the top scope for the component
- Add some proposals to the component and pick scopes for them
- Evaluate some of the proposals as accepted
- Create a budgets component and enable the top scope for the component
- Create 2 budgets with different scopes than the top scope (i.e. one of the subscopes)
  * Make sure you have proposals mapped to those subscopes
- Import proposals to either one of these budgets by selecting the correct scope for them (i.e. the same scope that is defined for that budget)
- Import the proposals
- See that incorrect proposals were imported
