### PR TITLE
Fix exception when going to debates new URL directly as non-logged user 

### DIFF
--- a/decidim-debates/app/controllers/decidim/debates/debates_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/debates_controller.rb
@@ -13,6 +13,7 @@ module Decidim
       include Decidim::Debates::Orderable
 
       helper_method :debates, :debate, :form_presenter, :paginated_debates, :close_debate_form
+      before_action :authenticate_user!, only: [:new, :create]
 
       def new
         enforce_permission_to :create, :debate

--- a/decidim-debates/spec/controllers/decidim/debates/debates_controller_spec.rb
+++ b/decidim-debates/spec/controllers/decidim/debates/debates_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Debates
+    describe DebatesController do
+      routes { Decidim::Debates::Engine.routes }
+
+      let(:user) { create(:user, :confirmed, organization: component.organization) }
+
+      let(:debate_params) do
+        {
+          component_id: component.id
+        }
+      end
+      let(:params) { { debate: debate_params } }
+
+      before do
+        request.env["decidim.current_organization"] = component.organization
+        request.env["decidim.current_participatory_space"] = component.participatory_space
+        request.env["decidim.current_component"] = component
+        stub_const("Decidim::Paginable::OPTIONS", [100])
+      end
+
+      describe "GET new" do
+        let(:component) { create(:debates_component, :with_creation_enabled) }
+
+        context "when user is not logged in" do
+          it "redirects to the login page" do
+            get(:new)
+            expect(response).to have_http_status(:found)
+            expect(response.body).to have_text("You are being redirected")
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
@@ -142,4 +142,14 @@ describe Decidim::Meetings::MeetingsController do
       end
     end
   end
+
+  describe "#new" do
+    context "when user is not logged in" do
+      it "redirects to the login page" do
+        get(:new)
+        expect(response).to have_http_status(:found)
+        expect(response.body).to have_text("You are being redirected")
+      end
+    end
+  end
 end

--- a/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -105,6 +105,16 @@ module Decidim
         end
       end
 
+      context "when user is not logged in" do
+        let(:component) { create(:proposal_component, :with_creation_enabled) }
+
+        it "redirects to the login page" do
+          get(:new)
+          expect(response).to have_http_status(:found)
+          expect(response.body).to have_text("You are being redirected")
+        end
+      end
+
       describe "POST create" do
         before { sign_in user }
 


### PR DESCRIPTION
#### :tophat: What? Why?

There's an exception when visiting a new debates form page directly as a visitor. This PR fixes it.

I've also added some specs for this same problem in components with the "Participants can create ..." setting: Proposals and Meetings.

#### :pushpin: Related Issues

- Fixes https://meta.decidim.org/processes/bug-report/f/210/proposals/17699

#### Testing

1. Sign in as admin
2. Enable debates created by participant in a debates component in a participatory space
3. Go to the debates index page
4. Click in the "New debate" button
5. Copy the URL 
6. Open it in a new incognito/private session in your browser
7. (Without the patch) see an exception
8. (With the patch) see that you're redirected to the login page 

:hearts: Thank you!
