### PR TITLE
Fix proposal bulk actions buttons display

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -6,9 +6,11 @@
         <%= t(".title") %>
         <span id="js-selected-proposals-count" class="component-counter " title="<%= t("decidim.proposals.admin.proposals.index.selected") %>"></span>
       </div>
-      <%= render partial: "bulk-actions" %>
-      <%= link_to t(".statuses"), proposal_states_path, class: "button button__sm button__secondary" %>
-      <%= render partial: "decidim/admin/components/resource_action" %>
+      <div class="flex items-center gap-x-4">
+        <%= render partial: "bulk-actions" %>
+        <%= link_to t(".statuses"), proposal_states_path, class: "button button__sm button__secondary" %>
+        <%= render partial: "decidim/admin/components/resource_action" %>
+      </div>
     </h1>
   </div>
   <%= admin_filter_selector(:proposals) %>


### PR DESCRIPTION
#### :tophat: What? Why?
Back in https://github.com/decidim/decidim/pull/11668 we left some items to slide through the cracks so that we move faster. In This PR, we fix one of the 2 issues that we intentionally left unhandled.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #11751
- Fixes #11751

#### Testing
1. Signin  as an admin 
2. Visit a budget admin component & navigate to admin projects 
3. Use the checkbox to select actions 
4. From actions menu select change category & see how is being displayed 
5. Visit a proposal admin component  & repeat steps 3 & 4
6. Apply patch 
7. Repeat steps 3 & 4, assess that menu is more compact 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

#### Before: 
![image](https://github.com/decidim/decidim/assets/105683/b9c8e459-0e78-48cc-b1df-0fe45e99d70b)

#### After:
![image](https://github.com/decidim/decidim/assets/105683/7e70d48b-49ef-4565-aed2-6eb68b09a491)

:hearts: Thank you!
