### PR TITLE
Fix flaky spec with multilingual organization name leftover

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -17,7 +17,7 @@ describe "Admin manages organization" do
     it "updates the values from the form" do
       visit decidim_admin.edit_organization_path
 
-      fill_in "Name", with: "My super-uber organization"
+      fill_in_i18n :organization_name, "#organization-name-tabs", en: "My super-uber organization"
 
       %w(X Facebook Instagram YouTube GitHub).each do |network|
         within "#organization_social_handlers" do


### PR DESCRIPTION
#### :tophat: What? Why?

While working with #12953, I found another flaky. It's a leftover from #12286. As that's not in v0.28, I separate these two fixes, as this will not be backported to any release. 

#### :pushpin: Related Issues
 
- Related to #12286 
- Related to #12953 

#### Testing

Everything should be green.

#### Stacktrace

```
Admin manages organization edit updates the values from the form
     Failure/Error: fill_in "Name", with: "My super-uber organization"

     Capybara::ElementNotFound:
       Unable to find field "Name" that is not disabled

     [Screenshot Image]: file:///home/apereira/Work/decidim/decidim/spec/decidim_dummy_app/tmp/capybara/failures_r_spec_example_groups_admin_manages_organization_edit_updates_the_values_from_
the_form_351.png

     [Screenshot HTML]: file:///home/apereira/Work/decidim/decidim/spec/decidim_dummy_app/tmp/capybara/failures_r_spec_example_groups_admin_manages_organization_edit_updates_the_values_from_t
he_form_351.html

     # ./spec/system/admin_manages_organization_spec.rb:20:in `block (3 levels) in <top (required)>'

``` 
:hearts: Thank you!
