### PR TITLE
Fix deprecation warnings from SASS

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -72,6 +72,15 @@
 .dropdown {
   @apply absolute border-2 border-gray-3 rounded min-w-max p-4 drop-shadow-md text-left z-10;
 
+  /*
+    NOTE: the calculated value is the sum of the arrow offset position plus the half of the arrow size:
+    - offset position: 20%
+    - arrow size: 1.5rem
+  */
+  --arrow-offset: 20%;
+  --arrow-size: 1.5rem;
+  --arrow-visible-size: var(--arrow-size) * 0.5;
+
   & > * {
     @apply relative z-10 p-3.5 first:pt-1.5 last:pb-1.5;
   }
@@ -89,15 +98,6 @@
       @apply underline [&>svg]:text-secondary;
     }
   }
-
-  /*
-    NOTE: the calculated value is the sum of the arrow offset position plus the half of the arrow size:
-    - offset position: 20%
-    - arrow size: 1.5rem
-  */
-  --arrow-offset: 20%;
-  --arrow-size: 1.5rem;
-  --arrow-visible-size: var(--arrow-size) * 0.5;
 
   &__bottom {
     @apply top-full right-0 mt-3 translate-x-[calc(var(--arrow-offset)-var(--arrow-visible-size))] before:content-[''] before:absolute before:right-[var(--arrow-offset)] before:-top-2 before:w-[var(--arrow-size)] before:h-[var(--arrow-size)] before:rotate-45 before:bg-white before:rounded before:border-2 before:border-gray-3 after:content-[''] after:absolute after:left-0 after:top-0 after:w-full after:h-full after:bg-white;

--- a/decidim-core/app/packs/stylesheets/decidim/_forms.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_forms.scss
@@ -53,16 +53,16 @@
   }
 
   select {
-    &:not(.reset-defaults) {
-      @apply pr-8;
-    }
-
     @apply appearance-none;
 
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 12 8'%3e%3cpath fill='%233E4C5C' d='M5.99962 4.97656L10.1246 0.851562L11.303 2.0299L5.99962 7.33323L0.696289 2.0299L1.87462 0.851562L5.99962 4.97656Z'/%3e%3c/svg%3e");
     background-position: right 1rem center;
     background-repeat: no-repeat;
     background-size: 0.75rem;
+
+    &:not(.reset-defaults) {
+      @apply pr-8;
+    }
   }
 }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_tooltip.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_tooltip.scss
@@ -1,6 +1,16 @@
 [role="tooltip"] {
   @apply absolute bg-black z-10 px-4 py-2 w-max max-w-xs rounded text-left text-white;
 
+  /*
+    NOTE: the calculated value is the sum of the arrow offset position plus the half of the arrow size:
+    - offset position: 20%
+    - arrow size: 16px
+  */
+  --arrow-offset: 20%;
+  --arrow-size: 16px;
+  --arrow-visible-size: var(--arrow-size) * 0.5;
+  --arrow-margin: var(--arrow-visible-size) * 1.4142135623730951; // due to the rotation, the margin is SQRT2 times the visible size
+
   & > * {
     @apply relative z-20;
   }
@@ -40,16 +50,6 @@
       visibility: hidden;
     }
   }
-
-  /*
-    NOTE: the calculated value is the sum of the arrow offset position plus the half of the arrow size:
-    - offset position: 20%
-    - arrow size: 16px
-  */
-  --arrow-offset: 20%;
-  --arrow-size: 16px;
-  --arrow-visible-size: var(--arrow-size) * 0.5;
-  --arrow-margin: var(--arrow-visible-size) * 1.4142135623730951; // due to the rotation, the margin is SQRT2 times the visible size
 
   &.top {
     @apply -translate-x-[calc(100%-var(--arrow-offset))] -translate-y-[calc(100%+var(--arrow-margin))] before:content-[''] before:absolute before:-z-10 before:right-[calc(var(--arrow-offset)-var(--arrow-visible-size))] before:-bottom-[var(--arrow-visible-size)] before:w-[var(--arrow-size)] before:h-[var(--arrow-size)] before:rotate-45 before:bg-black before:rounded-br;


### PR DESCRIPTION
#### :tophat: What? Why?

There are some deprecation warnings when building the assets that come from a change in SASS syntax:

```
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls
```

This PR fixes those error messages. The only deprecation warnings left are from tom-select, it was reported in this issue: https://github.com/orchidjs/tom-select/issues/742

#### Testing

Run `rm -rf public/decidim-packs/ ; bin/rails assets:precompile` and see the output (before and after this patch) 

:hearts: Thank you!
