### PR TITLE
Fix tab usage in comment action menu

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -37,13 +37,13 @@
             </li>
             <% if model.authored_by?(current_user) %>
               <li>
-                <button type="button" class="dropdown__item" data-dialog-open="<%= "editCommentModal#{model.id}" %>" title="<%= t("decidim.components.comment.edit") %>" aria-controls="<%= "editCommentModal#{model.id}" %>" aria-haspopup="dialog" tabindex="2">
+                <button type="button" class="dropdown__item" data-dialog-open="<%= "editCommentModal#{model.id}" %>" title="<%= t("decidim.components.comment.edit") %>" aria-controls="<%= "editCommentModal#{model.id}" %>" aria-haspopup="dialog">
                   <%= icon "edit-line" %>
                   <span><%= t("decidim.components.comment.edit") %></span>
                 </button>
               </li>
               <li>
-                <%= link_to comment_path, remote: true, method: :delete, class: "dropdown__item", data: { confirm: t("decidim.components.comment.confirm_destroy") }, tabindex: 3 do %>
+                <%= link_to comment_path, remote: true, method: :delete, class: "dropdown__item", data: { confirm: t("decidim.components.comment.confirm_destroy") } do %>
                   <%= icon "delete-bin-line" %>
                   <span><%= t("decidim.components.comment.delete") %></span>
                 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
While checking the accessibility on the Comision platform, the QA engineer noticed that menus "edit" & "delete" from comment action menu are not found when using "Tab" key to navigate that menu. I also noticed this issue when i have reviewed #12513

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12513

#### Testing

1. Using a chrome extension like [Screen Reader](https://chromewebstore.google.com/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn): 
2. Access the proposal / meeting detail page 
3. Go to Comments section and add a reply
4. Navigate using the tool, and see that it should say something like : 
  - Comments control menu list with 4 items
  - Report, button list item
  - Get link, link list item
  - Edit, button list item
  - Delete, link list item

:hearts: Thank you!
