### PR TITLE
Fix rubocop offense `Rails/WhereRange`

### DIFF
--- a/decidim-accountability/app/queries/decidim/accountability/metrics/results_metric_manage.rb
+++ b/decidim-accountability/app/queries/decidim/accountability/metrics/results_metric_manage.rb
@@ -39,7 +39,7 @@ module Decidim
                                                   .where(component: visible_components_from_spaces(spaces))
                                                   .joins(:component)
                                                   .left_outer_joins(:category)
-          @query = @query.where("decidim_accountability_results.created_at <= ?", end_time)
+          @query = @query.where(decidim_accountability_results: { created_at: ..end_time })
           @query = @query.group("decidim_categorizations.decidim_category_id",
                                 :participatory_space_type,
                                 :participatory_space_id,
@@ -48,7 +48,7 @@ module Decidim
         end
 
         def quantity
-          @quantity ||= query.where("decidim_accountability_results.created_at >= ?", start_time).count
+          @quantity ||= query.where(decidim_accountability_results: { created_at: start_time.. }).count
         end
       end
     end

--- a/decidim-assemblies/app/queries/decidim/assemblies/metrics/assemblies_metric_manage.rb
+++ b/decidim-assemblies/app/queries/decidim/assemblies/metrics/assemblies_metric_manage.rb
@@ -14,12 +14,12 @@ module Decidim
           return @query if @query
 
           @query = Decidim::Assembly.where(organization: @organization)
-          @query = @query.where("decidim_assemblies.published_at <= ?", end_time)
+          @query = @query.where(decidim_assemblies: { published_at: ..end_time })
           @query
         end
 
         def quantity
-          @quantity ||= query.where("decidim_assemblies.published_at >= ?", start_time).count
+          @quantity ||= query.where(decidim_assemblies: { published_at: start_time.. }).count
         end
       end
     end

--- a/decidim-blogs/app/models/decidim/blogs/post.rb
+++ b/decidim-blogs/app/models/decidim/blogs/post.rb
@@ -26,7 +26,7 @@ module Decidim
       validates :title, presence: true
 
       scope :created_at_desc, -> { order(arel_table[:created_at].desc) }
-      scope :published, -> { where("published_at <= ?", Time.current) }
+      scope :published, -> { where(published_at: ..Time.current) }
 
       searchable_fields({
                           participatory_space: { component: :participatory_space },

--- a/decidim-budgets/app/queries/decidim/budgets/filtered_projects.rb
+++ b/decidim-budgets/app/queries/decidim/budgets/filtered_projects.rb
@@ -28,8 +28,8 @@ module Decidim
       # by a range of dates.
       def query
         projects = Decidim::Budgets::Project.where(budget: budgets)
-        projects = projects.where("created_at >= ?", @start_at) if @start_at.present?
-        projects = projects.where("created_at <= ?", @end_at) if @end_at.present?
+        projects = projects.where(created_at: @start_at..) if @start_at.present?
+        projects = projects.where(created_at: ..@end_at) if @end_at.present?
         projects
       end
 

--- a/decidim-budgets/app/queries/decidim/budgets/metrics/budget_followers_metric_measure.rb
+++ b/decidim-budgets/app/queries/decidim/budgets/metrics/budget_followers_metric_measure.rb
@@ -15,10 +15,10 @@ module Decidim
           projects = Decidim::Budgets::Project.where(budget: budgets)
 
           budgets_followers = Decidim::Follow.where(followable: projects).joins(:user)
-                                             .where("decidim_follows.created_at <= ?", end_time)
+                                             .where(decidim_follows: { created_at: ..end_time })
           cumulative_users = budgets_followers.pluck(:decidim_user_id)
 
-          budgets_followers = budgets_followers.where("decidim_follows.created_at >= ?", start_time)
+          budgets_followers = budgets_followers.where(decidim_follows: { created_at: start_time.. })
           quantity_users = budgets_followers.pluck(:decidim_user_id)
 
           {

--- a/decidim-budgets/app/queries/decidim/budgets/metrics/budget_participants_metric_measure.rb
+++ b/decidim-budgets/app/queries/decidim/budgets/metrics/budget_participants_metric_measure.rb
@@ -14,11 +14,11 @@ module Decidim
           budgets = Decidim::Budgets::Budget.where(component: @resource)
           orders = Decidim::Budgets::Order.where(budget: budgets)
                                           .finished
-                                          .where("decidim_budgets_orders.checked_out_at <= ?", end_time)
+                                          .where(decidim_budgets_orders: { checked_out_at: ..end_time })
 
           {
             cumulative_users: orders.pluck(:decidim_user_id),
-            quantity_users: orders.where("decidim_budgets_orders.checked_out_at >= ?", start_time).pluck(:decidim_user_id)
+            quantity_users: orders.where(decidim_budgets_orders: { checked_out_at: start_time.. }).pluck(:decidim_user_id)
           }
         end
       end

--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -46,8 +46,8 @@ Decidim.register_component(:budgets) do |component|
   component.register_stat :orders_count do |components, start_at, end_at|
     budgets = Decidim::Budgets::Budget.where(component: components)
     orders = Decidim::Budgets::Order.where(budget: budgets)
-    orders = orders.where("created_at >= ?", start_at) if start_at.present?
-    orders = orders.where("created_at <= ?", end_at) if end_at.present?
+    orders = orders.where(created_at: start_at..) if start_at.present?
+    orders = orders.where(created_at: ..end_at) if end_at.present?
     orders.count
   end
 

--- a/decidim-comments/app/queries/decidim/comments/metrics/comment_participants_metric_measure.rb
+++ b/decidim-comments/app/queries/decidim/comments/metrics/comment_participants_metric_measure.rb
@@ -40,7 +40,7 @@ module Decidim
         def retrieve_comments_for_organization
           user_ids = Decidim::User.where(organization: @resource.organization).pluck(:id)
           Decidim::Comments::Comment.includes(:root_commentable).not_hidden.not_deleted
-                                    .where("decidim_comments_comments.created_at <= ?", end_time)
+                                    .where(decidim_comments_comments: { created_at: ..end_time })
                                     .where(decidim_comments_comments: { decidim_author_id: user_ids })
                                     .where(decidim_comments_comments: { decidim_author_type: "Decidim::UserBaseEntity" })
         end

--- a/decidim-comments/app/queries/decidim/comments/metrics/comments_metric_manage.rb
+++ b/decidim-comments/app/queries/decidim/comments/metrics/comments_metric_manage.rb
@@ -60,7 +60,7 @@ module Decidim
           user_ids = Decidim::User.select(:id).where(organization: @organization).collect(&:id)
           user_group_ids = Decidim::UserGroup.select(:id).where(organization: @organization).collect(&:id)
           Decidim::Comments::Comment.includes(:root_commentable).not_hidden.not_deleted
-                                    .where("decidim_comments_comments.created_at <= ?", end_time)
+                                    .where(decidim_comments_comments: { created_at: ..end_time })
                                     .where("decidim_comments_comments.decidim_author_id IN (?) OR
                                            decidim_comments_comments.decidim_user_group_id IN (?)", user_ids, user_group_ids)
         end

--- a/decidim-core/app/queries/decidim/metrics/blocked_users_metric_manage.rb
+++ b/decidim-core/app/queries/decidim/metrics/blocked_users_metric_manage.rb
@@ -14,12 +14,12 @@ module Decidim
         return @query if @query
 
         @query = Decidim::User.blocked.where(organization: @organization)
-        @query = @query.where("blocked_at <= ?", end_time)
+        @query = @query.where(blocked_at: ..end_time)
         @query
       end
 
       def quantity
-        @quantity ||= @query.where("blocked_at >= ?", start_time).count
+        @quantity ||= @query.where(blocked_at: start_time..).count
       end
     end
   end

--- a/decidim-core/app/queries/decidim/metrics/users_metric_manage.rb
+++ b/decidim-core/app/queries/decidim/metrics/users_metric_manage.rb
@@ -15,11 +15,11 @@ module Decidim
                                 .where("deleted_at IS NULL OR deleted_at > ?", end_time)
                                 .where("blocked_at IS NULL OR blocked_at > ?", end_time)
                                 .confirmed
-                                .where("created_at <= ?", end_time)
+                                .where(created_at: ..end_time)
       end
 
       def quantity
-        @quantity ||= query.where("created_at >= ?", start_time).count
+        @quantity ||= query.where(created_at: start_time..).count
       end
     end
   end

--- a/decidim-core/app/queries/decidim/stats_users_count.rb
+++ b/decidim-core/app/queries/decidim/stats_users_count.rb
@@ -16,8 +16,8 @@ module Decidim
 
     def query
       users = Decidim::User.where(organization: @organization).not_deleted.not_blocked.confirmed
-      users = users.where("created_at >= ?", @start_at) if @start_at.present?
-      users = users.where("created_at <= ?", @end_at) if @end_at.present?
+      users = users.where(created_at: @start_at..) if @start_at.present?
+      users = users.where(created_at: ..@end_at) if @end_at.present?
       users.count
     end
   end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -381,8 +381,8 @@ module Decidim
         Decidim.stats.register :processes_count, priority: StatsRegistry::HIGH_PRIORITY do |organization, start_at, end_at|
           processes = ParticipatoryProcesses::OrganizationPrioritizedParticipatoryProcesses.new(organization)
 
-          processes = processes.where("created_at >= ?", start_at) if start_at.present?
-          processes = processes.where("created_at <= ?", end_at) if end_at.present?
+          processes = processes.where(created_at: start_at..) if start_at.present?
+          processes = processes.where(created_at: ..end_at) if end_at.present?
           processes.count
         end
       end

--- a/decidim-core/lib/tasks/decidim_download_your_data_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_download_your_data_tasks.rake
@@ -64,7 +64,7 @@ namespace :decidim do
     input = $stdin.gets.chomp
     if input.casecmp("y").zero?
       puts %(  Continue...)
-      Decidim::User.where("newsletter_notifications_at < ?", Time.zone.parse("2018-05-25 00:00 +02:00")).find_each(&:newsletter_opt_in_notify)
+      Decidim::User.where(newsletter_notifications_at: ...Time.zone.parse("2018-05-25 00:00 +02:00")).find_each(&:newsletter_opt_in_notify)
     else
       puts %(  Execution cancelled...)
     end
@@ -76,9 +76,7 @@ namespace :decidim do
     attachments = ActiveStorage::Attachment.joins(:blob).where(
       name: "download_your_data_file",
       record_type: "Decidim::UserBaseEntity"
-    ).where(
-      "active_storage_blobs.created_at < ?", Decidim.download_your_data_expiry_time.ago
-    )
+    ).where(active_storage_blobs: { created_at: ...Decidim.download_your_data_expiry_time.ago })
     attachments.each do |attachment|
       delete_download_your_data_file attachment
     end

--- a/decidim-debates/app/queries/decidim/debates/metrics/debate_followers_metric_measure.rb
+++ b/decidim-debates/app/queries/decidim/debates/metrics/debate_followers_metric_measure.rb
@@ -14,10 +14,10 @@ module Decidim
           debates = Decidim::Debates::Debate.where(component: @resource).joins(:component)
 
           debates_followers = Decidim::Follow.where(followable: debates).joins(:user)
-                                             .where("decidim_follows.created_at <= ?", end_time)
+                                             .where(decidim_follows: { created_at: ..end_time })
           cumulative_users = debates_followers.pluck(:decidim_user_id)
 
-          debates_followers = debates_followers.where("decidim_follows.created_at >= ?", start_time)
+          debates_followers = debates_followers.where(decidim_follows: { created_at: start_time.. })
           quantity_users = debates_followers.pluck(:decidim_user_id)
 
           {

--- a/decidim-debates/app/queries/decidim/debates/metrics/debate_participants_metric_measure.rb
+++ b/decidim-debates/app/queries/decidim/debates/metrics/debate_participants_metric_measure.rb
@@ -12,13 +12,13 @@ module Decidim
 
         def calculate
           debates = Decidim::Debates::Debate.where(component: @resource).joins(:component)
-                                            .where("decidim_debates_debates.created_at <= ?", end_time)
+                                            .where(decidim_debates_debates: { created_at: ..end_time })
                                             .where(decidim_author_type: Decidim::UserBaseEntity.name)
                                             .where.not(author: nil)
 
           {
             cumulative_users: debates.pluck(:decidim_author_id),
-            quantity_users: debates.where("decidim_debates_debates.created_at >= ?", start_time).pluck(:decidim_author_id)
+            quantity_users: debates.where(decidim_debates_debates: { created_at: start_time.. }).pluck(:decidim_author_id)
           }
         end
       end

--- a/decidim-debates/app/queries/decidim/debates/metrics/debates_metric_manage.rb
+++ b/decidim-debates/app/queries/decidim/debates/metrics/debates_metric_manage.rb
@@ -29,7 +29,7 @@ module Decidim
 
           @query = Decidim::Debates::Debate.where(component: visible_components_from_spaces(retrieve_participatory_spaces)).joins(:component)
                                            .left_outer_joins(:category)
-          @query = @query.where("decidim_debates_debates.start_time <= ?", end_time)
+          @query = @query.where(decidim_debates_debates: { start_time: ..end_time })
           @query = @query.group("decidim_categorizations.decidim_category_id",
                                 :participatory_space_type,
                                 :participatory_space_id)
@@ -37,7 +37,7 @@ module Decidim
         end
 
         def quantity
-          @quantity ||= query.where("decidim_debates_debates.start_time >= ?", start_time).count
+          @quantity ||= query.where(decidim_debates_debates: { start_time: start_time.. }).count
         end
       end
     end

--- a/decidim-dev/config/rubocop/disabled.yml
+++ b/decidim-dev/config/rubocop/disabled.yml
@@ -66,6 +66,3 @@ Lint/SelfAssignment:
 
 Style/SendWithLiteralMethodName:
   Enabled: false
-
-Rails/WhereRange:
-  Enabled: false

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -85,12 +85,12 @@ module Decidim
     scope_search_multi :with_any_state, [:accepted, :rejected, :answered, :open, :closed]
 
     scope :currently_signable, lambda {
-      where("signature_start_date <= ?", Date.current)
-        .where("signature_end_date >= ?", Date.current)
+      where(signature_start_date: ..Date.current)
+        .where(signature_end_date: Date.current..)
     }
     scope :currently_unsignable, lambda {
       where("signature_start_date > ?", Date.current)
-        .or(where("signature_end_date < ?", Date.current))
+        .or(where(signature_end_date: ...Date.current))
     }
 
     scope :answered, -> { where.not(answered_at: nil) }

--- a/decidim-initiatives/app/queries/decidim/initiatives/outdated_validating_initiatives.rb
+++ b/decidim-initiatives/app/queries/decidim/initiatives/outdated_validating_initiatives.rb
@@ -23,7 +23,7 @@ module Decidim
       def query
         Decidim::Initiative
           .where(state: "validating")
-          .where("updated_at < ?", @period_length)
+          .where(updated_at: ...@period_length)
       end
     end
   end

--- a/decidim-initiatives/app/queries/decidim/initiatives/support_period_finished_initiatives.rb
+++ b/decidim-initiatives/app/queries/decidim/initiatives/support_period_finished_initiatives.rb
@@ -12,7 +12,7 @@ module Decidim
           .includes(:scoped_type)
           .where(state: "open")
           .where(signature_type: "online")
-          .where("signature_end_date < ?", Date.current)
+          .where(signature_end_date: ...Date.current)
       end
     end
   end

--- a/decidim-meetings/app/queries/decidim/meetings/filtered_meetings.rb
+++ b/decidim-meetings/app/queries/decidim/meetings/filtered_meetings.rb
@@ -28,8 +28,8 @@ module Decidim
       # by a range of dates.
       def query
         meetings = Decidim::Meetings::Meeting.not_hidden.published.where(component: @components)
-        meetings = meetings.where("created_at >= ?", @start_at) if @start_at.present?
-        meetings = meetings.where("created_at <= ?", @end_at) if @end_at.present?
+        meetings = meetings.where(created_at: @start_at..) if @start_at.present?
+        meetings = meetings.where(created_at: ..@end_at) if @end_at.present?
         meetings
       end
     end

--- a/decidim-meetings/app/queries/decidim/meetings/metrics/meeting_followers_metric_measure.rb
+++ b/decidim-meetings/app/queries/decidim/meetings/metrics/meeting_followers_metric_measure.rb
@@ -14,10 +14,10 @@ module Decidim
           meetings = Decidim::Meetings::Meeting.where(component: @resource).joins(:component)
 
           meetings_followers = Decidim::Follow.where(followable: meetings).joins(:user)
-                                              .where("decidim_follows.created_at <= ?", end_time)
+                                              .where(decidim_follows: { created_at: ..end_time })
           cumulative_users = meetings_followers.pluck(:decidim_user_id)
 
-          meetings_followers = meetings_followers.where("decidim_follows.created_at >= ?", start_time)
+          meetings_followers = meetings_followers.where(decidim_follows: { created_at: start_time.. })
           quantity_users = meetings_followers.pluck(:decidim_user_id)
 
           {

--- a/decidim-meetings/app/queries/decidim/meetings/metrics/meetings_metric_manage.rb
+++ b/decidim-meetings/app/queries/decidim/meetings/metrics/meetings_metric_manage.rb
@@ -32,7 +32,7 @@ module Decidim
           end
           @query = Decidim::Meetings::Meeting.where(component: visible_components_from_spaces(spaces)).joins(:component)
                                              .left_outer_joins(:category).visible
-          @query = @query.where("decidim_meetings_meetings.created_at <= ?", end_time)
+          @query = @query.where(decidim_meetings_meetings: { created_at: ..end_time })
           @query = @query.group("decidim_categorizations.decidim_category_id",
                                 :participatory_space_type,
                                 :participatory_space_id)
@@ -40,7 +40,7 @@ module Decidim
         end
 
         def quantity
-          @quantity ||= query.where("decidim_meetings_meetings.created_at >= ?", start_time).count
+          @quantity ||= query.where(decidim_meetings_meetings: { created_at: start_time.. }).count
         end
       end
     end

--- a/decidim-pages/lib/decidim/pages/component.rb
+++ b/decidim-pages/lib/decidim/pages/component.rb
@@ -32,8 +32,8 @@ Decidim.register_component(:pages) do |component|
 
   component.register_stat :pages_count do |components, start_at, end_at|
     pages = Decidim::Pages::Page.where(component: components)
-    pages = pages.where("created_at >= ?", start_at) if start_at.present?
-    pages = pages.where("created_at <= ?", end_at) if end_at.present?
+    pages = pages.where(created_at: start_at..) if start_at.present?
+    pages = pages.where(created_at: ..end_at) if end_at.present?
     pages.count
   end
 

--- a/decidim-participatory_processes/app/jobs/decidim/participatory_processes/change_active_step_job.rb
+++ b/decidim-participatory_processes/app/jobs/decidim/participatory_processes/change_active_step_job.rb
@@ -16,7 +16,7 @@ module Decidim
           active_step = process.steps.find_by(active: true)
           if steps.empty? && active_step
             next_position = active_step.position + 1
-            next_step = process.steps.where("start_date <= ?", Time.zone.now.to_date).find_by(position: next_position)
+            next_step = process.steps.where(start_date: ..Time.zone.now.to_date).find_by(position: next_position)
             if next_step.present?
               active_step.update(active: false)
               next_step.update(active: true)

--- a/decidim-participatory_processes/app/queries/decidim/participatory_processes/metrics/participatory_process_followers_metric_measure.rb
+++ b/decidim-participatory_processes/app/queries/decidim/participatory_processes/metrics/participatory_process_followers_metric_measure.rb
@@ -14,10 +14,10 @@ module Decidim
           participatory_process = @resource
 
           process_followers = Decidim::Follow.where(followable: participatory_process).joins(:user)
-                                             .where("decidim_follows.created_at <= ?", end_time)
+                                             .where(decidim_follows: { created_at: ..end_time })
           cumulative_users = process_followers.pluck(:decidim_user_id)
 
-          process_followers = process_followers.where("decidim_follows.created_at >= ?", start_time)
+          process_followers = process_followers.where(decidim_follows: { created_at: start_time.. })
           quantity_users = process_followers.pluck(:decidim_user_id)
 
           {

--- a/decidim-participatory_processes/app/queries/decidim/participatory_processes/metrics/participatory_processes_metric_manage.rb
+++ b/decidim-participatory_processes/app/queries/decidim/participatory_processes/metrics/participatory_processes_metric_manage.rb
@@ -14,12 +14,12 @@ module Decidim
           return @query if @query
 
           @query = Decidim::ParticipatoryProcess.where(organization: @organization)
-          @query = @query.where("decidim_participatory_processes.published_at <= ?", end_time)
+          @query = @query.where(decidim_participatory_processes: { published_at: ..end_time })
           @query
         end
 
         def quantity
-          @quantity ||= query.where("decidim_participatory_processes.published_at >= ?", start_time).count
+          @quantity ||= query.where(decidim_participatory_processes: { published_at: start_time.. }).count
         end
       end
     end

--- a/decidim-proposals/app/queries/decidim/proposals/filtered_proposals.rb
+++ b/decidim-proposals/app/queries/decidim/proposals/filtered_proposals.rb
@@ -28,8 +28,8 @@ module Decidim
       # by a range of dates.
       def query
         proposals = Decidim::Proposals::Proposal.where(component: @components)
-        proposals = proposals.where("created_at >= ?", @start_at) if @start_at.present?
-        proposals = proposals.where("created_at <= ?", @end_at) if @end_at.present?
+        proposals = proposals.where(created_at: @start_at..) if @start_at.present?
+        proposals = proposals.where(created_at: ..@end_at) if @end_at.present?
         proposals
       end
     end

--- a/decidim-proposals/app/queries/decidim/proposals/metrics/accepted_proposals_metric_manage.rb
+++ b/decidim-proposals/app/queries/decidim/proposals/metrics/accepted_proposals_metric_manage.rb
@@ -18,13 +18,13 @@ module Decidim
           end
           @query = Decidim::Proposals::Proposal.where(component: visible_components_from_spaces(spaces)).joins(:component)
                                                .left_outer_joins(:category)
-          @query = @query.where("decidim_proposals_proposals.created_at <= ?", end_time).accepted
+          @query = @query.where(decidim_proposals_proposals: { created_at: ..end_time }).accepted
           @query = @query.group("decidim_categorizations.id", :participatory_space_type, :participatory_space_id)
           @query
         end
 
         def quantity
-          @quantity ||= query.where("decidim_proposals_proposals.created_at >= ?", start_time).count
+          @quantity ||= query.where(decidim_proposals_proposals: { created_at: start_time.. }).count
         end
       end
     end

--- a/decidim-proposals/app/queries/decidim/proposals/metrics/endorsements_metric_manage.rb
+++ b/decidim-proposals/app/queries/decidim/proposals/metrics/endorsements_metric_manage.rb
@@ -41,7 +41,7 @@ module Decidim
                                        .joins(join_categories)
                                        .where(resource_id: proposals.pluck(:id))
                                        .where(resource_type: Decidim::Proposals::Proposal.name)
-          @query = @query.where("decidim_endorsements.created_at <= ?", end_time)
+          @query = @query.where(decidim_endorsements: { created_at: ..end_time })
           @query = @query.group("decidim_categorizations.id",
                                 :participatory_space_type,
                                 :participatory_space_id,
@@ -50,7 +50,7 @@ module Decidim
         end
 
         def quantity
-          @quantity ||= query.where("decidim_endorsements.created_at >= ?", start_time).count
+          @quantity ||= query.where(decidim_endorsements: { created_at: start_time.. }).count
         end
       end
     end

--- a/decidim-proposals/app/queries/decidim/proposals/metrics/proposal_followers_metric_measure.rb
+++ b/decidim-proposals/app/queries/decidim/proposals/metrics/proposal_followers_metric_measure.rb
@@ -30,17 +30,17 @@ module Decidim
 
         def retrieve_proposals_followers(from_start: false)
           @proposals_followers ||= Decidim::Follow.where(followable: retrieve_proposals).joins(:user)
-                                                  .where("decidim_follows.created_at <= ?", end_time)
+                                                  .where(decidim_follows: { created_at: ..end_time })
 
-          return @proposals_followers.where("decidim_follows.created_at >= ?", start_time) if from_start
+          return @proposals_followers.where(decidim_follows: { created_at: start_time.. }) if from_start
 
           @proposals_followers
         end
 
         def retrieve_drafts_followers(from_start: false)
           @drafts_followers ||= Decidim::Follow.where(followable: retrieve_collaborative_drafts).joins(:user)
-                                               .where("decidim_follows.created_at <= ?", end_time)
-          return @drafts_followers.where("decidim_follows.created_at >= ?", start_time) if from_start
+                                               .where(decidim_follows: { created_at: ..end_time })
+          return @drafts_followers.where(decidim_follows: { created_at: start_time.. }) if from_start
 
           @drafts_followers
         end

--- a/decidim-proposals/app/queries/decidim/proposals/metrics/proposal_participants_metric_measure.rb
+++ b/decidim-proposals/app/queries/decidim/proposals/metrics/proposal_participants_metric_measure.rb
@@ -41,19 +41,19 @@ module Decidim
                                                                 "Decidim::Meetings::Meeting"
                                                               ]
                                                             })
-                                                     .where("decidim_proposals_proposals.published_at <= ?", end_time)
+                                                     .where(decidim_proposals_proposals: { published_at: ..end_time })
                                                      .not_withdrawn
 
-          return @proposals.where("decidim_proposals_proposals.published_at >= ?", start_time) if from_start
+          return @proposals.where(decidim_proposals_proposals: { published_at: start_time.. }) if from_start
 
           @proposals
         end
 
         def retrieve_votes(from_start: false)
           @votes ||= Decidim::Proposals::ProposalVote.joins(:proposal).where(proposal: retrieve_proposals).joins(:author)
-                                                     .where("decidim_proposals_proposal_votes.created_at <= ?", end_time)
+                                                     .where(decidim_proposals_proposal_votes: { created_at: ..end_time })
 
-          return @votes.where("decidim_proposals_proposal_votes.created_at >= ?", start_time) if from_start
+          return @votes.where(decidim_proposals_proposal_votes: { created_at: start_time.. }) if from_start
 
           @votes
         end
@@ -61,10 +61,10 @@ module Decidim
         def retrieve_endorsements(from_start: false)
           @endorsements ||= Decidim::Endorsement.joins("INNER JOIN decidim_proposals_proposals proposals ON resource_id = proposals.id")
                                                 .where(resource: retrieve_proposals)
-                                                .where("decidim_endorsements.created_at <= ?", end_time)
+                                                .where(decidim_endorsements: { created_at: ..end_time })
                                                 .where(decidim_author_type: "Decidim::UserBaseEntity")
 
-          return @endorsements.where("decidim_endorsements.created_at >= ?", start_time) if from_start
+          return @endorsements.where(decidim_endorsements: { created_at: start_time.. }) if from_start
 
           @endorsements
         end

--- a/decidim-proposals/app/queries/decidim/proposals/metrics/proposals_metric_manage.rb
+++ b/decidim-proposals/app/queries/decidim/proposals/metrics/proposals_metric_manage.rb
@@ -32,7 +32,7 @@ module Decidim
           end
           @query = Decidim::Proposals::Proposal.where(component: visible_components_from_spaces(spaces)).joins(:component)
                                                .left_outer_joins(:category)
-          @query = @query.where("decidim_proposals_proposals.published_at <= ?", end_time).not_withdrawn.not_hidden
+          @query = @query.where(decidim_proposals_proposals: { published_at: ..end_time }).not_withdrawn.not_hidden
           @query = @query.group("decidim_categorizations.decidim_category_id",
                                 :participatory_space_type,
                                 :participatory_space_id)
@@ -40,7 +40,7 @@ module Decidim
         end
 
         def quantity
-          @quantity ||= query.where("decidim_proposals_proposals.published_at >= ?", start_time).count
+          @quantity ||= query.where(decidim_proposals_proposals: { published_at: start_time.. }).count
         end
       end
     end

--- a/decidim-proposals/app/queries/decidim/proposals/metrics/votes_metric_manage.rb
+++ b/decidim-proposals/app/queries/decidim/proposals/metrics/votes_metric_manage.rb
@@ -35,7 +35,7 @@ module Decidim
           @query = Decidim::Proposals::ProposalVote.joins(proposal: :component)
                                                    .left_outer_joins(proposal: :category)
                                                    .where(proposal: proposal_ids)
-          @query = @query.where("decidim_proposals_proposal_votes.created_at <= ?", end_time)
+          @query = @query.where(decidim_proposals_proposal_votes: { created_at: ..end_time })
           @query = @query.group("decidim_categorizations.id",
                                 :participatory_space_type,
                                 :participatory_space_id,
@@ -44,7 +44,7 @@ module Decidim
         end
 
         def quantity
-          @quantity ||= query.where("decidim_proposals_proposal_votes.created_at >= ?", start_time).count
+          @quantity ||= query.where(decidim_proposals_proposal_votes: { created_at: start_time.. }).count
         end
       end
     end

--- a/decidim-sortitions/app/queries/decidim/sortitions/admin/participatory_space_proposals.rb
+++ b/decidim-sortitions/app/queries/decidim/sortitions/admin/participatory_space_proposals.rb
@@ -26,7 +26,7 @@ module Decidim
                       .not_withdrawn
                       .published
                       .not_hidden
-                      .where("decidim_proposals_proposals.created_at < ?", request_timestamp)
+                      .where(decidim_proposals_proposals: { created_at: ...request_timestamp })
                       .where(component: sortition.decidim_proposals_component)
           proposals = proposals.where.not(id: proposals.only_status(:rejected))
 

--- a/decidim-sortitions/app/queries/decidim/sortitions/filtered_sortitions.rb
+++ b/decidim-sortitions/app/queries/decidim/sortitions/filtered_sortitions.rb
@@ -28,8 +28,8 @@ module Decidim
       # by a range of dates.
       def query
         sortitions = Decidim::Sortitions::Sortition.where(component: @components)
-        sortitions = sortitions.where("created_at >= ?", @start_at) if @start_at.present?
-        sortitions = sortitions.where("created_at <= ?", @end_at) if @end_at.present?
+        sortitions = sortitions.where(created_at: @start_at..) if @start_at.present?
+        sortitions = sortitions.where(created_at: ..@end_at) if @end_at.present?
         sortitions
       end
     end

--- a/decidim-surveys/app/queries/decidim/surveys/metrics/answers_metric_manage.rb
+++ b/decidim-surveys/app/queries/decidim/surveys/metrics/answers_metric_manage.rb
@@ -32,13 +32,13 @@ module Decidim
           @query = retrieve_surveys.each_with_object({}) do |survey, grouped_answers|
             answers = Decidim::Forms::Answer.joins(:questionnaire)
                                             .where(questionnaire: retrieve_questionnaires(survey))
-                                            .where("decidim_forms_answers.created_at <= ?", end_time)
+                                            .where(decidim_forms_answers: { created_at: ..end_time })
             next grouped_answers unless answers
 
             group_key = generate_group_key(survey)
             grouped_answers[group_key] ||= { cumulative: 0, quantity: 0 }
             grouped_answers[group_key][:cumulative] += answers.count
-            grouped_answers[group_key][:quantity] += answers.where("decidim_forms_answers.created_at >= ?", start_time).count
+            grouped_answers[group_key][:quantity] += answers.where(decidim_forms_answers: { created_at: start_time.. }).count
           end
           @query
         end

--- a/decidim-surveys/app/queries/decidim/surveys/metrics/survey_participants_metric_measure.rb
+++ b/decidim-surveys/app/queries/decidim/surveys/metrics/survey_participants_metric_measure.rb
@@ -17,11 +17,11 @@ module Decidim
 
           answers = Decidim::Forms::Answer.joins(:questionnaire)
                                           .where(questionnaire: questionnaires)
-                                          .where("decidim_forms_answers.created_at <= ?", end_time)
+                                          .where(decidim_forms_answers: { created_at: ..end_time })
 
           {
             cumulative_users: answers.pluck(:decidim_user_id).uniq,
-            quantity_users: answers.where("decidim_forms_answers.created_at >= ?", start_time).pluck(:decidim_user_id).uniq
+            quantity_users: answers.where(decidim_forms_answers: { created_at: start_time.. }).pluck(:decidim_user_id).uniq
           }
         end
       end

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -41,16 +41,16 @@ Decidim.register_component(:surveys) do |component|
 
   component.register_stat :surveys_count do |components, start_at, end_at|
     surveys = Decidim::Surveys::Survey.where(component: components)
-    surveys = surveys.where("created_at >= ?", start_at) if start_at.present?
-    surveys = surveys.where("created_at <= ?", end_at) if end_at.present?
+    surveys = surveys.where(created_at: start_at..) if start_at.present?
+    surveys = surveys.where(created_at: ..end_at) if end_at.present?
     surveys.count
   end
 
   component.register_stat :answers_count, primary: true, priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |components, start_at, end_at|
     surveys = Decidim::Surveys::Survey.includes(:questionnaire).where(component: components)
     answers = Decidim::Forms::Answer.where(questionnaire: surveys.map(&:questionnaire))
-    answers = answers.where("created_at >= ?", start_at) if start_at.present?
-    answers = answers.where("created_at <= ?", end_at) if end_at.present?
+    answers = answers.where(created_at: start_at..) if start_at.present?
+    answers = answers.where(created_at: ..end_at) if end_at.present?
     answers.group(:session_token).count.size
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #13146 we have upgraded rubocop & friends which added new rules that were disabled at that point. This PR makes sure the `Rails/WhereRange` rule is enforced by linter. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13146 

#### Testing
1. Make sure the pipeline is green

:hearts: Thank you!
