### PR TITLE
Do not allow registering to a meeting if it started

### DIFF
--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -171,7 +171,7 @@ module Decidim
       end
 
       def can_be_joined_by?(user)
-        !closed? && registrations_enabled? && can_participate?(user)
+        !started? && registrations_enabled? && can_participate?(user)
       end
 
       def can_register_invitation?(user)
@@ -181,6 +181,10 @@ module Decidim
 
       def closed?
         closed_at.present?
+      end
+
+      def started?
+        start_time < Time.current
       end
 
       def past?

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -156,6 +156,18 @@ describe "Meeting registrations" do
           login_as user, scope: :user
         end
 
+        context "and the meeting is happening now" do
+          before do
+            meeting.update!(start_time: Time.current - 1.hour, end_time: Time.current + 1.hour)
+          end
+
+          it "does not show the registration button" do
+            visit_meeting
+
+            expect(page).to have_no_css(".button", text: "Register")
+          end
+        end
+
         context "and they ARE NOT part of a verified user group" do
           it "they can join the meeting and automatically follow it" do
             visit_meeting

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -158,7 +158,7 @@ describe "Meeting registrations" do
 
         context "and the meeting is happening now" do
           before do
-            meeting.update!(start_time: Time.current - 1.hour, end_time: Time.current + 1.hour)
+            meeting.update!(start_time: 1.hour.ago, end_time: 1.hour.from_now)
           end
 
           it "does not show the registration button" do

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -228,7 +228,7 @@ describe "User creates meeting" do
             expect(page).to have_content(meeting_address)
             expect(page).to have_content(meeting_start_time)
             expect(page).to have_content(meeting_end_time)
-            expect(page).to have_css(".button", text: "Register")
+            expect(page).to have_no_css(".button", text: "Register")
             expect(page).to have_css("[data-author]", text: user_group.name)
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?

If a meeting has already started and has registration enabled the "Register" button is still shown. You can even Register to a meeting after it already passed (i.e. the end time is in the past). 

This PR fixes it, taking into account the `start_time` 

#### :pushpin: Related Issues
 
- Fixes #12934

#### Testing

1. Go to a meeting with registrations enabled
2. Change the start time so it's yesterday and the end time is in the future 
3. Go to the frontend 
4. (Without this patch) You see the "Register" button
5. (With this patch) You don't see the "Register" button

### :camera: Screenshots

#### Before

![Screenshot of the bug](https://github.com/decidim/decidim/assets/717367/0bcfcde9-f98f-4499-912b-418a26cb840c)

#### After

![Screenshot of the fix](https://github.com/decidim/decidim/assets/717367/5f5c267e-777a-4ee8-a112-75cc579e9090)

:hearts: Thank you!
