### PR TITLE
Fix markup for Badges explanation page

### DIFF
--- a/decidim-core/app/controllers/decidim/gamification/badges_controller.rb
+++ b/decidim-core/app/controllers/decidim/gamification/badges_controller.rb
@@ -9,6 +9,8 @@ module Decidim
         @badges = Decidim::Gamification.badges.sort_by(&:name)
       end
 
+      private
+
       def breadcrumb_item
         {
           label: t("decidim.gamification.badges.index.title"),

--- a/decidim-core/app/views/decidim/gamification/badges/index.html.erb
+++ b/decidim-core/app/views/decidim/gamification/badges/index.html.erb
@@ -1,38 +1,41 @@
-<div class="wrapper">
-  <div class="row column">
-    <h1><%= t ".title" %></h1>
-    <p>
-      <%= t ".page_description" %>
+<% add_decidim_meta_tags(
+  title: t(".title"),
+  description: t(".page_description")
+) %>
+
+<main class="layout-1col cols-10">
+
+  <header class="text-center py-10">
+    <h1 class="title-decorator inline-block text-left mb-12">
+      <%= t ".title" %>
+    </h1>
+    <p class="text-lg text-gray-2">
+    <%= t ".page_description" %>
     </p>
-  </div>
+  </header>
+
   <% @badges.each do |badge| %>
-    <div class="row column">
-      <div class="column">
-        <div class="card card--badge">
-          <div>
-            <div>
-              <%= image_tag badge.image %>
-            </div>
-            <div class="text-center">
-              <strong><%= badge.translated_name %></strong>
-            </div>
+    <div class="mb-12">
+      <h2 class="h4 mb-4"><%= t ".badge_title", name: badge.translated_name %></h2>
+      <div class="grid grid-cols-10 text-gray-2 leading-relaxed">
+        <div class="col-span-2">
+          <div class="flex justify-center items-center">
+            <%= image_tag badge.image, class: "w-32", alt: badge.translated_name %>
+          </div>
+          <div class="text-center mt-4">
+            <strong><%= badge.translated_name %></strong>
           </div>
         </div>
-      </div>
-      <div class="column">
-        <h6>
-          <strong><%= t ".badge_title", name: badge.translated_name %></strong>
-        </h6>
-        <p><%= badge.description(current_organization_name) %></p>
-        <h6>
-          <strong><%= t ".how" %></strong>
-        </h6>
-        <ol>
-          <% badge.conditions.each do |condition| %>
-            <li><%= condition %></li>
-          <% end %>
-        </ol>
+        <div class="col-span-7 ml-2">
+          <p><%= badge.description(current_organization_name) %></p>
+          <p class="mt-4"><strong><%= t ".how" %></strong></p>
+          <ol class="list-decimal">
+            <% badge.conditions.each do |condition| %>
+              <li><%= condition %></li>
+            <% end %>
+          </ol>
+        </div>
       </div>
     </div>
   <% end %>
-</div>
+</main>


### PR DESCRIPTION
#### :tophat: What? Why?

While checking out the breadcrumb calls, I found out that the Badges explanation page wasn't redesigned. This is pretty hidden, only linked from the profiles' badges pages.

This PR fixes it by making a fast design based on what we already had in the legacy design.  

#### Testing

1. Go to http://localhost:3000/gamification/badges and see it designed correctly

### :camera: Screenshots

#### Before 
![Screenshot of the bug](https://github.com/decidim/decidim/assets/717367/757c276f-1dbb-4442-a8a9-d7cc83caa9de)

#### After
![Screenshot of the fix](https://github.com/decidim/decidim/assets/717367/9f70f9cb-7f75-4b30-8daf-7840eff0e0d8)

#### Legacy (reference)
![Screenshot of the legacy page](https://github.com/decidim/decidim/assets/717367/02bd704b-e253-430a-ad01-b3ea30a36be7)

:hearts: Thank you!
