### PR TITLE
Fix 500 error when creating or updating an organization without a secret key

### DIFF
--- a/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -58,6 +58,7 @@ module Decidim
 
       validates :name, :host, :users_registration_mode, presence: true
       validate :validate_organization_uniqueness
+      validate :validate_secret_key_base_for_encryption
       validates :users_registration_mode, inclusion: { in: Decidim::Organization.users_registration_modes }
 
       def map_model(model)
@@ -107,6 +108,14 @@ module Decidim
       def validate_organization_uniqueness
         errors.add(:name, :taken) if Decidim::Organization.where(name:).where.not(id:).exists?
         errors.add(:host, :taken) if Decidim::Organization.where(host:).where.not(id:).exists?
+      end
+
+      # We need a valid secret key base for encrypting the SMTP password with it
+      # It is also necessary for other things in Rails (like Cookies encryption)
+      def validate_secret_key_base_for_encryption
+        return if Rails.application.secrets.secret_key_base&.length == 128
+
+        errors.add(:password, I18n.t("activemodel.errors.models.organization.attributes.password.secret_key"))
       end
     end
   end

--- a/decidim-system/app/views/decidim/system/organizations/edit.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/edit.html.erb
@@ -35,7 +35,7 @@
   </div>
 
   <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
-    <% if @organization.users.first&.invitation_pending? %>
+    <% if @organization&.users&.first&.invitation_pending? %>
       <%= link_to t(".resend_invitation"),
                   resend_invitation_organization_path(@organization),
                   method: :post,

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -32,6 +32,10 @@ en:
           attributes:
             redirect_uri:
               must_be_ssl: The redirect URI must be a SSL URI
+        organization:
+          attributes:
+            password:
+              secret_key: You need to define the SECRET_KEY_BASE environment variable to be able to save this field
   decidim:
     system:
       actions:

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -70,6 +70,22 @@ describe "Organizations" do
           expect(page).to have_content("There is an error in this field")
         end
       end
+
+      context "without the secret key defined" do
+        before do
+          allow(Rails.application.secrets).to receive(:secret_key_base).and_return(nil)
+        end
+
+        it "does not create an organization" do
+          fill_in "Name", with: "Citizen Corp"
+          fill_in "Host", with: "www.example.org"
+          fill_in "Reference prefix", with: "CCORP"
+          click_on "Create organization & invite admin"
+
+          click_on "Show advanced settings"
+          expect(page).to have_content("You need to define the SECRET_KEY_BASE environment variable to be able to save this field")
+        end
+      end
     end
 
     describe "resending the invitation" do
@@ -137,6 +153,21 @@ describe "Organizations" do
 
         expect(page).to have_css("div.flash.success")
         expect(page).to have_content("Citizens Rule!")
+      end
+
+      context "without the secret key defined" do
+        before do
+          allow(Rails.application.secrets).to receive(:secret_key_base).and_return(nil)
+        end
+
+        it "shows the error message" do
+          fill_in "Name", with: "Citizens Rule!"
+          fill_in "Host", with: "www.example.org"
+          click_on "Save"
+
+          click_on "Show advanced settings"
+          expect(page).to have_content("You need to define the SECRET_KEY_BASE environment variable to be able to save this field")
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This is the fix that I mentioned in #12846 

> There were a couple of bugs report related to not having defined the secret key in production and this produces a problem when creating or updating an Organization.

This PR solves the problem by adding a validation in the form

#### :pushpin: Related Issues

- Fixes to #12535
- Fixes to #12844 

#### Testing

1. Add the following initializer in  `development_app/config/initializers/rails_override_secrets.rb` 
```ruby
Rails::Application.class_eval do
  def secret_key_base
    ""
  end
end
```
2. Restart the development server
3. Sign in on http://localhost:3000/system
4. Create a new organization (it will not work with an existing as the secret is different and can't be decrypted)
5. Fill the required fields, save the form and...
6. (Without the patch) See the exception `TypeError (no implicit conversion of nil into String)` related to the attribute encryptor 
7. (With the patch) See the error message by clicking the "Show advanced settings" 

### :camera: Screenshots
 
![Screenshot of the validation](https://github.com/decidim/decidim/assets/717367/b2f8c04d-f1fe-4a69-a4c9-975a5cdf0c48)

:hearts: Thank you!
