### PR TITLE
Fix rubocop offense `Style/SuperWithArgsParentheses`

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/disable_redirection_to_external_host.rb
+++ b/decidim-core/app/controllers/concerns/decidim/disable_redirection_to_external_host.rb
@@ -8,7 +8,7 @@ module Decidim
 
     included do
       def redirect_back(fallback_location:, allow_other_host: true, **args) # rubocop:disable Lint/UnusedMethodArgument
-        super fallback_location:, allow_other_host: Decidim.allow_open_redirects, **args
+        super(fallback_location:, allow_other_host: Decidim.allow_open_redirects, **args)
       end
     end
   end

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -28,7 +28,7 @@ module Decidim
       def title(links: false, all_locales: false, html_escape: false)
         return unless debate
 
-        super debate.title, links, html_escape, all_locales
+        super(debate.title, links, html_escape, all_locales)
       end
 
       def description(strip_tags: false, extras: true, links: false, all_locales: false)

--- a/decidim-dev/config/rubocop/disabled.yml
+++ b/decidim-dev/config/rubocop/disabled.yml
@@ -52,8 +52,8 @@ Style/RedundantParentheses:
 Style/MapIntoArray:
   Enabled: false
 
-Style/SuperWithArgsParentheses:
-  Enabled: false
+
+
 
 Style/ArgumentsForwarding:
   Enabled: false

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -25,7 +25,7 @@ module Decidim
       def title(links: false, html_escape: false, all_locales: false)
         return unless meeting
 
-        super meeting.title, links, html_escape, all_locales
+        super(meeting.title, links, html_escape, all_locales)
       end
 
       def description(links: false, extras: true, strip_tags: false, all_locales: false)

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -40,7 +40,7 @@ module Decidim
       def title(links: false, extras: true, html_escape: false, all_locales: false)
         return unless proposal
 
-        super proposal.title, links, html_escape, all_locales, extras:
+        super(proposal.title, links, html_escape, all_locales, extras:)
       end
 
       def id_and_title(links: false, extras: true, html_escape: false)


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #13146 we have upgraded rubocop & friends which added new rules that were disabled at that point. This PR makes sure the `Style/SuperWithArgsParentheses` rule is enforced by linter. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13146 

#### Testing
1. Make sure the pipeline is green

:hearts: Thank you!
