### PR TITLE
Backport 'Fix WYSIWYG migration error with non li elements inside lists' to v0.28

### DIFF
--- a/decidim-core/lib/decidim/upgrade/wysiwyg_migrator.rb
+++ b/decidim-core/lib/decidim/upgrade/wysiwyg_migrator.rb
@@ -258,6 +258,9 @@ module Decidim
         parent
       end
 
+      # rubocop: disable Metrics/CyclomaticComplexity
+      # rubocop: disable Metrics/PerceivedComplexity
+
       # Quill.js did not support multi-level lists which is why it used a CSS
       # hack to make it visually look like the list has multiple levels. This
       # is not semantically correct but for users with no visual impairments it
@@ -321,6 +324,8 @@ module Decidim
         current_parent = parent
         current_level = 0
         list.children.each do |item|
+          next unless item.is_a?(Nokogiri::XML::Element) && item.name == "li"
+
           indent = detect_indent(item)
           if indent == current_level || li.nil?
             if item.child.name == "p"
@@ -356,6 +361,8 @@ module Decidim
 
         parent
       end
+      # rubocop: enable Metrics/CyclomaticComplexity
+      # rubocop: enable Metrics/PerceivedComplexity
 
       # Converts iframe embeds to the new format. We assume all iframes are
       # video embeds as this the only type of embed what Quill.js supported and

--- a/decidim-core/spec/lib/upgrade/wysiwyg_migrator_spec.rb
+++ b/decidim-core/spec/lib/upgrade/wysiwyg_migrator_spec.rb
@@ -211,6 +211,13 @@ module Decidim
           expect(subject).to eq(en: expected_content, es: "<p>Castellano</p>#{expected_content}")
         end
       end
+
+      context "when we have \\n inside a list" do
+        let(:original_content) { "<p>Vivamus rhoncus pretium neque et posuere:<ul>\n<li>Suspendisse gravida justo nec ornare rhoncus.</li>\n<li>Morbi venenatis metus augue.</li>\n</ul></p>" }
+        let(:expected_content) { "<p>Vivamus rhoncus pretium neque et posuere:</p><ul><li><p>Suspendisse gravida justo nec ornare rhoncus.</p></li><li><p>Morbi venenatis metus augue.</p></li></ul>" }
+
+        it_behaves_like "HTML content migration"
+      end
     end
 
     describe ".register_model" do


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12626 to v0.28

:hearts: Thank you!