### PR TITLE
Fix flaky spec on organization form (comment max length)

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -46,6 +46,8 @@ describe "Admin manages organization" do
 
       expect(page).to have_no_content("There is an error in this field.")
       fill_in :organization_comments_max_length, with: ""
+      find_by_id("organization_rich_text_editor_in_public_views").click
+
       expect(page).to have_content("There is an error in this field.")
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
 
While working on #12966, I found a flaky related of this feature: in this spec sometimes the error is shown but other times isn't shown. This PR fixes it.

#### :pushpin: Related Issues
 
- Related to #12966
 

#### Testing

Run this command before and after
```
for i in $(seq 1 50); do echo $i ; bin/rspec decidim-admin/spec/system/admin_manages_organization_spec.rb -e "marks the comments_max_quired" || break ; done
```
 
#### Stacktrace

https://github.com/decidim/decidim/actions/runs/9414402414/job/26006453673?pr=12966


```
  1) Admin manages organization edit marks the comments_max_length as required
     Failure/Error: expect(page).to have_content("There is an error in this field.")
       expected to find text "There is an error in this field." in "Processes\nAssemblies\nInitiatives\nVotings\nConferences\nGlobal moderations\nPages\nParticipants\nNewsletters\nSettings\nAdmin activity log\nTemplates\nFlatley-Schoen\nSee site\nEnglish\nuser32@example.org\n/\nSettings\n/\nConfiguration\nConfiguration\nAppearance\nHomepage\nScopes\nAreas\nHelp sections\nAllowed external domains\nEdit organization\nName*\nRequired field\nSocial\nX\nFacebook\nInstagram\nYouTube\nGitHub\nDefault locale*\nRequired field\nEnglish\nCatalà\nCastellano\nTime Zone*\nRequired field\n(GMT-12:00) International Date Line West\n(GMT-11:00) American Samoa\n(GMT-11:00) Midway Island\n(GMT-10:00) Hawaii\n(GMT-09:00) Alaska\n(GMT-08:00) Pacific Time (US & Canada)\n(GMT-08:00) Tijuana\n(GMT-07:00) Arizona\n(GMT-07:00) Mazatlan\n(GMT-07:00) Mountain Time (US & Canada)\n(GMT-06:00) Central America\n(GMT-06:00) Central Time (US & Canada)\n(GMT-06:00) Chihuahua\n(GMT-06:00) Guadalajara\n(GMT-06:00) Mexico City\n(GMT-06:00) Monterrey\n(GMT-06:00) Saskatchewan\n(GMT-05:00) Bogota\n(GMT-05:00) Eastern Time (US & Canada)\n(GMT-05:00) Indiana (East)\n(GMT-05:00) Lima\n(GMT-05:00) Quito\n(GMT-04:00) Atlantic Time (Canada)\n(GMT-04:00) Caracas\n(GMT-04:00) Georgetown\n(GMT-04:00) La Paz\n(GMT-04:00) Puerto Rico\n(GMT-04:00) Santiago\n(GMT-03:30) Newfoundland\n(GMT-03:00) Brasilia\n(GMT-03:00) Buenos Aires\n(GMT-03:00) Montevideo\n(GMT-02:00) Greenland\n(GMT-02:00) Mid-Atlantic\n(GMT-01:00) Azores\n(GMT-01:00) Cape Verde Is.\n(GMT+00:00) Edinburgh\n(GMT+00:00) Lisbon\n(GMT+00:00) London\n(GMT+00:00) Monrovia\n(GMT+00:00) UTC\n(GMT+01:00) Amsterdam\n(GMT+01:00) Belgrade\n(GMT+01:00) Berlin\n(GMT+01:00) Bern\n(GMT+01:00) Bratislava\n(GMT+01:00) Brussels\n(GMT+01:00) Budapest\n(GMT+01:00) Casablanca\n(GMT+01:00) Copenhagen\n(GMT+01:00) Dublin\n(GMT+01:00) Ljubljana\n(GMT+01:00) Madrid\n(GMT+01:00) Paris\n(GMT+01:00) Prague\n(GMT+01:00) Rome\n(GMT+01:00) Sarajevo\n(GMT+01:00) Skopje\n(GMT+01:00) Stockholm\n(GMT+01:00) Vienna\n(GMT+01:00) Warsaw\n(GMT+01:00) West Central Africa\n(GMT+01:00) Zagreb\n(GMT+01:00) Zurich\n(GMT+02:00) Athens\n(GMT+02:00) Bucharest\n(GMT+02:00) Cairo\n(GMT+02:00) Harare\n(GMT+02:00) Helsinki\n(GMT+02:00) Jerusalem\n(GMT+02:00) Kaliningrad\n(GMT+02:00) Kyiv\n(GMT+02:00) Pretoria\n(GMT+02:00) Riga\n(GMT+02:00) Sofia\n(GMT+02:00) Tallinn\n(GMT+02:00) Vilnius\n(GMT+03:00) Baghdad\n(GMT+03:00) Istanbul\n(GMT+03:00) Kuwait\n(GMT+03:00) Minsk\n(GMT+03:00) Moscow\n(GMT+03:00) Nairobi\n(GMT+03:00) Riyadh\n(GMT+03:00) St. Petersburg\n(GMT+03:00) Volgograd\n(GMT+03:30) Tehran\n(GMT+04:00) Abu Dhabi\n(GMT+04:00) Baku\n(GMT+04:00) Muscat\n(GMT+04:00) Samara\n(GMT+04:00) Tbilisi\n(GMT+04:00) Yerevan\n(GMT+04:30) Kabul\n(GMT+05:00) Almaty\n(GMT+05:00) Ekaterinburg\n(GMT+05:00) Islamabad\n(GMT+05:00) Karachi\n(GMT+05:00) Tashkent\n(GMT+05:30) Chennai\n(GMT+05:30) Kolkata\n(GMT+05:30) Mumbai\n(GMT+05:30) New Delhi\n(GMT+05:30) Sri Jayawardenepura\n(GMT+05:45) Kathmandu\n(GMT+06:00) Astana\n(GMT+06:00) Dhaka\n(GMT+06:00) Urumqi\n(GMT+06:30) Rangoon\n(GMT+07:00) Bangkok\n(GMT+07:00) Hanoi\n(GMT+07:00) Jakarta\n(GMT+07:00) Krasnoyarsk\n(GMT+07:00) Novosibirsk\n(GMT+08:00) Beijing\n(GMT+08:00) Chongqing\n(GMT+08:00) Hong Kong\n(GMT+08:00) Irkutsk\n(GMT+08:00) Kuala Lumpur\n(GMT+08:00) Perth\n(GMT+08:00) Singapore\n(GMT+08:00) Taipei\n(GMT+08:00) Ulaanbaatar\n(GMT+09:00) Osaka\n(GMT+09:00) Sapporo\n(GMT+09:00) Seoul\n(GMT+09:00) Tokyo\n(GMT+09:00) Yakutsk\n(GMT+09:30) Adelaide\n(GMT+09:30) Darwin\n(GMT+10:00) Brisbane\n(GMT+10:00) Canberra\n(GMT+10:00) Guam\n(GMT+10:00) Hobart\n(GMT+10:00) Melbourne\n(GMT+10:00) Port Moresby\n(GMT+10:00) Sydney\n(GMT+10:00) Vladivostok\n(GMT+11:00) Magadan\n(GMT+11:00) New Caledonia\n(GMT+11:00) Solomon Is.\n(GMT+11:00) Srednekolymsk\n(GMT+12:00) Auckland\n(GMT+12:00) Fiji\n(GMT+12:00) Kamchatka\n(GMT+12:00) Marshall Is.\n(GMT+12:00) Wellington\n(GMT+12:45) Chatham Is.\n(GMT+13:00) Nuku'alofa\n(GMT+13:00) Samoa\n(GMT+13:00) Tokelau Is.\nReference prefix*\nRequired field\nEnable badges\nEnable groups\nEnable participatory space filters\nComments max length (Leave 0 for default value)*\nRequired field\nEnable rich text editor for participants\nIn some text areas, participants will be able to insert some HTML tags by using the rich text editor.\nSend welcome notification\nCustomize welcome notification\nBody for the admin terms of service*\nRequired field\nEnglish\nCatalà\nCastellano\nNormal\nHeading 2\nHeading 3\nHeading 4\nHeading 5\nHeading 6\nPlaceat voluptates voluptas. 418\n\nUpdate". (However, it was found 5 times including non-visible text.)

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_organization_edit_marks_the_comments_max_length_as_required_47.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_organization_edit_marks_the_comments_max_length_as_required_47.html


     # ./spec/system/admin_manages_organization_spec.rb:49:in `block (3 levels) in <top (required)>'

(...)

Finished in 3 minutes 5.2 seconds (files took 9.18 seconds to load)
49 examples, 1 failure

Failed examples:

rspec ./spec/system/admin_manages_organization_spec.rb:43 # Admin manages organization edit marks the comments_max_length as required
```

:hearts: Thank you!
