### PR TITLE
Remove unecessary elements in fat footer for mobile views

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_footer.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_footer.scss
@@ -3,7 +3,7 @@ footer {
     @apply bg-gray-4;
 
     &__top {
-      @apply flex flex-col lg:flex-row gap-8 container py-10;
+      @apply hidden flex flex-col lg:flex-row lg:block gap-8 container py-10;
     }
 
     &__down {

--- a/decidim-core/app/views/layouts/decidim/footer/_main.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main.html.erb
@@ -11,7 +11,7 @@
     <nav class="md:w-1/2 lg:w-auto" role="navigation" aria-label="Legal">
       <%= render partial: "layouts/decidim/footer/main_legal" %>
     </nav>
-    <nav class="max-w-fit w-full md:w-auto md:ml-auto" role="navigation" aria-label="Social media">
+    <nav class="w-full md:w-auto md:ml-auto" role="navigation" aria-label="Social media">
       <%= render partial: "layouts/decidim/footer/main_social_media_links" %>
     </nav>
     <%= render partial: "layouts/decidim/footer/main_language_chooser" %>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_legal.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_legal.html.erb
@@ -1,4 +1,4 @@
-<ul class="flex flex-col md:flex-row gap-10 text-sm text-white [&_a]:underline">
+<ul class="flex flex-col gap-6 md:flex-row md:gap-10 text-sm text-white [&_a]:underline">
   <li>
     <%= link_to t("layouts.decidim.footer.terms_of_service"), decidim.page_path("terms-of-service") %>
   </li>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_social_media_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_social_media_links.html.erb
@@ -1,4 +1,4 @@
-<ul class="flex justify-between md:justify-start gap-6 text-sm text-white hover:[&_a]:opacity-50">
+<ul class="flex md:justify-between md:justify-start gap-6 text-sm text-white hover:[&_a]:opacity-50">
   <% if current_organization.twitter_handler.present? %>
     <li>
       <a target="_blank" data-external-link="text-only" rel="noopener noreferrer" href="https://twitter.com/<%= current_organization.twitter_handler %>">


### PR DESCRIPTION
#### :tophat: What? Why?

After the redesign, the footer has too many links and it's specially noisy in the mobile views. This PR fixes that by reducing lots of elements. I also fixed the social networks icons and played a bit with the gaps so it matches with the mockup from #13008

#### :pushpin: Related Issues
 
- Fixes #13008

#### Testing

1. Go to the mobile view of your web development tools
2. Check out the footer
3. Change the resolution to try different widths 

### :camera: Screenshots

#### Before

![Screenshot of the really fat footer](https://github.com/decidim/decidim/assets/717367/6a61968d-d83c-463f-b080-e1face71587c)

#### After
 
![Screenshot of the skinny footer](https://github.com/decidim/decidim/assets/717367/47a95377-9547-4fff-af99-d259204be71d)

:hearts: Thank you!
