### PR TITLE
Preserve filters when changing the view mode

### DIFF
--- a/decidim-proposals/app/helpers/decidim/proposals/proposals_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/proposals_helper.rb
@@ -17,8 +17,8 @@ module Decidim
           translated_attribute(@proposal.execution_period).present?
       end
 
-      def toggle_view_mode_link(current_mode, target_mode, title)
-        path = proposals_path(view_mode: target_mode)
+      def toggle_view_mode_link(current_mode, target_mode, title, params)
+        path = proposals_path(params.permit(:order, filter: {}).merge({ view_mode: target_mode }))
         icon_name = target_mode == "grid" ? "layout-grid-fill" : "list-check"
         icon_class = "view-icon--disabled" unless current_mode == target_mode
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
@@ -10,8 +10,8 @@
   <div class="flex items-center justify-between">
     <h2 class="h5 md:h3 decorator"><%= t("count", scope: "decidim.proposals.proposals.index", count: @proposals.total_count) %></h2>
     <div class="view-layout__links flex view_mode__links">
-      <%= toggle_view_mode_link(@view_mode, "list", t("list_mode", scope: "decidim.proposals.proposals.index")) %>
-      <%= toggle_view_mode_link(@view_mode, "grid", t("grid_mode", scope: "decidim.proposals.proposals.index")) %>
+      <%= toggle_view_mode_link(@view_mode, "list", t("list_mode", scope: "decidim.proposals.proposals.index"), params) %>
+      <%= toggle_view_mode_link(@view_mode, "grid", t("grid_mode", scope: "decidim.proposals.proposals.index"), params) %>
     </div>
   </div>
 

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -674,6 +674,23 @@ describe "Proposals" do
       end
     end
 
+    context "when participants are filtering proposals" do
+      let!(:evaluating_proposals) { create_list(:proposal, 3, :evaluating, component:) }
+      let!(:accepted_proposals) { create_list(:proposal, 5, :accepted, component:) }
+
+      it "filters the proposals and keeps the filter when changing the view mode" do
+        visit_component
+        uncheck "Evaluating"
+
+        expect(page).to have_css("[id^='proposals__proposal']", count: 5)
+
+        find("a[href*='view_mode=grid']").click
+
+        expect(page).to have_css(".card__grid-img svg#ri-proposal-placeholder-card-g", count: 5)
+        expect(page).to have_css("[id^='proposals__proposal']", count: 5)
+      end
+    end
+
     context "when participants are viewing a list of proposals" do
       it "shows a list of proposals" do
         visit_component


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing the v0.29.0.rc3 in Metadecidim, we found an issue regarding the new feature view mode: when you use it while filtering, it doesn't saves the filtered elements.

This PR fixes that.

It should only be backported to v0.29 (as this feature wasn't available in v0.28)

#### :pushpin: Related Issues
 
- Related to #12883

#### Testing

1. Go to a proposals component index page
2. Filter the proposals
3. Change the view mode
4. See that the filtered proposals remain

### :camera: Screenshots

[proposals-filters-view-mode.webm](https://github.com/user-attachments/assets/4fca8208-62d6-4b40-969f-8b284d24dc9e)

:hearts: Thank you!
