### PR TITLE
Remove the success, warning and alert colors from Organizations' appearance

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
@@ -30,10 +30,7 @@ module Decidim
           colors: {
             primary: form.primary_color,
             secondary: form.secondary_color,
-            tertiary: form.tertiary_color,
-            success: form.success_color,
-            warning: form.warning_color,
-            alert: form.alert_color
+            tertiary: form.tertiary_color
           }.compact_blank
         }
       end

--- a/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
@@ -30,9 +30,6 @@ module Decidim
       attribute :primary_color, String
       attribute :secondary_color, String
       attribute :tertiary_color, String
-      attribute :success_color, String
-      attribute :warning_color, String
-      attribute :alert_color, String
 
       translatable_attribute :cta_button_text, String
       translatable_attribute :description, String

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/form/_colors.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/form/_colors.html.erb
@@ -60,9 +60,6 @@
         <%= form.color_field :primary_color, value: current_organization.colors["primary"] %>
         <%= form.color_field :secondary_color, value: current_organization.colors["secondary"] %>
         <%= form.color_field :tertiary_color, value: current_organization.colors["tertiary"] %>
-        <%= form.color_field :success_color, value: current_organization.colors["success"] %>
-        <%= form.color_field :warning_color, value: current_organization.colors["warning"] %>
-        <%= form.color_field :alert_color, value: current_organization.colors["alert"] %>
       </div>
     </div>
   </div>

--- a/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
+++ b/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
@@ -36,9 +36,9 @@ module.exports = {
       primary: withOpacity("--primary-rgb"),
       secondary: withOpacity("--secondary-rgb"),
       tertiary: withOpacity("--tertiary-rgb"),
-      success: withOpacity("--success-rgb"),
-      alert: withOpacity("--alert-rgb"),
-      warning: withOpacity("--warning-rgb"),
+      success: "#28A745",
+      alert: "#ED1C24",
+      warning: "#FFB703",
       black: "#020203",
       gray: {
         DEFAULT: "#6B7280CC", // 80% opacity

--- a/decidim-core/lib/decidim/core/seeds.rb
+++ b/decidim-core/lib/decidim/core/seeds.rb
@@ -118,12 +118,9 @@ module Decidim
         ].sample
 
         colors = {
-          alert: "#e7131a",
           primary: primary_color,
           secondary: secondary_color,
-          tertiary: tertiary_color,
-          success: "#28a745",
-          warning: "#ffb703"
+          tertiary: tertiary_color
         }
 
         Decidim::Organization.first || Decidim::Organization.create!(

--- a/decidim-system/app/commands/decidim/system/create_organization.rb
+++ b/decidim-system/app/commands/decidim/system/create_organization.rb
@@ -76,10 +76,7 @@ module Decidim
 
       def default_colors
         {
-          alert: "#ec5840",
           primary: "#53bf40",
-          success: "#57d685",
-          warning: "#ffae00",
           tertiary: "#bf4053",
           secondary: "#4053bf"
         }

--- a/decidim-system/spec/commands/decidim/system/create_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/create_organization_spec.rb
@@ -110,10 +110,7 @@ module Decidim
             command.call
             organization = Organization.last
 
-            expect(organization.colors["alert"]).to eq("#ec5840")
             expect(organization.colors["primary"]).to eq("#53bf40")
-            expect(organization.colors["success"]).to eq("#57d685")
-            expect(organization.colors["warning"]).to eq("#ffae00")
             expect(organization.colors["tertiary"]).to eq("#bf4053")
             expect(organization.colors["secondary"]).to eq("#4053bf")
           end


### PR DESCRIPTION
#### :tophat: What? Why?

While discussing with @carolromero about what colors should we have in Organizations' appearance in admin panel for [#13034](https://github.com/decidim/decidim/pull/13034), we agreed that having the "success", "alert" and "warning" colors customization for the organizations is overkill. 

We didn't need to change this setting in almost 5 years of having this feature in Decidim, and we also believe that the "semaphore" is international and widely used. Just in case we asked to the Oracle (aka ChatGPT): 

> > The colors of the semaphor (green, red, yellow) are international? 
>
> ChatGPT: 
> Yes, the colors used in traffic signals (green, red, and yellow) are standardized and recognized internationally. This standardization helps ensure consistency and safety in traffic management across different countries and regions.
> 
> * Red: universally indicates "stop."
> * Green: universally indicates "go."
> * Yellow (or amber): universally indicates "caution" or "prepare to stop."
> 
> This color scheme has been adopted by most countries worldwide, facilitating a common understanding of traffic signals among drivers and pedestrians, regardless of their location. The standardization is guided by international agreements and recommendations, such as those from the Vienna Convention on Road Signs and Signals, which many countries adhere to.
> 

> > And how about using these colors for "success", "warning" and "alert"? 
> 
> ChatGPT:
> 
> The use of colors to indicate "success," "warning," and "alert" is also widely standardized and recognized in various fields, including user interface design, safety signage, and communication systems. The colors typically used are:
> 
> * Green: Indicates "success" or "okay." It conveys a positive outcome, such as a completed task or a correct operation.
> * Yellow (or Amber): Indicates "warning" or "caution." It signals that attention is needed but not necessarily an immediate threat. It often suggests that users should be aware of potential issues.
> * Red: Indicates "alert," "error," or "danger." It denotes a critical issue that requires immediate attention or action.
> 
> These color associations are not only intuitive but also supported by psychological studies on color perception, making them effective for conveying messages quickly and clearly across different cultures and contexts. This standardization is commonly seen in software interfaces, dashboard indicators, health and safety signs, and various other applications.
> 

#### :pushpin: Related Issues
 
- Related to #4696 - seems like the introduction was because of me, as I've blindly added by copy pasting the variables that we had in the SCSS colors definition 🤦🏽 

#### Testing

1. Go to http://localhost:3000/admin/organization/appearance/edit 
2. Scroll to the colors section
3. See that you don't have the "success", "warning" and "alert" colors anymore 

### :camera: Screenshots
 
![Screenshot of the colors section in organizations' Appearance admin form](https://github.com/decidim/decidim/assets/717367/dd618a45-4678-4549-bed1-ca439594dc90)

:hearts: Thank you!
