### PR TITLE
Backport 'Remove ComponentInterface from the ResultType in the API' to v0.27

### DIFF
--- a/decidim-accountability/lib/decidim/api/result_type.rb
+++ b/decidim-accountability/lib/decidim/api/result_type.rb
@@ -3,7 +3,6 @@
 module Decidim
   module Accountability
     class ResultType < Decidim::Api::Types::BaseObject
-      implements Decidim::Core::ComponentInterface
       implements Decidim::Core::CategorizableInterface
       implements Decidim::Comments::CommentableInterface
       implements Decidim::Core::ScopableInterface

--- a/decidim-accountability/spec/types/integration_schema_spec.rb
+++ b/decidim-accountability/spec/types/integration_schema_spec.rb
@@ -32,7 +32,6 @@ describe "Decidim::Api::QueryType" do
       "hasComments" => result.comment_threads.size.positive?,
       "id" => result.id.to_s,
       "parent" => result.parent,
-      "participatorySpace" => { "id" => result.participatory_space.id.to_s },
       "progress" => result.progress.to_f,
       "reference" => result.reference,
       "scope" => result.scope,
@@ -121,9 +120,6 @@ describe "Decidim::Api::QueryType" do
               hasComments
               id
               parent {
-                id
-              }
-              participatorySpace {
                 id
               }
               progress
@@ -230,9 +226,6 @@ describe "Decidim::Api::QueryType" do
           hasComments
           id
           parent {
-            id
-          }
-          participatorySpace {
             id
           }
           progress


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12653 to v0.27

:hearts: Thank you!