### PR TITLE
Fix details in login/account creation strings

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -163,6 +163,7 @@ csslintrc
 CSSs
 csvfile
 cta
+cuenta
 Cugat
 customise
 Customising

--- a/decidim-comments/config/locales/en.yml
+++ b/decidim-comments/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
           error: There was a problem voting the comment.
     components:
       add_comment_form:
-        account_message: <a href="%{sign_in_url}">Log in with your account</a> or <a href="%{sign_up_url}">create an account</a> to add your comment.
+        account_message: <a href="%{sign_in_url}">Log in</a> or <a href="%{sign_up_url}">create an account</a> to add your comment.
         form:
           body:
             label: Comment

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -21,7 +21,7 @@ module Decidim::Comments
         expect(subject).to have_css(".flash.primary.loading-comments", text: "Loading comments ...")
         expect(subject).to have_no_content(comment.body.values.first)
         expect(subject).to have_css(".add-comment")
-        expect(subject).to have_content("Log in with your account or create an account to add your comment.")
+        expect(subject).to have_content("Log in or create an account to add your comment.")
 
         {
           best_rated: "Best rated",

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -37,7 +37,7 @@ describe "Authentication" do
       end
 
       it "keeps the locale settings" do
-        click_on("Regístrate")
+        click_on("Crea una cuenta")
 
         within ".new_user" do
           fill_in :registration_user_email, with: "user@example.org"

--- a/decidim-core/spec/system/locales_spec.rb
+++ b/decidim-core/spec/system/locales_spec.rb
@@ -44,7 +44,7 @@ describe "Locales" do
 
       visit decidim_admin.root_path
 
-      expect(page).to have_content("Cal iniciar sessió o registrar-te abans de continuar.")
+      expect(page).to have_content("Has d'iniciar sessió o bé registrar-te abans de continuar.")
     end
 
     it "displays devise messages with the right locale when authentication fails" do

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -261,8 +261,8 @@ en:
           success: Organization successfully updated.
         users_registration_mode:
           disabled: Access only can be done with external accounts
-          enabled: Allow participants to register and log in
-          existing: Do not allow participants to register, but allow existing participants to log in
+          enabled: Allow participants to create an account and log in
+          existing: Do not allow participants to create an account, but allow existing participants to log in
       shared:
         notices:
           no_organization_warning_html: You must create an organization to get started. Make sure you read %{guide} before proceeding.

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -49,7 +49,7 @@ describe "Organizations" do
         fill_in "Organization admin email", with: "mayor@example.org"
         check "organization_available_locales_en"
         choose "organization_default_locale_en"
-        choose "Allow participants to register and log in"
+        choose "Allow participants to create an account and log in"
         check "Example authorization (Direct)"
         click_on "Create organization & invite admin"
 
@@ -176,7 +176,7 @@ describe "Organizations" do
         fill_in_i18n :update_organization_name, "#update_organization-name-tabs", en: "Citizens Rule!"
         fill_in "Host", with: "www.example.org"
         fill_in "Secondary hosts", with: "foobar.example.org\n\rbar.example.org"
-        choose "Do not allow participants to register, but allow existing participants to log in"
+        choose "Do not allow participants to create an account, but allow existing participants to log in"
         check "Example authorization (Direct)"
 
         click_on "Show advanced settings"


### PR DESCRIPTION
#### :tophat: What? Why?

While making the spanish and catalan translations that come from #13076, @carolromero mentioned that some source strings from English sounded funny and that we should correct them.

This PR does that.

#### :pushpin: Related Issues
 
- Related to #13076
 

#### Testing

The phrases should make sense 

:hearts: Thank you!
