### PR TITLE
Add mailer preview for Notifications and Reports and seeded Reports 

### DIFF
--- a/decidim-core/app/mailers/decidim/reported_mailer.rb
+++ b/decidim-core/app/mailers/decidim/reported_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Decidim
-  # A custom mailer for sending notifications to an admin when a report is created..
+  # A custom mailer for sending notifications to an admin when a report is created.
   class ReportedMailer < Decidim::ApplicationMailer
     helper Decidim::ResourceHelper
     helper Decidim::TranslationsHelper

--- a/decidim-core/lib/decidim/core/seeds.rb
+++ b/decidim-core/lib/decidim/core/seeds.rb
@@ -87,6 +87,8 @@ module Decidim
         settings = welcome_text.inject(settings) { |acc, (k, v)| acc.update("welcome_text_#{k}" => v) }
         hero_content_block.settings = settings
         hero_content_block.save!
+
+        create_user_report!(reportable: Decidim::User.take, current_user: Decidim::User.take)
       end
 
       def reset_column_information

--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -115,14 +115,14 @@ module Decidim
         user: current_user,
         locale: I18n.locale,
         reason: "spam",
-        details: "From the seeds",
+        details: "From the seeds"
       )
     rescue ActiveRecord::RecordInvalid
       # Ignore in case we have an error in the report creation.
       # Most likely is a "Validation failed: User has already been taken"
     end
 
-    def hide_report!(reportable:, current_user:)
+    def hide_report!(reportable:)
       moderation = Moderation.find_or_create_by!(reportable:, participatory_space: reportable.participatory_space)
       moderation.update!(hidden_at: Time.zone.now)
     end
@@ -131,7 +131,7 @@ module Decidim
       moderation = UserModeration.find_or_create_by!(user: reportable)
 
       UserReport.create!(
-        moderation: moderation,
+        moderation:,
         user: current_user,
         reason: "spam",
         details: "From the seeds"

--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -107,6 +107,37 @@ module Decidim
       )
     end
 
+    def create_report!(reportable:, current_user:)
+      moderation = Moderation.find_or_create_by!(reportable:, participatory_space: reportable.participatory_space)
+
+      Decidim::Report.create!(
+        moderation:,
+        user: current_user,
+        locale: I18n.locale,
+        reason: "spam",
+        details: "From the seeds",
+      )
+    rescue ActiveRecord::RecordInvalid
+      # Ignore in case we have an error in the report creation.
+      # Most likely is a "Validation failed: User has already been taken"
+    end
+
+    def hide_report!(reportable:, current_user:)
+      moderation = Moderation.find_or_create_by!(reportable:, participatory_space: reportable.participatory_space)
+      moderation.update!(hidden_at: Time.zone.now)
+    end
+
+    def create_user_report!(reportable:, current_user:)
+      moderation = UserModeration.find_or_create_by!(user: reportable)
+
+      UserReport.create!(
+        moderation: moderation,
+        user: current_user,
+        reason: "spam",
+        details: "From the seeds"
+      )
+    end
+
     def seed_components_manifests!(participatory_space:)
       Decidim.component_manifests.each do |manifest|
         manifest.seed!(participatory_space.reload)

--- a/decidim-core/spec/mailers/previews/notification_mailer_preview.rb
+++ b/decidim-core/spec/mailers/previews/notification_mailer_preview.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Decidim
+  class NotificationMailerPreview < ActionMailer::Preview
+    def event_received
+      NotificationMailer.event_received(event, event_class_name, resource, user, user_role, extra)
+    end
+
+    private
+
+    def event = "decidim.events.users.profile_updated"
+
+    def event_class_name = "Decidim::ProfileUpdatedEvent"
+
+    def resource = User.first
+
+    def user = User.second
+
+    def user_role = :follower
+
+    def extra = {}
+  end
+end

--- a/decidim-core/spec/mailers/previews/reported_mailer_preview.rb
+++ b/decidim-core/spec/mailers/previews/reported_mailer_preview.rb
@@ -2,22 +2,14 @@
 
 module Decidim
   class ReportedMailerPreview < ActionMailer::Preview
-    def report
-      ReportedMailer.report(user, reported_resource)
-    end
+    def report = ReportedMailer.report(user, reported_resource)
 
-    def hide
-      ReportedMailer.hide(user, reported_resource)
-    end
+    def hide = ReportedMailer.hide(user, reported_resource)
 
     private
 
-    def user
-      User.last
-    end
+    def user = User.last
 
-    def reported_resource
-      Decidim::Report.last
-    end
+    def reported_resource = Decidim::Report.last
   end
 end

--- a/decidim-core/spec/mailers/previews/reported_mailer_preview.rb
+++ b/decidim-core/spec/mailers/previews/reported_mailer_preview.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Decidim
+  class ReportedMailerPreview < ActionMailer::Preview
+    def report
+      ReportedMailer.report(user, reported_resource)
+    end
+
+    def hide
+      ReportedMailer.hide(user, reported_resource)
+    end
+
+    private
+
+    def user
+      User.last
+    end
+
+    def reported_resource
+      Decidim::Report.last
+    end
+  end
+end

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -36,6 +36,9 @@ module Decidim
         end
 
         update_traceability!(component:)
+
+        create_report!(reportable: Decidim::Proposals::Proposal.take, current_user: Decidim::User.take)
+        hide_report!(reportable: Decidim::Proposals::Proposal.take, current_user: Decidim::User.take)
       end
 
       def organization

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -38,7 +38,7 @@ module Decidim
         update_traceability!(component:)
 
         create_report!(reportable: Decidim::Proposals::Proposal.take, current_user: Decidim::User.take)
-        hide_report!(reportable: Decidim::Proposals::Proposal.take, current_user: Decidim::User.take)
+        hide_report!(reportable: Decidim::Proposals::Proposal.take)
       end
 
       def organization


### PR DESCRIPTION
## :tophat: What? Why?

While working in #12657, I wanted some improvements that weren't fixes, so I preferred to create a new PR with those new mini-improvements:

1.Seeds for reports
1. Mailer preview for Notifications
1. Mailer preview for Reported emails 

## :pushpin: Related Issues
 
- Related to #12657

## Testing

### 1. Seeds for reports

1. Recreate the database with `bin/rails db:drop db:create db:migrate db:seed`
2. Go to http://localhost:3000/admin/moderations 
3. Login as admin
4. See that you have some moderations there by default

### 2. Mailer preview for Notifications

1. Restart your app server (`bin/dev`) to clean the mailer previews cache
2. Go to http://localhost:3000/rails/mailers/decidim/notification_mailer/event_received 

#### 3. Mailer preview for Reported emails 

1. Restart your app server (`bin/dev`) to clean the mailer previews cache
2. Go to http://localhost:3000/rails/mailers/decidim/reported_mailer/report
3. Go to http://localhost:3000/rails/mailers/decidim/reported_mailer/hide

## :camera: Screenshots

![Global moderations in admin panel](https://github.com/decidim/decidim/assets/717367/9c79aaea-25de-461a-94b4-ebcb594de220)

![Mailer preview for Notifications](https://github.com/decidim/decidim/assets/717367/44a0dcc7-4e8b-462c-af50-1a577dca4114)

![Mailer preview for Reported emails (report)](https://github.com/decidim/decidim/assets/717367/4c3a6f60-5433-468d-ba5e-37076a043509)

![Mailer preview for Reported emails (hide)](https://github.com/decidim/decidim/assets/717367/a24bf252-4655-4724-b110-c4e37efe9665)


:hearts: Thank you!
