### PR TITLE
Restore tooltip positioning classes (top, bottom, left, right)

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -155,7 +155,6 @@ linters:
           - bio-extended
           - block-banner
           - bootstrap-tagsinput
-          - bottom
           - box__search
           - breadcrumb--separator
           - breadcrumbs
@@ -832,7 +831,6 @@ linters:
           - large-up-8
           - last-sorted
           - lead
-          - left
           - legal_text
           - legend
           - letter_spaced
@@ -1505,7 +1503,6 @@ linters:
           - reveal__list
           - reveal__title
           - reveal__trigger
-          - right
           - rowchart
           - scope-filters
           - scope-picker
@@ -1905,7 +1902,6 @@ linters:
           - toggle-show
           - tooltip
           - tooltip-content
-          - top
           - top-bar
           - top-bar-left
           - top-bar-right

--- a/decidim-core/app/cells/decidim/author/profile_minicard.erb
+++ b/decidim-core/app/cells/decidim/author/profile_minicard.erb
@@ -1,4 +1,4 @@
-<div class="author__tooltip" role="tooltip">
+<div class="author__tooltip bottom" role="tooltip">
   <div class="author__container">
     <%= render :avatar %>
 


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #12074  we have performed a class list cleanup, which, in this particular case appears to be too much. As a result, we lost the tooltip display capability on author cell. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12074
- Related to #13079

#### Testing
1. Visit design app on [Try.decidim](https://try.decidim.org/design/components/author) and hover the author names
2. Visit design app on [nightly](https://nightly.decidim.org/design/components/author) and hover the author names 
3. Visit any proposal and hover the endorser lists, or comment authors 
4. See the tooltip is not displayed 
5. Apply patch 
6. repeat 3
7. See the tooltip is displayed

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
