### PR TITLE
Publish and unpublish a conference speaker

### DIFF
--- a/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference_speaker.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference_speaker.rb
@@ -1,52 +1,51 @@
 # frozen_string_literal: true
 
 module Decidim
-    module Conferences
-      module Admin
-        # A command with all the business logic that publishes an
-        # existing conference speakers.
-        class PublishConferenceSpeaker < Decidim::Command
-          # Public: Initializes the command.
-          #
-          # conference_speaker - Decidim::Meetings::Meeting
-          # current_user - the user performing the action
-          def initialize(conference_speaker, current_user)
-            @conference_speaker = conference_speaker
-            @current_user = current_user
+  module Conferences
+    module Admin
+      # A command with all the business logic that publishes an
+      # existing conference speakers.
+      class PublishConferenceSpeaker < Decidim::Command
+        # Public: Initializes the command.
+        #
+        # conference_speaker - Decidim::Meetings::Meeting
+        # current_user - the user performing the action
+        def initialize(conference_speaker, current_user)
+          @conference_speaker = conference_speaker
+          @current_user = current_user
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form was not valid and we could not proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) if conference_speaker.published?
+
+          transaction do
+            publish_conference_speaker
           end
-  
-          # Executes the command. Broadcasts these events:
-          #
-          # - :ok when everything is valid.
-          # - :invalid if the form was not valid and we could not proceed.
-          #
-          # Returns nothing.
-          def call
-            return broadcast(:invalid) if conference_speaker.published?
-  
-            transaction do
-              publish_conference_speaker
-            end
-  
-            broadcast(:ok, conference_speaker)
-          end
-  
-          private
-  
-          attr_reader :conference_speaker, :current_user
-  
-          def publish_conference_speaker
-            @conference_speaker = Decidim.traceability.perform_action!(
-              :publish,
-              conference_speaker,
-              current_user
-            ) do
-              conference_speaker.publish!
-              conference_speaker
-            end
+
+          broadcast(:ok, conference_speaker)
+        end
+
+        private
+
+        attr_reader :conference_speaker, :current_user
+
+        def publish_conference_speaker
+          @conference_speaker = Decidim.traceability.perform_action!(
+            :publish,
+            conference_speaker,
+            current_user
+          ) do
+            conference_speaker.publish!
+            conference_speaker
           end
         end
       end
     end
   end
-  
+end

--- a/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference_speaker.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference_speaker.rb
@@ -4,7 +4,7 @@ module Decidim
   module Conferences
     module Admin
       # A command with all the business logic that publishes an
-      # existing conference speakers.
+      # existing conference speaker.
       class PublishConferenceSpeaker < Decidim::Command
         # Public: Initializes the command.
         #

--- a/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference_speaker.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference_speaker.rb
@@ -8,7 +8,7 @@ module Decidim
       class PublishConferenceSpeaker < Decidim::Command
         # Public: Initializes the command.
         #
-        # conference_speaker - Decidim::Meetings::Meeting
+        # conference_speaker - Decidim::Conferences::Admin::ConferenceSpeaker
         # current_user - the user performing the action
         def initialize(conference_speaker, current_user)
           @conference_speaker = conference_speaker

--- a/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference_speaker.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/publish_conference_speaker.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Decidim
+    module Conferences
+      module Admin
+        # A command with all the business logic that publishes an
+        # existing conference speakers.
+        class PublishConferenceSpeaker < Decidim::Command
+          # Public: Initializes the command.
+          #
+          # conference_speaker - Decidim::Meetings::Meeting
+          # current_user - the user performing the action
+          def initialize(conference_speaker, current_user)
+            @conference_speaker = conference_speaker
+            @current_user = current_user
+          end
+  
+          # Executes the command. Broadcasts these events:
+          #
+          # - :ok when everything is valid.
+          # - :invalid if the form was not valid and we could not proceed.
+          #
+          # Returns nothing.
+          def call
+            return broadcast(:invalid) if conference_speaker.published?
+  
+            transaction do
+              publish_conference_speaker
+            end
+  
+            broadcast(:ok, conference_speaker)
+          end
+  
+          private
+  
+          attr_reader :conference_speaker, :current_user
+  
+          def publish_conference_speaker
+            @conference_speaker = Decidim.traceability.perform_action!(
+              :publish,
+              conference_speaker,
+              current_user
+            ) do
+              conference_speaker.publish!
+              conference_speaker
+            end
+          end
+        end
+      end
+    end
+  end
+  

--- a/decidim-conferences/app/commands/decidim/conferences/admin/unpublish_conference_speaker.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/unpublish_conference_speaker.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Decidim
+    module Conferences
+      module Admin
+        # A command with all the business logic that publishes an
+        # existing conference speakers.
+        class UnpublishConferenceSpeaker < Decidim::Command
+          # Public: Initializes the command.
+          #
+          # conference_speaker - Decidim::Meetings::Meeting
+          # current_user - the user performing the action
+          def initialize(conference_speaker, current_user)
+            @conference_speaker = conference_speaker
+            @current_user = current_user
+          end
+  
+          # Executes the command. Broadcasts these events:
+          #
+          # - :ok when everything is valid.
+          # - :invalid if the form was not valid and we could not proceed.
+          #
+          # Returns nothing.
+          def call
+            return broadcast(:invalid) unless conference_speaker.published?
+  
+            @conference_speaker = Decidim.traceability.perform_action!(
+                :unpublish,
+                conference_speaker,
+                current_user
+              ) do
+                conference_speaker.unpublish!
+                conference_speaker
+              end
+              broadcast(:ok, conference_speaker)
+          end
+  
+          private
+  
+          attr_reader :conference_speaker, :current_user
+        end
+      end
+    end
+  end
+  

--- a/decidim-conferences/app/commands/decidim/conferences/admin/unpublish_conference_speaker.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/unpublish_conference_speaker.rb
@@ -8,7 +8,7 @@ module Decidim
       class UnpublishConferenceSpeaker < Decidim::Command
         # Public: Initializes the command.
         #
-        # conference_speaker - Decidim::Meetings::Meeting
+        # conference_speaker - Decidim::Conferences::Admin::ConferenceSpeaker
         # current_user - the user performing the action
         def initialize(conference_speaker, current_user)
           @conference_speaker = conference_speaker

--- a/decidim-conferences/app/commands/decidim/conferences/admin/unpublish_conference_speaker.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/unpublish_conference_speaker.rb
@@ -3,8 +3,8 @@
 module Decidim
   module Conferences
     module Admin
-      # A command with all the business logic that publishes an
-      # existing conference speakers.
+      # A command with all the business logic that unpublishes an
+      # existing conference speaker.
       class UnpublishConferenceSpeaker < Decidim::Command
         # Public: Initializes the command.
         #

--- a/decidim-conferences/app/commands/decidim/conferences/admin/unpublish_conference_speaker.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/unpublish_conference_speaker.rb
@@ -1,45 +1,44 @@
 # frozen_string_literal: true
 
 module Decidim
-    module Conferences
-      module Admin
-        # A command with all the business logic that publishes an
-        # existing conference speakers.
-        class UnpublishConferenceSpeaker < Decidim::Command
-          # Public: Initializes the command.
-          #
-          # conference_speaker - Decidim::Meetings::Meeting
-          # current_user - the user performing the action
-          def initialize(conference_speaker, current_user)
-            @conference_speaker = conference_speaker
-            @current_user = current_user
-          end
-  
-          # Executes the command. Broadcasts these events:
-          #
-          # - :ok when everything is valid.
-          # - :invalid if the form was not valid and we could not proceed.
-          #
-          # Returns nothing.
-          def call
-            return broadcast(:invalid) unless conference_speaker.published?
-  
-            @conference_speaker = Decidim.traceability.perform_action!(
-                :unpublish,
-                conference_speaker,
-                current_user
-              ) do
-                conference_speaker.unpublish!
-                conference_speaker
-              end
-              broadcast(:ok, conference_speaker)
-          end
-  
-          private
-  
-          attr_reader :conference_speaker, :current_user
+  module Conferences
+    module Admin
+      # A command with all the business logic that publishes an
+      # existing conference speakers.
+      class UnpublishConferenceSpeaker < Decidim::Command
+        # Public: Initializes the command.
+        #
+        # conference_speaker - Decidim::Meetings::Meeting
+        # current_user - the user performing the action
+        def initialize(conference_speaker, current_user)
+          @conference_speaker = conference_speaker
+          @current_user = current_user
         end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid.
+        # - :invalid if the form was not valid and we could not proceed.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) unless conference_speaker.published?
+
+          @conference_speaker = Decidim.traceability.perform_action!(
+            :unpublish,
+            conference_speaker,
+            current_user
+          ) do
+            conference_speaker.unpublish!
+            conference_speaker
+          end
+          broadcast(:ok, conference_speaker)
+        end
+
+        private
+
+        attr_reader :conference_speaker, :current_user
       end
     end
   end
-  
+end

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/conference_speakers_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/conference_speakers_controller.rb
@@ -80,7 +80,7 @@ module Decidim
           Decidim::Conference::Admin::PublishConferenceSpeaker.call(conference_speaker, current_user) do
             on(:ok) do
               flash[:notice] = I18n.t("conference_speakers.publish.success", scope: "decidim.admin")
-              redirect_to conference_speakers_path
+              redirect_to conference_speakers_path(current_conference)
             end
 
             on(:invalid) do
@@ -96,7 +96,7 @@ module Decidim
           Decidim::Conference::Admin::UnpublishConferenceSpeaker.call(conference_speaker, current_user) do
             on(:ok) do
               flash[:notice] = I18n.t("conference_speakers.unpublish.success", scope: "decidim.admin")
-              redirect_to conference_speakers_path
+              redirect_to conference_speakers_path(current_conference)
             end
 
             on(:invalid) do

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/conference_speakers_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/conference_speakers_controller.rb
@@ -74,6 +74,38 @@ module Decidim
           end
         end
 
+        def publish
+          enforce_permission_to(:update, :conference_speaker, speaker: conference_speaker)
+
+          Decidim::Conference::Admin::PublishConferenceSpeaker.call(conference_speaker, current_user) do
+            on(:ok) do
+              flash[:notice] = I18n.t("conference_speakers.publish.success", scope: "decidim.admin")
+              redirect_to conference_speakers_path
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("conference_speakers.publish.invalid", scope: "decidim.admin")
+              render action: "index"
+            end
+          end
+        end
+
+        def unpublish
+          enforce_permission_to(:update, :conference_speaker, speaker: conference_speaker)
+
+          Decidim::Conference::Admin::UnpublishConferenceSpeaker.call(conference_speaker, current_user) do
+            on(:ok) do
+              flash[:notice] = I18n.t("conference_speakers.unpublish.success", scope: "decidim.admin")
+              redirect_to conference_speakers_path
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("conference_speakers.unpublish.invalid", scope: "decidim.admin")
+              render action: "index"
+            end
+          end
+        end
+
         private
 
         def meetings_selected

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/conference_speakers_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/conference_speakers_controller.rb
@@ -77,7 +77,7 @@ module Decidim
         def publish
           enforce_permission_to(:update, :conference_speaker, speaker: conference_speaker)
 
-          Decidim::Conference::Admin::PublishConferenceSpeaker.call(conference_speaker, current_user) do
+          Decidim::Conferences::Admin::PublishConferenceSpeaker.call(conference_speaker, current_user) do
             on(:ok) do
               flash[:notice] = I18n.t("conference_speakers.publish.success", scope: "decidim.admin")
               redirect_to conference_speakers_path(current_conference)
@@ -93,7 +93,7 @@ module Decidim
         def unpublish
           enforce_permission_to(:update, :conference_speaker, speaker: conference_speaker)
 
-          Decidim::Conference::Admin::UnpublishConferenceSpeaker.call(conference_speaker, current_user) do
+          Decidim::Conferences::Admin::UnpublishConferenceSpeaker.call(conference_speaker, current_user) do
             on(:ok) do
               flash[:notice] = I18n.t("conference_speakers.unpublish.success", scope: "decidim.admin")
               redirect_to conference_speakers_path(current_conference)

--- a/decidim-conferences/app/controllers/decidim/conferences/conference_speakers_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conference_speakers_controller.rb
@@ -8,7 +8,7 @@ module Decidim
       helper_method :collection, :conference
 
       def index
-        raise ActionController::RoutingError, "No speakers for this conference " if speakers.published.empty?
+        raise ActionController::RoutingError, "No speakers for this conference " if speakers.empty?
 
         enforce_permission_to :list, :speakers
       end

--- a/decidim-conferences/app/controllers/decidim/conferences/conference_speakers_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conference_speakers_controller.rb
@@ -8,7 +8,7 @@ module Decidim
       helper_method :collection, :conference
 
       def index
-        raise ActionController::RoutingError, "No speakers for this conference " if speakers.empty?
+        raise ActionController::RoutingError, "No speakers for this conference " if speakers.published.empty?
 
         enforce_permission_to :list, :speakers
       end

--- a/decidim-conferences/app/controllers/decidim/conferences/conference_speakers_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conference_speakers_controller.rb
@@ -16,7 +16,7 @@ module Decidim
       private
 
       def speakers
-        @speakers ||= current_participatory_space.speakers
+        @speakers ||= current_participatory_space.speakers.published
       end
 
       alias collection speakers

--- a/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
+++ b/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
@@ -19,7 +19,7 @@ module Decidim
       #
       def conference_nav_items(participatory_space)
         [].tap do |items|
-          if participatory_space.speakers.exists?
+          if participatory_space.speakers.published.exists?
             items << {
               name: t("layouts.decidim.conferences_nav.conference_speaker_menu_item"),
               url: decidim_conferences.conference_conference_speakers_path(participatory_space)

--- a/decidim-conferences/app/models/decidim/conference_speaker.rb
+++ b/decidim-conferences/app/models/decidim/conference_speaker.rb
@@ -8,6 +8,7 @@ module Decidim
     include Decidim::Loggable
     include Decidim::HasUploadValidations
     include Decidim::TranslatableResource
+    include Decidim::Publicable
 
     translatable_fields :position, :affiliation, :short_bio
 

--- a/decidim-conferences/app/models/decidim/conference_speaker.rb
+++ b/decidim-conferences/app/models/decidim/conference_speaker.rb
@@ -18,6 +18,7 @@ module Decidim
     has_many :conference_meetings, through: :conference_speaker_conference_meetings, class_name: "Decidim::ConferenceMeeting"
 
     default_scope { order(full_name: :asc, created_at: :asc) }
+    scope :published, -> { where.not(published_at: nil) }
 
     has_one_attached :avatar
     validates_avatar :avatar, uploader: Decidim::AvatarUploader

--- a/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_speaker_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_speaker_presenter.rb
@@ -26,7 +26,8 @@ module Decidim
             position: "Decidim::Conferences::AdminLog::ValueTypes::SpeakerPositionPresenter",
             position_other: :string,
             weight: :integer,
-            ceased_date: :date
+            ceased_date: :date,
+            published_at: :date
           }
         end
 

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
@@ -55,10 +55,10 @@
               <% end %>
 
               <% if allowed_to? :update, :conference_speaker, speaker: speaker %>
-                <% if conference_speaker.published? %>
-                  <%= icon_link_to "close-circle-line", unpublish_conference_speaker_path(current_conference, speaker), t("actions.unpublish", scope: "decidim.admin"), method: :put, class: "action-icon--unpublish", data: { confirm: t("actions.unpublish", scope: "decidim.admin") } %>
+                <% if speaker.published? %>
+                  <%= icon_link_to "close-circle-line", unpublish_conference_speaker_path(current_conference, speaker.id), t("actions.unpublish", scope: "decidim.admin"), method: :put, class: "action-icon--unpublish", data: { confirm: t("actions.unpublish", scope: "decidim.admin") } %>
                 <% else %>
-                  <%= icon_link_to "check-line", publish_conference_speaker_path(current_conference, speaker), t("actions.publish", scope: "decidim.admin"), method: :put, class: "action-icon--publish" %>
+                  <%= icon_link_to "check-line", publish_conference_speaker_path(current_conference, speaker.id), t("actions.publish", scope: "decidim.admin"), method: :put, class: "action-icon--publish" %>
                 <% end %>
               <% else %>
                 <span class="action-space icon"></span>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
@@ -54,6 +54,16 @@
                 <%= icon_link_to "pencil-line", edit_conference_speaker_path(current_conference, speaker), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
               <% end %>
 
+              <% if allowed_to? :update, :conference_speaker, speaker: speaker %>
+                <% if conference_speaker.published? %>
+                  <%= icon_link_to "close-circle-line", unpublish_conference_speaker_path(current_conference, speaker), t("actions.unpublish", scope: "decidim.admin"), method: :put, class: "action-icon--unpublish", data: { confirm: t("actions.unpublish", scope: "decidim.admin") } %>
+                <% else %>
+                  <%= icon_link_to "check-line", publish_conference_speaker_path(current_conference, speaker), t("actions.publish", scope: "decidim.admin"), method: :put, class: "action-icon--publish" %>
+                <% end %>
+              <% else %>
+                <span class="action-space icon"></span>
+              <% end %>
+
               <% if allowed_to? :destroy, :conference_speaker, speaker: speaker %>
                 <%= icon_link_to "delete-bin-line", conference_speaker_path(current_conference, speaker), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
               <% end %>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
@@ -56,7 +56,7 @@
 
               <% if allowed_to? :update, :conference_speaker, speaker: speaker %>
                 <% if speaker.published? %>
-                  <%= icon_link_to "close-circle-line", unpublish_conference_speaker_path(current_conference, speaker.id), t("actions.unpublish", scope: "decidim.admin"), method: :put, class: "action-icon--unpublish", data: { confirm: t("actions.unpublish", scope: "decidim.admin") } %>
+                  <%= icon_link_to "close-circle-line", unpublish_conference_speaker_path(current_conference, speaker.id), t("actions.unpublish", scope: "decidim.admin"), method: :put, class: "action-icon--unpublish" %>
                 <% else %>
                   <%= icon_link_to "check-line", publish_conference_speaker_path(current_conference, speaker.id), t("actions.publish", scope: "decidim.admin"), method: :put, class: "action-icon--publish" %>
                 <% end %>

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -130,12 +130,12 @@ en:
         publish:
           invalid: There was a problem publishing this speaker.
           success: Conference speaker successfully published.
-        update:
-          error: There was a problem updating this conference speaker.
-          success: Conference speaker successfully updated.
         unpublish:
           invalid: There was a problem unpublishing this speaker.
           success: Conference speaker successfully unpublished.
+        update:
+          error: There was a problem updating this conference speaker.
+          success: Conference speaker successfully updated.
       conference_user_roles:
         create:
           error: There was a problem adding an admin to this conference.

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -127,9 +127,15 @@ en:
         new:
           create: Create
           title: New conference speaker.
+        publish:
+          invalid: There was a problem publishing this speaker.
+          success: Conference speaker successfully published.
         update:
           error: There was a problem updating this conference speaker.
           success: Conference speaker successfully updated.
+        unpublish:
+          invalid: There was a problem unpublishing this speaker.
+          success: Conference speaker successfully unpublished.
       conference_user_roles:
         create:
           error: There was a problem adding an admin to this conference.

--- a/decidim-conferences/db/migrate/20240613095855_add_published_at_to_conference_speakers.rb
+++ b/decidim-conferences/db/migrate/20240613095855_add_published_at_to_conference_speakers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPublishedAtToConferenceSpeakers < ActiveRecord::Migration[7.0]
   def change
     add_column :decidim_conference_speakers, :published_at, :datetime, index: true

--- a/decidim-conferences/db/migrate/20240613095855_add_published_at_to_conference_speakers.rb
+++ b/decidim-conferences/db/migrate/20240613095855_add_published_at_to_conference_speakers.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToConferenceSpeakers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :decidim_conference_speakers, :published_at, :datetime, index: true
+  end
+end

--- a/decidim-conferences/lib/decidim/api/conference_type.rb
+++ b/decidim-conferences/lib/decidim/api/conference_type.rb
@@ -45,6 +45,10 @@ module Decidim
       def banner_image
         object.attached_uploader(:banner_image).path
       end
+
+      def speakers
+        object.speakers.published
+      end
     end
   end
 end

--- a/decidim-conferences/lib/decidim/conferences/admin_engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/admin_engine.rb
@@ -18,7 +18,12 @@ module Decidim
         resources :conferences, param: :slug, except: [:show, :destroy] do
           resource :publish, controller: "conference_publications", only: [:create, :destroy]
           resources :copies, controller: "conference_copies", only: [:new, :create]
-          resources :speakers, controller: "conference_speakers"
+          resources :speakers, controller: "conference_speakers" do
+            member do
+              put :publish
+              put :unpublish
+            end
+          end
           resources :partners, controller: "partners", except: [:show]
           resources :media_links, controller: "media_links"
           resources :registration_types, controller: "registration_types" do

--- a/decidim-conferences/lib/decidim/conferences/seeds.rb
+++ b/decidim-conferences/lib/decidim/conferences/seeds.rb
@@ -84,6 +84,7 @@ module Decidim
               end,
               twitter_handle: ::Faker::Twitter.unique.screen_name,
               personal_url: ::Faker::Internet.url,
+              published_at: Time.current,
               conference:
             )
           end

--- a/decidim-conferences/lib/decidim/conferences/test/factories.rb
+++ b/decidim-conferences/lib/decidim/conferences/test/factories.rb
@@ -165,6 +165,10 @@ FactoryBot.define do
                                                                            skip_injection: evaluator.skip_injection)
       end
     end
+
+    trait :published do
+      published_at { Time.current }
+    end
   end
 
   factory :conference_speaker_conference_meeting, class: "Decidim::ConferenceSpeakerConferenceMeeting" do

--- a/decidim-conferences/spec/commands/publish_conference_speaker_spec.rb
+++ b/decidim-conferences/spec/commands/publish_conference_speaker_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+module Decidim
+  module Conferences
+    module Admin
+      describe PublishConferenceSpeaker, type: :command do
+        let(:organization) { create :organization, available_locales: [:en] }
+        let(:conference_speaker) { create(:conference_speaker, published_at: nil) }
+        let(:current_user) { create(:user, :admin, :confirmed, organization:) }
+        let(:command) { described_class.new(conference_speaker, current_user) }
+
+        describe "call" do
+          context "when the conference speaker is not already published" do
+            it "publishes the conference speaker" do
+              expect(Decidim.traceability).to receive(:perform_action!).with(
+                :publish,
+                conference_speaker,
+                current_user
+              ).and_call_original
+
+              expect(command).to broadcast(:ok, conference_speaker)
+            end
+          end
+
+          context "when the conference speaker is already published" do
+            before do
+              conference_speaker.update!(published_at: Time.current)
+            end
+
+            it "does not publish the conference speaker" do
+              expect { command.call }.not_to(change { conference_speaker.reload.published_at })
+
+              expect(command).to broadcast(:invalid)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-conferences/spec/commands/unpublish_conference_speaker_spec.rb
+++ b/decidim-conferences/spec/commands/unpublish_conference_speaker_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Conferences
+    module Admin
+      describe UnpublishConferenceSpeaker, type: :command do
+        let(:organization) { create :organization, available_locales: [:en] }
+        let(:conference_speaker) { create(:conference_speaker, published_at: Time.current) }
+        let(:current_user) { create(:user, :admin, :confirmed, organization:) }
+        let(:command) { described_class.new(conference_speaker, current_user) }
+
+        describe "call" do
+          context "when the conference speaker is published" do
+            it "unpublishes the conference speaker" do
+              expect(Decidim.traceability).to receive(:perform_action!).with(
+                :unpublish,
+                conference_speaker,
+                current_user
+              ).and_call_original
+
+              expect(command).to broadcast(:ok, conference_speaker)
+            end
+          end
+
+          context "when the conference speaker is not published" do
+            before do
+              conference_speaker.update!(published_at: nil)
+            end
+
+            it "does not unpublish the conference speaker" do
+              expect { command.call }.not_to(change { conference_speaker.reload.published_at })
+
+              expect(command).to broadcast(:invalid)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-conferences/spec/controllers/conference_speakers_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/conference_speakers_controller_spec.rb
@@ -30,8 +30,8 @@ module Decidim
         end
 
         context "when conference has speakers" do
-          let!(:speaker1) { create(:conference_speaker, conference:) }
-          let!(:speaker2) { create(:conference_speaker, conference:) }
+          let!(:speaker1) { create(:conference_speaker, :published, conference:) }
+          let!(:speaker2) { create(:conference_speaker, :published, conference:) }
           let!(:non_speaker) { create(:conference_speaker) }
 
           context "when user has permissions" do

--- a/decidim-conferences/spec/system/conference_speakers_spec.rb
+++ b/decidim-conferences/spec/system/conference_speakers_spec.rb
@@ -61,7 +61,7 @@ describe "Conference speakers" do
     end
   end
 
-  context "when admin publish and unplublish a speaker" do
+  context "when admin publishes and unpublishes a speaker" do
     let!(:conference_speakers) { create_list(:conference_speaker, 2, :published, conference:) }
     let!(:user) { create(:user, :admin, :confirmed, organization:) }
 
@@ -79,7 +79,7 @@ describe "Conference speakers" do
       end
     end
 
-    it "gets a conference speaker unpublish and then publish again" do
+    it "gets a conference speaker unpublishes and then publishes again" do
       expect(page).to have_content("Conference speaker successfully unpublished")
 
       within all(".table-list__actions").first do

--- a/decidim-conferences/spec/system/conference_speakers_spec.rb
+++ b/decidim-conferences/spec/system/conference_speakers_spec.rb
@@ -60,4 +60,33 @@ describe "Conference speakers" do
       end
     end
   end
+
+  context "when admin publish and unplublishes a speaker" do
+    let!(:conference_speakers) { create_list(:conference_speaker, 2, :published, conference:) }
+    let!(:user) { create(:user, :admin, :confirmed, organization:) }
+
+    before do
+      login_as user, scope: :user
+      visit decidim_admin.root_path
+      click_on "Conferences"
+      click_on "conference_title"
+      click_on "Speakers"
+    end
+
+    it "unpublishes conference speaker and then publishes again" do
+      within all(".table-list__actions").first do
+        expect(page).to have_link("Unpublish")
+        accept_confirm do
+          click_link_or_button "Unpublish"
+        end
+      end
+      expect(page).to have_content("Conference speaker successfully unpublished")
+
+      within all(".table-list__actions").first do
+        expect(page).to have_link("Publish")
+        click_link_or_button "Publish"
+      end
+      expect(page).to have_content("Conference speaker successfully published")
+    end
+  end
 end

--- a/decidim-conferences/spec/system/conference_speakers_spec.rb
+++ b/decidim-conferences/spec/system/conference_speakers_spec.rb
@@ -71,15 +71,15 @@ describe "Conference speakers" do
       click_on "Conferences"
       click_on "conference_title"
       click_on "Speakers"
-    end
-
-    it "unpublishes conference speaker and then publishes again" do
       within all(".table-list__actions").first do
         expect(page).to have_link("Unpublish")
         accept_confirm do
           click_link_or_button "Unpublish"
         end
       end
+    end
+
+    it "gets a conference speaker unpublish and then publish again" do
       expect(page).to have_content("Conference speaker successfully unpublished")
 
       within all(".table-list__actions").first do
@@ -87,6 +87,16 @@ describe "Conference speakers" do
         click_link_or_button "Publish"
       end
       expect(page).to have_content("Conference speaker successfully published")
+    end
+
+    context "when visit conference public view" do
+      before do
+        visit decidim_conferences.conference_conference_speakers_path(conference)
+      end
+
+      it "displays only conference speaker mark ask published" do
+        expect(page).to have_css(".conference__speaker__item-name", count: 1)
+      end
     end
   end
 end

--- a/decidim-conferences/spec/system/conference_speakers_spec.rb
+++ b/decidim-conferences/spec/system/conference_speakers_spec.rb
@@ -61,7 +61,7 @@ describe "Conference speakers" do
     end
   end
 
-  context "when admin publish and unplublishes a speaker" do
+  context "when admin publish and unplublish a speaker" do
     let!(:conference_speakers) { create_list(:conference_speaker, 2, :published, conference:) }
     let!(:user) { create(:user, :admin, :confirmed, organization:) }
 

--- a/decidim-conferences/spec/system/conference_speakers_spec.rb
+++ b/decidim-conferences/spec/system/conference_speakers_spec.rb
@@ -31,7 +31,7 @@ describe "Conference speakers" do
   end
 
   context "when there are some published conference speakers" do
-    let!(:conference_speakers) { create_list(:conference_speaker, 2, conference:) }
+    let!(:conference_speakers) { create_list(:conference_speaker, 2, :published, conference:) }
 
     before do
       visit decidim_conferences.conference_conference_speakers_path(conference)

--- a/decidim-conferences/spec/system/conference_speakers_spec.rb
+++ b/decidim-conferences/spec/system/conference_speakers_spec.rb
@@ -73,9 +73,7 @@ describe "Conference speakers" do
       click_on "Speakers"
       within all(".table-list__actions").first do
         expect(page).to have_link("Unpublish")
-        accept_confirm do
-          click_link_or_button "Unpublish"
-        end
+        click_link_or_button "Unpublish"
       end
     end
 

--- a/decidim-conferences/spec/types/conference_type_spec.rb
+++ b/decidim-conferences/spec/types/conference_type_spec.rb
@@ -11,6 +11,8 @@ module Decidim
       include_context "with a graphql class type"
 
       let(:model) { create(:conference) }
+      let!(:published_speaker) { create(:conference_speaker, :published, conference: model) }
+      let!(:unpublished_speaker) { create(:conference_speaker, conference: model) }
 
       include_examples "attachable interface"
       include_examples "categories container interface"
@@ -188,6 +190,14 @@ module Decidim
 
         it "returns all the required fields" do
           expect(response["registrationTerms"]["translation"]).to eq(model.registration_terms["en"])
+        end
+      end
+
+      describe "speakers" do
+        let(:query) { " { speakers { fullName } } " }
+
+        it "returns the list of published speakers" do
+          expect(response["speakers"].count).to eq(1)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR gives admins the ability to manage unpublished (conference speakers are now Publicable) and publish conference speakers as described in the issue.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #12935

#### Testing
Log in as an admin
Click on Conferences and select one of them.
Click on the Speakers option on the sidebar.

### :camera: Screenshots
![image](https://github.com/openpoke/decidim/assets/116598037/45c204fd-9197-45ab-a756-aef4d007cab9)
index view

:hearts: Thank you!