### PR TITLE
Backport 'Hide last activities on breadcrumb dropdown when organization is configured to force authentication' to v0.28

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/menu_breadcrumb_last_activity_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/menu_breadcrumb_last_activity_cell.rb
@@ -5,6 +5,12 @@ module Decidim
     # A cell to be rendered as a content block with the latest activities performed
     # in a Decidim Organization.
     class MenuBreadcrumbLastActivityCell < LastActivityCell
+      def show
+        return if current_user.blank? && current_organization&.force_users_to_authenticate_before_access_organization
+
+        super
+      end
+
       private
 
       def activities

--- a/decidim-core/app/helpers/decidim/menu_helper.rb
+++ b/decidim-core/app/helpers/decidim/menu_helper.rb
@@ -55,6 +55,8 @@ module Decidim
     end
 
     def menu_highlighted_participatory_process
+      return if current_user.blank? && current_organization&.force_users_to_authenticate_before_access_organization
+
       @menu_highlighted_participatory_process ||= (
         # The queries already include the order by weight
         Decidim::ParticipatoryProcesses::OrganizationParticipatoryProcesses.new(current_organization) |

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -287,6 +287,53 @@ describe "Homepage" do
         end
       end
 
+      context "when organization forces users to authenticate before access" do
+        let(:organization) do
+          create(
+            :organization,
+            official_url:,
+            force_users_to_authenticate_before_access_organization: true
+          )
+        end
+
+        context "when there are site activities and user is not authenticated" do
+          let(:participatory_space) { create(:participatory_process, organization:) }
+          let(:component) do
+            create(:component, :published, participatory_space:)
+          end
+          let(:commentable) { create(:dummy_resource, component:) }
+          let(:comment) { create(:comment, commentable:) }
+          let!(:action_log) do
+            create(:action_log, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: comment, organization:, participatory_space:)
+          end
+
+          before do
+            visit current_path
+            find_by_id("main-dropdown-summary").hover
+          end
+
+          it "does not show last activity section on menu bar main dropdown" do
+            expect(page).to have_no_content(translated(comment.body))
+            expect(page).to have_no_link("New comment")
+            expect(page).to have_no_link("Last activity")
+          end
+        end
+
+        context "when there is a promoted participatory space and user is not authenticated" do
+          let!(:participatory_space) { create(:participatory_process, :promoted, title:, organization:) }
+          let(:title) { { en: "Promoted, promoted, promoted!!!" } }
+
+          before do
+            visit current_path
+            find_by_id("main-dropdown-summary").hover
+          end
+
+          it "does not show last activity section on menu bar main dropdown" do
+            expect(page).to have_no_content(title[:en])
+          end
+        end
+      end
+
       describe "includes statistics" do
         let!(:users) { create_list(:user, 4, :confirmed, organization:) }
         let!(:participatory_process) do


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12685 to v0.28

:hearts: Thank you!