### PR TITLE
Fix artifact with the same name error in CI

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -119,6 +119,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: screenshots
+          name: screenshots-${{ github.run_number }}-${{ github.run_attempt }}
           path: ./spec/decidim_dummy_app/tmp/screenshots
           if-no-files-found: ignore


### PR DESCRIPTION
#### :tophat: What? Why?

We have a flaky related to the `actions/upload-artifact@v4` action. It seems like sometimes it tries to create two artifacts and it blows up with the following exception:

> Run actions/upload-artifact@v4
With the provided path, there will be 8 files uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

This was something that they introduced in v4. One of the documented workarounds is to have an unique artifact name (the screenshots.zip file in our case), so that's what I'm implementing here.

#### :pushpin: Related Issues

- Related to https://github.com/actions/upload-artifact/issues/478 

#### Testing

As it is a flaky in the CI I'm not 100% sure how to reproduce this. 

### Stacktrace

Example error: https://github.com/decidim/decidim/actions/runs/9834330869/job/27146183352?pr=13063

![Screenshot of the error](https://github.com/decidim/decidim/assets/717367/efbfe494-387d-4c4c-a873-883eeab4c16e)


:hearts: Thank you!
