### PR TITLE
Backport 'Fix exception when going to debates new URL directly as non-logged user ' to v0.27

### DIFF
--- a/decidim-debates/app/controllers/decidim/debates/debates_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/debates_controller.rb
@@ -14,6 +14,7 @@ module Decidim
       include Decidim::Debates::Orderable
 
       helper_method :debates, :debate, :form_presenter, :paginated_debates, :close_debate_form
+      before_action :authenticate_user!, only: [:new, :create]
 
       def new
         enforce_permission_to :create, :debate

--- a/decidim-debates/spec/controllers/decidim/debates/debates_controller_spec.rb
+++ b/decidim-debates/spec/controllers/decidim/debates/debates_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Debates
+    describe DebatesController do
+      routes { Decidim::Debates::Engine.routes }
+
+      let(:user) { create(:user, :confirmed, organization: component.organization) }
+
+      let(:debate_params) do
+        {
+          component_id: component.id
+        }
+      end
+      let(:params) { { debate: debate_params } }
+
+      before do
+        request.env["decidim.current_organization"] = component.organization
+        request.env["decidim.current_participatory_space"] = component.participatory_space
+        request.env["decidim.current_component"] = component
+        stub_const("Decidim::Paginable::OPTIONS", [100])
+      end
+
+      describe "GET new" do
+        let(:component) { create(:debates_component, :with_creation_enabled) }
+
+        context "when user is not logged in" do
+          it "redirects to the login page" do
+            get(:new)
+            expect(response).to have_http_status(:found)
+            expect(response.body).to have_text("You are being redirected")
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
@@ -142,4 +142,14 @@ describe Decidim::Meetings::MeetingsController, type: :controller do
       end
     end
   end
+
+  describe "#new" do
+    context "when user is not logged in" do
+      it "redirects to the login page" do
+        get(:new)
+        expect(response).to have_http_status(:found)
+        expect(response.body).to have_text("You are being redirected")
+      end
+    end
+  end
 end

--- a/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -104,6 +104,16 @@ module Decidim
         end
       end
 
+      context "when user is not logged in" do
+        let(:component) { create(:proposal_component, :with_creation_enabled) }
+
+        it "redirects to the login page" do
+          get(:new)
+          expect(response).to have_http_status(:found)
+          expect(response.body).to have_text("You are being redirected")
+        end
+      end
+
       describe "POST create" do
         before { sign_in user }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12864 to v0.27

:hearts: Thank you!