### PR TITLE
Prevent showing the dropdown menu when changing orientation of mobile devices

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/results/_scope_filters.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_scope_filters.html.erb
@@ -15,7 +15,7 @@
         <%= icon "arrow-down-s-line", class: "w-8 h-8 flex-none text-secondary fill-current" %>
         <%= icon "arrow-up-s-line", class: "w-8 h-8 flex-none text-secondary fill-current" %>
       </button>
-      <ul id="dropdown-menu-accountability" data-scope-filters>
+      <ul id="dropdown-menu-accountability" data-scope-filters aria-hidden="true">
         <% items.each do |item| %>
           <li>
             <%= link_to item[:url], class: "filter#{" is-active" if item[:active]}" do %>

--- a/decidim-accountability/app/views/decidim/accountability/results/_scope_filters.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_scope_filters.html.erb
@@ -4,7 +4,7 @@
 
   <% if current_component.has_subscopes? %>
     <div class="filter-container">
-      <button id="dropdown-trigger-accountability" data-component="dropdown" data-target="dropdown-menu-accountability" data-auto-close="true" data-disabled-md="true">
+      <button id="dropdown-trigger-accountability" data-component="dropdown" data-target="dropdown-menu-accountability" data-auto-close="true">
         <% items.each do |item| %>
           <%= content_tag :span, class: "#{"is-active" if item[:active]}" do %>
             <span class="sr-only"><%= item[:sr_text] %></span>

--- a/decidim-admin/app/views/layouts/decidim/admin/_sidebar_menu.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_sidebar_menu.html.erb
@@ -11,7 +11,7 @@
         <%= icon "arrow-up-s-line" %>
       </button>
 
-      <ul id="dropdown-menu-sidebar" class="md:hidden">
+      <ul id="dropdown-menu-sidebar" class="md:hidden" aria-hidden="true">
         <%= sidebar_menu(secondary_root_menu).render %>
       </ul>
     </div>

--- a/decidim-admin/app/views/layouts/decidim/admin/_sidebar_menu.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_sidebar_menu.html.erb
@@ -5,7 +5,7 @@
       <div class="hidden md:block">
         <%= sidebar_menu(secondary_root_menu).render %>
       </div>
-      <button data-component="dropdown" data-target="dropdown-menu-sidebar" data-auto-close="true" data-disabled-md="true" data-scroll-to-menu="true">
+      <button data-component="dropdown" data-target="dropdown-menu-sidebar" data-auto-close="true" data-scroll-to-menu="true">
         <span><%= t("menu", scope: "decidim.admin.titles") %></span>
         <%= icon "arrow-down-s-line" %>
         <%= icon "arrow-up-s-line" %>

--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -24,7 +24,7 @@ edit_link(
 
   <%= content_for :aside do %>
     <div class="conference__nav-container">
-      <button id="dropdown-trigger-conference" data-component="dropdown" data-target="dropdown-menu-conference" data-auto-close="true" data-disabled-md="true" data-scroll-to-menu="true">
+      <button id="dropdown-trigger-conference" data-component="dropdown" data-target="dropdown-menu-conference" data-auto-close="true" data-scroll-to-menu="true">
         <span><%= t("decidim.searches.filters.jump_to") %></span>
         <%= icon "arrow-down-s-line" %>
         <%= icon "arrow-up-s-line" %>

--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -29,7 +29,7 @@ edit_link(
         <%= icon "arrow-down-s-line" %>
         <%= icon "arrow-up-s-line" %>
       </button>
-      <ul id="dropdown-menu-conference" class="conference__nav">
+      <ul id="dropdown-menu-conference" class="conference__nav" aria-hidden="true">
         <%= render partial: "layouts/decidim/conferences/conference_nav_item", collection: conference_nav_items(current_participatory_space), as: :item %>
       </ul>
     </div>

--- a/decidim-core/app/cells/decidim/nav_links/show.erb
+++ b/decidim-core/app/cells/decidim/nav_links/show.erb
@@ -1,10 +1,10 @@
 <div class="participatory-space__nav-container">
-  <button id="dropdown-trigger-participatory-space" data-component="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-disabled-md="true" data-scroll-to-menu="true">
+  <button id="dropdown-trigger-participatory-space" data-component="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-disabled-md="true" data-scroll-to-menu="true" aria-hidden="true">
     <span><%= t("decidim.searches.filters.jump_to") %></span>
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>
   </button>
-  <ul id="dropdown-menu-participatory-space" class="participatory-space__nav">
+  <ul id="dropdown-menu-participatory-space" class="participatory-space__nav" aria-hidden="true">
     <% model.each do |item| %>
       <li>
         <%= link_to item[:url], class: "participatory-space__nav-item" do %>

--- a/decidim-core/app/cells/decidim/nav_links/show.erb
+++ b/decidim-core/app/cells/decidim/nav_links/show.erb
@@ -1,5 +1,5 @@
 <div class="participatory-space__nav-container">
-  <button id="dropdown-trigger-participatory-space" data-component="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-disabled-md="true" data-scroll-to-menu="true" aria-hidden="true">
+  <button id="dropdown-trigger-participatory-space" data-component="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-scroll-to-menu="true">
     <span><%= t("decidim.searches.filters.jump_to") %></span>
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>

--- a/decidim-core/app/cells/decidim/resource_types_filter/show.erb
+++ b/decidim-core/app/cells/decidim/resource_types_filter/show.erb
@@ -8,7 +8,7 @@
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>
   </button>
-  <%= filter_form_for filter, form_path, class: "new_filter", id: "dropdown-menu-resource", "aria-hidden" => true do |form| %>
+  <%= filter_form_for filter, form_path, :class => "new_filter", :id => "dropdown-menu-resource", "aria-hidden" => true do |form| %>
     <%= form.collection_radio_buttons(
           filter_param_key,
           resource_types,

--- a/decidim-core/app/cells/decidim/resource_types_filter/show.erb
+++ b/decidim-core/app/cells/decidim/resource_types_filter/show.erb
@@ -1,5 +1,5 @@
 <div id="<%= id %>" class="filter-container">
-  <button id="dropdown-trigger-resource" data-component="dropdown" data-target="dropdown-menu-resource" data-auto-close="true" data-disabled-md="true">
+  <button id="dropdown-trigger-resource" data-component="dropdown" data-target="dropdown-menu-resource" data-auto-close="true">
     <% resource_types.each do |resource_type| %>
       <span data-value="<%= resource_type[0] %>" class="<%= "is-active" if filter_param == resource_type[0] %>">
         <%= text_with_resource_icon(*resource_type) %>
@@ -8,7 +8,7 @@
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>
   </button>
-  <%= filter_form_for filter, form_path, class: "new_filter", id: "dropdown-menu-resource" do |form| %>
+  <%= filter_form_for filter, form_path, class: "new_filter", id: "dropdown-menu-resource", "aria-hidden" => true do |form| %>
     <%= form.collection_radio_buttons(
           filter_param_key,
           resource_types,

--- a/decidim-core/app/packs/src/decidim/a11y.js
+++ b/decidim-core/app/packs/src/decidim/a11y.js
@@ -104,6 +104,20 @@ const createDropdown = (component) => {
     });
   }
 
+  // Disable focus on children elements so we can pass the AXE accessibility tests
+  const dropdownMenu = document.getElementById(dropdownOptions.dropdown);
+  if (dropdownMenu.getAttribute("aria-hidden") === "true") {
+    dropdownMenu.
+      querySelectorAll("a, input, button").
+      forEach((element) => { element.tabIndex = -1 })
+  }
+
+  component.addEventListener("click", () => {
+    dropdownMenu.
+      querySelectorAll("a, input, button").
+      forEach((element) => { element.tabIndex = 0 })
+  })
+
   Dropdowns.render(component.id, dropdownOptions);
 }
 

--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -11,7 +11,7 @@
 
   <div class="vertical-tabs">
     <nav>
-      <button id="dropdown-trigger-pages" data-component="dropdown" data-target="dropdown-menu-pages" data-auto-close="true" data-disabled-md="true">
+      <button id="dropdown-trigger-pages" data-component="dropdown" data-target="dropdown-menu-pages" data-auto-close="true">
         <span>
           <%= translated_attribute(page.title) %>
         </span>

--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -18,7 +18,7 @@
         <%= icon "arrow-down-s-line" %>
         <%= icon "arrow-up-s-line" %>
       </button>
-      <ul id="dropdown-menu-pages" class="vertical-tabs__list">
+      <ul id="dropdown-menu-pages" class="vertical-tabs__list" aria-hidden="true">
         <% pages.each do |sibling| %>
           <li class="<%= "is-active" if page == sibling %>">
             <%= link_to translated_attribute(sibling.title), page_path(sibling.slug) %>

--- a/decidim-core/app/views/decidim/searches/_filters.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters.html.erb
@@ -11,7 +11,7 @@
     <%= icon "arrow-down-s-line", class: "w-8 h-8 flex-none text-secondary fill-current" %>
     <%= icon "arrow-up-s-line", class: "w-8 h-8 flex-none text-secondary fill-current" %>
   </button>
-  <div id="dropdown-menu-search">
+  <div id="dropdown-menu-search" aria-hidden="true">
     <div>
       <%= link_to main_search_path, class: "filter#{" is-active" if params.dig(:filter, :with_resource_type) == nil}" do %>
         <%= resource_type_icon("all") %>

--- a/decidim-core/app/views/decidim/searches/_filters.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters.html.erb
@@ -1,5 +1,5 @@
 <div class="filter-container search__filter">
-  <button id="dropdown-trigger-search" data-component="dropdown" data-target="dropdown-menu-search" data-auto-close="true" data-disabled-md="true">
+  <button id="dropdown-trigger-search" data-component="dropdown" data-target="dropdown-menu-search" data-auto-close="true">
     <%= content_tag :span, t("decidim.searches.filters_small_view.filter_by"), class: "#{"is-active" if params.dig(:filter, :with_resource_type) == nil}" %>
     <% @blocks.each do |elements| %>
       <% elements.each do |type, results| %>

--- a/decidim-core/app/views/decidim/shared/_filters.html.erb
+++ b/decidim-core/app/views/decidim/shared/_filters.html.erb
@@ -4,7 +4,7 @@
 <% if filter_sections.present? || local_assigns.has_key?(:search_variable) %>
   <%= filter_form_for filter, url_for, class: "new_filter self-stretch", data: { filters: "", component: "accordion" } do |form| %>
 
-    <button id="dropdown-trigger-filters" data-component="dropdown" data-target="dropdown-menu-filters" data-disabled-md="true">
+    <button id="dropdown-trigger-filters" data-component="dropdown" data-target="dropdown-menu-filters">
       <%= icon "arrow-down-s-line" %>
       <%= icon "arrow-up-s-line" %>
       <span>

--- a/decidim-core/app/views/decidim/shared/_filters.html.erb
+++ b/decidim-core/app/views/decidim/shared/_filters.html.erb
@@ -12,7 +12,7 @@
       </span>
     </button>
 
-    <div id="dropdown-menu-filters">
+    <div id="dropdown-menu-filters" aria-hidden="true">
       <% if local_assigns.has_key?(:skip_to_id) %>
         <%= link_to t("skip", scope: "decidim.shared.filter_form_help"), "##{skip_to_id}", class: "filter-skip" %>
       <% end %>

--- a/decidim-core/app/views/decidim/shared/_orders.html.erb
+++ b/decidim-core/app/views/decidim/shared/_orders.html.erb
@@ -3,7 +3,7 @@
   <%= icon "arrow-up-s-line" %>
   <span><%= t("#{i18n_scope}.label") %></span>
 </button>
-<div id="dropdown-menu-order" class="order-by">
+<div id="dropdown-menu-order" class="order-by" aria-hidden="true">
   <% orders.each do |order_name| %>
     <%= order_link order_name,
                    i18n_scope:,

--- a/decidim-core/app/views/decidim/shared/_orders.html.erb
+++ b/decidim-core/app/views/decidim/shared/_orders.html.erb
@@ -1,4 +1,4 @@
-<button class="order-by__button" id="dropdown-trigger-order" data-component="dropdown" data-target="dropdown-menu-order" data-open="false" data-disabled-md="true">
+<button class="order-by__button" id="dropdown-trigger-order" data-component="dropdown" data-target="dropdown-menu-order" data-open="false">
   <%= icon "arrow-down-s-line" %>
   <%= icon "arrow-up-s-line" %>
   <span><%= t("#{i18n_scope}.label") %></span>

--- a/decidim-core/app/views/layouts/decidim/shared/_layout_user_profile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/shared/_layout_user_profile.html.erb
@@ -10,7 +10,7 @@
 
   <div class="vertical-tabs">
     <nav aria-label="menu-vertical">
-      <button id="dropdown-trigger-profile" data-component="dropdown" data-target="dropdown-menu-profile" data-disabled-md="true" aria-hidden="true">
+      <button id="dropdown-trigger-profile" data-component="dropdown" data-target="dropdown-menu-profile">
         <span><%= user_menu.active_item&.label || t("decidim.searches.filters.jump_to") %></span>
         <%= icon "arrow-down-s-line" %>
         <%= icon "arrow-up-s-line" %>

--- a/decidim-core/app/views/layouts/decidim/shared/_layout_user_profile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/shared/_layout_user_profile.html.erb
@@ -10,12 +10,12 @@
 
   <div class="vertical-tabs">
     <nav aria-label="menu-vertical">
-      <button id="dropdown-trigger-profile" data-component="dropdown" data-target="dropdown-menu-profile" data-disabled-md="true">
+      <button id="dropdown-trigger-profile" data-component="dropdown" data-target="dropdown-menu-profile" data-disabled-md="true" aria-hidden="true">
         <span><%= user_menu.active_item&.label || t("decidim.searches.filters.jump_to") %></span>
         <%= icon "arrow-down-s-line" %>
         <%= icon "arrow-up-s-line" %>
       </button>
-      <ul id="dropdown-menu-profile" class="vertical-tabs__list">
+      <ul id="dropdown-menu-profile" class="vertical-tabs__list" aria-hidden="true">
         <%= user_menu.render %>
       </ul>
     </nav>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1445,7 +1445,7 @@ en:
           past: Past
       filters_small_view:
         filter: Filter
-        filter_and_search: Filter and Search
+        filter_and_search: Filter and search
         filter_by: Filter by
       results:
         view_all: View all (%{count})


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes multiple bugs with the dropdowns and mobile devices.

In pages with these dropdowns, when the devise changes orientation from landscape (horizontal) to landscape and the dropdown appears, there are two things that happen: 

- The menu is shown (it should not be shown, as the dropdown should be closed)
- The dropdown doesn't work (i.e. you click on it and it doesn't do anything)

If you refresh, this makes the dropdown to work again.

This can also be reproduced in a desktop by resizing the window and seeing the dropdown appear. 

Another related bug to this is that in mobile devices we see a FUOC (flash of unstyled content) while loading pages with these dropdowns.

This PR fixes all of these bugs in the dropdowns that I could found. 

At the technical level, for the moment I'm leaving the buggy `data-disabled-md` attribute, as it's still being used in System dashboard. The markup is that bad there that I couldn't find an easy way of fixing this bug, so we can tackle that problem in another PR (and drop the unnecessary `data-disabled-md` attr)

I also fixed a mini  bug in the "Filter and Search" button title for components, so it has the correct capitalization for English ("Filter and search") 

Finally I had to adapt the Javascript code that kicks in the Dropdowns, as there was an accessibility problem: if you have an element with `attr-hidden=true` and this element has children that could be focused, then we have an a11y validation (AXE) to fail ([aria-hidden-focus](https://dequeuniversity.com/rules/axe/4.9/aria-hidden-focus?application=axeAPI)). I fixed it by disabling focus when the dropdown is hidden (and enabling it again once it is open). 

#### :pushpin: Related Issues
 
- Fixes #11000

#### Testing

1. Go to each of these pages
2. Change orientation in a mobile device or resize the width resolution in your webdev tools (or browser) to the dropdown kicks in
3. (Before) see that you have the menu and you can't close it. Reload and see it fixed (but still see a FUOC)
4. (After) see that the dropdown is closed and you don't see the menu. You can open the dropdown. Reloading it you don't see the FUOC. 

Respecting the order of the files shown in GitHub to ease-up the review: 

- [x]  Accountability results index - http://localhost:3000/processes/general-ambiguous/f/1/ 
- [x] Assembly admin page (or any admin page with a sidebar) - http://localhost:3000/admin/assemblies/branch-introduction/edit
- [x] Conferences show page - http://localhost:3000/conferences/nursery-thirsty
- [x] Participatory process page (or any other participatory space) - http://localhost:3000/processes/general-ambiguous
- [x] Last activity page - http://localhost:3000/last_activities
- [x] Page in a topic - http://localhost:3000/pages/help
- [x] Search page - http://localhost:3000/search?term=Lorem 
- [x] Proposal index (or any other component) - http://localhost:3000/processes/general-ambiguous/f/7/proposals
- [x] My account page - http://localhost:3000/account

### :camera: Screenshots

#### Accountability results index

![Accountability results index screenshot](https://github.com/decidim/decidim/assets/717367/5912c3ad-c9e8-4a9f-b84e-d2fd926f14ff)

#### Assembly admin page (or any admin page with a sidebar)

![Assembly admin page (or any admin page with a sidebar) screenshot](https://github.com/decidim/decidim/assets/717367/7c232b2b-b7e1-4088-92b9-9a8f1d24d549)

#### Conferences show page 

![Conferences show page screenshot](https://github.com/decidim/decidim/assets/717367/70b37467-7d41-4549-947b-e490c2606d60)

#### Participatory process page (or any other participatory space)

![Participatory process page (or any other participatory space)](https://github.com/decidim/decidim/assets/717367/a2122b66-7d41-4cc4-b595-53cf57afc4a3)

#### Last activity page 

![Last activity page screenshot](https://github.com/decidim/decidim/assets/717367/991b374b-4cea-48ef-832c-c68129ce5efa)

#### Page in a topic

![Page in a topic screenshot](https://github.com/decidim/decidim/assets/717367/2807a273-b92f-4acd-ba07-874b120e0ca2)

#### Search page

![Search page screenshot](https://github.com/decidim/decidim/assets/717367/e90b621b-3d75-4ff8-8a13-512a41d52fb9)

#### Proposal index (or any other component)

![Proposal index (or any other component) screenshot](https://github.com/decidim/decidim/assets/717367/ca5726d6-ad84-46ae-9840-76c8c1a6db1d)

#### My account page

![My account page](https://github.com/decidim/decidim/assets/717367/af619ce1-1c2d-4d5e-938d-d483a27a022a)

:hearts: Thank you!
