### PR TITLE
Announce to screen reader when markers are added to the map

### DIFF
--- a/decidim-core/app/packs/src/decidim/a11y.js
+++ b/decidim-core/app/packs/src/decidim/a11y.js
@@ -176,10 +176,52 @@ const createDialog = (component) => {
   })
 }
 
+/**
+ * Announces a message to the screen reader dynamically.
+ *
+ * This should not be called concecutively multiple times because the screen
+ * reader may not read all the messages if the content is changed quickly.
+ *
+ * @param {String} message The message to be announced
+ * @param {String} mode The mode for the announcement, either "assertive"
+ *   (default) or "polite".
+ * @return {void}
+ */
+const announceForScreenReader = (message, mode = "assertive") => {
+  let element = document.getElementById("screen-reader-announcement");
+  if (!element) {
+    element = document.createElement("div");
+    element.setAttribute("id", "screen-reader-announcement");
+    element.classList.add("sr-only");
+    element.setAttribute("aria-atomic", true);
+    document.body.append(element);
+  }
+  if (mode === "polite") {
+    element.setAttribute("aria-live", mode);
+  } else {
+    element.setAttribute("aria-live", "assertive");
+  }
+
+  element.innerHTML = "";
+
+  setTimeout(() => {
+    // Wrap the text in a span with a random attribute value that changes every
+    // time to try to indicate to the screen reader the content has changed. This
+    // helps reading the message aloud if the message is exactly the same as the
+    // last time.
+    const randomIdentifier = `announcement-${new Date().getUTCMilliseconds()}-${Math.floor(Math.random() * 10000000)}`;
+    const announce = document.createElement("span")
+    announce.setAttribute("data-random", randomIdentifier);
+    announce.textContent = message;
+    element.append(announce);
+  }, 100);
+};
+
 export {
   createAccordion,
   createDialog,
   createDropdown,
+  announceForScreenReader,
   Accordions,
   Dialogs,
   Dropdowns

--- a/decidim-core/app/packs/src/decidim/a11y.js
+++ b/decidim-core/app/packs/src/decidim/a11y.js
@@ -188,6 +188,10 @@ const createDialog = (component) => {
  * @return {void}
  */
 const announceForScreenReader = (message, mode = "assertive") => {
+  if (!message || typeof message !== "string" || message.length < 1) {
+    return;
+  }
+
   let element = document.getElementById("screen-reader-announcement");
   if (!element) {
     element = document.createElement("div");

--- a/decidim-core/app/packs/src/decidim/a11y.js
+++ b/decidim-core/app/packs/src/decidim/a11y.js
@@ -179,7 +179,7 @@ const createDialog = (component) => {
 /**
  * Announces a message to the screen reader dynamically.
  *
- * This should not be called concecutively multiple times because the screen
+ * This should not be called consecutively multiple times because the screen
  * reader may not read all the messages if the content is changed quickly.
  *
  * @param {String} message The message to be announced

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -70,6 +70,7 @@ import {
   createAccordion,
   createDialog,
   createDropdown,
+  announceForScreenReader,
   Dialogs
 } from "src/decidim/a11y"
 import changeReportFormBehavior from "src/decidim/change_report_form_behavior"
@@ -83,7 +84,8 @@ window.Decidim = window.Decidim || {
   FormValidator,
   addInputEmoji,
   EmojiButton,
-  Dialogs
+  Dialogs,
+  announceForScreenReader
 };
 
 window.morphdom = morphdom

--- a/decidim-core/spec/controllers/concerns/content_security_policy_spec.rb
+++ b/decidim-core/spec/controllers/concerns/content_security_policy_spec.rb
@@ -20,6 +20,7 @@ module Decidim
           "media-src" => "https://example.org"
         }
       end
+      let(:maps_host) { Decidim::Dev::Test::MapServer.host }
 
       controller do
         include Decidim::Headers::ContentSecurityPolicy
@@ -43,8 +44,8 @@ module Decidim
         expect(response.headers["Content-Security-Policy"]).to include("default-src 'self' 'unsafe-inline' localhost:* #{organization.host}:*; ")
         expect(response.headers["Content-Security-Policy"]).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval' localhost:* #{organization.host}:*; ")
         expect(response.headers["Content-Security-Policy"]).to include("style-src 'self' 'unsafe-inline' localhost:* #{organization.host}:*;")
-        expect(response.headers["Content-Security-Policy"]).to include("img-src 'self' *.hereapi.com data: https://via.placeholder.com localhost:* #{organization.host}:*;")
-        expect(response.headers["Content-Security-Policy"]).to include("connect-src 'self' *.hereapi.com data: localhost:* #{organization.host}:*; ")
+        expect(response.headers["Content-Security-Policy"]).to include("img-src 'self' *.hereapi.com data: https://via.placeholder.com #{maps_host} localhost:* #{organization.host}:*;")
+        expect(response.headers["Content-Security-Policy"]).to include("connect-src 'self' *.hereapi.com data: #{maps_host} localhost:* #{organization.host}:*; ")
         expect(response.headers["Content-Security-Policy"]).to include("font-src 'self' localhost:* #{organization.host}:*; ")
         expect(response.headers["Content-Security-Policy"]).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com localhost:* #{organization.host}:* www.example.org;")
         expect(response.headers["Content-Security-Policy"]).to include("media-src 'self' localhost:* #{organization.host}:*")
@@ -58,8 +59,8 @@ module Decidim
           expect(response.headers["Content-Security-Policy"]).to include("default-src 'self' 'unsafe-inline' https://example.org; ")
           expect(response.headers["Content-Security-Policy"]).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval' https://script.example.org;")
           expect(response.headers["Content-Security-Policy"]).to include("style-src 'self' 'unsafe-inline' https://style.example.org;")
-          expect(response.headers["Content-Security-Policy"]).to include("img-src 'self' *.hereapi.com data: https://via.placeholder.com https://img.example.org;")
-          expect(response.headers["Content-Security-Policy"]).to include("connect-src 'self' *.hereapi.com data: https://connect.example.org;")
+          expect(response.headers["Content-Security-Policy"]).to include("img-src 'self' *.hereapi.com data: https://via.placeholder.com #{maps_host} https://img.example.org;")
+          expect(response.headers["Content-Security-Policy"]).to include("connect-src 'self' *.hereapi.com data: #{maps_host} https://connect.example.org;")
           expect(response.headers["Content-Security-Policy"]).to include("font-src 'self' https://font.example.org;")
           expect(response.headers["Content-Security-Policy"]).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com https://frame.example.org;")
           expect(response.headers["Content-Security-Policy"]).to include("media-src 'self' https://example.org")
@@ -119,8 +120,8 @@ module Decidim
           expect(response.headers["Content-Security-Policy"]).to include("default-src 'self' 'unsafe-inline' https://example.org localhost:* #{organization.host}:*; ")
           expect(response.headers["Content-Security-Policy"]).to include("script-src 'self' 'unsafe-inline' 'unsafe-eval' https://script.example.org localhost:* #{organization.host}:*; ")
           expect(response.headers["Content-Security-Policy"]).to include("style-src 'self' 'unsafe-inline' https://style.example.org localhost:* #{organization.host}:*; ")
-          expect(response.headers["Content-Security-Policy"]).to include("img-src 'self' *.hereapi.com data: https://img.example.org https://via.placeholder.com localhost:* #{organization.host}:*;")
-          expect(response.headers["Content-Security-Policy"]).to include("connect-src 'self' *.hereapi.com data: https://connect.example.org localhost:* #{organization.host}:*;")
+          expect(response.headers["Content-Security-Policy"]).to include("img-src 'self' *.hereapi.com data: https://img.example.org https://via.placeholder.com #{maps_host} localhost:* #{organization.host}:*;")
+          expect(response.headers["Content-Security-Policy"]).to include("connect-src 'self' *.hereapi.com data: https://connect.example.org #{maps_host} localhost:* #{organization.host}:*;")
           expect(response.headers["Content-Security-Policy"]).to include("font-src 'self' https://font.example.org localhost:* #{organization.host}:*;")
           expect(response.headers["Content-Security-Policy"]).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com https://frame.example.org localhost:* #{organization.host}:* www.example.org;")
           expect(response.headers["Content-Security-Policy"]).to include("media-src 'self' https://example.org localhost:* #{organization.host}:*")

--- a/decidim-core/spec/lib/map/autocomplete_spec.rb
+++ b/decidim-core/spec/lib/map/autocomplete_spec.rb
@@ -54,7 +54,7 @@ module Decidim
 
       it "creates the geocoding field markup" do
         config = escaped_html(
-          { url: "/photon_api" }.to_json
+          { url: "#{Decidim::Dev::Test::MapServer.host}/photon_api" }.to_json
         )
         expect(form_markup).to include(%(
           <input autocomplete="off" data-decidim-geocoding="#{config}" type="text" name="test[address]" id="test_address" />

--- a/decidim-dev/lib/decidim/dev/engine.rb
+++ b/decidim-dev/lib/decidim/dev/engine.rb
@@ -32,7 +32,7 @@ module Decidim
 
         require "decidim/dev/test/map_server"
 
-        # Add the test app server as the first middleware in the stack
+        # Add the test map server as the first middleware in the stack
         app.config.middleware.insert_before 0, Decidim::Dev::Test::MapServer
       end
 

--- a/decidim-dev/lib/decidim/dev/engine.rb
+++ b/decidim-dev/lib/decidim/dev/engine.rb
@@ -27,6 +27,15 @@ module Decidim
         Decidim.register_assets_path File.expand_path("app/packs", root)
       end
 
+      initializer "decidim_dev.middleware.test_map_server" do |app|
+        next unless Rails.env.test?
+
+        require "decidim/dev/test/map_server"
+
+        # Add the test app server as the first middleware in the stack
+        app.config.middleware.insert_before 0, Decidim::Dev::Test::MapServer
+      end
+
       initializer "decidim_dev.moderation_content" do
         config.to_prepare do
           ActiveSupport::Notifications.subscribe("decidim.admin.block_user:after") do |_event_name, data|

--- a/decidim-dev/lib/decidim/dev/test/map_server.rb
+++ b/decidim-dev/lib/decidim/dev/test/map_server.rb
@@ -52,7 +52,7 @@ module Decidim
           @tile_image_content ||= File.read(Decidim::Dev.asset("icon.png"))
         end
 
-        def serve_maptiles(_request, _tileprops)
+        def serve_maptiles(_request, _properties)
           [200, { "Content-Type" => "image/png" }, [tile_image_content]]
         end
 

--- a/decidim-dev/lib/decidim/dev/test/map_server.rb
+++ b/decidim-dev/lib/decidim/dev/test/map_server.rb
@@ -6,7 +6,7 @@ module Decidim
       # The test map server serves all map related requests for the app.
       #
       # Works as a rack middleware that is mounted to the Rails app during
-      # tests (at the decidim-dev module's config/initializers).
+      # tests (at the decidim-dev module's engine).
       class MapServer
         def self.host
           "http://#{hostname}:#{Capybara.server_port}"

--- a/decidim-dev/lib/decidim/dev/test/map_server.rb
+++ b/decidim-dev/lib/decidim/dev/test/map_server.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Dev
+    module Test
+      # The test map server serves all map related requests for the app.
+      #
+      # Works as a rack middleware that is mounted to the Rails app during
+      # tests (at the decidim-dev module's config/initializers).
+      class MapServer
+        def self.host
+          "http://#{hostname}:#{Capybara.server_port}"
+        end
+
+        def self.hostname
+          "maps.lvh.me"
+        end
+
+        def self.url(endpoint)
+          case endpoint
+          when :tiles
+            "#{host}/maptiles/{z}/{x}/{y}.png"
+          when :static
+            "#{host}/static"
+          when :autocomplete
+            "#{host}/photon_api"
+          end
+        end
+
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          request = Rack::Request.new(env)
+          return @app.call(env) unless request.host == self.class.hostname
+
+          if (match = request.path.match(%r{^/maptiles/([0-9]+)/([0-9]+)/([0-9]+).png$}))
+            return serve_maptiles(request, { z: match[1], x: match[2], y: match[3] })
+          elsif request.path == "/static"
+            return serve_static(request)
+          elsif request.path == "/photon_api"
+            return serve_autocomplete(request)
+          end
+
+          not_found
+        end
+
+        private
+
+        def tile_image_content
+          @tile_image_content ||= File.read(Decidim::Dev.asset("icon.png"))
+        end
+
+        def serve_maptiles(_request, _tileprops)
+          [200, { "Content-Type" => "image/png" }, [tile_image_content]]
+        end
+
+        def serve_static(_request)
+          [200, { "Content-Type" => "image/png" }, [tile_image_content]]
+        end
+
+        def serve_autocomplete(_request)
+          photon_response = {
+            features: [
+              {
+                properties: {
+                  name: "Park",
+                  street: "Street1",
+                  housenumber: "1",
+                  postcode: "123456",
+                  city: "City1",
+                  state: "State1",
+                  country: "Country1"
+                },
+                geometry: {
+                  coordinates: [2.234, 1.123]
+                }
+              },
+              {
+                properties: {
+                  street: "Street2",
+                  postcode: "654321",
+                  city: "City2",
+                  country: "Country2"
+                },
+                geometry: {
+                  coordinates: [4.456, 3.345]
+                }
+              },
+              {
+                properties: {
+                  street: "Street3",
+                  housenumber: "3",
+                  postcode: "142536",
+                  city: "City3",
+                  country: "Country3"
+                },
+                geometry: {
+                  coordinates: [6.678, 5.567]
+                }
+              }
+            ]
+          }.tap do |response|
+            Decidim::Map::Provider::Autocomplete::Test.stubs.length.positive? &&
+              response[:features] = Decidim::Map::Provider::Autocomplete::Test.stubs
+          end
+
+          [
+            200,
+            {
+              "Content-Type" => "application/json",
+              "Access-Control-Allow-Origin" => "*"
+            },
+            [photon_response.to_json.to_s]
+          ]
+        end
+
+        def not_found
+          [404, { "Content-Type" => "text/plain" }, ["Not found."]]
+        end
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/geocoder.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/geocoder.rb
@@ -31,11 +31,11 @@ module GeocoderHelpers
       api_key: "1234123412341234",
       dynamic: {
         tile_layer: {
-          url: "/maptiles/{z}/{x}/{y}.png"
+          url: Decidim::Dev::Test::MapServer.url(:tiles)
         }
       },
-      static: { url: "https://www.example.org/my_static_map" },
-      autocomplete: { url: "/photon_api" } # Locally drawn route for the tests
+      static: { url: Decidim::Dev::Test::MapServer.url(:static) },
+      autocomplete: { url: Decidim::Dev::Test::MapServer.url(:autocomplete) }
     }
   end
 end
@@ -107,92 +107,8 @@ RSpec.configure do |config|
     configure_maps
   end
 
-  config.before(:each, :serves_map) do
-    stub_request(:get, %r{https://www\.example\.org/my_static_map})
-      .to_return(body: "map_data")
-
-    # The map tiles are requested through JavaScript which means mocking the
-    # tiles requests would not work as the request is initiated through
-    # JavaScript. Therefore, the map tiles have to be served through the
-    # application itself.
-    Rails.application.routes.disable_clear_and_finalize = true
-    Rails.application.routes.draw do
-      get "maptiles/:z/:x/:y.png", to: ->(_) { [200, { "Content-Type" => "image/png" }, [""]] }
-    end
-    Rails.application.routes.disable_clear_and_finalize = false
-  end
-
-  config.after(:each, :serves_map) do
-    # Reset the routes back to original
-    Rails.application.reload_routes!
-  end
-
   config.before(:each, :serves_geocoding_autocomplete) do
     # Clear the autocomplete stubs
     Decidim::Map::Provider::Autocomplete::Test.clear_stubs
-
-    photon_response = lambda do
-      {
-        features: [
-          {
-            properties: {
-              name: "Park",
-              street: "Street1",
-              housenumber: "1",
-              postcode: "123456",
-              city: "City1",
-              state: "State1",
-              country: "Country1"
-            },
-            geometry: {
-              coordinates: [2.234, 1.123]
-            }
-          },
-          {
-            properties: {
-              street: "Street2",
-              postcode: "654321",
-              city: "City2",
-              country: "Country2"
-            },
-            geometry: {
-              coordinates: [4.456, 3.345]
-            }
-          },
-          {
-            properties: {
-              street: "Street3",
-              housenumber: "3",
-              postcode: "142536",
-              city: "City3",
-              country: "Country3"
-            },
-            geometry: {
-              coordinates: [6.678, 5.567]
-            }
-          }
-        ]
-      }.tap do |response|
-        Decidim::Map::Provider::Autocomplete::Test.stubs.length.positive? &&
-          response[:features] = Decidim::Map::Provider::Autocomplete::Test.stubs
-      end
-    end
-
-    # The Photon API path needs to be mounted in the application itself because
-    # otherwise we would have to run a separate server for the API itself.
-    # Mocking the request would not work here because the call to the Photon API
-    # is initialized by the front-end to the URL specified for the maps
-    # geocoding autocompletion configuration which is not proxied by the
-    # headless browser running the Capybara tests.
-    Rails.application.routes.disable_clear_and_finalize = true
-    Rails.application.routes.draw do
-      get "photon_api", to: ->(_) { [200, { "Content-Type" => "application/json" }, [photon_response.call.to_json.to_s]] }
-    end
-    Rails.application.routes.disable_clear_and_finalize = false
-  end
-
-  config.after(:each, :serves_geocoding_autocomplete) do
-    # Reset the routes back to original
-    Rails.application.reload_routes!
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/geocoder.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/geocoder.rb
@@ -29,6 +29,11 @@ module GeocoderHelpers
     Decidim.maps = {
       provider: :test,
       api_key: "1234123412341234",
+      dynamic: {
+        tile_layer: {
+          url: "/maptiles/{z}/{x}/{y}.png"
+        }
+      },
       static: { url: "https://www.example.org/my_static_map" },
       autocomplete: { url: "/photon_api" } # Locally drawn route for the tests
     }
@@ -105,6 +110,21 @@ RSpec.configure do |config|
   config.before(:each, :serves_map) do
     stub_request(:get, %r{https://www\.example\.org/my_static_map})
       .to_return(body: "map_data")
+
+    # The map tiles are requested through JavaScript which means mocking the
+    # tiles requests would not work as the request is initiated through
+    # JavaScript. Therefore, the map tiles have to be served through the
+    # application itself.
+    Rails.application.routes.disable_clear_and_finalize = true
+    Rails.application.routes.draw do
+      get "maptiles/:z/:x/:y.png", to: ->(_) { [200, { "Content-Type" => "image/png" }, [""]] }
+    end
+    Rails.application.routes.disable_clear_and_finalize = false
+  end
+
+  config.after(:each, :serves_map) do
+    # Reset the routes back to original
+    Rails.application.reload_routes!
   end
 
   config.before(:each, :serves_geocoding_autocomplete) do

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
@@ -2,4 +2,10 @@
 
 require "webmock/rspec"
 
-WebMock.disable_net_connect!(allow_localhost: true, allow: %r{https://validator.w3.org/})
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: [
+    %r{https://validator.w3.org/},
+    Decidim::Dev::Test::MapServer.host
+  ]
+)

--- a/decidim-dev/lib/decidim/dev/test/spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/spec_helper.rb
@@ -41,7 +41,8 @@ RSpec.configure do |config|
 
   config.before :all do
     Decidim.content_security_policies_extra = {
-      "img-src": %w(https://via.placeholder.com)
+      "img-src": %W(https://via.placeholder.com #{Decidim::Dev::Test::MapServer.host}),
+      "connect-src": %W(#{Decidim::Dev::Test::MapServer.host})
     }
   end
 end

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -425,7 +425,7 @@ describe "Explore meetings", :slow do
     end
   end
 
-  describe "show", :serves_map do
+  describe "show" do
     let(:meetings_count) { 1 }
     let(:meeting) { meetings.first }
     let(:date) { 10.days.from_now }

--- a/decidim-proposals/app/packs/src/decidim/proposals/add_proposal.js
+++ b/decidim-proposals/app/packs/src/decidim/proposals/add_proposal.js
@@ -11,7 +11,7 @@ $(() => {
     }
     $addressInputField.on("geocoder-suggest-coordinates.decidim", () => $map.show());
 
-    const markerAddedAnnouncement = $addressInputField.data("screen-reader-announcenent");
+    const markerAddedAnnouncement = $addressInputField.data("screen-reader-announcement");
     let latFieldName = "latitude";
     let longFieldName = "longitude";
 

--- a/decidim-proposals/app/packs/src/decidim/proposals/add_proposal.js
+++ b/decidim-proposals/app/packs/src/decidim/proposals/add_proposal.js
@@ -11,6 +11,7 @@ $(() => {
     }
     $addressInputField.on("geocoder-suggest-coordinates.decidim", () => $map.show());
 
+    const markerAddedAnnouncement = $addressInputField.data("screen-reader-announcenent");
     let latFieldName = "latitude";
     let longFieldName = "longitude";
 
@@ -35,6 +36,7 @@ $(() => {
           longitude: coordinates[1],
           address: $addressInputField.val()
         });
+        window.Decidim.announceForScreenReader(markerAddedAnnouncement);
       });
     });
   }

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -19,9 +19,13 @@
 <% end %>
 
 <% if @form.geocoding_enabled? %>
-  <%= form.geocoding_field :address, placeholder: t("decidim.proposals.proposals.placeholder.address"), data: {
-    screen_reader_announcement: t("decidim.proposals.proposals.edit_form_fields.marker_added")
-  } %>
+  <%= form.geocoding_field(
+    :address,
+    placeholder: t("decidim.proposals.proposals.placeholder.address"),
+    data: {
+      screen_reader_announcement: t("decidim.proposals.proposals.edit_form_fields.marker_added")
+    }
+  ) %>
 
   <div id="address_map" class="proposal__container">
     <p class="help-text">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -19,7 +19,9 @@
 <% end %>
 
 <% if @form.geocoding_enabled? %>
-  <%= form.geocoding_field :address, placeholder: t("decidim.proposals.proposals.placeholder.address") %>
+  <%= form.geocoding_field :address, placeholder: t("decidim.proposals.proposals.placeholder.address"), data: {
+    screen_reader_announcenent: t("decidim.proposals.proposals.edit_form_fields.marker_added")
+  } %>
 
   <div id="address_map" class="proposal__container">
     <p class="help-text">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -20,7 +20,7 @@
 
 <% if @form.geocoding_enabled? %>
   <%= form.geocoding_field :address, placeholder: t("decidim.proposals.proposals.placeholder.address"), data: {
-    screen_reader_announcenent: t("decidim.proposals.proposals.edit_form_fields.marker_added")
+    screen_reader_announcement: t("decidim.proposals.proposals.edit_form_fields.marker_added")
   } %>
 
   <div id="address_map" class="proposal__container">

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -789,6 +789,8 @@ en:
           discard_confirmation: Are you sure you want to discard this proposal draft?
           send: Preview
           title: Edit Proposal Draft
+        edit_form_fields:
+          marker_added: Marker added to the map.
         filters:
           activity: My activity
           all: All

--- a/decidim-proposals/spec/system/collaborative_drafts_fields_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_fields_spec.rb
@@ -114,7 +114,7 @@ describe "Collaborative drafts" do
           end
         end
 
-        context "when geocoding is enabled", :serves_geocoding_autocomplete, :serves_map do
+        context "when geocoding is enabled", :serves_geocoding_autocomplete do
           let!(:component) do
             create(:proposal_component,
                    :with_creation_enabled,
@@ -244,7 +244,7 @@ describe "Collaborative drafts" do
             expect(page).to have_author(user_group.name)
           end
 
-          context "when geocoding is enabled", :serves_geocoding_autocomplete, :serves_map do
+          context "when geocoding is enabled", :serves_geocoding_autocomplete do
             let!(:component) do
               create(:proposal_component,
                      :with_creation_enabled,

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -198,7 +198,7 @@ describe "Edit proposals" do
         stub_geocoding(new_address, [latitude, longitude])
       end
 
-      it "can be updated with address", :configures_map, :serves_geocoding_autocomplete, :serves_map do
+      it "can be updated with address", :serves_geocoding_autocomplete do
         visit_component
 
         click_on translated(proposal.title)

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -198,7 +198,7 @@ describe "Edit proposals" do
         stub_geocoding(new_address, [latitude, longitude])
       end
 
-      it "can be updated with address", :serves_geocoding_autocomplete do
+      it "can be updated with address", :configures_map, :serves_geocoding_autocomplete, :serves_map do
         visit_component
 
         click_on translated(proposal.title)
@@ -212,6 +212,11 @@ describe "Edit proposals" do
         fill_in :proposal_address, with: nil
         fill_in_geocoding :proposal_address, with: new_address
         expect(page).to have_content("You can move the point on the map.")
+
+        # Give time for the screen reader announcement to be added since there
+        # is a small delay before the message appears.
+        sleep 0.5
+        expect(page).to have_content("Marker added to the map.")
 
         click_on "Send"
         expect(page).to have_content(new_address)

--- a/decidim-proposals/spec/system/proposals_fields_spec.rb
+++ b/decidim-proposals/spec/system/proposals_fields_spec.rb
@@ -91,7 +91,7 @@ describe "Proposals" do
           expect(page).to have_author(user.name)
         end
 
-        context "when geocoding is enabled", :serves_geocoding_autocomplete, :serves_map do
+        context "when geocoding is enabled", :serves_geocoding_autocomplete do
           let!(:component) do
             create(:proposal_component,
                    :with_creation_enabled,
@@ -222,7 +222,7 @@ describe "Proposals" do
             expect(page).to have_author(user_group.name)
           end
 
-          context "when geocoding is enabled", :serves_geocoding_autocomplete, :serves_map do
+          context "when geocoding is enabled", :serves_geocoding_autocomplete do
             let!(:component) do
               create(:proposal_component,
                      :with_creation_enabled,


### PR DESCRIPTION
#### :tophat: What? Why?
It was suggested in an accessibility audit to announce to the screen reader when markers are added to the map.

This adds a new utility that allows announcing messages to screen reader dynamically and applies this utility to the proposal edit form map.

After seeing the CI failures, this PR also implements a basic test environment "map server" running as a rack middleware in order to avoid modifying the application routes for every map spec. The map tiles were not configured correctly for the test environment which caused JS errors to be shown on pages that display maps. After configuring the tile URLs for all specs, I started to see several different errors in the system specs that display maps. Therefore, I decided to create a new middleware that handles all the map related functionality in the test env. This particular PR requires the map to be shown on the page which requires the tile URLs to be configured correctly. If the URL is `null` as so far, Leaflet will show errors and the map display will fail which causes the spec added in this PR to work incorrectly (as the message never appears in the view, cannot be tested otherwise).

At the same time I noticed there were also errors printed out in the console on pages that display static maps. This was because Webmock disabled these requests and therefore they errored out with HTTP 500.

#### Testing
- Enable geocoding for the proposals component
- Make sure you have maps configured
- Go to create a new proposal and proceed to the complete step with the address field
- Enable screen reader
- Write an address that gives you results in the address field
- Pick one of the provided addresses (note that there is another a11y issue with the autocomplete which does not allow navigating through the results using keyboard)
- Hear the screen reader announce "Marker added to the map."