### PR TITLE
Fix gap in checkboxes/radio buttons filters' labels

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_filters.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_filters.scss
@@ -1,5 +1,7 @@
 .filter {
-  @apply flex items-center gap-2 p-1.5 rounded cursor-pointer relative;
+  label {
+    @apply flex items-center gap-2 p-1.5 rounded cursor-pointer relative;
+  }
 
   &-container {
     @apply rounded border-4 border-background md:border-0;


### PR DESCRIPTION
#### :tophat: What? Why?

A couple of months ago we introduced a mini bug in the styling of the labels in the filters. This PR fixes it. 

#### :pushpin: Related Issues

- Related to #12746 (as it's where I could find it was introduced this bug)
- Fixes #13138 
 
#### Testing

1. Go to http://localhost:3000/processes
2. Check out the filters (before and after this patch) 

### :camera: Screenshots

#### Before

![Screenshot of the bug](https://github.com/user-attachments/assets/a39aa391-6b5d-40a7-9cfa-1bac6393f3f3)

#### After

![Screenshot of the fix](https://github.com/user-attachments/assets/85ad9e6a-36d9-40f2-b876-27df612cc5f4)

:hearts: Thank you!
