### PR TITLE
Prevent cached signed global IDs from expiring

### DIFF
--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -238,6 +238,14 @@ module Decidim
         app.config.action_mailer.deliver_later_queue_name = :mailers
       end
 
+      initializer "decidim_core.signed_global_id", after: "global_id" do |app|
+        next if app.config.global_id.fetch(:expires_in, nil).present?
+
+        config.after_initialize do
+          SignedGlobalID.expires_in = nil
+        end
+      end
+
       initializer "decidim_core.middleware" do |app|
         if app.config.public_file_server.enabled
           headers = app.config.public_file_server.headers || {}

--- a/decidim-core/spec/models/decidim/organization_spec.rb
+++ b/decidim-core/spec/models/decidim/organization_spec.rb
@@ -239,5 +239,17 @@ module Decidim
         it_behaves_like "creates correct favicon variants"
       end
     end
+
+    describe "#to_sgid" do
+      subject { sgid }
+
+      let(:organization) { create(:organization) }
+      let(:sgid) { travel_to(5.years.ago) { organization.to_sgid.to_s } }
+
+      it "does not expire" do
+        located = GlobalID::Locator.locate_signed(subject)
+        expect(located).to eq(organization)
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
By default Decidim's cell caches are set to never expire:
https://github.com/decidim/decidim/blob/acbb11068c5944120f0cb74c012625f09270c5c0/decidim-core/lib/decidim/view_model.rb#L93-L95

This default is applied unless the individual cell overrides this value. There are only few cells that override this value.

This also applies to comment forms where signed global IDs are written to the output to refer to the comments. If the comment form has been cached more than 1 month ago, as the cache never expires, the commenting for that page is broken as the global signed ID has expired. Even worse, the user will not get any error message on what might have gone wrong because the commenting endpoint responds with HTTP 404, leaving them totally confused why commenting is not working (as well as leaving the maintainers of the instance confused why it's not working).

This fixes the issue by setting the global signed IDs to never expire. This can be changed in individual implementations by changing the value of `config.global_id.expires_in` within the instance configuration.

#### :pushpin: Related Issues
- Fixes #10609

#### Testing
- Run the spec added in this PR -> See it green
- Comment out the initializer added in this PR
- Run the spec added in this PR without the initializer -> See it fail