### PR TITLE
Change default proposal sorting word to automatic

### DIFF
--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -35,7 +35,7 @@ module Decidim
 
         def fetch_default_order
           default_order = current_settings.default_sort_order.presence || component_settings.default_sort_order
-          return order_by_default if default_order == "default"
+          return order_by_default if default_order == "automatic"
 
           possible_orders.include?(default_order) ? default_order : order_by_default
         end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -161,9 +161,9 @@ en:
             comments_enabled: Comments enabled
             comments_max_length: Comments max length (Leave 0 for default value)
             default_sort_order: Default proposal sorting
-            default_sort_order_help: Default means that if the votes are enabled, the proposals will be shown sorted by random, and if the votes are blocked, then they will be sorted by the most voted.
+            default_sort_order_help: Automatic means that if the votes are enabled, the proposals will be shown sorted by random, and if the votes are blocked, then they will be sorted by the most voted.
             default_sort_order_options:
-              default: Default
+              automatic: Automatic
               most_commented: Most commented
               most_endorsed: Most endorsed
               most_followed: Most followed
@@ -213,9 +213,9 @@ en:
             creation_enabled: Participants can create proposals
             creation_enabled_readonly: This setting is disabled when you activate the Participatory Texts functionality. To upload proposals as participatory text click on the Participatory Texts button and follow the instructions.
             default_sort_order: Default proposal sorting
-            default_sort_order_help: Default it means that if the votes are enabled, the proposals will be shown sorted by random, and if the votes are blocked, then they will be sorted by the most voted.
+            default_sort_order_help: Automatic means that if the votes are enabled, the proposals will be shown sorted by random, and if the votes are blocked, then they will be sorted by the most voted.
             default_sort_order_options:
-              default: Default
+              automatic: Automatic
               most_commented: Most commented
               most_endorsed: Most endorsed
               most_followed: Most followed

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -28,7 +28,7 @@ Decidim.register_component(:proposals) do |component|
 
   component.permissions_class_name = "Decidim::Proposals::Permissions"
 
-  POSSIBLE_SORT_ORDERS = %w(default random recent most_endorsed most_voted most_commented most_followed with_more_authors).freeze
+  POSSIBLE_SORT_ORDERS = %w(automatic random recent most_endorsed most_voted most_commented most_followed with_more_authors).freeze
 
   component.settings(:global) do |settings|
     settings.attribute :scopes_enabled, type: :boolean, default: false
@@ -42,7 +42,7 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :threshold_per_proposal, type: :integer, default: 0, required: true
     settings.attribute :can_accumulate_votes_beyond_threshold, type: :boolean, default: false
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
-    settings.attribute :default_sort_order, type: :select, default: "default", choices: -> { POSSIBLE_SORT_ORDERS }
+    settings.attribute :default_sort_order, type: :select, default: "automatic", choices: -> { POSSIBLE_SORT_ORDERS }
     settings.attribute :official_proposals_enabled, type: :boolean, default: true
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :comments_max_length, type: :integer, required: true

--- a/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
+++ b/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
@@ -27,7 +27,7 @@ module Decidim
                endorsements_enabled?: endorsements_enabled,
                comments_enabled?: comments_enabled)
       end
-      let(:component_default_sort_order) { "default" }
+      let(:component_default_sort_order) { "automatic" }
       let(:step_default_sort_order) { "" }
       let(:votes_enabled) { nil }
       let(:votes_blocked) { nil }
@@ -64,7 +64,7 @@ module Decidim
 
         context "when step has default default_sort_order" do
           let(:component_default_sort_order) { "most_followed" }
-          let(:step_default_sort_order) { "default" }
+          let(:step_default_sort_order) { "automatic" }
           let(:votes_blocked) { false }
 
           it "use it instead of component's" do
@@ -91,7 +91,7 @@ module Decidim
           end
 
           describe "by default" do
-            let(:default_sort_order) { "default" }
+            let(:default_sort_order) { "automatic" }
 
             it "default_order is random" do
               expect(controller.send(:default_order)).to eq("random")


### PR DESCRIPTION
#### :tophat: What? Why?

It was reported that having an option "Default" inside of a label called "Default proposal sorting" isn't clear. I agree 😄 

This PR changes it to "Automatic", to better reflect its meaning.

#### :pushpin: Related Issues
 
- Fixes #11427

#### Testing

1. Log in as admin
2. Go to proposals component configuration
3. See the "Default proposal sorting" label, its options and its help text

### :camera: Screenshots

!["Default proposal sorting" section in the proposals component configuration form](https://github.com/decidim/decidim/assets/717367/9fc0605b-fc01-4f65-af51-1c344dbcd801)

:hearts: Thank you!
