### PR TITLE
Fix rubocop offense `Style/ArgumentsForwarding`

### DIFF
--- a/decidim-core/lib/decidim/command.rb
+++ b/decidim-core/lib/decidim/command.rb
@@ -42,10 +42,10 @@ module Decidim
       @caller.respond_to?(method_name, include_private)
     end
 
-    def with_events(with_transaction: false, &block)
+    def with_events(with_transaction: false, &)
       ActiveSupport::Notifications.publish("#{event_namespace}:before", **event_arguments)
 
-      with_transaction ? transaction(&block) : yield
+      with_transaction ? transaction(&) : yield
 
       ActiveSupport::Notifications.publish("#{event_namespace}:after", **event_arguments)
     end

--- a/decidim-dev/config/rubocop/disabled.yml
+++ b/decidim-dev/config/rubocop/disabled.yml
@@ -55,9 +55,6 @@ Style/MapIntoArray:
 
 
 
-Style/ArgumentsForwarding:
-  Enabled: false
-
 Style/SuperArguments:
   Enabled: false
 


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #13146 we have upgraded rubocop & friends which added new rules that were disabled at that point. This PR makes sure the `Style/ArgumentsForwarding` rule is enforced by linter. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13146 

#### Testing
1. Make sure the pipeline is green

:hearts: Thank you!
