### PR TITLE
Show all the authorizations available for the organization in the admin

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -221,7 +221,28 @@ bin/rails db:drop db:create db:migrate assets:precompile db:seed
 
 You can see more details about this change on PR [\#12828](https://github.com/decidim/decidim/pull/12828)
 
-### 5.3. [[TITLE OF THE CHANGE]]
+### 5.3. Verifications need a help text
+
+In order to explain better to administrators what authorizations they have available we have added a new internationalization (i18n) key to the verifications workflows.
+
+If you have a custom authorization handler, you need to add the help text to the `config/locales/en.yml` file, where `en.yml` is the locale file for the language you are using.
+
+For instance, for the SMS authorization handler, you need to add the following key:
+
+```yaml
+en:
+  decidim:
+    authorization_handlers:
+      admin:
+        sms:
+          help:
+          - This is the help text for the SMS authorization handler
+          - This is the second line of the help text
+```
+
+You can see more details about this change on PR [\#13029](https://github.com/decidim/decidim/pull/13029)
+
+### 5.4. [[TITLE OF THE CHANGE]]
 
 In order to [[REASONING (e.g. improve the maintenance of the code base)]] we have changed...
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -353,6 +353,7 @@ ignore_unused:
   - decidim.meetings.polls.questions.index_admin.statuses.{closed,published,unpublished}
   - decidim.meetings.directory.meetings.index.space_type
   - decidim.authorization_modals.content.*
+  - decidim.authorization_handlers.admin.{another_dummy_authorization_handler,csv_census,dummy_authorization_handler,id_documents,postal_letter,sms}.help
   - time.buttons.*
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:

--- a/decidim-admin/app/controllers/decidim/admin/authorization_workflows_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/authorization_workflows_controller.rb
@@ -10,7 +10,7 @@ module Decidim
       def index
         enforce_permission_to :index, :authorization_workflow
 
-        @workflows = Decidim::Verifications.admin_workflows.select do |manifest|
+        @workflows = Decidim::Verifications.workflows.select do |manifest|
           current_organization.available_authorizations.include?(manifest.name.to_s)
         end
 

--- a/decidim-admin/app/views/decidim/admin/authorization_workflows/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/authorization_workflows/index.html.erb
@@ -18,20 +18,38 @@
       <thead>
         <tr>
           <th><%= t("decidim.authorization_handlers.name") %></th>
-          <th><%= t("decidim.authorization_handlers.help") %></th>
+          <th class="!text-left"><%= t("decidim.authorization_handlers.help") %></th>
         </tr>
       </thead>
       <tbody>
         <% @workflows.each do |manifest| %>
           <tr>
             <% workflow = Decidim::Verifications::Adapter.new(manifest) %>
-            <td><%= link_to workflow.fullname, workflow.admin_root_path %></td>
             <td>
-              <ul>
-                <% t("decidim.authorization_handlers.admin.#{workflow.key}.help").each do |tip| %>
-                  <li><%= tip %></li>
-                <% end %>
-              </ul>
+              <% if workflow.has_admin_root_path? %>
+                <%= link_to workflow.fullname, workflow.admin_root_path %>
+              <% else %>
+                <%= workflow.fullname %>
+              <% end %>
+            </td>
+            <td class="!text-left">
+              <% i18n_key = "decidim.authorization_handlers.admin.#{workflow.key}.help" %>
+              <% if I18n.exists?(i18n_key, current_locale) %>
+                <ul class="list-decimal ml-4">
+                  <% t(i18n_key).each do |tip| %>
+                    <li><%= tip %></li>
+                  <% end %>
+                </ul>
+              <% else %>
+                <div class="flash warning">
+                  <ul>
+                    <% default_help = t("decidim.authorization_handlers.admin.default.help", authorization_handler: i18n_key) %>
+                    <% default_help.each do |tip| %>
+                      <li><%= tip %></li>
+                    <% end %>
+                  </ul>
+                </div>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -57,10 +57,24 @@ en:
         grant_id_documents_offline_verification: "%{user_name} verified %{resource_name} using an offline Identity Documents authorization"
     authorization_handlers:
       admin:
+        another_dummy_authorization_handler:
+          help:
+          - An example authorization handler so developers can understand how a simple verification works.
+          - It is aimed for developers so they can understand how to implement their own verification system.
+          - Get verified by introducing a passport number starting with "A".
         csv_census:
           help:
           - Admins upload a CSV with the emails of the accepted participants.
           - Only participants with an email in that CSV file can get verified.
+        default:
+          help:
+          - The authorization handler help is not defined.
+          - A developer needs to define the help in the translation (i18n) key "%{authorization_handler}"
+        dummy_authorization_handler:
+          help:
+          - An example authorization handler so developers can understand how a simple verification works.
+          - It is aimed for developers so they can understand how to implement their own verification system.
+          - Get verified by introducing a document number ending with "X".
         id_documents:
           help:
           - Users fill in their identity information and upload a copy of their document.
@@ -73,6 +87,11 @@ en:
           - You send the letter to their address with the verification code.
           - You mark the letter as sent.
           - Once you mark the letter as sent, the participant will be able to introduce the code and get verified.
+        sms:
+          help:
+          - Participants request a verification code to be sent to their phone.
+          - They need to introduce the code to get verified.
+          - If they do not receive the code, they can request it again.
       csv_census:
         explanation: Get verified using the organization's census.
         name: Organization's census

--- a/decidim-verifications/lib/decidim/verifications/adapter.rb
+++ b/decidim-verifications/lib/decidim/verifications/adapter.rb
@@ -111,6 +111,15 @@ module Decidim
       end
 
       #
+      # Does this workflow manifest has an admin engine associated?
+      #
+      # Returns a boolean value.
+      #
+      def has_admin_root_path?
+        respond_to?("decidim_admin_#{name}")
+      end
+
+      #
       # Authorize user to perform an action using the authorization handler action authorizer.
       # Saves the action_authorizer object with its context for subsequent methods calls.
       #

--- a/decidim-verifications/spec/system/admin_manages_authorizations_spec.rb
+++ b/decidim-verifications/spec/system/admin_manages_authorizations_spec.rb
@@ -17,7 +17,7 @@ describe "Admin manages authorizations users" do
   end
 
   context "when multiple authorization handlers are available" do
-    let(:available_authorizations) { %w(id_documents postal_letter csv_census) }
+    let(:available_authorizations) { %w(id_documents postal_letter csv_census dummy_authorization_handler another_dummy_authorization_handler sms) }
 
     it "displays the menu entries" do
       within ".sidebar-menu" do
@@ -32,6 +32,9 @@ describe "Admin manages authorizations users" do
         expect(page).to have_content("Identity documents")
         expect(page).to have_content("Code by postal letter")
         expect(page).to have_content("Organization's census")
+        expect(page).to have_content("Example authorization")
+        expect(page).to have_content("Another example authorization")
+        expect(page).to have_content("Code by SMS")
       end
     end
   end
@@ -52,6 +55,9 @@ describe "Admin manages authorizations users" do
         expect(page).to have_content("Identity documents")
         expect(page).to have_content("Organization's census")
         expect(page).to have_no_content("Code by postal letter")
+        expect(page).to have_no_content("Example authorization")
+        expect(page).to have_no_content("Another example authorization")
+        expect(page).to have_no_content("Code by SMS")
       end
     end
   end
@@ -72,6 +78,9 @@ describe "Admin manages authorizations users" do
         expect(page).to have_no_content("Identity documents")
         expect(page).to have_no_content("Code by postal letter")
         expect(page).to have_no_content("Organization's census")
+        expect(page).to have_no_content("Example authorization")
+        expect(page).to have_no_content("Another example authorization")
+        expect(page).to have_no_content("Code by SMS")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

It was detected that some verifications that were enabled for the Organization weren't available in the admin panel. 

This PR adds them. 

As we could list custom verifications made by the implementers we have a default help text to explain to developers that they need to add these strings. I've also added instructions in the Releases Notes to let the implementers/developers about this new feature.

#### :pushpin: Related Issues

- Related to #12952
- Fixes #13018

#### Testing

1. Sign in as system administrator
2. Go to the verifications method for any organization (i.e. http://localhost:3000/system/organizations/1/edit)
3. Check that you have all the methods enabled
4. Sign in as administrator in that organization
5. Go to http://localhost:3000/admin/authorization_workflows
6. See that you have all the methods that you've seen before

To test the missing message you can remove any of the help strings introduced in the i18n file.

### :camera: Screenshots

![Admin panel with all the verifications](https://github.com/decidim/decidim/assets/717367/fbb1d5cc-0ce4-4585-ba08-71f6445c7adc)

:hearts: Thank you!
