### PR TITLE
Hide last activities on breadcrumb dropdown when organization is configured to force authentication

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/menu_breadcrumb_last_activity_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/menu_breadcrumb_last_activity_cell.rb
@@ -5,6 +5,12 @@ module Decidim
     # A cell to be rendered as a content block with the latest activities performed
     # in a Decidim Organization.
     class MenuBreadcrumbLastActivityCell < LastActivityCell
+      def show
+        return if current_user.blank? && current_organization.force_users_to_authenticate_before_access_organization
+
+        super
+      end
+
       private
 
       def activities

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -287,6 +287,37 @@ describe "Homepage" do
         end
       end
 
+      context "when organization forces users to authenticate before access" do
+        let(:organization) do
+          create(
+            :organization,
+            official_url:,
+            force_users_to_authenticate_before_access_organization: true
+          )
+        end
+
+        context "when there are site activities and user is not authenticated" do
+          let(:participatory_space) { create(:participatory_process, organization:) }
+          let(:component) do
+            create(:component, :published, participatory_space:)
+          end
+          let(:commentable) { create(:dummy_resource, component:) }
+          let(:comment) { create(:comment, commentable:) }
+          let!(:action_log) do
+            create(:action_log, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: comment, organization:, participatory_space:)
+          end
+
+          before do
+            visit current_path
+            find_by_id("main-dropdown-summary").hover
+          end
+
+          it "does not show last activity section on menu bar main dropdown" do
+            expect(page).to have_no_link("Last activity")
+          end
+        end
+      end
+
       describe "includes statistics" do
         let!(:users) { create_list(:user, 4, :confirmed, organization:) }
         let!(:participatory_process) do


### PR DESCRIPTION
#### :tophat: What? Why?

This PR avoids showing last activity section on menu breadcrumb when user is not authenticated and the organization is configured to force authentication of users before accessing the organization in the sign in page.

Includes a test to check the section is not shown under those conditions

#### :pushpin: Related Issues

- Fixes #12591

#### Testing

Configure the organization to force users to authenticate before access it and enter to the application not signed in. The menu breadcrumb dropdown on the sign in page should not include the "Last activity" block.

:hearts: Thank you!
