### PR TITLE
Allow valuators to use proposal answer templates

### DIFF
--- a/decidim-templates/app/controllers/decidim/templates/admin/proposal_answer_templates_controller.rb
+++ b/decidim-templates/app/controllers/decidim/templates/admin/proposal_answer_templates_controller.rb
@@ -55,7 +55,9 @@ module Decidim
         end
 
         def fetch
-          enforce_permission_to(:read, :template, template:)
+          enforce_permission_to(:read, :template, template:, proposal:)
+
+          return render json: { msg: I18n.t("templates.fetch.error", scope: "decidim.admin") }, status: :unprocessable_entity if template.blank?
 
           state = fetch_proposal_state(template)
 

--- a/decidim-templates/app/packs/src/decidim/templates/admin/proposal_answer_template_chooser.js
+++ b/decidim-templates/app/packs/src/decidim/templates/admin/proposal_answer_template_chooser.js
@@ -2,7 +2,6 @@
 document.addEventListener("DOMContentLoaded", () => {
   const proposalAnswerTemplateChooser = document.getElementById("proposal_answer_template_chooser");
   if (proposalAnswerTemplateChooser) {
-
     proposalAnswerTemplateChooser.addEventListener("change", () => {
       const dropdown =  document.getElementById("proposal_answer_template_chooser");
       const url = dropdown.getAttribute("data-url");
@@ -13,7 +12,12 @@ document.addEventListener("DOMContentLoaded", () => {
         return;
       }
       fetch(`${new URL(url).pathname}?${new URLSearchParams({ id: templateId, proposalId: proposalId })}`).
-        then((response) => response.json()).
+        then((response) => {
+          if (response.ok) {
+            return response.json();
+          }
+          return Promise.reject(response);
+        }).
         then((data) => {
           document.getElementById(`proposal_answer_internal_state_${data.state}`).click();
 
@@ -24,8 +28,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
             editor.commands.setContent(value, true);
           }
-        })
+        }).
+        catch((response) => {
+          response.json().then((data) => {
+            const el = document.createElement("p");
+            el.classList.add("text-alert");
+            el.textContent = data.msg;
+            dropdown.after(el);
+          });
+        });
     });
-
   }
 });

--- a/decidim-templates/app/permissions/decidim/templates/admin/permissions.rb
+++ b/decidim-templates/app/permissions/decidim/templates/admin/permissions.rb
@@ -5,20 +5,42 @@ module Decidim
     module Admin
       class Permissions < Decidim::DefaultPermissions
         def permissions
-          return permission_action unless user
-          return permission_action unless user.admin?
           return permission_action if permission_action.scope != :admin
+          return permission_action unless user
+          return permission_action if context[:current_organization] != user.organization
 
-          case permission_action.subject
-          when :template
-            allow! if [:read, :create, :update, :destroy, :copy].include? permission_action.action
-          when :templates
-            allow! if permission_action.action == :index
-          when :questionnaire
+          if user_has_a_role? && (permission_action.subject == :template && permission_action.action == :read)
             allow!
+          else
+            return permission_action unless user.admin?
+
+            case permission_action.subject
+            when :template
+              allow! if [:read, :create, :update, :destroy, :copy].include? permission_action.action
+            when :templates
+              allow! if permission_action.action == :index
+            when :questionnaire
+              allow!
+            end
           end
 
           permission_action
+        end
+
+        private
+
+        def participatory_space
+          @participatory_space ||= context[:proposal].try(:participatory_space)
+        end
+
+        def user_roles
+          @user_roles ||= participatory_space.try(:user_roles)
+        end
+
+        def user_has_a_role?
+          return unless user_roles
+
+          user_roles.exists?(user:)
         end
       end
     end

--- a/decidim-templates/config/locales/en.yml
+++ b/decidim-templates/config/locales/en.yml
@@ -26,6 +26,8 @@ en:
         destroy:
           success: Template deleted successfully.
         empty: There are no templates yet.
+        fetch:
+          error: Couldn't find this template. Please reload the page.
         missing_resource: "(missing resource)"
         update:
           error: There was a problem updating this template.

--- a/decidim-templates/config/locales/en.yml
+++ b/decidim-templates/config/locales/en.yml
@@ -27,7 +27,7 @@ en:
           success: Template deleted successfully.
         empty: There are no templates yet.
         fetch:
-          error: Couldn't find this template. Please reload the page.
+          error: Could not find this template. Please reload the page.
         missing_resource: "(missing resource)"
         update:
           error: There was a problem updating this template.

--- a/decidim-templates/spec/permissions/decidim/templates/admin/permissions_spec.rb
+++ b/decidim-templates/spec/permissions/decidim/templates/admin/permissions_spec.rb
@@ -9,7 +9,7 @@ describe Decidim::Templates::Admin::Permissions do
   let(:user) { create(:user, :admin, organization:) }
   let(:context) do
     {
-      current_organization: create(:organization)
+      current_organization: organization
     }
   end
   let(:permission_action) { Decidim::PermissionAction.new(**action) }
@@ -67,6 +67,34 @@ describe Decidim::Templates::Admin::Permissions do
 
   context "when reading a template" do
     it_behaves_like "action is allowed", :admin, :read, :template
+
+    context "when user is a valuator" do
+      let(:user) { create(:user, :confirmed, organization:) }
+      let!(:valuator_role) { create(:participatory_process_user_role, role: :valuator, user:, participatory_process: participatory_space) }
+      let!(:valuation_assignment) { create(:valuation_assignment, proposal:, valuator_role:) }
+      let(:proposal) { create :proposal, component: }
+      let(:component) { create(:proposal_component, participatory_space:) }
+      let(:participatory_space) { create :participatory_process, organization: }
+      let(:action) do
+        { scope: :admin, action: action_str, subject: :template }
+      end
+      let(:context) do
+        {
+          current_organization: organization,
+          proposal:
+        }
+      end
+
+      let(:action_str) { :read }
+
+      it { is_expected.to be true }
+
+      context "when other actions" do
+        let(:action_str) { :index }
+
+        it_behaves_like "permission is not set"
+      end
+    end
   end
 
   context "when creating a template" do

--- a/decidim-templates/spec/system/admin/valuator_uses_proposal_answer_templates_spec.rb
+++ b/decidim-templates/spec/system/admin/valuator_uses_proposal_answer_templates_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Valuator uses proposal answer templates" do
+  let(:field_values) { { proposal_state_id: } }
+  let(:token) { "rejected" }
+  let!(:organization) { create(:organization) }
+  let(:user) { create(:user, :confirmed, :admin_terms_accepted, organization:) }
+  let!(:valuator_role) { create(:participatory_process_user_role, role: :valuator, user:, participatory_process: participatory_space) }
+  let!(:valuation_assignment) { create(:valuation_assignment, proposal:, valuator_role:) }
+  let(:participatory_space) { create(:participatory_process, title: { en: "A participatory process" }, organization:) }
+  let!(:templatable) { create(:proposal_component, name: { en: "A component" }, participatory_space:) }
+  let(:proposal_state_id) { Decidim::Proposals::ProposalState.find_by(component: templatable, token:).id }
+  let(:description) { "Some meaningful answer" }
+  let!(:template) { create(:template, target: :proposal_answer, description: { en: description }, organization:, templatable:, field_values:) }
+  let!(:proposal) { create(:proposal, component: templatable) }
+  let!(:other_component) { create(:proposal_component, name: { en: "Another component" }, participatory_space:) }
+  let!(:other_component_template) { create(:template, target: :proposal_answer, description: { en: "Foo bar" }, field_values:, organization:, templatable: other_component) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit Decidim::EngineRouter.admin_proxy(templatable).root_path
+    find("a", class: "action-icon--show-proposal").click
+  end
+
+  it "uses the template" do
+    expect(proposal.reload.internal_state).to eq("not_answered")
+    within ".edit_proposal_answer" do
+      expect(page).to have_select(:proposal_answer_template_chooser, with_options: [translated(template.name)])
+      expect(page).to have_no_select(:proposal_answer_template_chooser, with_options: [translated(other_component_template.name)])
+      select template.name["en"], from: :proposal_answer_template_chooser
+      expect(page).to have_content(description)
+      click_on "Answer"
+    end
+
+    expect(page).to have_admin_callout("Proposal successfully answered")
+
+    within "tr", text: proposal.title["en"] do
+      expect(page).to have_content("Rejected")
+    end
+    expect(proposal.reload.internal_state).to eq("rejected")
+  end
+
+  context "when there are no templates" do
+    before do
+      template.destroy!
+      visit Decidim::EngineRouter.admin_proxy(templatable).root_path
+      find("a", class: "action-icon--show-proposal").click
+    end
+
+    it "hides the template selector in the proposal answer page" do
+      expect(page).to have_no_select(:proposal_answer_template_chooser)
+    end
+  end
+
+  context "when the template is destroyed while in the page" do
+    it "shows an error message if the template is removed" do
+      within ".edit_proposal_answer" do
+        template.destroy!
+        select template.name["en"], from: :proposal_answer_template_chooser
+        expect(page).to have_no_content(description)
+        expect(page).to have_content("Couldn't find this template")
+      end
+    end
+  end
+end

--- a/decidim-templates/spec/system/admin/valuator_uses_proposal_answer_templates_spec.rb
+++ b/decidim-templates/spec/system/admin/valuator_uses_proposal_answer_templates_spec.rb
@@ -61,7 +61,7 @@ describe "Valuator uses proposal answer templates" do
         template.destroy!
         select template.name["en"], from: :proposal_answer_template_chooser
         expect(page).to have_no_content(description)
-        expect(page).to have_content("Couldn't find this template")
+        expect(page).to have_content("Could not find this template")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

#11824 allows admins to use templates for quickly answer proposals. However valuators doing the same are forbidden access to the XHR request involved.

This solves this and also improves the user feedback when something goes wrong while obtaining the template.

I think this should be backported to 0.28.x series

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #11824

#### Testing

Just create some proposal answer templates, login as a valuator and try to use it. It won't work and you won't have any error message either.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!