### PR TITLE
Overwrite admin "Cell" -helper method

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/application_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/application_helper.rb
@@ -16,6 +16,19 @@ module Decidim
       include Decidim::Admin::ResourceScopeHelper
       include Decidim::Admin::SearchFormHelper
 
+      # Public: Overwrites the `cell` helper method to automatically set some
+      # common context.
+      #
+      # name - the name of the cell to render
+      # model - the cell model
+      # options - a Hash with options
+      #
+      # Renders the cell contents.
+      def cell(name, model, options = {}, &)
+        options = { context: { view_context: self, current_user: } }.deep_merge(options)
+        super
+      end
+
       def participatory_space_active_link?(component)
         endpoints = component.manifest.admin_engine.try(:participatory_space_endpoints)
         endpoints && is_active_link?(decidim_admin_participatory_processes.components_path(current_participatory_space), %r{/\d+/manage/(#{endpoints.join("|")})\b})


### PR DESCRIPTION
#### :tophat: What? Why?
When using cells in the Admin -side of Decidim, the view context was not automatically handled because of shakapacker and missing an overwrite that exists in the public side. This PR adds the overwrite to the admin side and allows cells to automatically set the context.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #13111

:hearts: Thank you!
