### PR TITLE
Fix DOM text reinterpreted as HTML in budgets' exit handler

### DIFF
--- a/decidim-budgets/app/packs/src/decidim/budgets/exit_handler.js
+++ b/decidim-budgets/app/packs/src/decidim/budgets/exit_handler.js
@@ -68,7 +68,7 @@ $(() => {
     }
 
     $exitLink.attr("href", url);
-    $exitLink.html(exitLinkText);
+    $exitLink.text(exitLinkText);
     window.Decidim.currentDialogs["exit-notification"].open();
   };
 


### PR DESCRIPTION
#### :tophat: What? Why?

Comes from CodeQL warning.  

#### Testing

Everything should be green.

The github security bot should not complain about this change.  

:hearts: Thank you!
