### PR TITLE
Fix clear-text storage of sensitive information in omniauth registration

### DIFF
--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -57,13 +57,11 @@ module Decidim
         # to be marked confirmed.
         @user.skip_confirmation! if !@user.confirmed? && @user.email == verified_email
       else
-        generated_password = SecureRandom.hex
-
         @user.email = (verified_email || form.email)
         @user.name = form.name
         @user.nickname = form.normalized_nickname
         @user.newsletter_notifications_at = nil
-        @user.password = generated_password
+        @user.password = SecureRandom.hex
         if form.avatar_url.present?
           url = URI.parse(form.avatar_url)
           filename = File.basename(url.path)


### PR DESCRIPTION
#### :tophat: What? Why?

There's a CodeQL alert, this PR fixes it. 

#### Testing

Everything should be green

:hearts: Thank you!
