### PR TITLE
Standarise ```current_user``` call within Commands tasks (Verifications)

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_item_show.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_item_show.scss
@@ -12,8 +12,8 @@
   &-title {
     @apply text-xl font-bold block sm:flex items-center justify-between gap-4 w-full first-letter:capitalize first:[&>div]:ml-0 first:[&>*]:ml-auto;
 
-    .dropdown-pane {
-      @apply font-normal;
+    .dropdown-pane li a {
+      @apply font-normal block;
     }
   }
 }

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_item_show.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_item_show.scss
@@ -12,8 +12,8 @@
   &-title {
     @apply text-xl font-bold block sm:flex items-center justify-between gap-4 w-full first-letter:capitalize first:[&>div]:ml-0 first:[&>*]:ml-auto;
 
-    .dropdown-pane li a {
-      @apply font-normal block;
+    .dropdown-pane {
+      @apply font-normal;
     }
   }
 }

--- a/decidim-verifications/app/commands/decidim/verifications/revoke_by_condition_authorizations.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/revoke_by_condition_authorizations.rb
@@ -47,7 +47,7 @@ module Decidim
             Decidim.traceability.perform_action!(
               :destroy,
               auth,
-              current_user:
+              current_user
             ) do
               auth.destroy
             end

--- a/decidim-verifications/app/commands/decidim/verifications/revoke_by_condition_authorizations.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/revoke_by_condition_authorizations.rb
@@ -4,14 +4,14 @@ module Decidim
   module Verifications
     # A command to revoke authorizations with filter
     class RevokeByConditionAuthorizations < Decidim::Command
+      delegate :current_user, to: :form
       # Public: Initializes the command.
       #
       # organization - Organization object.
       # current_user - The current user.
       # form - A form object with the verification data to confirm it.
-      def initialize(organization, current_user, form)
+      def initialize(organization, form)
         @organization = organization
-        @current_user = current_user
         @form = form
       end
 
@@ -43,11 +43,12 @@ module Decidim
                                      end
 
           auths = authorizations_to_revoke.query
+          byebug
           auths.find_each do |auth|
             Decidim.traceability.perform_action!(
               :destroy,
               auth,
-              current_user
+              current_user:
             ) do
               auth.destroy
             end
@@ -62,7 +63,7 @@ module Decidim
 
       private
 
-      attr_reader :organization, :current_user, :form
+      attr_reader :organization, :form
     end
   end
 end

--- a/decidim-verifications/app/commands/decidim/verifications/revoke_by_condition_authorizations.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/revoke_by_condition_authorizations.rb
@@ -43,7 +43,6 @@ module Decidim
                                      end
 
           auths = authorizations_to_revoke.query
-          byebug
           auths.find_each do |auth|
             Decidim.traceability.perform_action!(
               :destroy,

--- a/decidim-verifications/app/controllers/decidim/verifications/admin/verifications_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/admin/verifications_controller.rb
@@ -9,7 +9,7 @@ module Decidim
           return unless params.has_key?(:revocations_before_date)
 
           form = RevocationsBeforeDateForm.from_params(params[:revocations_before_date])
-          RevokeByConditionAuthorizations.call(current_organization, current_user, form) do
+          RevokeByConditionAuthorizations.call(current_organization, form) do
             on(:ok) do
               flash[:notice] = t("authorization_revocation.destroy_ok", scope: "decidim.admin.menu")
               redirect_to decidim_admin.authorization_workflows_url

--- a/decidim-verifications/spec/commands/decidim/verifications/revoke_by_condition_authorizations_spec.rb
+++ b/decidim-verifications/spec/commands/decidim/verifications/revoke_by_condition_authorizations_spec.rb
@@ -12,9 +12,19 @@ module Decidim::Verifications
         before_date:
       }
     end
+
     let(:form) do
-      Decidim::Verifications::Admin::RevocationsBeforeDateForm.from_params(params)
+      instance_double(
+        Decidim::Verifications::Admin::RevocationsBeforeDateForm,
+        current_user:,
+        valid?: true,
+        impersonated_only?: false,
+        before_date:,
+        organization:
+      )
     end
+
+    let(:authorization) { create(:authorization, id: 9234) }
     let(:now) { Time.zone.now }
     let(:prev_week) { Time.zone.today.prev_week }
     let(:prev_month) { Time.zone.today.prev_month }

--- a/decidim-verifications/spec/commands/decidim/verifications/revoke_by_condition_authorizations_spec.rb
+++ b/decidim-verifications/spec/commands/decidim/verifications/revoke_by_condition_authorizations_spec.rb
@@ -14,14 +14,9 @@ module Decidim::Verifications
     end
 
     let(:form) do
-      instance_double(
-        Decidim::Verifications::Admin::RevocationsBeforeDateForm,
-        current_user:,
-        valid?: true,
-        impersonated_only?: false,
-        before_date:,
-        organization:
-      )
+      Decidim::Verifications::Admin::RevocationsBeforeDateForm
+        .from_params(params)
+        .with_context(current_user:)
     end
 
     let(:authorization) { create(:authorization, id: 9234) }

--- a/decidim-verifications/spec/commands/decidim/verifications/revoke_by_condition_authorizations_spec.rb
+++ b/decidim-verifications/spec/commands/decidim/verifications/revoke_by_condition_authorizations_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 module Decidim::Verifications
   describe RevokeByConditionAuthorizations do
-    subject { described_class.new(organization, current_user, form) }
+    subject { described_class.new(organization, form) }
 
     let(:params) do
       {


### PR DESCRIPTION
#### :tophat: What? Why?
This PR standardize's the ```current_user``` call within the Verification's module. 

#### :pushpin: Related Issues
- Related to #10199 

#### Testing
run ```decidim-verifications/spec/commands/decidim/verifications/revoke_by_condition_authorizations_spec.rb``` 

### :camera: Screenshots

:hearts: Thank you!
