### PR TITLE
Show the admin bar for other roles

### DIFF
--- a/decidim-admin/lib/decidim/admin/test/admin_participatory_space_access_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/admin_participatory_space_access_examples.rb
@@ -31,6 +31,16 @@ shared_examples "admin participatory space access" do
   context "when the user has the role" do
     let(:user) { role }
 
+    context "and visits the root path" do
+      it "shows the admin bar" do
+        visit decidim.root_path
+
+        within "#admin-bar" do
+          expect(page).to have_link("Admin dashboard", href: "/admin/")
+        end
+      end
+    end
+
     context "and has permission" do
       before do
         visit target_path

--- a/decidim-admin/lib/decidim/admin/test/admin_participatory_space_access_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/admin_participatory_space_access_examples.rb
@@ -15,6 +15,23 @@ shared_examples "showing the unauthorized error message" do
   end
 end
 
+shared_examples "admin participatory space edit button" do
+  context "and visits the participatory space public page" do
+    before do
+      switch_to_host(organization.host)
+      login_as role, scope: :user
+    end
+
+    it "shows the admin bar with the Edit button" do
+      visit participatory_space_path
+
+      within "#admin-bar" do
+        expect(page).to have_link("Edit", href: target_path)
+      end
+    end
+  end
+end
+
 shared_examples "admin participatory space access" do
   before do
     switch_to_host(organization.host)

--- a/decidim-assemblies/spec/system/admin/admin_access_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_access_spec.rb
@@ -13,8 +13,10 @@ describe "AdminAccess" do
     let(:role) { create(:assembly_admin, :confirmed, organization:, assembly: participatory_space) }
     let(:target_path) { decidim_admin_assemblies.edit_assembly_path(participatory_space) }
     let(:unauthorized_target_path) { decidim_admin_assemblies.edit_assembly_path(other_participatory_space) }
+    let(:participatory_space_path) { decidim_assemblies.assembly_path(participatory_space) }
 
     it_behaves_like "admin participatory space access"
+    it_behaves_like "admin participatory space edit button"
   end
 
   context "with participatory space valuator" do

--- a/decidim-conferences/spec/system/admin/admin_access_spec.rb
+++ b/decidim-conferences/spec/system/admin/admin_access_spec.rb
@@ -13,8 +13,10 @@ describe "AdminAccess" do
     let(:role) { create(:conference_admin, :confirmed, organization:, conference: participatory_space) }
     let(:target_path) { decidim_admin_conferences.edit_conference_path(participatory_space) }
     let(:unauthorized_target_path) { decidim_admin_conferences.edit_conference_path(other_participatory_space) }
+    let(:participatory_space_path) { decidim_conferences.conference_path(participatory_space) }
 
     it_behaves_like "admin participatory space access"
+    it_behaves_like "admin participatory space edit button"
   end
 
   context "with participatory space valuator" do

--- a/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_wrapper.html.erb
@@ -11,9 +11,9 @@ end
 %>
 
 <div class="layout-container">
-  <header <%= "class=with-admin-bar" if current_user&.admin %>>
+  <header <%= "class=with-admin-bar" if current_user && allowed_to?(:read, :admin_dashboard) %>>
     <div id="sticky-header-container" data-sticky-header>
-      <%= render partial: "layouts/decidim/admin_links" if current_user&.admin %>
+      <%= render partial: "layouts/decidim/admin_links" if current_user && allowed_to?(:read, :admin_dashboard) %>
       <%= render partial: "layouts/decidim/header/main" %>
     </div>
     <div id="menu-bar-container">

--- a/decidim-participatory_processes/spec/system/admin/admin_access_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_access_spec.rb
@@ -13,8 +13,10 @@ describe "AdminAccess" do
     let(:role) { create(:process_admin, :confirmed, organization:, participatory_process: participatory_space) }
     let(:target_path) { decidim_admin_participatory_processes.edit_participatory_process_path(participatory_space) }
     let(:unauthorized_target_path) { decidim_admin_participatory_processes.edit_participatory_process_path(other_participatory_space) }
+    let(:participatory_space_path) { decidim_participatory_processes.participatory_process_path(participatory_space) }
 
     it_behaves_like "admin participatory space access"
+    it_behaves_like "admin participatory space edit button"
   end
 
   context "with participatory space valuator" do


### PR DESCRIPTION
#### :tophat: What? Why?

With the redesign, we've lost the direct links to the admin for other roles that aren't general admins, such as participatory space admins, moderators and valuators. 

This PR fixes it. 

#### :pushpin: Related Issues
 
- Fixes #13113

#### Testing

1. Sign in as participatory_process_1_admin@example.org, participatory_process_1_moderator@example.org or  participatory_process_1_valuator@example.org
2. Check out the header

### :camera: Screenshots

![Screenshot of the user account settings with the email participatory_process_1_admin@example.org](https://github.com/decidim/decidim/assets/717367/8d87909f-a01d-47ff-b377-8408d50d2492)

:hearts: Thank you!
