### PR TITLE
Fix flaky spec when pasting a link in the WYSIWYG editor

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -467,7 +467,7 @@ describe "Admin manages organization" do
         let(:parsed_content) do
           cnt = <<~HTML
             <p>testing</p>
-            <p><strong>foo</strong><br><a target="_blank" href="https://www.decidim.org/"><u>link</u></a></p>
+            <p><strong>foo</strong><br><a target="_blank" href="https://www.decidim.org/">link</a></p>
             <p><br></p>
           HTML
 


### PR DESCRIPTION
#### :tophat: What? Why?

While working with the backports, I found a flaky that's applicable to `develop`. Hopefully this fixes it. 

#### :pushpin: Related Issues

- #12938 - as an example of a PR with the error, but there are lots more. Even the `release/0.28-stable` has it, and I can reproduce this in `develop` in localhost

#### Testing

Everything should be green
You can check the flaky before (in develop) and after (in this branch) with

```
for i in $(seq 1 50); do echo $i ; bin/rspec decidim-admin/spec/system/admin_manages_organization_spec.rb:492    || break ; done
```
(I can reproduce the error with less than 5 but just in case let's run it 50 times)

### Stacktrace

```
  Admin manages organization edit when using the rich text editor when pasting content with bold text parses the pasted content correctly with the strong element
     Failure/Error:
       expect(find(
         "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
       )["innerHTML"]).to eq(parsed_content.sub(%r{<p><br></p>$}, ""))

       expected: "<p>testing</p><p><strong>foo</strong><br><a target=\"_blank\" href=\"https://www.decidim.org/\"><u>link</u></a></p>"
            got: "<p>testing</p><p><strong>foo</strong><br><a target=\"_blank\" href=\"https://www.decidim.org/\">link</a></p>"

       (compared using ==)

     [Screenshot Image]: file:///home/apereira/Work/decidim/decidim/spec/decidim_dummy_app/tmp/capybara/failures_r_spec_example_groups_admin_manages_organization_edit_when_using_the_rich_text
_editor_when_pasting_content_with_bold_text_parses_the_pasted_content_correctly_with_the_strong_element_772.png

     [Screenshot HTML]: file:///home/apereira/Work/decidim/decidim/spec/decidim_dummy_app/tmp/capybara/failures_r_spec_example_groups_admin_manages_organization_edit_when_using_the_rich_text_
editor_when_pasting_content_with_bold_text_parses_the_pasted_content_correctly_with_the_strong_element_772.html




     # ./spec/system/admin_manages_organization_spec.rb:492:in `block (5 levels) in <top (required)>'
```

:hearts: Thank you!
