### PR TITLE
Hide filters without options

### DIFF
--- a/decidim-assemblies/app/helpers/decidim/assemblies/filter_assemblies_helper.rb
+++ b/decidim-assemblies/app/helpers/decidim/assemblies/filter_assemblies_helper.rb
@@ -24,7 +24,7 @@ module Decidim
           { method: :with_any_scope, collection: filter_global_scopes_values, label_scope: "decidim.shared.participatory_space_filters.filters", id: "scope" },
           { method: :with_any_area, collection: filter_areas_values, label_scope: "decidim.shared.participatory_space_filters.filters", id: "area" },
           { method: :with_any_type, collection: filter_types_values, label_scope: "decidim.assemblies.assemblies.filters", id: "type" }
-        ].reject { |item| item[:collection].blank? }
+        ].reject { |item| empty_filter?(item[:collection]) }
       end
     end
   end

--- a/decidim-assemblies/spec/system/filter_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/filter_assemblies_spec.rb
@@ -62,9 +62,7 @@ describe "Filter Assemblies" do
     end
 
     it "does not show the assemblies types filter" do
-      within("#dropdown-menu-filters") do
-        expect(page).to have_no_css("#dropdown-menu-filters div.filter-container", text: "Type")
-      end
+      expect(page).to have_no_css("#dropdown-menu-filters")
     end
   end
 

--- a/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
+++ b/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
@@ -147,7 +147,7 @@ module Decidim
           end
         end
 
-        items.reject { |item| item[:collection].blank? }
+        items.reject { |item| empty_filter?(item[:collection]) }
       end
 
       def budgets_select_tag(name, options: {})

--- a/decidim-core/app/helpers/decidim/check_boxes_tree_helper.rb
+++ b/decidim-core/app/helpers/decidim/check_boxes_tree_helper.rb
@@ -133,7 +133,25 @@ module Decidim
       content_tag(:span, translation, id:).html_safe + content_tag(:span)
     end
 
+    def empty_filter?(collection)
+      return true if collection.blank?
+      return false unless collection.is_a?(TreeNode)
+      return false unless collection.node.is_a?(Array)
+
+      collection.node.all? { |node| empty_node?(node) }
+    end
+
     private
+
+    def empty_node?(node)
+      if node.is_a?(TreeNode)
+        node.leaf.value.empty?
+      elsif node.is_a?(TreePoint)
+        node.value.empty?
+      else
+        false
+      end
+    end
 
     def filter_scopes_values_from_parent(scope)
       scopes_values = []

--- a/decidim-core/app/helpers/decidim/check_boxes_tree_helper.rb
+++ b/decidim-core/app/helpers/decidim/check_boxes_tree_helper.rb
@@ -177,9 +177,7 @@ module Decidim
         )
       end
 
-      if scopes_values.any?
-        scopes_values.prepend(TreePoint.new("global", t("decidim.scopes.global"))) if participatory_space&.scope.blank?
-      end
+      scopes_values.prepend(TreePoint.new("global", t("decidim.scopes.global"))) if scopes_values.any? && participatory_space.present?
 
       filter_tree_from(scopes_values)
     end

--- a/decidim-core/app/helpers/decidim/check_boxes_tree_helper.rb
+++ b/decidim-core/app/helpers/decidim/check_boxes_tree_helper.rb
@@ -177,7 +177,9 @@ module Decidim
         )
       end
 
-      scopes_values.prepend(TreePoint.new("global", t("decidim.scopes.global"))) if participatory_space&.scope.blank?
+      if scopes_values.any?
+        scopes_values.prepend(TreePoint.new("global", t("decidim.scopes.global"))) if participatory_space&.scope.blank?
+      end
 
       filter_tree_from(scopes_values)
     end

--- a/decidim-debates/app/helpers/decidim/debates/application_helper.rb
+++ b/decidim-debates/app/helpers/decidim/debates/application_helper.rb
@@ -87,7 +87,7 @@ module Decidim
           items.append(method: :with_any_origin, collection: filter_origin_values, label_scope: "decidim.debates.debates.filters", id: "origin")
           items.append(method: :activity, collection: activity_filter_values, label_scope: "decidim.debates.debates.filters", id: "activity") if current_user
 
-          items.reject { |item| item[:collection].blank? }
+          items.reject { |item| empty_filter?(item[:collection]) }
         end
       end
 

--- a/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
@@ -32,7 +32,7 @@ module Decidim
         sections.append(method: :with_any_type, collection: filter_types_values, label_scope: "decidim.initiatives.initiatives.filters", id: "type") unless single_initiative_type?
         sections.append(method: :with_any_area, collection: filter_areas_values, label_scope: "decidim.initiatives.initiatives.filters", id: "area")
         sections.append(method: :author, collection: filter_author_values, label_scope: "decidim.initiatives.initiatives.filters", id: "author") if current_user
-        sections.reject { |item| item[:collection].blank? }
+        sections.reject { |section| empty_filter?(section[:collection]) }
       end
 
       def filter_author_values

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -76,7 +76,7 @@ module Decidim
           { method: :with_any_scope, collection: filter_global_scopes_values, label_scope: "decidim.shared.participatory_space_filters.filters", id: "scope" },
           { method: :with_any_area, collection: filter_areas_values, label_scope: "decidim.shared.participatory_space_filters.filters", id: "area" },
           { method: :with_any_type, collection: filter_types_values, label_scope: "decidim.participatory_processes.participatory_processes.filters", id: "type" }
-        ].reject { |item| item[:collection].blank? }
+        ].reject { |item| empty_filter?(item[:collection]) }
       end
 
       def process_types

--- a/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
@@ -131,40 +131,54 @@ describe "Filter Participatory Processes" do
   end
 
   context "when filtering processes by area" do
-    let!(:area) { create(:area, organization:) }
-    let!(:other_area) { create(:area, organization:) }
-    let!(:process_with_area) { create(:participatory_process, area:, organization:) }
-    let!(:process_without_area) { create(:participatory_process, organization:) }
-
-    before do
-      visit decidim_participatory_processes.participatory_processes_path
-    end
-
-    context "and choosing an area" do
-      before do
-        within "#panel-dropdown-menu-area" do
-          click_filter_item translated(area.name)
-        end
-      end
-
-      it "lists all processes belonging to that area" do
-        expect(page).to have_content(translated(process_with_area.title))
-        expect(page).to have_no_content(translated(process_without_area.title))
-      end
-    end
-
-    context "when filters are disabled" do
-      let!(:process_with_area) { create(:participatory_process, area: create(:area, organization:), organization:) }
-      let!(:process_with_scope) { create(:participatory_process, scope: create(:scope, organization:), organization:) }
-      let(:organization) { create(:organization, enable_participatory_space_filters: false) }
+    context "organization without areas" do
+      let!(:process_without_area) { create(:participatory_process, organization:) }
 
       before do
         visit decidim_participatory_processes.participatory_processes_path
       end
 
-      it "does not show filters" do
-        expect(page).to have_no_css(".with_area_areas_select_filter")
-        expect(page).to have_no_css(".with_scope_scopes_picker_filter")
+      it "does not show the area filter" do
+        expect(page).to have_no_css("#panel-dropdown-menu-area")
+      end
+    end
+
+    context "organization with areas" do
+      let!(:area) { create(:area, organization:) }
+      let!(:other_area) { create(:area, organization:) }
+      let!(:process_with_area) { create(:participatory_process, area:, organization:) }
+      let!(:process_without_area) { create(:participatory_process, organization:) }
+
+      before do
+        visit decidim_participatory_processes.participatory_processes_path
+      end
+
+      context "and choosing an area" do
+        before do
+          within "#panel-dropdown-menu-area" do
+            click_filter_item translated(area.name)
+          end
+        end
+
+        it "lists all processes belonging to that area" do
+          expect(page).to have_content(translated(process_with_area.title))
+          expect(page).to have_no_content(translated(process_without_area.title))
+        end
+      end
+
+      context "when filters are disabled" do
+        let!(:process_with_area) { create(:participatory_process, area: create(:area, organization:), organization:) }
+        let!(:process_with_scope) { create(:participatory_process, scope: create(:scope, organization:), organization:) }
+        let(:organization) { create(:organization, enable_participatory_space_filters: false) }
+
+        before do
+          visit decidim_participatory_processes.participatory_processes_path
+        end
+
+        it "does not show filters" do
+          expect(page).to have_no_css(".with_area_areas_select_filter")
+          expect(page).to have_no_css(".with_scope_scopes_picker_filter")
+        end
       end
     end
   end

--- a/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
@@ -131,7 +131,7 @@ describe "Filter Participatory Processes" do
   end
 
   context "when filtering processes by area" do
-    context "organization without areas" do
+    context "without organization areas" do
       let!(:process_without_area) { create(:participatory_process, organization:) }
 
       before do
@@ -143,7 +143,7 @@ describe "Filter Participatory Processes" do
       end
     end
 
-    context "organization with areas" do
+    context "with organization areas" do
       let!(:area) { create(:area, organization:) }
       let!(:other_area) { create(:area, organization:) }
       let!(:process_with_area) { create(:participatory_process, area:, organization:) }

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -241,7 +241,7 @@ module Decidim
         # rubocop:enable Metrics/PerceivedComplexity
         # rubocop:enable Metrics/CyclomaticComplexity
 
-        items.reject { |item| item[:collection].blank? }
+        items.reject { |item| empty_filter?(item[:collection]) }
       end
 
       def component_name

--- a/decidim-proposals/app/helpers/decidim/proposals/collaborative_draft_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/collaborative_draft_helper.rb
@@ -61,7 +61,7 @@ module Decidim
               type: :radio_buttons
             )
           end
-          items.reject { |item| item[:collection].blank? }
+          items.reject { |item| empty_filter?(item[:collection]) }
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Hide filters that doesn't have available options. 

#### :pushpin: Related Issues
- Fixes #12560 

#### Testing
Check that any page with sidebar filters, filters without any option are not shown. 

### :camera: Screenshots

<img width="958" alt="Screenshot 2024-05-23 at 11 44 39" src="https://github.com/decidim/decidim/assets/935744/45150f5e-6f1b-4ea8-bf10-7c263eeb16b3">

https://decidim-lot2.populate.tools/processes
