### PR TITLE
Bump tailwindcss from 3.3.2 to 3.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13472,8 +13472,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.18.2",
-      "license": "MIT",
+      "version": "1.21.6",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -18705,19 +18706,19 @@
       "peer": true
     },
     "node_modules/tailwindcss": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
-      "integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
+      "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.2.12",
+        "fast-glob": "^3.3.0",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.18.2",
+        "jiti": "^1.19.1",
         "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
@@ -18729,7 +18730,6 @@
         "postcss-load-config": "^4.0.1",
         "postcss-nested": "^6.0.1",
         "postcss-selector-parser": "^6.0.11",
-        "postcss-value-parser": "^4.2.0",
         "resolve": "^1.22.2",
         "sucrase": "^3.32.0"
       },
@@ -20705,7 +20705,7 @@
         "shakapacker": "~7.1.0",
         "source-map-loader": "^4.0.1",
         "style-loader": "^3.3.3",
-        "tailwindcss": "^3.3.2",
+        "tailwindcss": "3.4.1",
         "terser-webpack-plugin": "^5.3.9",
         "webpack": "^5.88.1",
         "webpack-assets-manifest": "^5.1.0",
@@ -22542,7 +22542,7 @@
         "shakapacker": "~7.1.0",
         "source-map-loader": "^4.0.1",
         "style-loader": "^3.3.3",
-        "tailwindcss": "^3.3.2",
+        "tailwindcss": "3.4.1",
         "terser-webpack-plugin": "^5.3.9",
         "webpack": "^5.88.1",
         "webpack-assets-manifest": "^5.1.0",
@@ -29800,7 +29800,9 @@
       }
     },
     "jiti": {
-      "version": "1.18.2"
+      "version": "1.21.6",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w=="
     },
     "jquery": {
       "version": "3.6.4"
@@ -33101,19 +33103,19 @@
       }
     },
     "tailwindcss": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
-      "integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
+      "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
       "requires": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.2.12",
+        "fast-glob": "^3.3.0",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.18.2",
+        "jiti": "^1.19.1",
         "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
@@ -33125,7 +33127,6 @@
         "postcss-load-config": "^4.0.1",
         "postcss-nested": "^6.0.1",
         "postcss-selector-parser": "^6.0.11",
-        "postcss-value-parser": "^4.2.0",
         "resolve": "^1.22.2",
         "sucrase": "^3.32.0"
       },

--- a/packages/webpacker/package.json
+++ b/packages/webpacker/package.json
@@ -42,7 +42,7 @@
     "shakapacker": "~7.1.0",
     "source-map-loader": "^4.0.1",
     "style-loader": "^3.3.3",
-    "tailwindcss": "^3.3.2",
+    "tailwindcss": "3.4.1",
     "terser-webpack-plugin": "^5.3.9",
     "webpack": "^5.88.1",
     "webpack-assets-manifest": "^5.1.0",


### PR DESCRIPTION
#### :tophat: What? Why?

When updating Metadecidim we detected that we were using a Tailwind class introduced in v3.4.0 (`min-w-24`). This was introduced in v0.28 with #12787. 

After merging this we should publish v0.28.2 to fix this problem. 

#### :pushpin: Related Issues
 
- See https://github.com/decidim/metadecidim/pull/128#issuecomment-2180694213

#### Testing

Follow the instructions in that comment. 

(The reproduction is specially difficult to reproduce as we're using the caret sign in the dependency resolving, so it's not being caught in the CI)
 
:hearts: Thank you!
