### PR TITLE
Fix incomplete regexp in webmock configuration

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
@@ -5,7 +5,7 @@ require "webmock/rspec"
 WebMock.disable_net_connect!(
   allow_localhost: true,
   allow: [
-    %r{https://validator.w3.org/},
+    %r{https://validator\.w3\.org/},
     Decidim::Dev::Test::MapServer.host
   ]
 )


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes a CodeQL arning about not doing a proper escaping in a webmock configuration. This can mean that someone with the URI "https://validatorxw3.org" could pass this regexp.

It's a non-existing risk because the only thing that they could do is surpass the mocks in our test suite, but I fix it so CodeQL does not complain anymore.  

#### Testing

Everything should be green.  

:hearts: Thank you!
