### PR TITLE
Fix admin name errors during organization creation

### DIFF
--- a/decidim-system/app/commands/decidim/system/create_organization.rb
+++ b/decidim-system/app/commands/decidim/system/create_organization.rb
@@ -33,8 +33,8 @@ module Decidim
           CreateDefaultContentBlocks.call(@organization)
           invite_form = invite_user_form(@organization)
           invitation_failed = invite_form.invalid?
+          raise ActiveRecord::RecordInvalid if invite_form.invalid?
         end
-        return broadcast(:invalid) if invitation_failed
 
         Decidim::InviteUser.call(invite_form) if @organization && invite_form
 

--- a/decidim-system/app/commands/decidim/system/create_organization.rb
+++ b/decidim-system/app/commands/decidim/system/create_organization.rb
@@ -35,7 +35,6 @@ module Decidim
           CreateDefaultHelpPages.call(@organization)
           CreateDefaultContentBlocks.call(@organization)
           invite_form = invite_user_form(@organization)
-          invite_form.invalid?
           raise InvitationFailedError if invite_form.invalid?
         end
 

--- a/decidim-system/app/commands/decidim/system/create_organization.rb
+++ b/decidim-system/app/commands/decidim/system/create_organization.rb
@@ -35,7 +35,7 @@ module Decidim
           CreateDefaultHelpPages.call(@organization)
           CreateDefaultContentBlocks.call(@organization)
           invite_form = invite_user_form(@organization)
-          invitation_failed = invite_form.invalid?
+          invite_form.invalid?
           raise InvitationFailedError if invite_form.invalid?
         end
 

--- a/decidim-system/app/commands/decidim/system/create_organization.rb
+++ b/decidim-system/app/commands/decidim/system/create_organization.rb
@@ -29,7 +29,6 @@ module Decidim
         @organization = nil
         invite_form = nil
 
-
         transaction do
           @organization = create_organization
           CreateDefaultPages.call(@organization)

--- a/decidim-system/app/commands/decidim/system/create_organization.rb
+++ b/decidim-system/app/commands/decidim/system/create_organization.rb
@@ -2,9 +2,13 @@
 
 module Decidim
   module System
+    class InvitationFailedError < ActiveRecord::RecordInvalid
+    end
+
     # A command with all the business logic when creating a new organization in
     # the system. It creates the organization and invites the admin to the
     # system.
+
     class CreateOrganization < Decidim::Command
       # Public: Initializes the command.
       #
@@ -24,7 +28,7 @@ module Decidim
 
         @organization = nil
         invite_form = nil
-        invitation_failed = false
+
 
         transaction do
           @organization = create_organization
@@ -33,12 +37,14 @@ module Decidim
           CreateDefaultContentBlocks.call(@organization)
           invite_form = invite_user_form(@organization)
           invitation_failed = invite_form.invalid?
-          raise ActiveRecord::RecordInvalid if invite_form.invalid?
+          raise InvitationFailedError if invite_form.invalid?
         end
 
         Decidim::InviteUser.call(invite_form) if @organization && invite_form
 
         broadcast(:ok)
+      rescue InvitationFailedError
+        broadcast(:invalid_invitation)
       rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
         broadcast(:invalid)
       end

--- a/decidim-system/app/controllers/decidim/system/organizations_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/organizations_controller.rb
@@ -22,6 +22,11 @@ module Decidim
             redirect_to organizations_path
           end
 
+          on(:invalid_invitation) do
+            flash.now[:alert] = t("organizations.create.error_invitation", scope: "decidim.system")
+            render :new
+          end
+
           on(:invalid) do
             flash.now[:alert] = t("organizations.create.error", scope: "decidim.system")
             render :new

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -143,6 +143,7 @@ en:
           show: Show advanced settings
         create:
           error: There was a problem creating a new organization.
+          error_invitation: There was a problem creating a new organization. Review your organization admin name.
           success_html: |
             <p>
               Organization successfully created.

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -103,7 +103,9 @@ describe "Organizations" do
         fill_in "Reference prefix", with: "CCORP"
         fill_in "Organization admin name", with: "system@system.com"
 
-        click_on "Create organization & invite admin"
+        expect do
+          click_on "Create organization & invite admin"
+        end.not_to change(Decidim::Organization, :count)
 
         within ".flash__message" do
           expect(page).to have_content("There was a problem creating a new organization. Review your organization admin name.")

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -98,7 +98,7 @@ describe "Organizations" do
         click_on "New"
       end
 
-      it "creates new organization with incorrect organization name" do
+      it "creates new organization with incorrect organization admin name" do
         fill_in "Name", with: "Citizen Corp 2"
         fill_in "Reference prefix", with: "CCORP"
         fill_in "Organization admin name", with: "system@system.com"

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -106,7 +106,7 @@ describe "Organizations" do
         click_on "Create organization & invite admin"
 
         within ".flash__message" do
-          expect(page).to have_content("There was a problem creating a new organization.")
+          expect(page).to have_content("There was a problem creating a new organization. Review your organization admin name.")
         end
       end
     end

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -88,6 +88,29 @@ describe "Organizations" do
       end
     end
 
+    describe "edits organization name" do
+      let!(:organization) do
+        create(:organization, name: { ca: "", en: "Citizen Corp", es: "" }, default_locale: :en, available_locales: ["en"], description: { en: "large text" })
+      end
+
+      before do
+        click_on "Organizations"
+        click_on "New"
+      end
+
+      it "creates new organization with incorrect organization name" do
+        fill_in "Name", with: "Citizen Corp 2"
+        fill_in "Reference prefix", with: "CCORP"
+        fill_in "Organization admin name", with: "system@system.com"
+
+        click_on "Create organization & invite admin"
+
+        within ".flash__message" do
+          expect(page).to have_content("There was a problem creating a new organization.")
+        end
+      end
+    end
+
     describe "resending the invitation" do
       let(:organization) { create(:organization) }
 

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -86,29 +86,23 @@ describe "Organizations" do
           expect(page).to have_content("You need to define the SECRET_KEY_BASE environment variable to be able to save this field")
         end
       end
-    end
 
-    describe "edits organization name" do
-      let!(:organization) do
-        create(:organization, name: { ca: "", en: "Citizen Corp", es: "" }, default_locale: :en, available_locales: ["en"], description: { en: "large text" })
-      end
+      context "with an invalid organization admin name" do
+        before do
+          click_on "Organizations"
+          click_on "New"
+        end
 
-      before do
-        click_on "Organizations"
-        click_on "New"
-      end
+        it "does not create an organization" do
+          fill_in "Name", with: "Citizen Corp 2"
+          fill_in "Reference prefix", with: "CCORP"
+          fill_in "Organization admin name", with: "system@system.com"
 
-      it "creates new organization with incorrect organization admin name" do
-        fill_in "Name", with: "Citizen Corp 2"
-        fill_in "Reference prefix", with: "CCORP"
-        fill_in "Organization admin name", with: "system@system.com"
-
-        expect do
           click_on "Create organization & invite admin"
-        end.not_to change(Decidim::Organization, :count)
 
-        within ".flash__message" do
-          expect(page).to have_content("There was a problem creating a new organization. Review your organization admin name.")
+          within ".flash__message", match: :first do
+            expect(page).to have_content("There was a problem creating a new organization. Review your organization admin name.")
+          end
         end
       end
     end

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -96,7 +96,7 @@ describe "Organizations" do
         it "does not create an organization" do
           fill_in "Name", with: "Citizen Corp 2"
           fill_in "Reference prefix", with: "CCORP"
-          fill_in "Organization admin name", with: "system@system.com"
+          fill_in "Organization admin name", with: "system@example.org"
 
           click_on "Create organization & invite admin"
 


### PR DESCRIPTION
#### :tophat: What? Why?
Newly created Organisation admins within system could have email address as name saved and created but still generate an error. This PR addresses a fix to this issue thanks to a solution provided by @alecslupu.

#### :pushpin: Related Issues
- Fixes #12848

#### Testing
1. Login as a system admin and click 'New Organization'.
2. Fill out the fields including putting a real email address in the 'Organization admin email' field. 
3. In the Name field add **'example@example.com'**.
4. Click create organization & invite admin.
5. See the field error.

### :camera: Screenshots

:hearts: Thank you!
