### PR TITLE
Fix malformed URL in version control page

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/versions/show.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/versions/show.html.erb
@@ -9,7 +9,7 @@
   <%= cell(
     "decidim/version",
     current_version,
-    index: params[:id],
+    index: params[:id].to_i,
     versioned_resource: versioned_resource,
     versions_path: proc { url_for(action: :index) },
     i18n_scope: "decidim.accountability.results.show.stats"

--- a/decidim-accountability/spec/system/explore_versions_spec.rb
+++ b/decidim-accountability/spec/system/explore_versions_spec.rb
@@ -103,5 +103,13 @@ describe "Explore versions", versioning: true, type: :system do
         end
       end
     end
+
+    context "when the version number is malformed" do
+      it "displays the page correctly" do
+        visit %{#{current_path}'XSS<script>alert('version')<%2Fscript>}
+
+        expect(page).to have_content("VERSION NUMBER\n2 out of 2")
+      end
+    end
   end
 end

--- a/decidim-core/app/cells/decidim/version_cell.rb
+++ b/decidim-core/app/cells/decidim/version_cell.rb
@@ -50,7 +50,7 @@ module Decidim
     end
 
     def i18n(string, **params)
-      t(string, **params, scope: i18n_scope, default: t(string, **params, scope: default_i18n_scope))
+      decidim_html_escape(t(string, **params, scope: i18n_scope, default: t(string, **params, scope: default_i18n_scope)))
     end
 
     def i18n_scope

--- a/decidim-debates/app/views/decidim/debates/versions/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/versions/show.html.erb
@@ -2,7 +2,7 @@
   <%= cell(
     "decidim/version",
     current_version,
-    index: params[:id],
+    index: params[:id].to_i,
     versioned_resource: versioned_resource,
     versions_path: proc { url_for(action: :index) },
     i18n_scope: "decidim.debates.debates.versions.debates"

--- a/decidim-debates/spec/system/debates_versions_spec.rb
+++ b/decidim-debates/spec/system/debates_versions_spec.rb
@@ -102,6 +102,14 @@ describe "Explore versions", versioning: true, type: :system do
         end
       end
     end
+
+    context "when the version number is malformed" do
+      it "displays the page correctly" do
+        visit %{#{current_path}'XSS<script>alert('version')<%2Fscript>}
+
+        expect(page).to have_content("VERSION NUMBER\n2 out of 2")
+      end
+    end
   end
 
   def update_debate

--- a/decidim-initiatives/app/views/decidim/initiatives/versions/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/versions/show.html.erb
@@ -2,7 +2,7 @@
   <%= cell(
     "decidim/version",
     current_version,
-    index: params[:id],
+    index: params[:id].to_i,
     versioned_resource: versioned_resource,
     versions_path: proc { url_for(action: :index) },
     i18n_scope: "decidim.initiatives.versions.shared"

--- a/decidim-initiatives/spec/system/initiatives_versions_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_versions_spec.rb
@@ -132,5 +132,13 @@ describe "Explore versions", versioning: true, type: :system do
         end
       end
     end
+
+    context "when the version number is malformed" do
+      it "displays the page correctly" do
+        visit %{#{current_path}'XSS<script>alert('version')<%2Fscript>}
+
+        expect(page).to have_content("VERSION NUMBER\n2 out of 2")
+      end
+    end
   end
 end

--- a/decidim-meetings/app/views/decidim/meetings/versions/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/versions/show.html.erb
@@ -2,7 +2,7 @@
   <%= cell(
     "decidim/version",
     current_version,
-    index: params[:id],
+    index: params[:id].to_i,
     versioned_resource: versioned_resource,
     versions_path: proc { url_for(action: :index) },
     i18n_scope: "decidim.meetings.versions"

--- a/decidim-meetings/spec/system/explore_versions_spec.rb
+++ b/decidim-meetings/spec/system/explore_versions_spec.rb
@@ -108,5 +108,13 @@ describe "Explore versions", versioning: true, type: :system do
         end
       end
     end
+
+    context "when the version number is malformed" do
+      it "displays the page correctly" do
+        visit %{#{current_path}'XSS<script>alert('version')<%2Fscript>}
+
+        expect(page).to have_content("VERSION NUMBER\n2 out of 2")
+      end
+    end
   end
 end

--- a/decidim-proposals/app/views/decidim/proposals/versions/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/versions/show.html.erb
@@ -10,7 +10,7 @@ end
   <%= cell(
     "decidim/version",
     current_version,
-    index: params[:id],
+    index: params[:id].to_i,
     versioned_resource: versioned_resource,
     versions_path: proc { url_for(action: :index) },
     i18n_scope: "decidim.proposals.versions.#{item_name.to_s.pluralize}"

--- a/decidim-proposals/spec/system/collaborative_drafts_versions_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_versions_spec.rb
@@ -114,6 +114,14 @@ describe "Explore versions", versioning: true, type: :system do
         end
       end
     end
+
+    context "when the version number is malformed" do
+      it "displays the page correctly" do
+        visit %{#{current_path}'XSS<script>alert('version')<%2Fscript>}
+
+        expect(page).to have_content("VERSION NUMBER\n2 out of 2")
+      end
+    end
   end
 
   context "when visiting the collaborative draft details" do

--- a/decidim-proposals/spec/system/proposals_versions_spec.rb
+++ b/decidim-proposals/spec/system/proposals_versions_spec.rb
@@ -134,5 +134,13 @@ describe "Explore versions", versioning: true, type: :system do
         end
       end
     end
+
+    context "when the version number is malformed" do
+      it "displays the page correctly" do
+        visit %{#{current_path}'XSS<script>alert('version')<%2Fscript>}
+
+        expect(page).to have_content("VERSION NUMBER\n2 out of 2")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

The version control page can receive a malformed param. This PR fixes it.  

As this only happens in v0.27, the fix is directly to that branch (instead of doing it as usual, by merging to develop and backporting)

#### Testing

Everything should be green

:hearts: Thank you!
