### PR TITLE
Backport 'Remove dependency on `decidim-system` from `decidim-core`' to v0.28

### DIFF
--- a/decidim-core/lib/decidim/core/seeds.rb
+++ b/decidim-core/lib/decidim/core/seeds.rb
@@ -209,7 +209,7 @@ module Decidim
 
         oauth_application.organization_logo.attach(io: File.open(File.join(seeds_root, "homepage_image.jpg")), filename: "organization_logo.jpg", content_type: "image/jpeg")
 
-        Decidim::System::CreateDefaultContentBlocks.call(organization)
+        Decidim::ContentBlocksCreator.new(organization).create_default!
 
         hero_content_block = Decidim::ContentBlock.find_by(organization:, manifest_name: :hero, scope_name: :homepage)
         hero_content_block.images_container.background_image = create_blob!(seeds_file: "homepage_image.jpg", filename: "homepage_image.jpg", content_type: "image/jpeg")


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #13059 to v0.28

:hearts: Thank you!