### PR TITLE
Remove customizations for labels on accountability

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,6 +47,12 @@ We have updated the Rails version to 7.0.8.1. You do not need to do anything.
 
 You can read more about this change on PR [#12616](https://github.com/decidim/decidim/pull/12616).
 
+## 2.3. Removal of the accountability naming customization
+
+We have removed the ability to customize the labels from the Accountability component, as it was not following the recommended way of handling these text customizations. If you want to migrate your current customizations, you can read about [Text customizations in Decidim Documentation](https://docs.decidim.org/en/develop/customize/texts)
+
+You can read more about this change on PR [#12853](https://github.com/decidim/decidim/pull/12853).
+
 ## 3. One time actions
 
 These are one time actions that need to be done after the code is updated in the production database.

--- a/decidim-accountability/app/cells/decidim/accountability/status_cell.rb
+++ b/decidim-accountability/app/cells/decidim/accountability/status_cell.rb
@@ -75,12 +75,7 @@ module Decidim
       end
 
       def heading_parent_level_results(count)
-        text = translated_attribute(component_settings.heading_parent_level_results).presence
-        if text
-          pluralize(count, text)
-        else
-          t("results.count.results_count", scope: "decidim.accountability", count:)
-        end
+        t("results.count.results_count", scope: "decidim.accountability", count:)
       end
 
       def render_count

--- a/decidim-accountability/app/helpers/decidim/accountability/application_helper.rb
+++ b/decidim-accountability/app/helpers/decidim/accountability/application_helper.rb
@@ -18,14 +18,6 @@ module Decidim
         (defined?(current_component) && translated_attribute(current_component&.name).presence) || t("decidim.components.accountability.name")
       end
 
-      def categories_label
-        translated_attribute(component_settings.categories_label).presence || t("results.home.categories_label", scope: "decidim.accountability")
-      end
-
-      def subcategories_label
-        translated_attribute(component_settings.subcategories_label).presence || t("results.home.subcategories_label", scope: "decidim.accountability")
-      end
-
       def filter_items_for(participatory_space:, category:)
         [
           {

--- a/decidim-accountability/app/views/decidim/accountability/results/_home_categories.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_home_categories.html.erb
@@ -9,12 +9,12 @@
     ) %>
 
     <div>
-      <span class="accountability__grid-title"><%= categories_label %></span>
+      <span class="accountability__grid-title"><%= t("results.home.categories_label", scope: "decidim.accountability") %></span>
       <%= subelements.call %>
     </div>
 
     <div>
-      <span class="accountability__grid-title"><%= subcategories_label %></span>
+      <span class="accountability__grid-title"><%= t("results.home.subcategories_label", scope: "decidim.accountability") %></span>
         <% if subelements.has_results? %>
           <div class="accountability__subgrid">
             <% category.subcategories.each do |subcategory| %>

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -255,16 +255,12 @@ en:
         name: Accountability
         settings:
           global:
-            categories_label: Name for "Categories"
             comments_enabled: Comments enabled
             comments_max_length: Comments max length (Leave 0 for default value)
             display_progress_enabled: Display progress
-            heading_leaf_level_results: Name for "Projects"
-            heading_parent_level_results: Name for "Results"
             intro: Intro
             scope_id: Scope
             scopes_enabled: Scopes enabled
-            subcategories_label: Name for "Subcategories"
           step:
             comments_blocked: Comments blocked
     events:

--- a/decidim-accountability/lib/decidim/accountability/component.rb
+++ b/decidim-accountability/lib/decidim/accountability/component.rb
@@ -30,10 +30,6 @@ Decidim.register_component(:accountability) do |component|
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :comments_max_length, type: :integer, required: true
     settings.attribute :intro, type: :text, translated: true, editor: true
-    settings.attribute :categories_label, type: :string, translated: true, editor: true
-    settings.attribute :subcategories_label, type: :string, translated: true, editor: true
-    settings.attribute :heading_parent_level_results, type: :string, translated: true, editor: true
-    settings.attribute :heading_leaf_level_results, type: :string, translated: true, editor: true
     settings.attribute :display_progress_enabled, type: :boolean, default: true
   end
 

--- a/decidim-accountability/lib/decidim/accountability/seeds.rb
+++ b/decidim-accountability/lib/decidim/accountability/seeds.rb
@@ -24,10 +24,6 @@ module Decidim
           participatory_space:,
           settings: {
             intro: Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(word_count: 4) },
-            categories_label: Decidim::Faker::Localized.word,
-            subcategories_label: Decidim::Faker::Localized.word,
-            heading_parent_level_results: Decidim::Faker::Localized.word,
-            heading_leaf_level_results: Decidim::Faker::Localized.word,
             scopes_enabled: true,
             scope_id: participatory_space.scope&.id
           }

--- a/decidim-accountability/lib/decidim/accountability/test/factories.rb
+++ b/decidim-accountability/lib/decidim/accountability/test/factories.rb
@@ -18,10 +18,6 @@ FactoryBot.define do
     settings do
       {
         intro: generate_localized_description(:accountability_component_intro, skip_injection:),
-        categories_label: generate_localized_word(:accountability_component_categories_label, skip_injection:),
-        subcategories_label: generate_localized_word(:accountability_component_subcategories_label, skip_injection:),
-        heading_parent_level_results: generate_localized_word(:accountability_component_heading_parent_level_results, skip_injection:),
-        heading_leaf_level_results: generate_localized_word(:accountability_component_heading_leaf_level_results, skip_injection:),
         scopes_enabled: true,
         scope_id: participatory_space.scope&.id
       }

--- a/decidim-dev/lib/decidim/dev/assets/assemblies.json
+++ b/decidim-dev/lib/decidim/dev/assets/assemblies.json
@@ -352,38 +352,6 @@
           "intro_en": "<p>Praesentium iste sit dicta.</p>",
           "intro_ca": "<p>Odit aperiam ea reiciendis.</p>",
           "intro_es": "<p>Repudiandae magni quo sit.</p>",
-          "categories_label": {
-            "ca": "rerum",
-            "en": "dolores",
-            "es": "voluptatem"
-          },
-          "categories_label_en": "dolores",
-          "categories_label_ca": "rerum",
-          "categories_label_es": "voluptatem",
-          "subcategories_label": {
-            "ca": "totam",
-            "en": "qui",
-            "es": "iure"
-          },
-          "subcategories_label_en": "qui",
-          "subcategories_label_ca": "totam",
-          "subcategories_label_es": "iure",
-          "heading_parent_level_results": {
-            "ca": "pariatur",
-            "en": "voluptatem",
-            "es": "molestias"
-          },
-          "heading_parent_level_results_en": "voluptatem",
-          "heading_parent_level_results_ca": "pariatur",
-          "heading_parent_level_results_es": "molestias",
-          "heading_leaf_level_results": {
-            "ca": "enim",
-            "en": "nam",
-            "es": "et"
-          },
-          "heading_leaf_level_results_en": "nam",
-          "heading_leaf_level_results_ca": "enim",
-          "heading_leaf_level_results_es": "et",
           "display_progress_enabled": true
         },
         "weight": 0,

--- a/decidim-dev/lib/decidim/dev/assets/participatory_processes.json
+++ b/decidim-dev/lib/decidim/dev/assets/participatory_processes.json
@@ -340,38 +340,6 @@
           "intro_en": "<p>Voluptatem praesentium maxime vitae.</p>",
           "intro_ca": "<p>Sapiente animi quo at.</p>",
           "intro_es": "<p>Illum veritatis porro nulla.</p>",
-          "categories_label": {
-            "ca": "alias",
-            "en": "aut",
-            "es": "omnis"
-          },
-          "categories_label_en": "aut",
-          "categories_label_ca": "alias",
-          "categories_label_es": "omnis",
-          "subcategories_label": {
-            "ca": "rerum",
-            "en": "reprehenderit",
-            "es": "nostrum"
-          },
-          "subcategories_label_en": "reprehenderit",
-          "subcategories_label_ca": "rerum",
-          "subcategories_label_es": "nostrum",
-          "heading_parent_level_results": {
-            "ca": "et",
-            "en": "explicabo",
-            "es": "officiis"
-          },
-          "heading_parent_level_results_en": "explicabo",
-          "heading_parent_level_results_ca": "et",
-          "heading_parent_level_results_es": "officiis",
-          "heading_leaf_level_results": {
-            "ca": "consectetur",
-            "en": "illum",
-            "es": "sunt"
-          },
-          "heading_leaf_level_results_en": "illum",
-          "heading_leaf_level_results_ca": "consectetur",
-          "heading_leaf_level_results_es": "sunt",
           "display_progress_enabled": true
         },
         "weight": 0,


### PR DESCRIPTION
#### :tophat: What? Why?

We allow some labels in Accountability module to be customized but that's not a way that we've followed for other modules. This PR removes this feature to be consistent with the official customization texts strategy. 

#### :pushpin: Related Issues
 
- Fixes #12570

#### Testing

1. Sign in as admin
2. Go to components settings in Accountability
3. See that you can't customize these labels anymore

:hearts: Thank you!
