### PR TITLE
Show an error message on initiatives admin when no initiatives types

### DIFF
--- a/decidim-core/app/helpers/decidim/scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/scopes_helper.rb
@@ -54,10 +54,12 @@ module Decidim
     #
     # Returns nothing.
     def scopes_select_field(form, name, root: false, options: {})
+      options = options.merge(include_blank: I18n.t("decidim.scopes.prompt")) unless options.has_key?(:include_blank)
+
       form.select(
         name,
         ordered_scopes_descendants_for_select(root),
-        options.merge(include_blank: I18n.t("decidim.scopes.prompt"))
+        options
       )
     end
 

--- a/decidim-core/app/packs/stylesheets/decidim/_flash.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_flash.scss
@@ -14,7 +14,7 @@
   &__message {
     @apply text-black font-medium text-md flex-col;
 
-    a {
+    a:not(.button) {
       @apply underline text-secondary;
 
       svg {

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -186,7 +186,7 @@ module Decidim
         private
 
         def show_initiative_type_callout?
-          Decidim::InitiativesType.where(organization: current_organization).all.empty?
+          Decidim::InitiativesType.where(organization: current_organization).none?
         end
 
         def collection

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -17,6 +17,8 @@ module Decidim
         helper Decidim::Initiatives::InitiativeHelper
         helper Decidim::Initiatives::SignatureTypeOptionsHelper
 
+        helper_method :show_initiative_type_callout?
+
         # GET /admin/initiatives
         def index
           enforce_permission_to :list, :initiative
@@ -182,6 +184,10 @@ module Decidim
         end
 
         private
+
+        def show_initiative_type_callout?
+          Decidim::InitiativesType.where(organization: current_organization).all.empty?
+        end
 
         def collection
           @collection ||= ManageableInitiatives.for(current_user)

--- a/decidim-initiatives/app/controllers/decidim/initiatives/application_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/application_controller.rb
@@ -14,7 +14,7 @@ module Decidim
                            ::Decidim::Permissions)
 
       before_action do
-        if Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).all.empty?
+        if Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).none?
           flash[:alert] = t("index.uninitialized", scope: "decidim.initiatives")
           redirect_to(decidim.root_path)
         end

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -47,9 +47,9 @@
             <td class="table-list__actions">
               <% if allowed_to? :edit, :initiative, initiative: initiative %>
                 <%= icon_link_to "pencil-line",
-                                decidim_admin_initiatives.edit_initiative_path(initiative.to_param),
-                                t("actions.configure", scope: "decidim.admin"),
-                                class: "action-icon--edit" %>
+                                 decidim_admin_initiatives.edit_initiative_path(initiative.to_param),
+                                 t("actions.configure", scope: "decidim.admin"),
+                                 class: "action-icon--edit" %>
               <% else %>
                 <span class="action-space icon"></span>
               <% end %>
@@ -62,22 +62,22 @@
 
               <% if allowed_to? :read, :initiative, initiative: initiative %>
                 <%= icon_link_to "printer-line",
-                                decidim_initiatives.print_initiative_path(initiative),
-                                t(".print"),
-                                class: "action-icon--print",
-                                target: "_blank",
-                                data: { "external-link": false } %>
+                                 decidim_initiatives.print_initiative_path(initiative),
+                                 t(".print"),
+                                 class: "action-icon--print",
+                                 target: "_blank",
+                                 data: { "external-link": false } %>
               <% else %>
                 <span class="action-space icon"></span>
               <% end %>
 
               <% if allowed_to? :preview, :initiative, initiative: initiative %>
                 <%= icon_link_to "eye-line",
-                                decidim_initiatives.initiative_path(initiative.to_param),
-                                t(".preview"),
-                                class: "action-icon--preview",
-                                target: "_blank",
-                                data: { "external-link": false } %>
+                                 decidim_initiatives.initiative_path(initiative.to_param),
+                                 t(".preview"),
+                                 class: "action-icon--preview",
+                                 target: "_blank",
+                                 data: { "external-link": false } %>
               <% else %>
                 <span class="action-space icon"></span>
               <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -10,79 +10,85 @@
     </h1>
   </div>
   <%= admin_filter_selector(:initiatives) %>
-  <div class="table-scroll">
-    <table class="table-list">
-      <thead>
-      <tr>
-        <th><%= t("models.initiatives.fields.id", scope: "decidim.admin") %></th>
-        <th class="!text-left"><%= t("models.initiatives.fields.title", scope: "decidim.admin") %></th>
-        <th><%= t("models.initiatives.fields.state", scope: "decidim.admin") %></th>
-        <th><%= sort_link(query, :supports_count, t("models.initiatives.fields.supports_count", scope: "decidim.admin"), default_order: :desc) %></th>
-        <th><%= sort_link(query, :created_at, t("models.initiatives.fields.created_at", scope: "decidim.admin"), default_order: :desc) %></th>
-        <th><%= sort_link(query, :published_at, t("models.initiatives.fields.published_at", scope: "decidim.admin"), default_order: :desc) %></th>
-        <th><%= t ".actions_title" %></th>
-      </tr>
-      </thead>
-      <tbody>
-      <% @initiatives.each do |initiative| %>
+
+  <% if show_initiative_type_callout? %>
+    <% link = link_to(t("button", scope:"decidim.initiatives.admin.index.initiatives_types"), new_initiatives_type_path, class: "button button__sm button__secondary mt-4") %>
+    <%= cell("decidim/announcement", t("alert_html", scope:"decidim.initiatives.admin.index.initiatives_types", link:), callout_class: "alert") %>
+  <% else %>
+    <div class="table-scroll">
+      <table class="table-list">
+        <thead>
         <tr>
-          <td><%= initiative.id %></td>
-          <td class="!text-left">
-            <% if allowed_to? :edit, :initiative, initiative: initiative %>
-              <%= link_to translated_attribute(initiative.title),
-                          decidim_admin_initiatives.edit_initiative_path(initiative.to_param) %>
-            <% else %>
-              <%= translated_attribute(initiative.title) %>
-            <% end %>
-          </td>
-          <td><%= humanize_admin_state initiative.state %></td>
-          <td><%= initiative.supports_count %>/<%= initiative.scoped_type.supports_required %></td>
-          <td class="table-list__date"><%= l initiative.created_at, format: :short %></td>
-          <td class="table-list__date"><%= initiative.published_at? ? l(initiative.published_at, format: :short) : "" %></td>
-          <td class="table-list__actions">
-            <% if allowed_to? :edit, :initiative, initiative: initiative %>
-              <%= icon_link_to "pencil-line",
-                               decidim_admin_initiatives.edit_initiative_path(initiative.to_param),
-                               t("actions.configure", scope: "decidim.admin"),
-                               class: "action-icon--edit" %>
-            <% else %>
-              <span class="action-space icon"></span>
-            <% end %>
-
-            <% if allowed_to?(:answer, :initiative, initiative: initiative) %>
-              <%= icon_link_to "chat-1-line", edit_initiative_answer_path(initiative.slug), t("actions.answer", scope: "decidim.initiatives"), class: "action-icon action-icon--answer" %>
-            <% else %>
-              <%= icon "chat-1-line", scope: "decidim.admin", class: "action-icon action-icon--disabled", role: "img", "aria-hidden": true %>
-            <% end %>
-
-            <% if allowed_to? :read, :initiative, initiative: initiative %>
-              <%= icon_link_to "printer-line",
-                               decidim_initiatives.print_initiative_path(initiative),
-                               t(".print"),
-                               class: "action-icon--print",
-                               target: "_blank",
-                               data: { "external-link": false } %>
-            <% else %>
-              <span class="action-space icon"></span>
-            <% end %>
-
-            <% if allowed_to? :preview, :initiative, initiative: initiative %>
-              <%= icon_link_to "eye-line",
-                               decidim_initiatives.initiative_path(initiative.to_param),
-                               t(".preview"),
-                               class: "action-icon--preview",
-                               target: "_blank",
-                               data: { "external-link": false } %>
-            <% else %>
-              <span class="action-space icon"></span>
-            <% end %>
-
-            <%= free_resource_permissions_link(initiative) || content_tag(:span, nil, class: "action-space icon") %>
-          </td>
+          <th><%= t("models.initiatives.fields.id", scope: "decidim.admin") %></th>
+          <th class="!text-left"><%= t("models.initiatives.fields.title", scope: "decidim.admin") %></th>
+          <th><%= t("models.initiatives.fields.state", scope: "decidim.admin") %></th>
+          <th><%= sort_link(query, :supports_count, t("models.initiatives.fields.supports_count", scope: "decidim.admin"), default_order: :desc) %></th>
+          <th><%= sort_link(query, :created_at, t("models.initiatives.fields.created_at", scope: "decidim.admin"), default_order: :desc) %></th>
+          <th><%= sort_link(query, :published_at, t("models.initiatives.fields.published_at", scope: "decidim.admin"), default_order: :desc) %></th>
+          <th><%= t ".actions_title" %></th>
         </tr>
-      <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+        <% @initiatives.each do |initiative| %>
+          <tr>
+            <td><%= initiative.id %></td>
+            <td class="!text-left">
+              <% if allowed_to? :edit, :initiative, initiative: initiative %>
+                <%= link_to translated_attribute(initiative.title),
+                            decidim_admin_initiatives.edit_initiative_path(initiative.to_param) %>
+              <% else %>
+                <%= translated_attribute(initiative.title) %>
+              <% end %>
+            </td>
+            <td><%= humanize_admin_state initiative.state %></td>
+            <td><%= initiative.supports_count %>/<%= initiative.scoped_type.supports_required %></td>
+            <td class="table-list__date"><%= l initiative.created_at, format: :short %></td>
+            <td class="table-list__date"><%= initiative.published_at? ? l(initiative.published_at, format: :short) : "" %></td>
+            <td class="table-list__actions">
+              <% if allowed_to? :edit, :initiative, initiative: initiative %>
+                <%= icon_link_to "pencil-line",
+                                decidim_admin_initiatives.edit_initiative_path(initiative.to_param),
+                                t("actions.configure", scope: "decidim.admin"),
+                                class: "action-icon--edit" %>
+              <% else %>
+                <span class="action-space icon"></span>
+              <% end %>
+
+              <% if allowed_to?(:answer, :initiative, initiative: initiative) %>
+                <%= icon_link_to "chat-1-line", edit_initiative_answer_path(initiative.slug), t("actions.answer", scope: "decidim.initiatives"), class: "action-icon action-icon--answer" %>
+              <% else %>
+                <%= icon "chat-1-line", scope: "decidim.admin", class: "action-icon action-icon--disabled", role: "img", "aria-hidden": true %>
+              <% end %>
+
+              <% if allowed_to? :read, :initiative, initiative: initiative %>
+                <%= icon_link_to "printer-line",
+                                decidim_initiatives.print_initiative_path(initiative),
+                                t(".print"),
+                                class: "action-icon--print",
+                                target: "_blank",
+                                data: { "external-link": false } %>
+              <% else %>
+                <span class="action-space icon"></span>
+              <% end %>
+
+              <% if allowed_to? :preview, :initiative, initiative: initiative %>
+                <%= icon_link_to "eye-line",
+                                decidim_initiatives.initiative_path(initiative.to_param),
+                                t(".preview"),
+                                class: "action-icon--preview",
+                                target: "_blank",
+                                data: { "external-link": false } %>
+              <% else %>
+                <span class="action-space icon"></span>
+              <% end %>
+
+              <%= free_resource_permissions_link(initiative) || content_tag(:span, nil, class: "action-space icon") %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    <% end %>
   </div>
 </div>
 <%= decidim_paginate @initiatives %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_type_scopes/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_type_scopes/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="card pt-4">
     <div class="card-section">
       <div class="row column">
-        <%= scopes_select_field form, :decidim_scopes_id, root: nil %>
+        <%= scopes_select_field form, :decidim_scopes_id, root: nil, options: { include_blank: t("decidim.scopes.global") } %>
       </div>
       <div class="row column">
         <%= form.number_field :supports_required, min: 1, step: 1 %>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -237,6 +237,10 @@ en:
               most_recent: Most recent
         exports:
           initiatives: Initiatives
+        index:
+          initiatives_types:
+            alert_html: <p>You must create at least one initiative type so participants can start creating initiatives.</p><p> %{link}</p>
+            button: New initiative type
         initiatives:
           edit:
             accept: Accept initiative

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -296,7 +296,7 @@ en:
         initiatives_types:
           create:
             error: An error has occurred.
-            success: A new initiative type has been successfully created.
+            success: A new initiative type has been successfully created. You need to define at least one scope for this initiative type so it can be used.
           destroy:
             success: The initiative type has been successfully removed.
           edit:

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -239,7 +239,7 @@ en:
           initiatives: Initiatives
         index:
           initiatives_types:
-            alert_html: <p>You must create at least one initiative type so participants can start creating initiatives.</p><p> %{link}</p>
+            alert_html: "<p>You must create at least one initiative type so participants can start creating initiatives.</p><p> %{link}</p>"
             button: New initiative type
         initiatives:
           edit:

--- a/decidim-initiatives/lib/decidim/initiatives/menu.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/menu.rb
@@ -10,7 +10,7 @@ module Decidim
                         decidim_initiatives.initiatives_path,
                         position: 2.4,
                         active: %r{^/(initiatives|create_initiative)},
-                        if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).none?
+                        if: Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).any?
         end
       end
 
@@ -21,7 +21,7 @@ module Decidim
                         decidim_initiatives.initiatives_path,
                         position: 30,
                         active: :inclusive,
-                        if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).none?
+                        if: Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).any?
         end
       end
 

--- a/decidim-initiatives/lib/decidim/initiatives/menu.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/menu.rb
@@ -10,7 +10,7 @@ module Decidim
                         decidim_initiatives.initiatives_path,
                         position: 2.4,
                         active: %r{^/(initiatives|create_initiative)},
-                        if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).all.empty?
+                        if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).none?
         end
       end
 
@@ -21,7 +21,7 @@ module Decidim
                         decidim_initiatives.initiatives_path,
                         position: 30,
                         active: :inclusive,
-                        if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).all.empty?
+                        if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).none?
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

As an admin that's a newcomer to Decidim, when I try to set-up initiatives is too complicated. Initiatives need an InitiativeType for working, and I don't have anything explaining that in the first setup.

This PR tries to solve this issue by showing a callout with a button with this explanation.

I've also added two other improvements in the initiatives types creation flow: 

a. In the create initiative type scope's scope selector says "Select a scope" and if you leave it as is it gets saved as "Global scope". I think it's more clear if we leave the "Global scope" option by default
b. Once you create the initiative type, you still need to create the scope in this type so it's available in the frontend. I added a new sentence in the callout to better explain that. 

#### Testing

0. Delete all your InitiativesTypes and Initiatives with `bin/rails runner "Decidim::Initiative.destroy_all; Decidim::InitiativesType.destroy_all"`
1. Sign in as admin
2. Go to http://localhost:3000/admin/initiatives
3. See the error message
4. Create a new initiative type
5. See the callout
6. Go to the bottom of the page, click in "New initiative type scope" 
7. See the default select in "Scopes" 

### :camera: Screenshots

![Screenshot of the new callout](https://github.com/decidim/decidim/assets/717367/134755b3-e48b-48e9-a3ef-4cefdca9b7cd)

![Screenshot of the fix](https://github.com/decidim/decidim/assets/717367/6adf183c-b2d0-4bbc-9629-c5793dad1dbc)

![Message with the scope type explanation](https://github.com/decidim/decidim/assets/717367/2c8f15e7-dd11-468a-8b98-4035b4bff059)

:hearts: Thank you!
