### PR TITLE
Fix rubocop offense Style/RedundantParentheses

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/resource_permissions_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/resource_permissions_controller.rb
@@ -87,7 +87,7 @@ module Decidim
       end
 
       def permissions
-        @permissions ||= (resource&.permissions || {})
+        @permissions ||= resource&.permissions || {}
       end
 
       def authorizations_for(action)

--- a/decidim-core/app/cells/decidim/notification_actions/buttons_cell.rb
+++ b/decidim-core/app/cells/decidim/notification_actions/buttons_cell.rb
@@ -34,7 +34,7 @@ module Decidim
       end
 
       def class_for(item)
-        (item[:class].presence || "button__transparent-secondary")
+        item[:class].presence || "button__transparent-secondary"
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/scopes_controller.rb
+++ b/decidim-core/app/controllers/decidim/scopes_controller.rb
@@ -20,10 +20,10 @@ module Decidim
           required:,
           title:,
           root:,
-          current: (current || root),
+          current: current || root,
           scopes: scopes&.order(name: :asc),
           parent_scopes:,
-          picker_target_id: (params[:target_element_id] || "content"),
+          picker_target_id: params[:target_element_id] || "content",
           global_value: params[:global_value],
           max_depth:,
           context:

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -62,7 +62,7 @@ module Decidim
     #
     # Renders form fields for each locale.
     def translated(type, name, options = {})
-      return translated_one_locale(type, name, locales.first, options.merge(label: (options[:label] || label_for(name)))) if locales.count == 1
+      return translated_one_locale(type, name, locales.first, options.merge(label: options[:label] || label_for(name))) if locales.count == 1
 
       tabs_id = sanitize_tabs_selector(options[:tabs_id] || "#{object_name}-#{name}-tabs")
 

--- a/decidim-core/lib/decidim/map/dynamic_map.rb
+++ b/decidim-core/lib/decidim/map/dynamic_map.rb
@@ -71,7 +71,7 @@ module Decidim
           content = template.capture { yield }.html_safe if block_given?
 
           template.content_tag(:div, map_html_options) do
-            (content || "")
+            content || ""
           end
         end
 

--- a/decidim-dev/config/rubocop/disabled.yml
+++ b/decidim-dev/config/rubocop/disabled.yml
@@ -46,8 +46,8 @@ Rubycw/Rubycw:
 Lint/SymbolConversion:
   Enabled: false
 
-Style/RedundantParentheses:
-  Enabled: false
+
+
 
 Style/MapIntoArray:
   Enabled: false

--- a/decidim-forms/app/forms/decidim/forms/admin/display_condition_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/admin/display_condition_form.rb
@@ -44,7 +44,7 @@ module Decidim
               question.translated_body,
               question.id,
               {
-                "disabled" => (question.question_type == "sorting" || question.id == id),
+                "disabled" => question.question_type == "sorting" || question.id == id,
                 "data-type" => question.question_type
               }
             ]

--- a/decidim-initiatives/app/controllers/concerns/decidim/initiatives/needs_initiative.rb
+++ b/decidim-initiatives/app/controllers/concerns/decidim/initiatives/needs_initiative.rb
@@ -51,7 +51,7 @@ module Decidim
         def detect_initiative
           request.env["current_initiative"] ||
             Initiative.find_by(
-              id: (id_from_slug(params[:slug]) || id_from_slug(params[:initiative_slug]) || params[:initiative_id] || params[:id]),
+              id: id_from_slug(params[:slug]) || id_from_slug(params[:initiative_slug]) || params[:initiative_id] || params[:id],
               organization: current_organization
             )
         end

--- a/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/participatory_text_proposal_cell.rb
@@ -69,7 +69,7 @@ module Decidim
       end
 
       def amendment_creation_enabled?
-        (current_component.settings.amendments_enabled? && current_settings.amendment_creation_enabled?)
+        current_component.settings.amendments_enabled? && current_settings.amendment_creation_enabled?
       end
 
       def amend_button_disabled?


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #13146 we have upgraded rubocop & friends which added new rules that were disabled at that point. This PR makes sure the `Style/RedundantParentheses` rule is enforced by linter. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13146 

#### Testing
1. Make sure the pipeline is green

:hearts: Thank you!
