### PR TITLE
Backport 'Use values from secrets to set default max attachment and avatar size' to v0.27

### DIFF
--- a/decidim-core/lib/decidim/organization_settings.rb
+++ b/decidim-core/lib/decidim/organization_settings.rb
@@ -130,11 +130,19 @@ module Decidim
               )
             },
             "maximum_file_size" => {
-              "default" => 10.0,
-              "avatar" => 5.0
+              "default" => default_maximum_attachment_size,
+              "avatar" => default_maximum_avatar_size
             }
           }
         }
+      end
+
+      def default_maximum_attachment_size
+        (Rails.application.secrets.decidim[:maximum_attachment_size].presence || 10).to_f
+      end
+
+      def default_maximum_avatar_size
+        (Rails.application.secrets.decidim[:maximum_avatar_size].presence || 5).to_f
       end
     end
 

--- a/decidim-core/spec/lib/organization_settings_spec.rb
+++ b/decidim-core/spec/lib/organization_settings_spec.rb
@@ -145,6 +145,21 @@ module Decidim
         expect(subject).to be_a(described_class)
         expect(struct_to_hash(subject)).to eq("upload" => default_settings)
       end
+
+      context "when the configuration from the secret has changed" do
+        let(:maximum_attachment_size) { 20 }
+
+        before do
+          allow(Rails.application.secrets.decidim).to receive(:[]).and_call_original
+          allow(Rails.application.secrets.decidim).to receive(:[]).with(:maximum_attachment_size).and_return(maximum_attachment_size)
+          # defaults method is memoized, we need to reset it to make sure it uses the stubbed values
+          described_class.instance_variable_set(:@defaults, nil)
+        end
+
+        it "returns a new instance using the values from the secrets" do
+          expect(subject.upload_maximum_file_size).to eq(maximum_attachment_size.megabytes.to_f)
+        end
+      end
     end
 
     describe "#wrap_upload_maximum_file_size" do


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12884 to v0.27

:hearts: Thank you!