### PR TITLE
Backport 'Fix illogical heading order on registration page' to v0.28

### DIFF
--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -41,7 +41,7 @@
     </div>
 
     <div id="card__tos" class="form__wrapper-block">
-      <h4 class="h4"><%= t("decidim.devise.registrations.new.tos_title") %></h4>
+      <h2 class="h4"><%= t("decidim.devise.registrations.new.tos_title") %></h2>
 
       <div class="tos-text">
         <% terms_of_service_summary_content_blocks.each do |content_block| %>
@@ -53,7 +53,7 @@
     </div>
 
     <div id="card__newsletter" class="form__wrapper-block">
-      <h4 class="h4"><%= t("decidim.devise.registrations.new.newsletter_title") %></h4>
+      <h2 class="h4"><%= t("decidim.devise.registrations.new.newsletter_title") %></h2>
       <%= f.check_box :newsletter, label: t("decidim.devise.registrations.new.newsletter"), checked: @form.newsletter, label_options: { class: "form__wrapper-checkbox-label" } %>
     </div>
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12745 to v0.28

:hearts: Thank you!