### PR TITLE
Withdraw Proposal Icon  

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_aside.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_aside.html.erb
@@ -22,7 +22,6 @@
   <% if @proposal.withdrawable_by?(current_user) %>
     <%= action_authorized_link_to :withdraw, withdraw_proposal_path(@proposal), method: :put, class: "button button__sm button__transparent-secondary w-full", title: t("withdraw_btn_hint", scope: "decidim.proposals.proposals.show" ), data: { confirm: t("withdraw_confirmation_html", scope: "decidim.proposals.proposals.show" ) } do %>
       <span><%= t("withdraw_proposal", scope: "decidim.proposals.proposals.show") %></span>
-      <%= icon "pencil-line" %>
     <% end %>
   <% end %>
 </section>


### PR DESCRIPTION
#### :tophat: What? Why?
The pencil icon was on the wrong button within Proposals (Withdraw). This PR removes the icon as withdrawing a proposal is not associated to it. 

#### :pushpin: Related Issues
- Fixes #13086 

#### Testing
1. Login.
2. Go to proposals.
3. Create one in the front end
4.  See the icon removed from the withdrawal icon.

### :camera: Screenshots


:hearts: Thank you!
