### PR TITLE
Fix proposal comparison step

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/compare.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/compare.html.erb
@@ -10,7 +10,7 @@
   <% if @similar_proposals.present? %>
     <div class="proposal__container my-10">
       <% @similar_proposals.each do |proposal| %>
-        <%= card_for @proposal %>
+        <%= card_for proposal %>
       <% end %>
     </div>
   <% end %>

--- a/decidim-proposals/spec/shared/proposals_wizards_examples.rb
+++ b/decidim-proposals/spec/shared/proposals_wizards_examples.rb
@@ -57,7 +57,7 @@ shared_examples "proposals wizards" do |options|
     context "when in step_2: Compare" do
       context "with similar results" do
         before do
-          create(:proposal, title: "More sidewalks and less roads", body: "Cities need more people, not more cars", component:)
+          create(:proposal, title: "More sidewalks and roads", body: "Cities need more people, not more cars", component:)
           create(:proposal, title: "More sidewalks and less roadways", body: "Green is always better", component:)
           visit_component
           click_on "New proposal"
@@ -78,7 +78,8 @@ shared_examples "proposals wizards" do |options|
 
         it "shows similar proposals" do
           expect(page).to have_content("Similar Proposals (2)")
-          expect(page).to have_css("[id^='proposals__proposal']", text: "More sidewalks and less roads")
+          expect(page).to have_css("[id^='proposals__proposal']", text: "More sidewalks and roads")
+          expect(page).to have_css("[id^='proposals__proposal']", text: "More sidewalks and less roadways")
           expect(page).to have_css("[id^='proposals__proposal']", count: 2)
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?

After the update to v0.28, the comparison step does not show the compared proposal but the always the create proposal in the compared cards.
This was not detected because the spec was not correct as it used the same data for the compared proposals and the new created one.

This PR fixes the issue.
This affects Decidim from v0.28 onward, so it should be backported.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
Create a new proposal similar to an existing proposal, you will see in the list that all proposal listed are the ones that you've created instead the ones supposed to be compared.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
