### PR TITLE
Show custom proposal states in grid view mode

### DIFF
--- a/decidim-proposals/app/cells/decidim/proposals/proposal_g/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_g/show.erb
@@ -9,7 +9,7 @@
   <div class="<%= classes[:text] %>">
     <div class="card__grid-text-title">
       <%= content_tag title_tag, title, class: title_class %>
-      <%= proposal_state_item[:text] if proposal_state_item.present? %>
+      <%= state_item[:text] if state_item.present? %>
     </div>
 
     <%= description if show_description? %>

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_g_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_g_cell.rb
@@ -10,7 +10,7 @@ module Decidim
       include Decidim::Proposals::ApplicationHelper
       include Decidim::LayoutHelper
 
-      delegate :state_class, to: :metadata_cell_instance
+      delegate :state_item, to: :metadata_cell_instance
 
       def show
         render
@@ -30,12 +30,6 @@ module Decidim
 
       def resource_image_path
         model.attachments.first&.url
-      end
-
-      def proposal_state_item
-        return if model.state.blank?
-
-        @proposal_state_item ||= { text: content_tag(:span, humanize_proposal_state(model.state), class: "label #{state_class}") }
       end
 
       private

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_g_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_g_cell_spec.rb
@@ -19,7 +19,8 @@ module Decidim::Proposals
 
     describe "show" do
       it "renders the proposal state item with appropriate class" do
-        expect(subject).to have_css("span.warning", text: "Evaluating")
+        expect(subject).to have_css("span.label", text: "Evaluating")
+        expect(subject).to have_css("span.label", style: "background-color: #FFF1E5; color: #BC4C00; border-color: #BC4C00;")
       end
 
       it "renders the proposal title" do
@@ -39,6 +40,18 @@ module Decidim::Proposals
 
         it "renders a placeholder image" do
           expect(subject).to have_css(".card__grid-img svg#ri-proposal-placeholder-card-g")
+        end
+      end
+
+      context "when the proposal has a custom state" do
+        let!(:state) { create(:proposal_state, component:, token: :finished, title: { en: "Finished" }) }
+
+        before do
+          proposal.update!(proposal_state: state)
+        end
+
+        it "renders the custom state" do
+          expect(subject).to have_content "Finished"
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

There's a  bug related to the new "Grid" view mode in proposals if there's a custom proposal state.

This PR fixes it.

It should only be backported to v0.29

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to  #12052
- Related to #12883 

#### Testing

1. Sign in as admin
2. Go to a proposals component in the admin
3. Create a new custom proposal state with any string and any color
4. Answer a proposal and assign it this new state
5. Go to the proposals index page for participants
6. See that you have the correct state in the "List" view mode
7. Change the view mode to "Grid"
8. (Before this patch) See that you have the "Not answered" state
9. (After this patch) See that you have the custom state 

### :camera: Screenshots

#### Before

![Card G with an incorrect state](https://github.com/user-attachments/assets/83919cda-70ea-4f7e-8e97-6fc88809374f)

#### After

![Card G with the correct state](https://github.com/user-attachments/assets/599d3ecd-33e0-48f0-a674-e2cfc70b6fec)

:hearts: Thank you!
