### PR TITLE
Fix flaky related to `Decidim.available_locales`

### DIFF
--- a/decidim-admin/spec/system/admin_manages_more_locales_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_more_locales_spec.rb
@@ -22,6 +22,8 @@ describe "Admin language selector" do
   end
 
   after do
+    Decidim.available_locales = %w(en ca es)
+    I18n.available_locales = %w(en ca es)
     Decidim::Admin.send(:remove_const, :StaticPageForm)
     load "#{Decidim::Admin::Engine.root}/app/forms/decidim/admin/static_page_form.rb"
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #12855, we have added a spec that changes the values of `I18n.available_locales` and `Decidim.available_locales` variables. Doing so, we started to see a failing spec when we have backported to the release 0.28. This PR fixes the failing spec, so that we can safely fix the 0.28 release 

```

  1) Organization scopes Managing scopes can create new scopes
     Failure/Error:
       fill_in_i18n :scope_name, "#scope-name-tabs", en: "My nice district",
                                                     es: "Mi lindo distrito",
                                                     ca: "El meu bonic barri"

     Capybara::ElementNotFound:
       Unable to find link "English" within #<Capybara::Node::Element tag="select" path="/HTML/BODY[1]/MAIN[1]/DIV[1]/DIV[2]/DIV[2]/DIV[4]/DIV[1]/DIV[2]/DIV[2]/FORM[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/SELECT[1]">

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_organization_scopes_managing_scopes_can_create_new_scopes_758.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_organization_scopes_managing_scopes_can_create_new_scopes_758.html


     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:116:in `block (2 levels) in fill_in_i18n_fields'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:115:in `block in fill_in_i18n_fields'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:114:in `each'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:114:in `fill_in_i18n_fields'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:50:in `fill_in_i18n'
     # ./spec/system/admin_manages_organization_scopes_spec.rb:29:in `block (4 levels) in <top (required)>'
     # ./spec/system/admin_manages_organization_scopes_spec.rb:28:in `block (3 levels) in <top (required)>'

```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12855

#### Testing
Since there are 2 tytpes of errors, Make sure the admin pipeline does not fail with the error presented in the below screenshot

### :camera: Screenshots
![image](https://github.com/decidim/decidim/assets/105683/16297cf9-6f24-4880-8d56-fdfebf7f9e96)

:hearts: Thank you!
