### PR TITLE
Add Linked Meetings feature to allow linking meetings to other spaces

### DIFF
--- a/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
+++ b/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
@@ -28,7 +28,7 @@ module Decidim
             next if ignored_key?(key.to_sym)
 
             alert_class = key_matching[key.to_sym]
-            concat alert_box(value.try(:html_safe), alert_class, closable)
+            concat alert_box(value, alert_class, closable)
           end
         end
       end
@@ -106,11 +106,11 @@ module Decidim
       end
 
       def message(value)
-        return content_tag(:div, value, class: "flash__message flex items-center") unless value.is_a?(Hash)
+        return content_tag(:div, value.try(:html_safe), class: "flash__message flex items-center") unless value.is_a?(Hash)
 
         content_tag(:div, class: "flash__message") do
-          concat value[:title]
-          concat content_tag(:span, value[:body], class: "flash__message-body")
+          concat value[:title].try(:html_safe)
+          concat content_tag(:span, value[:body].try(:html_safe), class: "flash__message-body")
         end
       end
     end

--- a/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
+++ b/decidim-core/app/helpers/concerns/decidim/flash_helper_extensions.rb
@@ -28,7 +28,7 @@ module Decidim
             next if ignored_key?(key.to_sym)
 
             alert_class = key_matching[key.to_sym]
-            concat alert_box(value, alert_class, closable)
+            concat alert_box(value.try(:html_safe), alert_class, closable)
           end
         end
       end
@@ -106,11 +106,11 @@ module Decidim
       end
 
       def message(value)
-        return content_tag(:div, value.try(:html_safe), class: "flash__message flex items-center") unless value.is_a?(Hash)
+        return content_tag(:div, value, class: "flash__message") unless value.is_a?(Hash)
 
         content_tag(:div, class: "flash__message") do
-          concat value[:title].try(:html_safe)
-          concat content_tag(:span, value[:body].try(:html_safe), class: "flash__message-body")
+          concat value[:title]
+          concat content_tag(:span, value[:body], class: "flash__message-body")
         end
       end
     end

--- a/decidim-core/app/models/decidim/component.rb
+++ b/decidim-core/app/models/decidim/component.rb
@@ -98,6 +98,16 @@ module Decidim
       participatory_space.can_participate?(user)
     end
 
+    def private_non_transparent_space?
+      return true unless participatory_space.private_space?
+
+      if participatory_space.respond_to?(:is_transparent?)
+        !participatory_space.is_transparent?
+      else
+        false
+      end
+    end
+
     # Public: Public URL for component with given share token as query parameter
     def shareable_url(share_token)
       EngineRouter.main_proxy(self).root_path(self, share_token: share_token.token)

--- a/decidim-core/app/models/decidim/component.rb
+++ b/decidim-core/app/models/decidim/component.rb
@@ -11,6 +11,7 @@ module Decidim
     include Loggable
     include Decidim::ShareableWithToken
     include ScopableComponent
+    include TranslatableAttributes
 
     belongs_to :participatory_space, polymorphic: true
 
@@ -77,6 +78,14 @@ module Decidim
     # Public: Returns the component's name as resource title
     def resource_title
       name
+    end
+
+    def hierarchy_title
+      [
+        I18n.t("decidim.admin.menu.#{participatory_space.class.name.demodulize.underscore.pluralize}"),
+        translated_attribute(participatory_space.title),
+        translated_attribute(name)
+      ].join(" / ")
     end
 
     # Public: Returns an empty description

--- a/decidim-core/app/models/decidim/component.rb
+++ b/decidim-core/app/models/decidim/component.rb
@@ -99,12 +99,12 @@ module Decidim
     end
 
     def private_non_transparent_space?
-      return true unless participatory_space.private_space?
+      return false unless participatory_space.private_space?
 
       if participatory_space.respond_to?(:is_transparent?)
         !participatory_space.is_transparent?
       else
-        false
+        true
       end
     end
 

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -194,6 +194,7 @@ module Decidim
         Decidim.icons.register(name: "profile", icon: "team-line", description: "Groups", category: "profile", engine: :core)
         Decidim.icons.register(name: "user_group", icon: "team-line", description: "Groups", category: "profile", engine: :core)
         Decidim.icons.register(name: "link", icon: "link", description: "web / URL", category: "profile", engine: :core)
+        Decidim.icons.register(name: "unlink", icon: "link-unlink-m", description: "Unlink", category: "profile", engine: :core)
         Decidim.icons.register(name: "following", icon: "eye-2-line", description: "Following", category: "profile", engine: :core)
         Decidim.icons.register(name: "activity", icon: "bubble-chart-line", description: "Activity", category: "profile", engine: :core)
         Decidim.icons.register(name: "followers", icon: "group-line", description: "Followers", category: "profile", engine: :core)

--- a/decidim-core/spec/models/decidim/component_spec.rb
+++ b/decidim-core/spec/models/decidim/component_spec.rb
@@ -34,6 +34,42 @@ module Decidim
       end
     end
 
+    describe "private_non_transparent_space?" do
+      subject { component }
+
+      let(:component) { create(:component, manifest_name: "another_dummy", participatory_space:) }
+
+      context "when the component belongs to a private space" do
+        let(:participatory_space) do
+          create(:participatory_process, organization:, private_space: true)
+        end
+
+        it "returns true" do
+          expect(subject.private_non_transparent_space?).to be true
+        end
+      end
+
+      context "when the component belongs to a non-private space" do
+        let(:participatory_space) do
+          create(:participatory_process, organization:, private_space: false)
+        end
+
+        it "returns false" do
+          expect(subject.private_non_transparent_space?).to be false
+        end
+      end
+
+      context "when the component belongs to a private transparent space" do
+        let(:participatory_space) do
+          create(:assembly, organization:, private_space: false, is_transparent: true)
+        end
+
+        it "returns false" do
+          expect(subject.private_non_transparent_space?).to be false
+        end
+      end
+    end
+
     describe "with no scope setting" do
       subject { component }
 

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
@@ -17,7 +17,19 @@ module Decidim
         render
       end
 
+      def url_extra_params
+        if current_component == meeting.component
+          {}
+        else
+          { previous_space: "#{current_space.class}##{current_space.id}" }
+        end
+      end
+
       private
+
+      def current_space
+        @current_space ||= current_component.participatory_space
+      end
 
       def metadata_cell
         "decidim/meetings/meeting_card_metadata"

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
@@ -18,11 +18,10 @@ module Decidim
       end
 
       def url_extra_params
-        if current_component == meeting.component
-          {}
-        else
-          { previous_space: "#{current_space.class}##{current_space.id}" }
-        end
+        return {} unless defined?(current_component)
+        return {} if current_component == meeting.component
+
+        { previous_space: "#{current_space.class}##{current_space.id}" }
       end
 
       private

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
@@ -20,6 +20,7 @@ module Decidim
       def url_extra_params
         return {} unless defined?(current_component)
         return {} if current_component == meeting.component
+        return {} if current_component.manifest_name == "accountability"
 
         { previous_space: "#{current_space.class}##{current_space.id}" }
       end

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
@@ -18,9 +18,9 @@ module Decidim
       end
 
       def url_extra_params
+        return options[:url_extra_params] if options[:url_extra_params]
         return {} unless defined?(current_component)
         return {} if current_component == meeting.component
-        return {} if current_component.manifest_name == "accountability"
 
         { previous_space: "#{current_space.class}##{current_space.id}" }
       end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
@@ -16,6 +16,7 @@ module Decidim
         def run_after_hooks
           create_services!
           create_follow_form_resource(form.current_user)
+          link_components!
         end
 
         def attributes
@@ -45,6 +46,11 @@ module Decidim
               description: service.description
             )
           end
+        end
+
+        def link_components!
+          resource.components = form.components
+          resource.save!
         end
 
         def create_follow_form_resource(user)

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
@@ -18,6 +18,7 @@ module Decidim
           send_notification if should_notify_followers?
           schedule_upcoming_meeting_notification if resource.published? && start_time_changed?
           update_services!
+          update_components!
         end
 
         def attributes
@@ -34,6 +35,11 @@ module Decidim
           resource.services = form.services_to_persist.map do |service|
             Decidim::Meetings::Service.new(title: service.title, description: service.description)
           end
+          resource.save!
+        end
+
+        def update_components!
+          resource.components = form.components
           resource.save!
         end
 

--- a/decidim-meetings/app/controllers/concerns/decidim/meetings/admin/filterable.rb
+++ b/decidim-meetings/app/controllers/concerns/decidim/meetings/admin/filterable.rb
@@ -16,7 +16,13 @@ module Decidim
           private
 
           def base_query
-            Meeting.not_hidden.where(component: current_component).order(start_time: :desc).page(params[:page]).per(15)
+            Meeting
+              .not_hidden
+              .where(component: current_component)
+              .or(MeetingLink.find_meetings(component: current_component))
+              .order(start_time: :desc)
+              .page(params[:page])
+              .per(15)
           end
 
           def filters

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
@@ -38,13 +38,13 @@ module Decidim
 
           if meeting.component != current_component
             redirect_to ::Decidim::ResourceLocatorPresenter.new(meeting).edit,
-                        notice: { body: I18n.t(
+                        notice: I18n.t(
                           "meetings.edit.redirect_notice",
                           scope: "decidim.meetings.admin",
                           destiny_space_name: translated_attribute(meeting.component.participatory_space.title),
                           original_space_name: translated_attribute(current_component.participatory_space.title),
                           original_space_url: meetings_path
-                        ) }
+                        )
           end
 
           @form = meeting_form.from_model(meeting)

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
@@ -36,17 +36,6 @@ module Decidim
         def edit
           enforce_permission_to(:update, :meeting, meeting:)
 
-          if meeting.component != current_component
-            redirect_to ::Decidim::ResourceLocatorPresenter.new(meeting).edit,
-                        notice: I18n.t(
-                          "meetings.edit.redirect_notice",
-                          scope: "decidim.meetings.admin",
-                          destiny_space_name: translated_attribute(meeting.component.participatory_space.title),
-                          original_space_name: translated_attribute(current_component.participatory_space.title),
-                          original_space_url: meetings_path
-                        )
-          end
-
           @form = meeting_form.from_model(meeting)
         end
 

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
@@ -37,7 +37,14 @@ module Decidim
           enforce_permission_to(:update, :meeting, meeting:)
 
           if meeting.component != current_component
-            redirect_to ::Decidim::ResourceLocatorPresenter.new(meeting).edit, notice: I18n.t("meetings.edit.redirect_notice", scope: "decidim.meetings.admin")
+            redirect_to ::Decidim::ResourceLocatorPresenter.new(meeting).edit,
+                        notice: { body: I18n.t(
+                          "meetings.edit.redirect_notice",
+                          scope: "decidim.meetings.admin",
+                          destiny_space_name: translated_attribute(meeting.component.participatory_space.title),
+                          original_space_name: translated_attribute(current_component.participatory_space.title),
+                          original_space_url: meetings_path
+                        ) }
           end
 
           @form = meeting_form.from_model(meeting)

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
@@ -36,6 +36,10 @@ module Decidim
         def edit
           enforce_permission_to(:update, :meeting, meeting:)
 
+          if meeting.component != current_component
+            redirect_to ::Decidim::ResourceLocatorPresenter.new(meeting).edit, notice: I18n.t("meetings.edit.redirect_notice", scope: "decidim.meetings.admin")
+          end
+
           @form = meeting_form.from_model(meeting)
         end
 

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -14,6 +14,7 @@ module Decidim
       helper Decidim::ResourceVersionsHelper
       helper Decidim::ShortLinkHelper
       include Decidim::AttachmentsHelper
+      include Decidim::SanitizeHelper
 
       helper_method :meetings, :meeting, :registration, :search, :tab_panel_items
 
@@ -185,8 +186,8 @@ module Decidim
           "meetings.show.redirect_notice",
           scope: "decidim.meetings",
           previous_space_url: request.referer,
-          previous_space_name: translated_attribute(previous_space.title),
-          current_space_name: translated_attribute(current_component.participatory_space.title)
+          previous_space_name: decidim_escape_translated(previous_space.title),
+          current_space_name: decidim_escape_translated(current_component.participatory_space.title)
         )
       end
 

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -120,12 +120,19 @@ module Decidim
       end
 
       def search_collection
-        Meeting.where(component: current_component).published.not_hidden.visible_for(current_user).with_availability(
-          filter_params[:with_availability]
-        ).includes(
-          :component,
-          attachments: :file_attachment
-        )
+        Meeting
+          .where(component: current_component)
+          .published
+          .not_hidden
+          .or(MeetingLink.find_meetings(component: current_component))
+          .visible_for(current_user)
+          .with_availability(
+            filter_params[:with_availability]
+          )
+          .includes(
+            :component,
+            attachments: :file_attachment
+          )
       end
 
       def meeting_form

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -70,7 +70,7 @@ module Decidim
 
         # linked components
         def components
-          return [] if participatory_space.private_space?
+          return [] if private_non_transparent_space?
 
           if private_meeting && !transparent
             []
@@ -81,6 +81,16 @@ module Decidim
 
         def participatory_space
           @participatory_space ||= current_component.participatory_space
+        end
+
+        def private_non_transparent_space?
+          return false unless participatory_space.private_space?
+
+          if participatory_space.respond_to?(:is_transparent?)
+            !participatory_space.is_transparent?
+          else
+            true
+          end
         end
 
         def number_of_services

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -79,9 +79,7 @@ module Decidim
           end
         end
 
-        def private_non_transparent_space?
-          current_component.private_non_transparent_space?
-        end
+        delegate :private_non_transparent_space?, to: :current_component
 
         def number_of_services
           services.size

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -8,6 +8,7 @@ module Decidim
         include TranslatableAttributes
 
         attribute :services, Array[MeetingServiceForm]
+        attribute :component_ids, Array[Integer]
         attribute :decidim_scope_id, Integer
         attribute :decidim_category_id, Integer
         attribute :private_meeting, Boolean
@@ -65,6 +66,21 @@ module Decidim
 
         def services_to_persist
           services.reject(&:deleted)
+        end
+
+        # linked components
+        def components
+          return [] if participatory_space.private_space?
+
+          if private_meeting && !transparent
+            []
+          else
+            Decidim::Component.where(id: component_ids)
+          end
+        end
+
+        def participatory_space
+          @participatory_space ||= current_component.participatory_space
         end
 
         def number_of_services

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -79,18 +79,8 @@ module Decidim
           end
         end
 
-        def participatory_space
-          @participatory_space ||= current_component.participatory_space
-        end
-
         def private_non_transparent_space?
-          return false unless participatory_space.private_space?
-
-          if participatory_space.respond_to?(:is_transparent?)
-            !participatory_space.is_transparent?
-          else
-            true
-          end
+          current_component.private_non_transparent_space?
         end
 
         def number_of_services

--- a/decidim-meetings/app/helpers/decidim/meetings/admin/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/admin/application_helper.rb
@@ -25,8 +25,8 @@ module Decidim
         def find_meeting_components_for_select
           spaces = current_organization.public_participatory_spaces
           meeting_components = Decidim::Component
-            .published
             .where(manifest_name: 'meetings', participatory_space_id: spaces.pluck(:id))
+            .where.not(id: current_component.id)
 
           meeting_components.map do |component|
             [component.hierarchy_title, component.id]

--- a/decidim-meetings/app/helpers/decidim/meetings/admin/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/admin/application_helper.rb
@@ -25,14 +25,12 @@ module Decidim
         def find_meeting_components_for_select
           spaces = current_organization.public_participatory_spaces
           meeting_components = Decidim::Component
-            .where(manifest_name: 'meetings', participatory_space_id: spaces.pluck(:id))
-            .where.not(id: current_component.id)
+                               .where(manifest_name: "meetings", participatory_space_id: spaces.pluck(:id))
+                               .where.not(id: current_component.id)
 
           meeting_components.map do |component|
             [component.hierarchy_title, component.id]
-          end.sort_by do |component|
-            component.first
-          end
+          end.sort_by(&:first)
         end
       end
     end

--- a/decidim-meetings/app/helpers/decidim/meetings/admin/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/admin/application_helper.rb
@@ -21,6 +21,19 @@ module Decidim
         def tabs_id_for_agenda_item_child(agenda_item)
           "meeting_agenda_item_#{agenda_item.to_param_child}"
         end
+
+        def find_meeting_components_for_select
+          spaces = current_organization.public_participatory_spaces
+          meeting_components = Decidim::Component
+            .published
+            .where(manifest_name: 'meetings', participatory_space_id: spaces.pluck(:id))
+
+          meeting_components.map do |component|
+            [component.hierarchy_title, component.id]
+          end.sort_by do |component|
+            component.first
+          end
+        end
       end
     end
   end

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -45,6 +45,8 @@ module Decidim
         foreign_key: :decidim_user_id,
         source: :user
       )
+      has_many :meeting_links, dependent: :destroy, class_name: "Decidim::Meetings::MeetingLink", foreign_key: "decidim_meeting_id"
+      has_many :components, through: :meeting_links, class_name: "Decidim::Component", foreign_key: "decidim_component_id"
 
       enum iframe_access_level: [:all, :signed_in, :registered], _prefix: true
       enum iframe_embed_type: [:none, :embed_in_meeting_page, :open_in_live_event_page, :open_in_new_tab], _prefix: true

--- a/decidim-meetings/app/models/decidim/meetings/meeting_link.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting_link.rb
@@ -15,15 +15,7 @@ module Decidim
                    .joins(:meeting_links)
                    .where("decidim_meetings_meeting_links.component": component)
                    .filter do |meeting|
-          space = meeting.component.participatory_space
-
-          next true unless space.private_space?
-
-          if space.respond_to?(:is_transparent?)
-            space.is_transparent?
-          else
-            false
-          end
+          !meeting.component.private_non_transparent_space?
         end
 
         Meeting.where(id: meetings.map(&:id))

--- a/decidim-meetings/app/models/decidim/meetings/meeting_link.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting_link.rb
@@ -8,6 +8,8 @@ module Decidim
       belongs_to :meeting, foreign_key: "decidim_meeting_id", class_name: "Decidim::Meetings::Meeting"
       belongs_to :component, foreign_key: "decidim_component_id", class_name: "Decidim::Component"
 
+      # Finds all the meetings linked to the given component
+      # filtering out meetings that belong to private not transparent spaces.
       def self.find_meetings(component:)
         meetings = Meeting
                    .joins(:meeting_links)

--- a/decidim-meetings/app/models/decidim/meetings/meeting_link.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting_link.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    class MeetingLink < Meetings::ApplicationRecord
+      include Decidim::HasComponent
+
+      belongs_to :meeting, foreign_key: "decidim_meeting_id", class_name: "Decidim::Meetings::Meeting"
+      belongs_to :component, foreign_key: "decidim_component_id", class_name: "Decidim::Component"
+
+      def self.find_meetings(component:)
+        meetings = Meeting
+          .joins(:meeting_links)
+          .where("decidim_meetings_meeting_links.component": component)
+          .filter do |meeting|
+            space = meeting.component.participatory_space
+
+            next true unless space.private_space?
+
+            if space.respond_to?(:is_transparent?)
+              space.is_transparent?
+            else
+              false
+            end
+          end
+
+        Meeting.where(id: meetings.map(&:id))
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/models/decidim/meetings/meeting_link.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting_link.rb
@@ -10,19 +10,19 @@ module Decidim
 
       def self.find_meetings(component:)
         meetings = Meeting
-          .joins(:meeting_links)
-          .where("decidim_meetings_meeting_links.component": component)
-          .filter do |meeting|
-            space = meeting.component.participatory_space
+                   .joins(:meeting_links)
+                   .where("decidim_meetings_meeting_links.component": component)
+                   .filter do |meeting|
+          space = meeting.component.participatory_space
 
-            next true unless space.private_space?
+          next true unless space.private_space?
 
-            if space.respond_to?(:is_transparent?)
-              space.is_transparent?
-            else
-              false
-            end
+          if space.respond_to?(:is_transparent?)
+            space.is_transparent?
+          else
+            false
           end
+        end
 
         Meeting.where(id: meetings.map(&:id))
       end

--- a/decidim-meetings/app/packs/entrypoints/decidim_meetings_admin.js
+++ b/decidim-meetings/app/packs/entrypoints/decidim_meetings_admin.js
@@ -1,5 +1,6 @@
 import "src/decidim/meetings/admin/agendas"
 import "src/decidim/meetings/admin/destroy_meeting_alert"
 import "src/decidim/meetings/admin/meetings_form"
+import "src/decidim/meetings/admin/meetings_components_form"
 import "src/decidim/meetings/admin/registrations_form"
 import "src/decidim/meetings/admin/registrations_invite_form"

--- a/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_components_form.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_components_form.js
@@ -1,4 +1,5 @@
 import TomSelect from "tom-select/dist/cjs/tom-select.popular";
+import createTooltip from "src/decidim/tooltips"
 
 /**
  * This module manages the Linked Spaces section from the
@@ -36,6 +37,12 @@ const handleAddButton = () => {
   handleRemoveButton(button);
 
   body.appendChild(clone);
+
+  const tooltips = body.querySelectorAll("[data-tooltip]")
+
+  if (tooltips.length) {
+    createTooltip(tooltips[tooltips.length - 1]);
+  }
 
   select.value = "";
   table.classList.remove("hidden");

--- a/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_components_form.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_components_form.js
@@ -8,13 +8,13 @@ import TomSelect from "tom-select/dist/cjs/tom-select.popular";
  * setup a TomSelect for the components selector.
  */
 
-function handleRemoveButton(button) {
-  button.addEventListener("click", function(event) {
+const handleRemoveButton = (button) => {
+  button.addEventListener("click", function() {
     button.closest("tr").remove();
   });
-}
+};
 
-function handleAddButton() {
+const handleAddButton = () => {
   const select = document.querySelector("select[name='add_component_select']");
   const componentId = select.value;
   const componentTitle = select.options[select.selectedIndex].text;
@@ -39,15 +39,15 @@ function handleAddButton() {
 
   select.value = "";
   table.classList.remove("hidden");
-}
+};
 
-function setupTomSelect() {
+const setupTomSelect = () => {
   const componentsSelect = document.querySelector(
     "#add_component_select"
   );
 
   const config = {
-    plugins: ["dropdown_input"],
+    plugins: ["dropdown_input"]
   };
 
   return new TomSelect(componentsSelect, config);

--- a/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_components_form.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_components_form.js
@@ -1,0 +1,61 @@
+import TomSelect from "tom-select/dist/cjs/tom-select.popular";
+
+/**
+ * This module manages the Linked Spaces section from the
+ * admin meeting edit form.
+ *
+ * It allows to add and remove components to the meeting and
+ * setup a TomSelect for the components selector.
+ */
+
+function handleRemoveButton(button) {
+  button.addEventListener("click", function(event) {
+    button.closest("tr").remove();
+  });
+}
+
+function handleAddButton() {
+  const select = document.querySelector("select[name='add_component_select']");
+  const componentId = select.value;
+  const componentTitle = select.options[select.selectedIndex].text;
+
+  if (!componentId) {
+    return;
+  }
+
+  const table = document.querySelector(".js-components");
+  const body = document.querySelector(".js-components tbody");
+  const template = document.querySelector("#meeting_component_template");
+  const clone = template.content.cloneNode(true);
+  const title = clone.querySelector(".js-component-title");
+  const id = clone.querySelector("input");
+  const button = clone.querySelector(".js-remove-component");
+
+  title.textContent = componentTitle;
+  id.value = componentId;
+  handleRemoveButton(button);
+
+  body.appendChild(clone);
+
+  select.value = "";
+  table.classList.remove("hidden");
+}
+
+function setupTomSelect() {
+  const componentsSelect = document.querySelector(
+    "#add_component_select"
+  );
+
+  const config = {
+    plugins: ["dropdown_input"],
+  };
+
+  return new TomSelect(componentsSelect, config);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(".js-remove-component").forEach(handleRemoveButton);
+  document.querySelector(".js-add-component").addEventListener("click", handleAddButton);
+
+  setupTomSelect();
+});

--- a/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
@@ -86,10 +86,14 @@ $(() => {
   if ($form.length > 0) {
     const $privateMeeting = $form.find("#private_meeting");
     const $transparent = $form.find("#transparent");
+    const $warning = $form.find(".js-private-warning");
 
     const toggleDisabledHiddenFields = () => {
       const enabledPrivateSpace = $privateMeeting.find("input[type='checkbox']").prop("checked");
+      const enabledTransparent = $transparent.find("input[type='checkbox']").prop("checked");
+
       $transparent.find("input[type='checkbox']").attr("disabled", "disabled");
+      $warning?.toggleClass('hidden', !enabledPrivateSpace || enabledTransparent);
 
       if (enabledPrivateSpace) {
         $transparent.find("input[type='checkbox']").attr("disabled", !enabledPrivateSpace);
@@ -97,6 +101,8 @@ $(() => {
     };
 
     $privateMeeting.on("change", toggleDisabledHiddenFields);
+    $transparent.on("change", toggleDisabledHiddenFields);
+
     toggleDisabledHiddenFields();
 
     attachGeocoding($form.find("#meeting_address"));

--- a/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
@@ -87,6 +87,7 @@ $(() => {
     const $privateMeeting = $form.find("#private_meeting");
     const $transparent = $form.find("#transparent");
     const $warning = $form.find(".js-private-warning");
+    const $assign = $form.find(".js-add-component");
 
     const toggleDisabledHiddenFields = () => {
       const enabledPrivateSpace = $privateMeeting.find("input[type='checkbox']").prop("checked");
@@ -94,6 +95,7 @@ $(() => {
 
       $transparent.find("input[type='checkbox']").attr("disabled", "disabled");
       $warning?.toggleClass("hidden", !enabledPrivateSpace || enabledTransparent);
+      $assign?.attr("disabled", enabledPrivateSpace && !enabledTransparent);
 
       if (enabledPrivateSpace) {
         $transparent.find("input[type='checkbox']").attr("disabled", !enabledPrivateSpace);

--- a/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
@@ -93,7 +93,7 @@ $(() => {
       const enabledTransparent = $transparent.find("input[type='checkbox']").prop("checked");
 
       $transparent.find("input[type='checkbox']").attr("disabled", "disabled");
-      $warning?.toggleClass('hidden', !enabledPrivateSpace || enabledTransparent);
+      $warning?.toggleClass("hidden", !enabledPrivateSpace || enabledTransparent);
 
       if (enabledPrivateSpace) {
         $transparent.find("input[type='checkbox']").attr("disabled", !enabledPrivateSpace);

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -103,6 +103,10 @@ module Decidim
         ""
       end
 
+      def space_title
+        translated_attribute component.participatory_space.title
+      end
+
       def profile_path
         resource_locator(meeting).path
       end

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_component.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_component.html.erb
@@ -6,8 +6,10 @@
     <%= hidden_field_tag "meeting[component_ids][]", component&.id %>
   </td>
   <td>
-    <button type="button" class="js-remove-component cursor text-secondary text-md font-semibold">
-      <%= icon "unlink" %>
-    </button>
+    <%= with_tooltip(t(".unlink"), class: :top) do %>
+      <button type="button" class="js-remove-component cursor text-secondary text-md font-semibold">
+        <%= icon "unlink" %>
+      </button>
+    <% end %>
   </td>
 </tr>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_component.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_component.html.erb
@@ -1,0 +1,13 @@
+<tr>
+  <td class="title">
+    <span class="js-component-title text-md">
+      <%= link_to component.hierarchy_title, main_component_path(component) if component %>
+    </span>
+    <%= hidden_field_tag "meeting[component_ids][]", component&.id %>
+  </td>
+  <td>
+    <button type="button" class="js-remove-component cursor text-secondary text-md font-semibold">
+      <%= icon "unlink" %>
+    </button>
+  </td>
+</tr>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -95,6 +95,7 @@
     </div>
   </div>
   <%= render "decidim/meetings/admin/meetings/services", form: , id: tabs_id_for_service(blank_service) %>
+  <%= render "decidim/meetings/admin/meetings/linked_spaces", form: %>
 </div>
 
 <%= append_javascript_pack_tag "decidim_meetings_admin" %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_linked_spaces.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_linked_spaces.html.erb
@@ -9,27 +9,28 @@
   </div>
 
   <div id="panel-linked-spaces" class="px-4">
-    <% if form.object.participatory_space.private_space? %>
+    <% if form.object.private_non_transparent_space? %>
       <%= cell("decidim/announcement", t(".private_space_warning"), callout_class: "warning") %>
     <% else %>
       <%= cell("decidim/announcement", t(".private_meeting_warning"), callout_class: "warning js-private-warning hidden") %>
-    <% end %>
-    <div>
-      <label>
-        <%= t(".link_a_space") %>
-      </label>
+
       <div>
-        <select id="add_component_select" name="add_component_select" placeholder="<%= t(".select") %>" class="w-full mt-2">
-          <option value=""><%= t(".select") %></option>
-          <%= find_meeting_components_for_select.map do |option| %>
-            <option value="<%= option[1] %>"><%= option[0] %></option>
-          <% end %>
-        </select>
-        <button class="button button__sm button__secondary add-service mt-2 js-add-component mb-8" type="button">
-          <%= t(".assign") %>
-        </button>
+        <label>
+          <%= t(".link_a_space") %>
+        </label>
+        <div>
+          <select id="add_component_select" name="add_component_select" placeholder="<%= t(".select") %>" class="w-full mt-2">
+            <option value=""><%= t(".select") %></option>
+            <%= find_meeting_components_for_select.map do |option| %>
+              <option value="<%= option[1] %>"><%= option[0] %></option>
+            <% end %>
+          </select>
+          <button class="button button__sm button__secondary add-service mt-2 js-add-component mb-8" type="button">
+            <%= t(".assign") %>
+          </button>
+        </div>
       </div>
-    </div>
+    <% end %>
 
     <template id="meeting_component_template">
       <%= render "decidim/meetings/admin/meetings/component", component: nil %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_linked_spaces.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_linked_spaces.html.erb
@@ -2,7 +2,7 @@
 
 <div class="card" data-component="accordion" id="accordion-linked-spaces">
   <div class="card-divider">
-    <button class="card-divider-button" data-open="true" data-controls="panel-linked-spaces" type="button">
+    <button class="card-divider-button" data-open="false" data-controls="panel-linked-spaces" type="button">
       <%= icon "arrow-right-s-line" %>
       <h2 class="card-title" id="linked-spaces"><%= t(".title") %></h2>
     </button>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_linked_spaces.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_linked_spaces.html.erb
@@ -1,0 +1,57 @@
+<%= append_stylesheet_pack_tag "decidim_proposals", media: "all" %>
+
+<div class="card" data-component="accordion" id="accordion-linked-spaces">
+  <div class="card-divider">
+    <button class="card-divider-button" data-open="true" data-controls="panel-linked-spaces" type="button">
+      <%= icon "arrow-right-s-line" %>
+      <h2 class="card-title" id="linked-spaces"><%= t('.title') %></h2>
+    </button>
+  </div>
+
+  <div id="panel-linked-spaces" class="px-4">
+    <% if meeting.participatory_space.private_space? %>
+      <%= cell("decidim/announcement", t('.private_space_warning'), callout_class: "warning") %>
+    <% else %>
+      <%= cell("decidim/announcement", t('.private_meeting_warning'), callout_class: "warning js-private-warning hidden") %>
+    <% end %>
+    <div>
+      <label>
+        <%= t('.link_a_space') %>
+      </label>
+      <div>
+        <select
+          id="add_component_select"
+          name="add_component_select"
+          placeholder="<%= t('.select') %>"
+          class="w-full mt-2"
+        >
+          <option value=""><%= t('.select') %></option>
+          <%= find_meeting_components_for_select.map do |option| %>
+            <option value="<%= option[1] %>"><%= option[0] %></option>
+          <% end %>
+        </select>
+        <button class="button button__sm button__secondary add-service mt-2 js-add-component mb-8" type="button">
+          <%= t('.assign') %>
+        </button>
+      </div>
+    </div>
+
+    <template id="meeting_component_template">
+      <%= render "decidim/meetings/admin/meetings/component", component: nil %>
+    </template>
+
+    <table class="table-list w-full js-components <%= form.object.components.empty? && "hidden" %>">
+      <thead>
+        <tr>
+          <th><%= t('.table.component') %></th>
+          <th><%= t('.table.actions') %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% form.object.components.each do |component| %>
+          <%= render "decidim/meetings/admin/meetings/component", component: component %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_linked_spaces.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_linked_spaces.html.erb
@@ -4,34 +4,29 @@
   <div class="card-divider">
     <button class="card-divider-button" data-open="true" data-controls="panel-linked-spaces" type="button">
       <%= icon "arrow-right-s-line" %>
-      <h2 class="card-title" id="linked-spaces"><%= t('.title') %></h2>
+      <h2 class="card-title" id="linked-spaces"><%= t(".title") %></h2>
     </button>
   </div>
 
   <div id="panel-linked-spaces" class="px-4">
     <% if meeting.participatory_space.private_space? %>
-      <%= cell("decidim/announcement", t('.private_space_warning'), callout_class: "warning") %>
+      <%= cell("decidim/announcement", t(".private_space_warning"), callout_class: "warning") %>
     <% else %>
-      <%= cell("decidim/announcement", t('.private_meeting_warning'), callout_class: "warning js-private-warning hidden") %>
+      <%= cell("decidim/announcement", t(".private_meeting_warning"), callout_class: "warning js-private-warning hidden") %>
     <% end %>
     <div>
       <label>
-        <%= t('.link_a_space') %>
+        <%= t(".link_a_space") %>
       </label>
       <div>
-        <select
-          id="add_component_select"
-          name="add_component_select"
-          placeholder="<%= t('.select') %>"
-          class="w-full mt-2"
-        >
-          <option value=""><%= t('.select') %></option>
+        <select id="add_component_select" name="add_component_select" placeholder="<%= t(".select") %>" class="w-full mt-2">
+          <option value=""><%= t(".select") %></option>
           <%= find_meeting_components_for_select.map do |option| %>
             <option value="<%= option[1] %>"><%= option[0] %></option>
           <% end %>
         </select>
         <button class="button button__sm button__secondary add-service mt-2 js-add-component mb-8" type="button">
-          <%= t('.assign') %>
+          <%= t(".assign") %>
         </button>
       </div>
     </div>
@@ -43,13 +38,13 @@
     <table class="table-list w-full js-components <%= form.object.components.empty? && "hidden" %>">
       <thead>
         <tr>
-          <th><%= t('.table.component') %></th>
-          <th><%= t('.table.actions') %></th>
+          <th><%= t(".table.component") %></th>
+          <th><%= t(".table.actions") %></th>
         </tr>
       </thead>
       <tbody>
         <% form.object.components.each do |component| %>
-          <%= render "decidim/meetings/admin/meetings/component", component: component %>
+          <%= render "decidim/meetings/admin/meetings/component", component: %>
         <% end %>
       </tbody>
     </table>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_linked_spaces.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_linked_spaces.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div id="panel-linked-spaces" class="px-4">
-    <% if meeting.participatory_space.private_space? %>
+    <% if form.object.participatory_space.private_space? %>
       <%= cell("decidim/announcement", t(".private_space_warning"), callout_class: "warning") %>
     <% else %>
       <%= cell("decidim/announcement", t(".private_meeting_warning"), callout_class: "warning js-private-warning hidden") %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting_actions.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting_actions.html.erb
@@ -1,0 +1,79 @@
+<% if allowed_to? :update, :meeting, meeting: meeting %>
+  <%= icon_link_to "pencil-line", edit_meeting_path(meeting), t("actions.edit", scope: "decidim.meetings"), class: "action-icon--edit" %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :copy, :meeting, meeting: meeting %>
+  <%= icon_link_to "file-copy-line", new_meeting_copy_path(meeting), t("actions.duplicate", scope: "decidim.admin"), class: "action-icon--copy" %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :update, :meeting, meeting: meeting %>
+  <%= icon_link_to "folder-line", meeting_attachment_collections_path(meeting), t("actions.attachment_collections", scope: "decidim.meetings"), class: "action-icon--attachment_collections" %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :update, :meeting, meeting: meeting %>
+  <%= icon_link_to "attachment-line", meeting_attachments_path(meeting), t("actions.attachments", scope: "decidim.meetings"), class: "action-icon--attachments" %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :update, :meeting, meeting: meeting %>
+  <% if meeting.registration_disabled? %>
+    <%= icon "group-line", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.registrations", scope: "decidim.meetings") %>
+  <% else %>
+    <%= icon_link_to "group-line", meeting.on_this_platform? ? edit_meeting_registrations_path(meeting) : meeting.registration_url, t("actions.registrations", scope: "decidim.meetings"), class: "action-icon--registrations" %>
+  <% end %>
+<% end %>
+
+<% if allowed_to? :update, :meeting, meeting: meeting %>
+  <%= icon_link_to "calendar-line", meeting.agenda.present? ? edit_meeting_agenda_path(meeting, meeting.agenda) : new_meeting_agenda_path(meeting), t("actions.agenda", scope: "decidim.meetings"), class: "action-icon--agenda" %>
+  <%= icon_link_to "list-check", edit_meeting_poll_path(meeting), t("actions.manage_poll", scope: "decidim.meetings"), class: "action-icon--manage-poll-questionnaire" %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :close, :meeting, meeting: meeting %>
+  <%= icon_link_to "lock-line" , edit_meeting_meeting_close_path(meeting_id: meeting.id, id: meeting.id), t("actions.close", scope: "decidim.meetings"), class: "action-icon--close" %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<% if allowed_to? :update, :meeting, meeting: meeting %>
+  <% if meeting.published? %>
+    <%= icon_link_to "close-circle-line", unpublish_meeting_path(meeting), t("actions.unpublish", scope: "decidim.admin"), method: :put, class: "action-icon--unpublish", data: { confirm: t("actions.unpublish", scope: "decidim.admin") } %>
+  <% else %>
+    <%= icon_link_to "check-line", publish_meeting_path(meeting), t("actions.publish", scope: "decidim.admin"), method: :put, class: "action-icon--publish" %>
+  <% end %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>
+
+<%= icon_link_to "eye-line", resource_locator(meeting).path, t("actions.preview", scope: "decidim.meetings"), class: "action-icon--preview", target: :blank, data: { "external-link": false } %>
+
+<%= resource_permissions_link(meeting) %>
+
+<% if allowed_to? :destroy, :meeting, meeting: meeting %>
+  <% if present(meeting).authored_proposals.empty? %>
+    <%= icon_link_to "delete-bin-line", meeting_path(meeting), t("actions.destroy", scope: "decidim.meetings"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.meetings") } %>
+  <% else %>
+    <%=
+      content_tag(:button,
+                  :class => ["action-icon", "action-icon--remove", "destroy-meeting-alert"],
+                  "data-invalid-destroy-message" => t("actions.invalid_destroy.proposals_count", count: present(meeting).authored_proposals.size, scope: "decidim.meetings"),
+                  "data-proposal-titles" => present(meeting).formatted_proposals_titles) do
+        content_tag(:span,
+                    data: { tooltip: true, disable_hover: false, click_open: false },
+                    title: t("actions.destroy", scope: "decidim.meetings")) do
+          icon("delete-bin-line")
+        end
+      end
+    %>
+  <% end %>
+<% else %>
+  <span class="action-space icon"></span>
+<% end %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -76,9 +76,9 @@
             <%= td_resource_scope_for(meeting.scope) %>
             <td class="table-list__actions">
               <% if is_linked %>
-                <%= t('.linked_meeting_warning_html', href: edit_meeting_path(meeting), name: present(meeting).space_title) %>
+                <%= t(".linked_meeting_warning_html", href: edit_meeting_path(meeting), name: present(meeting).space_title) %>
               <% else %>
-                <%= render "/decidim/meetings/admin/meetings/meeting_actions", meeting: meeting %>
+                <%= render "/decidim/meetings/admin/meetings/meeting_actions", meeting: %>
               <% end %>
             </td>
           </tr>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -42,6 +42,8 @@
       </thead>
       <tbody>
         <% meetings.each do |meeting| %>
+          <% is_linked = meeting.decidim_component_id != current_component.id %>
+
           <tr data-id="<%= meeting.id %>">
             <td>
               <%= meeting.id %><br>
@@ -73,84 +75,10 @@
             <% end %>
             <%= td_resource_scope_for(meeting.scope) %>
             <td class="table-list__actions">
-              <% if allowed_to? :update, :meeting, meeting: meeting %>
-                <%= icon_link_to "pencil-line", edit_meeting_path(meeting), t("actions.edit", scope: "decidim.meetings"), class: "action-icon--edit" %>
+              <% if is_linked %>
+                <%= t('.linked_meeting_warning_html', href: edit_meeting_path(meeting), name: present(meeting).space_title) %>
               <% else %>
-                <span class="action-space icon"></span>
-              <% end %>
-
-              <% if allowed_to? :copy, :meeting, meeting: meeting %>
-                <%= icon_link_to "file-copy-line", new_meeting_copy_path(meeting), t("actions.duplicate", scope: "decidim.admin"), class: "action-icon--copy" %>
-              <% else %>
-                <span class="action-space icon"></span>
-              <% end %>
-
-              <% if allowed_to? :update, :meeting, meeting: meeting %>
-                <%= icon_link_to "folder-line", meeting_attachment_collections_path(meeting), t("actions.attachment_collections", scope: "decidim.meetings"), class: "action-icon--attachment_collections" %>
-              <% else %>
-                <span class="action-space icon"></span>
-              <% end %>
-
-              <% if allowed_to? :update, :meeting, meeting: meeting %>
-                <%= icon_link_to "attachment-line", meeting_attachments_path(meeting), t("actions.attachments", scope: "decidim.meetings"), class: "action-icon--attachments" %>
-              <% else %>
-                <span class="action-space icon"></span>
-              <% end %>
-
-              <% if allowed_to? :update, :meeting, meeting: meeting %>
-                <% if meeting.registration_disabled? %>
-                  <%= icon "group-line", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.registrations", scope: "decidim.meetings") %>
-                <% else %>
-                  <%= icon_link_to "group-line", meeting.on_this_platform? ? edit_meeting_registrations_path(meeting) : meeting.registration_url, t("actions.registrations", scope: "decidim.meetings"), class: "action-icon--registrations" %>
-                <% end %>
-              <% end %>
-
-              <% if allowed_to? :update, :meeting, meeting: meeting %>
-                <%= icon_link_to "calendar-line", meeting.agenda.present? ? edit_meeting_agenda_path(meeting, meeting.agenda) : new_meeting_agenda_path(meeting), t("actions.agenda", scope: "decidim.meetings"), class: "action-icon--agenda" %>
-                <%= icon_link_to "list-check", edit_meeting_poll_path(meeting), t("actions.manage_poll", scope: "decidim.meetings"), class: "action-icon--manage-poll-questionnaire" %>
-              <% else %>
-                <span class="action-space icon"></span>
-              <% end %>
-
-              <% if allowed_to? :close, :meeting, meeting: meeting %>
-                <%= icon_link_to "lock-line" , edit_meeting_meeting_close_path(meeting_id: meeting.id, id: meeting.id), t("actions.close", scope: "decidim.meetings"), class: "action-icon--close" %>
-              <% else %>
-                <span class="action-space icon"></span>
-              <% end %>
-
-              <% if allowed_to? :update, :meeting, meeting: meeting %>
-                <% if meeting.published? %>
-                  <%= icon_link_to "close-circle-line", unpublish_meeting_path(meeting), t("actions.unpublish", scope: "decidim.admin"), method: :put, class: "action-icon--unpublish", data: { confirm: t("actions.unpublish", scope: "decidim.admin") } %>
-                <% else %>
-                  <%= icon_link_to "check-line", publish_meeting_path(meeting), t("actions.publish", scope: "decidim.admin"), method: :put, class: "action-icon--publish" %>
-                <% end %>
-              <% else %>
-                <span class="action-space icon"></span>
-              <% end %>
-
-              <%= icon_link_to "eye-line", resource_locator(meeting).path, t("actions.preview", scope: "decidim.meetings"), class: "action-icon--preview", target: :blank, data: { "external-link": false } %>
-
-              <%= resource_permissions_link(meeting) %>
-
-              <% if allowed_to? :destroy, :meeting, meeting: meeting %>
-                <% if present(meeting).authored_proposals.empty? %>
-                  <%= icon_link_to "delete-bin-line", meeting_path(meeting), t("actions.destroy", scope: "decidim.meetings"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.meetings") } %>
-                <% else %>
-                  <%=
-                    content_tag(:button,
-                                :class => ["action-icon", "action-icon--remove", "destroy-meeting-alert"],
-                                "data-invalid-destroy-message" => t("actions.invalid_destroy.proposals_count", count: present(meeting).authored_proposals.size, scope: "decidim.meetings"),
-                                "data-proposal-titles" => present(meeting).formatted_proposals_titles) do
-                      content_tag(:span,
-                                  data: { tooltip: true, disable_hover: false, click_open: false },
-                                  title: t("actions.destroy", scope: "decidim.meetings")) do
-                        icon("delete-bin-line")
-                      end
-                    end
-                  %>
-                <% end %>
-              <% else %>
-                <span class="action-space icon"></span>
+                <%= render "/decidim/meetings/admin/meetings/meeting_actions", meeting: meeting %>
               <% end %>
             </td>
           </tr>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -336,7 +336,7 @@ en:
             select_a_registration_type: Please select a registration type
             select_an_iframe_access_level: Please select an iframe access level
           index:
-            linked_meeting_warning_html: This meeting must be edited from <a href="%{href}">%{name}</a>
+            linked_meeting_warning_html: This meeting must be edited from <br><a href="%{href}">%{name}</a>
             title: Meetings
           linked_spaces:
             assign: Assign

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -321,9 +321,9 @@ en:
                 other: The meeting cannot be destroyed because it has %{count} proposals associated to it.
             success: Meeting successfully deleted
           edit:
+            redirect_notice: You have been redirected to a different space
             title: Edit meeting
             update: Update
-            redirect_notice: You have been redirected to a different space
           form:
             address_help: 'Address: used by Geocoder to find the location'
             disclaimer: 'Disclaimer: By using an external registration system, you are aware that the organizers of %{organization} are not responsible for the data provided by the users to the external service.'
@@ -336,17 +336,17 @@ en:
             select_a_registration_type: Please select a registration type
             select_an_iframe_access_level: Please select an iframe access level
           index:
-            title: Meetings
             linked_meeting_warning_html: This meeting must be edited from <a href="%{href}">%{name}</a>
+            title: Meetings
           linked_spaces:
             assign: Assign
             link_a_space: Link a space
-            private_space_warning: Linked spaces will not be applied when the meeting belongs to a private non transparent space.
             private_meeting_warning: Linked spaces will not be applied if the meeting is private and non transparent.
+            private_space_warning: Linked spaces will not be applied when the meeting belongs to a private non transparent space.
             select: Select a space
             table:
-              component: Linked spaces
               actions: Actions
+              component: Linked spaces
             title: Linked spaces
           new:
             create: Create

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -323,7 +323,7 @@ en:
                 other: The meeting cannot be destroyed because it has %{count} proposals associated to it.
             success: Meeting successfully deleted
           edit:
-            redirect_notice: You have been redirected to a different space
+            redirect_notice: This meeting is part of another space, so you have been moved to %{destiny_space_name}. <br>If you prefer, you can go back to <a href="%{original_space_url}">%{original_space_name}</a>.
             title: Edit meeting
             update: Update
           form:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -323,6 +323,7 @@ en:
           edit:
             title: Edit meeting
             update: Update
+            redirect_notice: You've been redirected to a different space
           form:
             address_help: 'Address: used by Geocoder to find the location'
             disclaimer: 'Disclaimer: By using an external registration system, you are aware that the organizers of %{organization} are not responsible for the data provided by the users to the external service.'
@@ -336,6 +337,17 @@ en:
             select_an_iframe_access_level: Please select an iframe access level
           index:
             title: Meetings
+            linked_meeting_warning_html: This meeting must be edited from <a href="%{href}">%{name}</a>
+          linked_spaces:
+            assign: Assign
+            link_a_space: Link a space
+            private_space_warning: Linked spaces won't be applied when the meeting belongs to a private non transparent space.
+            private_meeting_warning: Linked spaces won't be applied if the meeting is private and non transparent.
+            select: Select a space
+            table:
+              component: Linked spaces
+              actions: Actions
+            title: Linked spaces
           new:
             create: Create
             title: Create meeting

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -323,7 +323,6 @@ en:
                 other: The meeting cannot be destroyed because it has %{count} proposals associated to it.
             success: Meeting successfully deleted
           edit:
-            redirect_notice: This meeting is part of another space, so you have been moved to %{destiny_space_name}. <br>If you prefer, you can go back to <a href="%{original_space_url}">%{original_space_name}</a>.
             title: Edit meeting
             update: Update
           form:
@@ -576,6 +575,7 @@ en:
           micro_camera_permissions_warning: When you click on the button below, you will be asked for microphone and/or camera permissions, and you will join the videoconference
           no_slots_available: No slots available
           organizations: Attending organizations
+          redirect_notice: This meeting is part of another space, so you have been moved to %{current_space_name}. <br>If you prefer, you can go back to <a href="%{previous_space_url}">%{previous_space_name}</a>.
           registration_code_help_text: Your registration code
           registration_state:
             validated: VALIDATED

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -308,11 +308,11 @@ en:
             close: Close
             title: Close meeting
         meetings:
-          component:
-            unlink: Unlink
           close:
             invalid: There was a problem closing this meeting.
             success: Meeting successfully closed.
+          component:
+            unlink: Unlink
           create:
             invalid: There was a problem creating this meeting.
             success: Meeting successfully created. Notice this is unpublished yet, you need to manually publish it.

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -323,7 +323,7 @@ en:
           edit:
             title: Edit meeting
             update: Update
-            redirect_notice: You've been redirected to a different space
+            redirect_notice: You have been redirected to a different space
           form:
             address_help: 'Address: used by Geocoder to find the location'
             disclaimer: 'Disclaimer: By using an external registration system, you are aware that the organizers of %{organization} are not responsible for the data provided by the users to the external service.'
@@ -341,8 +341,8 @@ en:
           linked_spaces:
             assign: Assign
             link_a_space: Link a space
-            private_space_warning: Linked spaces won't be applied when the meeting belongs to a private non transparent space.
-            private_meeting_warning: Linked spaces won't be applied if the meeting is private and non transparent.
+            private_space_warning: Linked spaces will not be applied when the meeting belongs to a private non transparent space.
+            private_meeting_warning: Linked spaces will not be applied if the meeting is private and non transparent.
             select: Select a space
             table:
               component: Linked spaces

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -308,6 +308,8 @@ en:
             close: Close
             title: Close meeting
         meetings:
+          component:
+            unlink: Unlink
           close:
             invalid: There was a problem closing this meeting.
             success: Meeting successfully closed.

--- a/decidim-meetings/db/migrate/20240712104245_create_decidim_meetings_meeting_link.rb
+++ b/decidim-meetings/db/migrate/20240712104245_create_decidim_meetings_meeting_link.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateDecidimMeetingsMeetingLink < ActiveRecord::Migration[7.0]
+  def change
+    create_table :decidim_meetings_meeting_links do |t|
+      t.references :decidim_component, null: false, index: true
+      t.references :decidim_meeting, null: false, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -177,6 +177,11 @@ FactoryBot.define do
     end
   end
 
+  factory :meeting_link, class: "Decidim::Meetings::MeetingLink" do
+    meeting
+    component
+  end
+
   factory :registration, class: "Decidim::Meetings::Registration" do
     transient do
       skip_injection { false }

--- a/decidim-meetings/spec/commands/admin/create_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/create_meeting_spec.rb
@@ -27,6 +27,7 @@ module Decidim::Meetings
     let(:registrations_enabled) { true }
     let(:iframe_embed_type) { "embed_in_meeting_page" }
     let(:iframe_access_level) { "all" }
+    let(:components) { [] }
     let(:services) do
       [
         {
@@ -73,7 +74,8 @@ module Decidim::Meetings
         comments_enabled: true,
         comments_start_time: nil,
         comments_end_time: nil,
-        iframe_access_level:
+        iframe_access_level:,
+        components:
       )
     end
 

--- a/decidim-meetings/spec/commands/admin/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/update_meeting_spec.rb
@@ -31,6 +31,7 @@ module Decidim::Meetings
     let(:registrations_enabled) { true }
     let(:iframe_embed_type) { "none" }
     let(:iframe_access_level) { nil }
+    let(:components) { [] }
 
     let(:form) do
       double(
@@ -60,7 +61,8 @@ module Decidim::Meetings
         comments_enabled: true,
         comments_start_time: nil,
         comments_end_time: nil,
-        iframe_access_level:
+        iframe_access_level:,
+        components:
       )
     end
 
@@ -163,7 +165,8 @@ module Decidim::Meetings
             comments_enabled: true,
             comments_start_time: nil,
             comments_end_time: nil,
-            iframe_access_level:
+            iframe_access_level:,
+            components:
           )
         end
 

--- a/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
@@ -56,6 +56,7 @@ module Decidim::Meetings
     let(:registrations_enabled) { true }
     let(:available_slots) { 0 }
     let(:iframe_embed_type) { "none" }
+    let(:components) { [] }
     let(:attributes) do
       {
         decidim_scope_id: scope_id,
@@ -77,7 +78,8 @@ module Decidim::Meetings
         registrations_enabled:,
         type_of_meeting:,
         online_meeting_url:,
-        iframe_embed_type:
+        iframe_embed_type:,
+        components:
       }
     end
 

--- a/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/admin/meeting_form_spec.rb
@@ -56,7 +56,7 @@ module Decidim::Meetings
     let(:registrations_enabled) { true }
     let(:available_slots) { 0 }
     let(:iframe_embed_type) { "none" }
-    let(:components) { [] }
+    let(:component_ids) { [] }
     let(:attributes) do
       {
         decidim_scope_id: scope_id,
@@ -79,7 +79,7 @@ module Decidim::Meetings
         type_of_meeting:,
         online_meeting_url:,
         iframe_embed_type:,
-        components:
+        component_ids:
       }
     end
 
@@ -233,6 +233,24 @@ module Decidim::Meetings
       let(:iframe_embed_type) { "embed_in_meeting_page" }
 
       it { is_expected.not_to be_valid }
+    end
+
+    describe "when component_ids is present" do
+      let(:component_ids) { [current_component.id] }
+
+      it "returns the components" do
+        expect(form.components).to eq([current_component])
+      end
+    end
+
+    describe "when component_ids is present but meeting is private and non transparent" do
+      let(:component_ids) { [current_component.id] }
+      let(:private_meeting) { true }
+      let(:transparent) { false }
+
+      it "returns an empty array" do
+        expect(form.components).to eq([])
+      end
     end
   end
 end

--- a/decidim-meetings/spec/models/meeting_link_spec.rb
+++ b/decidim-meetings/spec/models/meeting_link_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Meetings
+  describe MeetingLink do
+    let(:component) { create(:component) }
+
+    describe "find_meetings" do
+      context "meeting without links" do
+        let!(:meeting) { create(:meeting) }
+
+        it "returns an empty array" do
+          expect(MeetingLink.find_meetings(component: component)).to eq([])
+        end
+      end
+
+      context "meeting with a link" do
+        let!(:meeting) { create(:meeting) }
+        let!(:meeting_link) { create(:meeting_link, meeting: meeting, component: component) }
+
+        it "returns the meeting" do
+          expect(MeetingLink.find_meetings(component: component)).to eq([meeting])
+        end
+      end
+
+      context "meeting in a private non transparent space with a link" do
+        let!(:private_process) { create(:participatory_process, organization: component.organization, private_space: true) }
+        let!(:private_component) { create(:component, manifest_name: "meetings", participatory_space: private_process) }
+        let!(:meeting) { create(:meeting, component: private_component) }
+        let!(:meeting_link) { create(:meeting_link, meeting: meeting, component: component) }
+
+        it "returns an empty array" do
+          expect(MeetingLink.find_meetings(component: component)).to eq([])
+        end
+      end
+
+      context "meeting in a private transparent space with a link" do
+        let!(:assembly) { create(:assembly, organization: component.organization, private_space: true, is_transparent: true) }
+        let!(:private_component) { create(:component, manifest_name: "meetings", participatory_space: assembly) }
+        let!(:meeting) { create(:meeting, component: private_component) }
+        let!(:meeting_link) { create(:meeting_link, meeting: meeting, component: component) }
+
+        it "returns the meeting" do
+          expect(MeetingLink.find_meetings(component: component)).to eq([meeting])
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/models/meeting_link_spec.rb
+++ b/decidim-meetings/spec/models/meeting_link_spec.rb
@@ -7,42 +7,42 @@ module Decidim::Meetings
     let(:component) { create(:component) }
 
     describe "find_meetings" do
-      context "meeting without links" do
+      context "when meeting without links" do
         let!(:meeting) { create(:meeting) }
 
         it "returns an empty array" do
-          expect(MeetingLink.find_meetings(component: component)).to eq([])
+          expect(MeetingLink.find_meetings(component:)).to eq([])
         end
       end
 
-      context "meeting with a link" do
+      context "when meeting with a link" do
         let!(:meeting) { create(:meeting) }
-        let!(:meeting_link) { create(:meeting_link, meeting: meeting, component: component) }
+        let!(:meeting_link) { create(:meeting_link, meeting:, component:) }
 
         it "returns the meeting" do
-          expect(MeetingLink.find_meetings(component: component)).to eq([meeting])
+          expect(MeetingLink.find_meetings(component:)).to eq([meeting])
         end
       end
 
-      context "meeting in a private non transparent space with a link" do
+      context "when meeting in a private non transparent space with a link" do
         let!(:private_process) { create(:participatory_process, organization: component.organization, private_space: true) }
         let!(:private_component) { create(:component, manifest_name: "meetings", participatory_space: private_process) }
         let!(:meeting) { create(:meeting, component: private_component) }
-        let!(:meeting_link) { create(:meeting_link, meeting: meeting, component: component) }
+        let!(:meeting_link) { create(:meeting_link, meeting:, component:) }
 
         it "returns an empty array" do
-          expect(MeetingLink.find_meetings(component: component)).to eq([])
+          expect(MeetingLink.find_meetings(component:)).to eq([])
         end
       end
 
-      context "meeting in a private transparent space with a link" do
+      context "when meeting in a private transparent space with a link" do
         let!(:assembly) { create(:assembly, organization: component.organization, private_space: true, is_transparent: true) }
         let!(:private_component) { create(:component, manifest_name: "meetings", participatory_space: assembly) }
         let!(:meeting) { create(:meeting, component: private_component) }
-        let!(:meeting_link) { create(:meeting_link, meeting: meeting, component: component) }
+        let!(:meeting_link) { create(:meeting_link, meeting:, component:) }
 
         it "returns the meeting" do
-          expect(MeetingLink.find_meetings(component: component)).to eq([meeting])
+          expect(MeetingLink.find_meetings(component:)).to eq([meeting])
         end
       end
     end

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_links_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_links_spec.rb
@@ -41,9 +41,9 @@ describe "Admin manages meetings" do
         expect(page).to have_content(other_meeting.component.manifest.name)
       end
 
-      expect {
+      expect do
         click_on "Update"
-      }.to change { meeting.meeting_links.count }.by(1)
+      end.to change { meeting.meeting_links.count }.by(1)
     end
   end
 end

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_links_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_links_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/dev/test/rspec_support/tom_select"
+
+describe "Admin manages meetings" do
+  let(:manifest_name) { "meetings" }
+  let!(:meeting) { create(:meeting, :published, scope:, component: current_component) }
+
+  let!(:other_participatory_space) { create(:participatory_process, organization: current_component.organization) }
+  let!(:other_component) { create(:meeting_component, participatory_space: other_participatory_space) }
+  let!(:other_meeting) { create(:meeting, :published, component: other_component) }
+
+  include_context "when managing a component as an admin"
+
+  describe "listing meeting links" do
+    before do
+      create(:meeting_link, meeting: other_meeting, component: current_component)
+      visit current_path
+    end
+
+    it "shows the meeting links" do
+      expect(page).to have_css("tbody tr:first-child", text: Decidim::Meetings::MeetingPresenter.new(other_meeting).title)
+      expect(page).to have_css("tbody tr:last-child", text: Decidim::Meetings::MeetingPresenter.new(meeting).title)
+    end
+  end
+
+  describe "linking a meeting" do
+    it "creates a new link" do
+      within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
+        click_on "Edit"
+      end
+
+      within "#accordion-linked-spaces" do
+        click_on "Linked spaces"
+        tom_select("#add_component_select", option_id: other_meeting.component.id)
+        click_on "Assign"
+      end
+
+      within ".js-components" do
+        expect(page).to have_content(other_meeting.component.manifest.name)
+      end
+
+      expect {
+        click_on "Update"
+      }.to change { meeting.meeting_links.count }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
- Allows linking a Meeting with a Meetings component from another Participatory Space. 
- The link can be created from the Admin Meeting edit form.
- Uses a new `MeetingLink` model (`belongs_to: :meeting and belongs_to: :component`).
- The Meeting Links are shown in the admin and front meeting lists.
- Takes into account that non transparent private meetings and meetings that belong to private non transparent spaces can't be linked (or won't be shown in case an old link is present).

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/13056

#### Testing
- See linked meetings in an [Admin meetings component](https://decidim-lot2.populate.tools/admin/participatory_processes/branch-highway/components/5/manage/). Click on the link to be redirected to the original space with a callout. 
- [Link an existing meeting](https://decidim-lot2.populate.tools/admin/participatory_processes/branch-highway/components/5/manage/meetings/13/edit) to another space' component
- See [linked meetings in the front](https://decidim-lot2.populate.tools/processes/branch-highway/f/5/meetings)
- Play with the meeting privacy and transparency.
- Play with the space privacy and transparency (in assemblies).

### :camera: Screenshots
<img width="784" alt="Screenshot 2024-07-17 at 12 39 18" src="https://github.com/user-attachments/assets/0a747656-716e-403f-b59e-7a84a12f2786">
<img width="937" alt="Screenshot 2024-07-17 at 12 42 19" src="https://github.com/user-attachments/assets/0406c0ab-47f8-42e2-b02d-421ef6e0a5c8">

<img width="1502" alt="Screenshot 2024-07-17 at 12 40 07" src="https://github.com/user-attachments/assets/3334f992-7697-4653-ae90-a8d40f1fc740">


:hearts: Thank you!
