### PR TITLE
Fix invalid dates on meetings' seeds

### DIFF
--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -89,7 +89,6 @@ module Decidim
         params = case type
                  when :hybrid
                    params.merge(
-                     end_time: Time.zone.now + [rand(1..4).hours, rand(1..20).days].sample,
                      type_of_meeting: :hybrid,
                      online_meeting_url: "https://www.youtube.com/watch?v=f6JMgJAQ2tc",
                      iframe_access_level: :all,
@@ -97,7 +96,6 @@ module Decidim
                    )
                  when :online
                    params.merge(
-                     end_time: Time.zone.now + [rand(1..4).hours, rand(1..20).days].sample,
                      location: nil,
                      location_hints: nil,
                      latitude: nil,
@@ -109,7 +107,6 @@ module Decidim
                    )
                  when :online_live_event
                    params.merge(
-                     end_time: Time.zone.now + [rand(1..4).hours, rand(1..20).days].sample,
                      location: nil,
                      location_hints: nil,
                      latitude: nil,


### PR DESCRIPTION
#### :tophat: What? Why?

When seeding a database, we have some invalid meetings, as the dates that they have is 

#### Testing

1. Seed a new database `bin/rails db:drop db:create db:migrate assets:precompile db:seeds`
2. Check out the meetings and see that all the meetings have valid dates on it (the end date time is after the start date time)

### :camera: Screenshots

![Screenshot of the bug](https://github.com/decidim/decidim/assets/717367/b40baa93-4c70-41f8-96ef-3b3a2bb308dc)

:hearts: Thank you!
