### PR TITLE
Use lazy load for the datepicker elements

### DIFF
--- a/decidim-core/app/packs/src/decidim/datepicker/form_datepicker.js
+++ b/decidim-core/app/packs/src/decidim/datepicker/form_datepicker.js
@@ -1,5 +1,5 @@
 /* eslint-disable require-jsdoc */
-import { WcDatepicker } from "wc-datepicker/dist/components/wc-datepicker";
+import { defineCustomElements } from "wc-datepicker/dist/loader";
 import generateDatePicker from "src/decidim/datepicker/generate_datepicker";
 import generateTimePicker from "src/decidim/datepicker/generate_timepicker";
 import { formatInputDate, formatInputTime } from "src/decidim/datepicker/datepicker_functions";
@@ -14,7 +14,7 @@ export default function formDatePicker(input) {
   const formats = { order: i18nDate.order, separator: i18nDate.separator, time: i18nTime.clock_format || 24 }
 
   if (!customElements.get("wc-datepicker")) {
-    customElements.define("wc-datepicker", WcDatepicker);
+    defineCustomElements();
   };
 
   if (!input.id) {


### PR DESCRIPTION
#### :tophat: What? Why?
While doing some [research with the assets bundling performance](https://github.com/decidim/decidim/discussions/8783#discussioncomment-9353659), I noticed that if ESBuild is used to build the assets, the following error is shown for the `wc-datepicker` element:

> The glob pattern import("./**/*.entry.js*") did not match any files [empty-glob]

This is an issue in the [Stencil compiler](https://github.com/ionic-team/stencil) used to generate the distributable files for that component. This is a known and documented issue in Stencil and apparently [there are no plans to fix it](https://github.com/ionic-team/stencil/issues/5427#issuecomment-2189806080).

The `wc-datepicker` component also provides an alternative way to load its JS assets only when the component is rendered on the page as described here (search for "lazy loading"):
https://sqrrl.github.io/wc-datepicker/

Using this alternative import strategy, the error is gone, so I suggest changing to this approach. Note that when using webpack, there is no visible difference in the asset building process. Just wanted to get rid of this error when using ESBuild.

#### :pushpin: Related Issues
- Related to ionic-team/stencil#5427

#### Testing
- Go to any page rendering the datepicker elements (e.g. edit a process)
- Check that date picker is working as expected
- Check that CI is green