### PR TITLE
Add missing require for ParallelTests

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "parallel_tests"
 require "selenium-webdriver"
 
 module Decidim


### PR DESCRIPTION
#### :tophat: What? Why?

While working in the update for Metadecidim, I found a missing require in decidim-dev. This PR adds it. 

We should backport this to v0.29 branch too. 

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/metadecidim/actions/runs/9970738269/job/27550280987?pr=129 

#### Testing

The pipeline should be green. I could workaround it by adding the [require in the Metadecidim app](https://github.com/decidim/metadecidim/pull/129/commits/e6da9ac52de7d3eb77e3ac2c52e88d6c7b139d3c) but we should just fix it in decidim-dev

### Stacktrace

```
DEPRECATION WARNING: Using legacy connection handling is deprecated. Please set
`legacy_connection_handling` to `false` in your application.

The new connection handling does not support `connection_handlers`
getter and setter.

Read more about how to migrate at: https://guides.rubyonrails.org/active_record_multiple_databases.html#migrate-to-the-new-connection-handling
 (called from <top (required)> at /home/runner/work/metadecidim/metadecidim/config/environment.rb:5)
DEPRECATION WARNING: Non-URL-safe CSRF tokens are deprecated. Use 6.1 defaults or above. (called from <top (required)> at /home/runner/work/metadecidim/metadecidim/spec/rails_helper.rb:7)

An error occurred while loading ./spec/features/authentication_spec.rb.
Failure/Error: require "decidim/dev/test/base_spec_helper"

NameError:
  uninitialized constant ParallelTests
# ./spec/rails_helper.rb:13:in `<top (required)>'
# ./spec/features/authentication_spec.rb:3:in `<top (required)>'

An error occurred while loading ./spec/features/homepage_spec.rb.
Failure/Error: require "decidim/dev/test/base_spec_helper"

NameError:
  uninitialized constant ParallelTests
# ./spec/rails_helper.rb:13:in `<top (required)>'
# ./spec/features/homepage_spec.rb:3:in `<top (required)>'

An error occurred while loading ./spec/features/menu_spec.rb.
Failure/Error: require "decidim/dev/test/base_spec_helper"

NameError:
  uninitialized constant ParallelTests
# ./spec/rails_helper.rb:13:in `<top (required)>'
# ./spec/features/menu_spec.rb:3:in `<top (required)>'

An error occurred while loading ./spec/features/proposals_answers_spec.rb.
Failure/Error: require "decidim/dev/test/base_spec_helper"

NameError:
  uninitialized constant ParallelTests
# ./spec/rails_helper.rb:13:in `<top (required)>'
# ./spec/features/proposals_answers_spec.rb:3:in `<top (required)>'
No examples found.


Finished in 0.00006 seconds (files took 7.63 seconds to load)
0 examples, 0 failures, 4 errors occurred outside of examples
```

:hearts: Thank you!
