### PR TITLE
Add description for the decidim:reminders:all task

### DIFF
--- a/decidim-core/lib/tasks/decidim_reminders_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_reminders_tasks.rake
@@ -2,7 +2,7 @@
 
 namespace :decidim do
   namespace :reminders do
-    desc "Sends all the email reminders defined in  the manifests"
+    desc "Sends all the email reminders defined in the manifests"
     task :all, [] => :environment do
       Decidim.reminders_registry.all.each do |reminder_manifest|
         call_reminder_job(reminder_manifest)

--- a/decidim-core/lib/tasks/decidim_reminders_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_reminders_tasks.rake
@@ -2,6 +2,7 @@
 
 namespace :decidim do
   namespace :reminders do
+    desc "Sends all the email reminders defined in  the manifests"
     task :all, [] => :environment do
       Decidim.reminders_registry.all.each do |reminder_manifest|
         call_reminder_job(reminder_manifest)


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing #12671, I could not find the reminders task. After seeing the code, I noticed that the description is missing, so it isn't show when doing `bin/rails -T`. This PR fixes it.  

#### Testing

1. Run `bin/rails -T |grep reminder` after and before this PR and see the command not showing/showing up

:hearts: Thank you!
