### PR TITLE
Backport 'Bump webpack-dev-middleware from 5.3.3 to 5.3.4' to v0.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20521,8 +20521,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "license": "MIT",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dependencies": {
         "colorette": "^2.0.10",
         "memfs": "^3.4.3",
@@ -35353,7 +35354,9 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "5.3.3",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "requires": {
         "colorette": "^2.0.10",
         "memfs": "^3.4.3",


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12661 to v0.28

:hearts: Thank you!