### PR TITLE
Standardise `current_user` call within Commands tasks (Forms)

### DIFF
--- a/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
+++ b/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
@@ -5,14 +5,14 @@ module Decidim
     # This command is executed when the user answers a Questionnaire.
     class AnswerQuestionnaire < Decidim::Command
       include ::Decidim::MultipleAttachmentsMethods
+      delegate :current_user, to: :form
 
       # Initializes a AnswerQuestionnaire Command.
       #
       # form - The form from which to get the data.
       # questionnaire - The current instance of the questionnaire to be answered.
-      def initialize(form, current_user, questionnaire)
+      def initialize(form, questionnaire)
         @form = form
-        @current_user = current_user
         @questionnaire = questionnaire
       end
 
@@ -34,7 +34,7 @@ module Decidim
         end
       end
 
-      attr_reader :form, :questionnaire, :current_user
+      attr_reader :form, :questionnaire
 
       private
 

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -30,7 +30,7 @@ module Decidim
 
             @form = form(Decidim::Forms::QuestionnaireForm).from_params(params, session_token:, ip_hash:)
 
-            Decidim::Forms::AnswerQuestionnaire.call(@form, current_user, questionnaire) do
+            Decidim::Forms::AnswerQuestionnaire.call(@form, questionnaire) do
               on(:ok) do
                 # i18n-tasks-use t("decidim.forms.questionnaires.answer.success")
                 flash[:notice] = I18n.t("answer.success", scope: i18n_flashes_scope)

--- a/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
+++ b/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
@@ -11,6 +11,7 @@ module Decidim
           form_params
         ).with_context(
           current_organization:,
+          current_user:,
           session_token:,
           ip_hash:
         )

--- a/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
+++ b/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 module Decidim
   module Forms
     describe AnswerQuestionnaire do
-      let(:command) { described_class.new(form, current_user, questionnaire) }
+      let(:command) { described_class.new(form, questionnaire) }
       let(:form) do
         QuestionnaireForm.from_params(
           form_params
@@ -228,7 +228,7 @@ module Decidim
               "tos_agreement" => "1"
             }
           end
-          let(:command) { described_class.new(form, current_user, questionnaire_conditioned) }
+          let(:command) { described_class.new(form, questionnaire_conditioned) }
 
           it "broadcasts ok" do
             expect { command.call }.to broadcast(:ok)


### PR DESCRIPTION
#### :tophat: What? Why?
Standardization of ```current_user``` to form within Decidim Forms module. 

#### :pushpin: Related Issues
- Related to #10199 

#### Testing
run ```rspec decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb``` 

### :camera: Screenshots

:hearts: Thank you!
