### PR TITLE
Prevent malformed URLs in the general search

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/paginable.rb
+++ b/decidim-core/app/controllers/concerns/decidim/paginable.rb
@@ -19,7 +19,7 @@ module Decidim
 
       def per_page
         if OPTIONS.include?(params[:per_page])
-          params[:per_page]
+          params[:per_page].to_i
         elsif params[:per_page]
           sorted = OPTIONS.sort
           params[:per_page].to_i.clamp(sorted.first, sorted.last)

--- a/decidim-core/app/helpers/decidim/cells_paginate_helper.rb
+++ b/decidim-core/app/helpers/decidim/cells_paginate_helper.rb
@@ -14,7 +14,7 @@ module Decidim
     end
 
     def per_page
-      params[:per_page] || Decidim::Paginable::OPTIONS.first
+      params[:per_page].to_i || Decidim::Paginable::OPTIONS.first
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/paginate_helper.rb
+++ b/decidim-core/app/helpers/decidim/paginate_helper.rb
@@ -20,7 +20,7 @@ module Decidim
     end
 
     def per_page
-      params[:per_page] || Decidim::Paginable::OPTIONS.first
+      params[:per_page].to_i || Decidim::Paginable::OPTIONS.first
     end
   end
 end

--- a/decidim-core/spec/system/search_spec.rb
+++ b/decidim-core/spec/system/search_spec.rb
@@ -67,4 +67,21 @@ describe "Search" do
       expect(page).to have_css("#input-search-mobile")
     end
   end
+
+  context "when there is a malformed URL" do
+    let(:participatory_space) { create(:participatory_process, :published, :with_steps, organization:) }
+    let!(:proposal_component) { create(:proposal_component, participatory_space:) }
+    let!(:proposals) { create_list(:proposal, 11, component: proposal_component) }
+
+    before do
+      proposals.each { |s| s.update(published_at: Time.current) }
+    end
+
+    it "displays the results page" do
+      visit %{/search?filter[with_resource_type]=Decidim::Proposals::Proposal&page=2&per_page=10'"()%26%25<zzz><ScRiPt >alert("XSS")</ScRiPt>}
+
+      expect(page).to have_content("22 Results for the search")
+      expect(page).to have_content("Results per page")
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

There are some malformed URLs that can produce problems in the general search controller. This PR prevents it.  

#### Testing

The spec should pass with the patch and fail without it  

:hearts: Thank you!
