### PR TITLE
Consider that the meetings module might not be installed

### DIFF
--- a/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
@@ -21,7 +21,9 @@
   <h2 class="h4 mb-4"><%= t("layouts.decidim.footer.resources") %></h2>
   <ul class="space-y-4 break-inside-avoid">
     <li class="font-semibold underline"><%= link_to t("decidim.profiles.show.activity"), decidim.last_activities_path %></li>
-    <li class="font-semibold underline"><%= link_to t("decidim.pages.home.extended.meetings"), Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path %></li>
+    <% if Decidim.module_installed?(:meetings) %>
+      <li class="font-semibold underline"><%= link_to t("decidim.pages.home.extended.meetings"), Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path %></li>
+    <% end %>
     <li class="font-semibold underline"><%= link_to t("layouts.decidim.footer.download_open_data"), decidim.open_data_download_path %></li>
   </ul>
 </nav>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
@@ -5,8 +5,10 @@
 </div>
 <div class="main-bar__links-desktop__item-wrapper">
   <div>
-    <%= link_to Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path, class: "main-bar__links-desktop__item", "aria-label": t("decidim.pages.home.extended.meetings") do %>
-      <%= icon "road-map-line" %><span><%= t("decidim.pages.home.extended.meetings") %></span>
+    <% if Decidim.module_installed?(:meetings) %>
+      <%= link_to Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path, class: "main-bar__links-desktop__item", "aria-label": t("decidim.pages.home.extended.meetings") do %>
+        <%= icon "road-map-line" %><span><%= t("decidim.pages.home.extended.meetings") %></span>
+      <% end %>
     <% end %>
   </div>
   <div>


### PR DESCRIPTION
#### :tophat: What? Why?
There are few hard coded references to the `Decidim::Meetings` module in the core currently.

It should be considered there might be instances where the meetings module is not installed.

#### :pushpin: Related Issues
- Related to #13052

#### Testing
See #13052