### PR TITLE
Remove unecessary constant in CreateDefaultContentBlocks class

### DIFF
--- a/decidim-system/app/commands/decidim/system/create_default_content_blocks.rb
+++ b/decidim-system/app/commands/decidim/system/create_default_content_blocks.rb
@@ -5,9 +5,6 @@ module Decidim
     # A command with all the business logic to create the default content blocks
     # for a newly-created organization.
     class CreateDefaultContentBlocks < Decidim::Command
-      DEFAULT_CONTENT_BLOCKS =
-        [:hero, :sub_hero, :highlighted_content_banner, :how_to_participate, :stats, :metrics, :footer_sub_hero].freeze
-
       # Public: Initializes the command.
       #
       # form - A form object with the params.


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing #13059 I found an unecessary constant. This PR removes it. 

#### :pushpin: Related Issues

- Related to https://github.com/decidim/decidim/pull/11109 - as it was a leftover from this PR. It was difficult to detect in the review as it was outside of the diff in the GitHub UI:
- 
![Screenshot of this part of GH UI](https://github.com/decidim/decidim/assets/717367/c748ced6-9c37-460b-ae33-9fa3ed58dbff)

#### Testing

1. Go to http://localhost:3000/system/ 
2. Sign in 
3. Create a new organization
4. See that you have the same content blocks

### :camera: Screenshots

![New organization created](https://github.com/decidim/decidim/assets/717367/96f3d3ab-aa07-4289-a33b-d25e747a9016)

:hearts: Thank you!
