### PR TITLE
Revert Chrome overrides

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -137,32 +137,8 @@ Capybara.save_path = Rails.root.join("tmp/screenshots")
 Capybara.default_max_wait_time = 10
 
 RSpec.configure do |config|
-  config.before :all, type: :system do
-    if ENV["BIG_SCREEN_SIZE"].present?
-      warn "[DECIDIM] ChromeDriver Workaround is being active: Setting window size to 1920x3000."
-    else
-      warn "[DECIDIM] ChromeDriver Workaround is being active: Setting window size to 1920x1080."
-    end
-  end
-
   config.before :each, type: :system do
     driven_by(:headless_chrome)
-
-    # Workaround for flaky spec related to resolution change
-    #
-    # For some unknown reason, depending on the order run for these specs, the resolution is changed to
-    # 800x600, which breaks the drag and drop. This forces the resolution to be 1920x1080.
-    # One possible culprit for the screen resolution change is the alert error intercepting which messes with the window focus.
-    # This has been reported to SeleniumHQ, https://github.com/SeleniumHQ/selenium/issues/13553
-    # and to the chromedriver project, https://bugs.chromium.org/p/chromedriver/issues/detail?id=4709
-    #
-    # Note to future maintainers: If you remove this workaround, please make sure to check if the issue has been fixed.
-    # If that is the case, please remove this comment, workaround, and the above warning that starts with "[DECIDIM] ChromeDriver Workaround".
-    if ENV["BIG_SCREEN_SIZE"].present?
-      current_window.resize_to(1920, 3000)
-    else
-      current_window.resize_to(1920, 1080)
-    end
 
     switch_to_default_host
     domain = (try(:organization) || try(:current_organization))&.host


### PR DESCRIPTION
#### :tophat: What? Why?
Back into #12398 we fixed the pipeline by adding a screen resize before each one of specs that were ran. This PR reverts this, as the fix has been applied on chromedriver. 
I am reverting this fix, as there are some log entries that we added, and now, i consider it just pollutes the 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12398

#### Testing
1. The pipeline should be green 
2. There should not be messages like `ChromeDriver Workaround is being active`  in the action log

:hearts: Thank you!
