### PR TITLE
Hide support instruction messages once support collection is finished

### DIFF
--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -145,7 +145,7 @@ module Decidim
       end
 
       def show_voting_rules?
-        return false unless votes_enabled?
+        return false if !votes_enabled? || current_settings.votes_blocked?
 
         return true if vote_limit_enabled?
         return true if threshold_per_proposal_enabled?

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -476,9 +476,11 @@ describe "Proposals" do
     end
 
     context "when voting is disabled" do
+      let(:proposals) { create_list(:proposal, 2, component:) }
       let!(:component) do
         create(:proposal_component,
                :with_votes_disabled,
+               :with_proposal_limit,
                manifest:,
                participatory_space: participatory_process)
       end
@@ -493,6 +495,58 @@ describe "Proposals" do
         visit_component
 
         expect(page).to have_css("[id^='proposals__proposal']", count: 2)
+      end
+
+      it "does not show the voting rules" do
+        proposal_title = translated(proposals.first&.title)
+
+        visit_component
+        expect(page).to have_no_css("#voting-rules")
+
+        click_on proposal_title
+        expect(page).to have_no_css("#voting-rules")
+      end
+    end
+
+    context "when voting is enabled" do
+      let(:proposals) { create_list(:proposal, 2, component:) }
+      let!(:component) do
+        create(:proposal_component,
+               :with_votes_enabled,
+               :with_proposal_limit,
+               manifest:,
+               participatory_space: participatory_process)
+      end
+
+      it "shows the voting rules" do
+        proposal_title = translated(proposals.first&.title)
+
+        visit_component
+        expect(page).to have_css("#voting-rules")
+
+        click_on proposal_title
+        expect(page).to have_css("#voting-rules")
+      end
+    end
+
+    context "when voting is blocked" do
+      let(:proposals) { create_list(:proposal, 2, component:) }
+      let!(:component) do
+        create(:proposal_component,
+               :with_votes_blocked,
+               :with_proposal_limit,
+               manifest:,
+               participatory_space: participatory_process)
+      end
+
+      it "does not show the voting rules" do
+        proposal_title = translated(proposals.first&.title)
+
+        visit_component
+        expect(page).to have_no_css("#voting-rules")
+
+        click_on proposal_title
+        expect(page).to have_no_css("#voting-rules")
       end
     end
 

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -476,7 +476,6 @@ describe "Proposals" do
     end
 
     context "when voting is disabled" do
-      let(:proposals) { create_list(:proposal, 2, component:) }
       let!(:component) do
         create(:proposal_component,
                :with_votes_disabled,
@@ -495,58 +494,6 @@ describe "Proposals" do
         visit_component
 
         expect(page).to have_css("[id^='proposals__proposal']", count: 2)
-      end
-
-      it "does not show the voting rules" do
-        proposal_title = translated(proposals.first&.title)
-
-        visit_component
-        expect(page).to have_no_css("#voting-rules")
-
-        click_on proposal_title
-        expect(page).to have_no_css("#voting-rules")
-      end
-    end
-
-    context "when voting is enabled" do
-      let(:proposals) { create_list(:proposal, 2, component:) }
-      let!(:component) do
-        create(:proposal_component,
-               :with_votes_enabled,
-               :with_proposal_limit,
-               manifest:,
-               participatory_space: participatory_process)
-      end
-
-      it "shows the voting rules" do
-        proposal_title = translated(proposals.first&.title)
-
-        visit_component
-        expect(page).to have_css("#voting-rules")
-
-        click_on proposal_title
-        expect(page).to have_css("#voting-rules")
-      end
-    end
-
-    context "when voting is blocked" do
-      let(:proposals) { create_list(:proposal, 2, component:) }
-      let!(:component) do
-        create(:proposal_component,
-               :with_votes_blocked,
-               :with_proposal_limit,
-               manifest:,
-               participatory_space: participatory_process)
-      end
-
-      it "does not show the voting rules" do
-        proposal_title = translated(proposals.first&.title)
-
-        visit_component
-        expect(page).to have_no_css("#voting-rules")
-
-        click_on proposal_title
-        expect(page).to have_no_css("#voting-rules")
       end
     end
 

--- a/decidim-proposals/spec/system/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/system/vote_proposal_spec.rb
@@ -144,6 +144,9 @@ describe "Support Proposal", slow: true do
         end
 
         describe "vote counter" do
+          let(:proposals) { create_list(:proposal, 2, component:) }
+          let(:proposal_title) { translated(proposals.first.title) }
+
           context "when votes are blocked" do
             let!(:component) do
               create(:proposal_component,
@@ -157,7 +160,12 @@ describe "Support Proposal", slow: true do
             it "does not show the remaining votes counter" do
               visit_component
 
-              expect(page).to have_css("#voting-rules")
+              expect(page).to have_no_css("#voting-rules")
+              expect(page).to have_no_css("#remaining-votes-count")
+
+              click_on proposal_title
+
+              expect(page).to have_no_css("#voting-rules")
               expect(page).to have_no_css("#remaining-votes-count")
             end
           end
@@ -177,6 +185,34 @@ describe "Support Proposal", slow: true do
 
               expect(page).to have_css("#voting-rules")
               expect(page).to have_css("#remaining-votes-count")
+
+              click_on proposal_title
+
+              expect(page).to have_css("#voting-rules")
+              expect(page).to have_css("#remaining-votes-count")
+            end
+          end
+
+          context "when votes are disabled" do
+            let!(:component) do
+              create(:proposal_component,
+                     :with_votes_disabled,
+                     :with_vote_limit,
+                     vote_limit:,
+                     manifest:,
+                     participatory_space: participatory_process)
+            end
+
+            it "does not show the remaining votes counter" do
+              visit_component
+
+              expect(page).to have_no_css("#voting-rules")
+              expect(page).to have_no_css("#remaining-votes-count")
+
+              click_on proposal_title
+
+              expect(page).to have_no_css("#voting-rules")
+              expect(page).to have_no_css("#remaining-votes-count")
             end
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?
This pull request implements functionality to automatically hide support instruction messages on the proposal index and proposal show page once the support collection period has ended. Currently, the messages remain visible even after the period has closed, which can be confusing for participants. By ensuring these messages are hidden when the support period is closed, we provide a clearer and more accurate interface for users.

#### :pushpin: Related Issues
Fixes #12363

#### Testing
To verify the correct behavior of this PR, follow these steps:

- Ensure "Supports enabled" is true and "Supports blocked" is false. Access the proposal index and specific proposal show page to confirm that support messages are visible.
- Change "Supports enabled" to false or "Supports blocked" to true and verify that the support instruction messages are no longer visible on both the proposal index and show page.
- Revert settings to ensure the system handles transitions between states accurately.

### :camera: Screenshots
![Screenshot 2024-05-28 at 18 51 57](https://github.com/decidim/decidim/assets/60363870/2b4f8e93-9309-422a-8b0f-a49e590f8cfd)

:hearts: Thank you!
