### PR TITLE
Fix user profile current tab

### DIFF
--- a/decidim-core/app/cells/decidim/profile/tabs.erb
+++ b/decidim-core/app/cells/decidim/profile/tabs.erb
@@ -1,6 +1,7 @@
 <% tab_items.each do |tab_item| %>
-  <li class="profile__tab<%= " is-active" if is_active_link?(tab_item[:path]) %>">
-    <%= link_to tab_item[:path], title: tab_item[:text], class: "profile__tab-item" do %>
+  <% active_link = is_active_link?(tab_item[:path]) %>
+  <li class="profile__tab<%= " is-active" if active_link %>">
+    <%= link_to tab_item[:path], title: tab_item[:text], class: "profile__tab-item", aria: { current: active_link ? "page" : nil } do %>
       <%= icon tab_item[:icon] %>
       <span><%= tab_item[:text] %></span>
       <% if tab_item[:count].present? %>

--- a/decidim-core/app/helpers/decidim/user_profile_helper.rb
+++ b/decidim-core/app/helpers/decidim/user_profile_helper.rb
@@ -14,9 +14,13 @@ module Decidim
     #
     # Returns a String with the menu tab.
     def user_profile_tab(text, link, options = {})
-      active = is_active_link?(link, (options[:aria_link_type] || :inclusive))
+      aria = {}
+      if is_active_link?(link, (options[:aria_link_type] || :inclusive))
+        cls << "is-active"
+        aria[:current] = "page"
+      end
 
-      content_tag(:li, class: "tabs-title#{active ? " is-active" : nil}") do
+      content_tag(:li, class: cls.join(" "), aria:) do
         link_to(text, link, options)
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
The user profile page does not mark the current tab correctly with the `aria-current="page"` attribute.

This fixes the issue.

#### Testing
- Go to any of the user profile pages (e.g. `/profiles/{username}/activity`)
- Check with the inspect element that the current tab's link is marked with `aria-current="page"`
- Check that none of the inactive links are marked with `aria-current="page"`
- Browse through the tabs
- See that the current page is always marked correctly