### PR TITLE
Improvements in the assignment of evaluators

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_item_show.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_item_show.scss
@@ -16,6 +16,14 @@
       @apply font-normal;
     }
   }
+
+  &--with-action-options {
+    @apply flex-row flex-wrap;
+  }
+
+  &__action-options {
+    @apply flex bg-background p-8 w-full mt-4 w-full;
+  }
 }
 
 .item_show__content {

--- a/decidim-proposals/app/commands/decidim/proposals/admin/assign_proposals_to_valuator.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/assign_proposals_to_valuator.rb
@@ -35,24 +35,26 @@ module Decidim
         def assign_proposals
           transaction do
             form.proposals.flat_map do |proposal|
-              find_assignment(proposal) || assign_proposal(proposal)
+              form.valuator_roles.each do |valuator_role|
+                find_assignment(proposal, valuator_role) || assign_proposal(proposal, valuator_role)
+              end
             end
           end
         end
 
-        def find_assignment(proposal)
+        def find_assignment(proposal, valuator_role)
           Decidim::Proposals::ValuationAssignment.find_by(
             proposal:,
-            valuator_role: form.valuator_role
+            valuator_role:
           )
         end
 
-        def assign_proposal(proposal)
+        def assign_proposal(proposal, valuator_role)
           Decidim.traceability.create!(
             Decidim::Proposals::ValuationAssignment,
             form.current_user,
             proposal:,
-            valuator_role: form.valuator_role
+            valuator_role:
           )
         end
       end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/unassign_proposals_from_valuator.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/unassign_proposals_from_valuator.rb
@@ -33,16 +33,18 @@ module Decidim
         def unassign_proposals
           transaction do
             form.proposals.flat_map do |proposal|
-              assignment = find_assignment(proposal)
-              unassign(assignment) if assignment
+              form.valuator_roles.each do |valuator_role|
+                assignment = find_assignment(proposal, valuator_role)
+                unassign(assignment) if assignment
+              end
             end
           end
         end
 
-        def find_assignment(proposal)
+        def find_assignment(proposal, valuator_role)
           Decidim::Proposals::ValuationAssignment.find_by(
             proposal:,
-            valuator_role: form.valuator_role
+            valuator_role:
           )
         end
 

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/valuation_assignments_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/valuation_assignments_controller.rb
@@ -25,7 +25,7 @@ module Decidim
         def destroy
           @form = form(Admin::ValuationAssignmentForm).from_params(destroy_params)
 
-          enforce_permission_to :unassign_from_valuator, :proposals, valuator: @form.valuator_user
+          # enforce_permission_to :unassign_from_valuator, :proposals, valuator: @form.valuator_user # fixme
 
           Admin::UnassignProposalsFromValuator.call(@form) do
             on(:ok) do |_proposal|

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/valuation_assignments_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/valuation_assignments_controller.rb
@@ -5,9 +5,11 @@ module Decidim
     module Admin
       class ValuationAssignmentsController < Admin::ApplicationController
         def create
-          enforce_permission_to :assign_to_valuator, :proposals
-
           @form = form(Admin::ValuationAssignmentForm).from_params(params)
+
+          @form.proposals.each do |proposal|
+            enforce_permission_to :assign_to_valuator, :proposals, proposal:
+          end
 
           Admin::AssignProposalsToValuator.call(@form) do
             on(:ok) do |_proposal|

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/valuation_assignments_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/valuation_assignments_controller.rb
@@ -23,9 +23,11 @@ module Decidim
         end
 
         def destroy
-          @form = form(Admin::ValuationAssignmentForm).from_params(destroy_params)
+          @form = form(Admin::ValuationAssignmentForm).from_params(params)
 
-          # enforce_permission_to :unassign_from_valuator, :proposals, valuator: @form.valuator_user # fixme
+          @form.valuator_roles.each do |valuator_role|
+            enforce_permission_to :unassign_from_valuator, :proposals, valuator: valuator_role.user
+          end
 
           Admin::UnassignProposalsFromValuator.call(@form) do
             on(:ok) do |_proposal|
@@ -41,13 +43,6 @@ module Decidim
         end
 
         private
-
-        def destroy_params
-          {
-            id: params.dig(:valuator_role, :id) || params[:id],
-            proposal_ids: params[:proposal_ids] || [params[:proposal_id]]
-          }
-        end
 
         def skip_manage_component_permission
           true

--- a/decidim-proposals/app/forms/decidim/proposals/admin/valuation_assignment_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/valuation_assignment_form.rb
@@ -4,8 +4,6 @@ module Decidim
   module Proposals
     module Admin
       class ValuationAssignmentForm < Decidim::Form
-        # mimic :valuator_role
-
         attribute :id, Integer
         attribute :proposal_ids, Array
         attribute :valuator_role_ids, Array
@@ -20,12 +18,6 @@ module Decidim
         def valuator_roles
           @valuator_roles ||= current_component.participatory_space.user_roles(:valuator).where(id: valuator_role_ids)
         end
-
-        # def valuator_users
-        #   return unless valuator_roles
-
-        #   @valuator_users ||= valuator_roles.user
-        # end
 
         def same_participatory_space
           return if valuator_roles.empty? || !current_component

--- a/decidim-proposals/app/forms/decidim/proposals/admin/valuation_assignment_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/valuation_assignment_form.rb
@@ -4,32 +4,38 @@ module Decidim
   module Proposals
     module Admin
       class ValuationAssignmentForm < Decidim::Form
-        mimic :valuator_role
+        # mimic :valuator_role
 
         attribute :id, Integer
         attribute :proposal_ids, Array
+        attribute :valuator_role_ids, Array
 
-        validates :valuator_role, :proposals, :current_component, presence: true
+        validates :valuator_roles, :proposals, :current_component, presence: true
         validate :same_participatory_space
 
         def proposals
           @proposals ||= Decidim::Proposals::Proposal.where(component: current_component, id: proposal_ids).uniq
         end
 
-        def valuator_role
-          @valuator_role ||= current_component.participatory_space.user_roles(:valuator).find_by(id:)
+        def valuator_roles
+          @valuator_roles ||= current_component.participatory_space.user_roles(:valuator).where(id: valuator_role_ids)
         end
 
-        def valuator_user
-          return unless valuator_role
+        # def valuator_users
+        #   return unless valuator_roles
 
-          @valuator_user ||= valuator_role.user
-        end
+        #   @valuator_users ||= valuator_roles.user
+        # end
 
         def same_participatory_space
-          return if !valuator_role || !current_component
+          return if valuator_roles.empty? || !current_component
 
-          errors.add(:id, :invalid) if current_component.participatory_space != valuator_role.participatory_space
+          valuator_roles.each do |valuator_role|
+            if current_component.participatory_space != valuator_role.participatory_space
+              errors.add(:id, :invalid)
+              break
+            end
+          end
         end
       end
     end

--- a/decidim-proposals/app/helpers/decidim/proposals/admin/proposal_bulk_actions_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/admin/proposal_bulk_actions_helper.rb
@@ -8,26 +8,12 @@ module Decidim
           Decidim::Proposals::Proposal.find(id)
         end
 
-        # Public: Generates a select field with the valuators of the given participatory space.
-        #
-        # participatory_space - A participatory space instance.
-        # prompt - An i18n string to show as prompt
-        #
-        # Returns a String.
-        def bulk_valuators_select(participatory_space, prompt)
-          options_for_select = find_valuators_for_select(participatory_space)
-          select(:valuator_role, :id, options_for_select, prompt:)
-        end
-
-        # A method to cache to queries to find the valuators for the
-        # current space.
+        # find the valuators for the current space.
         def find_valuators_for_select(participatory_space)
-          return @valuators_for_select if @valuators_for_select
-
           valuator_roles = participatory_space.user_roles(:valuator)
           valuators = Decidim::User.where(id: valuator_roles.pluck(:decidim_user_id)).to_a
 
-          @valuators_for_select = valuator_roles.map do |role|
+          valuator_roles.map do |role|
             valuator = valuators.find { |user| user.id == role.decidim_user_id }
 
             [valuator.name, role.id]

--- a/decidim-proposals/app/helpers/decidim/proposals/admin/proposal_bulk_actions_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/admin/proposal_bulk_actions_helper.rb
@@ -9,11 +9,15 @@ module Decidim
         end
 
         # find the valuators for the current space.
-        def find_valuators_for_select(participatory_space)
+        def find_valuators_for_select(participatory_space, current_user)
           valuator_roles = participatory_space.user_roles(:valuator)
           valuators = Decidim::User.where(id: valuator_roles.pluck(:decidim_user_id)).to_a
 
-          valuator_roles.map do |role|
+          filtered_valuator_roles = valuator_roles.filter do |role|
+            role.decidim_user_id != current_user.id
+          end
+
+          filtered_valuator_roles.map do |role|
             valuator = valuators.find { |user| user.id == role.decidim_user_id }
 
             [valuator.name, role.id]

--- a/decidim-proposals/app/helpers/decidim/proposals/admin/proposal_bulk_actions_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/admin/proposal_bulk_actions_helper.rb
@@ -19,7 +19,7 @@ module Decidim
           select(:valuator_role, :id, options_for_select, prompt:)
         end
 
-        # Internal: A method to cache to queries to find the valuators for the
+        # A method to cache to queries to find the valuators for the
         # current space.
         def find_valuators_for_select(participatory_space)
           return @valuators_for_select if @valuators_for_select

--- a/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals.js
+++ b/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals.js
@@ -86,9 +86,10 @@ $(() => {
 
     $("#js-bulk-actions-dropdown ul li button").click(function (e) {
       $("#js-bulk-actions-dropdown").removeClass("is-open");
+      hideBulkActionForms();
 
       let action = $(e.target).data("action");
-      const newActions = [
+      const panelActions = [
         "assign-proposals-to-valuator",
         "unassign-proposals-from-valuator"
       ];
@@ -97,7 +98,7 @@ $(() => {
         return;
       }
 
-      if (newActions.includes(action)) {
+      if (panelActions.includes(action)) {
         $(`#js-form-${action}`).submit(function () {
           $(".layout-content > div[data-callout-wrapper]").html("");
         });

--- a/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals.js
+++ b/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals.js
@@ -18,6 +18,8 @@ $(() => {
     const selectedProposalsNotPublishedAnswer = selectedProposalsNotPublishedAnswerCount();
     if (selectedProposals === 0) {
       $("#js-selected-proposals-count").text("")
+      $("#js-assign-proposals-to-valuator-actions").addClass("hide");
+      $("#js-unassign-proposals-from-valuator-actions").addClass("hide");
     } else {
       $("#js-selected-proposals-count").text(selectedProposals);
     }

--- a/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals.js
+++ b/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals.js
@@ -89,16 +89,19 @@ $(() => {
     $("#js-bulk-actions-button").addClass("hide");
 
     $("#js-bulk-actions-dropdown ul li button").click(function (e) {
-      // e.preventDefault();
       $("#js-bulk-actions-dropdown").removeClass("is-open");
 
       let action = $(e.target).data("action");
+      const newActions = [
+        "assign-proposals-to-valuator",
+        "unassign-proposals-from-valuator"
+      ];
 
       if (!action) {
         return;
       }
 
-      if (action === "assign-proposals-to-valuator") {
+      if (newActions.includes(action)) {
         $(`#js-form-${action}`).submit(function () {
           $(".layout-content > div[data-callout-wrapper]").html("");
         });

--- a/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals.js
+++ b/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals.js
@@ -5,22 +5,19 @@
 import TomSelect from "tom-select/dist/cjs/tom-select.popular";
 
 $(() => {
-  const selectedProposalsCount = function () {
-    return $(".table-list .js-check-all-proposal:checked").length;
-  };
+  const selectedProposalsCount = function() {
+    return $(".table-list .js-check-all-proposal:checked").length
+  }
 
-  const selectedProposalsNotPublishedAnswerCount = function () {
-    return $(
-      ".table-list [data-published-state=false] .js-check-all-proposal:checked"
-    ).length;
-  };
+  const selectedProposalsNotPublishedAnswerCount = function() {
+    return $(".table-list [data-published-state=false] .js-check-all-proposal:checked").length
+  }
 
-  const selectedProposalsCountUpdate = function () {
+  const selectedProposalsCountUpdate = function() {
     const selectedProposals = selectedProposalsCount();
-    const selectedProposalsNotPublishedAnswer =
-      selectedProposalsNotPublishedAnswerCount();
+    const selectedProposalsNotPublishedAnswer = selectedProposalsNotPublishedAnswerCount();
     if (selectedProposals === 0) {
-      $("#js-selected-proposals-count").text("");
+      $("#js-selected-proposals-count").text("")
     } else {
       $("#js-selected-proposals-count").text(selectedProposals);
     }
@@ -33,49 +30,46 @@ $(() => {
 
     if (selectedProposalsNotPublishedAnswer > 0) {
       $('button[data-action="publish-answers"]').parent().show();
-      $("#js-form-publish-answers-number").text(
-        selectedProposalsNotPublishedAnswer
-      );
+      $("#js-form-publish-answers-number").text(selectedProposalsNotPublishedAnswer);
     } else {
       $('button[data-action="publish-answers"]').parent().hide();
     }
-  };
+  }
 
-  const showBulkActionsButton = function () {
+  const showBulkActionsButton = function() {
     if (selectedProposalsCount() > 0) {
       $("#js-bulk-actions-button").removeClass("hide");
     }
-  };
+  }
 
-  const hideBulkActionsButton = function (force = false) {
+  const hideBulkActionsButton = function(force = false) {
     if (selectedProposalsCount() === 0 || force === true) {
       $("#js-bulk-actions-button").addClass("hide");
       $("#js-bulk-actions-dropdown").removeClass("is-open");
     }
-  };
+  }
 
-  const resetForms = function () {
-    $("#js-bulk-actions-dropdown button").each(function () {
+  const resetForms = function() {
+    $("#js-bulk-actions-dropdown button").each(function() {
       $(`#js-form-${$(this).data("action")}`)[0].reset();
-    });
-  };
+    })
+  }
 
-  const showOtherActionsButtons = function () {
+  const showOtherActionsButtons = function() {
     $("#js-other-actions-wrapper").removeClass("hide");
-  };
+  }
 
-  const hideOtherActionsButtons = function () {
+  const hideOtherActionsButtons = function() {
     $("#js-other-actions-wrapper").addClass("hide");
-  };
+  }
 
-  const hideBulkActionForms = function () {
+  const hideBulkActionForms = function() {
     $(".js-bulk-action-form").addClass("hide");
-  };
+  }
 
   // Expose functions to make them available in .js.erb templates
   window.selectedProposalsCount = selectedProposalsCount;
-  window.selectedProposalsNotPublishedAnswerCount =
-    selectedProposalsNotPublishedAnswerCount;
+  window.selectedProposalsNotPublishedAnswerCount = selectedProposalsNotPublishedAnswerCount;
   window.selectedProposalsCountUpdate = selectedProposalsCountUpdate;
   window.showBulkActionsButton = showBulkActionsButton;
   window.hideBulkActionsButton = hideBulkActionsButton;
@@ -119,7 +113,7 @@ $(() => {
     });
 
     // select all checkboxes
-    $(".js-check-all").change(function () {
+    $(".js-check-all").change(function() {
       $(".js-check-all-proposal").prop("checked", $(this).prop("checked"));
 
       if ($(this).prop("checked")) {
@@ -135,18 +129,15 @@ $(() => {
 
     // proposal checkbox change
     $(".table-list").on("change", ".js-check-all-proposal", function (e) {
-      let proposalId = $(this).val();
-      let checked = $(this).prop("checked");
+      let proposalId = $(this).val()
+      let checked = $(this).prop("checked")
 
       // uncheck "select all", if one of the listed checkbox item is unchecked
       if ($(this).prop("checked") === false) {
         $(".js-check-all").prop("checked", false);
       }
       // check "select all" if all checkbox proposals are checked
-      if (
-        $(".js-check-all-proposal:checked").length ===
-        $(".js-check-all-proposal").length
-      ) {
+      if ($(".js-check-all-proposal:checked").length === $(".js-check-all-proposal").length) {
         $(".js-check-all").prop("checked", true);
         showBulkActionsButton();
       }
@@ -163,14 +154,12 @@ $(() => {
         hideBulkActionsButton();
       }
 
-      $(".js-bulk-action-form")
-        .find(`.js-proposal-id-${proposalId}`)
-        .prop("checked", checked);
+      $(".js-bulk-action-form").find(`.js-proposal-id-${proposalId}`).prop("checked", checked);
       selectedProposalsCountUpdate();
     });
 
     $(".js-cancel-bulk-action").on("click", function (e) {
-      hideBulkActionForms();
+      hideBulkActionForms()
       showBulkActionsButton();
       showOtherActionsButtons();
     });

--- a/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals.js
+++ b/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals.js
@@ -2,20 +2,25 @@
 /* eslint no-unused-vars: 0 */
 /* eslint id-length: ["error", { "exceptions": ["e"] }] */
 
+import TomSelect from "tom-select/dist/cjs/tom-select.popular";
+
 $(() => {
-  const selectedProposalsCount = function() {
-    return $(".table-list .js-check-all-proposal:checked").length
-  }
+  const selectedProposalsCount = function () {
+    return $(".table-list .js-check-all-proposal:checked").length;
+  };
 
-  const selectedProposalsNotPublishedAnswerCount = function() {
-    return $(".table-list [data-published-state=false] .js-check-all-proposal:checked").length
-  }
+  const selectedProposalsNotPublishedAnswerCount = function () {
+    return $(
+      ".table-list [data-published-state=false] .js-check-all-proposal:checked"
+    ).length;
+  };
 
-  const selectedProposalsCountUpdate = function() {
+  const selectedProposalsCountUpdate = function () {
     const selectedProposals = selectedProposalsCount();
-    const selectedProposalsNotPublishedAnswer = selectedProposalsNotPublishedAnswerCount();
+    const selectedProposalsNotPublishedAnswer =
+      selectedProposalsNotPublishedAnswerCount();
     if (selectedProposals === 0) {
-      $("#js-selected-proposals-count").text("")
+      $("#js-selected-proposals-count").text("");
     } else {
       $("#js-selected-proposals-count").text(selectedProposals);
     }
@@ -28,46 +33,49 @@ $(() => {
 
     if (selectedProposalsNotPublishedAnswer > 0) {
       $('button[data-action="publish-answers"]').parent().show();
-      $("#js-form-publish-answers-number").text(selectedProposalsNotPublishedAnswer);
+      $("#js-form-publish-answers-number").text(
+        selectedProposalsNotPublishedAnswer
+      );
     } else {
       $('button[data-action="publish-answers"]').parent().hide();
     }
-  }
+  };
 
-  const showBulkActionsButton = function() {
+  const showBulkActionsButton = function () {
     if (selectedProposalsCount() > 0) {
       $("#js-bulk-actions-button").removeClass("hide");
     }
-  }
+  };
 
-  const hideBulkActionsButton = function(force = false) {
+  const hideBulkActionsButton = function (force = false) {
     if (selectedProposalsCount() === 0 || force === true) {
       $("#js-bulk-actions-button").addClass("hide");
       $("#js-bulk-actions-dropdown").removeClass("is-open");
     }
-  }
+  };
 
-  const resetForms = function() {
-    $("#js-bulk-actions-dropdown button").each(function() {
+  const resetForms = function () {
+    $("#js-bulk-actions-dropdown button").each(function () {
       $(`#js-form-${$(this).data("action")}`)[0].reset();
-    })
-  }
+    });
+  };
 
-  const showOtherActionsButtons = function() {
+  const showOtherActionsButtons = function () {
     $("#js-other-actions-wrapper").removeClass("hide");
-  }
+  };
 
-  const hideOtherActionsButtons = function() {
+  const hideOtherActionsButtons = function () {
     $("#js-other-actions-wrapper").addClass("hide");
-  }
+  };
 
-  const hideBulkActionForms = function() {
+  const hideBulkActionForms = function () {
     $(".js-bulk-action-form").addClass("hide");
-  }
+  };
 
   // Expose functions to make them available in .js.erb templates
   window.selectedProposalsCount = selectedProposalsCount;
-  window.selectedProposalsNotPublishedAnswerCount = selectedProposalsNotPublishedAnswerCount;
+  window.selectedProposalsNotPublishedAnswerCount =
+    selectedProposalsNotPublishedAnswerCount;
   window.selectedProposalsCountUpdate = selectedProposalsCountUpdate;
   window.showBulkActionsButton = showBulkActionsButton;
   window.hideBulkActionsButton = hideBulkActionsButton;
@@ -80,23 +88,35 @@ $(() => {
     hideBulkActionForms();
     $("#js-bulk-actions-button").addClass("hide");
 
-    $("#js-bulk-actions-dropdown ul li button").click(function(e) {
-      e.preventDefault();
+    $("#js-bulk-actions-dropdown ul li button").click(function (e) {
+      // e.preventDefault();
+      $("#js-bulk-actions-dropdown").removeClass("is-open");
+
       let action = $(e.target).data("action");
 
-      if (action) {
-        $(`#js-form-${action}`).submit(function() {
+      if (!action) {
+        return;
+      }
+
+      if (action === "assign-proposals-to-valuator") {
+        $(`#js-form-${action}`).submit(function () {
           $(".layout-content > div[data-callout-wrapper]").html("");
-        })
+        });
+
+        $(`#js-${action}-actions`).removeClass("hide");
+      } else {
+        $(`#js-form-${action}`).submit(function () {
+          $(".layout-content > div[data-callout-wrapper]").html("");
+        });
 
         $(`#js-${action}-actions`).removeClass("hide");
         hideBulkActionsButton(true);
         hideOtherActionsButtons();
       }
-    })
+    });
 
     // select all checkboxes
-    $(".js-check-all").change(function() {
+    $(".js-check-all").change(function () {
       $(".js-check-all-proposal").prop("checked", $(this).prop("checked"));
 
       if ($(this).prop("checked")) {
@@ -112,15 +132,18 @@ $(() => {
 
     // proposal checkbox change
     $(".table-list").on("change", ".js-check-all-proposal", function (e) {
-      let proposalId = $(this).val()
-      let checked = $(this).prop("checked")
+      let proposalId = $(this).val();
+      let checked = $(this).prop("checked");
 
       // uncheck "select all", if one of the listed checkbox item is unchecked
       if ($(this).prop("checked") === false) {
         $(".js-check-all").prop("checked", false);
       }
       // check "select all" if all checkbox proposals are checked
-      if ($(".js-check-all-proposal:checked").length === $(".js-check-all-proposal").length) {
+      if (
+        $(".js-check-all-proposal:checked").length ===
+        $(".js-check-all-proposal").length
+      ) {
         $(".js-check-all").prop("checked", true);
         showBulkActionsButton();
       }
@@ -137,14 +160,31 @@ $(() => {
         hideBulkActionsButton();
       }
 
-      $(".js-bulk-action-form").find(`.js-proposal-id-${proposalId}`).prop("checked", checked);
+      $(".js-bulk-action-form")
+        .find(`.js-proposal-id-${proposalId}`)
+        .prop("checked", checked);
       selectedProposalsCountUpdate();
     });
 
     $(".js-cancel-bulk-action").on("click", function (e) {
-      hideBulkActionForms()
+      hideBulkActionForms();
       showBulkActionsButton();
       showOtherActionsButtons();
     });
   }
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+  const valuatorMultiselectContainers = document.querySelectorAll(
+    ".js-valuator-multiselect"
+  );
+
+  valuatorMultiselectContainers.forEach((container) => {
+    const config = {
+      plugins: ["remove_button", "dropdown_input"],
+      allowEmptyOption: true
+    };
+
+    return new TomSelect(container, config);
+  });
 });

--- a/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
@@ -15,7 +15,11 @@ module Decidim
               can_create_proposal_answer?
             end
             can_export_proposals?
-            valuator_can_unassign_valuator_from_proposals?
+
+            if user_is_context_valuator?
+              can_unassign_valuator_from_proposals?
+              can_assign_valuator_to_proposals?
+            end
 
             return permission_action
           end
@@ -49,7 +53,7 @@ module Decidim
           allow! if permission_action.subject == :proposals && permission_action.action == :split
 
           # Every user allowed by the space can assign proposals to a valuator
-          allow! if permission_action.subject == :proposals && permission_action.action == :assign_to_valuator
+          can_assign_valuator_to_proposals?
 
           # Every user allowed by the space can unassign a valuator from proposals
           can_unassign_valuator_from_proposals?
@@ -145,12 +149,20 @@ module Decidim
           toggle_allow(admin_proposal_answering_is_enabled?) if permission_action.subject == :proposal_answer
         end
 
+        def can_assign_valuator_to_proposals?
+          allow! if permission_action.subject == :proposals && permission_action.action == :assign_to_valuator
+        end
+
         def can_unassign_valuator_from_proposals?
           allow! if permission_action.subject == :proposals && permission_action.action == :unassign_from_valuator
         end
 
         def valuator_can_unassign_valuator_from_proposals?
-          can_unassign_valuator_from_proposals? if user == context.fetch(:valuator, nil)
+          can_unassign_valuator_from_proposals?
+        end
+
+        def user_is_context_valuator?
+          user == context.fetch(:valuator, nil)
         end
 
         def can_export_proposals?

--- a/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
@@ -16,7 +16,6 @@ module Decidim
               can_assign_valuator_to_proposal?
             end
             can_export_proposals?
-            valuator_can_unassign_valuator_from_proposals?
 
             return permission_action
           end
@@ -152,10 +151,6 @@ module Decidim
 
         def can_assign_valuator_to_proposal?
           allow! if permission_action.subject == :proposals && permission_action.action == :assign_to_valuator
-        end
-
-        def valuator_can_unassign_valuator_from_proposals?
-          can_unassign_valuator_from_proposals? if user == context.fetch(:valuator, nil)
         end
 
         def can_export_proposals?

--- a/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
@@ -13,6 +13,7 @@ module Decidim
             if valuator_assigned_to_proposal?
               can_create_proposal_note?
               can_create_proposal_answer?
+              can_assign_valuator_to_proposal?
             end
             can_export_proposals?
             valuator_can_unassign_valuator_from_proposals?
@@ -49,7 +50,7 @@ module Decidim
           allow! if permission_action.subject == :proposals && permission_action.action == :split
 
           # Every user allowed by the space can assign proposals to a valuator
-          allow! if permission_action.subject == :proposals && permission_action.action == :assign_to_valuator
+          can_assign_valuator_to_proposal?
 
           # Every user allowed by the space can unassign a valuator from proposals
           can_unassign_valuator_from_proposals?
@@ -147,6 +148,10 @@ module Decidim
 
         def can_unassign_valuator_from_proposals?
           allow! if permission_action.subject == :proposals && permission_action.action == :unassign_from_valuator
+        end
+
+        def can_assign_valuator_to_proposal?
+          allow! if permission_action.subject == :proposals && permission_action.action == :assign_to_valuator
         end
 
         def valuator_can_unassign_valuator_from_proposals?

--- a/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/admin/permissions.rb
@@ -15,11 +15,7 @@ module Decidim
               can_create_proposal_answer?
             end
             can_export_proposals?
-
-            if user_is_context_valuator?
-              can_unassign_valuator_from_proposals?
-              can_assign_valuator_to_proposals?
-            end
+            valuator_can_unassign_valuator_from_proposals?
 
             return permission_action
           end
@@ -53,7 +49,7 @@ module Decidim
           allow! if permission_action.subject == :proposals && permission_action.action == :split
 
           # Every user allowed by the space can assign proposals to a valuator
-          can_assign_valuator_to_proposals?
+          allow! if permission_action.subject == :proposals && permission_action.action == :assign_to_valuator
 
           # Every user allowed by the space can unassign a valuator from proposals
           can_unassign_valuator_from_proposals?
@@ -149,20 +145,12 @@ module Decidim
           toggle_allow(admin_proposal_answering_is_enabled?) if permission_action.subject == :proposal_answer
         end
 
-        def can_assign_valuator_to_proposals?
-          allow! if permission_action.subject == :proposals && permission_action.action == :assign_to_valuator
-        end
-
         def can_unassign_valuator_from_proposals?
           allow! if permission_action.subject == :proposals && permission_action.action == :unassign_from_valuator
         end
 
         def valuator_can_unassign_valuator_from_proposals?
-          can_unassign_valuator_from_proposals?
-        end
-
-        def user_is_context_valuator?
-          user == context.fetch(:valuator, nil)
+          can_unassign_valuator_from_proposals? if user == context.fetch(:valuator, nil)
         end
 
         def can_export_proposals?

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
@@ -30,5 +30,4 @@
 <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/scope-change" %>
 <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/merge" %>
 <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/split" %>
-<%= render partial: "decidim/proposals/admin/proposals/bulk_actions/unassign_from_valuator" %>
 <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/publish_answers" %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
@@ -30,6 +30,5 @@
 <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/scope-change" %>
 <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/merge" %>
 <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/split" %>
-<%= render partial: "decidim/proposals/admin/proposals/bulk_actions/assign_to_valuator" %>
 <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/unassign_from_valuator" %>
 <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/publish_answers" %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
@@ -56,7 +56,7 @@
   </td>
 
   <td class="valuators-count">
-    <%= proposal.valuation_assignments.size %>
+    <%= proposal.valuation_assignments_count %>
   </td>
 
   <td>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_assign_to_valuator.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_assign_to_valuator.html.erb
@@ -6,9 +6,9 @@
       <% end %>
     </div>
 
-    <label class="w-full font-semibold" for="valuator_role_ids">
+    <label class="w-full font-semibold" for="assign_valuator_role_ids">
       <%= t("decidim.proposals.admin.proposals.index.assign_to_valuator") %>
-      <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/valuators_picker", locals: { participatory_space: current_participatory_space } %>
+      <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/valuators_picker", locals: { participatory_space: current_participatory_space, select_id: "assign_valuator_role_ids" } %>
     </label>
 
     <div class="flex justify-end gap-x-4 mt-2">

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_assign_to_valuator.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_assign_to_valuator.html.erb
@@ -1,15 +1,16 @@
-<div id="js-assign-proposals-to-valuator-actions" class="hide js-bulk-action-form">
-  <%= form_tag(valuation_assignment_path, method: :post, id: "js-form-assign-proposals-to-valuator", class: "form form-defaults flex items-center gap-x-2") do %>
+<div id="js-assign-proposals-to-valuator-actions" class="item_show__header__action-options js-bulk-action-form hide">
+  <%= form_tag(valuation_assignment_path, method: :post, id: "js-form-assign-proposals-to-valuator", class: "form form-defaults w-full") do %>
     <div class="hide">
       <% proposals.each do |proposal| %>
         <%= check_box_tag "proposal_ids[]", proposal.id, false, class: "js-check-all-proposal js-proposal-id-#{proposal.id}" %>
       <% end %>
     </div>
 
-    <%= bulk_valuators_select(current_participatory_space, t("decidim.proposals.admin.proposals.index.assign_to_valuator")) %>
+    <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/valuators_picker", locals: { participatory_space: current_participatory_space } %>
 
-    <%= submit_tag(t("decidim.proposals.admin.proposals.index.assign_to_valuator_button"), id: "js-submit-assign-proposals-to-valuator", class: "button button__sm button__secondary small button--simple float-left") %>
-
-    <button id="js-cancel-assign-proposals-to-valuator" class="button button__sm button__secondary js-cancel-bulk-action" type="button"><%= t("decidim.proposals.admin.proposals.index.cancel") %></button>
+    <div class="flex justify-end gap-x-4 mt-2">
+      <%= submit_tag(t("decidim.proposals.admin.proposals.index.assign_to_valuator_button"), id: "js-submit-assign-proposals-to-valuator", class: "button button__sm button__secondary small button--simple float-left") %>
+      <button class="button button__sm button__secondary js-cancel-bulk-action" type="button"><%= t("decidim.proposals.admin.proposals.index.cancel") %></button>
+    </div>
   <% end %>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_assign_to_valuator.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_assign_to_valuator.html.erb
@@ -6,7 +6,10 @@
       <% end %>
     </div>
 
-    <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/valuators_picker", locals: { participatory_space: current_participatory_space } %>
+    <label class="w-full font-semibold" for="valuator_role_ids">
+      <%= t("decidim.proposals.admin.proposals.index.assign_to_valuator") %>
+      <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/valuators_picker", locals: { participatory_space: current_participatory_space } %>
+    </label>
 
     <div class="flex justify-end gap-x-4 mt-2">
       <%= submit_tag(t("decidim.proposals.admin.proposals.index.assign_to_valuator_button"), id: "js-submit-assign-proposals-to-valuator", class: "button button__sm button__secondary small button--simple float-left") %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
@@ -42,11 +42,13 @@
           <%= t("decidim.proposals.admin.proposals.index.assign_to_valuator") %>
         </button>
       </li>
-      <li>
-        <button type="button" data-action="unassign-proposals-from-valuator">
-          <%= t("decidim.proposals.admin.proposals.index.unassign_from_valuator") %>
-        </button>
-      </li>
+      <% if allowed_to? :unassign_from_valuator, :proposals, valuator: current_user %>
+        <li>
+          <button type="button" data-action="unassign-proposals-from-valuator">
+            <%= t("decidim.proposals.admin.proposals.index.unassign_from_valuator") %>
+          </button>
+        </li>
+      <% end %>
       <li>
         <button type="button" data-action="publish-answers">
           <%= t("decidim.proposals.admin.proposals.index.publish_answers") %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_unassign_from_valuator.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_unassign_from_valuator.html.erb
@@ -1,15 +1,19 @@
-<div id="js-unassign-proposals-from-valuator-actions" class="hide js-bulk-action-form">
-  <%= form_tag(valuation_assignment_path, method: :delete, id: "js-form-unassign-proposals-from-valuator", class: "form form-defaults flex items-center gap-x-2") do %>
+<div id="js-unassign-proposals-from-valuator-actions" class="item_show__header__action-options js-bulk-action-form hide">
+  <%= form_tag(valuation_assignment_path, method: :delete, id: "js-form-unassign-proposals-from-valuator", class: "form form-defaults w-full") do %>
     <div class="hide">
       <% proposals.each do |proposal| %>
         <%= check_box_tag "proposal_ids[]", proposal.id, false, class: "js-check-all-proposal js-proposal-id-#{proposal.id}" %>
       <% end %>
     </div>
 
-    <%= bulk_valuators_select(current_participatory_space, t("decidim.proposals.admin.proposals.index.unassign_from_valuator")) %>
+    <label class="w-full font-semibold" for="valuator_role_ids">
+      <%= t("decidim.proposals.admin.proposals.index.unassign_from_valuator") %>
+      <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/valuators_picker", locals: { participatory_space: current_participatory_space } %>
+    </label>
 
-    <%= submit_tag(t("decidim.proposals.admin.proposals.index.unassign_from_valuator_button"), id: "js-submit-unassign-proposals-from-valuator", class: "button button__sm button__secondary small button--simple float-left") %>
-
-    <button id="js-cancel-unassign-proposals-from-valuator" class="button button__sm button__secondary js-cancel-bulk-action" type="button"><%= t("decidim.proposals.admin.proposals.index.cancel") %></button>
+    <div class="flex justify-end gap-x-4 mt-2">
+      <%= submit_tag(t("decidim.proposals.admin.proposals.index.unassign_from_valuator_button"), id: "js-submit-assign-proposals-from-valuator", class: "button button__sm button__secondary small button--simple float-left") %>
+      <button class="button button__sm button__secondary js-cancel-bulk-action" type="button"><%= t("decidim.proposals.admin.proposals.index.cancel") %></button>
+    </div>
   <% end %>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_unassign_from_valuator.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_unassign_from_valuator.html.erb
@@ -6,13 +6,13 @@
       <% end %>
     </div>
 
-    <label class="w-full font-semibold" for="valuator_role_ids">
+    <label class="w-full font-semibold" for="unassign_valuator_role_ids">
       <%= t("decidim.proposals.admin.proposals.index.unassign_from_valuator") %>
-      <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/valuators_picker", locals: { participatory_space: current_participatory_space } %>
+      <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/valuators_picker", locals: { participatory_space: current_participatory_space, select_id: "unassign_valuator_role_ids" } %>
     </label>
 
     <div class="flex justify-end gap-x-4 mt-2">
-      <%= submit_tag(t("decidim.proposals.admin.proposals.index.unassign_from_valuator_button"), id: "js-submit-assign-proposals-from-valuator", class: "button button__sm button__secondary small button--simple float-left") %>
+      <%= submit_tag(t("decidim.proposals.admin.proposals.index.unassign_from_valuator_button"), id: "js-submit-unassign-proposals-from-valuator", class: "button button__sm button__secondary small button--simple float-left") %>
       <button class="button button__sm button__secondary js-cancel-bulk-action" type="button"><%= t("decidim.proposals.admin.proposals.index.cancel") %></button>
     </div>
   <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_valuators_picker.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_valuators_picker.html.erb
@@ -3,7 +3,7 @@
 <select
   id="<%= select_id %>"
   name="valuator_role_ids[]"
-  placeholder="<%= t("decidim.proposals.admin.proposals.index.filter") %>"
+  placeholder="<%= t("decidim.proposals.admin.proposals.index.select_valuators") %>"
   class="w-full mt-2 js-valuator-multiselect"
   multiple>
   <%= find_valuators_for_select(participatory_space, current_user).map do |option| %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_valuators_picker.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_valuators_picker.html.erb
@@ -1,17 +1,13 @@
 <%= append_stylesheet_pack_tag "decidim_proposals", media: "all" %>
-<%= append_javascript_pack_tag "decidim_proposals" %>
 
-<label class="w-full font-semibold" for="valuators_multiselect">
-  Assign to valuator
-  <select
-    id="valuator_role_ids"
-    name="valuator_role_ids[]"
-    placeholder="Filtrar"
-    class="w-full mt-2 js-valuator-multiselect"
-    multiple
-  >
-    <%= find_valuators_for_select(participatory_space).map do |option| %>
-      <option value="<%= option[1] %>"><%= option[0] %></option>
-    <% end %>
-  </select>
-</label>
+<select
+  id="valuator_role_ids"
+  name="valuator_role_ids[]"
+  placeholder="<%= t("decidim.proposals.admin.proposals.index.filter") %>"
+  class="w-full mt-2 js-valuator-multiselect"
+  multiple
+>
+  <%= find_valuators_for_select(participatory_space).map do |option| %>
+    <option value="<%= option[1] %>"><%= option[0] %></option>
+  <% end %>
+</select>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_valuators_picker.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_valuators_picker.html.erb
@@ -1,7 +1,7 @@
 <%= append_stylesheet_pack_tag "decidim_proposals", media: "all" %>
 
 <select
-  id="valuator_role_ids"
+  id="<%= select_id %>"
   name="valuator_role_ids[]"
   placeholder="<%= t("decidim.proposals.admin.proposals.index.filter") %>"
   class="w-full mt-2 js-valuator-multiselect"

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_valuators_picker.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_valuators_picker.html.erb
@@ -5,8 +5,7 @@
   name="valuator_role_ids[]"
   placeholder="<%= t("decidim.proposals.admin.proposals.index.filter") %>"
   class="w-full mt-2 js-valuator-multiselect"
-  multiple
->
+  multiple>
   <%= find_valuators_for_select(participatory_space).map do |option| %>
     <option value="<%= option[1] %>"><%= option[0] %></option>
   <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_valuators_picker.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_valuators_picker.html.erb
@@ -1,0 +1,17 @@
+<%= append_stylesheet_pack_tag "decidim_proposals", media: "all" %>
+<%= append_javascript_pack_tag "decidim_proposals" %>
+
+<label class="w-full font-semibold" for="valuators_multiselect">
+  Assign to valuator
+  <select
+    id="valuator_role_ids"
+    name="valuator_role_ids[]"
+    placeholder="Filtrar"
+    class="w-full mt-2 js-valuator-multiselect"
+    multiple
+  >
+    <%= find_valuators_for_select(participatory_space).map do |option| %>
+      <option value="<%= option[1] %>"><%= option[0] %></option>
+    <% end %>
+  </select>
+</label>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_valuators_picker.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_valuators_picker.html.erb
@@ -6,7 +6,7 @@
   placeholder="<%= t("decidim.proposals.admin.proposals.index.filter") %>"
   class="w-full mt-2 js-valuator-multiselect"
   multiple>
-  <%= find_valuators_for_select(participatory_space).map do |option| %>
+  <%= find_valuators_for_select(participatory_space, current_user).map do |option| %>
     <option value="<%= option[1] %>"><%= option[0] %></option>
   <% end %>
 </select>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -12,6 +12,7 @@
     </h1>
 
     <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/assign_to_valuator" %>
+    <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/unassign_from_valuator" %>
   </div>
   <%= admin_filter_selector(:proposals) %>
   <div class="table-scroll mt-16">

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -1,6 +1,6 @@
 <% add_decidim_page_title(t(".title")) %>
 <div class="card">
-  <div class="item_show__header">
+  <div class="item_show__header item_show__header--with-action-options">
     <h1 class="item_show__header-title">
       <div>
         <%= t(".title") %>
@@ -10,6 +10,8 @@
       <%= link_to t(".statuses"), proposal_states_path, class: "button button__sm button__secondary" %>
       <%= render partial: "decidim/admin/components/resource_action" %>
     </h1>
+
+    <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/assign_to_valuator" %>
   </div>
   <%= admin_filter_selector(:proposals) %>
   <div class="table-scroll mt-16">

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
@@ -217,7 +217,7 @@
                 <% if allowed_to? :unassign_from_valuator, :proposals, valuator: assignment.valuator %>
                   <%= icon_link_to(
                         "delete-bin-line",
-                        proposal_valuation_assignment_path(proposal, assignment.valuator_role),
+                        valuation_assignment_path(proposal_ids: [proposal.id], valuator_role_ids: [assignment.valuator_role.id]),
                         t(".remove_assignment"),
                         method: :delete,
                         data: { confirm: t(".remove_assignment_confirmation") },

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -518,6 +518,7 @@ en:
             cancel: Cancel
             change_category: Change category
             change_scope: Change scope
+            filter: Filter
             merge: Merge into a new one
             merge_button: Merge
             publish: Publish

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -518,12 +518,12 @@ en:
             cancel: Cancel
             change_category: Change category
             change_scope: Change scope
-            filter: Select one or more valuators
             merge: Merge into a new one
             merge_button: Merge
             publish: Publish
             publish_answers: Publish answers
             select_component: Select a component
+            select_valuators: Select one or more valuators
             selected: selected
             split: Split proposals
             split_button: Split

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -518,7 +518,7 @@ en:
             cancel: Cancel
             change_category: Change category
             change_scope: Change scope
-            filter: Filter
+            filter: Select one or more valuators
             merge: Merge into a new one
             merge_button: Merge
             publish: Publish

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/assign_proposals_to_valuator_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/assign_proposals_to_valuator_spec.rb
@@ -13,13 +13,14 @@ module Decidim
           let(:organization) { space.organization }
           let(:user) { create(:user, organization:) }
           let(:valuator_role) { create(:participatory_process_user_role, role: :valuator, user:, participatory_process: space) }
+          let(:valuator_roles) { [valuator_role] }
           let(:form) do
             instance_double(
               ValuationAssignmentForm,
               current_user: user,
               current_component:,
               current_organization: current_component.organization,
-              valuator_role:,
+              valuator_roles:,
               proposals: [proposal],
               valid?: valid
             )

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/unassign_proposals_from_valuator_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/unassign_proposals_from_valuator_spec.rb
@@ -15,6 +15,7 @@ module Decidim
           let(:user) { create(:user, organization:) }
           let(:valuator) { create(:user, organization:) }
           let(:valuator_role) { create(:participatory_process_user_role, role: :valuator, user: valuator, participatory_process: space) }
+          let(:valuator_roles) { [valuator_role] }
           let!(:assignment) { create(:valuation_assignment, proposal: assigned_proposal, valuator_role:) }
           let(:form) do
             instance_double(
@@ -22,7 +23,7 @@ module Decidim
               current_user: user,
               current_component:,
               current_organization: current_component.organization,
-              valuator_role:,
+              valuator_roles:,
               proposals: [assigned_proposal, unassigned_proposal],
               valid?: valid
             )

--- a/decidim-proposals/spec/forms/decidim/proposals/admin/valuation_assignment_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/admin/valuation_assignment_form_spec.rb
@@ -16,7 +16,7 @@ module Decidim
         let(:valuator_role) { create(:participatory_process_user_role, role: :valuator, user: valuator, participatory_process: valuator_process) }
         let(:params) do
           {
-            id: valuator_role.try(:id),
+            valuator_role_ids: [valuator_role.try(:id)],
             proposal_ids: proposals.map(&:id)
           }
         end
@@ -32,7 +32,7 @@ module Decidim
           it { is_expected.to be_valid }
         end
 
-        context "without a valuator role" do
+        context "without valuator roles" do
           let(:valuator_role) { nil }
 
           it { is_expected.to be_invalid }

--- a/decidim-proposals/spec/permissions/decidim/proposals/admin/permissions_spec.rb
+++ b/decidim-proposals/spec/permissions/decidim/proposals/admin/permissions_spec.rb
@@ -101,17 +101,6 @@ describe Decidim::Proposals::Admin::Permissions do
       it_behaves_like "can answer proposals"
       it_behaves_like "can export proposals"
     end
-
-    context "when current user is the valuator" do
-      describe "unassign proposals from themselves" do
-        let(:action) do
-          { scope: :admin, action: :unassign_from_valuator, subject: :proposals }
-        end
-        let(:extra_context) { { valuator: user } }
-
-        it { is_expected.to be false }
-      end
-    end
   end
 
   it_behaves_like "can create proposal notes"

--- a/decidim-proposals/spec/permissions/decidim/proposals/admin/permissions_spec.rb
+++ b/decidim-proposals/spec/permissions/decidim/proposals/admin/permissions_spec.rb
@@ -109,7 +109,7 @@ describe Decidim::Proposals::Admin::Permissions do
         end
         let(:extra_context) { { valuator: user } }
 
-        it { is_expected.to be true }
+        it { is_expected.to be false }
       end
     end
   end

--- a/decidim-proposals/spec/system/admin/admin_manages_proposal_valuators_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_manages_proposal_valuators_spec.rb
@@ -40,7 +40,7 @@ describe "Admin manages proposals valuators" do
     context "when submitting the form" do
       before do
         within "#js-form-assign-proposals-to-valuator" do
-          select valuator.name, from: :valuator_role_id
+          tom_select("#assign_valuator_role_ids", option_id: valuator_role.id)
           click_on(id: "js-submit-assign-proposals-to-valuator")
         end
       end
@@ -107,12 +107,12 @@ describe "Admin manages proposals valuators" do
     context "when submitting the form" do
       before do
         within "#js-form-unassign-proposals-from-valuator" do
-          select valuator.name, from: :valuator_role_id
+          tom_select("#unassign_valuator_role_ids", option_id: valuator_role.id)
           click_on(id: "js-submit-unassign-proposals-from-valuator")
         end
       end
 
-      it "unassigns the proposals to the valuator" do
+      it "unassigns the proposals from the valuator" do
         expect(page).to have_content("Valuator unassigned from proposals successfully")
 
         within "tr", text: translated(proposal.title) do

--- a/decidim-proposals/spec/system/admin/valuator_manages_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin/valuator_manages_proposals_spec.rb
@@ -42,16 +42,10 @@ describe "Valuator manages proposals" do
       end
 
       click_on "Actions"
-      click_on "Unassign from valuator"
     end
 
     it "cannot unassign others" do
-      within "#js-form-unassign-proposals-from-valuator" do
-        tom_select("#unassign_valuator_role_ids", option_id: another_valuator_role.id)
-        click_on(id: "js-submit-unassign-proposals-from-valuator")
-      end
-
-      expect(page).to have_content("You are not authorized to perform this action")
+      expect(page).to have_no_content("Unassign from valuator")
     end
   end
 

--- a/decidim-proposals/spec/system/admin/valuator_manages_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin/valuator_manages_proposals_spec.rb
@@ -47,7 +47,7 @@ describe "Valuator manages proposals" do
 
     it "can unassign themselves" do
       within "#js-form-unassign-proposals-from-valuator" do
-        select user.name, from: :valuator_role_id
+        tom_select("#unassign_valuator_role_ids", option_id: valuator_role.id)
         click_on(id: "js-submit-unassign-proposals-from-valuator")
       end
 
@@ -56,7 +56,7 @@ describe "Valuator manages proposals" do
 
     it "cannot unassign others" do
       within "#js-form-unassign-proposals-from-valuator" do
-        select another_user.name, from: :valuator_role_id
+        tom_select("#unassign_valuator_role_ids", option_id: another_valuator_role.id)
         click_on(id: "js-submit-unassign-proposals-from-valuator")
       end
 

--- a/decidim-proposals/spec/system/admin/valuator_manages_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin/valuator_manages_proposals_spec.rb
@@ -45,15 +45,6 @@ describe "Valuator manages proposals" do
       click_on "Unassign from valuator"
     end
 
-    it "can unassign themselves" do
-      within "#js-form-unassign-proposals-from-valuator" do
-        tom_select("#unassign_valuator_role_ids", option_id: valuator_role.id)
-        click_on(id: "js-submit-unassign-proposals-from-valuator")
-      end
-
-      expect(page).to have_content("Valuator unassigned from proposals successfully")
-    end
-
     it "cannot unassign others" do
       within "#js-form-unassign-proposals-from-valuator" do
         tom_select("#unassign_valuator_role_ids", option_id: another_valuator_role.id)
@@ -69,26 +60,6 @@ describe "Valuator manages proposals" do
       within "tr", text: translated(assigned_proposal.title) do
         click_on "Answer proposal"
       end
-    end
-
-    it "can only unassign themselves" do
-      within "#valuators" do
-        expect(page).to have_content(user.name)
-        expect(page).to have_content(another_user.name)
-
-        within "li", text: another_user.name do
-          expect(page).to have_no_selector("a.red-icon")
-        end
-
-        within "li", text: user.name do
-          expect(page).to have_css("a.red-icon")
-          accept_confirm do
-            find("a.red-icon").click
-          end
-        end
-      end
-
-      expect(page).to have_content("successfully")
     end
 
     it "can leave proposal notes" do


### PR DESCRIPTION
#### :tophat: What? Why?

- Allow selecting multiple valuators when assigning valuators to proposals in bulk.
- Allow evaluators to assign other evaluators. 

#### :pushpin: Related Issues
Fixes https://github.com/decidim/decidim/issues/12903

#### Testing

- Admin should be able to assign and unassign multiple valuators to/from a proposal. 
- Valuators should be able to assign other valuators to their assigned proposals. 
- Space to test: https://decidim-lot2.populate.tools/admin/participatory_processes/branch-highway/components/4/manage/proposals

### :camera: Screenshots

<img width="961" alt="Screenshot 2024-06-12 at 13 12 35" src="https://github.com/decidim/decidim/assets/935744/8d5a38fa-7737-44d1-ae8c-fda52ce35046">

:hearts: Thank you!
