### PR TITLE
Enable admin's system tests

### DIFF
--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -30,10 +30,12 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          - command: bundle exec parallel_test --type rspec --pattern spec/ --exclude-pattern spec/system
+          - command: bundle exec parallel_test --type rspec --pattern spec/ --exclude-pattern 'spec/(system|lib)'
             name: "Tests without system specs"
-          - command: bundle exec parallel_test --type rspec --pattern spec/lib
+          - command: bundle exec parallel_test --type rspec --pattern spec/lib --exclude-pattern spec/system
             name: "Lib specs"
+          - command: bundle exec parallel_test --type rspec --pattern spec/ --exclude-pattern spec/lib
+            name: "Tests with system specs"
     needs: build_app
     name: ${{ matrix.test.name }}
     uses: ./.github/workflows/test_app.yml

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -32,9 +32,9 @@ jobs:
         test:
           - command: bundle exec parallel_test --type rspec --pattern spec/ --exclude-pattern 'spec/(system|lib)'
             name: "Tests without system specs"
-          - command: bundle exec parallel_test --type rspec --pattern spec/lib --exclude-pattern spec/system
+          - command: bundle exec parallel_test --type rspec --pattern spec/lib
             name: "Lib specs"
-          - command: bundle exec parallel_test --type rspec --pattern spec/ --exclude-pattern spec/lib
+          - command: bundle exec parallel_test --type rspec --pattern spec/system
             name: "Tests with system specs"
     needs: build_app
     name: ${{ matrix.test.name }}

--- a/decidim-admin/app/controllers/decidim/admin/help_sections_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/help_sections_controller.rb
@@ -27,7 +27,7 @@ module Decidim
           params[:help_sections]
         )
 
-        UpdateHelpSections.call(@form, current_organization, current_user) do
+        UpdateHelpSections.call(@form, current_organization) do
           on(:ok) do
             flash[:notice] = t("help_sections.success", scope: "decidim.admin")
             redirect_to action: :show

--- a/decidim-admin/app/controllers/decidim/admin/managed_users/promotions_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/managed_users/promotions_controller.rb
@@ -17,7 +17,7 @@ module Decidim
           enforce_permission_to(:promote, :managed_user, user:)
           @form = form(ManagedUserPromotionForm).from_params(params)
 
-          PromoteManagedUser.call(@form, user, current_user) do
+          PromoteManagedUser.call(@form, user) do
             on(:ok) do
               flash[:notice] = I18n.t("managed_users.promotion.success", scope: "decidim.admin")
               redirect_to impersonatable_users_path

--- a/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
@@ -71,7 +71,7 @@ module Decidim
         @form = form(NewsletterForm).from_params(params)
         @form.images = images_block_context unless has_images_block_context?
 
-        UpdateNewsletter.call(newsletter, @form, current_user) do
+        UpdateNewsletter.call(newsletter, @form) do
           on(:ok) do |newsletter|
             flash[:notice] = I18n.t("newsletters.update.success", scope: "decidim.admin")
             redirect_to action: :show, id: newsletter.id
@@ -117,7 +117,7 @@ module Decidim
         enforce_permission_to(:update, :newsletter, newsletter:)
         @form = form(SelectiveNewsletterForm).from_params(params)
 
-        DeliverNewsletter.call(newsletter, @form, current_user) do
+        DeliverNewsletter.call(newsletter, @form) do
           on(:ok) do
             flash[:notice] = I18n.t("newsletters.deliver.success", scope: "decidim.admin")
             redirect_to action: :index

--- a/decidim-admin/spec/system/admin_manages_more_locales_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_more_locales_spec.rb
@@ -60,6 +60,7 @@ describe "Admin language selector" do
       locales = %w(en ro es ca it fi)
       I18n.available_locales = locales
       Decidim.available_locales = locales
+      I18n.backend.reload!
       locales
     end
 

--- a/decidim-admin/spec/system/admin_manages_more_locales_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_more_locales_spec.rb
@@ -26,6 +26,7 @@ describe "Admin language selector" do
     I18n.available_locales = %w(en ca es)
     Decidim::Admin.send(:remove_const, :StaticPageForm)
     load "#{Decidim::Admin::Engine.root}/app/forms/decidim/admin/static_page_form.rb"
+    I18n.backend.reload!
   end
 
   context "with less than 5 fields" do
@@ -33,6 +34,7 @@ describe "Admin language selector" do
       locales = %w(ro fi en)
       I18n.available_locales = locales
       Decidim.available_locales = locales
+      I18n.backend.reload!
       locales
     end
 

--- a/decidim-admin/spec/system/admin_manages_newsletter_templates_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_newsletter_templates_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "Admin manages newsletter templates" do
-  let(:organization) { create(:organization) }
+  let(:organization) { create(:organization, name: { en: "Test organization" }) }
   let(:user) { create(:user, :admin, :confirmed, name: "Sarah Kerrigan", organization:) }
 
   before do
@@ -60,7 +60,7 @@ describe "Admin manages newsletter templates" do
         visit decidim_admin.preview_newsletter_template_path(template_id)
         expect(page).to have_link("notifications page", href: "#")
         expect(page).to have_link("Unsubscribe", href: "#")
-        expect(page).to have_link(organization.name, href: "#", count: 2)
+        expect(page).to have_link("Test organization", href: "#", count: 2)
       end
     end
 

--- a/decidim-admin/spec/system/admin_manages_organization_areas_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_areas_spec.rb
@@ -71,6 +71,8 @@ describe "Organization Areas" do
         within "table" do
           expect(page).to have_content(translated(attributes[:name]))
         end
+
+        visit decidim_admin.root_path
         expect(page).to have_content("updated the #{translated(attributes[:name])} area")
       end
 

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -473,7 +473,7 @@ describe "Admin manages organization" do
         let(:parsed_content) do
           cnt = <<~HTML
             <p>testing</p>
-            <p><strong>foo</strong><br><a target="_blank" href="https://www.decidim.org/">link</a></p>
+            <p><strong>foo</strong><br><a target="_blank" href="https://www.decidim.org/"><u>link</u></a></p>
             <p><br></p>
           HTML
 

--- a/decidim-admin/spec/system/admin_passwords_spec.rb
+++ b/decidim-admin/spec/system/admin_passwords_spec.rb
@@ -81,7 +81,7 @@ describe "Admin passwords" do
   end
 
   def manual_login(email, password)
-    click_on "Log in", match: :first
+    click_on "Login", match: :first
     within ".new_user" do
       fill_in :session_user_email, with: email
       fill_in :session_user_password, with: password

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -132,6 +132,7 @@ end
 Capybara.server = :puma, server_options
 
 Capybara.server_errors = [SyntaxError, StandardError]
+Capybara.save_path = Rails.root.join("tmp/screenshots")
 
 Capybara.default_max_wait_time = 10
 


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing the newsletters feature, I found out that we don't have the systems (aka capybara) specs enabled in the CI, as this particular feature was broken with #12983. 

This PR enables it again. 

#### :pushpin: Related Issues
 
- Related to #12983 
 

#### Testing

Everything should be green 


#### Traceback

For the reviewer, in case [github actions logs](https://github.com/decidim/decidim/actions/runs/9745819758/job/26894898750?pr=13068) of the first commit get cleaned: 

https://gist.github.com/andreslucena/6e58c7f8b37d4e52ccf51199ce576bfe

I can see failures from #12286 and #10199 and other PRs

:hearts: Thank you!
