### PR TITLE
Hide moderated content from notifications

### DIFF
--- a/decidim-accountability/app/events/decidim/accountability/base_result_event.rb
+++ b/decidim-accountability/app/events/decidim/accountability/base_result_event.rb
@@ -20,6 +20,10 @@ module Decidim
       def proposal
         @proposal ||= resource.linked_resources(:proposals, "included_proposals").find_by(id: extra[:proposal_id])
       end
+
+      def hidden_resource?
+        super || (proposal.respond_to?(:hidden?) && proposal.hidden?)
+      end
     end
   end
 end

--- a/decidim-accountability/spec/events/decidim/accountability/proposal_linked_event_spec.rb
+++ b/decidim-accountability/spec/events/decidim/accountability/proposal_linked_event_spec.rb
@@ -71,4 +71,22 @@ describe Decidim::Accountability::ProposalLinkedEvent do
       expect(subject.resource_text).to eq translated(resource.description)
     end
   end
+
+  describe "hidden_resource?" do
+    context "when resource is not moderated" do
+      let(:resource) { create(:proposal) }
+
+      it "returns false" do
+        expect(subject.hidden_resource?).to be false
+      end
+    end
+
+    context "when resource is moderated" do
+      let(:resource) { create(:proposal, :moderated) }
+
+      it "returns false" do
+        expect(subject.hidden_resource?).to be true
+      end
+    end
+  end
 end

--- a/decidim-accountability/spec/events/decidim/accountability/proposal_linked_event_spec.rb
+++ b/decidim-accountability/spec/events/decidim/accountability/proposal_linked_event_spec.rb
@@ -84,7 +84,7 @@ describe Decidim::Accountability::ProposalLinkedEvent do
     context "when resource is moderated" do
       let(:resource) { create(:proposal, :moderated) }
 
-      it "returns false" do
+      it "returns true" do
         expect(subject.hidden_resource?).to be true
       end
     end

--- a/decidim-accountability/spec/events/decidim/accountability/result_progress_updated_event_spec.rb
+++ b/decidim-accountability/spec/events/decidim/accountability/result_progress_updated_event_spec.rb
@@ -77,7 +77,7 @@ describe Decidim::Accountability::ResultProgressUpdatedEvent do
     context "when resource is moderated" do
       let(:resource) { create(:proposal, :moderated) }
 
-      it "returns false" do
+      it "returns true" do
         expect(subject.hidden_resource?).to be true
       end
     end

--- a/decidim-accountability/spec/events/decidim/accountability/result_progress_updated_event_spec.rb
+++ b/decidim-accountability/spec/events/decidim/accountability/result_progress_updated_event_spec.rb
@@ -64,4 +64,22 @@ describe Decidim::Accountability::ResultProgressUpdatedEvent do
       expect(subject.resource_text).to eq translated(resource.description)
     end
   end
+
+  describe "hidden_resource?" do
+    context "when resource is not moderated" do
+      let(:resource) { create(:proposal) }
+
+      it "returns false" do
+        expect(subject.hidden_resource?).to be false
+      end
+    end
+
+    context "when resource is moderated" do
+      let(:resource) { create(:proposal, :moderated) }
+
+      it "returns false" do
+        expect(subject.hidden_resource?).to be true
+      end
+    end
+  end
 end

--- a/decidim-comments/app/events/decidim/comments/comment_event.rb
+++ b/decidim-comments/app/events/decidim/comments/comment_event.rb
@@ -14,6 +14,10 @@ module Decidim
           comment.formatted_body(override_translation)
         end
 
+        def hidden_resource?
+          super || (comment.respond_to?(:hidden?) && comment.hidden?)
+        end
+
         def author
           comment.normalized_author
         end

--- a/decidim-comments/lib/decidim/comments/test/factories.rb
+++ b/decidim-comments/lib/decidim/comments/test/factories.rb
@@ -40,6 +40,12 @@ FactoryBot.define do
       end
       root_commentable { build(:dummy_resource, skip_injection:) }
     end
+
+    trait :moderated do
+      after(:create) do |comment, evaluator|
+        create(:moderation, reportable: comment, hidden_at: 2.days.ago, skip_injection: evaluator.skip_injection)
+      end
+    end
   end
 
   factory :comment_vote, class: "Decidim::Comments::CommentVote" do

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/comment_event.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/comment_event.rb
@@ -53,7 +53,7 @@ shared_examples_for "a comment event" do
     context "when comment is moderated" do
       let(:comment) { create(:comment, :moderated) }
 
-      it "returns false" do
+      it "returns true" do
         expect(subject.hidden_resource?).to be true
       end
     end

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/comment_event.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/comment_event.rb
@@ -42,4 +42,37 @@ shared_examples_for "a comment event" do
       expect(subject.resource_text).to eq comment.formatted_body
     end
   end
+
+  describe "hidden_resource?" do
+    context "when comment is not moderated" do
+      it "returns false" do
+        expect(subject.hidden_resource?).to be false
+      end
+    end
+
+    context "when comment is moderated" do
+      let(:comment) { create(:comment, :moderated) }
+
+      it "returns false" do
+        expect(subject.hidden_resource?).to be true
+      end
+    end
+
+    context "when resource is not moderated" do
+      it "returns false" do
+        expect(subject.hidden_resource?).to be false
+      end
+    end
+
+    context "when resource is moderated" do
+      before do
+        create(:moderation, reportable: resource, hidden_at: 2.days.ago)
+        resource.reload
+      end
+
+      it "returns true" do
+        expect(subject.hidden_resource?).to be true
+      end
+    end
+  end
 end

--- a/decidim-core/app/cells/decidim/notification/moderated.erb
+++ b/decidim-core/app/cells/decidim/notification/moderated.erb
@@ -1,0 +1,12 @@
+<div class="notification" data-notification>
+  <div class="notification__wrapper">
+    <div class="notification__time" title="<%= l(notification.created_at) %>"> <%= notification.created_at_in_words %></div>
+    <div class="notification__snippet">
+      <span class="notification__snippet-title"><%= t("decidim.notifications.show.moderated") %></span>
+    </div>
+  </div>
+  <%= link_to model, remote: true, method: :delete, class: "notification__button", data: { "notification-read": "" } do %>
+    <span class="sr-only md:not-sr-only"><%= t("mark_as_read", scope: "layouts.decidim.notifications_dashboard") %></span>
+    <%= icon "check-line", class: "fill-current" %>
+  <% end %>
+</div>

--- a/decidim-core/app/cells/decidim/notification/moderated.erb
+++ b/decidim-core/app/cells/decidim/notification/moderated.erb
@@ -2,7 +2,7 @@
   <div class="notification__wrapper">
     <div class="notification__time" title="<%= l(notification.created_at) %>"> <%= notification.created_at_in_words %></div>
     <div class="notification__snippet">
-      <span class="notification__snippet-title"><%= t("decidim.notifications.show.moderated") %></span>
+      <span class="notification__snippet-title text-gray"><%= t("decidim.notifications.show.moderated") %></span>
     </div>
   </div>
   <%= link_to model, remote: true, method: :delete, class: "notification__button", data: { "notification-read": "" } do %>

--- a/decidim-core/app/cells/decidim/notification_cell.rb
+++ b/decidim-core/app/cells/decidim/notification_cell.rb
@@ -7,7 +7,11 @@ module Decidim
     include Decidim::Core::Engine.routes.url_helpers
 
     def show
-      render :show
+      if notification.event_class_instance.try(:hidden_resource?)
+        render :moderated
+      else
+        render :show
+      end
     end
 
     def notification_title

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1,5 +1,6 @@
 ---
 en:
+
   activemodel:
     attributes:
       account:
@@ -1240,6 +1241,7 @@ en:
     notifications:
       no_notifications: No notifications yet.
       show:
+        moderated: Content moderated
         missing_event: Oops, this notification belongs to an item that is no longer available. You can discard it.
     notifications_digest_mailer:
       header:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1,6 +1,5 @@
 ---
 en:
-
   activemodel:
     attributes:
       account:
@@ -1241,8 +1240,8 @@ en:
     notifications:
       no_notifications: No notifications yet.
       show:
-        moderated: Content moderated
         missing_event: Oops, this notification belongs to an item that is no longer available. You can discard it.
+        moderated: Content moderated
     notifications_digest_mailer:
       header:
         daily: Daily Notification Digest

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -111,6 +111,10 @@ module Decidim
         Decidim::ContentProcessor.render_without_format(title, links: false).html_safe
       end
 
+      def hidden_resource?
+        resource.respond_to?(:hidden?) && resource.hidden?
+      end
+
       private
 
       def component

--- a/decidim-core/spec/cells/decidim/notification_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/notification_cell_spec.rb
@@ -30,4 +30,12 @@ describe Decidim::NotificationCell, type: :cell do
       expect(my_cell.notification_title).to include("this notification belongs to an item that is no longer available")
     end
   end
+
+  context "when resource is moderated" do
+    let!(:resource) { create(:dummy_resource, :moderated, component:) }
+
+    it "does not render the resource" do
+      expect(subject.to_s).to include("Content moderated")
+    end
+  end
 end

--- a/decidim-core/spec/lib/events/simple_event_spec.rb
+++ b/decidim-core/spec/lib/events/simple_event_spec.rb
@@ -6,21 +6,39 @@ module Decidim
   describe Events::SimpleEvent do
     let(:user) { build(:user) }
 
-    describe "i18n_options?" do
-      subject do
-        described_class.new(
-          resource:,
-          event_name: "some.event",
-          user:,
-          extra: {}
-        )
-      end
+    subject do
+      described_class.new(
+        resource:,
+        event_name: "some.event",
+        user:,
+        extra: {}
+      )
+    end
 
+    describe "i18n_options?" do
       let(:resource) { create(:dummy_resource, title: { en: "<script>alert('Hey');</script>" }) }
 
       it "sanitizes the HTML tags from the i18n options" do
         expect(subject.i18n_options[:resource_title])
           .to eq "alert('Hey');"
+      end
+    end
+
+    describe "hidden_resource?" do
+      context "when resource is not moderated" do
+        let(:resource) { create(:dummy_resource, title: { en: "<script>alert('Hey');</script>" }) }
+
+        it "returns false" do
+          expect(subject.hidden_resource?).to be false
+        end
+      end
+
+      context "when resource is moderated" do
+        let(:resource) { create(:dummy_resource, :moderated, title: { en: "<script>alert('Hey');</script>" }) }
+
+        it "returns false" do
+          expect(subject.hidden_resource?).to be true
+        end
       end
     end
   end

--- a/decidim-dev/lib/decidim/dev/test/factories.rb
+++ b/decidim-dev/lib/decidim/dev/test/factories.rb
@@ -35,6 +35,12 @@ FactoryBot.define do
         end
       end
     end
+
+    trait :moderated do
+      after(:create) do |resource, evaluator|
+        create(:moderation, reportable: resource, hidden_at: 2.days.ago, skip_injection: evaluator.skip_injection)
+      end
+    end
   end
 
   factory :nested_dummy_resource, class: "Decidim::Dev::NestedDummyResource" do

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -466,6 +466,12 @@ FactoryBot.define do
         proposal.attachments << create(:attachment, :with_pdf, attached_to: proposal, skip_injection: evaluator.skip_injection)
       end
     end
+
+    trait :moderated do
+      after(:create) do |proposal, evaluator|
+        create(:moderation, reportable: proposal, hidden_at: 2.days.ago, skip_injection: evaluator.skip_injection)
+      end
+    end
   end
 
   factory :proposal_vote, class: "Decidim::Proposals::ProposalVote" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR attempts to hide the moderated content from the notifications block. I have noticed that the moderated content is still being available in the notifications even though the content itself has been moderated. I have noticed that a while ago in MetaDecidim.

This PR adds a simple "Content moderated" string instead of actual notification, just to preserve the pagination integrity. It does not add any "Content moderated on %{date}" as we have on comments, because we do not have a very good grasp of the resource that is being hidden. Sometimes, the hidden content can be a comment, but sometimes it could be the resource commentable. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. Have a decidim installation with some notifications (alternatively you could use #12828) 
2. Login as admin and visit the notifications page 
3. Moderate 1 comment 
4. Moderate 1 other resource ( Meeting / Proposal) 
5. See the content is still being displayed in notification area 
6. Apply patch 
7. Refresh the notifications page. 
8. See the content is being replaced by a "Content Moderated" 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
A comment being moderated 
![image](https://github.com/decidim/decidim/assets/105683/80748a13-def9-4fab-abeb-b5a2592a2361)

A resource being moderated ( that also have comments associated: 1 meeting + 4 comments associated ) 
![image](https://github.com/decidim/decidim/assets/105683/32d56eaf-3b66-4d3f-8364-3a2b6ee1329f)

:hearts: Thank you!
