### PR TITLE
Remove unecessary accordion in Conferences' program

### DIFF
--- a/decidim-conferences/app/packs/stylesheets/decidim/conferences/_program.scss
+++ b/decidim-conferences/app/packs/stylesheets/decidim/conferences/_program.scss
@@ -14,7 +14,7 @@
   }
 
   &-category {
-    @apply h-10 w-full bg-background border-b-2 border-gray-3 text-center text-md text-gray-2 font-normal truncate;
+    @apply h-10 w-full bg-background-4 border-b-2 border-secondary text-center text-secondary font-semibold text-md truncate leading-10;
 
     &-container {
       @apply flex gap-2 [&>*]:grow [&>*]:min-w-0;
@@ -22,10 +22,6 @@
 
     &-content {
       @apply [&>a]:block [&>a]:py-4;
-    }
-
-    &[aria-expanded="true"] {
-      @apply bg-background-4 border-secondary text-secondary font-semibold;
     }
   }
 

--- a/decidim-conferences/app/views/decidim/conferences/conference_program/_program_item.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conference_program/_program_item.html.erb
@@ -3,23 +3,23 @@
     <div class="conference__program-time">
       <%= start_time.to_fs(:time) %> - <%= end_time.to_fs(:time) %>
     </div>
-    <div data-component="accordion" data-multiselectable="false" data-collapsible="false">
+    <div>
       <% categories = meetings.map(&:category).uniq %>
       <% seed = SecureRandom.hex(3).to_s %>
       <% if categories.present? %>
         <ul class="conference__program-category-container">
-          <% categories.each_with_index do |category, i| %>
+          <% categories.each do |category| %>
             <li>
-              <button id="conference-item-trigger-<%= seed %>-tab<%= i %>" class="conference__program-category" data-controls="conference-item-panel-<%= seed %>-tab<%= i %>" data-open="<%= "true" if i.zero? %>">
+              <div class="conference__program-category">
                 <%= category.present? ? translated_attribute(category.name) : "other" %>
-              </button>
+              </div>
             </li>
           <% end %>
         </ul>
       <% end %>
 
-      <% meetings.group_by(&:category).each_with_index do |categories_block, i| %>
-        <div id="conference-item-panel-<%= seed %>-tab<%= i %>" class="conference__program-category-content">
+      <% meetings.group_by(&:category).each do |categories_block| %>
+        <div class="conference__program-category-content">
           <% categories_block.last.each do |meeting| %>
             <%= render partial: "program_meeting", locals: { meeting: } %>
           <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

When you go to a Conference's program page, you can see the pointer in the category name, but it isn't clickable. 
Seems like a buggy (and unecessary) accordion was added here with the redesign. This PR removes that accordion so it isn't clickable (and you don't have the cursor pointer on it when hovering).

#### :pushpin: Related Issues
 
- Fixes #11271

#### Testing

1. Go to a conference's program
2. Hover in the category name 

### :camera: Screenshots
 
![Screenshot of this page](https://github.com/decidim/decidim/assets/717367/5789f430-3f6e-4390-8588-b9c2676bd5cf)

:hearts: Thank you!
