### PR TITLE
Fix strings for ordering when listing budgets

### DIFF
--- a/decidim-budgets/app/cells/decidim/budgets/budgets_list/main_list.erb
+++ b/decidim-budgets/app/cells/decidim/budgets/budgets_list/main_list.erb
@@ -1,5 +1,5 @@
 <h2 class="h5 md:h3 decorator"><%= t(:count, scope: i18n_scope, count: budgets.length) %></h2>
 
-<%= render partial: "decidim/shared/orders", formats: [:html], locals: { orders: AVAILABLE_ORDERS, i18n_scope: "decidim.budgets.projects.orders" } %>
+<%= render partial: "decidim/shared/orders", formats: [:html], locals: { orders: AVAILABLE_ORDERS, i18n_scope: "decidim.budgets.budgets_list.orders" } %>
 
 <%= render :card_list %>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -185,6 +185,11 @@ en:
         finished_message: You have finished the voting process. Thanks for participating!
         highlighted_cta: Vote on %{name}
         if_change_opinion: If you have changed your mind, you can
+        orders:
+          highest_cost: Highest cost
+          label: Order budgets by
+          lowest_cost: Lowest cost
+          random: Random order
         progress: Finish voting
         remove_vote: Remove vote
         show: See projects


### PR DESCRIPTION
#### :tophat: What? Why?

While checking out #11000, I found a mini-bug in the strings: if you go to a budget component with multiple components, instead of saying "Order budgets by" it says "Order projects by".

This PR fixes it. 

#### :pushpin: Related Issues
 
- Related to #11000 

#### Testing

1. Go to a process with multiple budgets in a mobile view
2. See the string for ordering the budgets 

### :camera: Screenshots
 
#### Before

![Screenshot of the wrong string](https://github.com/decidim/decidim/assets/717367/d31797a6-8e2e-482f-99fa-8d2e10c57dc3)

#### After

![Screenshot of the fixed string](https://github.com/decidim/decidim/assets/717367/82770109-dc84-46d1-80e7-9d32026ca911)


:hearts: Thank you!
