### PR TITLE
Backport 'Add missing require for ParallelTests' to v0.29

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "parallel_tests"
 require "selenium-webdriver"
 
 module Decidim


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #13170 to v0.29

:hearts: Thank you!