### PR TITLE
Fix attachments uploads with modal

### DIFF
--- a/decidim-core/app/cells/decidim/upload_modal/modal.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/modal.erb
@@ -37,10 +37,10 @@
             <%= icon "upload-cloud-2-line", class: "w-8 h-8 text-gray fill-current" %>
             <%= t("decidim.forms.upload_help.dropzone") %>
           </span>
-          <button class="button button__sm button__secondary" data-select-file-button>
+          <label class="button button__sm button__secondary" for="files-<%= modal_id %>">
             <span><%= t("decidim.forms.upload.select_file") %></span>
             <%= icon "arrow-right-line", class: "fill-current" %>
-          </button>
+          </label>
         </div>
       </div>
     </div>

--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
@@ -154,20 +154,16 @@ export default class UploadModal {
     // Disabled save button when any children have data-state="error"
     this.saveButton.disabled = Array.from(files).filter(({ dataset: { state } }) => state === STATUS.ERROR).length > 0;
 
-    const dataSelectFileButton = this.emptyItems.querySelector("[data-select-file-button]");
-
     // Only allow to continue the upload when the multiple option is true (default: false)
     const continueUpload = !files.length || this.options.multiple
     this.input.disabled = !continueUpload
     if (continueUpload) {
       this.emptyItems.classList.remove("is-disabled");
-      dataSelectFileButton.removeAttribute("disabled");
+      this.emptyItems.querySelector("label").removeAttribute("disabled");
     } else {
       this.emptyItems.classList.add("is-disabled");
-      dataSelectFileButton.disabled = true;
+      this.emptyItems.querySelector("label").disabled = true;
     }
-
-    dataSelectFileButton.addEventListener("click", () => this.input.click());
   }
 
   createUploadItem(file, errors, opts = {}) {

--- a/decidim-core/app/packs/stylesheets/decidim/_modal_update.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_modal_update.scss
@@ -28,9 +28,7 @@
           @apply w-24 flex-none flex justify-center;
         }
 
-        img:not([src^="data:image"]):not(
-            [src^="data:application/octet-stream"]
-          ) {
+        img[src="data:,"] {
           @apply hidden;
         }
 


### PR DESCRIPTION
#### :tophat: What? Why?

A couple of months ago I fixed some flakys that we have with the upload modal markup. The problem is that this also has broken the feature. 

This PR fixes it by partially reverting the refactor that introduced the problem. This means that we're also reintroducing the flaky, but I could not find a way (yet) to actually solve the markup and keep the feature working.  

I also found another problem where the preview of the images weren't showing in some browsers (Google Chrome at least, but all the browsers based on it probably). 
 
#### :pushpin: Related Issues

- Related to #12636 (where I broke the feature)
- Fixes #13104 
- Fixes #13023 

#### Testing

This is something that is shown with different behaviors in different browsers with different kind of modal uploads with different files 😅 - so yeah, this is going to be lots of clicks 

1. Sign in as admin
2. Go to http://localhost:3000/admin/organization/edit?locale=en 
3. Upload an image with the WYSIWYG editor, for instance in "Body for the admin terms of service*". See that it gets uploaded correctly with a  preview 
5. Go to a process, edit it, go to the Attachments section and click "New Attachment" . Click on "Add file" -> "Select file". Select an image, see that it gets uploaded correctly with a  preview 
6. Click on "Remove" and "Select file" again, this time a PDF. See that it gets saved without a preview. 

Try again with another browser. I tried with Firefox 127 and Chrome 126

### :camera: Screenshots

![File upload with an image](https://github.com/decidim/decidim/assets/717367/0efb50c9-bfd7-4e67-afa5-3c8e26944fc7)

:hearts: Thank you!
