### PR TITLE
Backport 'Do not update SMTP or omniauth attributes if no values are specified' to v0.27

### DIFF
--- a/decidim-core/app/mailers/decidim/application_mailer.rb
+++ b/decidim-core/app/mailers/decidim/application_mailer.rb
@@ -17,7 +17,7 @@ module Decidim
     attr_reader :organization
 
     def set_smtp
-      return if organization.nil? || organization.smtp_settings.blank?
+      return if organization.nil? || organization.smtp_settings.blank? || organization.smtp_settings.except("from", "from_label", "from_email").all?(&:blank?)
 
       mail.reply_to = mail.reply_to || Decidim.config.mailer_reply
       mail.delivery_method.settings.merge!(

--- a/decidim-core/spec/mailers/application_mailer_spec.rb
+++ b/decidim-core/spec/mailers/application_mailer_spec.rb
@@ -52,6 +52,44 @@ module Decidim
         end
       end
 
+      context "when smtp settings has blank values" do
+        let(:smtp_settings) do
+          {
+            "address" => "",
+            "port" => "",
+            "user_name" => "",
+            "encrypted_password" => "",
+            "from_email" => "",
+            "from_label" => "",
+            "from" => ""
+          }
+        end
+
+        it "returns default values" do
+          expect(mail.from).to eq(["change-me@example.org"])
+          expect(mail.delivery_method.settings).to be_blank
+        end
+
+        context "and from is set" do
+          let(:smtp_settings) do
+            {
+              "address" => "",
+              "port" => "",
+              "user_name" => "",
+              "encrypted_password" => "",
+              "from_email" => "",
+              "from_label" => "",
+              "from" => "Custom <custom@example.org>"
+            }
+          end
+
+          it "set default values for mail.from and mail.reply_to" do
+            expect(mail.header[:from].value).to eq("Custom <custom@example.org>")
+            expect(mail.delivery_method.settings).to be_blank
+          end
+        end
+      end
+
       context "when from is not set" do
         let(:from) { nil }
 

--- a/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -76,7 +76,9 @@ module Decidim
       def encrypted_smtp_settings
         smtp_settings["from"] = set_from
 
-        smtp_settings.merge(encrypted_password: Decidim::AttributeEncryptor.encrypt(password))
+        encrypted = smtp_settings.merge(encrypted_password: Decidim::AttributeEncryptor.encrypt(password))
+        # if all are empty, nil is returned so it does not break ENV vars configuration
+        encrypted.values.all?(&:blank?) ? nil : encrypted
       end
 
       def set_from
@@ -86,9 +88,11 @@ module Decidim
       end
 
       def encrypted_omniauth_settings
-        omniauth_settings.transform_values do |v|
+        encrypted = omniauth_settings.transform_values do |v|
           Decidim::OmniauthProvider.value_defined?(v) ? Decidim::AttributeEncryptor.encrypt(v) : v
         end
+        # if all are empty, nil is returned so it does not break ENV vars configuration
+        encrypted.values.all?(&:blank?) ? nil : encrypted
       end
 
       private

--- a/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
@@ -22,22 +22,30 @@ module Decidim
               secondary_hosts: "foo.example.org\r\n\r\nbar.example.org",
               force_users_to_authenticate_before_access_organization: false,
               users_registration_mode: "existing",
-              smtp_settings: {
-                "address" => "mail.example.org",
-                "port" => "25",
-                "user_name" => "f.laguardia",
-                "password" => Decidim::AttributeEncryptor.encrypt("password"),
-                "from_email" => "decide@example.org",
-                "from_label" => from_label
-              },
-              omniauth_settings_facebook_enabled: true,
-              omniauth_settings_facebook_app_id: "facebook-app-id",
-              omniauth_settings_facebook_app_secret: "facebook-app-secret",
+              **smtp_settings,
+              **omniauth_settings,
               file_upload_settings: params_for_uploads(upload_settings)
             }
           end
           let(:upload_settings) do
             Decidim::OrganizationSettings.default(:upload)
+          end
+          let(:omniauth_settings) do
+            {
+              "omniauth_settings_facebook_enabled" => true,
+              "omniauth_settings_facebook_app_id" => "facebook-app-id",
+              "omniauth_settings_facebook_app_secret" => "facebook-app-secret"
+            }
+          end
+          let(:smtp_settings) do
+            {
+              "address" => "mail.example.org",
+              "port" => "25",
+              "user_name" => "f.laguardia",
+              "password" => Decidim::AttributeEncryptor.encrypt("password"),
+              "from_email" => "decide@example.org",
+              "from_label" => from_label
+            }
           end
 
           it "returns a valid response" do
@@ -75,6 +83,45 @@ module Decidim
                 expect(organization.smtp_settings["from"]).to eq("decide@example.org")
                 expect(organization.smtp_settings["from_email"]).to eq("decide@example.org")
               end
+            end
+
+            context "when all smtp settings are blank" do
+              let(:smtp_settings) do
+                {
+                  "address" => "",
+                  "port" => "",
+                  "user_name" => "",
+                  "password" => "",
+                  "from_email" => "",
+                  "from_label" => ""
+                }
+              end
+
+              it "sets smtp_settings to nil" do
+                command.call
+                organization = Organization.last
+
+                expect(translated(organization.name)).to eq("Gotham City")
+                expect(organization.smtp_settings).to be_nil
+              end
+            end
+          end
+
+          context "when all omniauth settings are blank" do
+            let(:omniauth_settings) do
+              {
+                "omniauth_settings_facebook_enabled" => nil,
+                "omniauth_settings_facebook_app_id" => nil,
+                "omniauth_settings_facebook_app_secret" => nil
+              }
+            end
+
+            it "sets omniauth_settings to nil" do
+              command.call
+              organization = Organization.last
+
+              expect(translated(organization.name)).to eq("Gotham City")
+              expect(organization.omniauth_settings).to be_nil
             end
           end
         end

--- a/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
@@ -17,14 +17,16 @@ module Decidim::System
         users_registration_mode: "enabled",
         force_users_to_authenticate_before_access_organization: "false",
         **smtp_settings,
-        omniauth_settings: {
-          "omniauth_settings_facebook_enabled" => true,
-          "omniauth_settings_facebook_app_id" => facebook_app_id,
-          "omniauth_settings_facebook_app_secret" => facebook_app_secret
-        }
+        **omniauth_settings
       )
     end
-
+    let(:omniauth_settings) do
+      {
+        "omniauth_settings_facebook_enabled" => true,
+        "omniauth_settings_facebook_app_id" => facebook_app_id,
+        "omniauth_settings_facebook_app_secret" => facebook_app_secret
+      }
+    end
     let(:smtp_settings) do
       {
         "address" => "mail.example.org",
@@ -48,6 +50,20 @@ module Decidim::System
           expect(subject.omniauth_settings_facebook_enabled).to be(true)
           expect(subject.omniauth_settings_facebook_app_id).to eq(facebook_app_id)
           expect(subject.omniauth_settings_facebook_app_secret).to eq(facebook_app_secret)
+        end
+
+        context "when all values are blank" do
+          let(:omniauth_settings) do
+            {
+              "omniauth_settings_facebook_enabled" => nil,
+              "omniauth_settings_facebook_app_id" => nil,
+              "omniauth_settings_facebook_app_secret" => nil
+            }
+          end
+
+          it "returns nil" do
+            expect(subject.encrypted_omniauth_settings).to be_nil
+          end
         end
       end
 
@@ -87,6 +103,23 @@ module Decidim::System
         it "handles SMTP password properly" do
           expect(subject.smtp_settings).to eq(smtp_settings.except("password"))
           expect(Decidim::AttributeEncryptor.decrypt(subject.encrypted_smtp_settings[:encrypted_password])).to eq(password)
+        end
+
+        context "when all values are blank" do
+          let(:smtp_settings) do
+            {
+              "address" => "",
+              "port" => "",
+              "user_name" => "",
+              "password" => "",
+              "from_email" => "",
+              "from_label" => ""
+            }
+          end
+
+          it "returns nil" do
+            expect(subject.encrypted_smtp_settings).to be_nil
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #12865 to v0.27

:hearts: Thank you!