### PR TITLE
Fix details in filters' elements

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_filters.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_filters.scss
@@ -1,6 +1,8 @@
 .filter {
+  @apply flex gap-2 p-1.5 relative;
+
   label {
-    @apply flex items-center gap-2 p-1.5 rounded cursor-pointer relative;
+    @apply flex items-center gap-2 p-1.5 rounded cursor-pointer relative w-full;
   }
 
   &-container {


### PR DESCRIPTION
#### :tophat: What? Why?

After we merged #13142 we introduced some minor styling issues in the filters with SVG images (as it is in the General Search page, the Accountability page, and the Last Activities page).

This PR fixes those issues.

This should only be backported to v0.29 (as in v0.28 this doesn't happen)

#### :pushpin: Related Issues
 
- Related to  https://github.com/decidim/decidim/pull/12746 
 
#### Testing

1. Go to an accountability search, filter some elements 
2. Search something in the general search, filter some elements - http://localhost:3000/search?term=est
3. Go to the last activities page, filter some elements - http://localhost:3000/last_activities?locale=en 

### :camera: Screenshots

#### Before

![Accountability page (broken)](https://github.com/user-attachments/assets/e0243492-9166-46c7-b831-88b909d467bf)
![Search page (broken)](https://github.com/user-attachments/assets/f098a72d-3bdc-4e62-b6f3-25d47f36d930)

#### After

![Accountability page (fixed)](https://github.com/user-attachments/assets/2f09d0c7-6779-4e6e-ae1b-2820767e4824)
![Search page (fixed)](https://github.com/user-attachments/assets/b7224118-bc0b-4222-88cc-007d932f1719)

:hearts: Thank you!
