### PR TITLE
Fix rubocop offense Lint/SymbolConversion

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/content_blocks/update_content_block.rb
+++ b/decidim-admin/app/commands/decidim/admin/content_blocks/update_content_block.rb
@@ -70,7 +70,7 @@ module Decidim
 
             if form.images[image_name]
               content_block.images_container.send("#{image_name}=", form.images[image_name])
-            elsif form.images["remove_#{image_name}".to_sym] == "1"
+            elsif form.images[:"remove_#{image_name}"] == "1"
               content_block.images_container.send("#{image_name}=", nil)
             end
           end

--- a/decidim-admin/lib/decidim/admin/import/creator.rb
+++ b/decidim-admin/lib/decidim/admin/import/creator.rb
@@ -31,7 +31,7 @@ module Decidim
             @localize_headers ||= begin
               localize_headers = []
               locales.each do |locale|
-                localize_headers << "#{header}/#{locale}".to_sym
+                localize_headers << :"#{header}/#{locale}"
               end
               localize_headers
             end

--- a/decidim-admin/lib/decidim/admin/import/readers/json.rb
+++ b/decidim-admin/lib/decidim/admin/import/readers/json.rb
@@ -58,7 +58,7 @@ module Decidim
               data.each do |key, value|
                 if value.is_a?(Hash)
                   flat_hash(value).each do |subkey, subvalue|
-                    final["#{key}/#{subkey}".to_sym] = subvalue
+                    final[:"#{key}/#{subkey}"] = subvalue
                   end
                 else
                   final[key.to_sym] = value

--- a/decidim-core/app/cells/decidim/tags_cell.rb
+++ b/decidim-core/app/cells/decidim/tags_cell.rb
@@ -109,7 +109,7 @@ module Decidim
     end
 
     def filter_param(name)
-      candidates = ["with_any_#{name}".to_sym, "with_#{name}".to_sym]
+      candidates = [:"with_any_#{name}", :"with_#{name}"]
       return candidates.first unless controller.respond_to?(:default_filter_params, true)
 
       available_params = controller.send(:default_filter_params)

--- a/decidim-core/app/models/decidim/component.rb
+++ b/decidim-core/app/models/decidim/component.rb
@@ -58,7 +58,7 @@ module Decidim
       {
         :host => organization.host,
         :component_id => id,
-        "#{participatory_space.underscored_name}_slug".to_sym => participatory_space.slug
+        :"#{participatory_space.underscored_name}_slug" => participatory_space.slug
       }
     end
 

--- a/decidim-core/app/services/decidim/base_diff_renderer.rb
+++ b/decidim-core/app/services/decidim/base_diff_renderer.rb
@@ -46,7 +46,7 @@ module Decidim
         last_value = values.last.try(:[], locale)
         next if first_value == last_value
 
-        attribute_locale = "#{attribute}_#{locale}".to_sym
+        attribute_locale = :"#{attribute}_#{locale}"
         diff.update(
           attribute_locale => {
             type:,

--- a/decidim-core/lib/decidim/attachment_attributes.rb
+++ b/decidim-core/lib/decidim/attachment_attributes.rb
@@ -28,7 +28,7 @@ module Decidim
       # Returns nothing.
       def attachments_attribute(name)
         attribute name, Array[Integer]
-        attribute "add_#{name}".to_sym, Array
+        attribute :"add_#{name}", Array
 
         # Define the getter method that fetches the attachment records based on
         # their types. For Strings and Integers, assumes they are IDs and will

--- a/decidim-core/lib/decidim/core/test/shared_examples/versions_controller_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/versions_controller_examples.rb
@@ -5,9 +5,9 @@ require "spec_helper"
 shared_examples "versions controller" do
   let(:base_params) do
     if resource.is_a?(Decidim::Participable)
-      { "#{resource.model_name.singular_route_key}_slug".to_sym => resource.slug }
+      { :"#{resource.model_name.singular_route_key}_slug" => resource.slug }
     else
-      { "#{resource.model_name.singular_route_key}_id".to_sym => resource.id }
+      { :"#{resource.model_name.singular_route_key}_id" => resource.id }
     end
   end
 

--- a/decidim-core/lib/decidim/participable.rb
+++ b/decidim-core/lib/decidim/participable.rb
@@ -14,25 +14,25 @@ module Decidim
 
       def skip_space_slug?(method_name)
         [
-          "edit_#{underscored_name}_path".to_sym,
-          "edit_#{underscored_name}_url".to_sym,
-          "new_#{underscored_name}_path".to_sym,
-          "new_#{underscored_name}_url".to_sym,
-          "#{underscored_name}_path".to_sym,
-          "#{underscored_name}_url".to_sym,
-          "#{underscored_name.pluralize}_path".to_sym,
-          "#{underscored_name.pluralize}_url".to_sym
+          :"edit_#{underscored_name}_path",
+          :"edit_#{underscored_name}_url",
+          :"new_#{underscored_name}_path",
+          :"new_#{underscored_name}_url",
+          :"#{underscored_name}_path",
+          :"#{underscored_name}_url",
+          :"#{underscored_name.pluralize}_path",
+          :"#{underscored_name.pluralize}_url"
         ].include?(method_name)
       end
 
       def slug_param_name
-        "#{underscored_name}_slug".to_sym
+        :"#{underscored_name}_slug"
       end
 
       def mounted_params
         {
           :host => organization.host,
-          "#{underscored_name}_slug".to_sym => slug
+          :"#{underscored_name}_slug" => slug
         }
       end
 

--- a/decidim-dev/config/rubocop/disabled.yml
+++ b/decidim-dev/config/rubocop/disabled.yml
@@ -43,8 +43,6 @@ FactoryBot/AssociationStyle:
 Rubycw/Rubycw:
   Enabled: false
 
-Lint/SymbolConversion:
-  Enabled: false
 
 Style/RedundantParentheses:
   Enabled: false

--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -63,7 +63,7 @@ module Decidim
 
             path = promotal_committee_required? ? "promotal_committee" : "finish"
 
-            redirect_to send("#{path}_create_initiative_index_path".to_sym)
+            redirect_to send(:"#{path}_create_initiative_index_path")
           end
 
           on(:invalid) do
@@ -110,7 +110,7 @@ module Decidim
         return if action_name == destination_step
         return if initiative_type_id.present? && initiative_type.present?
 
-        redirect_to send("#{destination_step}_create_initiative_index_path".to_sym)
+        redirect_to send(:"#{destination_step}_create_initiative_index_path")
       end
 
       def scopes

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
@@ -47,7 +47,7 @@ describe "Admin manages initiatives" do
   include_context "with filterable context"
 
   STATES.each do |state|
-    let!("#{state}_initiative".to_sym) { create_initiative_with_trait(state) }
+    let!(:"#{state}_initiative") { create_initiative_with_trait(state) }
   end
 
   before do

--- a/decidim-system/app/forms/decidim/system/base_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/base_organization_form.rb
@@ -48,9 +48,9 @@ module Decidim
       OMNIATH_PROVIDERS_ATTRIBUTES = Decidim::OmniauthProvider.available.keys.map do |provider|
         Rails.application.secrets.dig(:omniauth, provider).keys.map do |setting|
           if setting == :enabled
-            ["omniauth_settings_#{provider}_enabled".to_sym, Boolean]
+            [:"omniauth_settings_#{provider}_enabled", Boolean]
           else
-            ["omniauth_settings_#{provider}_#{setting}".to_sym, String]
+            [:"omniauth_settings_#{provider}_#{setting}", String]
           end
         end
       end.flatten(1)

--- a/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -14,7 +14,7 @@ module Decidim
       private
 
       def validate_organization_name_presence
-        translated_attr = "name_#{current_organization.try(:default_locale) || Decidim.default_locale.to_s}".to_sym
+        translated_attr = :"name_#{current_organization.try(:default_locale) || Decidim.default_locale.to_s}"
         errors.add(translated_attr, :blank) if send(translated_attr).blank?
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #13146 we have upgraded rubocop & friends which added new rules that were disabled at that point. This PR makes sure the `Lint/SymbolConversion` rule is enforced by linter. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13146 

#### Testing
1. Make sure the pipeline is green

:hearts: Thank you!
