### PR TITLE
Use redis in CI to prevent conflicting/reserved capybara ports

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -64,6 +64,13 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v3
         with:

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -32,13 +32,23 @@ end
 1.step do
   port = rand(5000..6999)
   begin
-    Socket.tcp("127.0.0.1", port, connect_timeout: 5).close
-    warn "Port #{port} is already in use, trying another one."
-  rescue Errno::ECONNREFUSED
-    # When connection is refused, the port is available for use.
-    Capybara.server_port = port
+    redis = Redis.new
+    reserved_ports = (redis.get("decidim_test_capybara_reserved_ports") || "").split(",").map(&:to_i)
+    unless reserved_ports.include?(port)
+      reserved_ports << port
+      if ParallelTests.last_process?
+        redis.del("decidim_test_capybara_reserved_ports")
+      else
+        redis.set("decidim_test_capybara_reserved_ports", reserved_ports.sort.join(","))
+      end
+      break
+    end
+  rescue Redis::CannotConnectError
+    # Redis is not available
     break
   end
+ensure
+  Capybara.server_port = port
 end
 
 Capybara.register_driver :headless_chrome do |app|


### PR DESCRIPTION
#### :tophat: What? Why?
Capybara server sometimes fails to start due to a reserved port.

This is because the Rails server takes a while to start and when the Capybara setup is checking whether the port is reserved, it fails to do so because the server did not yet have enough time to start.

This PR adds the Redis service to the `test_app` pipeline to utilize a central database for all specs to store which ports are reserved.

#### :pushpin: Related Issues
- Related to #9661

#### Testing
- Run the specs normally without having Redis running in the background -> expect the specs to work
- Run the specs with Redis running in the background -> expect the specs to work
- Run the specs using `parallel_test` with Redis running in the background -> expect less issues with reserved ports

If you run `parallel_test` without Redis, expect to see the same issue as so far occasionally.