### PR TITLE
Validate email and show errors in omniauth registration failure

### DIFF
--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -19,6 +19,7 @@ module Decidim
     # Returns nothing.
     def call
       verify_oauth_signature!
+      return broadcast(:invalid) if form.invalid?
 
       begin
         if existing_identity

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -32,7 +32,7 @@ module Decidim
           end
 
           on(:invalid) do
-            set_flash_message :notice, :success, kind: @form.provider.capitalize
+            flash[:alert] = t("decidim.devise.omniauth_registrations.create.invalid")
             render :new
           end
 

--- a/decidim-core/app/forms/decidim/omniauth_registration_form.rb
+++ b/decidim-core/app/forms/decidim/omniauth_registration_form.rb
@@ -20,12 +20,25 @@ module Decidim
     validates :provider, presence: true
     validates :uid, presence: true
 
+    validates :email, presence: true, "valid_email_2/email": { disposable: true }
+    validate :email_unique_in_organization
+
     def self.create_signature(provider, uid)
       Digest::MD5.hexdigest("#{provider}-#{uid}-#{Rails.application.secrets.secret_key_base}")
     end
 
     def normalized_nickname
       UserBaseEntity.nicknamize(nickname || name, organization: current_organization)
+    end
+
+    private
+
+    def email_unique_in_organization
+      errors.add :email, :taken if valid_users.find_by(email:, organization: current_organization).present?
+    end
+
+    def valid_users
+      UserBaseEntity.where(invitation_token: nil)
     end
   end
 end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -582,6 +582,7 @@ en:
       omniauth_registrations:
         create:
           email_already_exists: Another account is using the same email address.
+          invalid: There was an error with your account creation.
         new:
           complete_profile: Complete profile
           nickname_help: Your alias in %{organization}. Can only contain letters, numbers, '-' and '_'.


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing #13128, I found a couple problems in the omniauth registration flow:

1. I could try to register myself with an invalid email (like the string "11111") 
2. The form didn't show any error, and it showed a success message

This PR fixes those errors, by adding some minimal validations and actually showing the error messages. 
 
#### Testing

1. Go to the login page
2. Click in the "Developer" omniauth strategy
3. Fill the "11111" in all the fields of the form
4. Submit
5. See the error 

### :camera: Screenshots

![Screenshot of the error message in this form](https://github.com/user-attachments/assets/ba9768a7-230d-48bd-9edb-dcac151512fa)

:hearts: Thank you!
