### PR TITLE
Fix stying in participatory texts

### DIFF
--- a/decidim-proposals/app/packs/entrypoints/participatory_texts_admin.js
+++ b/decidim-proposals/app/packs/entrypoints/participatory_texts_admin.js
@@ -1,0 +1,2 @@
+require.context("../images", true)
+import "stylesheets/decidim/proposals/admin/participatory_texts.scss"

--- a/decidim-proposals/app/packs/stylesheets/decidim/proposals/admin/participatory_texts.scss
+++ b/decidim-proposals/app/packs/stylesheets/decidim/proposals/admin/participatory_texts.scss
@@ -1,0 +1,23 @@
+#participatory-text {
+  li {
+    @apply py-4 hover:cursor-move;
+
+    a {
+      @apply font-bold flex;
+
+      > svg {
+        @apply text-2xl fill-black;
+      }
+
+      &[aria-expanded="true"] {
+        & > svg {
+          @apply rotate-90 transition-transform;
+        }
+      }
+
+      span {
+        @apply ml-auto;
+      }
+    }
+  }
+}

--- a/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/index.html.erb
@@ -1,4 +1,5 @@
 <% add_decidim_page_title(t(".title")) %>
+<%= append_stylesheet_pack_tag "participatory_texts_admin" %>
 
 <div class="item_show__header">
   <h1 class="item_show__header-title">
@@ -15,6 +16,7 @@
             <div class="row column">
               <p class="mt-3"><%= t(".info_1") %></p>
               <ul id="participatory-text" class="draggable-list js-connect js-list-actives mt-2.5 ml-2.5 mr-2.5"
+                  data-component="accordion"
                   data-accordion
                   data-sort-url="#"
                   data-multi-expand="true"
@@ -22,11 +24,13 @@
                 <%= form.fields_for(:proposals) do |prop_form| %>
                   <% proposal = @drafts[prop_form.index] %>
 
-                  <li class="py-4 draggable-content <%= proposal.article? ? "is-active" : nil %>" data-accordion-item draggable="true">
-                    <a href="#" class="font-bold mt-5"><%= preview_participatory_text_section_title(proposal) %>
+                  <li class="draggable-content is-active" data-accordion-item draggable="true">
+                    <a data-open="true" data-controls="article-<%= proposal.id %>">
+                      <%= icon "arrow-right-s-line" %>
+                      <%= preview_participatory_text_section_title(proposal) %>
                       <span><%= icon "menu-line", class: "fill-black" %></span>
                     </a>
-                    <div data-tab-content>
+                    <div data-tab-content id="article-<%= proposal.id %>">
                       <%= render "article-preview", { form: prop_form, proposal: } %>
                     </div>
                   </li>

--- a/decidim-proposals/config/assets.rb
+++ b/decidim-proposals/config/assets.rb
@@ -5,5 +5,6 @@ base_path = File.expand_path("..", __dir__)
 Decidim::Webpacker.register_path("#{base_path}/app/packs")
 Decidim::Webpacker.register_entrypoints(
   decidim_proposals: "#{base_path}/app/packs/entrypoints/decidim_proposals.js",
+  participatory_texts_admin: "#{base_path}/app/packs/entrypoints/participatory_texts_admin.js",
   decidim_proposals_admin: "#{base_path}/app/packs/entrypoints/decidim_proposals_admin.js"
 )


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #11668 we left some items to slide through the cracks so that we move faster. In This PR, we fix one of the 2 issues that we intentionally left unhandled.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #11751
- Fixes #11751

#### Testing
1. Create a new proposal component 
2. Enable the Participatory texts into it 
3. Import a document 
4. See how the drag and drop handle is being displayed 
5. Apply patch 
6. See the drag and drop is moved to the right 
7. See the element is properly marked as draggable using cursor property 
8. See there is a new icon signaling whcih element is collapsible

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
Before: 
![image](https://github.com/decidim/decidim/assets/105683/03a74dde-8b77-40c3-be0f-bfba7319f1ba)

After: 
![image](https://github.com/decidim/decidim/assets/105683/37e966b5-ec7b-4b98-b57e-e45c651925f5)

:hearts: Thank you!
