### PR TITLE
Map the redis port for the test app actions

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -66,6 +66,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
       redis:
         image: redis
+        ports: ["6379:6379"]
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -32,6 +32,8 @@ end
 
 1.step do
   port = rand(5000..6999)
+  next if port == 6379 # Reserved for Redis
+
   begin
     redis = Redis.new
     reserved_ports = (redis.get("decidim_test_capybara_reserved_ports") || "").split(",").map(&:to_i)


### PR DESCRIPTION
#### :tophat: What? Why?
I received the following error in a recent action run:
> #<Thread:0x00007f0b1b1519e0 /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/capybara-3.40.0/lib/capybara/server.rb:76 run> terminated with exception (report_on_exception is true):
/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/puma-6.4.2/lib/puma/binder.rb:334:in `initialize': Address already in use - bind(2) for "127.0.0.1" port 6242 (Errno::EADDRINUSE)
	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/puma-6.4.2/lib/puma/binder.rb:334:in `new'
	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/puma-6.4.2/lib/puma/binder.rb:334:in `add_tcp_listener'
	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/puma-6.4.2/lib/puma/binder.rb:163:in `block in parse'
	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/puma-6.4.2/lib/puma/binder.rb:146:in `each'
	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/puma-6.4.2/lib/puma/binder.rb:146:in `parse'
	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/capybara-3.40.0/lib/capybara/registrations/servers.rb:63:in `block (2 levels) in <top (required)>'
	from <internal:kernel>:90:in `tap'
	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/capybara-3.40.0/lib/capybara/registrations/servers.rb:62:in `block in <top (required)>'
	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/capybara-3.40.0/lib/capybara/config.rb:64:in `block in server='
	from /opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/gems/3.2.0/gems/capybara-3.40.0/lib/capybara/server.rb:77:in `block in boot'

Whole logs available at:
https://github.com/decidim/decidim/actions/runs/10042209706/job/27752308455?pr=12576

I think this is related to the fact that the Redis port is not mapped to the host machine because Redis should take care of keeping a list of reserved ports (although conflicts are still possible if the port resolution happens exactly at the same time.

Also I marked the Redis port to be skipped in order to keep that reserved for Redis.

#### :pushpin: Related Issues
- Related to #12705

#### Testing
I don't think there is an easy way to test this other than trying to re-introduce a port conflict which requires running the workflows several times.