### PR TITLE
Fix fat footer disposition in large resolution

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_footer.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_footer.scss
@@ -3,7 +3,7 @@ footer {
     @apply bg-gray-4;
 
     &__top {
-      @apply hidden flex flex-col lg:flex-row lg:block gap-8 container py-10;
+      @apply hidden lg:flex flex-row gap-8 container py-10;
     }
 
     &__down {

--- a/decidim-core/app/views/layouts/decidim/footer/_main.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main.html.erb
@@ -3,7 +3,7 @@
     <div class="lg:w-1/3">
       <%= render partial: "layouts/decidim/footer/main_intro" %>
     </div>
-    <div class="lg:w-2/3 grid grid-cols-1 gap-x-44 gap-y-10 lg:grid-cols-4 text-md text-white">
+    <div class="lg:w-2/3 grid grid-cols-1 gap-x-4 gap-y-10 lg:grid-cols-4 text-md text-white">
       <%= render partial: "layouts/decidim/footer/main_links" %>
     </div>
   </div>


### PR DESCRIPTION
#### :tophat: What? Why?

After we merged #13012, we actually have broken the fat footer in big resolutions. This PR fixes that.

This should only be backported to v0.29 

#### :pushpin: Related Issues
 
- Related to #13012 

#### Testing

1. Go to the footer in large and medium resolutions
2. See that it doesn't break 

### :camera: Screenshots

#### Before

![Broken footer](https://github.com/user-attachments/assets/7e73b664-4500-41cb-ba6c-43d2e581681b)

#### After

![Fixed footer (1/3)](https://github.com/user-attachments/assets/c2297e30-56f2-47de-a37a-3695f2972dc0)
![Fixed footer (2/3)](https://github.com/user-attachments/assets/4b4b8f83-635e-4066-8ba6-12aaedf267d3)
![Fixed footer (3/3)](https://github.com/user-attachments/assets/b872ce9e-94f4-4c3a-9c83-d9511b4c2b81)

:hearts: Thank you!
