### PR TITLE
Extend polls feature in meetings

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -701,7 +701,6 @@ linters:
           - is-accordion-submenu
           - is-accordion-submenu-parent
           - is-accordion-submenu-parent[aria-expanded=true]
-          - is-admin
           - is-anchored
           - is-at-bottom
           - is-at-top

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -349,7 +349,7 @@ ignore_unused:
   - layouts.decidim.assemblies.promoted_assembly.take_part
   - versions.dropdown.option_*
   - decidim.meetings.meetings.filters.*
-  - decidim.meetings.polls.questions.index_admin.statuses.*
+  - decidim.meetings.polls.questions.index_admin.statuses.{closed,published,unpublished}
   - decidim.meetings.directory.meetings.index.space_type
   - decidim.authorization_modals.content.*
   - time.buttons.*

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -349,6 +349,7 @@ ignore_unused:
   - layouts.decidim.assemblies.promoted_assembly.take_part
   - versions.dropdown.option_*
   - decidim.meetings.meetings.filters.*
+  - decidim.meetings.polls.questions.index_admin.statuses.*
   - decidim.meetings.directory.meetings.index.space_type
   - decidim.authorization_modals.content.*
   - time.buttons.*

--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -109,5 +109,9 @@ module Decidim
     def text_initials(name)
       name.split(/[\s.]+/).map(&:chr).slice(0, 2).join.upcase
     end
+
+    def add_body_classes(*class_names)
+      content_for :body_class, class_names.map { |class_name| " #{class_name.strip}" }.join
+    end
   end
 end

--- a/decidim-core/app/views/layouts/decidim/_application.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_application.html.erb
@@ -6,7 +6,7 @@
     <%= render partial: "layouts/decidim/head" %>
   </head>
 
-  <body class="text-black text-md form-defaults">
+  <body class="text-black text-md form-defaults<%= yield (:body_class) %>">
     <!--noindex--><!--googleoff: all-->
     <%= link_to t("skip_button", scope: "decidim.accessibility"), "#content", class: "layout-container__skip" %>
     <%= cell("decidim/data_consent", current_organization) %>

--- a/decidim-forms/app/forms/decidim/forms/answer_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/answer_form.rb
@@ -108,9 +108,9 @@ module Decidim
 
       def max_choices
         if matrix?
-          errors.add(:choices, :too_many) if grouped_choices.any? { |choices| choices.count > question.max_choices }
+          errors.add(:choices, :too_many, count: question.max_choices) if grouped_choices.any? { |choices| choices.count > question.max_choices }
         elsif selected_choices.size > question.max_choices
-          errors.add(:choices, :too_many)
+          errors.add(:choices, :too_many, count: question.max_choices)
         end
       end
 

--- a/decidim-forms/config/locales/en.yml
+++ b/decidim-forms/config/locales/en.yml
@@ -22,7 +22,7 @@ en:
               too_long: is too long
             choices:
               missing: are not complete
-              too_many: are too many
+              too_many: You can choose a maximum of %{count}.
         questionnaire:
           request_invalid: There was an error handling the request. Please try again.
   decidim:

--- a/decidim-meetings/app/cells/decidim/meetings/question_responses/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/question_responses/show.erb
@@ -1,7 +1,11 @@
 <% answer_options_with_percentages.each do |(answer_option_body, answer_percentage)| %>
-  <label><%= translated_attribute(answer_option_body) %></label>
   <div class="meeting-polls__answer">
-    <div class="meeting-polls__answer--value"><%= answer_percentage %></div>
-    <div class="meeting-polls__answer--bar"><div style="width: <%= answer_percentage %>"></div></div>
+    <div class="meeting-polls__answer--bar">
+      <div style="width: <%= answer_percentage %>"></div>
+    </div>
+    <div class="meeting-polls__answer--value">
+      <span><%= translated_attribute(answer_option_body) %></span>
+      <span><%= answer_percentage %></span>
+    </div>
   </div>
 <% end %>

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
@@ -45,10 +45,23 @@ module Decidim
 
         def update_questionnaire_questions
           @form.questions.each do |form_question|
-            next unless form_question.editable?
-
-            update_questionnaire_question(form_question)
+            if form_question.editable?
+              update_questionnaire_question(form_question)
+            else
+              update_questionnaire_question_position(form_question)
+            end
           end
+        end
+
+        def update_questionnaire_question_position(form_question)
+          record = @questionnaire.questions.find_by(id: form_question.id)
+          return if record.blank?
+
+          position = form_question.position
+
+          return if position == record.position
+
+          record.update!(position:)
         end
 
         def update_questionnaire_question(form_question)

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
@@ -25,7 +25,7 @@ module Decidim
             Decidim::Meetings::Questionnaire.transaction do
               create_questionnaire_for
               create_questionnaire
-              update_questionnaire_questions if @questionnaire.questions_editable?
+              update_questionnaire_questions
               @questionnaire
             end
           end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
@@ -45,6 +45,8 @@ module Decidim
 
         def update_questionnaire_questions
           @form.questions.each do |form_question|
+            next unless form_question.editable?
+
             update_questionnaire_question(form_question)
           end
         end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_questionnaire.rb
@@ -25,10 +25,7 @@ module Decidim
             Decidim::Meetings::Questionnaire.transaction do
               create_questionnaire_for
               create_questionnaire
-              if @questionnaire.questions_editable?
-                update_questionnaire_questions
-                delete_answers
-              end
+              update_questionnaire_questions if @questionnaire.questions_editable?
               @questionnaire
             end
           end
@@ -85,10 +82,6 @@ module Decidim
           else
             record.save!
           end
-        end
-
-        def delete_answers
-          @questionnaire.answers.destroy_all
         end
       end
     end

--- a/decidim-meetings/app/commands/decidim/meetings/create_answer.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/create_answer.rb
@@ -41,7 +41,7 @@ module Decidim
 
         form.selected_choices.each do |choice|
           answer.choices.build(
-            body: choice.body,
+            body: choice.body || translated_attribute(AnswerOption.find_by(id: choice.answer_option_id)&.body),
             decidim_answer_option_id: choice.answer_option_id
           )
         end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_poll_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_poll_controller.rb
@@ -23,7 +23,15 @@ module Decidim
         def update
           enforce_permission_to(:update, :poll, meeting:, poll:)
 
+          current_questions_forms = form(Admin::QuestionnaireForm).from_model(questionnaire).questions
           @form = form(Admin::QuestionnaireForm).from_params(params)
+          @form.questions = @form.questions.map do |question_form|
+            next question_form if question_form.editable?
+
+            full_form = current_questions_forms.find { |form| form.id.to_s == question_form.id.to_s }
+            full_form.position = question_form.position
+            full_form
+          end
 
           Admin::UpdateQuestionnaire.call(@form, questionnaire) do
             on(:ok) do

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_poll_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_poll_controller.rb
@@ -25,12 +25,16 @@ module Decidim
 
           current_questions_forms = form(Admin::QuestionnaireForm).from_model(questionnaire).questions
           @form = form(Admin::QuestionnaireForm).from_params(params)
+
+          # Although the question values (except the position) will be ignored if they are not editable,
+          # its information is completed so that if any update failure occurs, the form is rendered again
+          # with the full data for the disabled questions.
           @form.questions = @form.questions.map do |question_form|
             next question_form if question_form.editable?
 
-            full_form = current_questions_forms.find { |form| form.id.to_s == question_form.id.to_s }
-            full_form.position = question_form.position
-            full_form
+            full_question_form = current_questions_forms.find { |form| form.id.to_s == question_form.id.to_s }
+            full_question_form.position = question_form.position
+            full_question_form
           end
 
           Admin::UpdateQuestionnaire.call(@form, questionnaire) do

--- a/decidim-meetings/app/controllers/decidim/meetings/polls/answers_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/polls/answers_controller.rb
@@ -9,6 +9,10 @@ module Decidim
 
         helper_method :question
 
+        def index
+          enforce_permission_to(:reply_poll, :meeting, meeting:)
+        end
+
         def create
           enforce_permission_to(:create, :answer, question:)
           @form = form(AnswerForm).from_params(params.merge(question:, current_user:))

--- a/decidim-meetings/app/controllers/decidim/meetings/polls/answers_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/polls/answers_controller.rb
@@ -9,6 +9,10 @@ module Decidim
 
         helper_method :question
 
+        def admin
+          enforce_permission_to(:update, :poll, meeting:)
+        end
+
         def index
           enforce_permission_to(:reply_poll, :meeting, meeting:)
         end

--- a/decidim-meetings/app/forms/decidim/meetings/admin/question_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/question_form.rb
@@ -30,9 +30,7 @@ module Decidim
         end
 
         def editable?
-          return true if id.blank?
-
-          Decidim::Meetings::Question.unpublished.unanswered.exists?(id:)
+          @editable ||= id.blank? || Decidim::Meetings::Question.unpublished.unanswered.exists?(id:)
         end
 
         def number_of_options

--- a/decidim-meetings/app/forms/decidim/meetings/admin/question_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/question_form.rb
@@ -18,10 +18,10 @@ module Decidim
         translatable_attribute :description, String
 
         validates :position, numericality: { greater_than_or_equal_to: 0 }
-        validates :question_type, inclusion: { in: Decidim::Meetings::Question::QUESTION_TYPES }
-        validates :max_choices, numericality: { only_integer: true, greater_than: 1, less_than_or_equal_to: ->(form) { form.number_of_options } }, allow_blank: true
+        validates :question_type, inclusion: { in: Decidim::Meetings::Question::QUESTION_TYPES }, if: :editable?
+        validates :max_choices, numericality: { only_integer: true, greater_than: 1, less_than_or_equal_to: ->(form) { form.number_of_options } }, allow_blank: true, if: :editable?
         validates :body, translatable_presence: true, if: :requires_body?
-        validates :answer_options, presence: true
+        validates :answer_options, presence: true, if: :editable?
 
         def to_param
           return id if id.present?
@@ -42,7 +42,7 @@ module Decidim
         private
 
         def requires_body?
-          !deleted
+          editable? && !deleted
         end
       end
     end

--- a/decidim-meetings/app/forms/decidim/meetings/admin/question_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/question_form.rb
@@ -29,6 +29,12 @@ module Decidim
           "questionnaire-question-id"
         end
 
+        def unanswered?
+          return true if id.blank?
+
+          Decidim::Meetings::Question.unanswered.exists?(id:)
+        end
+
         def number_of_options
           answer_options.size
         end

--- a/decidim-meetings/app/forms/decidim/meetings/admin/question_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/question_form.rb
@@ -29,10 +29,10 @@ module Decidim
           "questionnaire-question-id"
         end
 
-        def unanswered?
+        def editable?
           return true if id.blank?
 
-          Decidim::Meetings::Question.unanswered.exists?(id:)
+          Decidim::Meetings::Question.unpublished.unanswered.exists?(id:)
         end
 
         def number_of_options

--- a/decidim-meetings/app/forms/decidim/meetings/answer_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/answer_form.rb
@@ -24,8 +24,8 @@ module Decidim
         @answer ||= Decidim::Meetings::Answer.find_by(decidim_user_id: current_user.id, decidim_question_id: question_id) if current_user
       end
 
-      def label(idx)
-        base = "#{idx + 1}. #{translated_attribute(question.body)}"
+      def label
+        base = translated_attribute(question.body)
         base += " (#{max_choices_label})" if question.max_choices
         base
       end

--- a/decidim-meetings/app/forms/decidim/meetings/answer_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/answer_form.rb
@@ -43,7 +43,7 @@ module Decidim
       end
 
       def selected_choices
-        choices.select(&:body)
+        choices.select(&:answer_option_id)
       end
 
       private

--- a/decidim-meetings/app/forms/decidim/meetings/answer_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/answer_form.rb
@@ -49,7 +49,7 @@ module Decidim
       private
 
       def max_choices
-        errors.add(:choices, :too_many) if selected_choices.size > question.max_choices
+        errors.add(:choices, :too_many, count: question.max_choices) if selected_choices.size > question.max_choices
       end
 
       def mandatory_label

--- a/decidim-meetings/app/models/decidim/meetings/poll.rb
+++ b/decidim-meetings/app/models/decidim/meetings/poll.rb
@@ -14,6 +14,10 @@ module Decidim
       delegate :organization, to: :meeting
 
       QUESTION_TYPES = %w(single_option multiple_option).freeze
+
+      def has_questions?
+        questionnaire&.questions&.exists?
+      end
     end
   end
 end

--- a/decidim-meetings/app/models/decidim/meetings/poll.rb
+++ b/decidim-meetings/app/models/decidim/meetings/poll.rb
@@ -18,6 +18,10 @@ module Decidim
       def has_questions?
         questionnaire&.questions&.exists?
       end
+
+      def has_open_questions?
+        has_questions? && questionnaire.questions.not_closed.exists?
+      end
     end
   end
 end

--- a/decidim-meetings/app/models/decidim/meetings/question.rb
+++ b/decidim-meetings/app/models/decidim/meetings/question.rb
@@ -28,6 +28,7 @@ module Decidim
       validates :question_type, inclusion: { in: QUESTION_TYPES }
 
       scope :visible, -> { where(status: [:published, :closed]) }
+      scope :unanswered, -> { where.missing(:answers) }
 
       def multiple_choice?
         %w(single_option multiple_option).include?(question_type)

--- a/decidim-meetings/app/models/decidim/meetings/questionnaire.rb
+++ b/decidim-meetings/app/models/decidim/meetings/questionnaire.rb
@@ -14,7 +14,7 @@ module Decidim
       # Public: returns whether the questionnaire questions can be modified or not.
       def questions_editable?
         has_component = questionnaire_for.meeting.respond_to? :component
-        (has_component && !questionnaire_for.meeting.component.published?) || answers.empty?
+        (has_component && !questionnaire_for.meeting.component.published?) || questions.unpublished.unanswered.exists?
       end
 
       def all_questions_unpublished?

--- a/decidim-meetings/app/models/decidim/meetings/questionnaire.rb
+++ b/decidim-meetings/app/models/decidim/meetings/questionnaire.rb
@@ -13,8 +13,7 @@ module Decidim
 
       # Public: returns whether the questionnaire questions can be modified or not.
       def questions_editable?
-        has_component = questionnaire_for.meeting.respond_to? :component
-        (has_component && !questionnaire_for.meeting.component.published?) || questions.unpublished.unanswered.exists?
+        true
       end
 
       def all_questions_unpublished?

--- a/decidim-meetings/app/models/decidim/meetings/questionnaire.rb
+++ b/decidim-meetings/app/models/decidim/meetings/questionnaire.rb
@@ -11,11 +11,6 @@ module Decidim
       has_many :questions, -> { order(:position) }, class_name: "Question", foreign_key: "decidim_questionnaire_id", dependent: :destroy
       has_many :answers, class_name: "Answer", foreign_key: "decidim_questionnaire_id", dependent: :destroy
 
-      # Public: returns whether the questionnaire questions can be modified or not.
-      def questions_editable?
-        true
-      end
-
       def all_questions_unpublished?
         questions.all?(&:unpublished?)
       end

--- a/decidim-meetings/app/packs/entrypoints/decidim_meetings.js
+++ b/decidim-meetings/app/packs/entrypoints/decidim_meetings.js
@@ -1,5 +1,5 @@
 import "src/decidim/meetings/meetings_form"
-import "src/decidim/meetings/meetings_polls"
+// import "src/decidim/meetings/meetings_polls"
 import "src/decidim/forms/forms"
 
 // Images

--- a/decidim-meetings/app/packs/entrypoints/decidim_meetings.js
+++ b/decidim-meetings/app/packs/entrypoints/decidim_meetings.js
@@ -1,5 +1,5 @@
 import "src/decidim/meetings/meetings_form"
-// import "src/decidim/meetings/meetings_polls"
+import "src/decidim/meetings/meetings_polls"
 import "src/decidim/forms/forms"
 
 // Images

--- a/decidim-meetings/app/packs/src/decidim/meetings/meetings_polls.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/meetings_polls.js
@@ -9,6 +9,8 @@ $(() => {
   if ($container.length) {
     const poll = new MeetingsPollComponent($container, $container.data("decidim-meetings-poll"), $counter);
 
+    poll.mountComponent();
+
     $(".meeting-polls__action-list").on("click", (event) => {
       event.preventDefault();
 

--- a/decidim-meetings/app/packs/src/decidim/meetings/meetings_polls.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/meetings_polls.js
@@ -31,6 +31,9 @@ $(() => {
 
   if ($adminContainer.length) {
     const adminPoll = new MeetingsPollComponent($adminContainer, $adminContainer.data("decidim-admin-meetings-poll"));
+
+    adminPoll.mountComponent();
+
     $(".meeting-polls__action-administrate").on("click", (event) => {
       event.preventDefault();
 

--- a/decidim-meetings/app/packs/src/decidim/meetings/poll.component.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/poll.component.js
@@ -201,7 +201,7 @@ export default class PollComponent {
       });
     });
 
-    $.unique($(".js-check-box-collection").parents(".answer")).each((idx, el) => {
+    $.unique($(".js-check-box-collection").parents("[data-max-choices]")).each((idx, el) => {
       const maxChoices = $(el).data("max-choices");
       if (maxChoices) {
         createMaxChoicesAlertComponent({

--- a/decidim-meetings/app/packs/src/decidim/meetings/poll.component.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/poll.component.js
@@ -142,12 +142,12 @@ export default class PollComponent {
       $el.prop(OPEN, true);
     }
 
-    if($el.data("status") === CLOSED && $el.data("status") !== questionStatus ) {
+    if ($el.data("status") === CLOSED && $el.data("status") !== questionStatus) {
       $el.data("status", `${CLOSED}-new`);
       document.getElementById(`closed-announcement-${questionId}`).hidden = false;
     }
 
-    if(answersStatuses) {
+    if (answersStatuses) {
       for (const [key, value] of Object.entries(answersStatuses)) {
         if (key.includes("[choices]")) {
           $el.find(`[name='${key}'][value='${value}']`).prop("checked", true);

--- a/decidim-meetings/app/packs/src/decidim/meetings/poll.component.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/poll.component.js
@@ -27,6 +27,8 @@ export default class PollComponent {
     this.pollingInterval = config.pollingInterval || 5000;
     this.mounted = false;
     this.questions = {};
+    this.questionsStatuses = {};
+    this.answersStatuses = {};
   }
 
   /**
@@ -92,6 +94,11 @@ export default class PollComponent {
     $("[data-question]", $parent).each((_i, el) => {
       const $el = $(el);
       const questionId = $el.data("question");
+      const elForm = $el.find("form");
+
+      if (elForm.length > 0) {
+        this.answersStatuses[questionId] = Object.fromEntries(new FormData(elForm[0]));
+      }
       if ($el[0].open === true) {
         this.questions[questionId] = OPEN;
       } else {
@@ -124,11 +131,27 @@ export default class PollComponent {
     const questionId = $el.data("question");
     // Current question state
     const state = this.questions[questionId];
+    const questionStatus = this.questionsStatuses[questionId];
+    const answersStatuses = this.answersStatuses[questionId];
+
     // New questions have a special class
     if (!state) {
       $el.addClass("is-new");
     } else if (state === OPEN) {
       $el.prop(OPEN, true);
+    }
+
+    if($el.data("status") === CLOSED && $el.data("status") !== questionStatus ) {
+      $el.data("status", `${CLOSED}-new`);
+      document.getElementById(`closed-announcement-${questionId}`).hidden = false;
+    }
+
+    if(answersStatuses) {
+      for (const [key, value] of Object.entries(answersStatuses)) {
+        if (key.includes("[choices]")) {
+          $el.find(`[name='${key}'][value='${value}']`).prop("checked", true);
+        }
+      }
     }
   }
 

--- a/decidim-meetings/app/packs/src/decidim/meetings/poll.component.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/poll.component.js
@@ -96,6 +96,7 @@ export default class PollComponent {
       const questionId = $el.data("question");
       const elForm = $el.find("form");
 
+      this.questionsStatuses[questionId] = $el.data("status");
       if (elForm.length > 0) {
         this.answersStatuses[questionId] = Object.fromEntries(new FormData(elForm[0]));
       }

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -268,7 +268,7 @@
   }
 
   &__admin-action {
-    @apply py-4 grid grid-cols-2 gap-4 border-t border-t-gray [&>*:nth-child(2)]:ml-auto [&>*:nth-child(3)]:col-span-2;
+    @apply py-4 grid grid-cols-2 gap-x-4 gap-y-8 border-t border-t-gray [&>*:nth-child(2)]:ml-auto [&>*:nth-child(3)]:col-span-2;
   }
 
   &__topbar {

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -175,3 +175,84 @@
     }
   }
 }
+
+// layout reset stuff
+.meeting-poll {
+  header,
+  footer {
+    @apply hidden md:block;
+  }
+}
+
+.meeting-polls {
+  counter-reset: question;
+
+  &__question {
+    @apply bg-white space-y-6;
+
+    summary {
+      @apply p-4 cursor-pointer font-normal text-black text-md transition bg-background marker:text-secondary;
+
+      transition: background-color 0.2s ease-in-out;
+
+      &::after {
+        counter-increment: question;
+        content: "#" counter(question);
+      }
+
+      & + * {
+        @apply space-y-6;
+      }
+    }
+
+    &[open] .meeting-polls__answer--bar > * {
+      opacity: 1;
+      transform: translateX(0);
+    }
+
+    &.is-new {
+      animation: animateHighlight 5s ease-in-out forwards;
+    }
+
+    & + & {
+      @apply mt-4;
+    }
+
+    @keyframes animateHighlight {
+      0%,
+      80% {
+        background-color: rgba(var(--warning-rgb), 0.1);
+      }
+    }
+  }
+
+  &__answer {
+    label {
+      @apply block p-4 ring-4 ring-background hover:ring-tertiary rounded hover:cursor-pointer transition;
+    }
+
+    & + & {
+      @apply mt-4;
+    }
+
+    &--value {
+      @apply flex gap-2 justify-between text-gray-2 text-lg;
+
+      > *:last-child {
+        @apply w-1/6 flex-none text-gray text-right;
+      }
+    }
+
+    &--bar {
+      @apply w-full h-2.5 overflow-hidden rounded bg-background;
+
+      > * {
+        @apply bg-primary h-full opacity-0;
+      }
+    }
+  }
+
+  &__admin-action {
+    @apply py-4 grid grid-cols-2 gap-4 border-t border-t-gray [&>*:nth-child(2)]:ml-auto [&>*:nth-child(3)]:col-span-2;
+  }
+}

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -177,14 +177,21 @@
 }
 
 // layout reset stuff
-.meeting-poll {
+.meeting-poll__layout {
   header,
+  main h1,
   footer {
     @apply hidden md:block;
+  }
+
+  .layout-1col {
+    padding: 0;
   }
 }
 
 .meeting-polls {
+  @apply m-0 md:mt-10 md:mb-24;
+
   counter-reset: question;
 
   &__question {
@@ -201,13 +208,17 @@
       }
 
       & + * {
-        @apply space-y-6;
+        @apply pr-4 pl-[calc(1rem+14px)] md:p-0 space-y-6;
       }
     }
 
     &[open] .meeting-polls__answer--bar > * {
       opacity: 1;
       transform: translateX(0);
+    }
+
+    &[open] summary {
+      @apply bg-secondary md:bg-background marker:text-white md:marker:text-secondary text-white md:text-black;
     }
 
     &.is-new {
@@ -231,6 +242,7 @@
       @apply block p-4 ring-4 ring-background hover:ring-tertiary rounded hover:cursor-pointer transition;
     }
 
+    label + label,
     & + & {
       @apply mt-4;
     }
@@ -254,5 +266,13 @@
 
   &__admin-action {
     @apply py-4 grid grid-cols-2 gap-4 border-t border-t-gray [&>*:nth-child(2)]:ml-auto [&>*:nth-child(3)]:col-span-2;
+  }
+
+  &__topbar {
+    @apply my-4 md:my-0 px-4 md:px-0 py-2 md:py-10 flex justify-between gap-4 bg-background md:bg-transparent;
+
+    &.is-admin {
+      @apply mt-0 bg-tertiary md:bg-transparent text-black;
+    }
   }
 }

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -195,26 +195,25 @@
   counter-reset: question;
 
   &__question {
-    @apply bg-white space-y-6;
+    @apply bg-white;
 
     summary {
-      @apply p-4 cursor-pointer font-normal text-black text-md transition bg-background marker:text-secondary;
+      @apply p-4 font-normal text-black text-md transition bg-background cursor-pointer marker:text-secondary;
 
       transition: background-color 0.2s ease-in-out;
 
-      &::after {
+      & > span:first-child::after {
         counter-increment: question;
         content: "#" counter(question);
       }
 
-      & + * {
-        @apply pr-4 pl-[calc(1rem+14px)] md:p-0 space-y-6;
+      & > span:last-child:not(:only-child) {
+        @apply text-sm font-semibold float-right;
       }
-    }
 
-    &[open] .meeting-polls__answer--bar > * {
-      opacity: 1;
-      transform: translateX(0);
+      & + * {
+        @apply mt-4 mb-8 md:mb-16 pr-4 pl-[calc(1rem+14px)] md:px-0 space-y-6;
+      }
     }
 
     &[open] summary {
@@ -239,7 +238,11 @@
 
   &__answer {
     label {
-      @apply block p-4 ring-4 ring-background hover:ring-tertiary rounded hover:cursor-pointer transition;
+      @apply block p-4 ring-4 ring-background rounded transition;
+
+      &:not(:has([disabled])) {
+        @apply hover:ring-tertiary hover:cursor-pointer;
+      }
     }
 
     label + label,
@@ -259,7 +262,7 @@
       @apply w-full h-2.5 overflow-hidden rounded bg-background;
 
       > * {
-        @apply bg-primary h-full opacity-0;
+        @apply bg-success h-full rounded;
       }
     }
   }

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_live_event.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_live_event.scss
@@ -18,7 +18,7 @@
   &__aside {
     @apply flex-none bg-background-2;
 
-    counter-reset: question;
+    // counter-reset: question;
 
     &.is-open {
       @apply w-1/5 [&+div]:w-4/5;
@@ -34,95 +34,95 @@
     }
   }
 
-  &__question {
-    @apply bg-white;
+  // &__question {
+  //   @apply bg-white;
 
-    summary {
-      @apply p-4 cursor-pointer font-bold text-secondary text-md transition border-b border-b-background hover:bg-background;
+  //   summary {
+  //     @apply p-4 cursor-pointer font-bold text-secondary text-md transition border-b border-b-background hover:bg-background;
 
-      transition: background-color 0.2s ease-in-out;
+  //     transition: background-color 0.2s ease-in-out;
 
-      &::after {
-        counter-increment: question;
-        content: "#" counter(question);
-      }
+  //     &::after {
+  //       counter-increment: question;
+  //       content: "#" counter(question);
+  //     }
 
-      & ~ * {
-        @apply p-4;
+  //     & ~ * {
+  //       @apply p-4;
 
-        // dynamic content
-        > :first-child {
-          @apply font-bold;
-        }
+  //       // dynamic content
+  //       > :first-child {
+  //         @apply font-bold;
+  //       }
 
-        label {
-          @apply flex items-baseline cursor-pointer;
-        }
+  //       label {
+  //         @apply flex items-baseline cursor-pointer;
+  //       }
 
-        label + label {
-          @apply mt-4;
-        }
-        // end dynamic content
-      }
-    }
+  //       label + label {
+  //         @apply mt-4;
+  //       }
+  //       // end dynamic content
+  //     }
+  //   }
 
-    &[open] .meeting-polls__answer--bar > * {
-      opacity: 1;
-      transform: translateX(0);
-    }
+  //   &[open] .meeting-polls__answer--bar > * {
+  //     opacity: 1;
+  //     transform: translateX(0);
+  //   }
 
-    &.is-new {
-      animation: animateHighlight 5s ease-in-out forwards;
-    }
+  //   &.is-new {
+  //     animation: animateHighlight 5s ease-in-out forwards;
+  //   }
 
-    @keyframes animateHighlight {
-      0%,
-      80% {
-        background-color: rgba(var(--warning-rgb), 0.1);
-      }
-    }
-  }
+  //   @keyframes animateHighlight {
+  //     0%,
+  //     80% {
+  //       background-color: rgba(var(--warning-rgb), 0.1);
+  //     }
+  //   }
+  // }
 
-  &__question--admin {
-    summary ~ * {
-      @apply border-t border-t-background p-4 bg-background-2;
+  // &__question--admin {
+  //   summary ~ * {
+  //     @apply border-t border-t-background p-4 bg-background-2;
 
-      a {
-        @apply my-4 block text-sm underline;
-      }
+  //     a {
+  //       @apply my-4 block text-sm underline;
+  //     }
 
-      > :first-child {
-        @apply font-normal;
-      }
-    }
-  }
+  //     > :first-child {
+  //       @apply font-normal;
+  //     }
+  //   }
+  // }
 
-  &__answer {
-    @apply flex items-center gap-2;
+  // &__answer {
+  //   @apply flex items-center gap-2;
 
-    &--value {
-      @apply w-1/5 font-bold;
-    }
+  //   &--value {
+  //     @apply w-1/5 font-bold;
+  //   }
 
-    &--bar {
-      @apply w-4/5 h-2.5 overflow-hidden;
+  //   &--bar {
+  //     @apply w-4/5 h-2.5 overflow-hidden;
 
-      > * {
-        @apply bg-primary h-full opacity-0;
-      }
-    }
-  }
+  //     > * {
+  //       @apply bg-primary h-full opacity-0;
+  //     }
+  //   }
+  // }
 
   // vertical flow
-  label + &__answer + label {
-    @apply mt-6;
-  }
+  // label + &__answer + label {
+  //   @apply mt-6;
+  // }
 
-  &__admin-label {
-    @apply p-4 bg-secondary text-white font-bold text-sm;
-  }
+  // &__admin-label {
+  //   @apply p-4 bg-secondary text-white font-bold text-sm;
+  // }
 
-  &__admin-action {
-    @apply py-2 flex items-center border-t-background [&>*]:flex-none first:[&>*]:w-2/5 last:[&>*]:w-3/5;
-  }
+  // &__admin-action {
+  //   @apply py-2 flex items-center border-t-background [&>*]:flex-none first:[&>*]:w-2/5 last:[&>*]:w-3/5;
+  // }
 }

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_live_event.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_live_event.scss
@@ -18,8 +18,6 @@
   &__aside {
     @apply flex-none bg-background-2;
 
-    // counter-reset: question;
-
     &.is-open {
       @apply w-1/5 [&+div]:w-4/5;
 
@@ -33,96 +31,4 @@
       }
     }
   }
-
-  // &__question {
-  //   @apply bg-white;
-
-  //   summary {
-  //     @apply p-4 cursor-pointer font-bold text-secondary text-md transition border-b border-b-background hover:bg-background;
-
-  //     transition: background-color 0.2s ease-in-out;
-
-  //     &::after {
-  //       counter-increment: question;
-  //       content: "#" counter(question);
-  //     }
-
-  //     & ~ * {
-  //       @apply p-4;
-
-  //       // dynamic content
-  //       > :first-child {
-  //         @apply font-bold;
-  //       }
-
-  //       label {
-  //         @apply flex items-baseline cursor-pointer;
-  //       }
-
-  //       label + label {
-  //         @apply mt-4;
-  //       }
-  //       // end dynamic content
-  //     }
-  //   }
-
-  //   &[open] .meeting-polls__answer--bar > * {
-  //     opacity: 1;
-  //     transform: translateX(0);
-  //   }
-
-  //   &.is-new {
-  //     animation: animateHighlight 5s ease-in-out forwards;
-  //   }
-
-  //   @keyframes animateHighlight {
-  //     0%,
-  //     80% {
-  //       background-color: rgba(var(--warning-rgb), 0.1);
-  //     }
-  //   }
-  // }
-
-  // &__question--admin {
-  //   summary ~ * {
-  //     @apply border-t border-t-background p-4 bg-background-2;
-
-  //     a {
-  //       @apply my-4 block text-sm underline;
-  //     }
-
-  //     > :first-child {
-  //       @apply font-normal;
-  //     }
-  //   }
-  // }
-
-  // &__answer {
-  //   @apply flex items-center gap-2;
-
-  //   &--value {
-  //     @apply w-1/5 font-bold;
-  //   }
-
-  //   &--bar {
-  //     @apply w-4/5 h-2.5 overflow-hidden;
-
-  //     > * {
-  //       @apply bg-primary h-full opacity-0;
-  //     }
-  //   }
-  // }
-
-  // vertical flow
-  // label + &__answer + label {
-  //   @apply mt-6;
-  // }
-
-  // &__admin-label {
-  //   @apply p-4 bg-secondary text-white font-bold text-sm;
-  // }
-
-  // &__admin-action {
-  //   @apply py-2 flex items-center border-t-background [&>*]:flex-none first:[&>*]:w-2/5 last:[&>*]:w-3/5;
-  // }
 }

--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -39,6 +39,8 @@ module Decidim
             toggle_allow(can_close_meeting?)
           when :register
             toggle_allow(can_register_invitation_meeting?)
+          when :reply_poll
+            toggle_allow(can_reply_poll?)
           end
         else
           return permission_action
@@ -110,6 +112,12 @@ module Decidim
       def can_register_invitation_meeting?
         meeting.can_register_invitation?(user) &&
           authorized?(:register, resource: meeting)
+      end
+
+      def can_reply_poll?
+        meeting.present? &&
+          meeting.poll.present? &&
+          authorized?(:reply_poll, resource: meeting)
       end
 
       def can_answer_question?

--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -42,6 +42,11 @@ module Decidim
           when :reply_poll
             toggle_allow(can_reply_poll?)
           end
+        when :poll
+          case permission_action.action
+          when :update
+            toggle_allow(can_update_poll?)
+          end
         else
           return permission_action
         end
@@ -118,6 +123,13 @@ module Decidim
         meeting.present? &&
           meeting.poll.present? &&
           authorized?(:reply_poll, resource: meeting)
+      end
+
+      def can_update_poll?
+        user.present? &&
+          user.admin? &&
+          meeting.present? &&
+          meeting.poll.present?
       end
 
       def can_answer_question?

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_answer_option_template.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_answer_option_template.html.erb
@@ -2,6 +2,6 @@
 
 <script type="text/template" class="decidim-answer-option-template decidim-template" id="<%= template_id %>">
   <%= fields_for "questionnaire[questions][#{question.to_param}][answer_options][]", blank_answer_option do |answer_option_form| %>
-    <%= render "decidim/meetings/admin/poll/answer_option", form: answer_option_form, question:, editable: %>
+    <%= render "decidim/meetings/admin/poll/answer_option", form: answer_option_form, question:, editable: question.editable? %>
   <% end %>
 </script>

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_form.html.erb
@@ -25,9 +25,9 @@
         <%= render "decidim/meetings/admin/poll/question",
                    form: question_form,
                    id: tabs_id_for_question(question),
-                   editable: questionnaire.questions_editable?,
+                   editable: question.editable?,
                    answer_option_template_selector: "#answer-option-template-#{index}" %>
-        <%= render "decidim/meetings/admin/poll/answer_option_template", form: question_form, editable: questionnaire.questions_editable?, template_id: "answer-option-template-#{index}" %>
+        <%= render "decidim/meetings/admin/poll/answer_option_template", form: question_form, editable: question.editable?, template_id: "answer-option-template-#{index}" %>
       <% end %>
     <% end %>
   </div>

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_form.html.erb
@@ -4,6 +4,7 @@
     <button type="button" class="button button__sm button__secondary expand-all"><%= t("expand", scope: "decidim.forms.admin.questionnaires.form") %></button>
   </div>
 
+  <%= cell("decidim/announcement", t("announcement_html", scope: "decidim.meetings.admin.poll.form"), callout_class: "info" ) %>
   <% if questionnaire.questions_editable? %>
     <%= fields_for "questionnaire[questions][#{blank_question.to_param}]", blank_question do |question_form| %>
       <script type="text/template" class="decidim-question-template decidim-template" id="question-template">

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_form.html.erb
@@ -4,11 +4,15 @@
     <button type="button" class="button button__sm button__secondary expand-all"><%= t("expand", scope: "decidim.forms.admin.questionnaires.form") %></button>
   </div>
 
-  <%= cell(
-    "decidim/announcement",
-    t("announcement_html", admin_link: Decidim::EngineRouter.main_proxy(meeting.component).admin_meeting_polls_answers_path(meeting), scope: "decidim.meetings.admin.poll.form"),
-    callout_class: "info"
-  ) %>
+  <% announcement_body = capture do %>
+    <ul>
+      <% t("announcement_html", admin_link: Decidim::EngineRouter.main_proxy(meeting.component).admin_meeting_polls_answers_path(meeting), scope: "decidim.meetings.admin.poll.form").each do |item| %>
+        <li> <%= item %></li>
+      <% end %>
+    </ul>
+  <% end %>
+  <%= cell("decidim/announcement", { body: announcement_body }, callout_class: "info") %>
+
   <% if questionnaire.questions_editable? %>
     <%= fields_for "questionnaire[questions][#{blank_question.to_param}]", blank_question do |question_form| %>
       <script type="text/template" class="decidim-question-template decidim-template" id="question-template">

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_form.html.erb
@@ -4,7 +4,11 @@
     <button type="button" class="button button__sm button__secondary expand-all"><%= t("expand", scope: "decidim.forms.admin.questionnaires.form") %></button>
   </div>
 
-  <%= cell("decidim/announcement", t("announcement_html", scope: "decidim.meetings.admin.poll.form"), callout_class: "info" ) %>
+  <%= cell(
+    "decidim/announcement",
+    t("announcement_html", admin_link: Decidim::EngineRouter.main_proxy(meeting.component).admin_meeting_polls_answers_path(meeting), scope: "decidim.meetings.admin.poll.form"),
+    callout_class: "info"
+  ) %>
   <% if questionnaire.questions_editable? %>
     <%= fields_for "questionnaire[questions][#{blank_question.to_param}]", blank_question do |question_form| %>
       <script type="text/template" class="decidim-question-template decidim-template" id="question-template">

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_form.html.erb
@@ -13,19 +13,15 @@
   <% end %>
   <%= cell("decidim/announcement", { body: announcement_body }, callout_class: "info") %>
 
-  <% if questionnaire.questions_editable? %>
-    <%= fields_for "questionnaire[questions][#{blank_question.to_param}]", blank_question do |question_form| %>
-      <script type="text/template" class="decidim-question-template decidim-template" id="question-template">
-        <%= render "decidim/meetings/admin/poll/question",
-                   form: question_form,
-                   id: tabs_id_for_question(blank_question),
-                   editable: questionnaire.questions_editable?,
-                   answer_option_template_selector: "#answer-option-template-dummy" %>
-      </script>
-      <%= render "decidim/meetings/admin/poll/answer_option_template", form: question_form, editable: questionnaire.questions_editable?, template_id: "answer-option-template-dummy" %>
-    <% end %>
-  <% else %>
-    <%= cell("decidim/announcement", t("already_answered_warning", scope: "decidim.forms.admin.questionnaires.form"), callout_class: "warning" ) %>
+  <%= fields_for "questionnaire[questions][#{blank_question.to_param}]", blank_question do |question_form| %>
+    <script type="text/template" class="decidim-question-template decidim-template" id="question-template">
+      <%= render "decidim/meetings/admin/poll/question",
+                 form: question_form,
+                 id: tabs_id_for_question(blank_question),
+                 editable: true,
+                 answer_option_template_selector: "#answer-option-template-dummy" %>
+    </script>
+    <%= render "decidim/meetings/admin/poll/answer_option_template", form: question_form, editable: true, template_id: "answer-option-template-dummy" %>
   <% end %>
 
   <div class="questionnaire-questions-list flex flex-col py-6 gap-6 last:pb-0">
@@ -41,17 +37,13 @@
     <% end %>
   </div>
 
-  <% if questionnaire.questions_editable? %>
-    <button class="button button__sm button__secondary add-question"><%= t("add_question", scope: "decidim.forms.admin.questionnaires.form") %></button>
-  <% end %>
+  <button class="button button__sm button__secondary add-question"><%= t("add_question", scope: "decidim.forms.admin.questionnaires.form") %></button>
 </div>
 
 <%= append_javascript_pack_tag "decidim_forms_admin" %>
 
-<% if questionnaire.questions_editable? %>
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      window.Decidim.createEditableForm()
-    })
-  </script>
-<% end %>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    window.Decidim.createEditableForm()
+  })
+</script>

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
@@ -68,10 +68,10 @@
       </div>
 
       <% if question.persisted? %>
-        <%= form.hidden_field :id, disabled: !editable %>
+        <%= form.hidden_field :id %>
       <% end %>
 
-      <%= form.hidden_field :position, value: question.position || 0, disabled: !editable %>
+      <%= form.hidden_field :position, value: question.position || 0 %>
       <%= form.hidden_field :deleted, disabled: !editable %>
 
       <div class="questionnaire-question-answer-options<%= question.editable? ? "" : "-disabled" %>" data-template="<%= answer_option_template_selector %>">

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
@@ -72,7 +72,7 @@
       <%= form.hidden_field :position, value: question.position || 0, disabled: !editable %>
       <%= form.hidden_field :deleted, disabled: !editable %>
 
-      <div class="questionnaire-question-answer-options" data-template="<%= answer_option_template_selector %>">
+      <div class="questionnaire-question-answer-options<%= question.editable? ? "" : "-disabled" %>" data-template="<%= answer_option_template_selector %>">
         <div class="questionnaire-question-answer-options-list">
           <% question.answer_options.each do |answer_option| %>
             <%= fields_for "questionnaire[questions][#{question.to_param}][answer_options][]", answer_option do |answer_option_form| %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
@@ -7,6 +7,8 @@
         <span>
           <% if editable %>
             <%== icon("drag-move-2-fill") %>
+          <% else %>
+            <%== icon("lock-line") %>
           <% end %>
           <%= dynamic_title(translated_attribute(question.body), class: "question-title-statement", max_length: 50, omission: "...", placeholder: t("question", scope: "decidim.forms.admin.questionnaires.question")) %>
         </span>

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
@@ -24,17 +24,17 @@
             </span>
           </button>
 
+          <button class="button button__sm button__transparent-secondary small alert move-up-question button--title">
+            <%= icon "arrow-up-line" %>
+            <span><%= t("up", scope: "decidim.forms.admin.questionnaires.question") %></span>
+          </button>
+
+          <button class="button button__sm button__transparent-secondary small alert move-down-question button--title">
+            <%= icon "arrow-down-line" %>
+            <span><%= t("down", scope: "decidim.forms.admin.questionnaires.question") %></span>
+          </button>
+
           <% if editable %>
-            <button class="button button__sm button__transparent-secondary small alert move-up-question button--title">
-              <%= icon "arrow-up-line" %>
-              <span><%= t("up", scope: "decidim.forms.admin.questionnaires.question") %></span>
-            </button>
-
-            <button class="button button__sm button__transparent-secondary small alert move-down-question button--title">
-              <%= icon "arrow-down-line" %>
-              <span><%= t("down", scope: "decidim.forms.admin.questionnaires.question") %></span>
-            </button>
-
             <button class="button button__sm button__transparent-secondary small alert remove-question button--title">
               <%= t("remove", scope: "decidim.forms.admin.questionnaires.question") %>
             </button>

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
@@ -89,7 +89,7 @@
         <% end %>
       </div>
 
-      <div class="row column questionnaire-question-max-choices">
+      <div class="row column questionnaire-question-max-choices<%= question.editable? ? "" : "-disabled" %>">
         <%=
           form.select(
             :max_choices,

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
@@ -76,7 +76,7 @@
         <div class="questionnaire-question-answer-options-list">
           <% question.answer_options.each do |answer_option| %>
             <%= fields_for "questionnaire[questions][#{question.to_param}][answer_options][]", answer_option do |answer_option_form| %>
-              <%= render "decidim/meetings/admin/poll/answer_option", form: answer_option_form, question:, editable: %>
+              <%= render "decidim/meetings/admin/poll/answer_option", form: answer_option_form, question:, editable: question.editable? %>
             <% end %>
           <% end %>
         </div>

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/edit.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/edit.html.erb
@@ -17,13 +17,11 @@
     <%= decidim_form_for(@form, url: update_url, method: :put, html: { class: "form-defaults form edit_questionnaire" }) do |form| %>
       <%= render partial: "decidim/meetings/admin/poll/form", object: form %>
 
-      <% if questionnaire.questions_editable? %>
-        <div class="item__edit-sticky">
-          <div class="item__edit-sticky-container">
-            <%= form.submit t("save", scope: "decidim.forms.admin.questionnaires.edit"), class: "button button__sm button__secondary" %>
-          </div>
+      <div class="item__edit-sticky">
+        <div class="item__edit-sticky-container">
+          <%= form.submit t("save", scope: "decidim.forms.admin.questionnaires.edit"), class: "button button__sm button__secondary" %>
         </div>
-      <% end %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/layouts/live_event.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/layouts/live_event.html.erb
@@ -14,18 +14,6 @@
     <%= render partial: "layouts/decidim/timeout_modal" %>
 
     <header class="meeting-polls__header">
-      <% if current_user && poll %>
-        <div class="flex gap-2">
-          <button class="button button__sm button__secondary meeting-polls__action-list">
-            <%= t("questions", scope: "decidim.meetings.layouts.live_event") %> <span id="visible-questions-count">(<%= questionnaire.questions.visible.count %>)</span>
-          </button>
-
-          <% if admin_allowed_to?(:update, :poll, meeting: meeting, poll: poll) %>
-            <button class="button button__sm button__secondary meeting-polls__action-administrate"><%= t("administrate", scope: "decidim.meetings.layouts.live_event") %></button>
-          <% end %>
-        </div>
-      <% end %>
-
       <div>
         <strong class="text-secondary"><%= current_organization_name %></strong> / <strong><%= present(meeting).title(links: true, html_escape: true ) %></strong>
       </div>
@@ -43,8 +31,6 @@
     </header>
 
     <main class="meeting-polls__main">
-      <aside class="meeting-polls__aside" id="meeting-poll-aside" data-decidim-meetings-poll='{"questionsUrl":"<%= meeting_polls_questions_path(meeting) %>"}'></aside>
-      <aside class="meeting-polls__aside" id="admin-meeting-poll-aside" data-decidim-admin-meetings-poll='{"questionsUrl":"<%= meeting_polls_questions_path(meeting, admin: true) %>"}'></aside>
       <%= yield %>
     </main>
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
@@ -3,6 +3,7 @@
     <h1 class="h2 decorator"><%= present(meeting).title(links: true, html_escape: true ) %></h1>
 
     <%= cell "decidim/meetings/dates_and_map", meeting %>
+    <%= render partial: "meeting_poll_actions", locals: { mobile: true } %>
 
     <div class="layout-author">
       <%= cell "decidim/author", author_presenter_for(meeting.normalized_author), from: meeting, context_actions: nil, layout: :compact %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
@@ -4,12 +4,6 @@
 
     <%= cell "decidim/meetings/dates_and_map", meeting %>
 
-    <% if meeting.poll&.has_questions? %>
-      <%= action_authorized_link_to :reply_poll, meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full", data: { "redirect_url" => meeting_polls_answers_path(meeting) }, resource: meeting do %>
-        <span><%= t("reply_poll", scope: "decidim.meetings.meetings.meeting") %></span>
-      <% end %>
-    <% end %>
-
     <div class="layout-author">
       <%= cell "decidim/author", author_presenter_for(meeting.normalized_author), from: meeting, context_actions: nil, layout: :compact %>
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
@@ -4,6 +4,10 @@
 
     <%= cell "decidim/meetings/dates_and_map", meeting %>
 
+    <%= action_authorized_link_to :reply_poll, meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full", data: { "redirect_url" => meeting_polls_answers_path(meeting) }, resource: meeting do %>
+      <span><%= t("reply_poll", scope: "decidim.meetings.meetings.meeting") %></span>
+    <% end %>
+
     <div class="layout-author">
       <%= cell "decidim/author", author_presenter_for(meeting.normalized_author), from: meeting, context_actions: nil, layout: :compact %>
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
@@ -4,8 +4,10 @@
 
     <%= cell "decidim/meetings/dates_and_map", meeting %>
 
-    <%= action_authorized_link_to :reply_poll, meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full", data: { "redirect_url" => meeting_polls_answers_path(meeting) }, resource: meeting do %>
-      <span><%= t("reply_poll", scope: "decidim.meetings.meetings.meeting") %></span>
+    <% if meeting.poll&.has_questions? %>
+      <%= action_authorized_link_to :reply_poll, meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full", data: { "redirect_url" => meeting_polls_answers_path(meeting) }, resource: meeting do %>
+        <span><%= t("reply_poll", scope: "decidim.meetings.meetings.meeting") %></span>
+      <% end %>
     <% end %>
 
     <div class="layout-author">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
@@ -1,17 +1,4 @@
-<% if meeting.poll&.has_questions? %>
-  <section class="layout-aside__section layout-aside__buttons">
-    <%= action_authorized_link_to :reply_poll, meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full", data: { "redirect_url" => meeting_polls_answers_path(meeting) }, resource: meeting do %>
-      <span>
-        <%= meeting.poll.has_open_questions? ? t("reply_poll", scope: "decidim.meetings.meetings.meeting") : t("view_poll", scope: "decidim.meetings.meetings.meeting") %>
-      </span>
-    <% end %>
-    <% if !allowed_to?(:reply_poll, :meeting, meeting:) && allowed_to?(:update, :poll, meeting:) %>
-      <%= link_to admin_meeting_polls_answers_path(meeting), class: "button button__sm button__transparent-secondary w-full" do %>
-        <span><%= t("administrate", scope: "decidim.meetings.polls.answers.index") %></span>
-      <% end %>
-    <% end %>
-  </section>
-<% end %>
+<%= render partial: "meeting_poll_actions" %>
 
 <% if meeting.can_be_joined_by?(current_user) || meeting.on_different_platform? %>
   <section class="layout-aside__section layout-aside__buttons">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
@@ -1,5 +1,10 @@
 <% if meeting.can_be_joined_by?(current_user) || meeting.on_different_platform? %>
   <section class="layout-aside__section layout-aside__buttons">
+    <% if meeting.poll&.has_questions? %>
+      <%= action_authorized_link_to :reply_poll, meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full", data: { "redirect_url" => meeting_polls_answers_path(meeting) }, resource: meeting do %>
+        <span><%= t("reply_poll", scope: "decidim.meetings.meetings.meeting") %></span>
+      <% end %>
+    <% end %>
     <%= cell "decidim/meetings/join_meeting_button", meeting, show_remaining_slots: true %>
   </section>
 <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
@@ -1,7 +1,7 @@
 <% if meeting.poll&.has_questions? %>
   <section class="layout-aside__section layout-aside__buttons">
     <%= action_authorized_link_to :reply_poll, meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full", data: { "redirect_url" => meeting_polls_answers_path(meeting) }, resource: meeting do %>
-      <span><%= t("reply_poll", scope: "decidim.meetings.meetings.meeting") %></span>
+      <span><%= t(meeting.poll.has_open_questions? ? "reply_poll" : "view_poll", scope: "decidim.meetings.meetings.meeting") %></span>
     <% end %>
     <% if !allowed_to?(:reply_poll, :meeting, meeting:) && allowed_to?(:update, :poll, meeting:) %>
       <%= link_to admin_meeting_polls_answers_path(meeting), class: "button button__sm button__transparent-secondary w-full" do %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
@@ -1,7 +1,9 @@
 <% if meeting.poll&.has_questions? %>
   <section class="layout-aside__section layout-aside__buttons">
     <%= action_authorized_link_to :reply_poll, meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full", data: { "redirect_url" => meeting_polls_answers_path(meeting) }, resource: meeting do %>
-      <span><%= t(meeting.poll.has_open_questions? ? "reply_poll" : "view_poll", scope: "decidim.meetings.meetings.meeting") %></span>
+      <span>
+        <%= meeting.poll.has_open_questions? ? t("reply_poll", scope: "decidim.meetings.meetings.meeting") : t("view_poll", scope: "decidim.meetings.meetings.meeting") %>
+      </span>
     <% end %>
     <% if !allowed_to?(:reply_poll, :meeting, meeting:) && allowed_to?(:update, :poll, meeting:) %>
       <%= link_to admin_meeting_polls_answers_path(meeting), class: "button button__sm button__transparent-secondary w-full" do %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
@@ -3,6 +3,11 @@
     <%= action_authorized_link_to :reply_poll, meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full", data: { "redirect_url" => meeting_polls_answers_path(meeting) }, resource: meeting do %>
       <span><%= t("reply_poll", scope: "decidim.meetings.meetings.meeting") %></span>
     <% end %>
+    <% if !allowed_to?(:reply_poll, :meeting, meeting:) && allowed_to?(:update, :poll, meeting:) %>
+      <%= link_to admin_meeting_polls_answers_path(meeting), class: "button button__sm button__transparent-secondary w-full" do %>
+        <span><%= t("administrate", scope: "decidim.meetings.polls.answers.index") %></span>
+      <% end %>
+    <% end %>
   </section>
 <% end %>
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
@@ -1,10 +1,13 @@
+<% if meeting.poll&.has_questions? %>
+  <section class="layout-aside__section layout-aside__buttons">
+    <%= action_authorized_link_to :reply_poll, meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full", data: { "redirect_url" => meeting_polls_answers_path(meeting) }, resource: meeting do %>
+      <span><%= t("reply_poll", scope: "decidim.meetings.meetings.meeting") %></span>
+    <% end %>
+  </section>
+<% end %>
+
 <% if meeting.can_be_joined_by?(current_user) || meeting.on_different_platform? %>
   <section class="layout-aside__section layout-aside__buttons">
-    <% if meeting.poll&.has_questions? %>
-      <%= action_authorized_link_to :reply_poll, meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full", data: { "redirect_url" => meeting_polls_answers_path(meeting) }, resource: meeting do %>
-        <span><%= t("reply_poll", scope: "decidim.meetings.meetings.meeting") %></span>
-      <% end %>
-    <% end %>
     <%= cell "decidim/meetings/join_meeting_button", meeting, show_remaining_slots: true %>
   </section>
 <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_poll_actions.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_poll_actions.html.erb
@@ -1,0 +1,15 @@
+<% extra_classes = local_assigns.fetch(:mobile, false) ? " block md:hidden" : " hidden md:block" %>
+<% if meeting.poll&.has_questions? %>
+  <section class="layout-aside__section layout-aside__buttons<%= extra_classes %>">
+    <%= action_authorized_link_to :reply_poll, meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full", data: { "redirect_url" => meeting_polls_answers_path(meeting) }, resource: meeting do %>
+      <span>
+        <%= meeting.poll.has_open_questions? ? t("reply_poll", scope: "decidim.meetings.meetings.meeting") : t("view_poll", scope: "decidim.meetings.meetings.meeting") %>
+      </span>
+    <% end %>
+    <% if !allowed_to?(:reply_poll, :meeting, meeting:) && allowed_to?(:update, :poll, meeting:) %>
+      <%= link_to admin_meeting_polls_answers_path(meeting), class: "button button__sm button__transparent-secondary w-full" do %>
+        <span><%= t("administrate", scope: "decidim.meetings.polls.answers.index") %></span>
+      <% end %>
+    <% end %>
+  </section>
+<% end %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/_multiple_option.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/_multiple_option.html.erb
@@ -2,8 +2,8 @@
   <% question.answer_options.each_with_index do |answer_option, idx| %>
     <% choice = answer.choices.find { |choice| choice.decidim_answer_option_id == answer_option.id } if answer %>
 
-    <%= label_tag "answer[choices][#{idx}][answer_option_id]", nil, class: "js-collection-input" do %>
-      <%= check_box_tag "answer[choices][#{idx}][answer_option_id]",
+    <%= label_tag "answer[choices][#{answer_option.id}][answer_option_id]", nil, class: "js-collection-input" do %>
+      <%= check_box_tag "answer[choices][#{answer_option.id}][answer_option_id]",
                         answer_option.id,
                         choice.present?, disabled: %>
 

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/_multiple_option.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/_multiple_option.html.erb
@@ -2,14 +2,12 @@
   <% question.answer_options.each_with_index do |answer_option, idx| %>
     <% choice = answer.choices.find { |choice| choice.decidim_answer_option_id == answer_option.id } if answer %>
 
-    <%= label_tag "answer[choices][#{idx}][body]", nil, class: "js-collection-input" do %>
-      <%= check_box_tag "answer[choices][#{idx}][body]",
-                        translated_attribute(answer_option.body),
+    <%= label_tag "answer[choices][#{idx}][answer_option_id]", nil, class: "js-collection-input" do %>
+      <%= check_box_tag "answer[choices][#{idx}][answer_option_id]",
+                        answer_option.id,
                         choice.present?, disabled: %>
 
       <%= translated_attribute(answer_option.body) %>
-
-      <%= hidden_field_tag "answer[choices][#{idx}][answer_option_id]", answer_option.id, disabled: %>
     <% end %>
   <% end %>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/_multiple_option.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/_multiple_option.html.erb
@@ -2,7 +2,7 @@
   <% question.answer_options.each_with_index do |answer_option, idx| %>
     <% choice = answer.choices.find { |choice| choice.decidim_answer_option_id == answer_option.id } if answer %>
 
-    <%= label_tag(class: "js-collection-input") do %>
+    <%= label_tag "answer[choices][#{idx}][body]", nil, class: "js-collection-input" do %>
       <%= check_box_tag "answer[choices][#{idx}][body]",
                         translated_attribute(answer_option.body),
                         choice.present?, disabled: %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/_multiple_option.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/_multiple_option.html.erb
@@ -2,16 +2,14 @@
   <% question.answer_options.each_with_index do |answer_option, idx| %>
     <% choice = answer.choices.find { |choice| choice.decidim_answer_option_id == answer_option.id } if answer %>
 
-    <div class="js-collection-input">
-      <%= label_tag do %>
-        <%= check_box_tag "answer[choices][#{idx}][body]",
-                          translated_attribute(answer_option.body),
-                          choice.present?, disabled: %>
+    <%= label_tag(class: "js-collection-input") do %>
+      <%= check_box_tag "answer[choices][#{idx}][body]",
+                        translated_attribute(answer_option.body),
+                        choice.present?, disabled: %>
 
-        <%= translated_attribute(answer_option.body) %>
+      <%= translated_attribute(answer_option.body) %>
 
-        <%= hidden_field_tag "answer[choices][#{idx}][answer_option_id]", answer_option.id, disabled: %>
-      <% end %>
-    </div>
+      <%= hidden_field_tag "answer[choices][#{idx}][answer_option_id]", answer_option.id, disabled: %>
+    <% end %>
   <% end %>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/_single_option.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/_single_option.html.erb
@@ -3,17 +3,11 @@
 <% question.answer_options.each_with_index do |answer_option, idx| %>
   <% choice_id = "#{field_id}_choices_#{idx}" %>
 
-  <%= label_tag "#{choice_id}_body" do %>
-    <%= radio_button_tag "answer[choices][#{question.id}][body]",
-                         translated_attribute(answer_option.body),
-                         answer_option.id == choice.try(:decidim_answer_option_id),
-                         id: "#{choice_id}_body", disabled: %>
-
-    <%= translated_attribute(answer_option.body) %>
-
-    <%= hidden_field_tag "answer[choices][#{question.id}][answer_option_id]",
+  <%= label_tag "#{choice_id}_answer_option" do %>
+    <%= radio_button_tag "answer[choices][#{question.id}][answer_option_id]",
                          answer_option.id,
-                         id: "#{choice_id}_answer_option",
-                         disabled: %>
+                         answer_option.id == choice.try(:decidim_answer_option_id),
+                         id: "#{choice_id}_answer_option", disabled: %>
+    <%= translated_attribute(answer_option.body) %>
   <% end %>
 <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/admin.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/admin.html.erb
@@ -1,0 +1,25 @@
+<% add_decidim_meta_tags({
+                           title: present(meeting).title,
+                           description: present(meeting).description,
+                           url: meeting_url(meeting.id)
+                         }) %>
+
+<%= link_to meeting_polls_answers_path(meeting), class: "button button__sm md:button__lg button__text-secondary" do %>
+  <%= icon "arrow-left-line" %>
+  <%= t("back_to_meeting", scope: "decidim.meetings.polls.answers.index_admin") %>
+<% end %>
+
+<%= render layout: "layouts/decidim/shared/layout_center" do %>
+  <div class="text-center py-10">
+    <h1 class="title-decorator inline-block text-left">
+      <%= t("title", scope: "decidim.meetings.polls.answers.index_admin") %>
+    </h1>
+  </div>
+
+  <div class="mb-24" id="admin-meeting-poll" data-decidim-admin-meetings-poll='{"questionsUrl":"<%= meeting_polls_questions_path(meeting, admin: true) %>"}'>
+    <%= render partial: "decidim/meetings/polls/questions/index_admin", locals: { open_question: nil } %>
+  </div>
+<% end %>
+
+<%= append_javascript_pack_tag "decidim_meetings" %>
+<%= append_javascript_pack_tag "decidim_forms" %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/admin.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/admin.html.erb
@@ -4,22 +4,31 @@
                            url: meeting_url(meeting.id)
                          }) %>
 
-<%= link_to meeting_polls_answers_path(meeting), class: "button button__sm md:button__lg button__text-secondary" do %>
-  <%= icon "arrow-left-line" %>
-  <%= t("back_to_meeting", scope: "decidim.meetings.polls.answers.index_admin") %>
-<% end %>
+<%= append_javascript_pack_tag "decidim_meetings" %>
+<%= append_stylesheet_pack_tag "decidim_meetings" %>
+<%= append_javascript_pack_tag "decidim_forms" %>
+
+<% add_body_classes "meeting-poll" %>
 
 <%= render layout: "layouts/decidim/shared/layout_center" do %>
-  <div class="text-center py-10">
+  <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
+    <%= link_to meeting_path(meeting), class: "button button__sm button__text-secondary" do %>
+      <%= icon "arrow-left-line" %>
+      <%= t("back_to_meeting", scope: "decidim.meetings.polls.answers.index_admin") %>
+    <% end %>
+
+    <%= link_to meeting_polls_answers_path(meeting), class: "button button__sm button__secondary" do %>
+      <%= t("view_poll", scope: "decidim.meetings.polls.answers.index_admin") %>
+    <% end %>
+  </div>
+
+  <div class="text-center">
     <h1 class="title-decorator inline-block text-left">
       <%= t("title", scope: "decidim.meetings.polls.answers.index_admin") %>
     </h1>
   </div>
 
-  <div class="mb-24" id="admin-meeting-poll" data-decidim-admin-meetings-poll='{"questionsUrl":"<%= meeting_polls_questions_path(meeting, admin: true) %>"}'>
+  <div class="mt-10 mb-24 meeting-polls" id="admin-meeting-poll" data-decidim-admin-meetings-poll='{"questionsUrl":"<%= meeting_polls_questions_path(meeting, admin: true) %>"}'>
     <%= render partial: "decidim/meetings/polls/questions/index_admin", locals: { open_question: nil } %>
   </div>
 <% end %>
-
-<%= append_javascript_pack_tag "decidim_meetings" %>
-<%= append_javascript_pack_tag "decidim_forms" %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/admin.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/admin.html.erb
@@ -17,7 +17,7 @@
       <%= t("back_to_meeting", scope: "decidim.meetings.polls.answers.index_admin") %>
     <% end %>
 
-    <%= link_to meeting_polls_answers_path(meeting), class: "button button__sm button__secondary" do %>
+    <%= action_authorized_link_to :reply_poll, meeting_polls_answers_path(meeting), class: "button button__sm button__secondary", data: { "redirect_url" => meeting_polls_answers_path(meeting) }, resource: meeting do %>
       <%= t("view_poll", scope: "decidim.meetings.polls.answers.index_admin") %>
     <% end %>
   </div>

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/admin.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/admin.html.erb
@@ -8,11 +8,11 @@
 <%= append_stylesheet_pack_tag "decidim_meetings" %>
 <%= append_javascript_pack_tag "decidim_forms" %>
 
-<% add_body_classes "meeting-poll" %>
+<% add_body_classes "meeting-poll__layout" %>
 
 <%= render layout: "layouts/decidim/shared/layout_center" do %>
-  <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
-    <%= link_to meeting_path(meeting), class: "button button__sm button__text-secondary" do %>
+  <div class="meeting-polls__topbar is-admin">
+    <%= link_to meeting_path(meeting), class: "button button__sm button__text md:button__text-secondary" do %>
       <%= icon "arrow-left-line" %>
       <%= t("back_to_meeting", scope: "decidim.meetings.polls.answers.index_admin") %>
     <% end %>
@@ -28,7 +28,7 @@
     </h1>
   </div>
 
-  <div class="mt-10 mb-24 meeting-polls" id="admin-meeting-poll" data-decidim-admin-meetings-poll='{"questionsUrl":"<%= meeting_polls_questions_path(meeting, admin: true) %>"}'>
+  <div class="meeting-polls" id="admin-meeting-poll" data-decidim-admin-meetings-poll='{"questionsUrl":"<%= meeting_polls_questions_path(meeting, admin: true) %>"}'>
     <%= render partial: "decidim/meetings/polls/questions/index_admin", locals: { open_question: nil } %>
   </div>
 <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/index.html.erb
@@ -1,19 +1,24 @@
-<% provide(:title, present(meeting).title) %>
-
 <% add_decidim_meta_tags({
                            title: present(meeting).title,
                            description: present(meeting).description,
                            url: meeting_url(meeting.id)
                          }) %>
+
 <%= link_to meeting_path(meeting), class: "button button__sm md:button__lg button__text-secondary" do %>
   <%= icon "arrow-left-line" %>
   <%= t("meeting", scope: "decidim.meetings.polls.answers.index") %>
 <% end %>
+<% if admin_allowed_to?(:update, :poll, meeting: meeting, poll: poll) %>
+  <%= link_to admin_meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full" do %>
+    <span><%= t("administrate", scope: "decidim.meetings.polls.answers.index") %></span>
+  <% end %>
+<% end %>
+
 <%= render layout: "layouts/decidim/shared/layout_center" do %>
   <div class="text-center py-10">
     <h1 class="title-decorator inline-block text-left">
       <%= present(meeting).title %>
-      <%= t("questions", scope: "decidim.meetings.layouts.live_event") %> <span id="visible-questions-count">(<%= questionnaire.questions.visible.count %>)</span>
+      <%= t("questions", scope: "decidim.meetings.polls.answers.index") %> <span id="visible-questions-count">(<%= questionnaire.questions.visible.count %>)</span>
     </h1>
   </div>
   <div class="mb-24" id="meeting-poll" data-decidim-meetings-poll='{"questionsUrl":"<%= meeting_polls_questions_path(meeting) %>"}'>

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/index.html.erb
@@ -1,0 +1,22 @@
+<% provide(:title, present(meeting).title) %>
+
+<% add_decidim_meta_tags({
+                           title: present(meeting).title,
+                           description: present(meeting).description,
+                           url: meeting_url(meeting.id)
+                         }) %>
+
+<%= render layout: "layouts/decidim/shared/layout_center" do %>
+  <div class="text-center py-10">
+    <h1 class="title-decorator inline-block text-left">
+      <%= present(meeting).title %>
+      <%= t("questions", scope: "decidim.meetings.layouts.live_event") %> <span id="visible-questions-count">(<%= questionnaire.questions.visible.count %>)</span>
+    </h1>
+  </div>
+  <div class="mb-24" id="meeting-poll" data-decidim-meetings-poll='{"questionsUrl":"<%= meeting_polls_questions_path(meeting) %>"}'>
+    <%= render partial: "decidim/meetings/polls/questions/index" %>
+  </div>
+<% end %>
+
+<%= append_javascript_pack_tag "decidim_meetings" %>
+<%= append_javascript_pack_tag "decidim_forms" %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/index.html.erb
@@ -26,8 +26,7 @@
 
   <div class="text-center">
     <h1 class="title-decorator inline-block text-left">
-      <%= present(meeting).title %>
-      <%= t("questions", scope: "decidim.meetings.polls.answers.index") %> <span id="visible-questions-count">(<%= questionnaire.questions.visible.count %>)</span>
+      <%= t("title", scope: "decidim.meetings.polls.answers.index") %>
     </h1>
   </div>
 

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/index.html.erb
@@ -4,27 +4,34 @@
                            url: meeting_url(meeting.id)
                          }) %>
 
-<%= link_to meeting_path(meeting), class: "button button__sm md:button__lg button__text-secondary" do %>
-  <%= icon "arrow-left-line" %>
-  <%= t("meeting", scope: "decidim.meetings.polls.answers.index") %>
-<% end %>
-<% if admin_allowed_to?(:update, :poll, meeting: meeting, poll: poll) %>
-  <%= link_to admin_meeting_polls_answers_path(meeting), class: "button button__xl button__secondary w-full" do %>
-    <span><%= t("administrate", scope: "decidim.meetings.polls.answers.index") %></span>
-  <% end %>
-<% end %>
+<%= append_javascript_pack_tag "decidim_meetings" %>
+<%= append_stylesheet_pack_tag "decidim_meetings" %>
+<%= append_javascript_pack_tag "decidim_forms" %>
+
+<% add_body_classes "meeting-poll" %>
 
 <%= render layout: "layouts/decidim/shared/layout_center" do %>
+  <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
+    <%= link_to meeting_path(meeting), class: "button button__sm button__text-secondary" do %>
+      <%= icon "arrow-left-line" %>
+      <%= t("back_to_meeting", scope: "decidim.meetings.polls.answers.index_admin") %>
+    <% end %>
+
+    <% if admin_allowed_to?(:update, :poll, meeting: meeting, poll: poll) %>
+      <%= link_to admin_meeting_polls_answers_path(meeting), class: "button button__sm button__primary" do %>
+        <%= t("administrate", scope: "decidim.meetings.polls.answers.index") %>
+      <% end %>
+    <% end %>
+  </div>
+
   <div class="text-center py-10">
     <h1 class="title-decorator inline-block text-left">
       <%= present(meeting).title %>
       <%= t("questions", scope: "decidim.meetings.polls.answers.index") %> <span id="visible-questions-count">(<%= questionnaire.questions.visible.count %>)</span>
     </h1>
   </div>
+
   <div class="mb-24" id="meeting-poll" data-decidim-meetings-poll='{"questionsUrl":"<%= meeting_polls_questions_path(meeting) %>"}'>
     <%= render partial: "decidim/meetings/polls/questions/index" %>
   </div>
 <% end %>
-
-<%= append_javascript_pack_tag "decidim_meetings" %>
-<%= append_javascript_pack_tag "decidim_forms" %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/index.html.erb
@@ -5,7 +5,10 @@
                            description: present(meeting).description,
                            url: meeting_url(meeting.id)
                          }) %>
-
+<%= link_to meeting_path(meeting), class: "button button__sm md:button__lg button__text-secondary" do %>
+  <%= icon "arrow-left-line" %>
+  <%= t("meeting", scope: "decidim.meetings.polls.answers.index") %>
+<% end %>
 <%= render layout: "layouts/decidim/shared/layout_center" do %>
   <div class="text-center py-10">
     <h1 class="title-decorator inline-block text-left">

--- a/decidim-meetings/app/views/decidim/meetings/polls/answers/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/answers/index.html.erb
@@ -8,10 +8,10 @@
 <%= append_stylesheet_pack_tag "decidim_meetings" %>
 <%= append_javascript_pack_tag "decidim_forms" %>
 
-<% add_body_classes "meeting-poll" %>
+<% add_body_classes "meeting-poll__layout" %>
 
 <%= render layout: "layouts/decidim/shared/layout_center" do %>
-  <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
+  <div class="meeting-polls__topbar">
     <%= link_to meeting_path(meeting), class: "button button__sm button__text-secondary" do %>
       <%= icon "arrow-left-line" %>
       <%= t("back_to_meeting", scope: "decidim.meetings.polls.answers.index_admin") %>
@@ -24,14 +24,14 @@
     <% end %>
   </div>
 
-  <div class="text-center py-10">
+  <div class="text-center">
     <h1 class="title-decorator inline-block text-left">
       <%= present(meeting).title %>
       <%= t("questions", scope: "decidim.meetings.polls.answers.index") %> <span id="visible-questions-count">(<%= questionnaire.questions.visible.count %>)</span>
     </h1>
   </div>
 
-  <div class="mb-24" id="meeting-poll" data-decidim-meetings-poll='{"questionsUrl":"<%= meeting_polls_questions_path(meeting) %>"}'>
+  <div class="meeting-polls" id="meeting-poll" data-decidim-meetings-poll='{"questionsUrl":"<%= meeting_polls_questions_path(meeting) %>"}'>
     <%= render partial: "decidim/meetings/polls/questions/index" %>
   </div>
 <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_closed_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_closed_question.html.erb
@@ -1,7 +1,7 @@
 <summary><%= t(".question_results") %></summary>
 
 <div>
-  <p><%= translated_attribute(question.body) %></p>
+  <p class="h3"><%= translated_attribute(question.body) %></p>
 
   <%= cell "decidim/meetings/question_responses", question %>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_closed_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_closed_question.html.erb
@@ -1,4 +1,7 @@
-<summary><%= t(".question_results") %></summary>
+<summary>
+  <span><%= t(".question") %></span>
+  <span><%= t(".question_results") %></span>
+</summary>
 
 <div>
   <p class="h3"><%= translated_attribute(question.body) %></p>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_closed_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_closed_question.html.erb
@@ -5,6 +5,9 @@
 
 <div>
   <p class="h3"><%= translated_attribute(question.body) %></p>
+  <span id="<%= "closed-announcement-#{question.id}" %>" hidden>
+    <%= cell "decidim/announcement", t("announcement", scope: "decidim.meetings.polls.questions.closed_question"), callout_class: "warning" %>
+  </span>
 
   <%= cell "decidim/meetings/question_responses", question %>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_index_admin.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_index_admin.html.erb
@@ -2,12 +2,15 @@
   <details class="meeting-polls__question meeting-polls__question--admin open" data-question="<%= question.id %>" <%= "open" if open_question == question.id %>>
     <summary>
       <span><%= t(".question") %></span>
+      <span><%= t(question.status, scope: "decidim.meetings.polls.questions.index_admin.statuses") %></span>
     </summary>
 
     <%= form_tag(meeting_polls_question_path(meeting, question), method: :patch, remote: true) do %>
       <p class="h3"><%= translated_attribute(question.body) %></p>
 
-      <%= link_to t(".edit"), Decidim::EngineRouter.admin_proxy(meeting.component).edit_meeting_poll_path(meeting), class: "button button__xs button__secondary mr-auto mt-2" %>
+      <% if question.unpublished? %>
+        <%= link_to t(".edit"), Decidim::EngineRouter.admin_proxy(meeting.component).edit_meeting_poll_path(meeting), class: "button button__xs button__secondary mr-auto mt-2" %>
+      <% end %>
 
       <div>
         <div class="meeting-polls__admin-action meeting-polls__admin-action-question">

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_index_admin.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_index_admin.html.erb
@@ -1,39 +1,35 @@
-<div class="meeting-polls__admin-label"><%= t(".admin_dashboard") %></div>
-
 <% questionnaire.questions.includes([:questionnaire]).each do |question| %>
   <details class="meeting-polls__question meeting-polls__question--admin open" data-question="<%= question.id %>" <%= "open" if open_question == question.id %>>
     <summary><%= t(".question") %></summary>
 
     <%= form_tag(meeting_polls_question_path(meeting, question), method: :patch, remote: true) do %>
+      <p class="h3"><%= translated_attribute(question.body) %></p>
+
+      <%= link_to t(".edit"), Decidim::EngineRouter.admin_proxy(meeting.component).edit_meeting_poll_path(meeting), class: "button button__xs button__secondary mr-auto mt-2" %>
+
       <div>
-        <p><%= translated_attribute(question.body) %></p>
-
-        <%= link_to t(".edit"), Decidim::EngineRouter.admin_proxy(meeting.component).edit_meeting_poll_path(meeting), target: "_blank", rel: "noopener noreferrer" %>
-
         <div class="meeting-polls__admin-action meeting-polls__admin-action-question">
-          <div><%= t(".question") %></div>
-          <div>
-            <% if question.unpublished? %>
-              <button class="button button__sm button__secondary"><%= t(".send") %></button>
-            <% else %>
-              <div><strong><%= t(".sent") %></strong></div>
-              <div><%= pluralize(question.answers_count, t(".received_answer"), t(".received_answers")) %></div>
-            <% end %>
-          </div>
+          <div class="h4"><%= t(".question") %><%= " · " + t(".sent") if question.published? %></div>
+
+          <% if question.unpublished? %>
+            <button class="button button__sm button__secondary"><%= t(".send") %></button>
+          <% else %>
+            <div><%= pluralize(question.answers_count, t(".received_answer"), t(".received_answers")) %></div>
+          <% end %>
         </div>
+
         <div class="meeting-polls__admin-action meeting-polls__admin-action-results">
-          <div><%= t(".results") %></div>
+          <div class="h4"><%= t(".results") %></div>
+
+          <% if question.unpublished? || question.closed? %>
+            <button class="button button__sm button__secondary" disabled><%= t(".send") %></button>
+          <% elsif question.published? %>
+            <button class="button button__sm button__secondary"><%= t(".send") %></button>
+          <% end %>
+
           <div>
             <% unless question.unpublished? %>
               <%= cell "decidim/meetings/question_responses", question %>
-            <% end %>
-
-            <% if question.unpublished? %>
-              <button class="button button__sm button__secondary" disabled><%= t(".send") %></button>
-            <% elsif question.published? %>
-              <button class="button button__sm button__secondary"><%= t(".send") %></button>
-            <% elsif question.closed? %>
-              <div class="mt-1"><strong><%= t(".sent") %></strong></div>
             <% end %>
           </div>
         </div>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_index_admin.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_index_admin.html.erb
@@ -9,7 +9,13 @@
       <p class="h3"><%= translated_attribute(question.body) %></p>
 
       <% if question.unpublished? %>
-        <%= link_to t(".edit"), Decidim::EngineRouter.admin_proxy(meeting.component).edit_meeting_poll_path(meeting), class: "button button__xs button__secondary mr-auto mt-2" %>
+        <%= link_to(
+          t(".edit"),
+          Decidim::EngineRouter.admin_proxy(meeting.component).edit_meeting_poll_path(meeting),
+          class: "button button__xs button__secondary mr-auto mt-2",
+          target: "_blank",
+          rel: "noopener noreferrer"
+        ) %>
       <% end %>
 
       <div>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_index_admin.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_index_admin.html.erb
@@ -1,6 +1,8 @@
 <% questionnaire.questions.includes([:questionnaire]).each do |question| %>
   <details class="meeting-polls__question meeting-polls__question--admin open" data-question="<%= question.id %>" <%= "open" if open_question == question.id %>>
-    <summary><%= t(".question") %></summary>
+    <summary>
+      <span><%= t(".question") %></span>
+    </summary>
 
     <%= form_tag(meeting_polls_question_path(meeting, question), method: :patch, remote: true) do %>
       <p class="h3"><%= translated_attribute(question.body) %></p>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_index_admin.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_index_admin.html.erb
@@ -26,11 +26,7 @@
         <div class="meeting-polls__admin-action meeting-polls__admin-action-results">
           <div class="h4"><%= t(".results") %></div>
 
-          <% if question.unpublished? || question.closed? %>
-            <button class="button button__sm button__secondary" disabled><%= t(".send") %></button>
-          <% elsif question.published? %>
-            <button class="button button__sm button__secondary"><%= t(".send") %></button>
-          <% end %>
+          <button class="button button__sm button__secondary" <%= question.published? ? "" : "disabled" %>><%= question.closed? ? t(".sent") : t(".send") %></button>
 
           <div>
             <% unless question.unpublished? %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_published_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_published_question.html.erb
@@ -3,9 +3,11 @@
 </summary>
 
 <div>
-  <p class="h3"><%= translated_attribute(question.body) %></p>
 
   <% @form = form || Decidim::Meetings::AnswerForm.new(question_id: question.id, current_user:) %>
+
+  <p class="h3"><%= @form.label %></p>
+
   <%= decidim_form_for(@form, url: meeting_polls_answers_path(meeting), method: :post, remote: true, html: { class: "form-defaults" }, data: { "safe-path" => meeting_live_event_path(meeting) }) do |form| %>
     <div class="meeting-polls__answer" data-max-choices="<%= question.max_choices %>">
       <p class="form-error max-choices-alert mt-0 mb-4"><%= t(".max_choices_alert") %></p>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_published_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_published_question.html.erb
@@ -1,11 +1,11 @@
 <summary><%= t(".question") %></summary>
 
 <div>
-  <p><%= translated_attribute(question.body) %></p>
+  <p class="h3"><%= translated_attribute(question.body) %></p>
 
   <% @form = form || Decidim::Meetings::AnswerForm.new(question_id: question.id, current_user:) %>
-  <%= decidim_form_for(@form, url: meeting_polls_answers_path(meeting), method: :post, remote: true, html: { class: "form-defaults mt-4" }, data: { "safe-path" => meeting_live_event_path(meeting) }) do |form| %>
-    <div class="answer question" data-max-choices="<%= question.max_choices %>">
+  <%= decidim_form_for(@form, url: meeting_polls_answers_path(meeting), method: :post, remote: true, html: { class: "form-defaults" }, data: { "safe-path" => meeting_live_event_path(meeting) }) do |form| %>
+    <div class="meeting-polls__answer" data-max-choices="<%= question.max_choices %>">
       <p class="form-error max-choices-alert mt-0 mb-4"><%= t(".max_choices_alert") %></p>
 
       <%= render partial: "decidim/meetings/polls/answers/#{question.question_type}", locals: { answer: @form.answer, question:, answer_form: form, disabled: question.answered_by?(current_user), field_id: question.id } %>
@@ -16,12 +16,11 @@
         <small class="form-error is-visible mt-1"><%= msg %></small>
       <% end %>
     </div>
+
     <% if question.answered_by?(current_user) %>
       <%= cell("decidim/announcement", t(".question_replied"), callout_class: "success" ) %>
     <% else %>
-      <div class="text-right">
-        <button class="ml-auto button button__sm button__secondary"><%= t(".reply_question") %></button>
-      </div>
+      <button class="ml-auto button button__sm button__secondary"><%= t(".reply_question") %></button>
     <% end %>
   <% end %>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_published_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_published_question.html.erb
@@ -1,4 +1,6 @@
-<summary><%= t(".question") %></summary>
+<summary>
+  <span><%= t(".question") %></span>
+</summary>
 
 <div>
   <p class="h3"><%= translated_attribute(question.body) %></p>
@@ -19,7 +21,7 @@
       <% if question.answered_by?(current_user) %>
         <%= cell("decidim/announcement", t(".question_replied"), callout_class: "success" ) %>
       <% else %>
-        <button class="ml-auto mt-4 button button__sm button__secondary"><%= t(".reply_question") %></button>
+        <button class="ml-auto mt-8 button button__lg button__secondary"><%= t(".reply_question") %></button>
       <% end %>
     </div>
   <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_published_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_published_question.html.erb
@@ -15,12 +15,12 @@
       <% @form.errors.full_messages.each do |msg| %>
         <small class="form-error is-visible mt-1"><%= msg %></small>
       <% end %>
-    </div>
 
-    <% if question.answered_by?(current_user) %>
-      <%= cell("decidim/announcement", t(".question_replied"), callout_class: "success" ) %>
-    <% else %>
-      <button class="ml-auto button button__sm button__secondary"><%= t(".reply_question") %></button>
-    <% end %>
+      <% if question.answered_by?(current_user) %>
+        <%= cell("decidim/announcement", t(".question_replied"), callout_class: "success" ) %>
+      <% else %>
+        <button class="ml-auto mt-4 button button__sm button__secondary"><%= t(".reply_question") %></button>
+      <% end %>
+    </div>
   <% end %>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_question.html.erb
@@ -1,4 +1,4 @@
-<details class="meeting-polls__question" data-question="<%= question.id %>" <%= "open" if local_assigns.fetch(:open_question, nil) == question %>>
+<details class="meeting-polls__question" data-question="<%= question.id %>" data-status=<%= question.status %> <%= "open" if local_assigns.fetch(:open_question, nil) == question %>>
   <% if question.published? %>
     <%= render partial: "decidim/meetings/polls/questions/published_question", locals: { question:, form: local_assigns.fetch(:form, nil) } %>
   <% elsif question.closed? %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/_question.html.erb
@@ -1,4 +1,4 @@
-<details class="meeting-polls__question" data-question="<%= question.id %>" data-status=<%= question.status %> <%= "open" if local_assigns.fetch(:open_question, nil) == question %>>
+<details class="meeting-polls__question" data-question="<%= question.id %>" data-status="<%= question.status %>" <%= "open" if local_assigns.fetch(:open_question, nil) == question %>>
   <% if question.published? %>
     <%= render partial: "decidim/meetings/polls/questions/published_question", locals: { question:, form: local_assigns.fetch(:form, nil) } %>
   <% elsif question.closed? %>

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/index.js.erb
@@ -1,4 +1,4 @@
-var $meetingPoll = $("#meeting-poll");
+var $meetingPoll = $("[data-decidim-meetings-poll]");
 
 if($meetingPoll.length){
   $meetingPoll.html('<%= j(render partial: "decidim/meetings/polls/questions/index").strip.html_safe %>');

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/index.js.erb
@@ -1,5 +1,5 @@
-var $aside = $("#meeting-poll-aside");
+var $meetingPoll = $("#meeting-poll");
 
-if($aside.length){
-  $aside.html('<%= j(render partial: "decidim/meetings/polls/questions/index").strip.html_safe %>');
+if($meetingPoll.length){
+  $meetingPoll.html('<%= j(render partial: "decidim/meetings/polls/questions/index").strip.html_safe %>');
 }

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/index_admin.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/index_admin.js.erb
@@ -1,4 +1,4 @@
-var $adminMeetingPoll = $("#admin-meeting-poll");
+var $adminMeetingPoll = $("[data-decidim-admin-meetings-poll]");
 
 if($adminMeetingPoll.length){
   $adminMeetingPoll.html('<%= j(render partial: "decidim/meetings/polls/questions/index_admin", locals: { open_question: }).strip.html_safe %>');

--- a/decidim-meetings/app/views/decidim/meetings/polls/questions/index_admin.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/polls/questions/index_admin.js.erb
@@ -1,5 +1,5 @@
-var $aside = $("#admin-meeting-poll-aside");
+var $adminMeetingPoll = $("#admin-meeting-poll");
 
-if($aside.length){
-  $aside.html('<%= j(render partial: "decidim/meetings/polls/questions/index_admin", locals: { open_question: }).strip.html_safe %>');
+if($adminMeetingPoll.length){
+  $adminMeetingPoll.html('<%= j(render partial: "decidim/meetings/polls/questions/index_admin", locals: { open_question: }).strip.html_safe %>');
 }

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -449,7 +449,7 @@ en:
       iframe_embed_type:
         embed_in_meeting_page: Embed in meeting page
         none: None
-        open_in_live_event_page: Open in live event page (with optional polls)
+        open_in_live_event_page: Open in live event page
         open_in_new_tab: Open URL in a new tab
       last_activity:
         meeting_updated: 'Meeting updated:'

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -599,7 +599,6 @@ en:
         answers:
           index:
             administrate: Administrate
-            meeting: Meeting
             title: Poll
           index_admin:
             back_to_meeting: Back to meeting

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -608,6 +608,7 @@ en:
             view_poll: View poll
         questions:
           closed_question:
+            announcement: The replies for this question have been closed.
             question: Question
             question_results: Results
           index:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -601,10 +601,10 @@ en:
           index:
             administrate: Administrate
             meeting: Meeting
-            questions: Questions
+            title: Poll
           index_admin:
             back_to_meeting: Back to meeting
-            title: Administrate
+            title: Administrate poll
             view_poll: View poll
         questions:
           closed_question:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -371,6 +371,7 @@ en:
               <li>When a question receives answers or is published/closed, it can no longer be edited.</li>
               <li>You can add a question at any time.</li>
               <li>The poll will be closed when the results of all created questions have been published.</li>
+              <li>Visit the <a href='%{admin_link}' target='_blank' data-external-domain-link='false'>poll administration page</a> to send questions and publish results.</li>
               </ul>
         registrations:
           edit:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -621,6 +621,10 @@ en:
             results: Results
             send: Send
             sent: Sent
+            statuses:
+              closed: Results sent (closed)
+              published: Sent (open)
+              unpublished: Pending to be sent
           published_question:
             max_choices_alert: There are too many choices selected
             question: Question

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -538,6 +538,7 @@ en:
           edit_meeting: Edit meeting
           join_meeting: Join meeting
           reply_poll: Reply poll
+          view_poll: View poll
         meetings:
           no_meetings_warning: No meetings match your search criteria or there is not any meeting scheduled.
           upcoming_meetings_warning: Currently, there are no scheduled meetings, but here you can find all the past meetings listed.

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -364,6 +364,14 @@ en:
           update:
             invalid: There was a problem updating this meeting poll.
             success: Meeting poll successfully updated.
+        poll:
+          form:
+            announcement_html: |-
+              <ul>
+              <li>When a question receives answers or is published/closed, it can no longer be edited.</li>
+              <li>You can add a question at any time.</li>
+              <li>The poll will be closed when the results of all created questions have been published.</li>
+              </ul>
         registrations:
           edit:
             save: Save

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -449,9 +449,7 @@ en:
         new_meeting: 'New meeting:'
       layouts:
         live_event:
-          administrate: Administrate
           close: close
-          questions: Questions
       mailer:
         invite_join_meeting_mailer:
           invite:
@@ -593,7 +591,12 @@ en:
       polls:
         answers:
           index:
+            administrate: Administrate
             meeting: Meeting
+            questions: Questions
+          index_admin:
+            back_to_meeting: Back to meeting
+            title: Administrate
         questions:
           closed_question:
             question_results: Question results

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -532,6 +532,7 @@ en:
           edit_close_meeting: Edit meeting report
           edit_meeting: Edit meeting
           join_meeting: Join meeting
+          reply_poll: Reply poll
         meetings:
           no_meetings_warning: No meetings match your search criteria or there is not any meeting scheduled.
           upcoming_meetings_warning: Currently, there are no scheduled meetings, but here you can find all the past meetings listed.

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -147,6 +147,7 @@ en:
         actions:
           comment: Comment
           join: Join
+          reply_poll: Reply poll
         name: Meetings
         settings:
           global:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -608,7 +608,8 @@ en:
             view_poll: View poll
         questions:
           closed_question:
-            question_results: Question results
+            question: Question
+            question_results: Results
           index:
             empty_questions: Throughout this meeting, some questions will be sent and you will be able to answer them. They will be displayed here.
           index_admin:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -366,13 +366,11 @@ en:
             success: Meeting poll successfully updated.
         poll:
           form:
-            announcement_html: |-
-              <ul>
-              <li>When a question receives answers or is published/closed, it can no longer be edited.</li>
-              <li>You can add a question at any time.</li>
-              <li>The poll will be closed when the results of all created questions have been published.</li>
-              <li>Visit the <a href='%{admin_link}' target='_blank' data-external-domain-link='false'>poll administration page</a> to send questions and publish results.</li>
-              </ul>
+            announcement_html:
+            - When a question receives answers or is published/closed, it can no longer be edited.
+            - You can add a question at any time.
+            - The poll will be closed when the results of all created questions have been published.
+            - Visit the <a href='%{admin_link}'>poll administration page</a> to send questions and publish results.
         registrations:
           edit:
             save: Save

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -591,6 +591,9 @@ en:
             start_time: Start date
             title: Title
       polls:
+        answers:
+          index:
+            meeting: Meeting
         questions:
           closed_question:
             question_results: Question results

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -605,13 +605,13 @@ en:
           index_admin:
             back_to_meeting: Back to meeting
             title: Administrate
+            view_poll: View poll
         questions:
           closed_question:
             question_results: Question results
           index:
             empty_questions: Throughout this meeting, some questions will be sent and you will be able to answer them. They will be displayed here.
           index_admin:
-            admin_dashboard: Administrator dashboard
             edit: Edit in the admin panel
             question: Question
             received_answer: received answer

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -19,7 +19,7 @@ Decidim.register_component(:meetings) do |component|
     resource.template = "decidim/meetings/meetings/linked_meetings"
     resource.card = "decidim/meetings/meeting"
     resource.reported_content_cell = "decidim/meetings/reported_content"
-    resource.actions = %w(join comment)
+    resource.actions = %w(join comment reply_poll)
     resource.searchable = true
   end
 

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -32,7 +32,11 @@ module Decidim
           resource :live_event, only: :show
           namespace :polls do
             resources :questions, only: [:index, :update]
-            resources :answers, only: [:index, :create]
+            resources :answers, only: [:index, :create] do
+              collection do
+                get :admin
+              end
+            end
           end
         end
         scope "/meetings" do

--- a/decidim-meetings/spec/models/decidim/meetings/questionnaire_spec.rb
+++ b/decidim-meetings/spec/models/decidim/meetings/questionnaire_spec.rb
@@ -34,13 +34,6 @@ module Decidim
         expect(questionnaire.questionnaire_for).to eq(questionable)
       end
 
-      describe "#questions_editable?" do
-        it "returns false when questionnaire has already answers" do
-          create(:meetings_poll_answer, questionnaire:)
-          expect(subject.reload).not_to be_questions_editable
-        end
-      end
-
       describe "#all_questions_unpublished?" do
         it "returns true when all questionnaire questions are in unpublished state" do
           subject.questions << create(:meetings_poll_question, :unpublished)

--- a/decidim-meetings/spec/system/meeting_questions_administrate_spec.rb
+++ b/decidim-meetings/spec/system/meeting_questions_administrate_spec.rb
@@ -65,6 +65,10 @@ describe "Meeting poll administration" do
       expect(page.all(".meeting-polls__question--admin").size).to eq(2)
     end
 
+    it "shows the status of each question" do
+      expect(page).to have_content("Pending to be sent", count: 2)
+    end
+
     it "allows to edit a question in the administrator" do
       open_first_question
 
@@ -84,6 +88,7 @@ describe "Meeting poll administration" do
         expect(page).to have_content("Sent")
         expect(page).to have_content("0 received answers")
       end
+      expect(page).to have_css("[data-question='#{question_multiple_option.id}']", text: "Sent (open)")
     end
   end
 
@@ -112,6 +117,10 @@ describe "Meeting poll administration" do
       expect(page).to have_content("100%")
     end
 
+    it "shows the status of each question" do
+      expect(page).to have_content("Sent (open)", count: 1)
+    end
+
     it "allows to close a published question" do
       open_first_question
 
@@ -122,6 +131,7 @@ describe "Meeting poll administration" do
 
       question_multiple_option.reload
       expect(question_multiple_option).to be_closed
+      expect(page).to have_css("[data-question='#{question_multiple_option.id}']", text: "Results sent (closed)")
     end
   end
 

--- a/decidim-meetings/spec/system/meeting_questions_administrate_spec.rb
+++ b/decidim-meetings/spec/system/meeting_questions_administrate_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Meeting live event poll administration" do
+describe "Meeting poll administration" do
   include_context "when managing a component" do
     let(:component_organization_traits) { admin_component_organization_traits }
   end
@@ -24,19 +24,12 @@ describe "Meeting live event poll administration" do
 
   let(:manifest_name) { "meetings" }
 
-  let(:meeting) { create(:meeting, :published, :online, :live, component:) }
+  let(:meeting) { create(:meeting, :published, component:) }
   let(:meeting_path) do
     decidim_participatory_process_meetings.meeting_path(
       participatory_process_slug: participatory_process.slug,
       component_id: component.id,
       id: meeting.id
-    )
-  end
-  let(:meeting_live_event_path) do
-    decidim_participatory_process_meetings.meeting_live_event_path(
-      participatory_process_slug: participatory_process.slug,
-      component_id: component.id,
-      meeting_id: meeting.id
     )
   end
   let(:body_multiple_option_question) do
@@ -56,14 +49,17 @@ describe "Meeting live event poll administration" do
   let!(:poll) { create(:poll, meeting:) }
   let!(:questionnaire) { create(:meetings_poll_questionnaire, questionnaire_for: poll) }
 
-  before do
-    visit meeting_live_event_path
-    click_on "Administrate"
-  end
-
   context "when all questions are unpublished" do
     let!(:question_multiple_option) { create(:meetings_poll_question, :unpublished, questionnaire:, body: body_multiple_option_question, question_type: "multiple_option") }
     let!(:question_single_option) { create(:meetings_poll_question, :unpublished, questionnaire:, body: body_single_option_question, question_type: "single_option") }
+
+    before do
+      visit meeting_path
+      within("[aria-label='aside']") do
+        click_link_or_button "Reply poll"
+      end
+      click_link_or_button "Administrate"
+    end
 
     it "list the questions in the Administrate section" do
       expect(page.all(".meeting-polls__question--admin").size).to eq(2)
@@ -100,6 +96,15 @@ describe "Meeting live event poll administration" do
     let!(:answer_choice_user1) { create(:meetings_poll_answer_choice, answer: answer_user1, answer_option: question_multiple_option.answer_options.first) }
     let!(:answer_choice_user2) { create(:meetings_poll_answer_choice, answer: answer_user2, answer_option: question_multiple_option.answer_options.first) }
 
+    before do
+      visit meeting_path
+      within("[aria-label='aside']") do
+        click_link_or_button "Reply poll"
+      end
+
+      click_link_or_button "Administrate"
+    end
+
     it "allows to see question answers" do
       open_first_question
 
@@ -127,6 +132,6 @@ describe "Meeting live event poll administration" do
   end
 
   def open_first_question
-    page.first(".meeting-polls__question--admin").click
+    find(".meeting-polls__question--admin", match: :first).click
   end
 end

--- a/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
+++ b/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Meeting live event poll answer" do
+describe "Meeting poll answer" do
   include_context "with a component"
   let(:manifest_name) { "meetings" }
 
@@ -13,11 +13,11 @@ describe "Meeting live event poll answer" do
   end
 
   let(:meeting) { create(:meeting, :published, :online, :live, component:) }
-  let(:meeting_live_event_path) do
-    decidim_participatory_process_meetings.meeting_live_event_path(
+  let(:meeting_path) do
+    decidim_participatory_process_meetings.meeting_path(
       participatory_process_slug: participatory_process.slug,
       component_id: component.id,
-      meeting_id: meeting.id
+      id: meeting.id
     )
   end
   let(:body_multiple_option_question) do
@@ -37,21 +37,19 @@ describe "Meeting live event poll answer" do
   let!(:poll) { create(:poll, meeting:) }
   let!(:questionnaire) { create(:meetings_poll_questionnaire, questionnaire_for: poll) }
 
-  before do
-    login_as user, scope: :user
-    visit meeting_live_event_path
-  end
-
   context "when all questions are unpublished" do
     let!(:question_multiple_option) { create(:meetings_poll_question, :unpublished, questionnaire:, body: body_multiple_option_question, question_type: "multiple_option") }
     let!(:question_single_option) { create(:meetings_poll_question, :unpublished, questionnaire:, body: body_single_option_question, question_type: "single_option") }
 
     before do
-      visit meeting_live_event_path
+      login_as user, scope: :user
+      visit meeting_path
+      within("[aria-label='aside']") do
+        click_link_or_button "Reply poll"
+      end
     end
 
     it "does not list any question" do
-      click_on "Questions (0)"
       expect(page.all(".meeting-polls__question--admin").size).to eq(0)
     end
   end
@@ -61,11 +59,14 @@ describe "Meeting live event poll answer" do
     let!(:question_single_option) { create(:meetings_poll_question, :published, questionnaire:, body: body_single_option_question, question_type: "single_option") }
 
     before do
-      visit meeting_live_event_path
+      login_as user, scope: :user
+      visit meeting_path
+      within("[aria-label='aside']") do
+        click_link_or_button "Reply poll"
+      end
     end
 
     it "allows to reply a question" do
-      click_on "Questions (2)"
       open_first_question
 
       check question_multiple_option.answer_options.first.body["en"]
@@ -75,7 +76,6 @@ describe "Meeting live event poll answer" do
     end
 
     it "does not allow selecting two single options" do
-      click_on "Questions (2)"
       find("details[data-question='#{question_single_option.id}']").click
 
       choose question_single_option.answer_options.first.body["en"]
@@ -88,14 +88,14 @@ describe "Meeting live event poll answer" do
     end
 
     it "does not allow selecting more than the maximum choices for multiple options" do
-      click_on "Questions (2)"
       open_first_question
 
       check question_multiple_option.answer_options.first.body["en"]
       check question_multiple_option.answer_options.second.body["en"]
       check question_multiple_option.answer_options.third.body["en"]
 
-      expect(page).to have_content("There are too many choices selected")
+      click_on "Reply question"
+      expect(page).to have_content("You can choose a maximum of 2.")
     end
   end
 
@@ -105,11 +105,14 @@ describe "Meeting live event poll answer" do
     let!(:answer_choice_user1) { create(:meetings_poll_answer_choice, answer: answer_user1) }
 
     before do
-      visit meeting_live_event_path
+      login_as user, scope: :user
+      visit meeting_path
+      within("[aria-label='aside']") do
+        click_link_or_button "View poll"
+      end
     end
 
     it "shows the responses" do
-      click_on "Questions (1)"
       open_first_question
 
       expect(page).to have_content("0%")
@@ -124,6 +127,6 @@ describe "Meeting live event poll answer" do
   end
 
   def open_first_question
-    page.first(".meeting-polls__question").click
+    find(".meeting-polls__question", match: :first).click
   end
 end

--- a/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
+++ b/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
@@ -77,6 +77,7 @@ describe "Meeting poll answer" do
     end
 
     it "allows to reply a question" do
+      sleep(2)
       open_first_question
 
       check question_multiple_option.answer_options.first.body["en"]

--- a/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
+++ b/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
@@ -6,7 +6,7 @@ describe "Meeting poll answer" do
   include_context "with a component"
   let(:manifest_name) { "meetings" }
 
-  let(:user2) do
+  let(:user) do
     create(:user,
            :confirmed,
            organization:)

--- a/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
+++ b/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
@@ -88,6 +88,7 @@ describe "Meeting poll answer" do
     end
 
     it "does not allow selecting more than the maximum choices for multiple options" do
+      sleep(2)
       open_first_question
 
       check question_multiple_option.answer_options.first.body["en"]

--- a/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
+++ b/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
@@ -37,6 +37,15 @@ describe "Meeting poll answer" do
   let!(:poll) { create(:poll, meeting:) }
   let!(:questionnaire) { create(:meetings_poll_questionnaire, questionnaire_for: poll) }
 
+  context "when there are no questions" do
+    it "does not show a link to reply poll" do
+      login_as user, scope: :user
+      visit meeting_path
+
+      expect(page).to have_no_content("Reply poll")
+    end
+  end
+
   context "when all questions are unpublished" do
     let!(:question_multiple_option) { create(:meetings_poll_question, :unpublished, questionnaire:, body: body_multiple_option_question, question_type: "multiple_option") }
     let!(:question_single_option) { create(:meetings_poll_question, :unpublished, questionnaire:, body: body_single_option_question, question_type: "single_option") }
@@ -51,6 +60,7 @@ describe "Meeting poll answer" do
 
     it "does not list any question" do
       expect(page.all(".meeting-polls__question--admin").size).to eq(0)
+      expect(page).to have_content("some questions will be sent")
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR:

* Allows users to reply polls in meetings regardless the meeting type
* Provides separated views to reply polls and administrate them (for admins) and removes those elements from live view meetings
* Adds a new permission to authorize users to reply polls
* Changes the admin part of polls allowing admins to edit polls at any moment. The admins have the ability to add questions at any moment and edit questions not published yet. The rest of questions are displayed but its contents are locked and the only thing an admin can do is reorder blocked questions
* Adds an authorized button from meetings show page aside to reply polls that is shown whenever the poll has at least a question not closed (sent or not)
* If the poll has questions and all of them are closed the authorized button displays a text to view poll.
* If the poll has no questions at all no button is shown
* If admins don't have authorization to reply polls a button appears to administrate the poll and send questions to users or close them
* If admins are allowed to reply a poll a link to administrate poll will appear in the reply poll page
* Changes the polling of questions in reply poll page:
  * Keeps the selected choices of the user on open questions
  * Refreshes questions from published to closed displaying a message to users
* Changes validation message of choice field of forms to include the max choices value

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #12542

#### Testing
* [Meeting without questions](https://decidim-lot2.populate.tools/processes/polls-in-meetings/f/3/meetings/2): No button to reply or view poll is shown
* [Meeting with only unpublished questions](https://decidim-lot2.populate.tools/processes/polls-in-meetings/f/3/meetings/10): A button to reply poll is shown in the meeting page and the reply poll page displays a message for upcoming questions
![Screenshot from 2024-06-05 20-43-05](https://github.com/decidim/decidim/assets/446459/9f9f7894-fe92-4773-87b8-17d49ee462fa)



* [Meeting with published questions](https://decidim-lot2.populate.tools/processes/polls-in-meetings/f/3/meetings/8): A link to reply poll appears in the meeting page. In the reply poll page a list of published and closed questions may appear. The polling refresh keeps the selected choices. If a question is closed a message appears
![Screenshot from 2024-06-05 20-29-58](https://github.com/decidim/decidim/assets/446459/bb95a6e1-14c7-46b5-85e9-4bc940b19f1b)

* [Meeting with all questions closed](https://decidim-lot2.populate.tools/processes/polls-in-meetings/f/3/meetings/9): A button to see the poll is shown to view results. Admins can create and publish new questions at any moment
![Screenshot from 2024-06-05 20-29-20](https://github.com/decidim/decidim/assets/446459/68a81796-077a-44f2-a4dc-17215c65b25b)

* [Meeting poll administration page](https://decidim-lot2.populate.tools/processes/polls-in-meetings/f/3/meetings/8/polls/answers/admin): This page has a polling refresh and the replies of open questions are updated. The unpublished questions have a link to edit in admin and the questions have buttons to publish and close questions.
![Screenshot from 2024-06-05 20-28-22](https://github.com/decidim/decidim/assets/446459/70b269fc-7f0e-4ef2-89b8-57513ef5e9d1)

* [Meeting questions admin page](https://decidim-lot2.populate.tools/admin/participatory_processes/polls-in-meetings/components/3/manage/meetings/8/poll/edit): The admin is able to add new questions and edit/delete unpublished questions. The rest of questions are locked and the admin can only change their order.
![Screenshot from 2024-06-05 20-54-58](https://github.com/decidim/decidim/assets/446459/02ab4b12-25bd-45c3-9224-c011cb0d3a8d)

* [Meeting with authorizations to reply poll](https://decidim-lot2.populate.tools/processes/polls-in-meetings/f/3/meetings/3): If an admin has no permissions to reply the poll the meeting page shows a button to administrate the poll questions. The reply poll button have a permissions modal associated
![Screenshot from 2024-06-05 20-26-32](https://github.com/decidim/decidim/assets/446459/62bd4ec2-7935-47f3-b8cc-73b949a1c2e1)

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
