### PR TITLE
Backport 'Enable admin's system tests' to v0.28

### DIFF
--- a/decidim-admin/spec/system/admin_manages_more_locales_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_more_locales_spec.rb
@@ -60,6 +60,7 @@ describe "Admin language selector" do
       locales = %w(en ro es ca it fi)
       I18n.available_locales = locales
       Decidim.available_locales = locales
+      I18n.backend.reload!
       locales
     end
 

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -469,7 +469,7 @@ describe "Admin manages organization" do
         let(:parsed_content) do
           cnt = <<~HTML
             <p>testing</p>
-            <p><strong>foo</strong><br><a target="_blank" href="https://www.decidim.org/">link</a></p>
+            <p><strong>foo</strong><br><a target="_blank" href="https://www.decidim.org/"><u>link</u></a></p>
             <p><br></p>
           HTML
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -121,6 +121,7 @@ end
 Capybara.server = :puma, server_options
 
 Capybara.server_errors = [SyntaxError, StandardError]
+Capybara.save_path = Rails.root.join("tmp/screenshots")
 
 Capybara.default_max_wait_time = 10
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #13068 to v0.28

-- 

This only backports the fixes that I think are relevant to v0.28

:hearts: Thank you!