### PR TITLE
Add proposal author when exporting proposals

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -19,6 +19,9 @@ module Decidim
       def serialize
         {
           id: proposal.id,
+          author: {
+            **author_fields
+          },
           category: {
             id: proposal.category.try(:id),
             name: proposal.category.try(:name) || empty_translatable
@@ -103,6 +106,54 @@ module Decidim
         return value.transform_values { |v| convert_to_plain_text(v) } if value.is_a?(Hash)
 
         convert_to_text(value)
+      end
+
+      def author_fields
+        is_author_user_group = resource.coauthorships.map(&:decidim_user_group_id).any?
+
+        {
+          id: resource.authors.map(&:id),
+          name: resource.authors.map do |author|
+            author_name(is_author_user_group ? resource.coauthorships.first.user_group : author)
+          end,
+          url: resource.authors.map do |author|
+            author_url(is_author_user_group ? resource.coauthorships.first.user_group : author)
+          end
+        }
+      end
+
+      def author_name(author)
+        if author.respond_to?(:name)
+          translated_attribute(author.name) # is a Decidim::User or Decidim::Organization or Decidim::UserGroup
+        elsif author.respond_to?(:title)
+          translated_attribute(author.title) # is a Decidim::Meetings::Meeting
+        end
+      end
+
+      def author_url(author)
+        if author.respond_to?(:nickname)
+          profile_url(author.nickname) # is a Decidim::User or Decidim::UserGroup
+        elsif author.respond_to?(:title)
+          meeting_url(author) # is a Decidim::Meetings::Meeting
+        else
+          root_url # is a Decidim::Organization
+        end
+      end
+
+      def profile_url(nickname)
+        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:)
+      end
+
+      def meeting_url(meeting)
+        Decidim::EngineRouter.main_proxy(meeting.component).meeting_url(id: meeting.id, host:)
+      end
+
+      def root_url
+        Decidim::Core::Engine.routes.url_helpers.root_url(host:)
+      end
+
+      def host
+        resource.organization.host
       end
     end
   end

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -47,6 +47,86 @@ module Decidim
           expect(serialized).to include(id: proposal.id)
         end
 
+        describe "author" do
+          context "when it is an official proposal" do
+            let!(:proposal) { create(:proposal, :official) }
+
+            before do
+              component.participatory_space.organization.update!(name: { en: "My organization" })
+              proposal.reload
+            end
+
+            it "serializes the organization name" do
+              expect(serialized[:author]).to include(name: ["My organization"])
+            end
+
+            it "serializes the link to the organization" do
+              expect(serialized[:author]).to include(url: [root_url])
+            end
+          end
+
+          context "when it is a user" do
+            let!(:proposal) { create(:proposal, :participant_author) }
+
+            before do
+              proposal.creator_author.update!(name: "John Doe")
+              proposal.reload
+            end
+
+            it "serializes the user name" do
+              expect(serialized[:author]).to include(name: ["John Doe"])
+            end
+
+            it "serializes the link to its profile" do
+              expect(serialized[:author]).to include(url: [profile_url(proposal.creator_author.nickname)])
+            end
+          end
+
+          context "when it is multiple users" do
+            let!(:coauthorships) { create_list(:coauthorship, 3, coauthorable: proposal) }
+
+            it "serializes the user names" do
+              expect(serialized[:author]).to include(name: proposal.authors.map(&:name))
+            end
+
+            it "serializes the link to the profiles" do
+              urls = proposal.authors.map { |author| profile_url(author.nickname) }
+              expect(serialized[:author]).to include(url: urls)
+            end
+          end
+
+          context "when it is a meeting" do
+            let!(:proposal) { create(:proposal, :official_meeting) }
+
+            it "serializes the title of the meeting" do
+              title = proposal.authors.map { |author| translated_attribute(author.title) }
+              expect(serialized[:author]).to include(name: title)
+            end
+
+            it "serializes the link to the meeting" do
+              urls = proposal.authors.map { |meeting| meeting_url(meeting) }
+              expect(serialized[:author]).to include(url: urls)
+            end
+          end
+
+          context "when it is a user group" do
+            let!(:proposal) { create(:proposal, :user_group_author) }
+
+            before do
+              proposal.coauthorships.first.user_group.update!(name: "ACME", nickname: "acme")
+              proposal.reload
+            end
+
+            it "serializes the user name of the user group" do
+              expect(serialized[:author]).to include(name: ["ACME"])
+            end
+
+            it "serializes the link to the profile of the user group" do
+              expect(serialized[:author]).to include(url: [profile_url("acme")])
+            end
+          end
+        end
+
         it "serializes the category" do
           expect(serialized[:category]).to include(id: category.id)
           expect(serialized[:category]).to include(name: category.name)
@@ -234,6 +314,22 @@ module Decidim
             end
           end
         end
+      end
+
+      def profile_url(nickname)
+        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:)
+      end
+
+      def meeting_url(meeting)
+        Decidim::EngineRouter.main_proxy(meeting.component).meeting_url(id: meeting.id, host:)
+      end
+
+      def root_url
+        Decidim::Core::Engine.routes.url_helpers.root_url(host:)
+      end
+
+      def host
+        proposal.organization.host
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

When you export proposals in the admin panel, you don't see the author of this proposal. This PR adds them. 

This is the thin line between a fix and a new feature, for the moment I'll add the `type: fix` as it's something that I didn't expected when I first read the report. I'm open to change it to a `type: feature` if the reviewer has a stronger opinion 😄 

#### :pushpin: Related Issues
 
- Fixes https://meta.decidim.org/processes/bug-report/f/210/proposals/17364

#### Testing

0. Sign in as admin
1. Export proposals in the admin
2. Go to http://localhost:3000/letter_opener
3. Download the zip
4. Open the CSV
5. See that you have the authors in the CSV

### :camera: Screenshots

![CSV with the exported proposals](https://github.com/decidim/decidim/assets/717367/ea9ddf12-e966-4a94-b8b8-d4008ed402be)

:hearts: Thank you!
