### PR TITLE
Fix migration of withdrawn state on Proposal

### DIFF
--- a/decidim-proposals/db/migrate/20240110203500_add_withdrawn_at_field_to_proposals.rb
+++ b/decidim-proposals/db/migrate/20240110203500_add_withdrawn_at_field_to_proposals.rb
@@ -12,6 +12,7 @@ class AddWithdrawnAtFieldToProposals < ActiveRecord::Migration[6.1]
 
     CustomProposal.withdrawn.find_each do |proposal|
       proposal.withdrawn_at = proposal.updated_at
+      proposal.state = :not_answered
       proposal.save!
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
While migrating applications to 0.29, we have noticed the withdrawn state is not being changed, causing errors when migrating the proposal states. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12289
- Related to #12052 
- Related to https://github.com/decidim/metadecidim/pull/129

#### Testing
1. create a 0.28 development app 
2. login as any user and create a proposal 
3. Withdrawn the respective proposal 
4. Upgrade the app to the version and run migrations 
5. See there is an error 
6. apply the patch from this branch & make sure u update the changed migration ...
8. Migrate everything 
9. There should be no error. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
