### PR TITLE
Send welcome notifications for omniauth users

### DIFF
--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -55,7 +55,12 @@ module Decidim
         # If user has left the account unconfirmed and later on decides to sign
         # in with omniauth with an already verified account, the account needs
         # to be marked confirmed.
-        @user.skip_confirmation! if !@user.confirmed? && @user.email == verified_email
+        if !@user.confirmed? && @user.email == verified_email
+          @user.skip_confirmation!
+          @user.after_confirmation
+        end
+        @user.tos_agreement = "1"
+        @user.save!
       else
         @user.email = (verified_email || form.email)
         @user.name = form.name
@@ -69,12 +74,11 @@ module Decidim
           @user.avatar.attach(io: file, filename:)
         end
         @user.skip_confirmation! if verified_email
+        @user.tos_agreement = "1"
+        @user.save!
+
+        @user.after_confirmation if verified_email
       end
-
-      @user.tos_agreement = "1"
-      @user.save!
-
-      @user.after_confirmation if verified_email
     end
 
     def create_identity

--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -73,6 +73,8 @@ module Decidim
 
       @user.tos_agreement = "1"
       @user.save!
+
+      @user.after_confirmation if verified_email
     end
 
     def create_identity

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -278,6 +278,18 @@ module Decidim
       false
     end
 
+    def after_confirmation
+      return unless organization.send_welcome_notification?
+
+      Decidim::EventsManager.publish(
+        event: "decidim.events.core.welcome_notification",
+        event_class: WelcomeNotificationEvent,
+        resource: self,
+        affected_users: [self],
+        extra: { force_email: true }
+      )
+    end
+
     protected
 
     # Overrides devise email required validation.
@@ -294,18 +306,6 @@ module Decidim
       return false if managed?
 
       super
-    end
-
-    def after_confirmation
-      return unless organization.send_welcome_notification?
-
-      Decidim::EventsManager.publish(
-        event: "decidim.events.core.welcome_notification",
-        event_class: WelcomeNotificationEvent,
-        resource: self,
-        affected_users: [self],
-        extra: { force_email: true }
-      )
     end
 
     private

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -102,6 +102,16 @@ module Decidim
 
             expect(ActiveSupport::Notifications)
               .to receive(:publish)
+              .with("decidim.events.core.welcome_notification",
+                    affected_users: [user],
+                    event_class: "Decidim::WelcomeNotificationEvent",
+                    extra: { force_email: true },
+                    followers: [user],
+                    force_send: false,
+                    resource: user)
+
+            expect(ActiveSupport::Notifications)
+              .to receive(:publish)
               .with(
                 "decidim.user.omniauth_registration",
                 user_id: user.id,

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -106,7 +106,7 @@ module Decidim
                     affected_users: [user],
                     event_class: "Decidim::WelcomeNotificationEvent",
                     extra: { force_email: true },
-                    followers: [user],
+                    followers: [],
                     force_send: false,
                     resource: user)
 

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -12,6 +12,10 @@ describe "Authentication" do
   end
 
   describe "Create an account" do
+    around do |example|
+      perform_enqueued_jobs { example.run }
+    end
+
     context "when using email and password" do
       it "creates a new User" do
         click_on("Create an account")
@@ -106,6 +110,23 @@ describe "Authentication" do
           expect_user_logged
         end
       end
+
+      it "sends a welcome notification" do
+        click_on("Create an account")
+
+        find(".login__omniauth-button.button--facebook").click
+        click_on "I agree with these terms"
+
+        within_user_menu do
+          click_on "Notifications"
+        end
+
+        within "#notifications" do
+          expect(page).to have_content("thanks for joining #{translated(organization.name)}")
+        end
+
+        expect(last_email_body).to include("thanks for joining #{translated(organization.name)}")
+      end
     end
 
     context "when using twitter" do
@@ -182,6 +203,23 @@ describe "Authentication" do
 
           expect_user_logged
         end
+
+        it "sends a welcome notification" do
+          click_on("Create an account")
+          find(".login__omniauth-button.button--x").click
+
+          click_on "I agree with these terms"
+
+          within_user_menu do
+            click_on "Notifications"
+          end
+
+          within "#notifications" do
+            expect(page).to have_content("thanks for joining #{translated(organization.name)}")
+          end
+
+          expect(last_email_body).to include("thanks for joining #{translated(organization.name)}")
+        end
       end
     end
 
@@ -217,6 +255,24 @@ describe "Authentication" do
         click_on "Log in with Google"
 
         expect_user_logged
+      end
+
+      it "sends a welcome notification" do
+        click_on("Create an account")
+
+        click_on "Log in with Google"
+
+        click_on "I agree with these terms"
+
+        within_user_menu do
+          click_on "Notifications"
+        end
+
+        within "#notifications" do
+          expect(page).to have_content("thanks for joining #{translated(organization.name)}")
+        end
+
+        expect(last_email_body).to include("thanks for joining #{translated(organization.name)}")
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
An organization that has the welcome notification configured to be sent, cannot send it to users that are joining up using Omniauth, as the account is marked as confirmed, thing that does not trigger the "afetr_confirmation" callback. 

Sending organization welcome message is not working for Omniauth installs. 

#### Testing
1. Login as admin and make sure you visit the organization settings 
2. Check "Send welcome notification" 
3. Check "Customize welcome notification"
4. Save changes
5. Register using omniauth 
6. Accept the TOS
7. Visit the notifications area 
8. See there are no notifications 
9. Apply patch 
10. repeat 2+3 
11. See there is a notification

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
