### PR TITLE
Basic test for `.gemspec` sanity

### DIFF
--- a/decidim-dev/config/rubocop/rspec.yml
+++ b/decidim-dev/config/rubocop/rspec.yml
@@ -27,6 +27,7 @@ RSpec/ContextWording:
 RSpec/DescribeClass:
   Exclude:
     - spec/gemfiles_spec.rb
+    - spec/gemspecs_spec.rb
     - spec/webpacker_spec.rb
     - spec/version_files_spec.rb
     - spec/spellcheck_spec.rb

--- a/spec/gemspecs_spec.rb
+++ b/spec/gemspecs_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+describe "Gemspec sanity" do
+  let(:root_dir) { File.expand_path("..", __dir__) }
+  let(:decidim_spec) { gemspec("decidim") }
+
+  describe "decidim module specs" do
+    let(:decidim_module_specs) do
+      decidim_spec.dependencies.select { |dep| dep.name =~ /^decidim-/ }.map(&:to_spec)
+    end
+
+    it "do not require the `decidim` gem" do
+      expect(decidim_module_specs).to all(be_decidim_clean)
+    end
+  end
+
+  describe "decidim-dev spec" do
+    let(:decidim_dev_spec) { gemspec("decidim-dev") }
+
+    it "does not require the `decidim` gem" do
+      expect(decidim_dev_spec).to be_decidim_clean
+    end
+  end
+
+  def gemspec(name)
+    gemspec_file =
+      if name == "decidim"
+        "#{root_dir}/decidim.gemspec"
+      else
+        "#{root_dir}/#{name}/#{name}.gemspec"
+      end
+
+    Gem::Specification.load(gemspec_file)
+  end
+
+  def be_decidim_clean
+    BeDecidimClean.new
+  end
+
+  class BeDecidimClean
+    attr_reader :spec
+
+    def matches?(given_spec)
+      @spec = given_spec
+      spec.dependencies.all? { |dep| dep.name != "decidim" }
+    end
+
+    def failure_message
+      "expected '#{spec.name}' gem not to have the 'decidim' gem as its dependency"
+    end
+
+    def failure_message_when_negated
+      "expected '#{spec.name}' gem to have the 'decidim' gem as its dependency"
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Since I recently noticed some cross dependency issues with the Decidim gem, I added this test to check that the `.gemspec` files do not define the `decidim` root gem as their dependency.

This might not fix the whole problem with the individual gems (see #13062) but it's a start to making sure that gems could work without requiring all the other gems as their dependencies.

Note that this PR remains a draft until #13052 is merged because that PR fixes an issue with the `decidim-dev` gem that this is testing.

#### :pushpin: Related Issues
- Related to #13052

#### Testing
- Wait for #13052 to be merged
- After merged, wait for this branch to be updated with the latest changes
- After updated, see that CI is green