### PR TITLE
Add notification to valuators when a proposal is assigned

### DIFF
--- a/decidim-core/app/commands/decidim/update_notifications_settings.rb
+++ b/decidim-core/app/commands/decidim/update_notifications_settings.rb
@@ -30,6 +30,7 @@ module Decidim
       current_user.notification_types = @form.notification_types
       current_user.direct_message_types = @form.direct_message_types
       current_user.email_on_moderations = @form.email_on_moderations
+      current_user.email_on_assigned_proposals = @form.email_on_assigned_proposals
       current_user.notification_settings = current_user.notification_settings.merge(@form.notification_settings)
       current_user.notifications_sending_frequency = @form.notifications_sending_frequency
     end

--- a/decidim-core/app/forms/decidim/notifications_settings_form.rb
+++ b/decidim-core/app/forms/decidim/notifications_settings_form.rb
@@ -7,6 +7,7 @@ module Decidim
     mimic :user
 
     attribute :email_on_moderations, Boolean
+    attribute :email_on_assigned_proposals, Boolean
     attribute :newsletter_notifications, Boolean
     attribute :notifications_from_followed, Boolean
     attribute :notifications_from_own_activity, Boolean

--- a/decidim-core/app/views/decidim/notifications_settings/show.html.erb
+++ b/decidim-core/app/views/decidim/notifications_settings/show.html.erb
@@ -99,6 +99,28 @@
         </label>
       </div>
 
+      <label>
+        <%= t("valuators", scope: "decidim.notifications_settings.show") %>
+      </label>
+      <div class="toggle__switch-trigger">
+        <label for="email_on_assigned_proposals" class="toggle__switch-toggle">
+          <span>
+            <input
+              <%== %(checked="checked") if @notifications_settings.email_on_assigned_proposals %>
+              id="email_on_assigned_proposals"
+              type="checkbox"
+              name="email_on_assigned_proposals">
+            <span class="toggle__switch-toggle-content">
+            </span>
+            <%= icon "check-line", class: "toggle__switch-toggle-icon" %>
+            <%= icon "close-line", class: "toggle__switch-toggle-icon" %>
+          </span>
+          <span class="toggle__switch-trigger-text">
+            <%= t("assigned_to_proposal", scope: "decidim.notifications_settings.show") %>
+          </span>
+        </label>
+      </div>
+
       <% if current_user.moderator? %>
         <label>
           <%= t("administrators", scope: "decidim.notifications_settings.show") %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1269,6 +1269,7 @@ en:
         administrators: Administrators
         allow_public_contact: Allow anyone to send me a direct message, even if I do not follow them.
         allow_push_notifications: Get push notifications to find out what is going on when you are not on the platform. You can turn them off anytime.
+        assigned_to_proposal: I want to receive an email when someone assigns me a proposal to evaluate
         direct_messages: Receive direct messages from anyone
         email_on_moderations: I want to receive an email every time something or someone is reported for moderation.
         everything_followed: Everything I follow
@@ -1287,6 +1288,7 @@ en:
         push_notifications_reminder: To get notifications from the platform, you will need to allow them in your browser settings first.
         receive_notifications_about: I want to get notifications about
         update_notifications_settings: Save changes
+        valuators: Evaluators
       update:
         error: There was a problem updating your notifications settings.
         success: Your notifications settings were successfully updated.

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -202,6 +202,7 @@ FactoryBot.define do
     accepted_tos_version { organization.tos_version }
     notifications_sending_frequency { "real_time" }
     email_on_moderations { true }
+    email_on_assigned_proposals { true }
     password_updated_at { Time.current }
     previous_passwords { [] }
     extended_data { {} }

--- a/decidim-core/spec/commands/decidim/update_notifications_settings_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_notifications_settings_spec.rb
@@ -9,7 +9,8 @@ module Decidim
     let(:valid) { true }
     let(:data) do
       {
-        email_on_moderations: true,
+        email_on_moderations: false,
+        email_on_assigned_proposals: false,
         newsletter_notifications_at: Time.current,
         direct_message_types: "followed-only",
         notification_settings: { close_meeting_reminder: "0" },
@@ -21,6 +22,7 @@ module Decidim
       double(
         notification_types: "none",
         email_on_moderations: data[:email_on_moderations],
+        email_on_assigned_proposals: data[:email_on_assigned_proposals],
         newsletter_notifications_at: data[:newsletter_notifications_at],
         direct_message_types: data[:direct_message_types],
         notification_settings: data[:notification_settings],
@@ -49,6 +51,8 @@ module Decidim
         expect(user.direct_message_types).to eq "followed-only"
         expect(user.notification_settings["close_meeting_reminder"]).to eq "0"
         expect(user.notifications_sending_frequency).to eq "weekly"
+        expect(user.email_on_moderations).to be_false
+        expect(user.email_on_assigned_proposals).to be_false
       end
     end
   end

--- a/decidim-core/spec/commands/decidim/update_notifications_settings_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_notifications_settings_spec.rb
@@ -51,8 +51,8 @@ module Decidim
         expect(user.direct_message_types).to eq "followed-only"
         expect(user.notification_settings["close_meeting_reminder"]).to eq "0"
         expect(user.notifications_sending_frequency).to eq "weekly"
-        expect(user.email_on_moderations).to be_false
-        expect(user.email_on_assigned_proposals).to be_false
+        expect(user.email_on_moderations).to be(false)
+        expect(user.email_on_assigned_proposals).to be(false)
       end
     end
   end

--- a/decidim-core/spec/forms/notifications_settings_form_spec.rb
+++ b/decidim-core/spec/forms/notifications_settings_form_spec.rb
@@ -10,6 +10,7 @@ module Decidim
         notifications_from_own_activity:,
         notifications_sending_frequency:,
         email_on_moderations:,
+        email_on_assigned_proposals:,
         newsletter_notifications:,
         allow_public_contact:
       ).with_context(
@@ -22,6 +23,7 @@ module Decidim
     let(:notifications_from_followed) { "1" }
     let(:notifications_from_own_activity) { "1" }
     let(:email_on_moderations) { "1" }
+    let(:email_on_assigned_proposals) { "1" }
     let(:newsletter_notifications) { "1" }
     let(:allow_public_contact) { "1" }
     let(:notifications_sending_frequency) { "real_time" }

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -242,6 +242,7 @@ describe "Account" do
 
         it "updates the administrator's notifications" do
           page.find("[for='email_on_moderations']").click
+          page.find("[for='email_on_assigned_proposals']").click
           page.find("[for='user_notification_settings[close_meeting_reminder]']").click
 
           within "form.edit_user" do

--- a/decidim-proposals/app/commands/decidim/proposals/admin/assign_proposals_to_valuator.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/assign_proposals_to_valuator.rb
@@ -37,6 +37,7 @@ module Decidim
             form.proposals.flat_map do |proposal|
               form.valuator_roles.each do |valuator_role|
                 find_assignment(proposal, valuator_role) || assign_proposal(proposal, valuator_role)
+                notify_valuator(proposal, valuator_role)
               end
             end
           end
@@ -56,6 +57,19 @@ module Decidim
             proposal:,
             valuator_role:
           )
+        end
+
+        def notify_valuator(proposal, valuator_role)
+          return unless valuator_role.user.email_on_assigned_proposals?
+
+          data = {
+            event: "decidim.events.proposals.admin.proposal_assigned_to_valuator",
+            event_class: Decidim::Proposals::Admin::ProposalAssignedToValuatorEvent,
+            resource: proposal,
+            affected_users: [valuator_role.user]
+          }
+
+          Decidim::EventsManager.publish(**data)
         end
       end
     end

--- a/decidim-proposals/app/events/decidim/proposals/admin/proposal_assigned_to_valuator_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/admin/proposal_assigned_to_valuator_event.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      class ProposalAssignedToValuatorEvent < Decidim::Events::SimpleEvent
+        include Rails.application.routes.mounted_helpers
+
+        i18n_attributes :admin_proposal_info_url, :admin_proposal_info_path
+
+        def admin_proposal_info_path
+          ResourceLocatorPresenter.new(resource).show
+        end
+
+        def admin_proposal_info_url
+          send(resource.component.mounted_admin_engine).proposal_url(resource, resource.component.mounted_params)
+        end
+
+        private
+
+        def organization
+          @organization ||= component.participatory_space.organization
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -235,6 +235,11 @@ en:
     events:
       proposals:
         admin:
+          proposal_assigned_to_valuator:
+            email_intro: You have been assigned as a valuator to the proposal "%{resource_title}". This means you have been trusted to give them feedback and a proper response in the next coming days. Check it out at <a href="%{admin_proposal_info_url}">the admin panel</a>.
+            email_outro: You have received this notification because you can valuate the proposal.
+            email_subject: You have been assigned as a valuator to the proposal %{resource_title}.
+            notification_title: You have been assigned as a valuator to the proposal <a href="%{resource_path}">%{resource_title}</a>. Check it out at <a href="%{admin_proposal_info_path}">the admin panel</a>.
           proposal_note_created:
             email_intro: Someone has left a note on the proposal "%{resource_title}". Check it out at <a href="%{admin_proposal_info_url}">the admin panel</a>.
             email_outro: You have received this notification because you can valuate the proposal.

--- a/decidim-proposals/db/migrate/20240617091140_add_email_on_assigned_proposals_to_users.rb
+++ b/decidim-proposals/db/migrate/20240617091140_add_email_on_assigned_proposals_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEmailOnAssignedProposalsToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :decidim_users, :email_on_assigned_proposals, :boolean, default: true
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Sends a notification to the valuator when a proposal is assigned to them.

#### :pushpin: Related Issues
Closes https://github.com/decidim/decidim/issues/12909

#### Testing
- Assign a proposal to a valuator, the valuator receives a notification and an email. https://decidim-lot2.populate.tools/admin/participatory_processes/branch-highway/components/4/manage/
- The valuator can opt out from receiving a notification when a proposal is assigned to them. https://decidim-lot2.populate.tools/notifications_settings

### :camera: Screenshots

<img width="1437" alt="Screenshot 2024-06-19 at 09 30 15" src="https://github.com/decidim/decidim/assets/935744/747c65ce-7013-403f-8fc1-304a89fb5e51">

<img width="1088" alt="Screenshot 2024-06-19 at 09 29 17" src="https://github.com/decidim/decidim/assets/935744/24407bfd-f9f0-4a03-8559-a5e905715631">


:hearts: Thank you!
