### PR TITLE
Fix exceptions there isn't an organization with a host

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
+++ b/decidim-core/app/controllers/concerns/decidim/force_authentication.rb
@@ -17,7 +17,7 @@ module Decidim
     # Breaks the request lifecycle, if user is not authenticated.
     # Otherwise returns.
     def ensure_authenticated!
-      return true unless current_organization.force_users_to_authenticate_before_access_organization
+      return true unless current_organization&.force_users_to_authenticate_before_access_organization
 
       # Next stop: Check whether auth is ok
       unless user_signed_in?

--- a/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb
+++ b/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb
@@ -25,7 +25,7 @@ module Decidim
       #
       # Returns a String.
       def organization_time_zone
-        @organization_time_zone ||= current_organization.time_zone
+        @organization_time_zone ||= current_organization&.time_zone
       end
     end
   end

--- a/decidim-core/spec/controllers/concerns/force_authentication_spec.rb
+++ b/decidim-core/spec/controllers/concerns/force_authentication_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe "ForceAuthentication" do
+    let(:organization) { create(:organization, force_users_to_authenticate_before_access_organization:) }
+
+    controller do
+      include Decidim::ForceAuthentication
+
+      def current_organization
+        request.env["decidim.current_organization"]
+      end
+
+      def show
+        render plain: "Hello world"
+      end
+
+      def locale
+        render plain: "Locale changed"
+      end
+    end
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      routes.draw do
+        get "show" => "anonymous#show"
+        get "locale" => "anonymous#locale"
+      end
+    end
+
+    context "when the organization is configured to force user authentication" do
+      let(:force_users_to_authenticate_before_access_organization) { true }
+
+      it "forces authentication" do
+        get :show
+        expect(response.location).to eq("http://test.host/users/sign_in")
+        expect(response.body).to have_text("You are being redirected")
+        expect(response.status).to eq(302)
+      end
+
+      it "allows accessing the locale page" do
+        get :locale
+        expect(request.path).to eq("/locale")
+        expect(response.body).to have_text("Locale changed")
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when the organization is configured to not force user authentication" do
+      let(:force_users_to_authenticate_before_access_organization) { false }
+
+      it "shows the page" do
+        get :show
+        expect(request.path).to eq("/show")
+        expect(response.body).to have_text("Hello world")
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when there is no organization" do
+      let(:organization) { nil }
+
+      it "shows the page" do
+        get :show
+        expect(request.path).to eq("/show")
+        expect(response.body).to have_text("Hello world")
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+end

--- a/decidim-core/spec/controllers/concerns/force_authentication_spec.rb
+++ b/decidim-core/spec/controllers/concerns/force_authentication_spec.rb
@@ -37,14 +37,14 @@ module Decidim
         get :show
         expect(response.location).to eq("http://test.host/users/sign_in")
         expect(response.body).to have_text("You are being redirected")
-        expect(response.status).to eq(302)
+        expect(response).to have_http_status(:found)
       end
 
       it "allows accessing the locale page" do
         get :locale
         expect(request.path).to eq("/locale")
         expect(response.body).to have_text("Locale changed")
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
       end
     end
 
@@ -55,7 +55,7 @@ module Decidim
         get :show
         expect(request.path).to eq("/show")
         expect(response.body).to have_text("Hello world")
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
       end
     end
 
@@ -66,7 +66,7 @@ module Decidim
         get :show
         expect(request.path).to eq("/show")
         expect(response.body).to have_text("Hello world")
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
       end
     end
   end

--- a/decidim-core/spec/controllers/concerns/use_organization_time_zone_spec.rb
+++ b/decidim-core/spec/controllers/concerns/use_organization_time_zone_spec.rb
@@ -85,5 +85,17 @@ module Decidim
         end
       end
     end
+
+    context "when there is no organization" do
+      let(:time_zone) { utc_time_zone }
+
+      before do
+        request.env["decidim.current_organization"] = nil
+      end
+
+      it "controller uses nil" do
+        expect(controller.organization_time_zone).to eq(nil)
+      end
+    end
   end
 end

--- a/decidim-core/spec/controllers/concerns/use_organization_time_zone_spec.rb
+++ b/decidim-core/spec/controllers/concerns/use_organization_time_zone_spec.rb
@@ -94,7 +94,7 @@ module Decidim
       end
 
       it "controller uses nil" do
-        expect(controller.organization_time_zone).to eq(nil)
+        expect(controller.organization_time_zone).to be_nil
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

When there is a host (i.e. a domain or subdomain) pointing to Decidim but there isn't an organization with that host (i.e. when there is a proxy misconfiguration) the application is giving an Exception instead of redirecting to System login (as it should do). 

When fixing this exception then you have another exception 😅 

This PR fixes these Exceptions. 
 
#### Testing

1. Add a host in your host file (`/etc/hosts` in GNU/Linux). For instance `127.0.1.1 localhost999`
2. Add the host to you config/application.rb: `     config.hosts << "localhost999" 
3. Restart your app server 
4. Visit `http://localhost999:3000/processes` with a browser (Mind that you can't have the exceptions if you go to http://localhost999:3000/)
5. See the exception (without the patch)
6. Apply the patch
7. See that the redirection works

### Stacktrace

#### First exception (`UseOrganizationTimeZone`)

```ruby
NoMethodError (undefined method `time_zone' for nil:NilClass):

home/apereira/Work/decidim/decidim/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb:28:in `organization_time_zone'
home/apereira/Work/decidim/decidim/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb:21:in `use_organization_time_zone'
``` 

#### Second exception (`ForceAuthentication`)

```ruby
NoMethodError (undefined method `force_users_to_authenticate_before_access_organization' for nil:NilClass):

/home/apereira/Work/decidim/decidim/decidim-core/app/controllers/concerns/decidim/force_authentication.rb:20:in `ensure_authenticated!'
```
:hearts: Thank you!
