### PR TITLE
Fix i18n string misplacement in decidim-initiatives

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -571,6 +571,7 @@ en:
         appearance: Appearance
         area_types: Area types
         areas: Areas
+        components: Components
         configuration: Configuration
         content: Reported content
         external_domain_allowlist: Allowed external domains

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -188,6 +188,7 @@ en:
         export: Export all
         export-selection: Export selection
         import: Import
+        manage: Manage
         newsletter:
           new: New newsletter
         participatory_space_private_user:

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -80,7 +80,6 @@ en:
   decidim:
     admin:
       actions:
-        manage: Manage
         new_initiative_type: New initiative type
         new_initiative_type_scope: New initiative type scope
       filters:

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -106,7 +106,6 @@ en:
       menu:
         attachments: Attachments
         committee_members: Committee members
-        components: Components
         information: Information
         initiative_type_scopes: Initiative type scopes
         initiatives: Initiatives


### PR DESCRIPTION
#### :tophat: What? Why?

If you don't enable initiatives, which is very common on Decidim for organizations, you will notice that the top menu for components in the admin shows the raw i18n key "decidim.admin.actions.manage".
This is because this key is defined in the en.yml file on initiatives. It should be in the admin module.

This should backported as it's there from long time ago.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
Just' don't install initiatives, run decidim, try to administrate a component. 
In production mode you will see a raw i18n key. In development it just breaks the application which makes development very uncomfortable.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
