### PR TITLE
Ensure presence of selectors to fix flaky examples in meetings answers polls

### DIFF
--- a/decidim-meetings/spec/system/meeting_questions_administrate_spec.rb
+++ b/decidim-meetings/spec/system/meeting_questions_administrate_spec.rb
@@ -142,6 +142,7 @@ describe "Meeting poll administration" do
   end
 
   def open_first_question
+    expect(page).to have_css(".meeting-polls__question--admin", match: :first)
     find(".meeting-polls__question--admin", match: :first).click
   end
 end

--- a/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
+++ b/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
@@ -77,7 +77,6 @@ describe "Meeting poll answer" do
     end
 
     it "allows to reply a question" do
-      sleep(2)
       open_first_question
 
       check question_multiple_option.answer_options.first.body["en"]
@@ -87,7 +86,7 @@ describe "Meeting poll answer" do
     end
 
     it "does not allow selecting two single options" do
-      sleep(2)
+      expect(page).to have_css("details[data-question='#{question_single_option.id}']:not([disabled])")
       find("details[data-question='#{question_single_option.id}']").click
 
       choose question_single_option.answer_options.first.body["en"]
@@ -100,7 +99,6 @@ describe "Meeting poll answer" do
     end
 
     it "does not allow selecting more than the maximum choices for multiple options" do
-      sleep(2)
       open_first_question
 
       check question_multiple_option.answer_options.first.body["en"]
@@ -126,7 +124,6 @@ describe "Meeting poll answer" do
     end
 
     it "shows the responses" do
-      sleep(2)
       open_first_question
 
       expect(page).to have_content("0%")
@@ -141,6 +138,7 @@ describe "Meeting poll answer" do
   end
 
   def open_first_question
+    expect(page).to have_css(".meeting-polls__question")
     find(".meeting-polls__question", match: :first).click
   end
 end

--- a/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
+++ b/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
@@ -87,6 +87,7 @@ describe "Meeting poll answer" do
     end
 
     it "does not allow selecting two single options" do
+      sleep(2)
       find("details[data-question='#{question_single_option.id}']").click
 
       choose question_single_option.answer_options.first.body["en"]
@@ -125,6 +126,7 @@ describe "Meeting poll answer" do
     end
 
     it "shows the responses" do
+      sleep(2)
       open_first_question
 
       expect(page).to have_content("0%")


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes some flaky tests replying polls (https://github.com/decidim/decidim/pull/12957#issuecomment-2173242571)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12957

#### Testing


### :camera: Screenshots

:hearts: Thank you!
