### PR TITLE
Backport 'Fix flaky spec on join user group command spec' to v0.27

### DIFF
--- a/decidim-core/spec/commands/decidim/join_user_group_spec.rb
+++ b/decidim-core/spec/commands/decidim/join_user_group_spec.rb
@@ -55,7 +55,7 @@ module Decidim
                 event: "decidim.events.groups.join_request_created",
                 event_class: JoinRequestCreatedEvent,
                 resource: user_group,
-                affected_users: affected_users,
+                affected_users: match_array(affected_users),
                 extra: {
                   user_group_name: user_group.name,
                   user_group_nickname: user_group.nickname


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12642 to v0.27

:hearts: Thank you!