### PR TITLE
Fix saving date fields on forms

### DIFF
--- a/decidim-core/lib/decidim/attributes/time_with_zone.rb
+++ b/decidim-core/lib/decidim/attributes/time_with_zone.rb
@@ -19,7 +19,7 @@ module Decidim
         fallback = super
         return fallback unless fallback.is_a?(Time)
 
-        ActiveSupport::TimeWithZone.new(fallback, Time.zone)
+        Time.zone.parse(fallback.strftime("%F %T"))
       end
     end
   end

--- a/decidim-core/spec/lib/attributes/time_with_timezone_spec.rb
+++ b/decidim-core/spec/lib/attributes/time_with_timezone_spec.rb
@@ -21,14 +21,42 @@ module Decidim
         end
       end
 
-      context "when given a String" do
-        let(:value) { "01/02/2017 15:00" }
-
-        context "with a different timezone" do
+      shared_context "with date and time parsing" do
+        context "and timezone offset" do
           it "parses the String in the correct timezone" do
             Time.use_zone("CET") do
               expect(subject.utc.to_s).to eq("2017-02-01 14:00:00 UTC")
             end
+          end
+        end
+
+        context "and no timezone offset" do
+          it "parses the String in the correct timezone" do
+            expect(subject.utc.to_s).to eq("2017-02-01 15:00:00 UTC")
+          end
+        end
+      end
+
+      context "when given a String" do
+        context "with formatted DateTime" do
+          context "when d/m/Y" do
+            let(:value) { "01/02/2017 15:00" }
+            include_context "with date and time parsing"
+          end
+
+          context "when Y-m-d HH:MM" do
+            let(:value) { "2017-02-01 15:00" }
+            include_context "with date and time parsing"
+          end
+
+          context "when Y-m-d HH:MM:SS TZ" do
+            let(:value) { "2017-02-01 16:00:00 +01:00" }
+            include_context "with date and time parsing"
+          end
+
+          context "when %Y-%m-%d %H:%M:%S.%N %z" do
+            let(:value) { "2017-02-01 16:00:00.000000000 +0100" }
+            include_context "with date and time parsing"
           end
         end
 

--- a/decidim-core/spec/lib/attributes/time_with_timezone_spec.rb
+++ b/decidim-core/spec/lib/attributes/time_with_timezone_spec.rb
@@ -41,21 +41,25 @@ module Decidim
         context "with formatted DateTime" do
           context "when d/m/Y" do
             let(:value) { "01/02/2017 15:00" }
+
             include_context "with date and time parsing"
           end
 
           context "when Y-m-d HH:MM" do
             let(:value) { "2017-02-01 15:00" }
+
             include_context "with date and time parsing"
           end
 
           context "when Y-m-d HH:MM:SS TZ" do
             let(:value) { "2017-02-01 16:00:00 +01:00" }
+
             include_context "with date and time parsing"
           end
 
           context "when %Y-%m-%d %H:%M:%S.%N %z" do
             let(:value) { "2017-02-01 16:00:00.000000000 +0100" }
+
             include_context "with date and time parsing"
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?
While investigating the fix for #12518 with @greenwoodt, we have noticed that the database record is being persitsted as it should, while the frontend data is being displayed respecting the organization timezone settings. However, when the dates are being saved to database the Organization timezone offset is always added to the submitted data. 

Upon further investigation, we noticed that the issue may be cause by the date-time parsing of the user input, which made us conclude that user was submitting his local time, but the server was parsing it as UTC, to which, adds again the Offset. However this is not happening all the time, but only when parsing the format `"%d/%m/%Y %H:%M"` (time.formats.decidim_short) fails.

Setting the datetime fields in 0.28 and 0.29 is using a different field value, set to `%FT%R` (2007-11-19T08:37) and this means the parting by the format `"%d/%m/%Y %H:%M"`  will always fail, defaulting to the code i just modified.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/decidim/decidim/issues/12567
- Fixes #12518

#### Testing
1. Visit the admin panel 
2. Visit organization settings and Set organization timezone to something else that UTC 
3. After that, navigate to processes, components and find a meeting 
4. Edit a meeting ( and check start and end time ) 
5. Observe how the time is being set in the future by the Timezone offset 
6. Apply patch & restart the server 
7. repeat 3 & 4 
8. Check that the time remains unchanged & repeat several times 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
