### PR TITLE
Fix lighthouse URLs

### DIFF
--- a/decidim-dev/lib/tasks/lighthouse_report.rake
+++ b/decidim-dev/lib/tasks/lighthouse_report.rake
@@ -43,8 +43,8 @@ namespace :decidim do
     def lighthouse_paths
       ["/"].tap do |urls|
         urls << Decidim::ResourceLocatorPresenter.new(Decidim::ParticipatoryProcess.published.first).path
-        urls << Decidim::ResourceLocatorPresenter.new(Decidim::Meetings::Meeting.published.first).path
-        urls << Decidim::ResourceLocatorPresenter.new(Decidim::Proposals::Proposal.published.first).path
+        urls << Decidim::ResourceLocatorPresenter.new(Decidim::Meetings::Meeting.published.not_hidden.first).path
+        urls << Decidim::ResourceLocatorPresenter.new(Decidim::Proposals::Proposal.published.not_hidden.first).path
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
After merging #12765, i have noticed that the Performance metrics pipeline has started to fail with 404 status code on the proposals. This PR tries to fix the 404 status code. 

Tracking the issue, i have seen that #12766 has introduced the moderations to the seeds, which means that always the first proposal will be moderated, as per `take` [implementation](https://apidock.com/rails/ActiveRecord/FinderMethods/take). 

```
    # File activerecord/lib/active_record/relation/finder_methods.rb, line 97
    def take(limit = nil)
      limit ? find_take_with_limit(limit) : find_take
    end

# we do not specify the limit, nor order when creating the seeds which means we are using find_take

      # File activerecord/lib/active_record/relation/finder_methods.rb, line 520
      def find_take
        if loaded?
          records.first
        else
          @take ||= limit(1).records.first
        end
      end
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12765
- Related to #12766

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![image](https://github.com/decidim/decidim/assets/105683/e2c22758-5fd3-4908-9485-b495b6caa99a)

:hearts: Thank you!
