### PR TITLE
Remove sidebar when conference has no components

### DIFF
--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -37,7 +37,8 @@ edit_link(
 
   <%= render partial: "conference_hero" %>
 
-  <%= render layout: "layouts/decidim/shared/#{conference_nav_items(current_participatory_space).any? ? "layout_two_col" : "layout_center"}", locals: { reverse: true, main_enabled: false, columns: 10 } do %>
+  <% layout_style = conference_nav_items(current_participatory_space).any? ? "layout_two_col" : "layout_center" %>
+  <%= render layout: "layouts/decidim/shared/#{layout_style}", locals: { reverse: true, main_enabled: false, columns: 10 } do %>
 
     <%= participatory_space_floating_help %>
 

--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -37,7 +37,7 @@ edit_link(
 
   <%= render partial: "conference_hero" %>
 
-  <%= render layout: "layouts/decidim/shared/#{conference_nav_items(current_participatory_space).any? ? "layout_two_col" : "layout_center"}", locals: { reverse: true, main_enabled: false } do %>
+  <%= render layout: "layouts/decidim/shared/#{conference_nav_items(current_participatory_space).any? ? "layout_two_col" : "layout_center"}", locals: { reverse: true, main_enabled: false, columns: 10 } do %>
 
     <%= participatory_space_floating_help %>
 

--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -37,7 +37,7 @@ edit_link(
 
   <%= render partial: "conference_hero" %>
 
-  <%= render layout: "layouts/decidim/shared/layout_two_col", locals: { reverse: true, main_enabled: false } do %>
+  <%= render layout: "layouts/decidim/shared/#{conference_nav_items(current_participatory_space).any? ? "layout_two_col" : "layout_center"}", locals: { reverse: true, main_enabled: false } do %>
 
     <%= participatory_space_floating_help %>
 

--- a/decidim-conferences/spec/commands/join_conference_spec.rb
+++ b/decidim-conferences/spec/commands/join_conference_spec.rb
@@ -9,7 +9,7 @@ module Decidim::Conferences
     let(:registrations_enabled) { true }
     let(:available_slots) { 10 }
     let(:organization) { create(:organization) }
-    let!(:conference) { create(:conference, organization:, registrations_enabled:, available_slots:) }
+    let!(:conference) { create(:conference, organization:, title: { en: "A great conference", ca: "Bona jornada", es: "Buena conferencia" }, registrations_enabled:, available_slots:) }
     let!(:conference_admin) { create(:conference_admin, conference:) }
     let!(:registration_type) { create(:registration_type, conference:) }
     let(:user) { create(:user, :confirmed, organization:) }

--- a/decidim-conferences/spec/commands/join_conference_spec.rb
+++ b/decidim-conferences/spec/commands/join_conference_spec.rb
@@ -9,7 +9,7 @@ module Decidim::Conferences
     let(:registrations_enabled) { true }
     let(:available_slots) { 10 }
     let(:organization) { create(:organization) }
-    let!(:conference) { create(:conference, organization:, title: { en: "A great conference", ca: "Bona jornada", es: "Buena conferencia" }, registrations_enabled:, available_slots:) }
+    let!(:conference) { create(:conference, organization:, registrations_enabled:, available_slots:) }
     let!(:conference_admin) { create(:conference_admin, conference:) }
     let!(:registration_type) { create(:registration_type, conference:) }
     let(:user) { create(:user, :confirmed, organization:) }

--- a/decidim-conferences/spec/system/conferences_spec.rb
+++ b/decidim-conferences/spec/system/conferences_spec.rb
@@ -280,7 +280,7 @@ describe "Conferences" do
     end
 
     it "has a sidebar" do
-      expect(page).not_to have_css(".conference__nav-container")
+      expect(page).to have_no_css(".conference__nav-container")
     end
   end
 end

--- a/decidim-conferences/spec/system/conferences_spec.rb
+++ b/decidim-conferences/spec/system/conferences_spec.rb
@@ -279,7 +279,7 @@ describe "Conferences" do
       visit decidim_conferences.conference_path(conference)
     end
 
-    it "has a sidebar" do
+    it "has no sidebar" do
       expect(page).to have_no_css(".conference__nav-container")
     end
   end

--- a/decidim-conferences/spec/system/conferences_spec.rb
+++ b/decidim-conferences/spec/system/conferences_spec.rb
@@ -141,6 +141,10 @@ describe "Conferences" do
       visit decidim_conferences.conference_path(conference)
     end
 
+    it "has a sidebar" do
+      expect(page).to have_css(".conference__nav-container")
+    end
+
     describe "follow button" do
       let!(:user) { create(:user, :confirmed, organization:) }
       let(:followable) { conference }
@@ -265,6 +269,18 @@ describe "Conferences" do
           expect(page).to have_css(".conference__map-address", count: 3)
         end
       end
+    end
+  end
+
+  describe "when the conference has no components" do
+    let!(:conference) { base_conference }
+
+    before do
+      visit decidim_conferences.conference_path(conference)
+    end
+
+    it "has a sidebar" do
+      expect(page).not_to have_css(".conference__nav-container")
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Although there is nothing in the submenu of the participatory space, the sidebar appears.
Nothing should be displayed if there is no sub-menu section. 

To fix this a conditional render was added so if there are any conference_nav_items, then layout_two_col will be displayed in another case layout_center.

#### :pushpin: Related Issues
- Related to #
- Fixes #?

#### Testing
- Go to Decidim 
- Sign in at http://localhost:3000
- Visit conferences
- Create a new conference(don't add any component) and publish.
- See the site, there is an empty sidebar.

### :camera: Screenshots
before
![image](https://github.com/decidim/decidim/assets/116598037/537dc1a3-beaf-4ba7-8eff-723a4146733e)

after 
![image](https://github.com/decidim/decidim/assets/116598037/cefb5c46-1cc5-44d8-be7e-7ab88eeb5ae6)


:hearts: Thank you!
