### PR TITLE
Fix submit on enter in forms with Datepicker 

### DIFF
--- a/decidim-core/app/packs/src/decidim/datepicker/generate_datepicker.js
+++ b/decidim-core/app/packs/src/decidim/datepicker/generate_datepicker.js
@@ -17,6 +17,7 @@ export default function generateDatePicker(input, row, formats) {
   const calendar = document.createElement("button");
   calendar.innerHTML = icon("calendar-line");
   calendar.setAttribute("class", "datepicker__calendar-button");
+  calendar.setAttribute("type", "button");
 
   dateColumn.appendChild(date);
   dateColumn.appendChild(calendar);
@@ -35,11 +36,13 @@ export default function generateDatePicker(input, row, formats) {
   const closeCalendar = document.createElement("button");
   closeCalendar.innerText = i18n.close;
   closeCalendar.setAttribute("class", "datepicker__close-calendar button button__transparent-secondary button__xs");
+  closeCalendar.setAttribute("type", "button");
 
   const pickCalendar = document.createElement("button");
   pickCalendar.innerText = i18n.select;
   pickCalendar.setAttribute("class", "datepicker__pick-calendar button button__secondary button__xs");
   pickCalendar.setAttribute("disabled", true);
+  pickCalendar.setAttribute("type", "button");
 
   datePickerContainer.appendChild(pickCalendar);
   datePickerContainer.appendChild(closeCalendar);

--- a/decidim-core/app/packs/src/decidim/datepicker/generate_timepicker.js
+++ b/decidim-core/app/packs/src/decidim/datepicker/generate_timepicker.js
@@ -17,6 +17,7 @@ export default function generateTimePicker(input, row, formats) {
   const clock = document.createElement("button");
   clock.innerHTML = icon("time-line")
   clock.setAttribute("class", "datepicker__clock-button");
+  clock.setAttribute("type", "button");
 
   timeColumn.appendChild(time);
   timeColumn.appendChild(clock);
@@ -34,10 +35,12 @@ export default function generateTimePicker(input, row, formats) {
   const hourUp = document.createElement("button");
   hourUp.setAttribute("class", "datepicker__hour-up");
   hourUp.innerHTML = icon("arrow-drop-up-line", {class: "w-10 h-6 pr-1"});
+  hourUp.setAttribute("type", "button");
 
   const hourDown = document.createElement("button");
   hourDown.setAttribute("class", "datepicker__hour-down");
   hourDown.innerHTML = icon("arrow-drop-down-line", {class: "w-10 h-6 pr-1"});
+  hourDown.setAttribute("type", "button");
 
   hourColumn.appendChild(hours);
   hourColumn.appendChild(hourUp);
@@ -54,10 +57,12 @@ export default function generateTimePicker(input, row, formats) {
   const minuteUp = document.createElement("button");
   minuteUp.setAttribute("class", "datepicker__minute-up");
   minuteUp.innerHTML = icon("arrow-drop-up-line", {class: "w-10 h-6 pr-1"});
+  minuteUp.setAttribute("type", "button");
 
   const minuteDown = document.createElement("button");
   minuteDown.setAttribute("class", "datepicker__minute-down");
   minuteDown.innerHTML = icon("arrow-drop-down-line", {class: "w-10 h-6 pr-1"});
+  minuteDown.setAttribute("type", "button");
 
   minuteColumn.appendChild(minutes);
   minuteColumn.appendChild(minuteUp);
@@ -140,14 +145,17 @@ export default function generateTimePicker(input, row, formats) {
   const closeClock = document.createElement("button");
   closeClock.innerText = i18n.close;
   closeClock.setAttribute("class", "datepicker__close-clock button button__transparent-secondary button__xs");
+  closeClock.setAttribute("type", "button");
 
   const resetClock = document.createElement("button");
   resetClock.innerText = i18n.reset;
   resetClock.setAttribute("class", "datepicker__reset-clock button button__xs button__text-secondary");
+  resetClock.setAttribute("type", "button");
 
   const selectClock = document.createElement("button");
   selectClock.innerText = i18n.select;
   selectClock.setAttribute("class", "datepicker__select-clock button button__secondary button__xs");
+  selectClock.setAttribute("type", "button");
 
   timePicker.appendChild(resetClock);
   timePicker.appendChild(selectClock);


### PR DESCRIPTION
#### :tophat: What? Why?

There's a mini bug with the UX when filling forms with datepicker (i.e. when creating a Meeting).

When you submit the form with enter, instead of submitting, the datepicker is opened. This isn't consistent with other forms. 

This PR fixes it.

#### :pushpin: Related Issues
 
- Related to #11768

#### Testing

1. Sign in as admin
2. Go to an official meeting
3. Click on the Edit button
4. Change the title
5. Press enter
6. (Without the patch) see that the datepicker is opened
7. (With the patch) see that the form is submitted 

:hearts: Thank you!
