### PR TITLE
Fix flaky spec on long registration type titles

### DIFF
--- a/decidim-conferences/spec/commands/join_conference_spec.rb
+++ b/decidim-conferences/spec/commands/join_conference_spec.rb
@@ -52,7 +52,7 @@ module Decidim::Conferences
         email = last_email
 
         expect(email.subject).to include("pending")
-        expect(email.text_part.body.to_s).to include(translated(registration_type.title).first(60))
+        expect(email.text_part.body.to_s.split.join(" ")).to include(translated(registration_type.title))
       end
 
       it "sends a notification to the user with the pending validation" do


### PR DESCRIPTION
#### :tophat: What? Why?

Fix a flaky spec in the Join conferences spec. This is because the matcher logic that we're currently used breaks when the registration type title is too long. 

#### :pushpin: Related Issues

- Related to  #12347 (as I think this is when we changed the factory logic)
- https://github.com/decidim/decidim/actions/runs/9251159335/job/25446227084?pr=12889 (as it's a CI job output this will be gone in a couple of days like tears in the rain) 

#### Testing

Run the following one-liner (before and after the patch) 

```bash
for i in $(seq 1 50); do echo $i ; bin/rspec decidim-conferences/spec/commands/join_conference_spec.rb:55 || break; done
```


### Stacktrace

```
  1) Decidim::Conferences::JoinConference when everything is ok sends an email with the pending validation
     Failure/Error: expect(email.text_part.body.to_s).to include(translated(registration_type.title).first(60))

       expected "-->\r\n\r\nReilly Inc ( http://354.lvh.me/ ) \r\n\r\nYour registration for the conference\r\n<script...ication email\r\naddress that cannot accept incoming email. Please do not reply to\r\nthis message." to include "<script>alert(\"registration_type_title\");</script> Sapiente "
       Diff:
       @@ -1,21 +1,41 @@
       -<script>alert("registration_type_title");</script> Sapiente 
       +-->
       +
       +Reilly Inc ( http://354.lvh.me/ ) 
       +
       +Your registration for the conference
       +<script>alert("conference_title");</script> At cum est. 11263 
       +( http://354.lvh.me:6808/conferences/capital-distant-216 ) is
       +pending confirmation.
       +
       +You have registered to
       +<script>alert("registration_type_title");</script> Sapiente
       +voluptate unde. 11284 type with a cost of €192.00 and you can
       +attend to the following events:
       +
       +You will receive the confirmation shortly
       +
       +Reilly Inc ( http://354.lvh.me/ )
       +
       +This email was sent from a notification email
       +address that cannot accept incoming email. Please do not reply to
       +this message.
     # ./spec/commands/join_conference_spec.rb:55:in `block (3 levels) in <module:Conferences>'
``` 

:hearts: Thank you!
