### PR TITLE
Fix flaky specs with last job matcher with concurreny

### DIFF
--- a/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
@@ -192,7 +192,16 @@ shared_examples "assembly admin manage assembly components" do
           click_on "Publish"
         end
 
-        expect(enqueued_jobs.last[:args]).to include("decidim.events.components.component_published")
+        expect(Decidim::EventPublisherJob).to(have_been_enqueued.with(
+                                                "decidim.events.components.component_published", {
+                                                  resource: component,
+                                                  event_class: "Decidim::ComponentPublishedEvent",
+                                                  affected_users: [],
+                                                  followers: [follower],
+                                                  force_send: false,
+                                                  extra: {}
+                                                }
+                                              ))
       end
     end
 

--- a/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
@@ -192,7 +192,16 @@ shared_examples "manage assembly components" do
           click_on "Publish"
         end
 
-        expect(enqueued_jobs.last[:args]).to include("decidim.events.components.component_published")
+        expect(Decidim::EventPublisherJob).to(have_been_enqueued.with(
+                                                "decidim.events.components.component_published", {
+                                                  resource: component,
+                                                  event_class: "Decidim::ComponentPublishedEvent",
+                                                  affected_users: [],
+                                                  followers: [follower],
+                                                  force_send: false,
+                                                  extra: {}
+                                                }
+                                              ))
       end
 
       it_behaves_like "manage component share tokens"

--- a/decidim-conferences/spec/shared/manage_conference_components_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_components_examples.rb
@@ -192,7 +192,16 @@ shared_examples "manage conference components" do
           click_on "Publish"
         end
 
-        expect(enqueued_jobs.last[:args]).to include("decidim.events.components.component_published")
+        expect(Decidim::EventPublisherJob).to(have_been_enqueued.with(
+                                                "decidim.events.components.component_published", {
+                                                  resource: component,
+                                                  event_class: "Decidim::ComponentPublishedEvent",
+                                                  affected_users: [],
+                                                  followers: [follower],
+                                                  force_send: false,
+                                                  extra: {}
+                                                }
+                                              ))
       end
 
       it_behaves_like "manage component share tokens"

--- a/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
@@ -319,7 +319,16 @@ shared_examples "manage process components" do
           click_on "Publish"
         end
 
-        expect(enqueued_jobs.last[:args]).to include("decidim.events.components.component_published")
+        expect(Decidim::EventPublisherJob).to(have_been_enqueued.with(
+                                                "decidim.events.components.component_published", {
+                                                  resource: component,
+                                                  event_class: "Decidim::ComponentPublishedEvent",
+                                                  affected_users: [],
+                                                  followers: [follower],
+                                                  force_send: false,
+                                                  extra: {}
+                                                }
+                                              ))
       end
 
       it_behaves_like "manage component share tokens"


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes a flaky related to concurrency (with parallel specs probably) in the test suite. 

Basically, sometimes in the CI we have an error where it is expecting that the last job is the one for the components published event, but it gets another (for instance, when you upload an image). 

This is because we're manually checking the last job instead of using the rspec matcher for ActiveJob. As far as I could try it out, this matcher is smarter and takes into account this scenario, so it checks against the last set of jobs (instead of only the last job).

~~I found the error in Conferences multiple times, but as far as I could see this could happen in other Spaces, as the matcher was copy pasted.~~ I found it with other spaces (for instance [Assemblies](https://github.com/decidim/decidim/actions/runs/9250981395/job/25445700439))

#### :pushpin: Related Issues

- Related to https://github.com/decidim/decidim/actions/runs/9253010042/job/25451987355?pr=12890 (it will be gone in a couple days/weeks) 

#### Testing

I could not reproduce it locally, so everything should be green in the checks, and we can check out to see if this error happens again in the following days/weeks after merging this. 

### Stacktrace

```diff
Admin manages conference components behaves like manage conference components publish and unpublish a component when the component is unpublished notifies its followers
Failure/Error: expect(enqueued_jobs.last[:args]).to include("decidim.events.components.component_published")

expected [{"_aj_globalid" => "gid://decidim-test-app/ActiveStorage::Blob/545"}] to include "decidim.events.components.component_published"
Diff:
@@ -1 +1 @@
-["decidim.events.components.component_published"]
+[{"_aj_globalid"=>"gid://decidim-test-app/ActiveStorage::Blob/545"}]

[Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/capybara/failures_r_spec_example_groups_admin_manages_conference_components_behaves_like_manage_conference_components_publish_and_unpublish_a_component_when_the_component_is_unpublished_notifies_its_followers_342.png

[Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/capybara/failures_r_spec_example_groups_admin_manages_conference_components_behaves_like_manage_conference_components_publish_and_unpublish_a_component_when_the_component_is_unpublished_notifies_its_followers_342.html

Shared Example Group: "manage conference components" called from ./spec/system/admin/admin_manages_conference_components_spec.rb:8
# ./spec/shared/manage_conference_components_examples.rb:195:in `block (4 levels) in <top (required)>'

```

:hearts: Thank you!
