### PR TITLE
Define an admin filters registry

### DIFF
--- a/decidim-core/lib/decidim/admin_filter.rb
+++ b/decidim-core/lib/decidim/admin_filter.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Decidim
+  #
+  # This class handles all logic regarding registering filters
+  #
+  class AdminFilter
+    attr_accessor :filters, :filters_with_values
+
+    def initialize(name)
+      @name = name
+      @filters = []
+      @filters_with_values = {}
+    end
+
+    def add_filters(*filters)
+      @filters += filters
+    end
+
+    def add_filters_with_values(**items)
+      @filters_with_values.merge!(items)
+    end
+
+    def build_for(context)
+      raise "Filter #{@name} is not registered" if registry.blank?
+
+      registry.configurations.each do |configuration|
+        context.instance_exec(self, &configuration)
+      end
+      self
+    end
+
+    private
+
+    def registry
+      @registry ||= AdminFiltersRegistry.find(@name)
+    end
+  end
+end

--- a/decidim-core/lib/decidim/admin_filter.rb
+++ b/decidim-core/lib/decidim/admin_filter.rb
@@ -5,16 +5,21 @@ module Decidim
   # This class handles all logic regarding registering filters
   #
   class AdminFilter
-    attr_accessor :filters, :filters_with_values
+    attr_accessor :filters, :dynamically_translated_filters, :filters_with_values
 
     def initialize(name)
       @name = name
       @filters = []
+      @dynamically_translated_filters = []
       @filters_with_values = {}
     end
 
     def add_filters(*filters)
       @filters += filters
+    end
+
+    def add_dynamically_translated_filters(*filters)
+      @dynamically_translated_filters += filters
     end
 
     def add_filters_with_values(**items)

--- a/decidim-core/lib/decidim/admin_filters_registry.rb
+++ b/decidim-core/lib/decidim/admin_filters_registry.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Decidim
+  #
+  # This class handles all logic regarding registering filters
+  #
+  class AdminFiltersRegistry
+    class << self
+      #
+      # Finds a filter by name or creates it if it does not exist.
+      #
+      # @param name [Symbol] Name of the filter
+      # @param &block [Filter] Registration body of the filter. It is stored to
+      #                        be evaluated at rendering time
+      #
+      def register(name, &block)
+        filter = find(name) || create(name)
+
+        filter.configurations << block
+
+        filter
+      end
+
+      #
+      # Finds a filter by name
+      #
+      # @param name [Symbol] The name of the filter
+      #
+      def find(name)
+        all[name]
+      end
+
+      #
+      # Creates an empty named filter
+      #
+      # @param name [Symbol] The name of the filter
+      #
+      def create(name)
+        all[name] = new
+      end
+
+      private
+
+      def all
+        @all ||= {}
+      end
+    end
+
+    attr_reader :configurations
+
+    def initialize
+      @configurations = []
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -53,6 +53,8 @@ module Decidim
   autoload :Menu, "decidim/menu"
   autoload :MenuItem, "decidim/menu_item"
   autoload :MenuRegistry, "decidim/menu_registry"
+  autoload :AdminFilter, "decidim/admin_filter"
+  autoload :AdminFiltersRegistry, "decidim/admin_filters_registry"
   autoload :ManifestRegistry, "decidim/manifest_registry"
   autoload :AssetRouter, "decidim/asset_router"
   autoload :EngineRouter, "decidim/engine_router"
@@ -762,6 +764,10 @@ module Decidim
 
   def self.icons
     @icons ||= Decidim::IconRegistry.new
+  end
+
+  def self.admin_filter(name, &)
+    AdminFiltersRegistry.register(name.to_sym, &)
   end
 
   # Public: Stores an instance of ViewHooks

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/admin/filterable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/admin/filterable.rb
@@ -13,6 +13,8 @@ module Decidim
 
           private
 
+          delegate :filters, :filters_with_values, to: :filter_config
+
           # Comment about participatory_texts_enabled.
           def base_query
             return collection.order(:position) if current_component.settings.participatory_texts_enabled?
@@ -30,26 +32,8 @@ module Decidim
             :id_string_or_title_cont
           end
 
-          def filters
-            [
-              :is_emendation_true,
-              :state_eq,
-              :with_any_state,
-              :scope_id_eq,
-              :category_id_eq,
-              :valuator_role_ids_has
-            ]
-          end
-
-          def filters_with_values
-            {
-              is_emendation_true: %w(true false),
-              state_eq: state_eq_values,
-              with_any_state: %w(state_published state_not_published),
-              scope_id_eq: scope_ids_hash(scopes.top_level),
-              category_id_eq: category_ids_hash(categories.first_class),
-              valuator_role_ids_has: valuator_role_ids
-            }
+          def filter_config
+            @filter_config ||= Decidim::AdminFilter.new(:proposals).build_for(self)
           end
 
           # Cannot user `super` here, because it does not belong to a superclass

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/admin/filterable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/admin/filterable.rb
@@ -13,7 +13,7 @@ module Decidim
 
           private
 
-          delegate :filters, :filters_with_values, to: :filter_config
+          delegate :filters, :dynamically_translated_filters, :filters_with_values, to: :filter_config
 
           # Comment about participatory_texts_enabled.
           def base_query
@@ -34,12 +34,6 @@ module Decidim
 
           def filter_config
             @filter_config ||= Decidim::AdminFilter.new(:proposals).build_for(self)
-          end
-
-          # Cannot user `super` here, because it does not belong to a superclass
-          # but to a concern.
-          def dynamically_translated_filters
-            [:scope_id_eq, :category_id_eq, :valuator_role_ids_has, :proposal_state_id_eq, :state_eq]
           end
 
           def translated_state_eq(state)

--- a/decidim-proposals/lib/decidim/proposals/admin_engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/admin_engine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/proposals/admin_filter"
+
 module Decidim
   module Proposals
     # This is the engine that runs on the public interface of `decidim-proposals`.
@@ -38,6 +40,10 @@ module Decidim
         end
 
         root to: "proposals#index"
+      end
+
+      initializer "decidim_proposals.admin_filters" do
+        Decidim::Proposals::AdminFilter.register_filter!
       end
 
       def load_seed

--- a/decidim-proposals/lib/decidim/proposals/admin_filter.rb
+++ b/decidim-proposals/lib/decidim/proposals/admin_filter.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    class AdminFilter
+      def self.register_filter!
+        Decidim.admin_filter(:proposals) do |configuration|
+          configuration.add_filters(
+            :is_emendation_true,
+            :state_eq,
+            :with_any_state,
+            :scope_id_eq,
+            :category_id_eq,
+            :valuator_role_ids_has
+          )
+
+          configuration.add_filters_with_values(
+            is_emendation_true: %w(true false),
+            state_eq: state_eq_values,
+            with_any_state: %w(state_published state_not_published),
+            scope_id_eq: scope_ids_hash(scopes.top_level),
+            category_id_eq: category_ids_hash(categories.first_class),
+            valuator_role_ids_has: valuator_role_ids
+          )
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/lib/decidim/proposals/admin_filter.rb
+++ b/decidim-proposals/lib/decidim/proposals/admin_filter.rb
@@ -22,6 +22,14 @@ module Decidim
             category_id_eq: category_ids_hash(categories.first_class),
             valuator_role_ids_has: valuator_role_ids
           )
+
+          configuration.add_dynamically_translated_filters(
+            :scope_id_eq,
+            :category_id_eq,
+            :valuator_role_ids_has,
+            :proposal_state_id_eq,
+            :state_eq
+          )
         end
       end
     end

--- a/decidim-proposals/spec/controllers/concerns/admin_filterable_spec.rb
+++ b/decidim-proposals/spec/controllers/concerns/admin_filterable_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    class FilterableFakeController < Decidim::ApplicationController
+      include Decidim::Proposals::Admin::Filterable
+
+      def example_method
+        {
+          new_filter: [:a, :b, :c]
+        }
+      end
+    end
+
+    describe FilterableFakeController do
+      let(:organization) { create(:organization) }
+      let(:participatory_process) { create(:participatory_process, :with_steps, organization:) }
+      let(:component) { create(:component, :with_one_step, participatory_space: participatory_process, manifest_name: "proposals") }
+      let(:view) { controller.view_context }
+
+      before do
+        allow(controller).to receive(:current_organization).and_return(organization)
+        allow(controller).to receive(:current_participatory_space).and_return(participatory_process)
+        allow(controller).to receive(:current_component).and_return(component)
+      end
+
+      context "with default configuration including extra configuration registry" do
+        let!(:default_configuration) do
+          ::Decidim::AdminFilter.new(:proposals).build_for(controller)
+        end
+
+        before do
+          Decidim::AdminFiltersRegistry.register :proposals do |configuration|
+            configuration.add_filters(*example_method.keys)
+            configuration.add_filters_with_values(**example_method)
+          end
+        end
+
+        describe "#filters" do
+          it "returns the list of defined filters including the existing filters and the custom items" do
+            expect(controller.send(:filters)).to include(*default_configuration.filters)
+            expect(controller.send(:filters)).to include(:new_filter)
+          end
+        end
+
+        describe "#filters_with_values" do
+          it "returns the hash of defined filters with values including the custom filters with values" do
+            expect(controller.send(:filters_with_values)).to include(**default_configuration.filters_with_values)
+            expect(controller.send(:filters_with_values)).to include(new_filter: [:a, :b, :c])
+          end
+        end
+      end
+    end
+  end
+end

--- a/docs/modules/customize/pages/admin_filters.adoc
+++ b/docs/modules/customize/pages/admin_filters.adoc
@@ -1,0 +1,32 @@
+= Admin filters
+
+Filters in admin panels are defined with a common Filterable concern and each one defines a series of methods defining the different available filters, the options for each one, etc.
+
+Decidim provides an Api to manage and add custom elements to each admin filter defined in the application. Each defined filter can be accessed by a unique symbol and provides the methods `add_filters` and `add_dynamically_translated_filters` which allows us to add new items to the respective `filters` and `dynamically_translated` arrays provided by the filter registry and `add_filters_with_values` which allows us to merge new items into the `filters_with_values` hash also provided by the registry.
+
+Note that those methods are called at filter rendering time, so all methods provided by the controller and the concern filterable are available to evaluate when defining new elements
+
+For example, to add new filter to proposals index:
+
+[source,ruby]
+....
+Decidim.admin_filter(:proposals) do |filter|
+  # An example of how to access to the context. In this case the custom
+  # filter is only enabled for valuators of the space
+  if current_participatory_space.user_roles(:valuator).where(user: current_user).exists?
+    filter.add_filters(:custom_new_filter)
+    filter.add_filters_with_values(custom_new_filter: %w(custom_new_value_1 custom_new_value_2))
+  end
+end
+....
+
+The filter registry definition block is called from the proposals filterable concern in this way:
+
+[source,ruby]
+....
+delegate :filters, :dynamically_translated_filters, :filters_with_values, to: :filter_config
+
+def filter_config
+  @filter_config ||= Decidim::AdminFilter.new(:proposals).build_for(self)
+end
+....

--- a/docs/modules/customize/pages/index.adoc
+++ b/docs/modules/customize/pages/index.adoc
@@ -23,6 +23,7 @@ Inside of your application you can customize it in different ways:
 * xref:customize:javascript.adoc[JavaScript]
 * xref:customize:logic.adoc[Logic]
 * xref:customize:menu.adoc[Menu]
+* xref:customize:admin_filters.adoc[Admin filters]
 * xref:customize:oauth.adoc[OAuth]
 * xref:customize:styles.adoc[Styles]
 * xref:customize:texts.adoc[Texts]


### PR DESCRIPTION
#### :tophat: What? Why?

This PR allows to move part of the code existing in Filterable concerns used in different admin controllers allowing to define the filters and their options from an engine and add filter options from external modules with methods provided by the admin filter class combined with the registry in a similar way to how it is done with menus

New admin proposals filter options can be added from an initializer in this way:

```ruby
Decidim.admin_filter(:proposals) do |configuration|
  configuration.add_filters(
    :new_filter,
    :another_new_filter
  )

  configuration.add_filters_with_values(
    new_filter: %w(true false),
    another_new_filter: current_organization.categories.map(&:name)
  ) 
end
```
Note that the block passed to `Decidim.admin_filter` is evaluated from the filterable concern calling it so all the required methods to build the filter are present

This approach can be extended to all the other admin filters of the application

Some tests for the proposals filterable concern has been added to check the addition of new filters

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to AjuntamentdeBarcelona/decidim-internal-evaluation-module#3

#### Testing

The filters in proposals admin index should work as usual, but new options can be added to check the feature as described previously

:hearts: Thank you!
