### PR TITLE
Backport 'Do not show scopes column in budgets if there isn't subscopes' to v0.28

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
@@ -22,7 +22,9 @@
           <th><%= t("models.budget.fields.name", scope: "decidim.budgets") %></th>
           <th><%= t("models.budget.fields.total_budget", scope: "decidim.budgets") %></th>
           <th><%= t("models.budget.fields.projects_count", scope: "decidim.budgets") %></th>
-          <%= th_resource_scope_label %>
+          <% if current_component.has_subscopes? %>
+           <%= th_resource_scope_label %>
+          <% end %>
           <th class="actions"><%= t("actions.title", scope: "decidim.budgets") %></th>
         </tr>
       </thead>
@@ -42,7 +44,9 @@
             <td>
               <%= link_to budget.projects.count, budget_projects_path(budget) %>
             </td>
-            <%= td_resource_scope_for(budget.scope) %>
+            <% if current_component.has_subscopes? %>
+              <%= td_resource_scope_for(budget.scope) %>
+            <% end %>
             <td class="table-list__actions">
               <% if allowed_to? :update, :budget, budget: budget %>
                 <%= icon_link_to "pencil-line", edit_budget_path(budget), t("actions.edit", scope: "decidim.budgets"), class: "action-icon--edit" %>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/_project-tr.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/_project-tr.html.erb
@@ -17,7 +17,9 @@
       <%= translated_attribute project.category.name %>
     <% end %>
   </td>
-  <%= td_resource_scope_for(project.scope) %>
+  <% if current_component.has_subscopes? %>
+    <%= td_resource_scope_for(project.scope) %>
+  <% end %>
   <td>
     <%= project.confirmed_orders_count %>
   </td>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
@@ -19,7 +19,9 @@
           <th><%= sort_link(query, :id, t("models.project.fields.id", scope: "decidim.budgets"), default_order: :desc) %></th>
           <th class="!text-left"><%= sort_link(query, :title, t("models.project.fields.title", scope: "decidim.budgets")) %></th>
           <th><%= sort_link(query, :category_name, t("models.project.fields.category", scope: "decidim.budgets") ) %></th>
-          <%= th_scope_sort_link %>
+          <% if current_component.has_subscopes? %>
+            <%= th_scope_sort_link %>
+          <% end %>
           <th><%= sort_link(query, :confirmed_orders_count, t("index.confirmed_orders_count")) %></th>
           <th><%= sort_link(query, :selected, t(".selected")) %></th>
           <th class="actions"><%= t("actions.title", scope: "decidim.budgets") %></th>

--- a/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
@@ -111,6 +111,62 @@ describe "Admin manages budgets" do
     end
   end
 
+  describe "when managing a budget with scopes" do
+    let!(:scopes) { create_list(:subscope, 3, organization:, parent: scope) }
+    let(:scope_id) { scope.id }
+    let(:participatory_space) { create(:participatory_process, organization:, scopes_enabled:) }
+    let!(:component) { create(:component, manifest:, settings: { scopes_enabled:, scope_id: }, participatory_space:) }
+    let!(:budget) { create(:budget, component: current_component) }
+    let!(:scope) { create(:scope, organization:) }
+    let(:scopes_enabled) { true }
+
+    before do
+      visit current_path
+    end
+
+    context "when the scope has subscopes" do
+      context "when scopes_enabled is true" do
+        it "displays the scope column" do
+          expect(component).to be_scopes_enabled
+          expect(component).to have_subscopes
+          expect(page).to have_content("Scope")
+        end
+      end
+
+      context "when scopes_enabled is false" do
+        let(:scopes_enabled) { false }
+
+        it "displays the scope column" do
+          expect(component).not_to be_scopes_enabled
+          expect(component).not_to have_subscopes
+          expect(page).to have_no_content("Scope")
+        end
+      end
+    end
+
+    context "when the scope does not have subscopes" do
+      let(:scope_id) { scopes.first.id }
+
+      context "when scopes_enabled is true" do
+        it "hides the scope column" do
+          expect(component).to be_scopes_enabled
+          expect(component).not_to have_subscopes
+          expect(page).to have_no_content("Scope")
+        end
+      end
+
+      context "when scopes_enabled is false" do
+        let(:scopes_enabled) { false }
+
+        it "displays the scope column" do
+          expect(component).not_to be_scopes_enabled
+          expect(component).not_to have_subscopes
+          expect(page).to have_no_content("Scope")
+        end
+      end
+    end
+  end
+
   describe "component page shows finished and pending orders of all budgets" do
     context "when component has many budgets with orders" do
       let(:budget2) { create(:budget, :with_projects, component: current_component) }

--- a/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
@@ -139,7 +139,7 @@ describe "Admin manages budgets" do
         it "displays the scope column" do
           expect(component).not_to be_scopes_enabled
           expect(component).not_to have_subscopes
-          expect(page).to have_no_content("Scope")
+          expect(page).not_to have_content("Scope")
         end
       end
     end
@@ -151,7 +151,7 @@ describe "Admin manages budgets" do
         it "hides the scope column" do
           expect(component).to be_scopes_enabled
           expect(component).not_to have_subscopes
-          expect(page).to have_no_content("Scope")
+          expect(page).not_to have_content("Scope")
         end
       end
 
@@ -161,7 +161,7 @@ describe "Admin manages budgets" do
         it "displays the scope column" do
           expect(component).not_to be_scopes_enabled
           expect(component).not_to have_subscopes
-          expect(page).to have_no_content("Scope")
+          expect(page).not_to have_content("Scope")
         end
       end
     end

--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -94,7 +94,7 @@ describe "Admin manages projects" do
       let!(:scope) { create(:scope, organization: current_component.organization) }
 
       it "does not display subscopes" do
-        expect(page).to have_no_content(scope.name)
+        expect(page).not_to have_content(scope.name)
       end
     end
 

--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -89,6 +89,15 @@ describe "Admin manages projects" do
       expect(Decidim::Budgets::Project.find(project2.id).selected_at).to eq(Time.zone.today)
     end
 
+    describe "when managing a project with scopes" do
+      let!(:project) { create(:project, component: current_component) }
+      let!(:scope) { create(:scope, organization: current_component.organization) }
+
+      it "does not display subscopes" do
+        expect(page).to have_no_content(scope.name)
+      end
+    end
+
     describe "update projects budget" do
       let!(:another_component) { create(:budgets_component, organization:, participatory_space: current_component.participatory_space) }
       let!(:another_budget) { create(:budget, component: another_component) }


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12020 to v0.28

:hearts: Thank you!