### PR TITLE
Prevents showing a malformed value in WYSIWYG editor

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -468,6 +468,31 @@ describe "Admin manages organization", type: :system do
           )
         end
       end
+
+      context "when adding malformed content" do
+        let(:organization) { create(:organization, admin_terms_of_use_body: {}) }
+
+        it "does not saves it" do
+          WebMock.stub_request(:get, "http://example.org/x").to_return(status: 404)
+
+          accept_alert do
+            page.execute_script(
+              <<~JS
+                var element = document.querySelector("#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 div[contenteditable='true'].ql-editor");
+                element.innerHTML = "testing <img src='http://example.org/x' onerror=alert(1) >";
+              JS
+            )
+          end
+
+          click_button "Update"
+
+          sleep 1
+
+          expect(find(
+            "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
+          )["innerHTML"]).to eq("<p>testing</p><p><img src=\"http://example.org/x\"></p>")
+        end
+      end
     end
   end
 

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -221,7 +221,7 @@ describe "Admin manages organization", type: :system do
           expect(page).to have_content("Organization updated successfully")
           expect(find(
             "#organization-admin_terms_of_use_body-tabs-admin_terms_of_use_body-panel-0 .editor .ql-editor"
-          )["innerHTML"]).to eq("<p>bar baz</p>")
+          )["innerHTML"]).to eq("<p>bar baz</p><p><br></p>")
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes an issue where a user could save a malformed value in the WYSIWYG editor and this value is shown.

Mind that this value can only be shown in the text editor area, not in the frontend as we're already sanitizing there. That means that the possible attack vector is really limited.  

This only happens in v0.27, so the PR is against that version. 
 
#### Testing

1. Everything should be green
 
:hearts: Thank you!
