### PR TITLE
Fix published initiatives in seeds

### DIFF
--- a/decidim-initiatives/lib/decidim/initiatives/seeds.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/seeds.rb
@@ -64,6 +64,8 @@ module Decidim
       end
 
       def create_initiative!(state:)
+        published_at = %w(published rejected accepted).include?(state) ? 7.days.ago : nil
+
         params = {
           title: Decidim::Faker::Localized.sentence(word_count: 3),
           description: Decidim::Faker::Localized.sentence(word_count: 25),
@@ -72,7 +74,7 @@ module Decidim
           signature_type: "online",
           signature_start_date: Date.current - 7.days,
           signature_end_date: Date.current + 7.days,
-          published_at: 7.days.ago,
+          published_at:,
           author: Decidim::User.all.sample,
           organization:
         }


### PR DESCRIPTION
#### :tophat: What? Why?

I found out that in seeds we have an invalid status for some of the Initiatives: they're published but actually have an invalid status (such as :validating ot "Technical validation"). This generates bugs like having them in the list of initiatives but not being able of actually going to their page. 

This PR fixes this bug in the seeds by only publishing the ones that need to be published. 

#### :pushpin: Related Issues

- Related to #11356 (as that's the bug that I was trying to fix when I found out this other bug)

#### Testing

0. (Without the patch). Go to /initiatives without any user (i.e. non logged in)
1. Click on "All" in the Status filter to see all the initiatives
2. See that you have initiatives that you should not see (i.e. in Created or Technical validation) 
3. Click on them 
4. See that you have an "unauthorized" error
5. Apply the patch
6. Redo the seeds (if you don't want to wait for the 15 or so minutes that seeds take, you can do a partial redo with 
`bin/rails runner 'Decidim::Initiative.destroy_all ; require "decidim/seeds" ;require "decidim/initiatives/seeds" ; Decidim::Initiatives::Seeds.new.call'`
7. Repeat steps 0,1,2 and see that the bug was fixed 

### :camera: Screenshots

#### Bug 

![Nightly with invalid initiatives](https://github.com/decidim/decidim/assets/717367/81a5e930-de8b-49a7-a313-19ce34043b89)

#### Fix

![Localhost with valid initiatives](https://github.com/decidim/decidim/assets/717367/dd927d11-d484-44f7-a8c8-8ed89a04df48)

:hearts: Thank you!
