### PR TITLE
Add configuration for autolabeler

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,3 +1,4 @@
+autolabeler
 github
 https
 ssh

--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,0 +1,42 @@
+configuration:
+  - .github/**/*
+  - /config/**/*
+  - /*.json
+  - /*.yml
+  - /*.yaml
+dependencies:
+  - "*.gemspec"
+  - Gemfile
+  - Gemfile.lock
+  - package.json
+  - package-lock.json
+javascript: "*.js"
+"module: accountability": decidim-accountability/**/*
+"module: admin": decidim-admin/**/*
+"module: api": decidim-api/**/*
+"module: assemblies": decidim-assemblies/**/*
+"module: blogs": decidim-blogs/**/*
+"module: budgets": decidim-budgets/**/*
+"module: comments": decidim-comments/**/*
+"module: conferences": decidim-conferences/**/*
+"module: consultations": decidim-consultations/**/*
+"module: core": decidim-core/**/*
+"module: debates": decidim-debates/**/*
+"module: design": decidim-design/**/*
+"module: dev": decidim-dev/**/*
+"module: elections": decidim-elections/**/*
+"module: forms": decidim-forms/**/*
+"module: generators": decidim-generators/**/*
+"module: initiatives": decidim-initiatives/**/*
+"module: meetings": decidim-meetings/**/*
+"module: pages": decidim-pages/**/*
+"module: participatory processes": decidim-participatory_processes/**/*
+"module: proposals": decidim-proposals/**/*
+"module: sortitions": decidim-sortitions/**/*
+"module: surveys": decidim-surveys/**/*
+"module: system": decidim-system/**/*
+"module: templates": decidim-templates/**/*
+"module: verifications": decidim-verifications/**/*
+"team: documentation":
+  - docs/**/*
+  - /README.adoc


### PR DESCRIPTION
#### :tophat: What? Why?
Add configuration for [Probot Autolabeler](https://github.com/apps/probot-autolabeler) in order to automate parts of the labeling process as I think most of the labels can be applied automatically.

Noticed that the Rails repo is using this so I thought it might be useful here as well.

Note that the [Probot Autolabeler](https://github.com/apps/probot-autolabeler) also has to be added to the repository.

#### Testing
- Merge this PR
- Add [Probot Autolabeler](https://github.com/apps/probot-autolabeler) to the repository