### PR TITLE
Remove unused helpers from assemblies

### DIFF
--- a/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
+++ b/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
@@ -12,32 +12,6 @@ module Decidim
       include Decidim::FiltersHelper
       include FilterAssembliesHelper
 
-      # Public: Returns the characteristics of an assembly in a readable format like
-      # "title: close, no public, no transparent and is restricted to the members of the assembly"
-      # deprecated
-      def participatory_processes_for_assembly(assembly_participatory_processes)
-        html = ""
-        html += %( <div class="section"> ).html_safe
-        html += %( <h4>#{t("assemblies.show.related_participatory_processes", scope: "decidim")}</h4> ).html_safe
-        html += %( <div class="row small-up-1 medium-up-2 card-grid"> ).html_safe
-        assembly_participatory_processes.each do |assembly_participatory_process|
-          html += render partial: "decidim/participatory_processes/participatory_process", locals: { participatory_process: assembly_participatory_process }
-        end
-        html += %( </div> ).html_safe
-        html += %( </div> ).html_safe
-
-        html.html_safe
-      end
-
-      def assembly_features(assembly)
-        html = "".html_safe
-        html += "<strong>#{translated_attribute(assembly.title)}: </strong>".html_safe
-        html += t("assemblies.show.private_space", scope: "decidim").to_s.html_safe
-        html += ", #{t("assemblies.show.is_transparent.#{assembly.is_transparent}", scope: "decidim")}".html_safe if assembly.is_transparent?
-        html += " #{decidim_sanitize_editor translated_attribute(assembly.special_features)}".html_safe
-        html.html_safe
-      end
-
       # Items to display in the navigation of an assembly
       def assembly_nav_items(participatory_space)
         components = participatory_space.components.published.or(Decidim::Component.where(id: try(:current_component)))

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -397,11 +397,7 @@ en:
       show:
         assembly_type: Assembly type
         duration: Duration
-        is_transparent:
-          'false': opaque
-          'true': transparent
         private_space: This is a private assembly
-        related_participatory_processes: Related participatory processes
         social_networks_title: Visit assembly on
     assembly_members:
       assembly_member:


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing #12547 I noticed some helpers that were no longer used in v0.28. This PR removes them.

They were only used in https://github.com/decidim/decidim/blob/develop/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb 
 
#### Testing

Everything in the pipeline should pass, specially the assemblies related actions 

:hearts: Thank you!
