### PR TITLE
Fix the flaky seeds for comments

### DIFF
--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -87,7 +87,6 @@ module Decidim
           end
 
           nil
-
         rescue ActiveRecord::AssociationTypeMismatch
           nil # in case there is a mismatch, we ignore the error as it is not important for the seeding
         end

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -87,6 +87,9 @@ module Decidim
           end
 
           nil
+
+        rescue ActiveRecord::AssociationTypeMismatch
+          nil # in case there is a mismatch, we ignore the error as it is not important for the seeding
         end
 
         def random_user

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -99,7 +99,10 @@ module Decidim
         end
 
         def random_user_group(user)
-          [true, false].sample ? Decidim::UserGroups::ManageableUserGroups.for(user).verified.sample : nil
+          user_group = Decidim::UserGroups::ManageableUserGroups.for(user).verified.sample
+          return nil unless user_group&.valid?
+
+          [true, false].sample ? user_group : nil
         end
       end
     end

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -79,14 +79,12 @@ module Decidim
         # @return nil
         def create_votes(comment)
           rand(0..12).times do
-            author = random_user
-            user_group = random_user_group(author)
+            user = random_user
+            user_group = random_user_group(user)
+            author = [user, user_group].compact.sample
+            next if CommentVote.where(comment:, author:).any?
 
-            CommentVote.find_or_create_by(
-              comment:,
-              author: [author, user_group].compact.sample,
-              weight: [1, -1].sample
-            )
+            CommentVote.create!(comment:, author:, weight: [1, -1].sample)
           end
 
           nil

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -50,8 +50,8 @@ module Decidim
         #
         # @return [Decidim::Comments::Comment]
         def create_comment(resource, root_commentable = nil)
-          author = user
-          user_group = user_group(author)
+          author = random_user
+          user_group = random_user_group(author)
 
           params = {
             commentable: resource,
@@ -79,8 +79,8 @@ module Decidim
         # @return nil
         def create_votes(comment)
           rand(0..12).times do
-            author = user
-            user_group = user_group(author)
+            author = random_user
+            user_group = random_user_group(author)
 
             CommentVote.find_or_create_by(
               comment:,
@@ -92,11 +92,11 @@ module Decidim
           nil
         end
 
-        def user
-          Decidim::User.where(organization:).all.sample
+        def random_user
+          Decidim::User.where(organization:).not_deleted.not_blocked.confirmed.sample
         end
 
-        def user_group(user)
+        def random_user_group(user)
           [true, false].sample ? Decidim::UserGroups::ManageableUserGroups.for(user).verified.sample : nil
         end
       end

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -31,9 +31,8 @@ module Decidim
 
             next if [true, false].sample
 
-            [comment1, comment2].compact.each do |comment|
-              create_votes(comment)
-            end
+            create_votes(comment1) if comment1
+            create_votes(comment2) if comment2
           end
         end
 

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -93,7 +93,9 @@ module Decidim
         end
 
         def random_user
-          Decidim::User.where(organization:).not_deleted.not_blocked.confirmed.sample
+          user = Decidim::User.where(organization:).not_deleted.not_blocked.confirmed.sample
+
+          user.valid? ? user : random_user
         end
 
         def random_user_group(user)


### PR DESCRIPTION
#### :tophat: What? Why?

We have some flaky seeds in comments, where sometimes you run the `db:seeds` command and it fails.

I think it's related to making the query for Users wrongly, as we need to add the usual scopes (i.e. confirmed, not deleted, not moderated).

This PR fixes it. I also added a small refactor for the method names to better reflect what they do. 

#### Testing

1. Run `bin/rails db:drop db:create db:migrate assets:precompile db:seed` and see that it doesn't fails a couple of times  

### Stacktrace

These were the exceptions that I saw:

#### `create_votes` method

```
Creating seeds for decidim-core...
xdg-open /home/apereira/Work/decidim/decidim/development_app/tmp/letter_opener/1718623535_5383859_9bed0f9/rich.html
Creating seeds for decidim-system...
Creating seeds for decidim-templates...
Creating seeds for the participatory_processes space...
-- Creating accountability component seeds for the participatory space with ID: 1...
-- Creating blogs component seeds for the participatory space with ID: 1...
-- Creating budgets component seeds for the participatory space with ID: 1...
-- Creating debates component seeds for the participatory space with ID: 1...
-- Creating meetings component seeds for the participatory space with ID: 1...
rake aborted!
ActiveRecord::AssociationTypeMismatch: Comment(#452080) expected, got #<Decidim::Comments::Comment id: 226, decidim_commentable_type: "Decidim::Meetings::Meeting", decidim_commentable_id: 4, decidim_author_id: 15
, created_at: "2024-06-17 11:27:13.598810440 +0000", updated_at: "2024-06-17 11:27:13.944918670 +0000", depth: 0, alignment: 0, decidim_user_group_id: nil, decidim_root_commentable_type: "Decidim::Meetings::Meeti
ng", decidim_root_commentable_id: 4, decidim_author_type: "Decidim::UserBaseEntity", body: {"en"=>"Possimus fugiat laboriosam laudantium qui sed ipsam nam facilis saepe natus pariatur laborum aliquid architecto d
ignissimos repellat at enim est velit ut quis impedit praesentium dolor nostrum dolorem rerum voluptatem provident corrupti est voluptatum cum cumque perferendis facere numquam qui asperiores iste temporibus iust
o exercitationem dolores sunt non autem commodi."}, comments_count: 0, decidim_participatory_space_type: nil, decidim_participatory_space_id: nil, deleted_at: nil, up_votes_count: 0, down_votes_count: 1> which is
 an instance of Decidim::Comments::Comment(#80840) (ActiveRecord::AssociationTypeMismatch)
/home/apereira/Work/decidim/decidim/decidim-comments/app/models/decidim/comments/seed.rb:87:in `block in create_votes'
/home/apereira/Work/decidim/decidim/decidim-comments/app/models/decidim/comments/seed.rb:83:in `times'
/home/apereira/Work/decidim/decidim/decidim-comments/app/models/decidim/comments/seed.rb:83:in `create_votes'
/home/apereira/Work/decidim/decidim/decidim-comments/app/models/decidim/comments/seed.rb:35:in `block (2 levels) in comments_for'
/home/apereira/Work/decidim/decidim/decidim-comments/app/models/decidim/comments/seed.rb:34:in `each'
/home/apereira/Work/decidim/decidim/decidim-comments/app/models/decidim/comments/seed.rb:34:in `block in comments_for'
/home/apereira/Work/decidim/decidim/decidim-comments/app/models/decidim/comments/seed.rb:23:in `times'
/home/apereira/Work/decidim/decidim/decidim-comments/app/models/decidim/comments/seed.rb:23:in `comments_for'
/home/apereira/Work/decidim/decidim/decidim-meetings/lib/decidim/meetings/seeds.rb:174:in `create_meeting!'
/home/apereira/Work/decidim/decidim/decidim-meetings/lib/decidim/meetings/seeds.rb:22:in `block in call'
/home/apereira/Work/decidim/decidim/decidim-meetings/lib/decidim/meetings/seeds.rb:18:in `times'
/home/apereira/Work/decidim/decidim/decidim-meetings/lib/decidim/meetings/seeds.rb:18:in `call'
/home/apereira/Work/decidim/decidim/decidim-meetings/lib/decidim/meetings/component.rb:101:in `block (2 levels) in <top (required)>'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/component_manifest.rb:142:in `seed!'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/seeds.rb:143:in `block in seed_components_manifests!'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/seeds.rb:142:in `each'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/seeds.rb:142:in `seed_components_manifests!'
/home/apereira/Work/decidim/decidim/decidim-participatory_processes/lib/decidim/participatory_processes/seeds.rb:44:in `block in call'
/home/apereira/Work/decidim/decidim/decidim-participatory_processes/lib/decidim/participatory_processes/seeds.rb:26:in `times'
/home/apereira/Work/decidim/decidim/decidim-participatory_processes/lib/decidim/participatory_processes/seeds.rb:26:in `call'
/home/apereira/Work/decidim/decidim/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb:62:in `block (2 levels) in <top (required)>'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/participatory_space_manifest.rb:102:in `seed!'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core.rb:155:in `block in seed!'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core.rb:154:in `seed!'
/home/apereira/Work/decidim/decidim/development_app/db/seeds.rb:9:in `<top (required)>'
<internal:/home/apereira/.local/share/mise/installs/ruby/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
<internal:/home/apereira/.local/share/mise/installs/ruby/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
-e:1:in `<main>'
Tasks: TOP => db:seed
(See full trace by running task with --trace)
```

#### `create_comment` method

```
Creating seeds for decidim-core...
xdg-open /home/apereira/Work/decidim/decidim/development_app/tmp/letter_opener/1718621613_141223_ee5b446/rich.html
Creating seeds for decidim-system...
Creating seeds for decidim-templates...
Creating seeds for the participatory_processes space...
-- Creating accountability component seeds for the participatory space with ID: 1...
-- Creating blogs component seeds for the participatory space with ID: 1...
-- Creating budgets component seeds for the participatory space with ID: 1...
-- Creating debates component seeds for the participatory space with ID: 1...
-- Creating meetings component seeds for the participatory space with ID: 1...
rake aborted!
ActiveRecord::RecordInvalid: Validation failed: Author is invalid (ActiveRecord::RecordInvalid)
/home/apereira/Work/decidim/decidim/decidim-core/app/services/decidim/traceability.rb:47:in `block in create!'
/home/apereira/Work/decidim/decidim/decidim-core/app/services/decidim/traceability.rb:64:in `block (2 levels) in perform_action!'
/home/apereira/Work/decidim/decidim/decidim-core/app/services/decidim/traceability.rb:63:in `block in perform_action!'
/home/apereira/Work/decidim/decidim/decidim-core/app/services/decidim/traceability.rb:62:in `perform_action!'
/home/apereira/Work/decidim/decidim/decidim-core/app/services/decidim/traceability.rb:46:in `create!'
/home/apereira/Work/decidim/decidim/decidim-comments/app/models/decidim/comments/seed.rb:64:in `create_comment'
/home/apereira/Work/decidim/decidim/decidim-comments/app/models/decidim/comments/seed.rb:28:in `block in comments_for'
/home/apereira/Work/decidim/decidim/decidim-comments/app/models/decidim/comments/seed.rb:23:in `times'
/home/apereira/Work/decidim/decidim/decidim-comments/app/models/decidim/comments/seed.rb:23:in `comments_for'
/home/apereira/Work/decidim/decidim/decidim-meetings/lib/decidim/meetings/seeds.rb:174:in `create_meeting!'
/home/apereira/Work/decidim/decidim/decidim-meetings/lib/decidim/meetings/seeds.rb:20:in `block in call'
/home/apereira/Work/decidim/decidim/decidim-meetings/lib/decidim/meetings/seeds.rb:18:in `times'
/home/apereira/Work/decidim/decidim/decidim-meetings/lib/decidim/meetings/seeds.rb:18:in `call'
/home/apereira/Work/decidim/decidim/decidim-meetings/lib/decidim/meetings/component.rb:101:in `block (2 levels) in <top (required)>'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/component_manifest.rb:142:in `seed!'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/seeds.rb:143:in `block in seed_components_manifests!'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/seeds.rb:142:in `each'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/seeds.rb:142:in `seed_components_manifests!'
/home/apereira/Work/decidim/decidim/decidim-participatory_processes/lib/decidim/participatory_processes/seeds.rb:44:in `block in call'
/home/apereira/Work/decidim/decidim/decidim-participatory_processes/lib/decidim/participatory_processes/seeds.rb:26:in `times'
/home/apereira/Work/decidim/decidim/decidim-participatory_processes/lib/decidim/participatory_processes/seeds.rb:26:in `call'
/home/apereira/Work/decidim/decidim/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb:62:in `block (2 levels) in <top (required)>'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/participatory_space_manifest.rb:102:in `seed!'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core.rb:155:in `block in seed!'
/home/apereira/Work/decidim/decidim/decidim-core/lib/decidim/core.rb:154:in `seed!'
/home/apereira/Work/decidim/decidim/development_app/db/seeds.rb:9:in `<top (required)>'
<internal:/home/apereira/.local/share/mise/installs/ruby/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
<internal:/home/apereira/.local/share/mise/installs/ruby/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
-e:1:in `<main>'
Tasks: TOP => db:seed
(See full trace by running task with --trace)
```


:hearts: Thank you!
