### PR TITLE
Backport 'Show extended information when a new comment is in a digest email' to v0.27

### DIFF
--- a/decidim-core/app/presenters/decidim/notification_to_mailer_presenter.rb
+++ b/decidim-core/app/presenters/decidim/notification_to_mailer_presenter.rb
@@ -7,11 +7,16 @@ module Decidim
   class NotificationToMailerPresenter < SimpleDelegator
     include Decidim::TranslatableAttributes
 
+    EXTENDED_NOTIFICATIONS_CLASSES = [
+      "Decidim::Comments::CommentCreatedEvent"
+    ].freeze
+
     delegate :url_helpers, to: "Decidim::Core::Engine.routes"
     delegate :resource_title, to: :event
     delegate :resource_url, to: :event
     delegate :email_intro, to: :event
     delegate :resource_path, to: :event
+    delegate :safe_resource_text, to: :event
 
     def date_time
       if frequency == :daily
@@ -19,6 +24,10 @@ module Decidim
       else
         I18n.l(created_at, format: :decidim_short)
       end
+    end
+
+    def show_extended_information?
+      EXTENDED_NOTIFICATIONS_CLASSES.include?(event_class)
     end
 
     private

--- a/decidim-core/app/views/decidim/notifications_digest_mailer/_email_content.html.erb
+++ b/decidim-core/app/views/decidim/notifications_digest_mailer/_email_content.html.erb
@@ -8,4 +8,11 @@
       <%= link_to decidim_sanitize(notification.resource_title, strip_tags: true), notification.resource_url %>
     </p>
   <% end %>
+  <% if notification.show_extended_information? %>
+    <blockquote>
+      <p>
+      <%= notification.safe_resource_text %>
+      </p>
+    </blockquote>
+  <% end %>
 </div>

--- a/decidim-core/spec/mailers/notification_digest_mailer_spec.rb
+++ b/decidim-core/spec/mailers/notification_digest_mailer_spec.rb
@@ -19,6 +19,18 @@ module Decidim
           %(<a href="#{::Decidim::ResourceLocatorPresenter.new(resource).url}">Testing resource</a>)
         )
       end
+
+      context "when the notification is a comment" do
+        let(:comment) { create(:comment, body: "This is a comment") }
+        let(:event_name) { "decidim.events.comments.comment_created" }
+        let(:event_class) { "Decidim::Comments::CommentCreatedEvent" }
+        let(:extra) { { "comment_id" => comment.id, "received_as" => "follower" } }
+        let(:notification) { create(:notification, user:, resource:, event_name:, event_class:, extra:) }
+
+        it "includes the comment body" do
+          expect(subject.body).to include("This is a comment")
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/mailers/previews/notifications_digest_mailer_preview.rb
+++ b/decidim-core/spec/mailers/previews/notifications_digest_mailer_preview.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  class NotificationsDigestMailerPreview < ActionMailer::Preview
+    def digest_mail
+      NotificationsDigestMailer.digest_mail(user, notification_ids)
+    end
+
+    private
+
+    def user
+      User.last
+    end
+
+    def notification_ids
+      Decidim::Notification.last(10).pluck(:id)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12563 to v0.27

:hearts: Thank you!