### PR TITLE
Remove initializer that updates the proposal status when linked in results

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -90,21 +90,6 @@ module Decidim
         end
       end
 
-      # Subscribes to ActiveSupport::Notifications that may affect a Proposal.
-      initializer "decidim_proposals.subscribe_to_events" do
-        # when a proposal is linked from a result
-        event_name = "decidim.resourceable.included_proposals.created"
-        ActiveSupport::Notifications.subscribe event_name do |_name, _started, _finished, _unique_id, data|
-          payload = data[:this]
-          if payload[:from_type] == Decidim::Accountability::Result.name && payload[:to_type] == Proposal.name
-            proposal = Proposal.find(payload[:to_id])
-
-            proposal.assign_state("accepted")
-            proposal.update(state_published_at: Time.current)
-          end
-        end
-      end
-
       initializer "decidim_proposals.add_cells_view_paths" do
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Proposals::Engine.root}/app/cells")
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Proposals::Engine.root}/app/views") # for proposal partials


### PR DESCRIPTION
#### :tophat: What? Why?
As an admin, when I link proposals to a result, they automatically change to the accepted state. I want to be able to link proposals with results without automatically changing the state of the proposals.

#### :pushpin: Related Issues
Fixes https://github.com/decidim/decidim/issues/12912

#### Testing
Link a proposal in a result and check that it didn't update the proposal's state. 