### PR TITLE
Remove unused helpers from initiatives

### DIFF
--- a/decidim-initiatives/app/helpers/decidim/initiatives/initiative_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/initiative_helper.rb
@@ -7,18 +7,6 @@ module Decidim
       include Decidim::SanitizeHelper
       include Decidim::ResourceVersionsHelper
 
-      # Public: The css class applied based on the initiative state to
-      #         the initiative badge.
-      #
-      # initiative - Decidim::Initiative
-      #
-      # Returns a String.
-      def state_badge_css_class(initiative)
-        return "success" if initiative.accepted?
-
-        "warning"
-      end
-
       def metadata_badge_css_class(initiative)
         case initiative
         when "accepted", "published"
@@ -32,17 +20,6 @@ module Decidim
         end
       end
 
-      # Public: The state of an initiative in a way a human can understand.
-      #
-      # initiative - Decidim::Initiative.
-      #
-      # Returns a String.
-      def humanize_state(initiative)
-        I18n.t(initiative.accepted? ? "accepted" : "expired",
-               scope: "decidim.initiatives.states",
-               default: :expired)
-      end
-
       # Public: The state of an initiative from an administration perspective in
       # a way that a human can understand.
       #
@@ -51,51 +28,6 @@ module Decidim
       # Returns a String
       def humanize_admin_state(state)
         I18n.t(state, scope: "decidim.initiatives.admin_states", default: :created)
-      end
-
-      def popularity_tag(initiative)
-        content_tag(:div, class: "extra__popularity popularity #{popularity_class(initiative)}".strip) do
-          5.times do
-            concat(content_tag(:span, class: "popularity__item") do
-              # empty block
-            end)
-          end
-
-          concat(content_tag(:span, class: "popularity__desc") do
-            I18n.t("decidim.initiatives.initiatives.vote_cabin.supports_required",
-                   total_supports: initiative.scoped_type.supports_required)
-          end)
-        end
-      end
-
-      def popularity_class(initiative)
-        return "popularity--level1" if popularity_level1?(initiative)
-        return "popularity--level2" if popularity_level2?(initiative)
-        return "popularity--level3" if popularity_level3?(initiative)
-        return "popularity--level4" if popularity_level4?(initiative)
-        return "popularity--level5" if popularity_level5?(initiative)
-
-        ""
-      end
-
-      def popularity_level1?(initiative)
-        initiative.percentage.positive? && initiative.percentage < 40
-      end
-
-      def popularity_level2?(initiative)
-        initiative.percentage >= 40 && initiative.percentage < 60
-      end
-
-      def popularity_level3?(initiative)
-        initiative.percentage >= 60 && initiative.percentage < 80
-      end
-
-      def popularity_level4?(initiative)
-        initiative.percentage >= 80 && initiative.percentage < 100
-      end
-
-      def popularity_level5?(initiative)
-        initiative.percentage >= 100
       end
 
       def authorized_create_modal_button(type, html_options, &)
@@ -138,12 +70,6 @@ module Decidim
 
       def can_edit_custom_signature_end_date?(initiative)
         return false unless initiative.custom_signature_end_date_enabled?
-
-        initiative.created? || initiative.validating?
-      end
-
-      def can_edit_area?(initiative)
-        return false unless initiative.area_enabled?
 
         initiative.created? || initiative.validating?
       end

--- a/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
@@ -19,13 +19,6 @@ module Decidim
 
       private
 
-      # Creates a unique namespace for a filter form to prevent duplicate IDs in
-      # the DOM when multiple filter forms are rendered with the same fields (e.g.
-      # for desktop and mobile).
-      def filter_form_namespace
-        "filters_#{SecureRandom.uuid}"
-      end
-
       # i18n-tasks-use t('decidim.initiatives.initiatives.filters.state')
       # i18n-tasks-use t('decidim.initiatives.initiatives.filters.scope')
       # i18n-tasks-use t('decidim.initiatives.initiatives.filters.type')

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -542,7 +542,6 @@ en:
           other: " signatures"
         vote_cabin:
           already_voted: Already signed
-          supports_required: "%{total_supports} signatures required"
           verification_required: Verify your account to sign the initiative
           vote: Sign
           votes_blocked: Signing disabled

--- a/decidim-initiatives/spec/helpers/decidim/initiatives/initiative_helper_spec.rb
+++ b/decidim-initiatives/spec/helpers/decidim/initiatives/initiative_helper_spec.rb
@@ -5,38 +5,6 @@ require "spec_helper"
 module Decidim
   module Initiatives
     describe InitiativeHelper do
-      context "with state_badge_css_class" do
-        let(:initiative) { create(:initiative) }
-
-        it "success for accepted initiatives" do
-          allow(initiative).to receive(:accepted?).and_return(true)
-
-          expect(helper.state_badge_css_class(initiative)).to eq("success")
-        end
-
-        it "warning in any other case" do
-          allow(initiative).to receive(:accepted?).and_return(false)
-
-          expect(helper.state_badge_css_class(initiative)).to eq("warning")
-        end
-      end
-
-      context "with humanize_state" do
-        let(:initiative) { create(:initiative) }
-
-        it "accepted for accepted state" do
-          allow(initiative).to receive(:accepted?).and_return(true)
-
-          expect(helper.humanize_state(initiative)).to eq(I18n.t("accepted", scope: "decidim.initiatives.states"))
-        end
-
-        it "expired in any other case" do
-          allow(initiative).to receive(:accepted?).and_return(false)
-
-          expect(helper.humanize_state(initiative)).to eq(I18n.t("expired", scope: "decidim.initiatives.states"))
-        end
-      end
-
       context "with humanize_admin_state" do
         let(:available_states) { [:created, :validating, :discarded, :published, :rejected, :accepted] }
 
@@ -44,35 +12,6 @@ module Decidim
           available_states.each do |state|
             expect(humanize_admin_state(state)).not_to be_blank
           end
-        end
-      end
-
-      context "with popularity_tag" do
-        let(:initiative) { build(:initiative) }
-
-        it "level1 from 0% to 40%" do
-          expect(initiative).to receive(:percentage).at_least(:once).and_return(20)
-          expect(popularity_tag(initiative)).to include("popularity--level1")
-        end
-
-        it "level2 from 40% to 60%" do
-          expect(initiative).to receive(:percentage).at_least(:once).and_return(50)
-          expect(popularity_tag(initiative)).to include("popularity--level2")
-        end
-
-        it "level3 from 60% to 80%" do
-          expect(initiative).to receive(:percentage).at_least(:once).and_return(70)
-          expect(popularity_tag(initiative)).to include("popularity--level3")
-        end
-
-        it "level4 from 80% to 100%" do
-          expect(initiative).to receive(:percentage).at_least(:once).and_return(90)
-          expect(popularity_tag(initiative)).to include("popularity--level4")
-        end
-
-        it "level5 at 100%" do
-          expect(initiative).to receive(:percentage).at_least(:once).and_return(100)
-          expect(popularity_tag(initiative)).to include("popularity--level5")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing the codebase, I found some dead code in Initiatives: some helpers that weren't referenced anywhere. 

#### Testing

Everything should be green 

:hearts: Thank you!
