### PR TITLE
Backport 'Fix flaky spec when pasting a link in the WYSIWYG editor' to v0.28

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -467,7 +467,7 @@ describe "Admin manages organization" do
         let(:parsed_content) do
           cnt = <<~HTML
             <p>testing</p>
-            <p><strong>foo</strong><br><a target="_blank" href="https://www.decidim.org/"><u>link</u></a></p>
+            <p><strong>foo</strong><br><a target="_blank" href="https://www.decidim.org/">link</a></p>
             <p><br></p>
           HTML
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12953 to v0.28

:hearts: Thank you!