### PR TITLE
Backport 'Fix graphiql initial query escaping' to v0.28

### DIFF
--- a/decidim-api/lib/decidim/api/engine.rb
+++ b/decidim-api/lib/decidim/api/engine.rb
@@ -35,9 +35,9 @@ module Decidim
       initializer "decidim_api.graphiql" do
         Decidim::GraphiQL::Rails.config.tap do |config|
           config.query_params = true
-          config.initial_query = File.read(
-            File.join(__dir__, "graphiql-initial-query.txt")
-          ).html_safe
+          config.initial_query = ERB::Util.html_escape(
+            File.read(File.join(__dir__, "graphiql-initial-query.txt"))
+          )
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12639 to v0.28

:hearts: Thank you!