### PR TITLE
Add design guide page for Tooltips component

### DIFF
--- a/decidim-design/app/views/decidim/design/components/tooltips.html.erb
+++ b/decidim-design/app/views/decidim/design/components/tooltips.html.erb
@@ -1,0 +1,104 @@
+<% content_for :heading do %>
+  <%= t(".title") %>
+<% end %>
+
+<% content_for :description do %>
+  <%= t(".description") %>
+<% end %>
+
+<% content_for :toc do %>
+  <a href="#demo"><%= t(".demo") %></a>
+  <a href="#usage"><%= t(".usage") %></a>
+<% end %>
+
+<section id="demo" class="design__section">
+  <h2><%= t(".demo") %></h2>
+
+  <p><%= t(".demo_description") %></p>
+
+  <table class="design__table">
+    <thead>
+      <th><%= t(".demo") %></th>
+      <th><%= t(".usage") %></th>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <%= with_tooltip("Hello world", class: :top) do %>
+            <span>Hover me</span>
+          <% end %>
+        </td>
+        <td>
+          class: :top
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <%= with_tooltip("Hello world", class: :bottom) do %>
+            <span>Hover me</span>
+          <% end %>
+        </td>
+        <td>
+          class: :bottom
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <%= with_tooltip("Hello world", class: :left) do %>
+            <span>Hover me</span>
+          <% end %>
+        </td>
+        <td>
+          class: :left
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <%= with_tooltip("Hello world", class: :right) do %>
+            <span>Hover me</span>
+          <% end %>
+        </td>
+        <td>
+          class: :right
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="usage" class="design__section">
+  <h2><%= t(".usage") %></h2>
+
+  <p><%= t(".usage_p") %></p>
+
+  <p><%= t(".usage_p_1_html") %></p>
+
+  <p><%= t(".usage_p_2_html") %></p>
+
+  <p><%= t(".usage_p_3_html") %></p>
+
+  <div class="design__section-snippet" style="margin-top: inherit;">
+    <% github_link = "https://github.com/decidim/decidim/blob/develop/decidim-core/app/packs/src/decidim/tooltips.js" %>
+    <p><%= t(".github_source_html", github_link: link_to("decidim-core/app/packs/src/decidim/tooltips.js", github_link, target: "_blank", rel: "noopener noreferrer")) %></p>
+
+    <code>
+      <textarea spellcheck="false" rows="16">
+<%%= with_tooltip("Hello world", class: :top) do %>
+  <span>Hover me</span>
+<%% end %>
+
+<%%= with_tooltip("Hello world", class: :bottom) do %>
+  <span>Hover me</span>
+<%% end %>
+
+<%%= with_tooltip("Hello world", class: :right) do %>
+  <span>Hover me</span>
+<%% end %>
+
+<%%= with_tooltip("Hello world", class: :left) do %>
+  <span>Hover me</span>
+<%% end %>
+      </textarea>
+    </code>
+  </div>
+</section>

--- a/decidim-design/config/locales/en.yml
+++ b/decidim-design/config/locales/en.yml
@@ -71,7 +71,7 @@ en:
           github_source_html: Source code on GitHub %{github_link}
           title: Tooltips
           usage: Usage
-          usage_p: "A tooltip requires the usage of the `with_tooltip` helper, with three arguments:"
+          usage_p: 'A tooltip requires the usage of the `with_tooltip` helper, with three arguments:'
           usage_p_1_html: 1. A string with the value of the tooltip. In the example of this page is "Hello world".
           usage_p_2_html: 2. An optional class with a symbol on where the tooltip will be displayed. Possible values are <code>:top</code>, <code>:bottom</code>, <code>:right</code>, or <code>:left</code>.
           usage_p_3_html: 3. A block with the string that the user needs to hover to be displayed.

--- a/decidim-design/config/locales/en.yml
+++ b/decidim-design/config/locales/en.yml
@@ -64,6 +64,17 @@ en:
           title: Share
         tab_panels:
           title: Tab Panels
+        tooltips:
+          demo: Demo
+          demo_description: For this component to work a participant need to hover on the element.
+          description: A tooltip is a component that users can hover their mouse to have extra information about it.
+          github_source_html: Source code on GitHub %{github_link}
+          title: Tooltips
+          usage: Usage
+          usage_p: "A tooltip requires the usage of the `with_tooltip` helper, with three arguments:"
+          usage_p_1_html: 1. A string with the value of the tooltip. In the example of this page is "Hello world".
+          usage_p_2_html: 2. An optional class with a symbol on where the tooltip will be displayed. Possible values are <code>:top</code>, <code>:bottom</code>, <code>:right</code>, or <code>:left</code>.
+          usage_p_3_html: 3. A block with the string that the user needs to hover to be displayed.
       foundations:
         accessibility:
           accessibility_labels: Accessibility labels

--- a/decidim-design/spec/system/components_spec.rb
+++ b/decidim-design/spec/system/components_spec.rb
@@ -72,4 +72,8 @@ describe "Components" do
   context "when on tab panels page" do
     it_behaves_like "showing the design page", "Tab Panels", "layout_item"
   end
+
+  context "when on tooltips page" do
+    it_behaves_like "showing the design page", "Tooltips", "top"
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

For a fix that I'm working on, I have to create a new Tooltip. As it isn't that obvious how to implement it (I had to use my grep-fu in multiple files) I think it's good to document this in the Decidim Design Guide. This PR adds this page to it.

Note that I didn't used the typical flow of the View Helpers, as this isn't calling to a cell but to a helper itself (i.e. `with_tooltip`), so the cleanest way that I could found is to just create the full table myself. 
 
#### Testing

1. Go to http://localhost:3000/design/components/tooltips and read the docs

### :camera: Screenshots
 
![Screenshot of the Tooltips page in the Decidim Design Guide](https://github.com/decidim/decidim/assets/717367/9f8f559c-3f47-434e-ba07-672d3a0e3928)

:hearts: Thank you!
