### PR TITLE
Fix class of `Decidim::Assemblies::ContentBlocks::DatesMetadataCell#space_presenter`

### DIFF
--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/dates_metadata_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/dates_metadata_cell.rb
@@ -11,7 +11,7 @@ module Decidim
         end
 
         def space_presenter
-          AssemblyPresenter
+          Decidim::Assemblies::AssemblyPresenter
         end
 
         def translations_scope

--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/extra_data_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/extra_data_cell.rb
@@ -13,7 +13,7 @@ module Decidim
         end
 
         def presented_resource
-          AssemblyPresenter.new(resource)
+          Decidim::Assemblies::AssemblyPresenter.new(resource)
         end
 
         def type_item

--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/metadata_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/metadata_cell.rb
@@ -11,7 +11,7 @@ module Decidim
         end
 
         def space_presenter
-          AssemblyPresenter
+          Decidim::Assemblies::AssemblyPresenter
         end
 
         def translations_scope


### PR DESCRIPTION
#### :tophat: What? Why?

In `Decidim::Assemblies::ContentBlocks::DatesMetadataCell` it seems that when abbreviated class names are used, the search for class names (constants) sometimes fails. Therefore, I will modify it to use unabbreviated class names.

#### :pushpin: Related Issues
- Fixes #12692

#### Testing

This issue does not always occur, so the reproduction method written in the original issue does not always reproduce the issue. However, it seemed to no longer reproduce after several attempts.
Note that I was using v0.28.0 in the reproduction environment.

### :camera: Screenshots

When the error does not occur, the assembly is displayed correctly.

<img alt="screen shot" src="https://github.com/decidim/decidim/assets/10401/a743c2d2-f446-46a0-bbf5-5926d83f55a0">


:hearts: Thank you!
