### PR TITLE
Backport 'Fix DOM text reinterpreted as HTML in budgets' exit handler' to v0.28

### DIFF
--- a/decidim-budgets/app/packs/src/decidim/budgets/exit_handler.js
+++ b/decidim-budgets/app/packs/src/decidim/budgets/exit_handler.js
@@ -68,7 +68,7 @@ $(() => {
     }
 
     $exitLink.attr("href", url);
-    $exitLink.html(exitLinkText);
+    $exitLink.text(exitLinkText);
     window.Decidim.currentDialogs["exit-notification"].open();
   };
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12673 to v0.28

:hearts: Thank you!