### PR TITLE
Add email notifications for evaluators

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,5 @@ tmp
 decidim-packs
 # inner package-lock files inside the packages/ folder
 packages/**/package-lock.json
+
+**/locales/*.yml

--- a/decidim-core/app/presenters/decidim/resource_locator_presenter.rb
+++ b/decidim-core/app/presenters/decidim/resource_locator_presenter.rb
@@ -70,6 +70,16 @@ module Decidim
       admin_route_proxy.send("edit_#{member_route_name}_path", target, options)
     end
 
+    # Generates and admin url only if the manifest has the property :admin_route_name defined
+    # this allows to distinct from resources that can be administrated from those that are not
+    #
+    # options - An optional hash of options to pass to the Rails router
+    #
+    # Returns a String.
+    def admin_url(options = {})
+      admin_member_route("url", options.merge(host: root_resource.organization.host))
+    end
+
     private
 
     def polymorphic?
@@ -160,6 +170,27 @@ module Decidim
 
     def admin_route_proxy
       @admin_route_proxy ||= EngineRouter.admin_proxy(component || target)
+    end
+
+    def admin_member_route(route_type, options)
+      return if manifest_for(target).admin_route_name.blank?
+
+      options.merge!(options_for_polymorphic)
+      admin_route_proxy.send("#{admin_member_route_name}_#{route_type}", target, options)
+    end
+
+    def admin_member_route_name
+      if polymorphic?
+        admin_polymorphic_member_route_name
+      else
+        manifest_for(target).admin_route_name
+      end
+    end
+
+    def admin_polymorphic_member_route_name
+      return unless polymorphic?
+
+      resource.map { |record| manifest_for(record).admin_route_name }.join("_")
     end
   end
 end

--- a/decidim-core/lib/decidim/resource_manifest.rb
+++ b/decidim-core/lib/decidim/resource_manifest.rb
@@ -33,6 +33,11 @@ module Decidim
     # When not explicitly set, it will use the model name.
     attribute :route_name, String
 
+    # The name of the named Rails route to create the url to admin the resource
+    # If it is not defined, the resource will be considered non-administrable
+    # and no link will be generated in some places
+    attribute :admin_route_name, String
+
     # The template to use to render the collection of the resource.
     attribute :template, String
 

--- a/decidim-proposals/app/commands/decidim/proposals/admin/assign_proposals_to_valuator.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/assign_proposals_to_valuator.rb
@@ -24,6 +24,7 @@ module Decidim
 
           assign_proposals
           broadcast(:ok)
+          send_email
         rescue ActiveRecord::RecordInvalid
           broadcast(:invalid)
         end
@@ -31,6 +32,10 @@ module Decidim
         private
 
         attr_reader :form
+
+        def send_email
+          ProposalsValuatorMailer.notify_proposals_valuator(form.valuator_role.user, form.current_user, form.proposals).deliver_later
+        end
 
         def assign_proposals
           transaction do

--- a/decidim-proposals/app/mailers/decidim/proposals/admin/proposals_valuator_mailer.rb
+++ b/decidim-proposals/app/mailers/decidim/proposals/admin/proposals_valuator_mailer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      class ProposalsValuatorMailer < Decidim::ApplicationMailer
+        include Decidim::TranslationsHelper
+        include Decidim::SanitizeHelper
+        include Decidim::ApplicationHelper
+        include Decidim::TranslatableAttributes
+
+        helper Decidim::ResourceHelper
+        helper Decidim::TranslationsHelper
+        helper Decidim::ApplicationHelper
+
+        def notify_proposals_valuator(user, admin, proposals)
+          @valuator_user = user
+          @admin = admin
+          @proposals = proposals
+          @organization = user.organization
+
+          with_user(user) do
+            mail to: "#{user.name} <#{user.email}>",
+                 subject: t(".subject")
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals_valuator_mailer/notify_proposals_valuator.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals_valuator_mailer/notify_proposals_valuator.html.erb
@@ -1,0 +1,17 @@
+<p class="email-greeting"><%= t(".greeting", name: @valuator_user.name) %></p>
+
+<p class="email-instructions"><%= t(".email_body") %></p>
+
+<p class="email-instructions">
+  <ul>
+    <% @proposals.each do |proposal| %>
+      <li class="mb-sm">
+        <span><%= translated_attribute(proposal.title) %></span>:
+        <%= sanitize link_to(t(".public_side"), Decidim::ResourceLocatorPresenter.new(proposal).url), tags: ["a"], attributes: ["href"] %>,
+        <%= sanitize link_to(t(".admin_panel"), Decidim::ResourceLocatorPresenter.new(proposal).admin_url), tags: ["a"], attributes: ["href"] %>
+      </li>
+    <% end %>
+  </ul>
+</p>
+
+<p class="email-closing"><%= t(".gratitude") %></p>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -587,7 +587,7 @@ en:
         proposals_valuator_mailer:
           notify_proposals_valuator:
             admin_panel: admin panel
-            email_body: You've been assigned as a valuator for the proposals listed below. This means you've been trusted to give them feedback and a proper response in the next coming days.
+            email_body: You have been assigned as a valuator for the proposals listed below. This means you have been trusted to give them feedback and a proper response in the next coming days.
             gratitude: Thanks for your help!
             greeting: Hi %{name}
             public_side: public side

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -584,6 +584,14 @@ en:
           create:
             invalid: 'There has been a problem splitting the selected proposals because some of them:'
             success: Successfully splitted the proposals into new ones.
+        proposals_valuator_mailer:
+          notify_proposals_valuator:
+            admin_panel: admin panel
+            email_body: You've been assigned as a valuator for the proposals listed below. This means you've been trusted to give them feedback and a proper response in the next coming days.
+            gratitude: Thanks for your help!
+            greeting: Hi %{name}
+            public_side: public side
+            subject: New proposals assigned to you for evaluation
         valuation_assignments:
           create:
             invalid: There was an error assigning proposals to a valuator.

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -95,6 +95,7 @@ Decidim.register_component(:proposals) do |component|
     resource.reported_content_cell = "decidim/proposals/reported_content"
     resource.actions = %w(endorse vote amend comment vote_comment)
     resource.searchable = true
+    resource.admin_route_name = "proposal"
   end
 
   component.register_resource(:collaborative_draft) do |resource|

--- a/decidim-proposals/spec/mailers/proposals_valuator_mailer_spec.rb
+++ b/decidim-proposals/spec/mailers/proposals_valuator_mailer_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module Decidim::Proposals::Admin
-  describe ProposalsValuatorMailer, type: :mailer do
+  describe ProposalsValuatorMailer do
     include ActionView::Helpers::SanitizeHelper
 
     let(:organization) { create(:organization) }

--- a/decidim-proposals/spec/mailers/proposals_valuator_mailer_spec.rb
+++ b/decidim-proposals/spec/mailers/proposals_valuator_mailer_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Proposals::Admin
+  describe ProposalsValuatorMailer, type: :mailer do
+    include ActionView::Helpers::SanitizeHelper
+
+    let(:organization) { create(:organization) }
+    let(:participatory_process) { create(:participatory_process, organization: organization) }
+    let(:proposals_component) { create(:component, manifest_name: "proposals", participatory_space: participatory_process) }
+    let(:user) { create(:user, organization: organization, name: "Tamilla", email: "valuator@example.org") }
+    let(:admin) { create(:user, :admin, organization: organization, name: "Mark") }
+    let(:proposals) { create_list(:proposal, 3, component: proposals_component) }
+
+    def proposal_url(proposal)
+      Decidim::ResourceLocatorPresenter.new(proposal).url
+    end
+
+    context "when valuator assigned" do
+      let(:mail) { described_class.notify_proposals_valuator(user, admin, proposals) }
+
+      it "set subject email" do
+        expect(mail.subject).to eq("New proposals assigned to you for evaluation")
+      end
+
+      it "set email from" do
+        expect(mail.from).to eq([Decidim::Organization.first.smtp_settings["from"]])
+      end
+
+      it "set email to" do
+        expect(mail.to).to eq(["valuator@example.org"])
+      end
+
+      it "body email has valuator name" do
+        expect(email_body(mail)).to include("Tamilla")
+      end
+
+      it "body email has proposal links" do
+        body = email_body(mail)
+        expect(body).to have_link(href: proposal_url(proposals.first))
+        expect(body).to have_link(href: proposal_url(proposals.second))
+        expect(body).to have_link(href: proposal_url(proposals.third))
+        expect(body).to have_link(href: Decidim::ResourceLocatorPresenter.new(proposals.first).admin_url)
+        expect(body).to have_link(href: Decidim::ResourceLocatorPresenter.new(proposals.second).admin_url)
+        expect(body).to have_link(href: Decidim::ResourceLocatorPresenter.new(proposals.third).admin_url)
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/mailers/proposals_valuator_mailer_spec.rb
+++ b/decidim-proposals/spec/mailers/proposals_valuator_mailer_spec.rb
@@ -7,10 +7,10 @@ module Decidim::Proposals::Admin
     include ActionView::Helpers::SanitizeHelper
 
     let(:organization) { create(:organization) }
-    let(:participatory_process) { create(:participatory_process, organization: organization) }
+    let(:participatory_process) { create(:participatory_process, organization:) }
     let(:proposals_component) { create(:component, manifest_name: "proposals", participatory_space: participatory_process) }
-    let(:user) { create(:user, organization: organization, name: "Tamilla", email: "valuator@example.org") }
-    let(:admin) { create(:user, :admin, organization: organization, name: "Mark") }
+    let(:user) { create(:user, organization:, name: "Ada", email: "valuator@example.org") }
+    let(:admin) { create(:user, :admin, organization:, name: "Mark") }
     let(:proposals) { create_list(:proposal, 3, component: proposals_component) }
 
     def proposal_url(proposal)
@@ -33,7 +33,7 @@ module Decidim::Proposals::Admin
       end
 
       it "body email has valuator name" do
-        expect(email_body(mail)).to include("Tamilla")
+        expect(email_body(mail)).to include("Ada")
       end
 
       it "body email has proposal links" do

--- a/decidim-proposals/spec/system/admin/admin_manages_proposal_valuators_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_manages_proposal_valuators_spec.rb
@@ -12,7 +12,7 @@ describe "Admin manages proposals valuators" do
   end
   let!(:valuator) { create(:user, organization:) }
   let!(:valuator_role) { create(:participatory_process_user_role, role: :valuator, user: valuator, participatory_process:) }
-  let!(:admin) { create(:user, :admin, organization: organization) }
+  let!(:admin) { create(:user, :admin, organization:) }
 
   include Decidim::ComponentPathHelper
 
@@ -60,7 +60,7 @@ describe "Admin manages proposals valuators" do
         expect(last_email.subject).to include("New proposals assigned to you for evaluation")
         expect(last_email.from).to eq([Decidim::Organization.first.smtp_settings["from"]])
         expect(last_email.to).to eq([valuator.email])
-        expect(last_email.body.encoded).to include("You've been assigned as a valuator")
+        expect(last_email.body.encoded).to include("You have been assigned as a valuator")
         expect(last_email.body.encoded).to include(Decidim::ResourceLocatorPresenter.new(proposal).admin_url)
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Right now if an admin assigns you a proposal to evaluate, you didn’t receive any notification, so it’s difficult to be up to date of your evaluation tasks. As an evaluator, I want to receive a notification when a proposal is assigned to me, a private note is added or someone tag me in a private note.

Cherry picked code from https://github.com/openpoke/decidim/pull/23, I'm opening a draft to discuss some of the decisions.

#### :pushpin: Related Issues
Closes https://github.com/decidim/decidim/issues/12909

#### Testing

- [ ] Given that I’m an evaluator
When an administrator assigns me to a proposal
then I receive a notification saying “You have been assigned to evaluate the proposal %{ProposalName}[link to admin]”
- [ ] Given that I’m an evaluator
When an administrator assigns me to different proposals at the same time
Then I receive a notification saying “You have been assigned to evaluate this proposals: %{ProposalName}[link to admin]”
- [ ] Given that I’m an evaluator
When another evaluator adds a private note to a proposal I have assigned
Then I receive a notification saying “The evaluator %{name} has add a private note the {%ProposalName}[link to admin]”

### :camera: Screenshots

<img width="603" alt="Screenshot 2024-06-05 at 14 41 07" src="https://github.com/decidim/decidim/assets/935744/c286eb6a-05f7-47af-abc9-67e1f04eedff">

<img width="598" alt="Screenshot 2024-06-05 at 15 23 27" src="https://github.com/decidim/decidim/assets/935744/e25ae396-262c-476d-bc66-3cf962bea812">



:hearts: Thank you!
