### PR TITLE
Backport 'Fix flaky spec on long registration type titles' to v0.28

### DIFF
--- a/decidim-conferences/spec/commands/join_conference_spec.rb
+++ b/decidim-conferences/spec/commands/join_conference_spec.rb
@@ -52,7 +52,7 @@ module Decidim::Conferences
         email = last_email
 
         expect(email.subject).to include("pending")
-        expect(email.text_part.body.to_s).to include(translated(registration_type.title).first(60))
+        expect(email.text_part.body.to_s.split.join(" ")).to include(translated(registration_type.title))
       end
 
       it "sends a notification to the user with the pending validation" do


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12902 to v0.28

:hearts: Thank you!