### PR TITLE
Backport 'Do not show scopes column in budgets if there isn't subscopes' to v0.27

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
@@ -27,7 +27,9 @@
             <th><%= t("models.budget.fields.name", scope: "decidim.budgets") %></th>
             <th><%= t("models.budget.fields.total_budget", scope: "decidim.budgets") %></th>
             <th><%= t("models.budget.fields.projects_count", scope: "decidim.budgets") %></th>
-            <%= th_resource_scope_label %>
+            <% if current_component.has_subscopes? %>
+              <%= th_resource_scope_label %>
+            <% end %>
             <th class="actions"><%= t("actions.title", scope: "decidim.budgets") %></th>
           </tr>
         </thead>
@@ -43,7 +45,9 @@
               <td>
                 <%= link_to budget.projects.count, budget_projects_path(budget) %>
               </td>
-              <%= td_resource_scope_for(budget.scope) %>
+              <% if current_component.has_subscopes? %>
+                <%= td_resource_scope_for(budget.scope) %>
+              <% end %>
               <td class="table-list__actions">
                 <%= icon_link_to "eye", resource_locator(budget).path, t("actions.preview", scope: "decidim.budgets"), class: "action-icon--preview", target: :blank %>
 

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/_project-tr.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/_project-tr.html.erb
@@ -13,7 +13,9 @@
       <%= translated_attribute project.category.name %>
     <% end %>
   </td>
-  <%= td_resource_scope_for(project.scope) %>
+  <% if current_component.has_subscopes? %>
+    <%= td_resource_scope_for(project.scope) %>
+  <% end %>
   <td>
     <%= project.confirmed_orders_count %>
   </td>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
@@ -21,7 +21,9 @@
             <th><%= sort_link(query, :id, t("models.project.fields.id", scope: "decidim.budgets"), default_order: :desc) %>
             <th><%= sort_link(query, :title, t("models.project.fields.title", scope: "decidim.budgets")) %></th>
             <th><%= sort_link(query, :category_name, t("models.project.fields.category", scope: "decidim.budgets") ) %></th>
-            <%= th_scope_sort_link %>
+            <% if current_component.has_subscopes? %>
+              <%= th_scope_sort_link %>
+            <% end %>
             <th><%= sort_link(query, :confirmed_orders_count, t("index.confirmed_orders_count")) %></th>
             <th><%= sort_link(query, :selected, t(".selected")) %></th>
             <th class="actions"><%= t("actions.title", scope: "decidim.budgets") %></th>

--- a/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
@@ -121,6 +121,62 @@ describe "Admin manages budgets", type: :system do
     end
   end
 
+  describe "when managing a budget with scopes" do
+    let!(:scopes) { create_list(:subscope, 3, organization:, parent: scope) }
+    let(:scope_id) { scope.id }
+    let(:participatory_space) { create(:participatory_process, organization:, scopes_enabled:) }
+    let!(:component) { create(:component, manifest:, settings: { scopes_enabled:, scope_id: }, participatory_space:) }
+    let!(:budget) { create(:budget, component: current_component) }
+    let!(:scope) { create(:scope, organization:) }
+    let(:scopes_enabled) { true }
+
+    before do
+      visit current_path
+    end
+
+    context "when the scope has subscopes" do
+      context "when scopes_enabled is true" do
+        it "displays the scope column" do
+          expect(component).to be_scopes_enabled
+          expect(component).to have_subscopes
+          expect(page).to have_content("Scope")
+        end
+      end
+
+      context "when scopes_enabled is false" do
+        let(:scopes_enabled) { false }
+
+        it "displays the scope column" do
+          expect(component).not_to be_scopes_enabled
+          expect(component).not_to have_subscopes
+          expect(page).to have_no_content("Scope")
+        end
+      end
+    end
+
+    context "when the scope does not have subscopes" do
+      let(:scope_id) { scopes.first.id }
+
+      context "when scopes_enabled is true" do
+        it "hides the scope column" do
+          expect(component).to be_scopes_enabled
+          expect(component).not_to have_subscopes
+          expect(page).to have_no_content("Scope")
+        end
+      end
+
+      context "when scopes_enabled is false" do
+        let(:scopes_enabled) { false }
+
+        it "displays the scope column" do
+          expect(component).not_to be_scopes_enabled
+          expect(component).not_to have_subscopes
+          expect(page).to have_no_content("Scope")
+        end
+      end
+    end
+  end
+
   describe "component page shows finished and pending orders of all budgets" do
     context "when component has many budgets with orders" do
       let(:budget2) { create(:budget, :with_projects, component: current_component) }

--- a/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
@@ -122,12 +122,12 @@ describe "Admin manages budgets", type: :system do
   end
 
   describe "when managing a budget with scopes" do
-    let!(:scopes) { create_list(:subscope, 3, organization:, parent: scope) }
+    let!(:scopes) { create_list(:subscope, 3, organization: organization, parent: scope) }
     let(:scope_id) { scope.id }
-    let(:participatory_space) { create(:participatory_process, organization:, scopes_enabled:) }
-    let!(:component) { create(:component, manifest:, settings: { scopes_enabled:, scope_id: }, participatory_space:) }
+    let(:participatory_space) { create(:participatory_process, organization: organization, scopes_enabled: scopes_enabled) }
+    let!(:component) { create(:component, manifest: manifest, settings: { scopes_enabled: scopes_enabled, scope_id: scope_id }, participatory_space: participatory_space) }
     let!(:budget) { create(:budget, component: current_component) }
-    let!(:scope) { create(:scope, organization:) }
+    let!(:scope) { create(:scope, organization: organization) }
     let(:scopes_enabled) { true }
 
     before do

--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -95,7 +95,7 @@ describe "Admin manages projects", type: :system do
     end
 
     describe "update projects budget" do
-      let!(:another_component) { create(:budgets_component, organization:, participatory_space: current_component.participatory_space) }
+      let!(:another_component) { create(:budgets_component, organization: organization, participatory_space: current_component.participatory_space) }
       let!(:another_budget) { create(:budget, component: another_component) }
 
       it "shows all of the budgets within the participatory_space" do
@@ -104,7 +104,7 @@ describe "Admin manages projects", type: :system do
         find_by_id("js-bulk-actions-button").click
         click_on "Change budget"
         options = ["Select budget", format_title(destination_budget), format_title(budget), format_title(another_budget)]
-        expect(page).to have_select("reference_id", options:)
+        expect(page).to have_select("reference_id", options: options)
       end
 
       it "changes project budget" do

--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -93,35 +93,5 @@ describe "Admin manages projects", type: :system do
         expect(page).to have_no_content(scope.name)
       end
     end
-
-    describe "update projects budget" do
-      let!(:another_component) { create(:budgets_component, organization: organization, participatory_space: current_component.participatory_space) }
-      let!(:another_budget) { create(:budget, component: another_component) }
-
-      it "shows all of the budgets within the participatory_space" do
-        visit current_path
-        find_by_id("projects_bulk").set(true)
-        find_by_id("js-bulk-actions-button").click
-        click_on "Change budget"
-        options = ["Select budget", format_title(destination_budget), format_title(budget), format_title(another_budget)]
-        expect(page).to have_select("reference_id", options: options)
-      end
-
-      it "changes project budget" do
-        find_by_id("projects_bulk").set(true)
-        find_by_id("js-bulk-actions-button").click
-        click_on "Change budget"
-        select translated(destination_budget.title), from: "reference_id"
-        click_on "Update project's budget"
-        within_flash_messages do
-          expect(page).to have_content("Projects successfully updated to the budget: #{translated(project.title)} and #{translated(project2.title)}")
-        end
-        expect(page).to have_no_css("tr[data-id='#{project.id}']")
-        expect(page).to have_no_css("tr[data-id='#{project2.id}']")
-
-        expect(project.reload.budget).to eq(destination_budget)
-        expect(project2.reload.budget).to eq(destination_budget)
-      end
-    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12020 to v0.27

:hearts: Thank you!