### PR TITLE
Show meeting timezone for visitors and participants

### DIFF
--- a/decidim-core/app/cells/decidim/address/online.erb
+++ b/decidim-core/app/cells/decidim/address/online.erb
@@ -1,11 +1,25 @@
-<div class="address__container">
-  <%= icon "map-pin-line" %>
-  <div class="address">
-    <div class="address__location"><%= t(model.type_of_meeting, scope: "decidim.meetings.meetings.filters.type_values") %></div>
-      <% if display_online_meeting_url? %>
-        <a href="<%= model.online_meeting_url %>" target="_blank" rel="noopener noreferrer" class="address__hints underline break-all">
-          <%= model.online_meeting_url %>
-      <% end %>
-    </a>
-  </div>
-</div>
+<ul>
+  <li class="mb-4">
+    <div class="address__container">
+      <%= icon "map-pin-line" %>
+      <div class="address">
+        <div class="address__location"><%= t(model.type_of_meeting, scope: "decidim.meetings.meetings.filters.type_values") %></div>
+        <% if display_online_meeting_url? %>
+          <a href="<%= model.online_meeting_url %>" target="_blank" rel="noopener noreferrer" class="address__hints underline break-all">
+            <%= model.online_meeting_url %>
+          <% end %>
+          </a>
+      </div>
+    </div>
+  </li>
+  <li>
+    <div class="address__container">
+      <%= icon "time-line" %>
+      <div class="address">
+        <div class="address__location">
+          <%= start_and_end_time %>
+        </div>
+      </div>
+    </div>
+  </li>
+</ul>

--- a/decidim-core/app/cells/decidim/address/online.erb
+++ b/decidim-core/app/cells/decidim/address/online.erb
@@ -12,14 +12,16 @@
       </div>
     </div>
   </li>
-  <li>
-    <div class="address__container">
-      <%= icon "time-line" %>
-      <div class="address">
-        <div class="address__location">
-          <%= start_and_end_time %>
+  <% if display_start_and_end_time? %>
+    <li>
+      <div class="address__container">
+        <%= icon "time-line" %>
+        <div class="address">
+          <div class="address__location">
+            <%= start_and_end_time %>
+          </div>
         </div>
       </div>
-    </div>
-  </li>
+    </li>
+  <% end %>
 </ul>

--- a/decidim-core/app/cells/decidim/address/show.erb
+++ b/decidim-core/app/cells/decidim/address/show.erb
@@ -15,13 +15,15 @@
       </div>
     </div>
   </li>
-  <li>
-    <div class="address__container">
-      <%= icon "time-line" %>
-      <div class="address">
-        <div class="address__location">
-          <%= start_and_end_time %>
-      </div>
-    </div>
-  </li>
+  <% if display_start_and_end_time? %>
+    <li>
+      <div class="address__container">
+        <%= icon "time-line" %>
+        <div class="address">
+          <div class="address__location">
+            <%= start_and_end_time %>
+          </div>
+        </div>
+    </li>
+  <% end %>
 </ul>

--- a/decidim-core/app/cells/decidim/address/show.erb
+++ b/decidim-core/app/cells/decidim/address/show.erb
@@ -1,14 +1,27 @@
-<div class="address__container">
-  <%= icon "map-pin-line" %>
-  <div class="address">
-    <% if has_location? %>
-      <div class="address__location"><%= location %></div>
-    <% end %>
+<ul>
+  <li class="mb-4">
+    <div class="address__container">
+      <%= icon "map-pin-line" %>
+      <div class="address">
+        <% if has_location? %>
+          <div class="address__location"><%= location %></div>
+        <% end %>
 
-    <div class="address__address"><%= address %></div>
+        <div class="address__address"><%= address %></div>
 
-    <% if has_location_hints? %>
-      <div class="address__hints"><%= location_hints %></div>
-    <% end %>
-  </div>
-</div>
+        <% if has_location_hints? %>
+          <div class="address__hints"><%= location_hints %></div>
+        <% end %>
+      </div>
+    </div>
+  </li>
+  <li>
+    <div class="address__container">
+      <%= icon "time-line" %>
+      <div class="address">
+        <div class="address__location">
+          <%= start_and_end_time %>
+      </div>
+    </div>
+  </li>
+</ul>

--- a/decidim-core/app/cells/decidim/address_cell.rb
+++ b/decidim-core/app/cells/decidim/address_cell.rb
@@ -31,11 +31,29 @@ module Decidim
       decidim_sanitize_translated(model.address)
     end
 
+    def start_and_end_time
+      <<~HTML
+        #{with_tooltip(l(model.start_time, format: :tooltip)) { start_time }}
+        -
+        #{with_tooltip(l(model.end_time, format: :tooltip)) { end_time }}
+      HTML
+    end
+
     def display_online_meeting_url?
       return true unless model.respond_to?(:online?)
       return true unless model.respond_to?(:iframe_access_level_allowed_for_user?)
 
       model.online? && model.iframe_access_level_allowed_for_user?(current_user)
+    end
+
+    private
+
+    def start_time
+      l model.start_time, format: "%H:%M %p"
+    end
+
+    def end_time
+      l model.end_time, format: "%H:%M %p %Z"
     end
   end
 end

--- a/decidim-core/app/cells/decidim/address_cell.rb
+++ b/decidim-core/app/cells/decidim/address_cell.rb
@@ -31,6 +31,10 @@ module Decidim
       decidim_sanitize_translated(model.address)
     end
 
+    def display_start_and_end_time?
+      model.respond_to?(:start_time) && model.respond_to?(:end_time)
+    end
+
     def start_and_end_time
       <<~HTML
         #{with_tooltip(l(model.start_time, format: :tooltip)) { start_time }}

--- a/decidim-core/app/cells/decidim/card_metadata_cell.rb
+++ b/decidim-core/app/cells/decidim/card_metadata_cell.rb
@@ -101,11 +101,11 @@ module Decidim
       }
     end
 
-    def duration_item
+    def start_date_item
       return if dates_blank?
 
       {
-        text: distance_of_time_in_words(start_date, end_date, scope: "datetime.distance_in_words.short"),
+        text: I18n.l(start_date, format: "%H:%M %p %Z"),
         icon: "time-line"
       }
     end

--- a/decidim-core/app/packs/stylesheets/decidim/_cards.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_cards.scss
@@ -127,13 +127,13 @@
       @apply text-black text-2xl font-bold;
     }
 
-    &-time {
+    &-year {
       @apply text-black text-xs;
     }
 
     &-month,
     &-day,
-    &-time {
+    &-year {
       @apply inline-flex items-center justify-evenly empty:[&>span]:hidden;
     }
   }

--- a/decidim-core/app/packs/stylesheets/decidim/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_layout.scss
@@ -51,18 +51,18 @@
 }
 
 .layout-item {
-  @apply container grid grid-cols-1 md:grid-cols-12 py-4 md:py-24 gap-12 md:gap-x-0;
+  @apply container grid grid-cols-1 lg:grid-cols-12 py-4 lg:py-24 gap-12 lg:gap-x-0;
 
   &__main {
-    @apply lg:col-start-2 md:col-span-8 lg:col-span-7 relative;
+    @apply xl:col-start-2 lg:col-span-8 xl:col-span-7 relative;
   }
 
   &__aside {
-    @apply md:col-start-10 lg:col-start-10 md:col-span-3 lg:col-span-2;
+    @apply lg:col-start-10 xl:col-start-10 lg:col-span-3 xl:col-span-2;
   }
 
   &__back {
-    @apply mb-4 md:mb-0 md:absolute md:-left-[1em] md:-top-8 md:-translate-y-full;
+    @apply mb-4 lg:mb-0 lg:absolute lg:-left-[1em] lg:-top-8 lg:-translate-y-full;
   }
 
   &__arrow {

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2060,6 +2060,7 @@ en:
       long_with_particles: "%B %d, %Y at %H:%M"
       short: "%d/%m/%Y %H:%M"
       time_of_day: "%H:%M"
+      tooltip: "%Y-%m-%d %H:%M %p %Z (GMT %:z)"
   versions:
     directions:
       left: Deletions

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2060,7 +2060,7 @@ en:
       long_with_particles: "%B %d, %Y at %H:%M"
       short: "%d/%m/%Y %H:%M"
       time_of_day: "%H:%M"
-      tooltip: "%Y-%m-%d %H:%M %p %Z (GMT %:z)"
+      tooltip: "%d-%m-%Y %H:%M %p %Z (GMT %:z)"
   versions:
     directions:
       left: Deletions

--- a/decidim-core/spec/cells/decidim/card_metadata_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/card_metadata_cell_spec.rb
@@ -110,11 +110,11 @@ describe Decidim::CardMetadataCell, type: :cell do
       end
     end
 
-    context "when duration_item enabled" do
-      let(:items_list) { [:duration_item] }
+    context "when start_date_item enabled" do
+      let(:items_list) { [:start_date_item] }
 
       context "and one of dates is blank" do
-        let(:start_date) { Date.current }
+        let(:end_date) { Date.current }
 
         it "displays nothing" do
           expect(cell_html.text).to be_blank
@@ -126,7 +126,7 @@ describe Decidim::CardMetadataCell, type: :cell do
         let(:end_date) { 5.days.from_now.at_beginning_of_day }
 
         it "displays the duration" do
-          expect(cell_html).to have_content("1d")
+          expect(cell_html).to have_content("00:00 AM UTC")
         end
       end
     end

--- a/decidim-design/app/helpers/decidim/design/address_helper.rb
+++ b/decidim-design/app/helpers/decidim/design/address_helper.rb
@@ -52,7 +52,7 @@ module Decidim
         Class.new(ApplicationRecord) do
           self.table_name = Decidim::Pages::Page.table_name
 
-          attr_accessor :organization, :location, :address, :latitude, :longitude, :online_meeting_url, :type_of_meeting
+          attr_accessor :organization, :location, :address, :latitude, :longitude, :online_meeting_url, :type_of_meeting, :start_time, :end_time
 
           geocoded_by :address
         end
@@ -64,7 +64,9 @@ module Decidim
           location: "Barcelona",
           address: "Carrer del Pare Llaurador, 113",
           latitude: 40.1234,
-          longitude: 2.1234
+          longitude: 2.1234,
+          start_time: 2.days.from_now,
+          end_time: 2.days.from_now + 4.hours
         )
       end
 
@@ -72,7 +74,9 @@ module Decidim
         addressable_class.new(
           organization: current_organization,
           type_of_meeting: "online",
-          online_meeting_url: "https://meet.jit.si/DecidimTry"
+          online_meeting_url: "https://meet.jit.si/DecidimTry",
+          start_time: 2.days.from_now,
+          end_time: 2.days.from_now + 4.hours
         )
       end
     end

--- a/decidim-design/app/views/decidim/design/components/cards/_static-card-l-meetings.html.erb
+++ b/decidim-design/app/views/decidim/design/components/cards/_static-card-l-meetings.html.erb
@@ -2,7 +2,7 @@
   <time class="card__calendar" datetime="2023-10-07T00:00:00Z">
     <div class="card__calendar-month">Oct</div>
     <div class="card__calendar-day">07</div>
-    <div class="card__calendar-time">00:00</div>
+    <div class="card__calendar-year">2023</div>
   </time>
   <div class="card__list-content">
     <h3 class="h4 card__list-title">

--- a/decidim-design/app/views/decidim/design/components/cards/_static-card-l-meetings.html.erb
+++ b/decidim-design/app/views/decidim/design/components/cards/_static-card-l-meetings.html.erb
@@ -10,12 +10,12 @@
     </h3>
     <div class="card__list-metadata">
       <span>
-        <%= icon("home-wifi-line") %>
-        Hybrid
+        <%= icon("time-line") %>
+        14:00 PM CEST
       </span>
       <span>
-        <%= icon("time-line") %>
-        16d
+        <%= icon("home-wifi-line") %>
+        Hybrid
       </span>
       <span data-comments-count="">
         <%= icon("wechat-line") %>

--- a/decidim-meetings/app/cells/decidim/meetings/dates_and_map/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/dates_and_map/show.erb
@@ -10,10 +10,8 @@
       <span class="meeting__calendar-separator"><%= "-" if !same_day? || !same_month? %></span>
       <span><%= l(end_time, format: "%d") if !same_day? || !same_month? %></span>
     </div>
-    <div class="meeting__calendar-time">
-      <time datetime="<%= start_time.iso8601 %>"><%= l(start_time, format: "%H:%M") %></time>
-      <span class="meeting__calendar-separator"><%= "-" %></span>
-      <time datetime="<%= end_time.iso8601 %>"><%= l(end_time, format: "%H:%M") %></time>
+    <div class="meeting__calendar-year">
+      <span><%= year %></span>
     </div>
   </div>
 

--- a/decidim-meetings/app/cells/decidim/meetings/dates_and_map_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/dates_and_map_cell.rb
@@ -17,6 +17,10 @@ module Decidim
         return render :static_map if display_map?
       end
 
+      def year
+        l model.start_time, format: "%Y"
+      end
+
       private
 
       def same_month?

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_card_metadata_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_card_metadata_cell.rb
@@ -20,7 +20,7 @@ module Decidim
       private
 
       def meeting_items
-        [type, duration_item, comments_count_item, category_item, withdrawn_item]
+        [start_date_item, type, comments_count_item, category_item, withdrawn_item]
       end
 
       def meeting_items_for_map

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_l/image.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_l/image.erb
@@ -1,5 +1,5 @@
 <time class="card__calendar" datetime="<%= meeting.start_time.iso8601 %>">
   <div class="card__calendar-month"><%= l(meeting.start_time, format: "%b") %></div>
   <div class="card__calendar-day"><%= l(meeting.start_time, format: "%d") %></div>
-  <div class="card__calendar-time"><%= l(meeting.start_time, format: "%H:%M") %></div>
+  <div class="card__calendar-year"><%= l(meeting.start_time, format: "%Y") %></div>
 </time>

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -40,13 +40,13 @@
       @apply text-black text-2xl font-bold;
     }
 
-    &-time {
+    &-year {
       @apply text-black text-xs;
     }
 
     &-month,
     &-day,
-    &-time {
+    &-year {
       @apply inline-flex items-center justify-evenly empty:[&>span]:hidden;
     }
 
@@ -66,7 +66,7 @@
       @apply text-5xl;
     }
 
-    &__lg &-time {
+    &__lg &-year {
       @apply text-md pb-2;
     }
   }

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -13,7 +13,7 @@
     }
 
     &-container {
-      @apply grid grid-cols-[auto_1fr] md:grid-cols-[auto_1fr_1fr] items-center gap-0 md:gap-x-5 border-4 border-background rounded md:h-[120px] overflow-hidden;
+      @apply grid grid-cols-[auto_1fr] md:grid-cols-[auto_1fr_1fr] items-center gap-0 md:gap-x-5 border-4 border-background rounded md:h-[140px] overflow-hidden;
 
       > *:nth-child(2) {
         @apply p-4 md:p-0;
@@ -28,7 +28,7 @@
       }
 
       > *:nth-child(3) {
-        @apply order-1 md:order-2 h-[116px] md:h-full;
+        @apply order-1 md:order-2 h-[135px] md:h-full;
       }
     }
 
@@ -55,7 +55,7 @@
     }
 
     &__lg {
-      @apply w-fit justify-center [&>*]:px-2;
+      @apply w-fit justify-center [&>*]:px-2 min-w-24 h-[8.5rem];
     }
 
     &__lg &-month {

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -446,12 +446,27 @@ describe "Explore meetings", :slow do
       expect(page).to have_i18n_content(meeting.location_hints, strip_tags: true)
       expect(page).to have_content(meeting.address)
       expect(page).to have_content(meeting.reference)
+      expect(page).to have_content(I18n.l(meeting.start_time, format: "%H:%M"))
+      expect(page).to have_content(I18n.l(meeting.end_time, format: "%H:%M"))
+      expect(page).to have_content("UTC")
 
       within ".meeting__calendar-day" do
         expect(page).to have_content(date.day)
       end
-      within ".meeting__calendar-time" do
-        expect(page).to have_content(/00:00\s-\s23:59/)
+      within ".meeting__calendar-year" do
+        expect(page).to have_content(/20\d\d/)
+      end
+    end
+
+    context "when the organization has a different timezone" do
+      before do
+        organization.update!(time_zone: "Hawaii")
+
+        visit resource_locator(meeting).path
+      end
+
+      it "shows the correct time zone" do
+        expect(page).to have_content("HST")
       end
     end
 

--- a/decidim-meetings/spec/system/meeting_spec.rb
+++ b/decidim-meetings/spec/system/meeting_spec.rb
@@ -124,11 +124,11 @@ describe "Meeting", download: true do
   context "when the meeting is the same as the current year" do
     let(:meeting) { create(:meeting, :published, component:, start_time: Time.current) }
 
-    it "does not show the year" do
+    it "shows the year" do
       visit_meeting
 
       within ".meeting__calendar-container .meeting__calendar" do
-        expect(page).to have_no_content(meeting.start_time.year)
+        expect(page).to have_content(meeting.start_time.year)
       end
     end
   end

--- a/decidim-meetings/spec/system/show_spec.rb
+++ b/decidim-meetings/spec/system/show_spec.rb
@@ -17,5 +17,21 @@ describe "show" do
     it "shows the meeting title" do
       expect(page).to have_content meeting.title[I18n.locale.to_s]
     end
+
+    it "shows correct the time zone" do
+      expect(page).to have_content("UTC")
+    end
+
+    context "when the organization has a different timezone" do
+      before do
+        organization.update!(time_zone: "Hawaii")
+
+        visit resource_locator(meeting).path
+      end
+
+      it "shows the correct time zone" do
+        expect(page).to have_content("HST")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

A couple of months ago, we had an online meeting with Metadecidim. It wasn't clear even inside of the Decidim team if the hour that we have published the meeting was in UTC/GMT or in CET (Central European Time UTC+1 in that moment).

For fixing that, we discussed that the timezone should be somewhat visible, at least in the meeting information. We should see in a case by case basis if it makes sense in other places too. See #12567 for more details on what we've talked about. 

Some decisions that I've talked with @carolromero that we departed to what we've discussed there:

1. We will not show the offset from GMT/UTC (i.e. +01:00) as that brings noise.
2. This is extra information is visible as a tooltip in the start/end time of the show page
3. We didn't apply this tooltip extra information in the meeting index page as it's too noise while hovering different elements 

#### :pushpin: Related Issues
 
- Fixes #12567

#### Testing

1. Sign in as admin
4. Change the organization timezone
5. Create a meeting
6. Go to the meeting index (i.e. the list of the meetings) and show page (i.e. the individual page for the meeting).
7. Change the viewport size to check that the responsiveness doesn't break 
8. Edit the meeting to reflect different meetings configurations:
  6.1. Meeting with multiple days (i.e. start and end date are different)
  6.2. Different types of meetings:
    * Online meeting
    * In person meeting
    * Hybrid meeting

### :camera: Screenshots

![Meetings in the index page](https://github.com/decidim/decidim/assets/717367/02f74965-8b6b-4345-b91e-c2ea89ff8f61)
![Meeting in the show page](https://github.com/decidim/decidim/assets/717367/a00dbff0-1875-48ec-bcb4-78b05d489dd4)
![Meeting in the show page with a narrower viewport](https://github.com/decidim/decidim/assets/717367/346d0a00-b4f7-4c29-8465-a1dc3304e1c6)


:hearts: Thank you!
