### PR TITLE
Fix rubocop offense `FactoryBot/ConsistentParenthesesStyle`

### DIFF
--- a/decidim-accountability/lib/decidim/accountability/test/factories.rb
+++ b/decidim-accountability/lib/decidim/accountability/test/factories.rb
@@ -44,7 +44,7 @@ FactoryBot.define do
     description { generate_localized_description(:result_description, skip_injection:) }
     start_date { "12/7/2017" }
     end_date { "30/9/2017" }
-    status { create :status, component:, skip_injection: }
+    status { create(:status, component:, skip_injection:) }
     progress { rand(1..100) }
   end
 

--- a/decidim-admin/lib/decidim/admin/test/commands/destroy_category_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/commands/destroy_category_examples.rb
@@ -29,7 +29,7 @@ module Decidim
         end
 
         context "when the category is not empty" do
-          let!(:subcategory) { create :subcategory, parent: category }
+          let!(:subcategory) { create(:subcategory, parent: category) }
 
           it "does not destroy the category" do
             expect do
@@ -39,7 +39,7 @@ module Decidim
         end
 
         context "when the category is a subcategory" do
-          let!(:parent_category) { create :category, participatory_space: }
+          let!(:parent_category) { create(:category, participatory_space:) }
 
           before do
             category.parent = parent_category

--- a/decidim-admin/lib/decidim/admin/test/destroy_admin_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/destroy_admin_examples.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 shared_examples "destroys participatory space role" do
-  let!(:current_user) { create :user, email: "some_email@example.org", organization: my_process.organization }
-  let!(:user) { create :user, :confirmed, organization: my_process.organization }
+  let!(:current_user) { create(:user, email: "some_email@example.org", organization: my_process.organization) }
+  let!(:user) { create(:user, :confirmed, organization: my_process.organization) }
 
   let(:log_info) do
     {

--- a/decidim-admin/lib/decidim/admin/test/forms/attachment_collection_form_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/forms/attachment_collection_form_examples.rb
@@ -41,7 +41,7 @@ module Decidim
           }
         }
       end
-      let(:organization) { create :organization }
+      let(:organization) { create(:organization) }
 
       context "with correct data" do
         it "is valid" do

--- a/decidim-admin/lib/decidim/admin/test/forms/attachment_form_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/forms/attachment_form_examples.rb
@@ -32,7 +32,7 @@ module Decidim
       let(:file) { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
       let(:attachment_collection) { create(:attachment_collection, collection_for: attached_to) }
       let(:attachment_collection_id) { attachment_collection.id }
-      let(:organization) { create :organization }
+      let(:organization) { create(:organization) }
 
       let(:attributes) do
         {

--- a/decidim-admin/lib/decidim/admin/test/forms/category_form_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/forms/category_form_examples.rb
@@ -32,7 +32,7 @@ module Decidim
           }
         }
       end
-      let(:organization) { create :organization }
+      let(:organization) { create(:organization) }
 
       context "when everything is OK" do
         it { is_expected.to be_valid }
@@ -50,7 +50,7 @@ module Decidim
       end
 
       context "when the parent_id is set" do
-        let!(:category) { create :category, participatory_space: }
+        let!(:category) { create(:category, participatory_space:) }
 
         context "and it is set to a first-class category" do
           let(:parent_id) { category.id }
@@ -59,7 +59,7 @@ module Decidim
         end
 
         context "and it is set to a subcategory" do
-          let!(:subcategory) { create :subcategory, parent: category }
+          let!(:subcategory) { create(:subcategory, parent: category) }
           let(:parent_id) { subcategory.id }
 
           it { is_expected.not_to be_valid }

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -62,7 +62,7 @@ shared_examples "manage moderations" do
 
   context "when listing moderations" do
     it "only lists moderations for the current organization" do
-      external_reportable = create :dummy_resource
+      external_reportable = create(:dummy_resource)
       external_moderation = create(:moderation, reportable: external_reportable, report_count: 1, reported_content: external_reportable.reported_searchable_content_text)
       create(:report, moderation: external_moderation)
 

--- a/decidim-api/lib/decidim/api/test/component_context.rb
+++ b/decidim-api/lib/decidim/api/test/component_context.rb
@@ -9,7 +9,7 @@ shared_context "with a graphql decidim component" do
 
   let(:locale) { "en" }
 
-  let(:participatory_process) { create :participatory_process, organization: current_organization }
+  let(:participatory_process) { create(:participatory_process, organization: current_organization) }
   let(:category) { create(:category, participatory_space: participatory_process) }
 
   let(:component_type) { nil }

--- a/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
@@ -57,7 +57,7 @@ FactoryBot.define do
     announcement { generate_localized_title(:assembly_announcement, skip_injection:) }
 
     trait :with_type do
-      assembly_type { create :assemblies_type, organization:, skip_injection: }
+      assembly_type { create(:assemblies_type, organization:, skip_injection:) }
     end
 
     trait :promoted do
@@ -73,7 +73,7 @@ FactoryBot.define do
     end
 
     trait :with_parent do
-      parent { create :assembly, organization:, skip_injection: }
+      parent { create(:assembly, organization:, skip_injection:) }
     end
 
     trait :public do
@@ -115,7 +115,7 @@ FactoryBot.define do
       skip_injection { false }
     end
     user
-    assembly { create :assembly, organization: user.organization, skip_injection: }
+    assembly { create(:assembly, organization: user.organization, skip_injection:) }
     role { "admin" }
   end
 
@@ -129,11 +129,11 @@ FactoryBot.define do
     admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
-      create :assembly_user_role,
+      create(:assembly_user_role,
              user:,
              assembly: evaluator.assembly,
              skip_injection: evaluator.skip_injection,
-             role: :admin
+             role: :admin)
     end
   end
 
@@ -147,11 +147,11 @@ FactoryBot.define do
     admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
-      create :assembly_user_role,
+      create(:assembly_user_role,
              user:,
              assembly: evaluator.assembly,
              role: :moderator,
-             skip_injection: evaluator.skip_injection
+             skip_injection: evaluator.skip_injection)
     end
   end
 
@@ -165,11 +165,11 @@ FactoryBot.define do
     admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
-      create :assembly_user_role,
+      create(:assembly_user_role,
              user:,
              assembly: evaluator.assembly,
              role: :collaborator,
-             skip_injection: evaluator.skip_injection
+             skip_injection: evaluator.skip_injection)
     end
   end
 
@@ -183,11 +183,11 @@ FactoryBot.define do
     admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
-      create :assembly_user_role,
+      create(:assembly_user_role,
              user:,
              assembly: evaluator.assembly,
              role: :valuator,
-             skip_injection: evaluator.skip_injection
+             skip_injection: evaluator.skip_injection)
     end
   end
 

--- a/decidim-budgets/spec/requests/line_items_spec.rb
+++ b/decidim-budgets/spec/requests/line_items_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Project search" do
   include Decidim::ComponentPathHelper
 
   let(:user) { create(:user, :confirmed) }
-  let(:participatory_space) { create :participatory_process, :with_steps, organization: user.organization }
+  let(:participatory_space) { create(:participatory_process, :with_steps, organization: user.organization) }
   let(:component) { create(:budgets_component, participatory_space:, settings:) }
   let(:settings) { { vote_threshold_percent: 50 } }
   let(:budget) { create(:budget, component:, total_budget: 100_000) }

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/comment_event.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/comment_event.rb
@@ -10,7 +10,7 @@ shared_context "when it is a comment event" do
 
   let(:resource) { comment.commentable }
 
-  let(:comment) { create :comment }
+  let(:comment) { create(:comment) }
   let(:comment_author) { comment.author }
   let(:normalized_comment_author) { comment.author }
   let(:comment_author_name) { decidim_html_escape comment.author.name }

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/comment_voted_event.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/comment_voted_event.rb
@@ -7,8 +7,8 @@ shared_examples_for "a comment voted event" do
 
   let(:resource) { comment.commentable }
 
-  let(:comment) { create :comment }
-  let(:comment_vote) { create :comment_vote, comment: }
+  let(:comment) { create(:comment) }
+  let(:comment_vote) { create(:comment_vote, comment:) }
   let(:comment_vote_author) { comment_vote.author }
 
   let(:extra) { { comment_id: comment.id, author_id: comment_vote_author.id, weight:, downvotes: 100, upvotes: 999 } }

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/create_comment_context.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/create_comment_context.rb
@@ -7,7 +7,7 @@ RSpec.shared_context "when creating a comment" do
   let(:user) { create(:user, organization:) }
   let(:author) { create(:user, organization:) }
   let(:current_user) { author }
-  let(:dummy_resource) { create :dummy_resource, component: }
+  let(:dummy_resource) { create(:dummy_resource, component:) }
   let(:commentable) { dummy_resource }
   let(:body) { Faker::Lorem.paragraph }
   let(:alignment) { 1 }

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/translatable_comment.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/translatable_comment.rb
@@ -6,10 +6,10 @@ shared_examples_for "a translated comment event" do
   describe "translated notifications" do
     let(:en_body) { "This is Sparta!" }
     let(:body) { { en: en_body, machine_translations: { ca: "C'est Sparta!" } } }
-    let(:participatory_process) { create :participatory_process, organization: }
+    let(:participatory_process) { create(:participatory_process, organization:) }
     let(:component) { create(:component, participatory_space: participatory_process) }
     let(:commentable) { create(:dummy_resource, component:) }
-    let(:comment) { create :comment, body:, commentable: }
+    let(:comment) { create(:comment, body:, commentable:) }
     let(:en_version) { "<div><p>#{comment.body["en"]}</p></div>" }
     let(:machine_translated) { "<div><p>#{comment.body["machine_translations"]["ca"]}</p></div>" }
 

--- a/decidim-conferences/lib/decidim/conferences/test/factories.rb
+++ b/decidim-conferences/lib/decidim/conferences/test/factories.rb
@@ -56,7 +56,7 @@ FactoryBot.define do
       skip_injection { false }
     end
     user
-    conference { create :conference, organization: user.organization, skip_injection: }
+    conference { create(:conference, organization: user.organization, skip_injection:) }
     role { "admin" }
   end
 
@@ -70,11 +70,11 @@ FactoryBot.define do
     admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
-      create :conference_user_role,
+      create(:conference_user_role,
              user:,
              conference: evaluator.conference,
              role: :admin,
-             skip_injection: evaluator.skip_injection
+             skip_injection: evaluator.skip_injection)
     end
   end
 
@@ -88,11 +88,11 @@ FactoryBot.define do
     admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
-      create :conference_user_role,
+      create(:conference_user_role,
              user:,
              conference: evaluator.conference,
              role: :moderator,
-             skip_injection: evaluator.skip_injection
+             skip_injection: evaluator.skip_injection)
     end
   end
 
@@ -106,11 +106,11 @@ FactoryBot.define do
     admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
-      create :conference_user_role,
+      create(:conference_user_role,
              user:,
              conference: evaluator.conference,
              role: :collaborator,
-             skip_injection: evaluator.skip_injection
+             skip_injection: evaluator.skip_injection)
     end
   end
 
@@ -124,11 +124,11 @@ FactoryBot.define do
     admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
-      create :conference_user_role,
+      create(:conference_user_role,
              user:,
              conference: evaluator.conference,
              role: :valuator,
-             skip_injection: evaluator.skip_injection
+             skip_injection: evaluator.skip_injection)
     end
   end
 

--- a/decidim-conferences/spec/commands/publish_conference_speaker_spec.rb
+++ b/decidim-conferences/spec/commands/publish_conference_speaker_spec.rb
@@ -5,7 +5,7 @@ module Decidim
   module Conferences
     module Admin
       describe PublishConferenceSpeaker, type: :command do
-        let(:organization) { create :organization, available_locales: [:en] }
+        let(:organization) { create(:organization, available_locales: [:en]) }
         let(:conference_speaker) { create(:conference_speaker, published_at: nil) }
         let(:current_user) { create(:user, :admin, :confirmed, organization:) }
         let(:command) { described_class.new(conference_speaker, current_user) }

--- a/decidim-conferences/spec/commands/unpublish_conference_speaker_spec.rb
+++ b/decidim-conferences/spec/commands/unpublish_conference_speaker_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   module Conferences
     module Admin
       describe UnpublishConferenceSpeaker, type: :command do
-        let(:organization) { create :organization, available_locales: [:en] }
+        let(:organization) { create(:organization, available_locales: [:en]) }
         let(:conference_speaker) { create(:conference_speaker, published_at: Time.current) }
         let(:current_user) { create(:user, :admin, :confirmed, organization:) }
         let(:command) { described_class.new(conference_speaker, current_user) }

--- a/decidim-core/lib/decidim/core/test/shared_examples/permissions.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/permissions.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 
 shared_examples_for "general conversation permissions" do
   let(:context) { { conversation: } }
-  let(:another_user) { create :user }
-  let(:group) { create :user_group }
+  let(:another_user) { create(:user) }
+  let(:group) { create(:user_group) }
 
   context "when the originator of the conversation is the user" do
     let!(:conversation) do
@@ -46,7 +46,7 @@ shared_examples_for "general conversation permissions" do
   context "when the interlocutor is specified in the context" do
     let(:context) { { conversation:, interlocutor: } }
     let(:originator) { interlocutor }
-    let(:interlocutor) { create :user }
+    let(:interlocutor) { create(:user) }
 
     let!(:conversation) do
       Decidim::Messaging::Conversation.start!(
@@ -113,8 +113,8 @@ end
 
 shared_examples_for "restricted conversation permissions" do
   let(:context) { { conversation: } }
-  let(:user) { create :user }
-  let(:interlocutor) { create :user, organization: user.organization }
+  let(:user) { create(:user) }
+  let(:interlocutor) { create(:user, organization: user.organization) }
   let!(:conversation) do
     Decidim::Messaging::Conversation.start(
       originator: user,
@@ -128,14 +128,14 @@ shared_examples_for "restricted conversation permissions" do
   end
 
   context "when interlocutor restricts communications" do
-    let(:interlocutor) { create :user, direct_message_types: "followed-only" }
+    let(:interlocutor) { create(:user, direct_message_types: "followed-only") }
 
     context "and does not follow the user" do
       it { is_expected.to eq false }
     end
 
     context "and follows the user" do
-      let!(:follow) { create :follow, user: interlocutor, followable: user }
+      let!(:follow) { create(:follow, user: interlocutor, followable: user) }
 
       it { is_expected.to eq true }
     end

--- a/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
@@ -122,23 +122,23 @@ shared_examples "reports by user type" do
     include_examples "higher user role hides"
   end
   context "When reporting user is process admin" do
-    let!(:user) { create :process_admin, :confirmed, participatory_process: }
+    let!(:user) { create(:process_admin, :confirmed, participatory_process:) }
 
     include_examples "higher user role reports"
     include_examples "higher user role hides"
   end
   context "When reporting user is process collaborator" do
-    let!(:user) { create :process_collaborator, :confirmed, participatory_process: }
+    let!(:user) { create(:process_collaborator, :confirmed, participatory_process:) }
     include_examples "higher user role reports"
     include_examples "higher user role does not have hide"
   end
   context "When reporting user is process moderator" do
-    let!(:user) { create :process_moderator, :confirmed, participatory_process: }
+    let!(:user) { create(:process_moderator, :confirmed, participatory_process:) }
     include_examples "higher user role reports"
     include_examples "higher user role hides"
   end
   context "When reporting user is process valuator" do
-    let!(:user) { create :process_valuator, :confirmed, participatory_process: }
+    let!(:user) { create(:process_valuator, :confirmed, participatory_process:) }
     include_examples "higher user role reports"
     include_examples "higher user role does not have hide"
   end

--- a/decidim-core/lib/decidim/core/test/shared_examples/resource_endorsed_event_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/resource_endorsed_event_examples.rb
@@ -6,10 +6,10 @@ shared_examples_for "resource endorsed event" do
   include_context "when a simple event"
 
   let(:event_name) { "decidim.events.resource_endorsed" }
-  let(:author) { create :user, organization: resource.organization }
+  let(:author) { create(:user, organization: resource.organization) }
 
   let(:extra) { { endorser_id: author.id } }
-  let(:endorsement) { create :endorsement, resource:, author: }
+  let(:endorsement) { create(:endorsement, resource:, author:) }
   let(:resource_path) { resource_locator(resource).path }
   let(:follower) { create(:user, organization: resource.organization) }
   let(:follow) { create(:follow, followable: author, user: follower) }

--- a/decidim-core/lib/decidim/core/test/shared_examples/resource_search_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/resource_search_examples.rb
@@ -29,9 +29,9 @@ shared_examples_for "a resource search with scopes" do |factory_name|
   describe "scope_id filter" do
     let(:filter_params) { { with_any_scope: scope_ids } }
 
-    let(:scope1) { create :scope, organization: component.organization }
-    let(:scope2) { create :scope, organization: component.organization }
-    let(:subscope1) { create :scope, organization: component.organization, parent: scope1 }
+    let(:scope1) { create(:scope, organization: component.organization) }
+    let(:scope2) { create(:scope, organization: component.organization) }
+    let(:subscope1) { create(:scope, organization: component.organization, parent: scope1) }
 
     let!(:resource) { create(factory_name, { component:, scope: scope1 }.merge(factory_params)) }
     let!(:resource2) { create(factory_name, { component:, scope: scope2 }.merge(factory_params)) }
@@ -134,9 +134,9 @@ shared_examples_for "a resource search with categories" do |factory_name, catego
   end
 
   describe "results" do
-    let(:category1) { create :category, participatory_space: }
-    let(:category2) { create :category, participatory_space: }
-    let(:child_category) { create :category, participatory_space:, parent: category2 }
+    let(:category1) { create(:category, participatory_space:) }
+    let(:category2) { create(:category, participatory_space:) }
+    let(:child_category) { create(:category, participatory_space:, parent: category2) }
     let!(:resource) { create(factory_name, { component: }.merge(factory_params)) }
     let!(:resource2) { create(factory_name, { component:, category: category1 }.merge(factory_params)) }
     let!(:resource3) { create(factory_name, { component:, category: category2 }.merge(factory_params)) }

--- a/decidim-core/lib/decidim/core/test/shared_examples/searchable_resources_shared_context.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/searchable_resources_shared_context.rb
@@ -3,7 +3,7 @@
 RSpec.shared_context "when a resource is ready for global search" do
   let!(:organization) { create(:organization) }
   let!(:author) { create(:user, :admin, organization:) }
-  let!(:scope1) { create :scope, organization: }
+  let!(:scope1) { create(:scope, organization:) }
 
   let(:test_locales) { [:ca, :en, :es] }
   let(:description1) do

--- a/decidim-core/lib/decidim/core/test/shared_examples/translated_event_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/translated_event_examples.rb
@@ -26,7 +26,7 @@ shared_examples_for "a translated event" do
   end
 
   context "when is machine translated" do
-    let(:user) { create :user, organization:, locale: "ca" }
+    let(:user) { create(:user, organization:, locale: "ca") }
 
     around do |example|
       I18n.with_locale(user.locale) { example.run }

--- a/decidim-core/lib/decidim/core/test/shared_examples/with_endorsable_permissions_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/with_endorsable_permissions_examples.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 # users of this test should declare the `subject` variable.
 shared_examples "with endorsable permissions can perform actions related to endorsable" do
   let(:action_subject) { :endorsement }
-  let(:resource) { create :dummy_resource, component: }
+  let(:resource) { create(:dummy_resource, component:) }
   before do
     context[:current_settings] = double(current_settings)
     context[:resource] = resource

--- a/decidim-dev/config/rubocop/disabled.yml
+++ b/decidim-dev/config/rubocop/disabled.yml
@@ -10,8 +10,6 @@ Naming/MemoizedInstanceVariableName:
 RSpec/VerifiedDoubleReference:
   Enabled: false
 
-FactoryBot/ConsistentParenthesesStyle:
-  Enabled: false
 
 FactoryBot/ExcessiveCreateList:
   Enabled: false

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb
@@ -22,7 +22,7 @@ end
 
 shared_context "with a component" do
   let(:manifest) { Decidim.find_component_manifest(manifest_name) }
-  let(:user) { create :user, :confirmed, organization: }
+  let(:user) { create(:user, :confirmed, organization:) }
 
   let!(:organization) { create(:organization, *organization_traits, available_authorizations: %w(dummy_authorization_handler another_dummy_authorization_handler)) }
 
@@ -38,8 +38,8 @@ shared_context "with a component" do
            participatory_space:)
   end
 
-  let!(:category) { create :category, participatory_space: }
-  let!(:scope) { create :scope, organization: }
+  let!(:category) { create(:category, participatory_space:) }
+  let!(:scope) { create(:scope, organization:) }
 
   let(:organization_traits) { [] }
 
@@ -91,10 +91,10 @@ shared_context "when managing a component as an admin" do
   let(:admin_component_organization_traits) { [] }
 
   let(:user) do
-    create :user,
+    create(:user,
            :admin,
            :confirmed,
-           organization:
+           organization:)
   end
 end
 
@@ -102,9 +102,9 @@ shared_context "when managing a component as a process admin" do
   include_context "when managing a component"
 
   let(:user) do
-    create :process_admin,
+    create(:process_admin,
            :confirmed,
            organization:,
-           participatory_process:
+           participatory_process:)
   end
 end

--- a/decidim-forms/lib/decidim/forms/test/factories.rb
+++ b/decidim-forms/lib/decidim/forms/test/factories.rb
@@ -149,8 +149,8 @@ FactoryBot.define do
 
     trait :with_attachments do
       after(:create) do |answer, evaluator|
-        create :attachment, :with_image, attached_to: answer, skip_injection: evaluator.skip_injection
-        create :attachment, :with_pdf, attached_to: answer, skip_injection: evaluator.skip_injection
+        create(:attachment, :with_image, attached_to: answer, skip_injection: evaluator.skip_injection)
+        create(:attachment, :with_pdf, attached_to: answer, skip_injection: evaluator.skip_injection)
       end
     end
   end

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_answers.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_answers.rb
@@ -5,13 +5,13 @@ require "spec_helper"
 shared_examples_for "manage questionnaire answers" do
   let(:first_type) { "short_answer" }
   let!(:first) do
-    create :questionnaire_question, questionnaire:, position: 1, question_type: first_type
+    create(:questionnaire_question, questionnaire:, position: 1, question_type: first_type)
   end
   let!(:second) do
-    create :questionnaire_question, questionnaire:, position: 2, question_type: "single_option"
+    create(:questionnaire_question, questionnaire:, position: 2, question_type: "single_option")
   end
   let!(:third) do
-    create :questionnaire_question, questionnaire:, position: 3, question_type: "files"
+    create(:questionnaire_question, questionnaire:, position: 3, question_type: "files")
   end
   let(:questions) do
     [first, second, third]
@@ -25,10 +25,10 @@ shared_examples_for "manage questionnaire answers" do
   end
 
   context "when there are answers" do
-    let!(:answer1) { create :answer, questionnaire:, question: first }
-    let!(:answer2) { create :answer, body: "second answer", questionnaire:, question: first }
-    let!(:answer3) { create :answer, questionnaire:, question: second }
-    let!(:file_answer) { create :answer, :with_attachments, questionnaire:, question: third, body: nil, user: answer3.user, session_token: answer3.session_token }
+    let!(:answer1) { create(:answer, questionnaire:, question: first) }
+    let!(:answer2) { create(:answer, body: "second answer", questionnaire:, question: first) }
+    let!(:answer3) { create(:answer, questionnaire:, question: second) }
+    let!(:file_answer) { create(:answer, :with_attachments, questionnaire:, question: third, body: nil, user: answer3.user, session_token: answer3.session_token) }
 
     it "shows the answer admin link" do
       visit questionnaire_edit_path
@@ -76,9 +76,9 @@ shared_examples_for "manage questionnaire answers" do
 
       context "when multiple answer choice" do
         let(:first_type) { "multiple_option" }
-        let!(:answer1) { create :answer, questionnaire:, question: first, body: nil }
-        let!(:answer_option) { create :answer_option, question: first }
-        let!(:answer_choice) { create :answer_choice, answer: answer1, answer_option:, body: translated(answer_option.body, locale: I18n.locale) }
+        let!(:answer1) { create(:answer, questionnaire:, question: first, body: nil) }
+        let!(:answer_option) { create(:answer_option, question: first) }
+        let!(:answer_choice) { create(:answer_choice, answer: answer1, answer_option:, body: translated(answer_option.body, locale: I18n.locale)) }
 
         it "shows the answers page with custom body" do
           new_window = window_opened_by { find_all("a.action-icon.action-icon--eye").first.click }
@@ -94,7 +94,7 @@ shared_examples_for "manage questionnaire answers" do
     end
 
     context "and managing individual answer page" do
-      let!(:answer11) { create :answer, questionnaire:, body: "", user: answer1.user, question: second }
+      let!(:answer11) { create(:answer, questionnaire:, body: "", user: answer1.user, question: second) }
 
       before do
         visit questionnaire_edit_path
@@ -133,10 +133,10 @@ shared_examples_for "manage questionnaire answers" do
       end
 
       context "when the file answer does not have a title for the attachment" do
-        let!(:file_answer) { create :answer, questionnaire:, question: third, body: nil, user: answer3.user, session_token: answer3.session_token }
+        let!(:file_answer) { create(:answer, questionnaire:, question: third, body: nil, user: answer3.user, session_token: answer3.session_token) }
 
         before do
-          create :attachment, :with_image, attached_to: file_answer, title: {}, description: {}
+          create(:attachment, :with_image, attached_to: file_answer, title: {}, description: {})
         end
 
         it "third answer has download link for the attachments" do

--- a/decidim-meetings/lib/decidim/meetings/test/translated_event.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/translated_event.rb
@@ -4,17 +4,17 @@ shared_examples_for "a translated meeting event" do
   describe "translated notifications" do
     let(:en_body) { "This is Sparta!" }
     let(:body) { { en: en_body, machine_translations: { ca: "C'est Sparta!" } } }
-    let(:participatory_process) { create :participatory_process, organization: }
+    let(:participatory_process) { create(:participatory_process, organization:) }
     let(:meeting_component) { create(:meeting_component, participatory_space: participatory_process) }
     let(:translatable) { true }
     let(:en_version) { resource.description["en"] }
     let(:machine_translated) { resource.description["machine_translations"]["ca"] }
 
     let(:resource) do
-      create :meeting,
+      create(:meeting,
              component: meeting_component,
              title: { en: "A nice event", machine_translations: { ca: "Une belle event" } },
-             description: body
+             description: body)
     end
 
     it_behaves_like "a translated event"

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -82,7 +82,7 @@ FactoryBot.define do
 
     trait :with_scope do
       scopes_enabled { true }
-      scope { create :scope, organization:, skip_injection: }
+      scope { create(:scope, organization:, skip_injection:) }
     end
 
     trait :with_content_blocks do
@@ -186,10 +186,10 @@ FactoryBot.define do
     admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
-      create :participatory_process_user_role,
+      create(:participatory_process_user_role,
              user:,
              participatory_process: evaluator.participatory_process,
-             role: :admin, skip_injection: evaluator.skip_injection
+             role: :admin, skip_injection: evaluator.skip_injection)
     end
   end
 
@@ -203,10 +203,10 @@ FactoryBot.define do
     admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
-      create :participatory_process_user_role,
+      create(:participatory_process_user_role,
              user:,
              participatory_process: evaluator.participatory_process,
-             role: :collaborator, skip_injection: evaluator.skip_injection
+             role: :collaborator, skip_injection: evaluator.skip_injection)
     end
   end
 
@@ -220,10 +220,10 @@ FactoryBot.define do
     admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
-      create :participatory_process_user_role,
+      create(:participatory_process_user_role,
              user:,
              participatory_process: evaluator.participatory_process,
-             role: :moderator, skip_injection: evaluator.skip_injection
+             role: :moderator, skip_injection: evaluator.skip_injection)
     end
   end
 
@@ -237,10 +237,10 @@ FactoryBot.define do
     admin_terms_accepted_at { Time.current }
 
     after(:create) do |user, evaluator|
-      create :participatory_process_user_role,
+      create(:participatory_process_user_role,
              user:,
              participatory_process: evaluator.participatory_process,
-             role: :valuator, skip_injection: evaluator.skip_injection
+             role: :valuator, skip_injection: evaluator.skip_injection)
     end
   end
 
@@ -249,7 +249,7 @@ FactoryBot.define do
       skip_injection { false }
     end
     user
-    participatory_process { create :participatory_process, organization: user.organization, skip_injection: }
+    participatory_process { create(:participatory_process, organization: user.organization, skip_injection:) }
     role { "admin" }
   end
 end

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -572,7 +572,7 @@ FactoryBot.define do
     valuator_role do
       space = proposal.component.participatory_space
       organization = space.organization
-      build :participatory_process_user_role, role: :valuator, skip_injection:, user: build(:user, organization:, skip_injection:)
+      build(:participatory_process_user_role, role: :valuator, skip_injection:, user: build(:user, organization:, skip_injection:))
     end
   end
 end

--- a/decidim-templates/spec/permissions/decidim/templates/admin/permissions_spec.rb
+++ b/decidim-templates/spec/permissions/decidim/templates/admin/permissions_spec.rb
@@ -72,9 +72,9 @@ describe Decidim::Templates::Admin::Permissions do
       let(:user) { create(:user, :confirmed, organization:) }
       let!(:valuator_role) { create(:participatory_process_user_role, role: :valuator, user:, participatory_process: participatory_space) }
       let!(:valuation_assignment) { create(:valuation_assignment, proposal:, valuator_role:) }
-      let(:proposal) { create :proposal, component: }
+      let(:proposal) { create(:proposal, component:) }
       let(:component) { create(:proposal_component, participatory_space:) }
-      let(:participatory_space) { create :participatory_process, organization: }
+      let(:participatory_space) { create(:participatory_process, organization:) }
       let(:action) do
         { scope: :admin, action: action_str, subject: :template }
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #13146 we have upgraded rubocop & friends which added new rules that were disabled at that point. This PR makes sure the `FactoryBot/ConsistentParenthesesStyle` rule is enforced by linter. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13146 

#### Testing
1. Make sure the pipeline is green

:hearts: Thank you!
