### PR TITLE
Fix escaping in initiatives type description HTML

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
@@ -16,7 +16,7 @@
           <%= icon "lightbulb-flash-line", class: "verification__icon " %>
           <div class="initiatives__selection__text">
             <h2 class="h5 text-secondary"><%= translated_attribute(type.title) %></h2>
-            <span><%= decidim_escape_translated(type.description) %></span>
+            <span><%= decidim_sanitize_admin(translated_attribute(type.description)) %></span>
           </div>
           <%= icon "arrow-right-s-line", class: "fill-secondary initiatives__selection__icon" %>
         </button>
@@ -26,7 +26,7 @@
         <%= icon "lightbulb-flash-line", class: "verification__icon " %>
         <div class="initiatives__selection__text">
           <h2 class="h5 text-secondary"><%= translated_attribute(type.title) %></h2>
-          <span><%= decidim_escape_translated(type.description) %></span>
+          <span><%= decidim_sanitize_admin(translated_attribute(type.description)) %></span>
           <%= authorized_create_modal_button(type, remote: true, class: "button button__sm button__secondary") do %>
             <%= t("verification_required", scope: "decidim.initiatives.create_initiative.select_initiative_type") %>
           <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

While working on #13042, I found a bug in the frontend of the initiative type description. As this is happening in v0.28.1 (I can reproduce it in try.decidim.org), I'm adding the fix as a new PR so we can backport it.

#### Testing

1. Sign in as admin
2. Create a new initiative type with an scope:
2.1. Go to http://localhost:3000/admin/initiatives_types/new
2.2. Fill the form (title, description and banner image) 
2.3. Click on save
2.4. Go to the bottom of the page, click in "New initiative type scope"
2.5. Fill any scope and any number of signatures
2.6. Save it
3. Go to frontend and click in "New intiative"
4. See the error

Mind that as in seeds we don't use HTML for the description this bug can't be found there

### :camera: Screenshots

#### Before

![Screenshot of the bug in the "Create a new initiative" form](https://github.com/decidim/decidim/assets/717367/46a91ccd-ad47-4ee8-9c62-7b5af900f560)

#### After

![Screenshot of the fix in the "Create a new initiative" form](https://github.com/decidim/decidim/assets/717367/e34dd823-d3ee-473d-92ca-13e0d405c459)

:hearts: Thank you!
