### PR TITLE
Remove navigation arrows from show pages

### DIFF
--- a/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
@@ -8,7 +8,7 @@ module Decidim
       helper Decidim::TraceabilityHelper
       helper Decidim::Accountability::BreadcrumbHelper
 
-      helper_method :results, :result, :first_class_categories, :count_calculator, :nav_paths
+      helper_method :results, :result, :first_class_categories, :count_calculator
 
       def show
         raise ActionController::RoutingError, "Not Found" unless result
@@ -27,24 +27,6 @@ module Decidim
 
       def result
         @result ||= search_collection.includes(:timeline_entries).find_by(id: params[:id])
-      end
-
-      def next_result
-        return if search_collection.size < 2
-
-        search_collection.order(:start_date, :id).where(Decidim::Accountability::Result.arel_table[:id].gt(result.id)).first
-      end
-
-      def prev_result
-        return if search_collection.size < 2
-
-        search_collection.order(:start_date, :id).where(Decidim::Accountability::Result.arel_table[:id].lt(result.id)).last
-      end
-
-      def nav_paths
-        return {} if result.blank?
-
-        { prev_path: prev_result, next_path: next_result }.compact_blank.transform_values { |result| result_path(result) }
       end
 
       def search_collection

--- a/decidim-accountability/app/views/decidim/accountability/results/_project.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_project.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: "layouts/decidim/shared/layout_item", locals: nav_paths do %>
+<%= render layout: "layouts/decidim/shared/layout_item" do %>
   <%= cell("decidim/accountability/project", result) %>
 
   <section class="layout-main__section layout-main__buttons" data-buttons>

--- a/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
+++ b/decidim-core/app/views/layouts/decidim/shared/_layout_item.html.erb
@@ -7,20 +7,6 @@
       <%= render partial: "layouts/decidim/shared/linked_resource" %>
     <% end %>
 
-    <% if local_assigns.has_key?(:prev_path) %>
-      <%= link_to prev_path, class: "layout-item__arrow prev", title: t(".prev") do %>
-        <%= icon "arrow-left-s-line" %>
-        <span class="sr-only">%<%= t(".prev") %></span>
-      <% end %>
-    <% end %>
-
-    <% if local_assigns.has_key?(:next_path) %>
-      <%= link_to next_path, class: "layout-item__arrow next", title: t(".next") do %>
-        <%= icon "arrow-right-s-line" %>
-        <span class="sr-only"><%= t(".next") %></span>
-      <% end %>
-    <% end %>
-
     <%= yield %>
   </main>
   <aside class="layout-item__aside" aria-label="aside">

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1958,10 +1958,6 @@ en:
         mark_as_read: Mark as read
       offline_banner:
         cache_version_page: Oooops! Your network is offline. This is a previously cached version of the page you are visiting, perhaps the content is not up to date.
-      shared:
-        layout_item:
-          next: Next item
-          prev: Previous item
       social_media_links:
         facebook: "%{organization} at Facebook"
         github: "%{organization} at GitHub"

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -15,7 +15,7 @@ module Decidim
       helper Decidim::ShortLinkHelper
       include Decidim::AttachmentsHelper
 
-      helper_method :meetings, :meeting, :registration, :search, :nav_paths, :tab_panel_items
+      helper_method :meetings, :meeting, :registration, :search, :tab_panel_items
 
       before_action :add_additional_csp_directives, only: [:show]
 
@@ -108,36 +108,6 @@ module Decidim
 
       def meeting
         @meeting ||= Meeting.not_hidden.where(component: current_component).find_by(id: params[:id])
-      end
-
-      def next_meeting
-        return if search_collection.size < 2
-
-        search_collection.order(:start_time, :id).where(
-          Decidim::Meetings::Meeting.arel_table[:start_time].gt(meeting.start_time).or(
-            Decidim::Meetings::Meeting.arel_table[:start_time].eq(meeting.start_time).and(
-              Decidim::Meetings::Meeting.arel_table[:id].gt(meeting.id)
-            )
-          )
-        ).first
-      end
-
-      def prev_meeting
-        return if search_collection.size < 2
-
-        search_collection.order(:start_time, :id).where(
-          Decidim::Meetings::Meeting.arel_table[:start_time].lt(meeting.start_time).or(
-            Decidim::Meetings::Meeting.arel_table[:start_time].eq(meeting.start_time).and(
-              Decidim::Meetings::Meeting.arel_table[:id].lt(meeting.id)
-            )
-          )
-        ).last
-      end
-
-      def nav_paths
-        return {} if meeting.blank?
-
-        { prev_path: prev_meeting, next_path: next_meeting }.compact_blank.transform_values { |meeting| meeting_path(meeting) }
       end
 
       def meetings

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: "layouts/decidim/shared/layout_item", locals: nav_paths do %>
+<%= render layout: "layouts/decidim/shared/layout_item" do %>
   <section class="layout-main__section layout-main__heading">
     <h1 class="h2 decorator"><%= present(meeting).title(links: true, html_escape: true ) %></h1>
 


### PR DESCRIPTION
#### :tophat: What? Why?

During the redesign process we added some navigation arrows in some modules. For different reasons we decided to remove them. This PR does that. See #13007 for more details in the reasoning. 

#### :pushpin: Related Issues
 
- Fixes [#13007](https://github.com/decidim/decidim/issues/13007)

#### Testing

1. Go to a meetings page. See that you don't have the arrows in the sides (left and right)
2. Go to a project page in accountability. See that you don't have the arrows in the sides (left and right)

### :camera: Screenshots

#### Before

![Project page with arrows](https://github.com/decidim/decidim/assets/717367/2f57b8d7-0b23-476e-8361-448139b6724e)

![Meeting page with arrows](https://github.com/decidim/decidim/assets/717367/fda28656-0572-47e4-8635-002dc2ac9b12)

#### After

![Project page without arrows](https://github.com/decidim/decidim/assets/717367/844598cb-7ec7-49f9-8f9f-573d36850792)

![Meeting page without arrows](https://github.com/decidim/decidim/assets/717367/fe9ebb01-e991-4dea-8ea3-8685abc52cb6)
 
:hearts: Thank you!
