### PR TITLE
Fix layout in Safari when there are few elements in the page

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_layout.scss
@@ -38,7 +38,7 @@
   }
 
   &__main {
-    @apply col-span-8 lg:col-span-9 bg-white md:pl-16 py-6 md:py-12;
+    @apply col-span-8 lg:col-span-9 bg-white md:pl-16 py-6 md:py-12 min-h-[60vh];
   }
 
   &__reverse &__aside {

--- a/decidim-core/app/packs/stylesheets/decidim/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_layout.scss
@@ -6,7 +6,7 @@
   }
 
   [data-content] {
-    @apply min-h-[60vh] relative flex flex-col;
+    @apply relative flex flex-col;
   }
 }
 
@@ -31,7 +31,7 @@
 }
 
 .layout-2col {
-  @apply md:grid grid-cols-12 container grow min-h-[60vh];
+  @apply md:grid grid-cols-12 container grow auto-rows-max;
 
   &__aside {
     @apply col-span-4 lg:col-span-3 md:pr-16 py-6 md:py-12 gap-6 md:gap-12 flex flex-col justify-between items-start md:justify-start before:content-[''] before:absolute before:top-0 before:left-0 before:h-full before:w-1/2 before:-z-10 md:before:bg-background;


### PR DESCRIPTION
#### :tophat: What? Why?
Solve a layout issue regarding safari and the layout-2col.
Safari tends to expand the content of layout-2col (layout-2col__main and layout-2col__aside) to 100vh, overlapping the footer.

The fix does:
1. Reintroduce the grid-auto-max for the layout-2col;
2. eliminates the min-h-[60vh] from both layout-2col and is container;
3. set min-h-[60vh] for layout-2col__main

Tested on Mac and Windows (safari, chromium browsers, firefox, opera)

#### :pushpin: Related Issues
*Link your PR to an issue*
https://github.com/decidim/decidim/issues/12687
https://github.com/decidim/decidim/pull/12156
https://github.com/decidim/decidim/pull/11821

#### Testing
Open with Safari
https://nightly.decidim.org/processes
https://nightly.decidim.org/assemblies
https://nightly.decidim.org/conferences

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

I've eliminated the content from aside and main to replicate the min-height issue.

![Screenshot 2024-04-11 at 13 18 32](https://github.com/decidim/decidim/assets/63818661/5a78fddd-4ef5-4a9e-a7c8-84f7a3d6fba8)
![Screenshot 2024-04-11 at 13 18 45](https://github.com/decidim/decidim/assets/63818661/c31f9a7c-5472-4c57-8a20-cd56687f594b)
![Screenshot 2024-04-11 at 13 18 03](https://github.com/decidim/decidim/assets/63818661/8c93731d-7a13-43d3-b87d-6ceb946cd11b)
![Screenshot 2024-04-11 at 13 18 17](https://github.com/decidim/decidim/assets/63818661/fa9404a9-be43-47cd-aa89-ef45014e8a09)


:hearts: Thank you!
