### PR TITLE
Add counter cache for proposals' ValuationAssignments

### DIFF
--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -120,11 +120,11 @@ module Decidim
       }
 
       scope :sort_by_valuation_assignments_count_asc, lambda {
-        order(Arel.sql("#{sort_by_valuation_assignments_count_nulls_last_query} ASC NULLS FIRST").to_s)
+        order(valuation_assignments_count: :asc)
       }
 
       scope :sort_by_valuation_assignments_count_desc, lambda {
-        order(Arel.sql("#{sort_by_valuation_assignments_count_nulls_last_query} DESC NULLS LAST").to_s)
+        order(valuation_assignments_count: :desc)
       }
 
       scope :state_eq, lambda { |state|
@@ -387,18 +387,6 @@ module Decidim
 
       def self.ransack(params = {}, options = {})
         ProposalSearch.new(self, params, options)
-      end
-
-      # Defines the base query so that ransack can actually sort by this value
-      def self.sort_by_valuation_assignments_count_nulls_last_query
-        <<-SQL.squish
-        (
-          SELECT COUNT(decidim_proposals_valuation_assignments.id)
-          FROM decidim_proposals_valuation_assignments
-          WHERE decidim_proposals_valuation_assignments.decidim_proposal_id = decidim_proposals_proposals.id
-          GROUP BY decidim_proposals_valuation_assignments.decidim_proposal_id
-        )
-        SQL
       end
 
       # method to filter by assigned valuator role ID

--- a/decidim-proposals/app/models/decidim/proposals/valuation_assignment.rb
+++ b/decidim-proposals/app/models/decidim/proposals/valuation_assignment.rb
@@ -9,7 +9,8 @@ module Decidim
       include Decidim::Traceable
       include Decidim::Loggable
 
-      belongs_to :proposal, foreign_key: "decidim_proposal_id", class_name: "Decidim::Proposals::Proposal"
+      belongs_to :proposal, foreign_key: "decidim_proposal_id", class_name: "Decidim::Proposals::Proposal",
+                            counter_cache: true
       belongs_to :valuator_role, polymorphic: true
 
       def self.log_presenter_class_for(_log)

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
@@ -56,7 +56,7 @@
   </td>
 
   <td class="valuators-count">
-    <%= proposal.valuation_assignments.count %>
+    <%= proposal.valuation_assignments.size %>
   </td>
 
   <td>

--- a/decidim-proposals/db/migrate/20240404202756_add_valuation_assignments_count_to_decidim_proposals_proposals.rb
+++ b/decidim-proposals/db/migrate/20240404202756_add_valuation_assignments_count_to_decidim_proposals_proposals.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddValuationAssignmentsCountToDecidimProposalsProposals < ActiveRecord::Migration[6.1]
+  def change
+    add_column :decidim_proposals_proposals, :valuation_assignments_count, :integer, default: 0
+
+    reversible do |dir|
+      dir.up do
+        Decidim::Proposals::Proposal.reset_column_information
+        Decidim::Proposals::Proposal.find_each do |record|
+          Decidim::Proposals::Proposal.reset_counters(record.id, :valuation_assignments)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/lib/decidim/proposals/valuatable.rb
+++ b/decidim-proposals/lib/decidim/proposals/valuatable.rb
@@ -8,7 +8,8 @@ module Decidim
       include Decidim::Comments::Commentable
 
       included do
-        has_many :valuation_assignments, foreign_key: "decidim_proposal_id", dependent: :destroy
+        has_many :valuation_assignments, foreign_key: "decidim_proposal_id", dependent: :destroy,
+                                         counter_cache: :valuation_assignments_count, class_name: "Decidim::Proposals::ValuationAssignment"
 
         def valuators
           valuator_role_ids = valuation_assignments.where(proposal: self).pluck(:valuator_role_id)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a small optimization for the Proposals module. We are adding a counter cache on ValuatorAssignments to simplify the sorting query. 

Also fixes the issue reported by @microstudi in #12650: 
```
lib/active_record/sanitization.rb:145:in `disallow_raw_sql!': Query method called with non-attribute argument(s): "( SELECT COUNT(decidim_proposals_valuation_assignments.id) FROM decidim_proposals_valuation_assignments WHERE decidim_proposals_valuation_assignments.decidim_proposal_id = decidim_proposals_proposals.id GROUP BY decidim_proposals_valuation_assignments.decidim_proposal_id ) ASC NULLS FIRST" (ActiveRecord::UnknownAttributeReference)
```

This PR originated from the [comment](https://github.com/decidim/decidim/pull/12650#issuecomment-2023862969), and [comment](https://github.com/decidim/decidim/pull/12650#issuecomment-2026010973)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12650

#### Testing

- Enter the console of any Decidim (`bin/rails c`)
- Run the following: `Decidim::Proposals::Proposal.sort_by_valuation_assignments_count_asc`
- See the error described above
- Apply this fix
- See it working normally

:hearts: Thank you!
