### PR TITLE
Standardise `current_user` call within Commands tasks (Meetings part 2)

### DIFF
--- a/decidim-conferences/app/commands/decidim/conferences/join_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/join_conference.rb
@@ -51,7 +51,7 @@ module Decidim
         meetings = Decidim::Meetings::Meeting.where(component: published_meeting_components).where(id: @registration_type.conference_meetings.pluck(:id))
 
         meetings.each do |meeting|
-          Decidim::Meetings::Registration.create!(meeting:, user: current_user)
+          Decidim::Meetings::Registration.create!(meeting:, user:)
         end
       end
 

--- a/decidim-conferences/app/commands/decidim/conferences/join_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/join_conference.rb
@@ -51,7 +51,7 @@ module Decidim
         meetings = Decidim::Meetings::Meeting.where(component: published_meeting_components).where(id: @registration_type.conference_meetings.pluck(:id))
 
         meetings.each do |meeting|
-          Decidim::Meetings::Registration.create!(meeting:, user:)
+          Decidim::Meetings::Registration.create!(meeting:, user: current_user)
         end
       end
 

--- a/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
+++ b/decidim-forms/app/commands/decidim/forms/answer_questionnaire.rb
@@ -4,15 +4,15 @@ module Decidim
   module Forms
     # This command is executed when the user answers a Questionnaire.
     class AnswerQuestionnaire < Decidim::Command
+      delegate :current_user, to: :form
       include ::Decidim::MultipleAttachmentsMethods
 
       # Initializes a AnswerQuestionnaire Command.
       #
       # form - The form from which to get the data.
       # questionnaire - The current instance of the questionnaire to be answered.
-      def initialize(form, current_user, questionnaire)
+      def initialize(form, questionnaire)
         @form = form
-        @current_user = current_user
         @questionnaire = questionnaire
       end
 
@@ -34,7 +34,7 @@ module Decidim
         end
       end
 
-      attr_reader :form, :questionnaire, :current_user
+      attr_reader :form, :questionnaire
 
       private
 
@@ -82,7 +82,7 @@ module Decidim
         Answer.transaction(requires_new: true) do
           form.responses_by_step.flatten.select(&:display_conditions_fulfilled?).each do |form_answer|
             answer = Answer.new(
-              user: @current_user,
+              user: current_user,
               questionnaire: @questionnaire,
               question: form_answer.question,
               body: form_answer.body,

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -30,7 +30,7 @@ module Decidim
 
             @form = form(Decidim::Forms::QuestionnaireForm).from_params(params, session_token:, ip_hash:)
 
-            Decidim::Forms::AnswerQuestionnaire.call(@form, current_user, questionnaire) do
+            Decidim::Forms::AnswerQuestionnaire.call(@form, questionnaire) do
               on(:ok) do
                 # i18n-tasks-use t("decidim.forms.questionnaires.answer.success")
                 flash[:notice] = I18n.t("answer.success", scope: i18n_flashes_scope)

--- a/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
+++ b/decidim-forms/spec/commands/decidim/forms/answer_questionnaire_spec.rb
@@ -5,12 +5,13 @@ require "spec_helper"
 module Decidim
   module Forms
     describe AnswerQuestionnaire do
-      let(:command) { described_class.new(form, current_user, questionnaire) }
+      let(:command) { described_class.new(form, questionnaire) }
       let(:form) do
         QuestionnaireForm.from_params(
           form_params
         ).with_context(
           current_organization:,
+          current_user:,
           session_token:,
           ip_hash:
         )
@@ -228,7 +229,7 @@ module Decidim
               "tos_agreement" => "1"
             }
           end
-          let(:command) { described_class.new(form, current_user, questionnaire_conditioned) }
+          let(:command) { described_class.new(form, questionnaire_conditioned) }
 
           it "broadcasts ok" do
             expect { command.call }.to broadcast(:ok)

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -8,7 +8,6 @@ module Decidim
       # Initializes a JoinMeeting Command.
       #
       # meeting - The current instance of the meeting to be joined.
-      # user - The user joining the meeting.
       # form - A form object with params; can be a questionnaire.
       def initialize(meeting, form)
         @meeting = meeting

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -71,7 +71,7 @@ module Decidim
 
       def can_join_meeting?
         meeting.registrations_enabled? && meeting.has_available_slots? &&
-          !meeting.has_registration_for?(user:)
+          !meeting.has_registration_for?(user: current_user)
       end
 
       def send_email_confirmation

--- a/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/join_meeting.rb
@@ -71,7 +71,7 @@ module Decidim
 
       def can_join_meeting?
         meeting.registrations_enabled? && meeting.has_available_slots? &&
-          !meeting.has_registration_for?(:user)
+          !meeting.has_registration_for?(user:)
       end
 
       def send_email_confirmation

--- a/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
@@ -32,7 +32,7 @@ module Decidim
       def create
         enforce_permission_to(:register, :meeting, meeting:)
 
-        @form = JoinMeetingForm.from_params(params, user: current_user)
+        @form = JoinMeetingForm.from_params(params).with_context(current_user:)
 
         JoinMeeting.call(meeting, @form) do
           on(:ok) do

--- a/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
@@ -32,7 +32,7 @@ module Decidim
       def create
         enforce_permission_to(:register, :meeting, meeting:)
 
-        @form = JoinMeetingForm.from_params(params)
+        @form = JoinMeetingForm.from_params.merge(params)
 
         JoinMeeting.call(meeting, @form) do
           on(:ok) do

--- a/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       def answer
         enforce_permission_to(:join, :meeting, meeting:)
 
-        @form = form(Decidim::Forms::QuestionnaireForm).from_params(params.merge(session_token:))
+        @form = form(Decidim::Forms::QuestionnaireForm).from_params(params, session_token:)
 
         JoinMeeting.call(meeting, @form) do
           on(:ok) do
@@ -32,7 +32,7 @@ module Decidim
       def create
         enforce_permission_to(:register, :meeting, meeting:)
 
-        @form = JoinMeetingForm.from_params(params)
+        @form = JoinMeetingForm.from_params.merge(params)
 
         JoinMeeting.call(meeting, @form) do
           on(:ok) do

--- a/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
@@ -32,7 +32,7 @@ module Decidim
       def create
         enforce_permission_to(:register, :meeting, meeting:)
 
-        @form = JoinMeetingForm.from_params(params)
+        @form = JoinMeetingForm.from_params(params, user: current_user)
 
         JoinMeeting.call(meeting, @form) do
           on(:ok) do

--- a/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       def answer
         enforce_permission_to(:join, :meeting, meeting:)
 
-        @form = form(Decidim::Forms::QuestionnaireForm).from_params(params.merge(session_token:)gi)
+        @form = form(Decidim::Forms::QuestionnaireForm).from_params(params.merge(session_token:))
 
         JoinMeeting.call(meeting, @form) do
           on(:ok) do

--- a/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       def answer
         enforce_permission_to(:join, :meeting, meeting:)
 
-        @form = form(Decidim::Forms::QuestionnaireForm).from_params(params, session_token:)
+        @form = form(Decidim::Forms::QuestionnaireForm).from_params(params.merge(session_token:)gi)
 
         JoinMeeting.call(meeting, @form) do
           on(:ok) do
@@ -32,7 +32,7 @@ module Decidim
       def create
         enforce_permission_to(:register, :meeting, meeting:)
 
-        @form = JoinMeetingForm.from_params.merge(params)
+        @form = JoinMeetingForm.from_params(params)
 
         JoinMeeting.call(meeting, @form) do
           on(:ok) do

--- a/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
@@ -11,7 +11,7 @@ module Decidim
 
         @form = form(Decidim::Forms::QuestionnaireForm).from_params(params, session_token:)
 
-        JoinMeeting.call(meeting, current_user, @form) do
+        JoinMeeting.call(meeting, @form) do
           on(:ok) do
             flash[:notice] = I18n.t("registrations.create.success", scope: "decidim.meetings")
             redirect_to after_answer_path
@@ -34,7 +34,7 @@ module Decidim
 
         @form = JoinMeetingForm.from_params(params)
 
-        JoinMeeting.call(meeting, current_user, @form) do
+        JoinMeeting.call(meeting, @form) do
           on(:ok) do
             flash[:notice] = I18n.t("registrations.create.success", scope: "decidim.meetings")
             redirect_after_path

--- a/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
@@ -32,7 +32,7 @@ module Decidim
       def create
         enforce_permission_to(:register, :meeting, meeting:)
 
-        @form = JoinMeetingForm.from_params.merge(params)
+        @form = JoinMeetingForm.from_params(params)
 
         JoinMeeting.call(meeting, @form) do
           on(:ok) do

--- a/decidim-meetings/spec/commands/join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/join_meeting_spec.rb
@@ -42,8 +42,6 @@ module Decidim::Meetings
       )
     end
 
-    # { Decidim::Meetings::JoinMeetingForm.new }
-
     let(:badge_notification) { hash_including(event: "decidim.events.gamification.badge_earned") }
     let(:user_notification) do
       {
@@ -72,9 +70,6 @@ module Decidim::Meetings
       end
 
       it "creates a registration for the meeting and the user no public participation" do
-        # puts user.id
-        # puts form.current_user.id
-        # byebug
         expect { subject.call }.to change(Registration, :count).by(1)
         last_registration = Registration.last
         expect(last_registration.user).to eq(user)

--- a/decidim-meetings/spec/commands/join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/join_meeting_spec.rb
@@ -37,7 +37,7 @@ module Decidim::Meetings
       Decidim::Meetings::JoinMeetingForm.from_params(
         form_params
       ).with_context(
-        current_user: user
+       current_user: user
       )
     end
 

--- a/decidim-meetings/spec/commands/join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/join_meeting_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 module Decidim::Meetings
   describe JoinMeeting do
-    subject { described_class.new(meeting, user, registration_form) }
+    subject { described_class.new(meeting, form) }
 
     let(:organization) { create(:organization) }
     let(:participatory_process) { create(:participatory_process, organization:) }
@@ -24,7 +24,24 @@ module Decidim::Meetings
 
     let(:user) { create(:user, :confirmed, organization:, notifications_sending_frequency: "none") }
 
-    let(:registration_form) { Decidim::Meetings::JoinMeetingForm.new }
+    let(:command) { described_class.new(form) }
+
+    let(:user_group) { create(:user_group) }
+
+    let(:form_params) do {
+        user_group_id: user_group.id
+      }
+    end
+
+    let(:form) do
+      Decidim::Meetings::JoinMeetingForm.from_params(
+        form_params
+      ).with_context(
+        current_user: user
+      )
+    end
+
+    # { Decidim::Meetings::JoinMeetingForm.new }
 
     let(:badge_notification) { hash_including(event: "decidim.events.gamification.badge_earned") }
     let(:user_notification) do
@@ -54,6 +71,9 @@ module Decidim::Meetings
       end
 
       it "creates a registration for the meeting and the user no public participation" do
+        # puts user.id
+        # puts form.current_user.id
+        # byebug
         expect { subject.call }.to change(Registration, :count).by(1)
         last_registration = Registration.last
         expect(last_registration.user).to eq(user)
@@ -63,7 +83,7 @@ module Decidim::Meetings
 
       context "when the form has public_participation set to true" do
         before do
-          registration_form.public_participation = true
+          form.public_participation = true
         end
 
         it "creates a registration for the meeting and the user with public participation" do
@@ -252,7 +272,7 @@ module Decidim::Meetings
       let!(:questionnaire) { create(:questionnaire) }
       let!(:question) { create(:questionnaire_question, questionnaire:) }
       let(:session_token) { "some-token" }
-      let(:registration_form) { Decidim::Forms::QuestionnaireForm.from_model(questionnaire).with_context(session_token:) }
+      let(:form) { Decidim::Forms::QuestionnaireForm.from_model(questionnaire).with_context(session_token:, current_user: user) }
 
       context "and the registration form is invalid" do
         it "broadcast invalid_form" do
@@ -262,8 +282,8 @@ module Decidim::Meetings
 
       context "and everything is ok" do
         before do
-          registration_form.tos_agreement = true
-          registration_form.responses.first.body = "My answer response"
+          form.tos_agreement = true
+          form.responses.first.body = "My answer response"
         end
 
         it "broadcasts ok" do
@@ -288,9 +308,9 @@ module Decidim::Meetings
 
         context "when the form has public_participation set to true" do
           before do
-            registration_form.tos_agreement = true
-            registration_form.responses.first.body = "My answer response"
-            registration_form.public_participation = true
+            form.tos_agreement = true
+            form.responses.first.body = "My answer response"
+            form.public_participation = true
           end
 
           it "creates a registration for the meeting and the user with public participation" do

--- a/decidim-meetings/spec/commands/join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/join_meeting_spec.rb
@@ -28,7 +28,8 @@ module Decidim::Meetings
 
     let(:user_group) { create(:user_group) }
 
-    let(:form_params) do {
+    let(:form_params) do
+      {
         user_group_id: user_group.id
       }
     end
@@ -37,7 +38,7 @@ module Decidim::Meetings
       Decidim::Meetings::JoinMeetingForm.from_params(
         form_params
       ).with_context(
-       current_user: user
+        current_user: user
       )
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Standardized the ```form``` module but having an negative affect on on ```decidim-meetings/app/commands/decidim/meetings/join_meeting.rb``` command. 

#### :pushpin: Related Issues
- Related to #10199 

#### Testing
run rspec ```decidim-meetings/spec/commands/join_meeting_spec.rb``` 

### :camera: Screenshots

:hearts: Thank you!
