### PR TITLE
Backport 'Fix DOM text reinterpreted as HTML in budgets' exit handler' to v0.27

### DIFF
--- a/decidim-budgets/app/packs/src/decidim/budgets/exit_handler.js
+++ b/decidim-budgets/app/packs/src/decidim/budgets/exit_handler.js
@@ -65,7 +65,7 @@ $(() => {
     }
 
     $exitLink.attr("href", url);
-    $exitLink.html(exitLinkText);
+    $exitLink.text(exitLinkText);
     $exitNotification.foundation("open");
   };
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12673 to v0.27

:hearts: Thank you!