### PR TITLE
Extract methods from accountabilty seeds

### DIFF
--- a/decidim-accountability/lib/decidim/accountability/seeds.rb
+++ b/decidim-accountability/lib/decidim/accountability/seeds.rb
@@ -4,7 +4,7 @@ require "decidim/components/namer"
 
 module Decidim
   module Accountability
-    class Seeds
+    class Seeds < Decidim::Seeds
       attr_reader :participatory_space
 
       def initialize(participatory_space:)
@@ -12,11 +12,6 @@ module Decidim
       end
 
       def call
-        admin_user = Decidim::User.find_by(
-          organization: participatory_space.organization,
-          email: "admin@example.org"
-        )
-
         params = {
           name: Decidim::Components::Namer.new(participatory_space.organization.available_locales, :accountability).i18n_name,
           manifest_name: :accountability,

--- a/decidim-accountability/lib/decidim/accountability/seeds.rb
+++ b/decidim-accountability/lib/decidim/accountability/seeds.rb
@@ -14,13 +14,7 @@ module Decidim
       def call
         component = create_component!
 
-        5.times do |i|
-          Decidim::Accountability::Status.create!(
-            component:,
-            name: Decidim::Faker::Localized.word,
-            key: "status_#{i}"
-          )
-        end
+        create_statuses!(component:)
 
         3.times do
           parent_category = participatory_space.categories.sample
@@ -103,6 +97,16 @@ module Decidim
 
         component = Decidim.traceability.perform_action!("publish", Decidim::Component, admin_user, visibility: "all") do
           Decidim::Component.create!(params)
+        end
+      end
+
+      def create_statuses!(component:)
+        5.times do |i|
+          Decidim::Accountability::Status.create!(
+            component:,
+            name: Decidim::Faker::Localized.word,
+            key: "status_#{i}"
+          )
         end
       end
     end

--- a/decidim-accountability/lib/decidim/accountability/seeds.rb
+++ b/decidim-accountability/lib/decidim/accountability/seeds.rb
@@ -17,19 +17,7 @@ module Decidim
         create_statuses!(component:)
 
         3.times do
-          parent_category = participatory_space.categories.sample
-          categories = [parent_category]
-
-          2.times do
-            categories << Decidim::Category.create!(
-              name: Decidim::Faker::Localized.sentence(word_count: 5),
-              description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-                Decidim::Faker::Localized.paragraph(sentence_count: 3)
-              end,
-              parent: parent_category,
-              participatory_space:
-            )
-          end
+          categories = create_categories!
 
           categories.each do |category|
             result = Decidim.traceability.create!(
@@ -108,6 +96,24 @@ module Decidim
             key: "status_#{i}"
           )
         end
+      end
+
+      def create_categories!
+        parent_category = participatory_space.categories.sample
+        categories = [parent_category]
+
+        2.times do
+          categories << Decidim::Category.create!(
+            name: Decidim::Faker::Localized.sentence(word_count: 5),
+            description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+              Decidim::Faker::Localized.paragraph(sentence_count: 3)
+            end,
+            parent: parent_category,
+            participatory_space:
+          )
+        end
+
+        categories
       end
     end
   end

--- a/decidim-accountability/lib/decidim/accountability/seeds.rb
+++ b/decidim-accountability/lib/decidim/accountability/seeds.rb
@@ -12,21 +12,7 @@ module Decidim
       end
 
       def call
-        params = {
-          name: Decidim::Components::Namer.new(participatory_space.organization.available_locales, :accountability).i18n_name,
-          manifest_name: :accountability,
-          published_at: Time.current,
-          participatory_space:,
-          settings: {
-            intro: Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(word_count: 4) },
-            scopes_enabled: true,
-            scope_id: participatory_space.scope&.id
-          }
-        }
-
-        component = Decidim.traceability.perform_action!("publish", Decidim::Component, admin_user, visibility: "all") do
-          Decidim::Component.create!(params)
-        end
+        component = create_component!
 
         5.times do |i|
           Decidim::Accountability::Status.create!(
@@ -99,6 +85,24 @@ module Decidim
               Decidim::Comments::Seed.comments_for(child_result)
             end
           end
+        end
+      end
+
+      def create_component!
+        params = {
+          name: Decidim::Components::Namer.new(participatory_space.organization.available_locales, :accountability).i18n_name,
+          manifest_name: :accountability,
+          published_at: Time.current,
+          participatory_space:,
+          settings: {
+            intro: Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(word_count: 4) },
+            scopes_enabled: true,
+            scope_id: participatory_space.scope&.id
+          }
+        }
+
+        component = Decidim.traceability.perform_action!("publish", Decidim::Component, admin_user, visibility: "all") do
+          Decidim::Component.create!(params)
         end
       end
     end

--- a/decidim-accountability/lib/decidim/accountability/seeds.rb
+++ b/decidim-accountability/lib/decidim/accountability/seeds.rb
@@ -20,7 +20,7 @@ module Decidim
           categories = create_categories!
 
           categories.each do |category|
-            result = create_result!(component:, category:)
+            create_result!(component:, category:)
           end
         end
       end
@@ -38,7 +38,7 @@ module Decidim
           }
         }
 
-        component = Decidim.traceability.perform_action!("publish", Decidim::Component, admin_user, visibility: "all") do
+        Decidim.traceability.perform_action!("publish", Decidim::Component, admin_user, visibility: "all") do
           Decidim::Component.create!(params)
         end
       end

--- a/decidim-accountability/lib/decidim/accountability/seeds.rb
+++ b/decidim-accountability/lib/decidim/accountability/seeds.rb
@@ -20,52 +20,7 @@ module Decidim
           categories = create_categories!
 
           categories.each do |category|
-            result = Decidim.traceability.create!(
-              Decidim::Accountability::Result,
-              admin_user,
-              {
-                component:,
-                scope: participatory_space.organization.scopes.sample,
-                category:,
-                title: Decidim::Faker::Localized.sentence(word_count: 2),
-                description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-                  Decidim::Faker::Localized.paragraph(sentence_count: 3)
-                end
-              },
-              visibility: "all"
-            )
-
-            Decidim::Comments::Seed.comments_for(result)
-
-            3.times do
-              child_result = Decidim.traceability.create!(
-                Decidim::Accountability::Result,
-                admin_user,
-                {
-                  component:,
-                  parent: result,
-                  start_date: Time.zone.today,
-                  end_date: Time.zone.today + 10,
-                  status: Decidim::Accountability::Status.all.sample,
-                  progress: rand(1..100),
-                  title: Decidim::Faker::Localized.sentence(word_count: 2),
-                  description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-                    Decidim::Faker::Localized.paragraph(sentence_count: 3)
-                  end
-                },
-                visibility: "all"
-              )
-
-              rand(0..5).times do |i|
-                child_result.timeline_entries.create!(
-                  entry_date: child_result.start_date + i.days,
-                  title: Decidim::Faker::Localized.sentence(word_count: 2),
-                  description: Decidim::Faker::Localized.paragraph(sentence_count: 1)
-                )
-              end
-
-              Decidim::Comments::Seed.comments_for(child_result)
-            end
+            result = create_result!(component:, category:)
           end
         end
       end
@@ -114,6 +69,55 @@ module Decidim
         end
 
         categories
+      end
+
+      def create_result!(component:, category:)
+        result = Decidim.traceability.create!(
+          Decidim::Accountability::Result,
+          admin_user,
+          {
+            component:,
+            scope: participatory_space.organization.scopes.sample,
+            category:,
+            title: Decidim::Faker::Localized.sentence(word_count: 2),
+            description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+              Decidim::Faker::Localized.paragraph(sentence_count: 3)
+            end
+          },
+          visibility: "all"
+        )
+
+        Decidim::Comments::Seed.comments_for(result)
+
+        3.times do
+          child_result = Decidim.traceability.create!(
+            Decidim::Accountability::Result,
+            admin_user,
+            {
+              component:,
+              parent: result,
+              start_date: Time.zone.today,
+              end_date: Time.zone.today + 10,
+              status: Decidim::Accountability::Status.all.sample,
+              progress: rand(1..100),
+              title: Decidim::Faker::Localized.sentence(word_count: 2),
+              description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+                Decidim::Faker::Localized.paragraph(sentence_count: 3)
+              end
+            },
+            visibility: "all"
+          )
+
+          rand(0..5).times do |i|
+            child_result.timeline_entries.create!(
+              entry_date: child_result.start_date + i.days,
+              title: Decidim::Faker::Localized.sentence(word_count: 2),
+              description: Decidim::Faker::Localized.paragraph(sentence_count: 1)
+            )
+          end
+
+          Decidim::Comments::Seed.comments_for(child_result)
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Refactors the accountability seeds to individual methods.

This is following the same methodology and reasoning from #12005, so refer to that issue for the explanations.   

To ease-up the review process, I was disciplined and made the changes in a commit by commit basis 😎 
 
#### Testing

Regenerating the `development_app` database should have different kind of meetings (almost the same as before):

```console
$ bin/rails db:drop db:create db:migrate assets:precompile db:seed
``` 

:hearts: Thank you!
