### PR TITLE
Fix timeline entries display in result page

### DIFF
--- a/decidim-accountability/app/cells/decidim/accountability/project/timeline.erb
+++ b/decidim-accountability/app/cells/decidim/accountability/project/timeline.erb
@@ -6,14 +6,14 @@
       </div>
       <div class="accountability__project-timeline-entry-attributes">
         <h3>
-          <%= translated_attribute timeline_entry.title %>
+          <%= decidim_sanitize_translated timeline_entry.title %>
         </h3>
         <div>
           <%= l timeline_entry.entry_date, format: :decidim_short %>
         </div>
         <% if translated_attribute(timeline_entry.description).present? %>
           <div>
-            <%= translated_attribute(timeline_entry.description).html_safe %>
+            <%= decidim_sanitize_translated(timeline_entry.description) %>
           </div>
         <% end %>
       </div>

--- a/decidim-accountability/app/cells/decidim/accountability/project_cell.rb
+++ b/decidim-accountability/app/cells/decidim/accountability/project_cell.rb
@@ -12,10 +12,14 @@ module Decidim
       alias result model
 
       def show
-        render
+        render template
       end
 
       private
+
+      def template
+        @template ||= options[:template] || :show
+      end
 
       def title
         decidim_escape_translated result.title
@@ -32,12 +36,12 @@ module Decidim
       def tab_panel_items
         [
           {
-            enabled: children.any?,
-            id: "list",
+            enabled: timeline_entries.any?,
+            id: "timeline_entries",
             text: t("decidim.accountability.results.timeline.title"),
             icon: "route-line",
             method: :cell,
-            args: ["decidim/accountability/results", result.children]
+            args: ["decidim/accountability/project", result, { template: :timeline }]
           },
           {
             enabled: result.linked_resources(:proposals, "included_proposals").present?,

--- a/decidim-accountability/app/cells/decidim/accountability/project_cell.rb
+++ b/decidim-accountability/app/cells/decidim/accountability/project_cell.rb
@@ -44,6 +44,14 @@ module Decidim
             args: ["decidim/accountability/project", result, { template: :timeline }]
           },
           {
+            enabled: children.any?,
+            id: "included_results",
+            text: t("activemodel.attributes.result.subresults"),
+            icon: "briefcase-2-line",
+            method: :cell,
+            args: ["decidim/accountability/results", result.children]
+          },
+          {
             enabled: result.linked_resources(:proposals, "included_proposals").present?,
             id: "included_proposals",
             text: t("activemodel.attributes.result.proposals"),

--- a/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
@@ -10,6 +10,8 @@ module Decidim
 
       helper_method :results, :result, :first_class_categories, :count_calculator, :nav_paths
 
+      before_action :set_controller_breadcrumb
+
       def show
         raise ActionController::RoutingError, "Not Found" unless result
       end
@@ -65,6 +67,24 @@ module Decidim
 
       def count_calculator(scope_id, category_id)
         Decidim::Accountability::ResultsCalculator.new(current_component, scope_id, category_id).count
+      end
+
+      def controller_breadcrumb_items
+        @controller_breadcrumb_items ||= []
+      end
+
+      def set_controller_breadcrumb
+        controller_breadcrumb_items << breadcrumb_item
+      end
+
+      def breadcrumb_item
+        return {} if result&.parent.blank?
+
+        {
+          label: translated_attribute(result.parent.title),
+          url: result_path(result.parent),
+          active: true
+        }
       end
     end
   end

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
         project_ids: Included projects
         proposals: Included proposals
         start_date: Start date
+        subresults: Subresults
         title: Title
         updated_at: Updated at
       status:

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -325,6 +325,24 @@ describe "Explore results", :versioning do
         end
       end
 
+      context "with subresults" do
+        let!(:subresults) { create_list(:result, 3, component:, parent: result) }
+
+        before do
+          visit current_path
+        end
+
+        it "shows the tab" do
+          expect(page).to have_content("Subresults")
+        end
+
+        it "shows subresults" do
+          subresults.each do |subresult|
+            expect(page).to have_content(translated(subresult.title))
+          end
+        end
+      end
+
       context "with linked proposals" do
         let(:proposal_component) do
           create(:component, manifest_name: :proposals, participatory_space: result.component.participatory_space)

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -290,7 +290,7 @@ describe "Explore results", :versioning do
         end
       end
 
-      context "when a proposal has comments" do
+      context "when a result has comments" do
         let(:result) { results.first }
         let(:author) { create(:user, :confirmed, organization: component.organization) }
         let!(:comments) { create_list(:comment, 3, commentable: result) }

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -306,6 +306,25 @@ describe "Explore results", :versioning do
         end
       end
 
+      context "with timeline entries" do
+        let!(:timeline_entries) { create_list(:timeline_entry, 3, result:) }
+        let(:timeline_entry) { timeline_entries.first }
+
+        before do
+          visit current_path
+        end
+
+        it "shows the tab" do
+          expect(page).to have_content("Project evolution")
+        end
+
+        it "shows the timeline entry" do
+          expect(page).to have_content(decidim_sanitize_translated(timeline_entry.title))
+          expect(page).to have_content(I18n.l(timeline_entry.entry_date, format: :decidim_short))
+          expect(page).to have_content(decidim_sanitize_translated(timeline_entry.description))
+        end
+      end
+
       context "with linked proposals" do
         let(:proposal_component) do
           create(:component, manifest_name: :proposals, participatory_space: result.component.participatory_space)

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -327,6 +327,7 @@ describe "Explore results", :versioning do
 
       context "with subresults" do
         let!(:subresults) { create_list(:result, 3, component:, parent: result) }
+        let(:first_subresult) { subresults.first }
 
         before do
           visit current_path
@@ -340,6 +341,16 @@ describe "Explore results", :versioning do
           subresults.each do |subresult|
             expect(page).to have_content(translated(subresult.title))
           end
+        end
+
+        it "the result is mentioned in the subresult page" do
+          click_on translated(first_subresult.title)
+          expect(page).to have_i18n_content(result.title)
+        end
+
+        it "a banner links back to the result" do
+          click_on translated(first_subresult.title)
+          expect(page).to have_content(translated(result.title))
         end
       end
 

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_items.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_items.html.erb
@@ -1,4 +1,6 @@
 <% breadcrumb_items.each_with_index do |item, i| %>
+  <% next if item.blank? %>
+
   <% item_label = translated_attribute(item[:label]) %>
   <span>/</span>
   <% if item[:dropdown_cell].present? %>


### PR DESCRIPTION
#### :tophat: What? Why?

With the redesign we have removed the Timeline entries from a Result page in Accountability. This PR fixes it. 
 
~~Although the code was showing children results as timeline entries, these are different things. Also, to clarify, as a Subresult can't have more children results, it doesn't make sense to show them in this page.~~ 

After diving in Legacy and seeing how the Ancient people wanted this to work (and specially talking with @carolromero a lot about this feature and this page), we have the following result:

- If a result has a Timeline, then there's a tab called "Project evolution" with this timeline
- If a result has Subresults (aka Children results), then there's a tab called "Subresults" where there are links to these other results. As we've lost the breadcrumb in Accountability, we add the link to the parent result in the breadcrumb Menu

#### Testing

1. Sign in as admin
2. Go to a parent Result (with subresults) in an accountability component in the admin
3. Add a timeline entry
4. See the public (show) page for this Result. See that you have two tabs, one with the "Project evolution" and another one with the "Subresults"
5. Click in the Subresults tab and click in a Subresult
6. See that you have the parent result link in the breadcrumb

### :camera: Screenshots
![Project evolution tab in a Result page](https://github.com/decidim/decidim/assets/717367/5370cc4d-8616-42e6-9f41-d5925eab209d)
![Subresults tab in a Result page](https://github.com/decidim/decidim/assets/717367/193ca143-54c0-47d4-81f5-7675773468ba)
![Link to the parent Result page in the children result page](https://github.com/decidim/decidim/assets/717367/a507a7d3-a3be-4470-b794-0cb77676af8a)

:hearts: Thank you!
