### PR TITLE
Fix ProposalStates migration

### DIFF
--- a/decidim-proposals/db/migrate/20240110203504_create_default_proposal_states.rb
+++ b/decidim-proposals/db/migrate/20240110203504_create_default_proposal_states.rb
@@ -14,6 +14,8 @@ class CreateDefaultProposalStates < ActiveRecord::Migration[6.1]
   end
 
   def up
+    CustomProposal.reset_column_information
+    Decidim::Proposals::ProposalState.reset_column_information
     Decidim::Component.where(manifest_name: "proposals").find_each do |component|
       admin_user = component.organization.admins.first
       Decidim::Proposals.create_default_states!(component, admin_user)

--- a/decidim-proposals/db/migrate/20240110203504_create_default_proposal_states.rb
+++ b/decidim-proposals/db/migrate/20240110203504_create_default_proposal_states.rb
@@ -15,14 +15,13 @@ class CreateDefaultProposalStates < ActiveRecord::Migration[6.1]
 
   def up
     Decidim::Component.where(manifest_name: "proposals").find_each do |component|
-
       admin_user = component.organization.admins.first
       Decidim::Proposals.create_default_states!(component, admin_user)
 
       CustomProposal.where(decidim_component_id: component.id).find_each do |proposal|
         next if proposal.old_state == "not_answered"
-      
-        proposal.update!(proposal_state: Decidim::Proposals::ProposalState.where(component: component, token: proposal.old_state).first!)
+
+        proposal.update!(proposal_state: Decidim::Proposals::ProposalState.where(component:, token: proposal.old_state).first!)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR attempt to fix the Proposal states migration. During the upgrade of MetaDecidim and some other projects from 0.28 to the latest 0.29,  we noticed the states are not properly migrated  resulting in errors on the search results page. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13164

#### Testing
1. Create a 0.28 development application 
2. Follow 0.29 upgrade steps
3. Run migrations 
4. start the server and visit the search page 
5. See the proposals are raising errors or is not displaying any state 
6. Apply the patch 
7. Repeat 1,2,3,4
8. See the proposals are displaying the states properly.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
