### PR TITLE
Add image to proposals' seeds

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -76,21 +76,9 @@ module Decidim
       end
 
       def create_proposal!(component:)
-        n = rand(5)
-
-        proposal_state, answer, state_published_at = if n > 3
-                                                       [:accepted, Decidim::Faker::Localized.sentence(word_count: 10), Time.current]
-                                                     elsif n > 2
-                                                       [:rejected, nil, Time.current]
-                                                     elsif n > 1
-                                                       [:evaluating, nil, Time.current]
-                                                     elsif n.positive?
-                                                       [:accepted, Decidim::Faker::Localized.sentence(word_count: 10), nil]
-                                                     else
-                                                       [:not_answered, nil, nil]
-                                                     end
-
+        proposal_state, answer, state_published_at = random_state_answer
         proposal_state = Decidim::Proposals::ProposalState.where(component:, token: proposal_state).first
+
         params = {
           component:,
           category: participatory_space.categories.sample,
@@ -139,6 +127,22 @@ module Decidim
         create_attachment(attached_to: proposal, filename: "city.jpeg") if component.settings.attachments_allowed?
 
         proposal
+      end
+
+      def random_state_answer
+        n = rand(5)
+
+        if n > 3
+          [:accepted, Decidim::Faker::Localized.sentence(word_count: 10), Time.current]
+        elsif n > 2
+          [:rejected, nil, Time.current]
+        elsif n > 1
+          [:evaluating, nil, Time.current]
+        elsif n.positive?
+          [:accepted, Decidim::Faker::Localized.sentence(word_count: 10), nil]
+        else
+          [:not_answered, nil, nil]
+        end
       end
 
       def random_nickname

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -59,6 +59,7 @@ module Decidim
           participatory_space:,
           settings: {
             vote_limit: 0,
+            attachments_allowed: [true, false].sample,
             collaborative_drafts_enabled: true
           },
           step_settings:
@@ -134,6 +135,10 @@ module Decidim
 
           proposal
         end
+
+        create_attachment(attached_to: proposal, filename: "city.jpeg") if component.settings.attachments_allowed?
+
+        proposal
       end
 
       def random_nickname

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -99,18 +99,7 @@ module Decidim
           visibility: "all"
         ) do
           proposal = Decidim::Proposals::Proposal.new(params)
-          meeting_component = participatory_space.components.find_by(manifest_name: "meetings")
-
-          coauthor = case n
-                     when 0
-                       Decidim::User.where(organization:).sample
-                     when 1
-                       Decidim::UserGroup.where(organization:).sample
-                     when 2
-                       Decidim::Meetings::Meeting.where(component: meeting_component).sample
-                     else
-                       organization
-                     end
+          coauthor = random_coauthor
           proposal.add_coauthor(coauthor)
           proposal.save!
 
@@ -142,6 +131,23 @@ module Decidim
           [:accepted, Decidim::Faker::Localized.sentence(word_count: 10), nil]
         else
           [:not_answered, nil, nil]
+        end
+      end
+
+      def random_coauthor
+        n = rand(5)
+
+        case n
+        when 0
+          Decidim::User.where(organization:).sample
+        when 1
+          Decidim::UserGroup.where(organization:).sample
+        when 2
+          meeting_component = participatory_space.components.find_by(manifest_name: "meetings")
+
+          Decidim::Meetings::Meeting.where(component: meeting_component).sample
+        else
+          organization
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

As we have a new view for proposals with images, we may need to debug this locally in an easy way. For that, I've updated the proposals seeds so we randomly have images/grid view mode in this component.

I had to also refactor this method as I had a rubocop offence regarding the complexity. 

#### :pushpin: Related Issues
 
- Related to #12883

#### Testing

1. Run the seeds in a new database
```bash
bin/rails db:drop db:create db:migrate assets:precompile db:seed
``` 
2. Go to different proposals in a participatory space. Notice that there are some that have images and others that do not have images.

### :camera: Screenshots

![View mode with seeded images in proposals](https://github.com/decidim/decidim/assets/717367/ed1cd1ec-9e8b-442a-8040-bb71ddceea46)


:hearts: Thank you!
