### PR TITLE
Fix rubocop offense Style/SendWithLiteralMethodName

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/locale_switcher.rb
+++ b/decidim-core/app/controllers/concerns/decidim/locale_switcher.rb
@@ -46,14 +46,14 @@ module Decidim
       #
       # Returns an Array of Strings.
       def available_locales
-        @available_locales ||= (current_organization || Decidim).public_send(:available_locales)
+        @available_locales ||= (current_organization || Decidim).available_locales
       end
 
       # The default locale of this organization.
       #
       # Returns a String with the default locale.
       def default_locale
-        @default_locale ||= (current_organization || Decidim).public_send(:default_locale)
+        @default_locale ||= (current_organization || Decidim).default_locale
       end
 
       # Detects the locale priority: query string, user saved, session, browser

--- a/decidim-core/app/models/decidim/push_notification_message.rb
+++ b/decidim-core/app/models/decidim/push_notification_message.rb
@@ -26,7 +26,7 @@ module Decidim
     end
 
     def url
-      EngineRouter.new("decidim", {}).public_send(:conversation_path, host: organization.host, id: @conversation)
+      EngineRouter.new("decidim", {}).conversation_path(host: organization.host, id: @conversation)
     end
 
     private

--- a/decidim-core/app/validators/passthru_validator.rb
+++ b/decidim-core/app/validators/passthru_validator.rb
@@ -33,7 +33,7 @@ class PassthruValidator < ActiveModel::EachValidator
       value = dummy.public_send(dummy_attr)
     elsif dummy.respond_to? :file
       dummy.public_send("file=", value)
-      value = dummy.public_send(:file)
+      value = dummy.file
     end
 
     target_validators(attribute).each do |validator|

--- a/decidim-dev/config/rubocop/disabled.yml
+++ b/decidim-dev/config/rubocop/disabled.yml
@@ -64,8 +64,5 @@ Style/SuperArguments:
 Lint/SelfAssignment:
   Enabled: false
 
-Style/SendWithLiteralMethodName:
-  Enabled: false
-
 Rails/WhereRange:
   Enabled: false


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #13146 we have upgraded rubocop & friends which added new rules that were disabled at that point. This PR makes sure the `Style/SendWithLiteralMethodName` rule is enforced by linter. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13146 

#### Testing
1. Make sure the pipeline is green

:hearts: Thank you!
