### PR TITLE
Backport 'Fix flaky spec on endorsements controller' to v0.27

### DIFF
--- a/decidim-core/spec/controllers/decidim/endorsements_controller_as_user_spec.rb
+++ b/decidim-core/spec/controllers/decidim/endorsements_controller_as_user_spec.rb
@@ -46,7 +46,7 @@ module Decidim
             get :identities, params: params
 
             expect(response).to have_http_status(:ok)
-            expect(assigns[:user_verified_groups]).to eq user.user_groups
+            expect(assigns[:user_verified_groups]).to match_array(user.user_groups)
             expect(subject).to render_template("decidim/endorsements/identities")
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12641 to v0.27

:hearts: Thank you!