### PR TITLE
Backport 'Fix flaky specs when organization name has an apostrophe' to v0.28

### DIFF
--- a/decidim-core/lib/decidim/core/test/shared_examples/logo_email.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/logo_email.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 shared_examples "email with logo" do
   context "when organization has a logo" do
     let(:organization_logo) { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
-    let(:organization) { create(:organization, logo: organization_logo) }
+    let(:organization) { create(:organization, name: "O'Higgins", logo: organization_logo) }
     let(:mail) { described_class.event_received(event, event_class_name, resource, user, :follower, extra) }
     let(:logo_path) { Rails.application.routes.url_helpers.rails_representation_path(organization.logo.variant(resize_to_fit: [600, 160]), only_path: true) }
 
@@ -14,7 +14,7 @@ shared_examples "email with logo" do
     end
 
     it "includes organization logo with full link" do
-      expect(mail.body).to include("alt=\"#{organization.name}\"")
+      expect(mail.body).to include("alt=\"#{decidim_escape_translated(organization.name)}\"")
       expect(mail.body).to match(%r{https{0,1}://#{organization.host}:#{Capybara.server_port}#{logo_path}})
     end
   end

--- a/decidim-core/spec/mailers/reported_mailer_spec.rb
+++ b/decidim-core/spec/mailers/reported_mailer_spec.rb
@@ -13,6 +13,10 @@ module Decidim
     let!(:report) { create(:report, moderation:, details: "bacon eggs spam") }
     let(:decidim) { Decidim::Core::Engine.routes.url_helpers }
 
+    before do
+      reportable.coauthorships.first.author.update!(name: "O'Higgins")
+    end
+
     describe "#report" do
       let(:mail) { described_class.report(user, report) }
 
@@ -107,7 +111,7 @@ module Decidim
           let(:reportable) { create(:proposal, :official) }
 
           it "includes the name of the organization" do
-            expect(email_body(mail)).to match(author.name)
+            expect(email_body(mail)).to match(decidim_escape_translated(author.name))
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12657 to v0.28

:hearts: Thank you!