### PR TITLE
Backport 'Fix overly permissive regular expression range in "has reference" specs' to v0.28

### DIFF
--- a/decidim-core/lib/decidim/core/test/shared_examples/has_reference.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/has_reference.rb
@@ -8,7 +8,7 @@ shared_examples_for "has reference" do
 
     context "when there is not a custom resource reference generator present" do
       it "generates a valid reference" do
-        expect(subject.reference).to match(/[A-z]+/)
+        expect(subject.reference).to match(/[a-zA-Z]+/)
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12670 to v0.28

:hearts: Thank you!