### PR TITLE
Fix UX details in hamburger menu

### DIFF
--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -60,6 +60,7 @@ module Decidim
 
       initializer "decidim_assemblies.menu" do
         Decidim::Assemblies::Menu.register_menu!
+        Decidim::Assemblies::Menu.register_mobile_menu!
         Decidim::Assemblies::Menu.register_home_content_block_menu!
       end
 

--- a/decidim-assemblies/lib/decidim/assemblies/menu.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/menu.rb
@@ -14,6 +14,17 @@ module Decidim
         end
       end
 
+      def self.register_mobile_menu!
+        Decidim.menu :mobile_menu do |menu|
+          menu.add_item :assemblies,
+                        I18n.t("menu.assemblies", scope: "decidim"),
+                        decidim_assemblies.assemblies_path,
+                        position: 2.2,
+                        if: OrganizationPublishedAssemblies.new(current_organization, current_user).any?,
+                        active: :inclusive
+        end
+      end
+
       def self.register_home_content_block_menu!
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :assemblies,

--- a/decidim-conferences/lib/decidim/conferences/engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/engine.rb
@@ -74,6 +74,7 @@ module Decidim
 
       initializer "decidim_conferences.menu" do
         Decidim::Conferences::Menu.register_menu!
+        Decidim::Conferences::Menu.register_mobile_menu!
         Decidim::Conferences::Menu.register_home_content_block_menu!
       end
 

--- a/decidim-conferences/lib/decidim/conferences/menu.rb
+++ b/decidim-conferences/lib/decidim/conferences/menu.rb
@@ -14,6 +14,17 @@ module Decidim
         end
       end
 
+      def self.register_mobile_menu!
+        Decidim.menu :mobile_menu do |menu|
+          menu.add_item :conferences,
+                        I18n.t("menu.conferences", scope: "decidim"),
+                        decidim_conferences.conferences_path,
+                        position: 2.8,
+                        if: Decidim::Conference.where(organization: current_organization).published.any?,
+                        active: :inclusive
+        end
+      end
+
       def self.register_home_content_block_menu!
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :conferences,

--- a/decidim-core/app/helpers/decidim/menu_helper.rb
+++ b/decidim-core/app/helpers/decidim/menu_helper.rb
@@ -43,6 +43,14 @@ module Decidim
       )
     end
 
+    def mobile_breadcrumb_root_menu
+      @mobile_breadcrumb_root_menu ||= ::Decidim::BreadcrumbRootMenuPresenter.new(
+        :mobile_menu,
+        self,
+        container_options: { class: "menu-bar__main-dropdown__menu" }
+      )
+    end
+
     def footer_menu
       @footer_menu ||= ::Decidim::FooterMenuPresenter.new(
         :menu,

--- a/decidim-core/app/packs/src/decidim/sticky_header.js
+++ b/decidim-core/app/packs/src/decidim/sticky_header.js
@@ -2,6 +2,8 @@
 // Sticky headers allow users to quickly access the navigation, search, and utility-navigation elements without scrolling up to the top of the page. They increase the discoverability of the elements in the header.
 // The sticky buttons in the other hand, those are some of the main Call to Actions (CTAs) that remain accessible on the screen as the user scrolls through the detailed view of the Meetings, Proposals, Surveys, and Budgets components.
 
+import { screens } from "tailwindcss/defaultTheme"
+
 let prevScroll = window.scrollY;
 const stickyHeader = document.querySelector("[data-sticky-header]");
 const footer = document.querySelector("footer");
@@ -27,10 +29,41 @@ const adjustCtasButtons = () => {
   }
 };
 
+// Fix the menu bar container margin top when there are multiple elements in the sticky header
+// As there could be different heights and we cannot know beforehand, we need to adjust this in a dynamic way
+// For instance we could have the omnipresent banner, the admin bar and the offline banner
+const fixMenuBarContainerMargin = () => {
+  if (!stickyHeader) {
+    return;
+  }
+
+  const isMaxScreenSize = (key) => {
+    return window.matchMedia(`(max-width: ${screens[key]})`).matches;
+  }
+
+  const menuBarContainer = document.querySelector("#menu-bar-container");
+  const marginTop = isMaxScreenSize("md")
+    ? stickyHeader.offsetHeight
+    : 0;
+
+  menuBarContainer.style.marginTop = `${marginTop}px`;
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  fixMenuBarContainerMargin();
+});
+
+window.addEventListener("resize", () => {
+  fixMenuBarContainerMargin();
+});
+
 if (stickyHeader) {
   document.addEventListener("scroll", () => {
+    fixMenuBarContainerMargin();
+
     // if a subelement is not visible it has no offsetParent
     const header = document.getElementById("main-bar").offsetParent;
+
     if (header && window.getComputedStyle(stickyHeader).position === "fixed") {
       let currentScroll = window.scrollY;
       let goingDown = prevScroll > currentScroll;

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -33,9 +33,27 @@
   }
 }
 
-[data-target*="dropdown-menu-language-chooser"] {
+[data-target="dropdown-menu-language-chooser"] {
   & > span {
     @apply block font-semibold text-black text-xs;
+  }
+
+  > svg {
+    @apply w-5 h-6 flex-none text-xs font-normal text-black fill-current;
+  }
+
+  & > ul {
+    @apply w-6 bg-gray;
+
+    > li {
+      @apply w-6 bg-gray;
+    }
+  }
+}
+
+[data-target="dropdown-menu-language-chooser-mobile"] {
+  & > span {
+    @apply block text-black font-normal text-sm;
   }
 
   > svg {

--- a/decidim-core/app/packs/stylesheets/decidim/_forms.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_forms.scss
@@ -1,5 +1,5 @@
 #form-search-mobile {
-  @apply py-1.5 px-4 bg-gray-5 rounded-sm;
+  @apply py-1.5 px-4 bg-gray-5 rounded-lg border border-gray outline outline-1 outline-transparent;
 
   input[type="text"] {
     @apply bg-gray-5;

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -24,10 +24,6 @@ header {
     @apply mt-28 md:mt-0;
   }
 
-  #menu-bar-container {
-    @apply mt-24 md:mt-0;
-  }
-
   &.with-admin-bar {
     #flash-messages-container {
       @apply mt-40 md:mt-0;

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -372,7 +372,7 @@ header {
     }
 
     &__main-dropdown {
-      @apply bg-white divide-y divide-gray-3 rounded-b shadow-lg text-black w-full lg:w-[1280px];
+      @apply bg-white divide-y divide-gray-3 rounded-b shadow-lg text-black w-full lg:w-[1280px] h-screen md:h-auto;
 
       &__bottom,
       &__top {

--- a/decidim-core/app/views/layouts/decidim/_application.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_application.html.erb
@@ -10,10 +10,6 @@
     <!--noindex--><!--googleoff: all-->
     <%= link_to t("skip_button", scope: "decidim.accessibility"), "#content", class: "layout-container__skip" %>
     <%= cell("decidim/data_consent", current_organization) %>
-    <%= render partial: "layouts/decidim/impersonation_warning" %>
-    <%= render partial: "layouts/decidim/omnipresent_banner" %>
-    <%= render partial: "layouts/decidim/timeout_modal" %>
-    <%= render partial: "layouts/decidim/offline_banner" %>
     <!--googleon: all--><!--/noindex-->
 
     <%= render "layouts/decidim/wrapper" do %>
@@ -22,6 +18,7 @@
       <%= yield %>
     <% end %>
 
+    <%= render partial: "layouts/decidim/timeout_modal" %>
     <%= render partial: "decidim/shared/confirm_modal" %>
     <%= render partial: "decidim/shared/login_modal" unless current_user %>
     <%= render partial: "decidim/shared/authorization_modal" %>

--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -13,6 +13,9 @@ end
 <div class="layout-container">
   <header <%= "class=with-admin-bar" if current_user&.admin %>>
     <div id="sticky-header-container" data-sticky-header>
+      <%= render partial: "layouts/decidim/impersonation_warning" %>
+      <%= render partial: "layouts/decidim/omnipresent_banner" %>
+      <%= render partial: "layouts/decidim/offline_banner" %>
       <%= render partial: "layouts/decidim/admin_links" if current_user&.admin %>
       <%= render partial: "layouts/decidim/header/main" %>
     </div>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_main_dropdown_mobile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_main_dropdown_mobile.html.erb
@@ -3,7 +3,7 @@
     <div class="mb-8">
       <%= render partial: "layouts/decidim/header/menu_form_search_mobile" %>
     </div>
-    <%= breadcrumb_root_menu.render %>
+    <%= mobile_breadcrumb_root_menu.render %>
     <%= render partial: "layouts/decidim/header/mobile_language_choose" %>
   </div>
   <div class="menu-bar__main-dropdown__bottom">

--- a/decidim-core/app/views/layouts/decidim/header/_menu_form_search_mobile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_form_search_mobile.html.erb
@@ -3,7 +3,7 @@
             :term,
             nil,
             id: "input-search-mobile",
-            class: "reset-defaults outline-none",
+            class: "reset-defaults",
             value: params[:term] || params.dig(:filter, :term),
             placeholder: t("decidim.search.term_input_placeholder"),
             title: t("decidim.search.term_input_placeholder"),

--- a/decidim-core/app/views/layouts/decidim/header/_mobile_language_choose.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_mobile_language_choose.html.erb
@@ -1,6 +1,6 @@
 <% if available_locales.length > 1 %>
     <div>
-        <button id="dropdown-trigger-language-chooser-mobile" data-component="dropdown" data-target="dropdown-menu-language-chooser-mobile" class="mt-8 rounded-lg py-0 bg-gray-5 h-10">
+        <button id="dropdown-trigger-language-chooser-mobile" data-component="dropdown" data-target="dropdown-menu-language-chooser-mobile" class="mt-8 rounded-lg py-0 bg-gray-5 h-10 border border-gray outline outline-1 outline-transparent">
             <span><%= t("name", scope: "locale" ) %></span>
             <%= icon "arrow-down-s-line" %>
             <%= icon "arrow-up-s-line" %>

--- a/decidim-core/app/views/layouts/decidim/header/_mobile_language_choose.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_mobile_language_choose.html.erb
@@ -1,6 +1,6 @@
 <% if available_locales.length > 1 %>
     <div>
-        <button id="dropdown-trigger-language-chooser-mobile" data-component="dropdown" data-target="dropdown-menu-language-chooser-mobile" class="mt-8 border border-black rounded-lg py-0 bg-gray-5">
+        <button id="dropdown-trigger-language-chooser-mobile" data-component="dropdown" data-target="dropdown-menu-language-chooser-mobile" class="mt-8 rounded-lg py-0 bg-gray-5">
             <span><%= t("name", scope: "locale" ) %></span>
             <%= icon "arrow-down-s-line" %>
             <%= icon "arrow-up-s-line" %>

--- a/decidim-core/app/views/layouts/decidim/header/_mobile_language_choose.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_mobile_language_choose.html.erb
@@ -1,6 +1,6 @@
 <% if available_locales.length > 1 %>
     <div>
-        <button id="dropdown-trigger-language-chooser-mobile" data-component="dropdown" data-target="dropdown-menu-language-chooser-mobile" class="mt-8 rounded-lg py-0 bg-gray-5">
+        <button id="dropdown-trigger-language-chooser-mobile" data-component="dropdown" data-target="dropdown-menu-language-chooser-mobile" class="mt-8 rounded-lg py-0 bg-gray-5 h-10">
             <span><%= t("name", scope: "locale" ) %></span>
             <%= icon "arrow-down-s-line" %>
             <%= icon "arrow-up-s-line" %>
@@ -15,8 +15,8 @@
     <div id="dropdown-menu-language-chooser-mobile" class="bg-gray-5 relative" aria-hidden="true">
         <ul class="menu-bar__language-chooser" role="menu">
         <% (available_locales - [I18n.locale.to_s]).each do |locale| %>
-            <li class="text-black text-xs hover:bg-secondary hover:text-white transition" role="presentation">
-            <%= link_to locale_name(locale), decidim.locale_path(locale:), method: :post, role: "menuitem", lang: locale, class: "p-2 w-full block" %>
+            <li class="text-black text-sm hover:bg-secondary hover:text-white transition h-10" role="presentation">
+              <%= link_to locale_name(locale), decidim.locale_path(locale:), method: :post, role: "menuitem", lang: locale, class: "p-2 w-full block" %>
             </li>
         <% end %>
         </ul>

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -381,6 +381,7 @@ module Decidim
 
       initializer "decidim_core.menu" do
         Decidim::Core::Menu.register_menu!
+        Decidim::Core::Menu.register_mobile_menu!
         Decidim::Core::Menu.register_user_menu!
       end
 

--- a/decidim-core/lib/decidim/core/menu.rb
+++ b/decidim-core/lib/decidim/core/menu.rb
@@ -13,6 +13,22 @@ module Decidim
         end
       end
 
+      def self.register_mobile_menu!
+        Decidim.menu :mobile_menu do |menu|
+          menu.add_item :root,
+                        I18n.t("menu.home", scope: "decidim"),
+                        decidim.root_path,
+                        position: 1,
+                        active: :exclusive
+
+          menu.add_item :help,
+                        I18n.t("menu.help", scope: "decidim"),
+                        decidim.pages_path,
+                        position: 10,
+                        active: :exclusive
+        end
+      end
+
       def self.register_user_menu!
         Decidim.menu :user_menu do |menu|
           menu.add_item :account,

--- a/decidim-core/spec/system/menu_spec.rb
+++ b/decidim-core/spec/system/menu_spec.rb
@@ -34,6 +34,26 @@ describe "Menu" do
     end
   end
 
+  context "when the device is mobile" do
+    let!(:participatory_space) { create(:participatory_process, organization:) }
+
+    before do
+      driven_by(:iphone)
+      switch_to_host(organization.host)
+      visit decidim.root_path
+    end
+
+    it "shows the mobile menu" do
+      click_on(id: "main-dropdown-summary-mobile")
+
+      within "#breadcrumb-main-dropdown-mobile" do
+        expect(page).to have_link("Home", href: "/")
+        expect(page).to have_link("Processes", href: "/processes")
+        expect(page).to have_link("Help", href: "/pages")
+      end
+    end
+  end
+
   context "when rendering a component with special characters" do
     let(:component_name) { "Collaborative Drafts & Amendments" }
     let(:participatory_space) { create(:participatory_process, organization:) }

--- a/decidim-initiatives/lib/decidim/initiatives/engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/engine.rb
@@ -104,6 +104,7 @@ module Decidim
 
       initializer "decidim_initiatives.menu" do
         Decidim::Initiatives::Menu.register_menu!
+        Decidim::Initiatives::Menu.register_mobile_menu!
         Decidim::Initiatives::Menu.register_home_content_block_menu!
       end
 

--- a/decidim-initiatives/lib/decidim/initiatives/menu.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/menu.rb
@@ -14,6 +14,17 @@ module Decidim
         end
       end
 
+      def self.register_mobile_menu!
+        Decidim.menu :mobile_menu do |menu|
+          menu.add_item :initiatives,
+                        I18n.t("menu.initiatives", scope: "decidim"),
+                        decidim_initiatives.initiatives_path,
+                        position: 2.4,
+                        active: %r{^/(initiatives|create_initiative)},
+                        if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).all.empty?
+        end
+      end
+
       def self.register_home_content_block_menu!
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :initiatives,

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -65,6 +65,7 @@ module Decidim
 
       initializer "decidim_participatory_processes.menu" do
         Decidim::ParticipatoryProcesses::Menu.register_menu!
+        Decidim::ParticipatoryProcesses::Menu.register_mobile_menu!
         Decidim::ParticipatoryProcesses::Menu.register_home_content_block_menu!
       end
 

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/menu.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/menu.rb
@@ -14,6 +14,17 @@ module Decidim
         end
       end
 
+      def self.register_mobile_menu!
+        Decidim.menu :mobile_menu do |menu|
+          menu.add_item :participatory_processes,
+                        I18n.t("menu.processes", scope: "decidim"),
+                        decidim_participatory_processes.participatory_processes_path,
+                        position: 2,
+                        if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
+                        active: %r{^/process(es|_groups)}
+        end
+      end
+
       def self.register_home_content_block_menu!
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :participatory_processes,


### PR DESCRIPTION
#### :tophat: What? Why?

This PR introduces a couple of mini changes based on #12932 

#### :pushpin: Related Issues
 
- Fixes [#13015](https://github.com/decidim/decidim/issues/13015)

#### Testing

Open the hamburguer menu in a mobile resolution. Check the Acceptance criteria from #13015:

- [x] Given the hamburger menu is opened, when the menu expands, then it should occupy 100% of the screen height.
- [ ] Given the hamburger menu is opened, when participants view the menu items, then the access to help pages (/pages) should be visible after the menu items.
- [x] Given the language selector is in the hamburger menu, when participants use the language selector, then it should have the same style as the locale configuration in the participant's account settings.

### :camera: Screenshots
 
![Changes introduced in this PR](https://github.com/decidim/decidim/assets/717367/76fed20e-cc50-4552-87e2-d2d813143d3f)

:hearts: Thank you!
