### PR TITLE
Fix external URL with a fragment

### DIFF
--- a/decidim-core/app/controllers/decidim/links_controller.rb
+++ b/decidim-core/app/controllers/decidim/links_controller.rb
@@ -37,7 +37,19 @@ module Decidim
     end
 
     def external_url
-      @external_url ||= URI.parse(URI::Parser.new.escape(params[:external_url]))
+      @external_url ||= URI.parse(escape_url(params[:external_url]))
+    end
+
+    def escape_url(external_url)
+      before_fragment, fragment = external_url.split("#", 2)
+      escaped_before_fragment = URI::Parser.new.escape(before_fragment)
+
+      if fragment
+        escaped_fragment = URI::Parser.new.escape(fragment)
+        "#{escaped_before_fragment}##{escaped_fragment}"
+      else
+        escaped_before_fragment
+      end
     end
   end
 end

--- a/decidim-core/app/views/decidim/links/new.html.erb
+++ b/decidim-core/app/views/decidim/links/new.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title t("decidim.links.warning.title") %>
+
 <%= render layout: "layouts/decidim/shared/layout_center" do %>
 
   <div class="flex justify-center">

--- a/decidim-core/spec/system/external_domain_warning_spec.rb
+++ b/decidim-core/spec/system/external_domain_warning_spec.rb
@@ -39,6 +39,18 @@ describe "ExternalDomainWarning" do
     end
   end
 
+  context "when url has a fragment" do
+    let(:destination) { "https://example.org/test/#/bar/edit/12345" }
+    # URI need to be escaped, as if not the fragment will be ignored
+    let(:url) { "http://#{organization.host}/link?external_url=#{URI::Parser.new.escape(destination)}" }
+
+    it "does not show invalid url alert" do
+      visit url
+      expect(page).to have_no_content("Invalid URL")
+      expect(page).to have_content("https://example.org/test/#/bar/edit/12345")
+    end
+  end
+
   context "when url is invalid" do
     let(:invalid_url) { "http://#{organization.host}/link?external_url=foo" }
 


### PR DESCRIPTION
#### :tophat: What? Why?

When we add a link with a fragment in it, the number sign/hash/pound sign/octothorp ("#") is escaped. This is a problem because it's breaking some links like "https://cryptpad.fr/pad/#/2/pad/edit/Z1iziK+IDo-6TA7zokMdszVb/embed". 

This PR fixes that.

I also found a missing title in this page, so I fixed that too. 

#### :pushpin: Related Issues

- Related to #11472 
- Fixes #12472 

#### Testing

1. Sign in 
2. Go to a proposal with comments
3. Add a comment with this link https://cryptpad.fr/pad/#/2/pad/edit/Z1iziK+IDo-6TA7zokMdszVb/embed 
4. (Before the patch) see that once you go to the external URL, you have a 404
5. (After the patch) once you go to the external URL, it shows the correct page

### :camera: Screenshots

![Modal with the correct URL](https://github.com/decidim/decidim/assets/717367/c4f86e5e-dc54-4cf1-836f-625d0481aeab)

:hearts: Thank you!
