### PR TITLE
Fix endorsement seeds with low amount of users

### DIFF
--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -198,8 +198,13 @@ module Decidim
       resource_type.constantize.find_each do |resource|
         # exclude the users that already endorsed
         users = resource.endorsements.map(&:author)
-        rand(50).times do
+        remaining_count = Decidim::User.count - users.count
+        next if remaining_count < 1
+
+        rand([50, remaining_count].min).times do
           user = (Decidim::User.all - users).sample
+          next unless user
+
           Decidim::Endorsement.create!(resource:, author: user)
           users << user
         end


### PR DESCRIPTION
#### :tophat: What? Why?
When trying to seed the database with a low amount of users, the endorsement seeds can fail due to author being `nil` and it is a required attribute for the endorsement.

This can happen if not all modules are installed as many different modules are creating users to the DB currently.

#### :pushpin: Related Issues
- Related to #13052

#### Testing
See #13052