### PR TITLE
Do not show unecessary actions in the initiative page

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_send_to_technical_validation.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_send_to_technical_validation.html.erb
@@ -1,8 +1,0 @@
-<% if allowed_to? :send_to_technical_validation, :initiative, initiative: current_initiative %>
-  <%= link_to title,
-              send_to_technical_validation_initiative_path(current_initiative),
-              class: "button button__xl w-full button__secondary mt-4",
-              data: { confirm: } %>
-<% else %>
-  <%= link_to title, "#", class: "button button__xl w-full button__secondary mt-4 disabled", disabled: true %>
-<% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -39,7 +39,9 @@ edit_link(
     <% end %>
 
     <section class="layout-aside__section">
-      <%= render partial: "progress_bar" %>
+      <% unless current_initiative.validating? %>
+        <%= render partial: "progress_bar" %>
+      <% end %>
     </section>
 
     <section class="layout-aside__section">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -22,27 +22,29 @@ edit_link(
         </section>
       <% end %>
     <% else %>
-      <section class="layout-aside__section layout-aside__buttons">
-        <% if allowed_to? :edit, :initiative, initiative: current_initiative %>
-          <%= link_to t(".edit"),
-                      edit_initiative_path(current_initiative),
-                      class: "button button__xl w-full button__secondary" %>
-        <% end %>
+      <% if allowed_to?(:edit, :initiative, initiative: current_initiative) || allowed_to?(:send_to_technical_validation, :initiative, initiative: current_initiative) %>
+        <section class="layout-aside__section layout-aside__buttons">
+          <% if allowed_to? :edit, :initiative, initiative: current_initiative %>
+            <%= link_to t(".edit"),
+                        edit_initiative_path(current_initiative),
+                        class: "button button__xl w-full button__secondary" %>
+          <% end %>
 
-        <% if allowed_to? :send_to_technical_validation, :initiative, initiative: current_initiative %>
-          <%= link_to t(".send_to_technical_validation"),
-                      send_to_technical_validation_initiative_path(current_initiative),
-                      class: "button button__xl w-full button__secondary mt-4",
-                      data: { confirm: t(".confirm") } %>
-        <% end %>
-      </section>
+          <% if allowed_to? :send_to_technical_validation, :initiative, initiative: current_initiative %>
+            <%= link_to t(".send_to_technical_validation"),
+                        send_to_technical_validation_initiative_path(current_initiative),
+                        class: "button button__xl w-full button__secondary mt-4",
+                        data: { confirm: t(".confirm") } %>
+          <% end %>
+        </section>
+      <% end %>
     <% end %>
 
-    <section class="layout-aside__section">
-      <% unless current_initiative.validating? %>
+    <% unless current_initiative.validating? %>
+      <section class="layout-aside__section">
         <%= render partial: "progress_bar" %>
-      <% end %>
-    </section>
+      </section>
+    <% end %>
 
     <section class="layout-aside__section">
       <%= cell("decidim/nav_links", initiative_nav_items(current_initiative)) %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -29,7 +29,12 @@ edit_link(
                       class: "button button__xl w-full button__secondary" %>
         <% end %>
 
-        <%= render partial: "send_to_technical_validation", locals: { title: t(".send_to_technical_validation"), confirm: t(".confirm") } %>
+        <% if allowed_to? :send_to_technical_validation, :initiative, initiative: current_initiative %>
+          <%= link_to t(".send_to_technical_validation"),
+                      send_to_technical_validation_initiative_path(current_initiative),
+                      class: "button button__xl w-full button__secondary mt-4",
+                      data: { confirm: t(".confirm") } %>
+        <% end %>
       </section>
     <% end %>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -23,9 +23,12 @@ edit_link(
       <% end %>
     <% else %>
       <section class="layout-aside__section layout-aside__buttons">
-        <%= link_to t(".edit"),
-                    edit_initiative_path(current_initiative),
-                    class: "button button__xl w-full button__secondary" %>
+        <% if allowed_to? :edit, :initiative, initiative: current_initiative %>
+          <%= link_to t(".edit"),
+                      edit_initiative_path(current_initiative),
+                      class: "button button__xl w-full button__secondary" %>
+        <% end %>
+
         <%= render partial: "send_to_technical_validation", locals: { title: t(".send_to_technical_validation"), confirm: t(".confirm") } %>
       </section>
     <% end %>

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -170,6 +170,7 @@ describe "Initiative" do
         let(:state) { :validating }
 
         it { expect(page).to have_no_link("Edit") }
+
         it_behaves_like "initiative does not show send to technical validation"
       end
 

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -146,10 +146,6 @@ describe "Initiative" do
         it { expect(page).to have_no_link("Send to technical validation") }
       end
 
-      shared_examples_for "initiative shows send to technical validation disabled" do
-        it { expect(page).to have_link("Send to technical validation", href: "#") }
-      end
-
       context "when initiative state is created" do
         let(:state) { :created }
 
@@ -159,8 +155,9 @@ describe "Initiative" do
             visit decidim_initiatives.initiative_path(initiative)
           end
 
-          it_behaves_like "initiative shows send to technical validation disabled"
+          it_behaves_like "initiative does not show send to technical validation"
           it { expect(page).to have_content("Before sending your initiative for technical validation") }
+          it { expect(page).to have_link("Edit") }
         end
 
         context "when the user can send the initiative to technical validation" do
@@ -172,7 +169,8 @@ describe "Initiative" do
       context "when initiative state is validating" do
         let(:state) { :validating }
 
-        it_behaves_like "initiative shows send to technical validation disabled"
+        it { expect(page).to have_no_link("Edit") }
+        it_behaves_like "initiative does not show send to technical validation"
       end
 
       context "when initiative state is discarded" do


### PR DESCRIPTION
#### :tophat: What? Why?

When an initiative is in technical validation, it shows some actions/information to the creator that doesn't make sense:

1. We show the "Edit" button, but if you click on it, you get an error "You are not authorized to perform this action."
2. We show the "Send to technical validation" button, but you can't click on it as it's disabled
3. We show the progress bar with the amount of signatures needed, but no one can't sign it. This is a regression from the redesign, as we didn't show this. 

#### :pushpin: Related Issues
 
- Related to [#13042](https://github.com/decidim/decidim/pull/13042) (as these are things that I noticed in that PR) 

#### Testing

1. Go to initiatives
2. Create a new initiative 
3. Send it to technical validation
4. Go to the initiative show page 

### :camera: Screenshots

#### Before

![Screenshot of the bug](https://github.com/decidim/decidim/assets/717367/0e32c9e9-c68b-461d-8840-901614791776)

#### After

![Screenshot of the fix](https://github.com/decidim/decidim/assets/717367/91116d17-e1fe-4122-9714-44a9a0147532)

:hearts: Thank you!
