### PR TITLE
Fix hard dependency on meetings for `decidim-proposals`

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "decidim/meetings"
-
 Decidim.register_component(:proposals) do |component|
   component.engine = Decidim::Proposals::Engine
   component.admin_engine = Decidim::Proposals::AdminEngine

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -136,6 +136,7 @@ module Decidim
 
       def random_coauthor
         n = rand(5)
+        n = 3 if n == 2 && !Decidim.module_installed?(:meetings)
 
         case n
         when 0


### PR DESCRIPTION
#### :tophat: What? Why?
The `decidim-proposals` module requires the `decidim-meetings` module currently. Otherwise it won't load.

The require is in the component definition which is required for the main application even when seeds are not loaded.

Note that the proposals seeds currently require the meetings component but this PR fixes it by checking whether the module is installed or not.

#### :pushpin: Related Issues
- Related to #13052

#### Testing
See #13052