### PR TITLE
Fix alert with dummy_resource in comment search specs

### DIFF
--- a/decidim-comments/spec/system/search_comments_spec.rb
+++ b/decidim-comments/spec/system/search_comments_spec.rb
@@ -9,10 +9,13 @@ describe "Search comments" do
   let(:manifest_name) { "dummy" }
   let!(:commentable) { create(:dummy_resource, component:) }
   let!(:searchables) { create_list(:comment, 3, commentable:) }
-  let!(:term) { strip_tags(translated(searchables.first.body)).split.last }
+  let!(:term) { "FooBar" }
   let(:hashtag) { "#decidim" }
 
   before do
+    comment = create(:comment, body: "FooBar", commentable:)
+    searchables << comment
+
     hashtag_comment = create(:comment, body: "A comment with a hashtag #{hashtag}", commentable:)
     searchables << hashtag_comment
   end

--- a/decidim-core/app/cells/decidim/card/show.erb
+++ b/decidim-core/app/cells/decidim/card/show.erb
@@ -1,5 +1,5 @@
 <div class="py-4 space-y-2">
-  <a href="" class="text-lg text-secondary font-semibold hover:underline"><%= title %></a>
+  <a href="" class="text-lg text-secondary font-semibold hover:underline"><%= decidim_html_escape(title) %></a>
   <div class="flex items-center divide-x divide-gray-3">
    <% metadata.first(4).each do |item| %>
     <div class="flex items-center gap-1 px-4 lg:px-6 first:pl-0 last:pr-0 max-w-xs">


### PR DESCRIPTION
## :tophat: What? Why?

We have a flaky in the comments' search specs. Basically what is happening is that sometimes we can find a resource when it shouldn't be found in this particular context: https://github.com/decidim/decidim/blob/6be7828e67b544009dbc820f27575fb744b3df97/decidim-core/lib/decidim/core/test/shared_examples/searchable_results_examples.rb#L76 

This generates two kind of errors:

1. A JS alert when we use the default card as a fallback in the case of the DummyResource factory. To fix that we need to  escape the title. 
2. When that's fixed, then we have a second error where it is finding a content that should not be found. The culprit of this is that the entropy of the words used by Faker for the contents is limited. As we're getting the term search from the generated comment body, sometimes they can actually match with the User name for instance (i.e. if the term is short like "ad" or "est" and things like that). To fix that we need to hard code the term to search and the comment to be searched. 

## Testing

Run the following one-liner 
```bash
for i in $(seq 1 50); do echo $i ; bin/rspec decidim-comments/spec/system/search_comments_spec.rb -e "when participatory space is private" || break; done 
``` 

I was not able to reproduce it in the other implementers of this context ("searchable results", but it may happen there too. Just in case, these are the specs that may have this bug: 

- ./decidim-comments/spec/system/search_comments_spec.rb
- ./decidim-meetings/spec/system/search_meetings_spec.rb
- ./decidim-debates/spec/system/search_debates_spec.rb
- ./decidim-proposals/spec/system/search_proposals_spec.rb
- ./decidim-core/spec/commands/decidim/search_spec.rb

## Stacktraces

#### Alert

```
Search comments
[DECIDIM] ChromeDriver Workaround is being active: Setting window size to 1920x1080.
  when searching for indexed searchables
    when participatory space is not visible
      when participatory space is private
        behaves like no searches found
          does not find content by hashtag
          not contains these searchables (FAILED - 1)

Failures:

  1)Search comments when searching for indexed searchables when participatory space is not visible when participatory space is private behaves like no searches found not contains these searchables
     Failure/Error: Unable to infer file and line number from backtrace

     Selenium::WebDriver::Error::UnexpectedAlertOpenError:
       unexpected alert open: {Alert text : dummy_resource_title}
         (Session info: chrome=125.0.6422.78) 
```

#### Search term found

```
Search comments
[DECIDIM] ChromeDriver Workaround is being active: Setting window size to 1920x1080.
  when searching for indexed searchables
    when participatory space is not visible
      when participatory space is private
        behaves like no searches found 
          not contains these searchables (FAILED - 1)
          does not find content by hashtag

Failures:

  1) Search comments when searching for indexed searchables when participatory space is not visible when participatory space is private behaves like no searches found not contains these searchables
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
       expected `1.positive?` to be falsey, got true

```
:hearts: Thank you!
