### PR TITLE
Backport 'Fix clear-text storage of sensitive information in omniauth registration' to v0.27

### DIFF
--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -57,14 +57,12 @@ module Decidim
         # to be marked confirmed.
         @user.skip_confirmation! if !@user.confirmed? && @user.email == verified_email
       else
-        generated_password = SecureRandom.hex
-
         @user.email = (verified_email || form.email)
         @user.name = form.name
         @user.nickname = form.normalized_nickname
         @user.newsletter_notifications_at = nil
-        @user.password = generated_password
-        @user.password_confirmation = generated_password
+        @user.password = SecureRandom.hex
+        @user.password_confirmation = @user.password
         if form.avatar_url.present?
           url = URI.parse(form.avatar_url)
           filename = File.basename(url.path)


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12662 to v0.27

:hearts: Thank you!