### PR TITLE
Backport 'Fix incomplete regexp in webmock configuration' to v0.27

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
@@ -2,4 +2,4 @@
 
 require "webmock/rspec"
 
-WebMock.disable_net_connect!(allow_localhost: true, allow: %r{https://validator.w3.org/})
+WebMock.disable_net_connect!(allow_localhost: true, allow: %r{https://validator\.w3\.org/})


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12931 to v0.27

:hearts: Thank you!