### PR TITLE
Add the `rel="nofollow noopener noreferrer"` attribute to external links

### DIFF
--- a/decidim-core/app/cells/decidim/profile/details.erb
+++ b/decidim-core/app/cells/decidim/profile/details.erb
@@ -9,7 +9,7 @@
         <%= icon detail[:icon] %>
         <span>
           <% if detail[:url].present? %>
-            <%= link_to(detail[:url], detail[:text]) %>
+            <%= link_to(detail[:url], detail[:text], rel: "nofollow noopener noreferrer") %>
           <% else %>
             <%= detail[:text] %>
           <% end %>

--- a/decidim-core/app/controllers/decidim/links_controller.rb
+++ b/decidim-core/app/controllers/decidim/links_controller.rb
@@ -14,7 +14,7 @@ module Decidim
     rescue_from URI::InvalidURIError, with: :modal
 
     def new
-      headers["X-Robots-Tag"] = "noindex"
+      headers["X-Robots-Tag"] = "none"
     end
 
     private

--- a/decidim-core/app/controllers/decidim/links_controller.rb
+++ b/decidim-core/app/controllers/decidim/links_controller.rb
@@ -15,6 +15,7 @@ module Decidim
 
     def new
       headers["X-Robots-Tag"] = "none"
+      headers["Link"] = %(<#{url_for}>; rel="canonical")
     end
 
     private

--- a/decidim-core/app/views/decidim/links/_modal.html.erb
+++ b/decidim-core/app/views/decidim/links/_modal.html.erb
@@ -16,6 +16,6 @@
     <button class="button button__lg button__transparent-secondary" data-dialog-close="external-domain-warning">
       <%= t("decidim.links.warning.cancel") %>
     </button>
-    <%= link_to t("decidim.links.warning.proceed"), external_url.to_s , target: "_blank", class: "button button__lg button__secondary" %>
+    <%= link_to t("decidim.links.warning.proceed"), external_url.to_s , target: "_blank", class: "button button__lg button__secondary", rel: "nofollow noopener noreferrer" %>
   </div>
 <% end %>

--- a/decidim-core/app/views/decidim/links/new.html.erb
+++ b/decidim-core/app/views/decidim/links/new.html.erb
@@ -12,7 +12,7 @@
   </code>
 
   <div class="form__wrapper-block">
-    <%= link_to t("decidim.links.warning.proceed"), external_url.to_s, class: "button button__lg button__secondary ml-auto" %>
+    <%= link_to t("decidim.links.warning.proceed"), external_url.to_s, class: "button button__lg button__secondary ml-auto", rel: "nofollow noopener noreferrer" %>
   </div>
 
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
The external links are being abused by the annoying SEO "experts", so let's block this behavior from them.

They should not be able to abuse the external link for any URL that provides them any SEO value.

#### Testing
Check the `rel` attribute on the external links using an inspector.