### PR TITLE
Switch from Rails.application.secrets to Rails.application.credentials

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,7 +42,36 @@ You can read more about this change on PR [#13185](https://github.com/decidim/de
 
 These are one time actions that need to be done after the code is updated in the production database.
 
-### 3.1. [[TITLE OF THE ACTION]]
+### 3.1. Migration from secrets to credentials
+
+Starting with the rails 7.1 upgrade, we have noticed that the screts will be removed starting with rails 7.2. In order to upgrade more easy to rails 7.2, we have removed the secrets from our application, converting them to credentials.
+
+If your application is using `Rails.application.secrets` anywhere, please change your code to use `Rails.application.credentials`.
+
+In case you do not want to rely on the old `config/secrets.yml` file, please follow the next steps:
+
+```bash
+EDITOR=vim ./bin/rails credentials:edit --environment production
+```
+
+This will open a vim editor where you can add add your credentials. This will generate you 2 new files:
+
+```bash
+config/credentials/production.key
+config/credentials/production.yml.enc
+```
+
+You will need to repeat the same process for all 3 environments :
+```bash
+EDITOR=vim ./bin/rails credentials:edit --environment test
+EDITOR=vim ./bin/rails credentials:edit --environment development
+```
+
+**Please note:** The new credentials files do not support reading environment variables.
+
+You can read more about this change on PR [#13220](https://github.com/decidim/decidim/pull/13220).
+
+### 3.2. [[TITLE OF THE ACTION]]
 
 You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,7 +44,7 @@ These are one time actions that need to be done after the code is updated in the
 
 ### 3.1. Migration from secrets to credentials
 
-Starting with the rails 7.1 upgrade, we have noticed that the screts will be removed starting with rails 7.2. In order to upgrade more easy to rails 7.2, we have removed the secrets from our application, converting them to credentials.
+Starting with the rails 7.1 upgrade, we have noticed that the secrets will be removed starting with rails 7.2. In order to upgrade more easy to rails 7.2, we have removed the secrets from our application, converting them to credentials.
 
 If your application is using `Rails.application.secrets` anywhere, please change your code to use `Rails.application.credentials`.
 
@@ -54,7 +54,7 @@ In case you do not want to rely on the old `config/secrets.yml` file, please fol
 EDITOR=vim ./bin/rails credentials:edit --environment production
 ```
 
-This will open a vim editor where you can add add your credentials. This will generate you 2 new files:
+This will open a vim editor where you can add your credentials. This will generate you 2 new files:
 
 ```bash
 config/credentials/production.key

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -61,7 +61,8 @@ config/credentials/production.key
 config/credentials/production.yml.enc
 ```
 
-You will need to repeat the same process for all 3 environments :
+You will need to repeat the same process for all 3 environments:
+
 ```bash
 EDITOR=vim ./bin/rails credentials:edit --environment test
 EDITOR=vim ./bin/rails credentials:edit --environment development

--- a/decidim-core/app/forms/decidim/notifications_settings_form.rb
+++ b/decidim-core/app/forms/decidim/notifications_settings_form.rb
@@ -46,7 +46,7 @@ module Decidim
     end
 
     def meet_push_notifications_requirements?
-      Rails.application.secrets.dig(:vapid, :enabled) || false
+      Rails.application.credentials.dig(:vapid, :enabled) || false
     end
   end
 end

--- a/decidim-core/app/forms/decidim/omniauth_registration_form.rb
+++ b/decidim-core/app/forms/decidim/omniauth_registration_form.rb
@@ -21,7 +21,7 @@ module Decidim
     validates :uid, presence: true
 
     def self.create_signature(provider, uid)
-      Digest::MD5.hexdigest("#{provider}-#{uid}-#{Rails.application.secrets.secret_key_base}")
+      Digest::MD5.hexdigest("#{provider}-#{uid}-#{Rails.application.credentials.secret_key_base}")
     end
 
     def normalized_nickname

--- a/decidim-core/app/models/decidim/omniauth_provider.rb
+++ b/decidim-core/app/models/decidim/omniauth_provider.rb
@@ -3,7 +3,7 @@
 module Decidim
   class OmniauthProvider
     def self.available
-      Rails.application.secrets[:omniauth] || {}
+      Rails.application.credentials[:omniauth] || {}
     end
 
     def self.enabled

--- a/decidim-core/app/models/decidim/omniauth_provider.rb
+++ b/decidim-core/app/models/decidim/omniauth_provider.rb
@@ -3,7 +3,7 @@
 module Decidim
   class OmniauthProvider
     def self.available
-      Rails.application.credentials[:omniauth] || {}
+      Rails.application.credentials.omniauth || {}
     end
 
     def self.enabled

--- a/decidim-core/app/services/decidim/send_push_notification.rb
+++ b/decidim-core/app/services/decidim/send_push_notification.rb
@@ -19,7 +19,7 @@ module Decidim
     #
     # @return [Array<Net::HTTPCreated>, nil] the result of the dispatch or nil if user or subscription are empty
     def perform(notification, title = nil)
-      return unless Rails.application.secrets.dig(:vapid, :enabled)
+      return unless Rails.application.credentials.dig(:vapid, :enabled)
       raise ArgumentError, "Need to provide a title if the notification is a PushNotificationMessage" if notification.is_a?(Decidim::PushNotificationMessage) && title.nil?
 
       user = notification.user
@@ -66,8 +66,8 @@ module Decidim
         p256dh: subscription["p256dh"],
         auth: subscription["auth"],
         vapid: {
-          public_key: Rails.application.secrets.vapid[:public_key],
-          private_key: Rails.application.secrets.vapid[:private_key]
+          public_key: Rails.application.credentials.vapid[:public_key],
+          private_key: Rails.application.credentials.vapid[:private_key]
         }
       }
     end

--- a/decidim-core/app/views/decidim/notifications_settings/show.html.erb
+++ b/decidim-core/app/views/decidim/notifications_settings/show.html.erb
@@ -194,7 +194,7 @@
           </div>
         </div>
 
-        <input id="vapidPublicKey" name="vapid_public_key" type="hidden" value="<%= Base64.urlsafe_decode64(Rails.application.secrets.vapid[:public_key]).bytes %>">
+        <input id="vapidPublicKey" name="vapid_public_key" type="hidden" value="<%= Base64.urlsafe_decode64(Rails.application.credentials.vapid[:public_key]).bytes %>">
         <input id="subKeys" name="sub_key" type="hidden" value="<%= current_user.notifications_subscriptions.keys %>">
       <% end %>
 

--- a/decidim-core/config/initializers/omniauth.rb
+++ b/decidim-core/config/initializers/omniauth.rb
@@ -13,7 +13,7 @@ def setup_provider_proc(provider, config_mapping = {})
 end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  omniauth_config = Rails.application.secrets[:omniauth]
+  omniauth_config = Rails.application.credentials[:omniauth]
 
   if omniauth_config
     if omniauth_config[:developer].present?

--- a/decidim-core/config/initializers/omniauth.rb
+++ b/decidim-core/config/initializers/omniauth.rb
@@ -13,7 +13,7 @@ def setup_provider_proc(provider, config_mapping = {})
 end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  omniauth_config = Rails.application.credentials[:omniauth]
+  omniauth_config = Rails.application.credentials.omniauth
 
   if omniauth_config
     if omniauth_config[:developer].present?

--- a/decidim-core/config/initializers/secrets_to_credentials.rb
+++ b/decidim-core/config/initializers/secrets_to_credentials.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-source = ERB.new(IO.read("config/secrets.yml")).result
+source = ERB.new(IO.read(Rails.root.join("config/secrets.yml"))).result
 secrets = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(source) : YAML.load(source)
 Rails.application.credentials.deep_merge!(secrets[Rails.env].deep_symbolize_keys)

--- a/decidim-core/config/initializers/secrets_to_credentials.rb
+++ b/decidim-core/config/initializers/secrets_to_credentials.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source = ERB.new(IO.read("config/secrets.yml")).result
+secrets = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(source) : YAML.load(source)
+Rails.application.credentials.deep_merge!(secrets[Rails.env].deep_symbolize_keys)

--- a/decidim-core/config/initializers/secrets_to_credentials.rb
+++ b/decidim-core/config/initializers/secrets_to_credentials.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-source = ERB.new(IO.read(Rails.root.join("config/secrets.yml"))).result
+source = ERB.new(Rails.root.join("config/secrets.yml").read).result
 secrets = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(source) : YAML.load(source)
 Rails.application.credentials.deep_merge!(secrets[Rails.env].deep_symbolize_keys)

--- a/decidim-core/config/initializers/secrets_to_credentials.rb
+++ b/decidim-core/config/initializers/secrets_to_credentials.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-source = ERB.new(Rails.root.join("config/secrets.yml").read).result
-secrets = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(source) : YAML.load(source)
-Rails.application.credentials.deep_merge!(secrets[Rails.env].deep_symbolize_keys)

--- a/decidim-core/lib/decidim/asset_router/storage.rb
+++ b/decidim-core/lib/decidim/asset_router/storage.rb
@@ -104,7 +104,7 @@ module Decidim
       # @return [Hash] The remote storage options hash
       def remote_storage_options
         @remote_storage_options ||= {
-          host: Rails.application.secrets.dig(:storage, :cdn_host)
+          host: Rails.application.credentials.dig(:storage, :cdn_host)
         }.compact
       end
 

--- a/decidim-core/lib/decidim/attribute_encryptor.rb
+++ b/decidim-core/lib/decidim/attribute_encryptor.rb
@@ -21,7 +21,7 @@ module Decidim
     def self.cryptor
       @cryptor ||= begin
         key = ActiveSupport::KeyGenerator.new("attribute").generate_key(
-          Rails.application.secrets.secret_key_base, ActiveSupport::MessageEncryptor.key_len
+          Rails.application.credentials.secret_key_base, ActiveSupport::MessageEncryptor.key_len
         )
         ActiveSupport::MessageEncryptor.new(key)
       end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -356,7 +356,7 @@ module Decidim
               Decidim.configure do |config|
                 config.maps = {
                   provider: :here,
-                  api_key: Rails.application.secrets.maps[:api_key],
+                  api_key: Rails.application.credentials.maps[:api_key],
                   static: { url: "#{Decidim.geocoder.fetch(:static_map_url)}" }
                 }
               end

--- a/decidim-core/lib/decidim/newsletter_encryptor.rb
+++ b/decidim-core/lib/decidim/newsletter_encryptor.rb
@@ -14,7 +14,7 @@ module Decidim
 
     def self.crypt_data
       key = ActiveSupport::KeyGenerator.new("sent_at").generate_key(
-        Rails.application.secrets.secret_key_base, ActiveSupport::MessageEncryptor.key_len
+        Rails.application.credentials.secret_key_base, ActiveSupport::MessageEncryptor.key_len
       )
       ActiveSupport::MessageEncryptor.new(key)
     end

--- a/decidim-core/lib/decidim/organization_settings.rb
+++ b/decidim-core/lib/decidim/organization_settings.rb
@@ -137,11 +137,11 @@ module Decidim
       end
 
       def default_maximum_attachment_size
-        (Rails.application.secrets.decidim[:maximum_attachment_size].presence || 10).to_f
+        (Rails.application.credentials.decidim[:maximum_attachment_size].presence || 10).to_f
       end
 
       def default_maximum_avatar_size
-        (Rails.application.secrets.decidim[:maximum_avatar_size].presence || 5).to_f
+        (Rails.application.credentials.decidim[:maximum_avatar_size].presence || 5).to_f
       end
     end
 

--- a/decidim-core/lib/decidim/paddable.rb
+++ b/decidim-core/lib/decidim/paddable.rb
@@ -66,7 +66,7 @@ module Decidim
           return tokenizer.hex_digest(id)
         end
 
-        Digest::MD5.hexdigest("#{id}-#{Rails.application.secrets.secret_key_base}")
+        Digest::MD5.hexdigest("#{id}-#{Rails.application.credentials.secret_key_base}")
       end
 
       def build_pad_url(id)

--- a/decidim-core/spec/forms/notifications_settings_form_spec.rb
+++ b/decidim-core/spec/forms/notifications_settings_form_spec.rb
@@ -178,7 +178,7 @@ module Decidim
     describe "#meet_push_notifications_requirements?" do
       context "when the notifications requirements are met" do
         before do
-          Rails.application.secrets[:vapid] = { enabled: true }
+          Rails.application.credentials[:vapid] = { enabled: true }
         end
 
         it "returns true" do
@@ -188,7 +188,7 @@ module Decidim
 
       context "when vapid secrets are not present" do
         before do
-          Rails.application.secrets.delete(:vapid)
+          Rails.application.credentials.delete(:vapid)
         end
 
         it "returns false" do
@@ -198,7 +198,7 @@ module Decidim
 
       context "when the notifications requirements are not met" do
         before do
-          Rails.application.secrets[:vapid] = { enabled: false }
+          Rails.application.credentials[:vapid] = { enabled: false }
         end
 
         it "returns false" do

--- a/decidim-core/spec/lib/asset_router/storage_spec.rb
+++ b/decidim-core/spec/lib/asset_router/storage_spec.rb
@@ -189,8 +189,8 @@ module Decidim::AssetRouter
 
       context "when the CDN host is defined" do
         before do
-          allow(Rails.application.secrets).to receive(:dig).and_call_original
-          allow(Rails.application.secrets).to receive(:dig).with(:storage, :cdn_host).and_return("https://cdn.example.org")
+          allow(Rails.application.credentials).to receive(:dig).and_call_original
+          allow(Rails.application.credentials).to receive(:dig).with(:storage, :cdn_host).and_return("https://cdn.example.org")
         end
 
         it "creates the route to the CDN blob" do

--- a/decidim-core/spec/lib/attribute_encryptor_spec.rb
+++ b/decidim-core/spec/lib/attribute_encryptor_spec.rb
@@ -76,7 +76,7 @@ module Decidim
         before do
           # Temporarily change the secret so that it matches the secret used
           # when encrypting the value.
-          allow(Rails.application.secrets).to receive(
+          allow(Rails.application.credentials).to receive(
             :secret_key_base
           ).and_return("testsecret")
         end

--- a/decidim-core/spec/lib/organization_settings_spec.rb
+++ b/decidim-core/spec/lib/organization_settings_spec.rb
@@ -148,8 +148,8 @@ module Decidim
         let(:maximum_attachment_size) { 20 }
 
         before do
-          allow(Rails.application.secrets.decidim).to receive(:[]).and_call_original
-          allow(Rails.application.secrets.decidim).to receive(:[]).with(:maximum_attachment_size).and_return(maximum_attachment_size)
+          allow(Rails.application.credentials.decidim).to receive(:[]).and_call_original
+          allow(Rails.application.credentials.decidim).to receive(:[]).with(:maximum_attachment_size).and_return(maximum_attachment_size)
           # defaults method is memoized, we need to reset it to make sure it uses the stubbed values
           described_class.instance_variable_set(:@defaults, nil)
         end

--- a/decidim-core/spec/lib/paddable_spec.rb
+++ b/decidim-core/spec/lib/paddable_spec.rb
@@ -111,7 +111,7 @@ module Decidim
       end
 
       def unsecure_hash(id)
-        Digest::MD5.hexdigest("#{id}-#{Rails.application.secrets.secret_key_base}")
+        Digest::MD5.hexdigest("#{id}-#{Rails.application.credentials.secret_key_base}")
       end
 
       def secure_hash(id)

--- a/decidim-core/spec/models/decidim/organization_spec.rb
+++ b/decidim-core/spec/models/decidim/organization_spec.rb
@@ -99,11 +99,11 @@ module Decidim
           let!(:previous_omniauth_secrets) { Rails.application.credentials[:omniauth] }
 
           before do
-            Rails.application.credentials[:omniauth] = nil
+            Rails.application.credentials.omniauth = nil
           end
 
           after do
-            Rails.application.credentials[:omniauth] = previous_omniauth_secrets
+            Rails.application.credentials.omniauth = previous_omniauth_secrets
           end
 
           it "returns no providers" do

--- a/decidim-core/spec/models/decidim/organization_spec.rb
+++ b/decidim-core/spec/models/decidim/organization_spec.rb
@@ -96,14 +96,14 @@ module Decidim
         end
 
         context "when providers are not enabled in secrets.yml" do
-          let!(:previous_omniauth_secrets) { Rails.application.secrets[:omniauth] }
+          let!(:previous_omniauth_secrets) { Rails.application.credentials[:omniauth] }
 
           before do
-            Rails.application.secrets[:omniauth] = nil
+            Rails.application.credentials[:omniauth] = nil
           end
 
           after do
-            Rails.application.secrets[:omniauth] = previous_omniauth_secrets
+            Rails.application.credentials[:omniauth] = previous_omniauth_secrets
           end
 
           it "returns no providers" do

--- a/decidim-core/spec/services/decidim/send_push_notification_spec.rb
+++ b/decidim-core/spec/services/decidim/send_push_notification_spec.rb
@@ -9,13 +9,13 @@ describe Decidim::SendPushNotification do
   let(:user) { create(:user, notification_settings: { subscriptions: }) }
 
   before do
-    Rails.application.secrets[:vapid] = { enabled: true, public_key: "public_key", private_key: "private_key" }
+    Rails.application.credentials[:vapid] = { enabled: true, public_key: "public_key", private_key: "private_key" }
   end
 
   shared_examples "send a push notification" do
     context "without vapid settings config" do
       before do
-        Rails.application.secrets.delete(:vapid)
+        Rails.application.credentials.delete(:vapid)
       end
 
       describe "#perform" do
@@ -27,7 +27,7 @@ describe Decidim::SendPushNotification do
 
     context "without vapid enabled" do
       before do
-        Rails.application.secrets[:vapid] = { enabled: false }
+        Rails.application.credentials[:vapid] = { enabled: false }
       end
 
       describe "#perform" do

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -353,7 +353,7 @@ describe "Account" do
 
     context "when VAPID keys are set" do
       before do
-        Rails.application.secrets[:vapid] = vapid_keys
+        Rails.application.credentials[:vapid] = vapid_keys
         driven_by(:pwa_chrome)
         switch_to_host(organization.host)
         login_as user, scope: :user
@@ -383,7 +383,7 @@ describe "Account" do
 
     context "when VAPID is disabled" do
       before do
-        Rails.application.secrets[:vapid] = { enabled: false }
+        Rails.application.credentials[:vapid] = { enabled: false }
         driven_by(:pwa_chrome)
         switch_to_host(organization.host)
         login_as user, scope: :user
@@ -397,7 +397,7 @@ describe "Account" do
 
     context "when VAPID keys are not set" do
       before do
-        Rails.application.secrets.delete(:vapid)
+        Rails.application.credentials.delete(:vapid)
         driven_by(:pwa_chrome)
         switch_to_host(organization.host)
         login_as user, scope: :user

--- a/decidim-core/spec/uploaders/application_uploader_spec.rb
+++ b/decidim-core/spec/uploaders/application_uploader_spec.rb
@@ -195,8 +195,8 @@ module Decidim
         before do
           allow(Rails.env).to receive(:development?).and_return(false)
           allow(Rails.env).to receive(:test?).and_return(false)
-          allow(Rails.application.secrets).to receive(:dig).and_call_original
-          allow(Rails.application.secrets).to receive(:dig).with(:storage, :cdn_host).and_return(cdn_host)
+          allow(Rails.application.credentials).to receive(:dig).and_call_original
+          allow(Rails.application.credentials).to receive(:dig).with(:storage, :cdn_host).and_return(cdn_host)
         end
 
         it "returns a URL containing the CDN configurations" do

--- a/decidim-forms/db/migrate/20190315203056_add_session_token_to_decidim_forms_answers.rb
+++ b/decidim-forms/db/migrate/20190315203056_add_session_token_to_decidim_forms_answers.rb
@@ -10,7 +10,7 @@ class AddSessionTokenToDecidimFormsAnswers < ActiveRecord::Migration[5.2]
     add_index :decidim_forms_answers, :session_token
 
     Answer.find_each do |answer|
-      answer.session_token = Digest::MD5.hexdigest("#{answer.decidim_user_id}-#{Rails.application.secrets.secret_key_base}")
+      answer.session_token = Digest::MD5.hexdigest("#{answer.decidim_user_id}-#{Rails.application.credentials.secret_key_base}")
       answer.save!
     end
   end

--- a/decidim-generators/lib/decidim/generators.rb
+++ b/decidim-generators/lib/decidim/generators.rb
@@ -6,7 +6,7 @@ module Decidim
   module Generators
     def self.edge_git_branch
       if Decidim::Generators.version.match?(/\.dev$/)
-        "develop"
+        "chore/migrate-credentials"
       else
         "release/#{Decidim::Generators.version.match(/^[0-9]+\.[0-9]+/)[0]}-stable"
       end

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -190,6 +190,10 @@ module Decidim
         end
       end
 
+      def patch_credentials
+        run "rails decidim:patch_environments"
+      end
+
       def add_storage_provider
         template "storage.yml.erb", "config/storage.yml", force: true
 

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -198,7 +198,7 @@ module Decidim
         abort("#{providers} is not supported as storage provider, please use local, s3, gcs or azure") unless (providers - %w(local s3 gcs azure)).empty?
         gsub_file "config/environments/production.rb",
                   /config.active_storage.service = :local/,
-                  "config.active_storage.service = Rails.application.secrets.dig(:storage, :provider) || :local"
+                  "config.active_storage.service = Rails.application.credentials.dig(:storage, :provider) || :local"
 
         add_production_gems do
           gem "aws-sdk-s3", require: false if providers.include?("s3")
@@ -335,8 +335,8 @@ module Decidim
                   /#{Regexp.escape("# config.available_locales = %w(en ca es)")}/,
                   "config.available_locales = %w(#{options[:locales].gsub(",", " ")})"
         gsub_file "config/initializers/decidim.rb",
-                  /#{Regexp.escape("config.available_locales = Rails.application.secrets.decidim[:available_locales].presence || [:en]")}/,
-                  "# config.available_locales = Rails.application.secrets.decidim[:available_locales].presence || [:en]"
+                  /#{Regexp.escape("config.available_locales = Rails.application.credentials.decidim[:available_locales].presence || [:en]")}/,
+                  "# config.available_locales = Rails.application.credentials.decidim[:available_locales].presence || [:en]"
       end
 
       def dev_performance_config

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -2,29 +2,29 @@
 
 Decidim.configure do |config|
   # The name of the application
-  config.application_name = Rails.application.secrets.decidim[:application_name]
+  config.application_name = Rails.application.credentials.decidim[:application_name]
 
   # The email that will be used as sender in all emails from Decidim
-  config.mailer_sender = Rails.application.secrets.decidim[:mailer_sender]
+  config.mailer_sender = Rails.application.credentials.decidim[:mailer_sender]
 
   # Sets the list of available locales for the whole application.
   #
   # When an organization is created through the System area, system admins will
   # be able to choose the available languages for that organization. That list
   # of languages will be equal or a subset of the list in this file.
-  config.available_locales = Rails.application.secrets.decidim[:available_locales].presence || [:en]
+  config.available_locales = Rails.application.credentials.decidim[:available_locales].presence || [:en]
   # Or block set it up manually and prevent ENV manipulation:
   # config.available_locales = %w(en ca es)
 
   # Sets the default locale for new organizations. When creating a new
   # organization from the System area, system admins will be able to overwrite
   # this value for that specific organization.
-  config.default_locale = Rails.application.secrets.decidim[:default_locale].presence || :en
+  config.default_locale = Rails.application.credentials.decidim[:default_locale].presence || :en
 
   # Restrict access to the system part with an authorized ip list.
   # You can use a single ip like ("1.2.3.4"), or an ip subnet like ("1.2.3.4/24")
   # You may specify multiple ip in an array ["1.2.3.4", "1.2.3.4/24"]
-  config.system_accesslist_ips = Rails.application.secrets.decidim[:system_accesslist_ips] if Rails.application.secrets.decidim[:system_accesslist_ips].present?
+  config.system_accesslist_ips = Rails.application.credentials.decidim[:system_accesslist_ips] if Rails.application.credentials.decidim[:system_accesslist_ips].present?
 
   # Defines a list of custom content processors. They are used to parse and
   # render specific tags inside some user-provided content. Check the docs for
@@ -33,17 +33,17 @@ Decidim.configure do |config|
 
   # Whether SSL should be enabled or not.
   # if this var is not defined, it is decided automatically per-rails-environment
-  config.force_ssl = Rails.application.secrets.decidim[:force_ssl].present? unless Rails.application.secrets.decidim[:force_ssl] == "auto"
+  config.force_ssl = Rails.application.credentials.decidim[:force_ssl].present? unless Rails.application.credentials.decidim[:force_ssl] == "auto"
   # or set it up manually and prevent any ENV manipulation:
   # config.force_ssl = true
 
   # Enable the service worker. By default is disabled in development and enabled in the rest of environments
-  config.service_worker_enabled = Rails.application.secrets.decidim[:service_worker_enabled].present?
+  config.service_worker_enabled = Rails.application.credentials.decidim[:service_worker_enabled].present?
 
   # Sets the list of static pages' slugs that can include content blocks.
   # By default is only enabled in the terms-of-service static page to allow a summary to be added and include
   # sections with a two-pane view
-  config.page_blocks = Rails.application.secrets.decidim[:page_blocks].presence || %w(terms-of-service)
+  config.page_blocks = Rails.application.credentials.decidim[:page_blocks].presence || %w(terms-of-service)
 
   # Map and Geocoder configuration
   #
@@ -53,7 +53,7 @@ Decidim.configure do |config|
   # == HERE Maps ==
   # config.maps = {
   #   provider: :here,
-  #   api_key: Rails.application.secrets.maps[:api_key],
+  #   api_key: Rails.application.credentials.maps[:api_key],
   #   static: { url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview" }
   # }
   #
@@ -72,7 +72,7 @@ Decidim.configure do |config|
   #
   # config.maps = {
   #   provider: :osm,
-  #   api_key: Rails.application.secrets.maps[:api_key],
+  #   api_key: Rails.application.credentials.maps[:api_key],
   #   dynamic: {
   #     tile_layer: {
   #       url: "https://tiles.example.org/{z}/{x}/{y}.png?key={apiKey}&{foo}",
@@ -92,10 +92,10 @@ Decidim.configure do |config|
   # == Combination (OpenStreetMap default + HERE Maps dynamic map tiles) ==
   # config.maps = {
   #   provider: :osm,
-  #   api_key: Rails.application.secrets.maps[:api_key],
+  #   api_key: Rails.application.credentials.maps[:api_key],
   #   dynamic: {
   #     provider: :here,
-  #     api_key: Rails.application.secrets.maps[:here_api_key]
+  #     api_key: Rails.application.credentials.maps[:here_api_key]
   #   },
   #   static: { url: "https://staticmap.example.org/" },
   #   geocoding: { host: "nominatim.example.org", use_https: true }
@@ -114,27 +114,27 @@ Decidim.configure do |config|
   #   cache: Redis.new,
   #   cache_prefix: "..."
   # }
-  if Rails.application.secrets.maps.present? && Rails.application.secrets.maps[:static_provider].present?
-    static_provider = Rails.application.secrets.maps[:static_provider]
-    dynamic_provider = Rails.application.secrets.maps[:dynamic_provider]
-    dynamic_url = Rails.application.secrets.maps[:dynamic_url]
-    static_url = Rails.application.secrets.maps[:static_url]
+  if Rails.application.credentials.maps.present? && Rails.application.credentials.maps[:static_provider].present?
+    static_provider = Rails.application.credentials.maps[:static_provider]
+    dynamic_provider = Rails.application.credentials.maps[:dynamic_provider]
+    dynamic_url = Rails.application.credentials.maps[:dynamic_url]
+    static_url = Rails.application.credentials.maps[:static_url]
     static_url = "https://image.maps.ls.hereapi.com/mia/1.6/mapview" if static_provider == "here" && static_url.blank?
     config.maps = {
       provider: static_provider,
-      api_key: Rails.application.secrets.maps[:static_api_key],
+      api_key: Rails.application.credentials.maps[:static_api_key],
       static: { url: static_url },
       dynamic: {
         provider: dynamic_provider,
-        api_key: Rails.application.secrets.maps[:dynamic_api_key]
+        api_key: Rails.application.credentials.maps[:dynamic_api_key]
       }
     }
-    config.maps[:geocoding] = { host: Rails.application.secrets.maps[:geocoding_host], use_https: true } if Rails.application.secrets.maps[:geocoding_host]
+    config.maps[:geocoding] = { host: Rails.application.credentials.maps[:geocoding_host], use_https: true } if Rails.application.credentials.maps[:geocoding_host]
     config.maps[:dynamic][:tile_layer] = {}
     config.maps[:dynamic][:tile_layer][:url] = dynamic_url if dynamic_url
-    config.maps[:dynamic][:tile_layer][:attribution] = Rails.application.secrets.maps[:attribution] if Rails.application.secrets.maps[:attribution]
-    if Rails.application.secrets.maps[:extra_vars].present?
-      vars = URI.decode_www_form(Rails.application.secrets.maps[:extra_vars])
+    config.maps[:dynamic][:tile_layer][:attribution] = Rails.application.credentials.maps[:attribution] if Rails.application.credentials.maps[:attribution]
+    if Rails.application.credentials.maps[:extra_vars].present?
+      vars = URI.decode_www_form(Rails.application.credentials.maps[:extra_vars])
       vars.each do |key, value|
         # perform a naive type conversion
         config.maps[:dynamic][:tile_layer][key] = case value
@@ -156,20 +156,20 @@ Decidim.configure do |config|
   # end
 
   # Currency unit
-  config.currency_unit = Rails.application.secrets.decidim[:currency_unit] if Rails.application.secrets.decidim[:currency_unit].present?
+  config.currency_unit = Rails.application.credentials.decidim[:currency_unit] if Rails.application.credentials.decidim[:currency_unit].present?
 
   # Workaround to enable SVG assets cors
-  config.cors_enabled = Rails.application.secrets.decidim[:cors_enabled].present?
+  config.cors_enabled = Rails.application.credentials.decidim[:cors_enabled].present?
 
   # Defines the quality of image uploads after processing. Image uploads are
   # processed by Decidim, this value helps reduce the size of the files.
-  config.image_uploader_quality = Rails.application.secrets.decidim[:image_uploader_quality].to_i
+  config.image_uploader_quality = Rails.application.credentials.decidim[:image_uploader_quality].to_i
 
-  config.maximum_attachment_size = Rails.application.secrets.decidim[:maximum_attachment_size].to_i.megabytes
-  config.maximum_avatar_size = Rails.application.secrets.decidim[:maximum_avatar_size].to_i.megabytes
+  config.maximum_attachment_size = Rails.application.credentials.decidim[:maximum_attachment_size].to_i.megabytes
+  config.maximum_avatar_size = Rails.application.credentials.decidim[:maximum_avatar_size].to_i.megabytes
 
   # The number of reports which a resource can receive before hiding it
-  config.max_reports_before_hiding = Rails.application.secrets.decidim[:max_reports_before_hiding].to_i
+  config.max_reports_before_hiding = Rails.application.credentials.decidim[:max_reports_before_hiding].to_i
 
   # Custom HTML Header snippets
   #
@@ -184,22 +184,22 @@ Decidim.configure do |config|
   # that an organization's administrator injects malicious scripts to spy on or
   # take over user accounts.
   #
-  config.enable_html_header_snippets = Rails.application.secrets.decidim[:enable_html_header_snippets].present?
+  config.enable_html_header_snippets = Rails.application.credentials.decidim[:enable_html_header_snippets].present?
 
   # Allow organizations admins to track newsletter links.
-  config.track_newsletter_links = Rails.application.secrets.decidim[:track_newsletter_links].present? unless Rails.application.secrets.decidim[:track_newsletter_links] == "auto"
+  config.track_newsletter_links = Rails.application.credentials.decidim[:track_newsletter_links].present? unless Rails.application.credentials.decidim[:track_newsletter_links] == "auto"
 
   # Amount of time that the download your data files will be available in the server.
-  config.download_your_data_expiry_time = Rails.application.secrets.decidim[:download_your_data_expiry_time].to_i.days
+  config.download_your_data_expiry_time = Rails.application.credentials.decidim[:download_your_data_expiry_time].to_i.days
 
   # Max requests in a time period to prevent DoS attacks. Only applied on production.
-  config.throttling_max_requests = Rails.application.secrets.decidim[:throttling_max_requests].to_i
+  config.throttling_max_requests = Rails.application.credentials.decidim[:throttling_max_requests].to_i
 
   # Time window in which the throttling is applied.
-  config.throttling_period = Rails.application.secrets.decidim[:throttling_period].to_i.minutes
+  config.throttling_period = Rails.application.credentials.decidim[:throttling_period].to_i.minutes
 
   # Time window were users can access the website even if their email is not confirmed.
-  config.unconfirmed_access_for = Rails.application.secrets.decidim[:unconfirmed_access_for].to_i.days
+  config.unconfirmed_access_for = Rails.application.credentials.decidim[:unconfirmed_access_for].to_i.days
 
   # A base path for the uploads. If set, make sure it ends in a slash.
   # Uploads will be set to `<base_path>/uploads/`. This can be useful if you
@@ -207,7 +207,7 @@ Decidim.configure do |config|
   # environments, but in different folders.
   #
   # If not set, it will be ignored.
-  config.base_uploads_path = Rails.application.secrets.decidim[:base_uploads_path] if Rails.application.secrets.decidim[:base_uploads_path].present?
+  config.base_uploads_path = Rails.application.credentials.decidim[:base_uploads_path] if Rails.application.credentials.decidim[:base_uploads_path].present?
 
   # SMS gateway configuration
   #
@@ -285,16 +285,16 @@ Decidim.configure do |config|
   # Only needed if you want to have Etherpad integration with Decidim. See
   # Decidim docs at https://docs.decidim.org/en/services/etherpad/ in order to set it up.
   #
-  if Rails.application.secrets.etherpad.present? && Rails.application.secrets.etherpad[:server].present?
+  if Rails.application.credentials.etherpad.present? && Rails.application.credentials.etherpad[:server].present?
     config.etherpad = {
-      server: Rails.application.secrets.etherpad[:server],
-      api_key: Rails.application.secrets.etherpad[:api_key],
-      api_version: Rails.application.secrets.etherpad[:api_version]
+      server: Rails.application.credentials.etherpad[:server],
+      api_key: Rails.application.credentials.etherpad[:api_key],
+      api_version: Rails.application.credentials.etherpad[:api_version]
     }
   end
 
   # Sets Decidim::Exporters::CSV's default column separator
-  config.default_csv_col_sep = Rails.application.secrets.decidim[:default_csv_col_sep] if Rails.application.secrets.decidim[:default_csv_col_sep].present?
+  config.default_csv_col_sep = Rails.application.credentials.decidim[:default_csv_col_sep] if Rails.application.credentials.decidim[:default_csv_col_sep].present?
 
   # The list of roles a user can have, not considering the space-specific roles.
   # config.user_roles = %w(admin user_manager)
@@ -342,11 +342,11 @@ Decidim.configure do |config|
   # config.machine_translation_service = "MyTranslationService"
 
   # Defines the social networking services used for social sharing
-  config.social_share_services = Rails.application.secrets.decidim[:social_share_services]
+  config.social_share_services = Rails.application.credentials.decidim[:social_share_services]
 
   # Defines the name of the cookie used to check if the user allows Decidim to
   # set cookies.
-  config.consent_cookie_name = Rails.application.secrets.decidim[:consent_cookie_name] if Rails.application.secrets.decidim[:consent_cookie_name].present?
+  config.consent_cookie_name = Rails.application.credentials.decidim[:consent_cookie_name] if Rails.application.credentials.decidim[:consent_cookie_name].present?
 
   # Defines data consent categories and the data stored in each category.
   # config.consent_categories = [
@@ -383,87 +383,87 @@ Decidim.configure do |config|
   config.content_security_policies_extra = {}
 
   # Admin admin password configurations
-  Rails.application.secrets.dig(:decidim, :admin_password, :strong).tap do |strong_pw|
+  Rails.application.credentials.dig(:decidim, :admin_password, :strong).tap do |strong_pw|
     # When the strong password is not configured, default to true
     config.admin_password_strong = strong_pw.nil? ? true : strong_pw.present?
   end
-  config.admin_password_expiration_days = Rails.application.secrets.dig(:decidim, :admin_password, :expiration_days).presence || 90
-  config.admin_password_min_length = Rails.application.secrets.dig(:decidim, :admin_password, :min_length).presence || 15
-  config.admin_password_repetition_times = Rails.application.secrets.dig(:decidim, :admin_password, :repetition_times).presence || 5
+  config.admin_password_expiration_days = Rails.application.credentials.dig(:decidim, :admin_password, :expiration_days).presence || 90
+  config.admin_password_min_length = Rails.application.credentials.dig(:decidim, :admin_password, :min_length).presence || 15
+  config.admin_password_repetition_times = Rails.application.credentials.dig(:decidim, :admin_password, :repetition_times).presence || 5
 
   # Additional optional configurations (see decidim-core/lib/decidim/core.rb)
-  config.cache_key_separator = Rails.application.secrets.decidim[:cache_key_separator] if Rails.application.secrets.decidim[:cache_key_separator].present?
-  config.expire_session_after = Rails.application.secrets.decidim[:expire_session_after].to_i.minutes if Rails.application.secrets.decidim[:expire_session_after].present?
-  config.enable_remember_me = Rails.application.secrets.decidim[:enable_remember_me].present? unless Rails.application.secrets.decidim[:enable_remember_me] == "auto"
-  if Rails.application.secrets.decidim[:session_timeout_interval].present?
-    config.session_timeout_interval = Rails.application.secrets.decidim[:session_timeout_interval].to_i.seconds
+  config.cache_key_separator = Rails.application.credentials.decidim[:cache_key_separator] if Rails.application.credentials.decidim[:cache_key_separator].present?
+  config.expire_session_after = Rails.application.credentials.decidim[:expire_session_after].to_i.minutes if Rails.application.credentials.decidim[:expire_session_after].present?
+  config.enable_remember_me = Rails.application.credentials.decidim[:enable_remember_me].present? unless Rails.application.credentials.decidim[:enable_remember_me] == "auto"
+  if Rails.application.credentials.decidim[:session_timeout_interval].present?
+    config.session_timeout_interval = Rails.application.credentials.decidim[:session_timeout_interval].to_i.seconds
   end
-  config.follow_http_x_forwarded_host = Rails.application.secrets.decidim[:follow_http_x_forwarded_host].present?
-  config.maximum_conversation_message_length = Rails.application.secrets.decidim[:maximum_conversation_message_length].to_i
-  config.password_similarity_length = Rails.application.secrets.decidim[:password_similarity_length] if Rails.application.secrets.decidim[:password_similarity_length].present?
-  config.denied_passwords = Rails.application.secrets.decidim[:denied_passwords] if Rails.application.secrets.decidim[:denied_passwords].present?
-  config.allow_open_redirects = Rails.application.secrets.decidim[:allow_open_redirects] if Rails.application.secrets.decidim[:allow_open_redirects].present?
+  config.follow_http_x_forwarded_host = Rails.application.credentials.decidim[:follow_http_x_forwarded_host].present?
+  config.maximum_conversation_message_length = Rails.application.credentials.decidim[:maximum_conversation_message_length].to_i
+  config.password_similarity_length = Rails.application.credentials.decidim[:password_similarity_length] if Rails.application.credentials.decidim[:password_similarity_length].present?
+  config.denied_passwords = Rails.application.credentials.decidim[:denied_passwords] if Rails.application.credentials.decidim[:denied_passwords].present?
+  config.allow_open_redirects = Rails.application.credentials.decidim[:allow_open_redirects] if Rails.application.credentials.decidim[:allow_open_redirects].present?
 end
 
 if Decidim.module_installed? :api
   Decidim::Api.configure do |config|
-    config.schema_max_per_page = Rails.application.secrets.dig(:decidim, :api, :schema_max_per_page).presence || 50
-    config.schema_max_complexity = Rails.application.secrets.dig(:decidim, :api, :schema_max_complexity).presence || 5000
-    config.schema_max_depth = Rails.application.secrets.dig(:decidim, :api, :schema_max_depth).presence || 15
+    config.schema_max_per_page = Rails.application.credentials.dig(:decidim, :api, :schema_max_per_page).presence || 50
+    config.schema_max_complexity = Rails.application.credentials.dig(:decidim, :api, :schema_max_complexity).presence || 5000
+    config.schema_max_depth = Rails.application.credentials.dig(:decidim, :api, :schema_max_depth).presence || 15
   end
 end
 
 if Decidim.module_installed? :proposals
   Decidim::Proposals.configure do |config|
-    config.participatory_space_highlighted_proposals_limit = Rails.application.secrets.dig(:decidim, :proposals, :participatory_space_highlighted_proposals_limit).presence || 4
-    config.process_group_highlighted_proposals_limit = Rails.application.secrets.dig(:decidim, :proposals, :process_group_highlighted_proposals_limit).presence || 3
+    config.participatory_space_highlighted_proposals_limit = Rails.application.credentials.dig(:decidim, :proposals, :participatory_space_highlighted_proposals_limit).presence || 4
+    config.process_group_highlighted_proposals_limit = Rails.application.credentials.dig(:decidim, :proposals, :process_group_highlighted_proposals_limit).presence || 3
   end
 end
 
 if Decidim.module_installed? :meetings
   Decidim::Meetings.configure do |config|
-    config.upcoming_meeting_notification = Rails.application.secrets.dig(:decidim, :meetings, :upcoming_meeting_notification).to_i.days
-    if Rails.application.secrets.dig(:decidim, :meetings, :embeddable_services).present?
-      config.embeddable_services = Rails.application.secrets.dig(:decidim, :meetings, :embeddable_services)
+    config.upcoming_meeting_notification = Rails.application.credentials.dig(:decidim, :meetings, :upcoming_meeting_notification).to_i.days
+    if Rails.application.credentials.dig(:decidim, :meetings, :embeddable_services).present?
+      config.embeddable_services = Rails.application.credentials.dig(:decidim, :meetings, :embeddable_services)
     end
-    unless Rails.application.secrets.dig(:decidim, :meetings, :enable_proposal_linking) == "auto"
-      config.enable_proposal_linking = Rails.application.secrets.dig(:decidim, :meetings, :enable_proposal_linking).present?
+    unless Rails.application.credentials.dig(:decidim, :meetings, :enable_proposal_linking) == "auto"
+      config.enable_proposal_linking = Rails.application.credentials.dig(:decidim, :meetings, :enable_proposal_linking).present?
     end
   end
 end
 
 if Decidim.module_installed? :budgets
   Decidim::Budgets.configure do |config|
-    unless Rails.application.secrets.dig(:decidim, :budgets, :enable_proposal_linking) == "auto"
-      config.enable_proposal_linking = Rails.application.secrets.dig(:decidim, :budgets, :enable_proposal_linking).present?
+    unless Rails.application.credentials.dig(:decidim, :budgets, :enable_proposal_linking) == "auto"
+      config.enable_proposal_linking = Rails.application.credentials.dig(:decidim, :budgets, :enable_proposal_linking).present?
     end
   end
 end
 
 if Decidim.module_installed? :accountability
   Decidim::Accountability.configure do |config|
-    unless Rails.application.secrets.dig(:decidim, :accountability, :enable_proposal_linking) == "auto"
-      config.enable_proposal_linking = Rails.application.secrets.dig(:decidim, :accountability, :enable_proposal_linking).present?
+    unless Rails.application.credentials.dig(:decidim, :accountability, :enable_proposal_linking) == "auto"
+      config.enable_proposal_linking = Rails.application.credentials.dig(:decidim, :accountability, :enable_proposal_linking).present?
     end
   end
 end
 
 if Decidim.module_installed? :initiatives
   Decidim::Initiatives.configure do |config|
-    unless Rails.application.secrets.dig(:decidim, :initiatives, :creation_enabled) == "auto"
-      config.creation_enabled = Rails.application.secrets.dig(:decidim, :initiatives, :creation_enabled).present?
+    unless Rails.application.credentials.dig(:decidim, :initiatives, :creation_enabled) == "auto"
+      config.creation_enabled = Rails.application.credentials.dig(:decidim, :initiatives, :creation_enabled).present?
     end
-    config.minimum_committee_members = Rails.application.secrets.dig(:decidim, :initiatives, :minimum_committee_members).presence || 2
-    config.default_signature_time_period_length = Rails.application.secrets.dig(:decidim, :initiatives, :default_signature_time_period_length).presence || 120
-    config.default_components = Rails.application.secrets.dig(:decidim, :initiatives, :default_components)
-    config.first_notification_percentage = Rails.application.secrets.dig(:decidim, :initiatives, :first_notification_percentage).presence || 33
-    config.second_notification_percentage = Rails.application.secrets.dig(:decidim, :initiatives, :second_notification_percentage).presence || 66
-    config.stats_cache_expiration_time = Rails.application.secrets.dig(:decidim, :initiatives, :stats_cache_expiration_time).to_i.minutes
-    config.max_time_in_validating_state = Rails.application.secrets.dig(:decidim, :initiatives, :max_time_in_validating_state).to_i.days
-    unless Rails.application.secrets.dig(:decidim, :initiatives, :print_enabled) == "auto"
-      config.print_enabled = Rails.application.secrets.dig(:decidim, :initiatives, :print_enabled).present?
+    config.minimum_committee_members = Rails.application.credentials.dig(:decidim, :initiatives, :minimum_committee_members).presence || 2
+    config.default_signature_time_period_length = Rails.application.credentials.dig(:decidim, :initiatives, :default_signature_time_period_length).presence || 120
+    config.default_components = Rails.application.credentials.dig(:decidim, :initiatives, :default_components)
+    config.first_notification_percentage = Rails.application.credentials.dig(:decidim, :initiatives, :first_notification_percentage).presence || 33
+    config.second_notification_percentage = Rails.application.credentials.dig(:decidim, :initiatives, :second_notification_percentage).presence || 66
+    config.stats_cache_expiration_time = Rails.application.credentials.dig(:decidim, :initiatives, :stats_cache_expiration_time).to_i.minutes
+    config.max_time_in_validating_state = Rails.application.credentials.dig(:decidim, :initiatives, :max_time_in_validating_state).to_i.days
+    unless Rails.application.credentials.dig(:decidim, :initiatives, :print_enabled) == "auto"
+      config.print_enabled = Rails.application.credentials.dig(:decidim, :initiatives, :print_enabled).present?
     end
-    config.do_not_require_authorization = Rails.application.secrets.dig(:decidim, :initiatives, :do_not_require_authorization).present?
+    config.do_not_require_authorization = Rails.application.credentials.dig(:decidim, :initiatives, :do_not_require_authorization).present?
   end
 end
 

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -187,7 +187,9 @@ Decidim.configure do |config|
   config.enable_html_header_snippets = Rails.application.credentials.decidim[:enable_html_header_snippets].present?
 
   # Allow organizations admins to track newsletter links.
-  config.track_newsletter_links = Rails.application.credentials.decidim[:track_newsletter_links].present? unless Rails.application.credentials.decidim[:track_newsletter_links] == "auto"
+  unless Rails.application.credentials.decidim[:track_newsletter_links] == "auto"
+    config.track_newsletter_links = Rails.application.credentials.decidim[:track_newsletter_links].present?
+  end
 
   # Amount of time that the download your data files will be available in the server.
   config.download_your_data_expiry_time = Rails.application.credentials.decidim[:download_your_data_expiry_time].to_i.days
@@ -400,7 +402,9 @@ Decidim.configure do |config|
   end
   config.follow_http_x_forwarded_host = Rails.application.credentials.decidim[:follow_http_x_forwarded_host].present?
   config.maximum_conversation_message_length = Rails.application.credentials.decidim[:maximum_conversation_message_length].to_i
-  config.password_similarity_length = Rails.application.credentials.decidim[:password_similarity_length] if Rails.application.credentials.decidim[:password_similarity_length].present?
+  if Rails.application.credentials.decidim[:password_similarity_length].present?
+    config.password_similarity_length = Rails.application.credentials.decidim[:password_similarity_length]
+  end
   config.denied_passwords = Rails.application.credentials.decidim[:denied_passwords] if Rails.application.credentials.decidim[:denied_passwords].present?
   config.allow_open_redirects = Rails.application.credentials.decidim[:allow_open_redirects] if Rails.application.credentials.decidim[:allow_open_redirects].present?
 end

--- a/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
@@ -174,7 +174,7 @@ test:
 # instead read values from the environment.
 production:
   <<: *default
-  secret_key_base: <%%= ENV["SECRET_KEY_BASE"] %>
+  secret_key_base: <%%= ENV["SECRET_KEY_BASE"] || "<%= SecureRandom.hex(64) %>" %>
   smtp_username: <%%= ENV["SMTP_USERNAME"] %>
   smtp_password: <%%= ENV["SMTP_PASSWORD"] %>
   smtp_address: <%%= ENV["SMTP_ADDRESS"] %>

--- a/decidim-generators/lib/decidim/generators/app_templates/storage.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/storage.yml.erb
@@ -8,33 +8,33 @@ local:
 
 s3:
   service: S3
-  access_key_id: <%%= Rails.application.secrets.dig(:storage, :s3, :access_key_id) %>
-  secret_access_key: <%%= Rails.application.secrets.dig(:storage, :s3, :secret_access_key) %>
-  bucket: <%%= Rails.application.secrets.dig(:storage, :s3, :bucket) %>
-  <%%= "region: #{Rails.application.secrets.dig(:storage, :s3, :region)}" if Rails.application.secrets.dig(:storage, :s3, :region) %>
-  <%%= "endpoint: #{Rails.application.secrets.dig(:storage, :s3, :endpoint)}" if Rails.application.secrets.dig(:storage, :s3, :endpoint) %>
+  access_key_id: <%%= Rails.application.credentials.dig(:storage, :s3, :access_key_id) %>
+  secret_access_key: <%%= Rails.application.credentials.dig(:storage, :s3, :secret_access_key) %>
+  bucket: <%%= Rails.application.credentials.dig(:storage, :s3, :bucket) %>
+  <%%= "region: #{Rails.application.credentials.dig(:storage, :s3, :region)}" if Rails.application.credentials.dig(:storage, :s3, :region) %>
+  <%%= "endpoint: #{Rails.application.credentials.dig(:storage, :s3, :endpoint)}" if Rails.application.credentials.dig(:storage, :s3, :endpoint) %>
 
 azure:
   service: AzureStorage
-  storage_account_name: <%%= Rails.application.secrets.dig(:storage, :azure, :storage_account_name) %>
-  storage_access_key: <%%= Rails.application.secrets.dig(:storage, :azure, :storage_access_key) %>
-  container: <%%= Rails.application.secrets.dig(:storage, :azure, :container) %>
+  storage_account_name: <%%= Rails.application.credentials.dig(:storage, :azure, :storage_account_name) %>
+  storage_access_key: <%%= Rails.application.credentials.dig(:storage, :azure, :storage_access_key) %>
+  container: <%%= Rails.application.credentials.dig(:storage, :azure, :container) %>
 
 gcs:
   service: GCS
-  project: <%%= Rails.application.secrets.dig(:storage, :gcs, :project) %>
-  bucket: <%%= Rails.application.secrets.dig(:storage, :gcs, :bucket) %>
+  project: <%%= Rails.application.credentials.dig(:storage, :gcs, :project) %>
+  bucket: <%%= Rails.application.credentials.dig(:storage, :gcs, :bucket) %>
   credentials:
-    type: <%%= Rails.application.secrets.dig(:storage, :gcs, :type) %>
-    project_id: <%%= Rails.application.secrets.dig(:storage, :gcs, :project_id) %>
-    private_key_id: <%%= Rails.application.secrets.dig(:storage, :gcs, :private_key_id) %>
-    private_key: <%%= Rails.application.secrets.dig(:storage, :gcs, :private_key) %>
-    client_email: <%%= Rails.application.secrets.dig(:storage, :gcs, :client_email) %>
-    client_id: <%%= Rails.application.secrets.dig(:storage, :gcs, :client_id) %>
-    auth_uri: <%%= Rails.application.secrets.dig(:storage, :gcs, :auth_uri) %>
-    token_uri: <%%= Rails.application.secrets.dig(:storage, :gcs, :token_uri) %>
-    auth_provider_x509_cert_url: <%%= Rails.application.secrets.dig(:storage, :gcs, :auth_provider_x509_cert_url) %>
-    client_x509_cert_url: <%%= Rails.application.secrets.dig(:storage, :gcs, :client_x509_cert_url) %>
+    type: <%%= Rails.application.credentials.dig(:storage, :gcs, :type) %>
+    project_id: <%%= Rails.application.credentials.dig(:storage, :gcs, :project_id) %>
+    private_key_id: <%%= Rails.application.credentials.dig(:storage, :gcs, :private_key_id) %>
+    private_key: <%%= Rails.application.credentials.dig(:storage, :gcs, :private_key) %>
+    client_email: <%%= Rails.application.credentials.dig(:storage, :gcs, :client_email) %>
+    client_id: <%%= Rails.application.credentials.dig(:storage, :gcs, :client_id) %>
+    auth_uri: <%%= Rails.application.credentials.dig(:storage, :gcs, :auth_uri) %>
+    token_uri: <%%= Rails.application.credentials.dig(:storage, :gcs, :token_uri) %>
+    auth_provider_x509_cert_url: <%%= Rails.application.credentials.dig(:storage, :gcs, :auth_provider_x509_cert_url) %>
+    client_x509_cert_url: <%%= Rails.application.credentials.dig(:storage, :gcs, :client_x509_cert_url) %>
 
 # mirror:
 #   service: Mirror

--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -60,13 +60,13 @@ module Decidim
           cut <<~RUBY
             |
             |  config.action_mailer.smtp_settings = {
-            |    :address        => Rails.application.secrets.smtp_address,
-            |    :port           => Rails.application.secrets.smtp_port,
-            |    :authentication => Rails.application.secrets.smtp_authentication,
-            |    :user_name      => Rails.application.secrets.smtp_username,
-            |    :password       => Rails.application.secrets.smtp_password,
-            |    :domain         => Rails.application.secrets.smtp_domain,
-            |    :enable_starttls_auto => Rails.application.secrets.smtp_starttls_auto,
+            |    :address        => Rails.application.credentials.smtp_address,
+            |    :port           => Rails.application.credentials.smtp_port,
+            |    :authentication => Rails.application.credentials.smtp_authentication,
+            |    :user_name      => Rails.application.credentials.smtp_username,
+            |    :password       => Rails.application.credentials.smtp_password,
+            |    :domain         => Rails.application.credentials.smtp_domain,
+            |    :enable_starttls_auto => Rails.application.credentials.smtp_starttls_auto,
             |    :openssl_verify_mode => 'none'
             |  }
           RUBY

--- a/decidim-generators/lib/decidim/generators/test/generator_examples.rb
+++ b/decidim-generators/lib/decidim/generators/test/generator_examples.rb
@@ -948,7 +948,7 @@ shared_examples_for "an application with storage and queue gems" do
 end
 
 def json_secrets_for(path, env)
-  JSON.parse cmd_capture(path, "bin/rails runner 'puts Rails.application.secrets.to_json'", env:)
+  JSON.parse cmd_capture(path, "bin/rails runner 'puts Rails.application.credentials.to_json'", env:)
 end
 
 def initializer_config_for(path, env, mod = "Decidim")

--- a/decidim-generators/spec/lib/generators_spec.rb
+++ b/decidim-generators/spec/lib/generators_spec.rb
@@ -17,7 +17,7 @@ module Decidim
         let(:test_version) { "0.27.0.dev" }
 
         it "returns the develop branch" do
-          expect(subject.edge_git_branch).to eq("develop")
+          expect(subject.edge_git_branch).to eq("chore/migrate-credentials")
         end
       end
 

--- a/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
@@ -48,7 +48,7 @@ module Decidim
           [
             initiative.id,
             document_number || signer.id,
-            Rails.application.secrets.secret_key_base
+            Rails.application.credentials.secret_key_base
           ].compact.join("-")
         )
       end

--- a/decidim-initiatives/app/services/decidim/initiatives/data_encryptor.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/data_encryptor.rb
@@ -9,7 +9,7 @@ module Decidim
       def initialize(args = {})
         @secret = args.fetch(:secret) || "default"
         @key = ActiveSupport::KeyGenerator.new(secret).generate_key(
-          Rails.application.secrets.secret_key_base, ActiveSupport::MessageEncryptor.key_len
+          Rails.application.credentials.secret_key_base, ActiveSupport::MessageEncryptor.key_len
         )
         @encryptor = ActiveSupport::MessageEncryptor.new(@key)
       end

--- a/decidim-system/app/cells/decidim/system/system_checks_cell.rb
+++ b/decidim-system/app/cells/decidim/system/system_checks_cell.rb
@@ -23,7 +23,7 @@ module Decidim
       end
 
       def correct_secret_key_base?
-        Rails.application.secrets.secret_key_base&.length == 128
+        Rails.application.credentials.secret_key_base&.length == 128
       end
 
       def generated_secret_key

--- a/decidim-system/app/controllers/decidim/system/organizations_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/organizations_controller.rb
@@ -96,7 +96,7 @@ module Decidim
       end
 
       def provider_enabled?(provider)
-        Rails.application.secrets.dig(:omniauth, provider, :enabled)
+        Rails.application.credentials.dig(:omniauth, provider, :enabled)
       end
     end
   end

--- a/decidim-system/app/forms/decidim/system/base_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/base_organization_form.rb
@@ -46,7 +46,7 @@ module Decidim
       attribute :file_upload_settings, FileUploadSettingsForm
 
       OMNIATH_PROVIDERS_ATTRIBUTES = Decidim::OmniauthProvider.available.keys.map do |provider|
-        Rails.application.secrets.dig(:omniauth, provider).keys.map do |setting|
+        Rails.application.credentials.dig(:omniauth, provider).keys.map do |setting|
           if setting == :enabled
             [:"omniauth_settings_#{provider}_enabled", Boolean]
           else
@@ -114,7 +114,7 @@ module Decidim
       # We need a valid secret key base for encrypting the SMTP password with it
       # It is also necessary for other things in Rails (like Cookies encryption)
       def validate_secret_key_base_for_encryption
-        return if Rails.application.secrets.secret_key_base&.length == 128
+        return if Rails.application.credentials.secret_key_base&.length == 128
 
         errors.add(:password, I18n.t("activemodel.errors.models.organization.attributes.password.secret_key"))
       end

--- a/decidim-system/app/views/decidim/system/organizations/_omniauth_provider.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/_omniauth_provider.html.erb
@@ -11,7 +11,7 @@
     label_options: { class: "form__wrapper-checkbox-label" }
   ) %>
 
-  <% Rails.application.secrets.dig(:omniauth, provider.to_sym).keys.select { |k| k != :enabled }.each do |setting| %>
+  <% Rails.application.credentials.dig(:omniauth, provider.to_sym).keys.select { |k| k != :enabled }.each do |setting| %>
   <%= f.text_field("omniauth_settings_#{provider}_#{setting}", label: I18n.t(
         ".#{setting}",
         scope: [:icon, :icon_path].include?(setting) ? i18n_scope : "#{i18n_scope}.#{provider}"

--- a/decidim-system/spec/cells/decidim/system/system_checks_cell_spec.rb
+++ b/decidim-system/spec/cells/decidim/system/system_checks_cell_spec.rb
@@ -24,7 +24,7 @@ describe Decidim::System::SystemChecksCell, type: :cell do
 
   describe "secret_key_check" do
     before do
-      allow(Rails.application.secrets).to receive(:secret_key_base).and_return(secret_key)
+      allow(Rails.application.credentials).to receive(:secret_key_base).and_return(secret_key)
     end
 
     context "when the secret key is correct" do

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -213,7 +213,7 @@ describe "Organizations" do
 
       before do
         secrets = Rails.application.credentials
-        allow(Rails.application).to receive(:secrets).and_return(
+        allow(Rails.application).to receive(:credentials).and_return(
           secrets.merge(
             omniauth: {
               facebook: {

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -73,7 +73,7 @@ describe "Organizations" do
 
       context "without the secret key defined" do
         before do
-          allow(Rails.application.secrets).to receive(:secret_key_base).and_return(nil)
+          allow(Rails.application.credentials).to receive(:secret_key_base).and_return(nil)
         end
 
         it "does not create an organization" do
@@ -192,7 +192,7 @@ describe "Organizations" do
 
       context "without the secret key defined" do
         before do
-          allow(Rails.application.secrets).to receive(:secret_key_base).and_return(nil)
+          allow(Rails.application.credentials).to receive(:secret_key_base).and_return(nil)
         end
 
         it "shows the error message" do
@@ -212,7 +212,7 @@ describe "Organizations" do
       end
 
       before do
-        secrets = Rails.application.secrets
+        secrets = Rails.application.credentials
         allow(Rails.application).to receive(:secrets).and_return(
           secrets.merge(
             omniauth: {

--- a/decidim-verifications/app/forms/decidim/verifications/sms/mobile_phone_form.rb
+++ b/decidim-verifications/app/forms/decidim/verifications/sms/mobile_phone_form.rb
@@ -18,7 +18,7 @@ module Decidim
         # A mobile phone can only be verified once but it should be private.
         def unique_id
           Digest::MD5.hexdigest(
-            "#{mobile_phone_number}-#{Rails.application.secrets.secret_key_base}"
+            "#{mobile_phone_number}-#{Rails.application.credentials.secret_key_base}"
           )
         end
 

--- a/docs/modules/configure/pages/initializer.adoc
+++ b/docs/modules/configure/pages/initializer.adoc
@@ -107,7 +107,7 @@ Allows to make geographical mapping in some components, like Proposals or Meetin
 ....
   config.geocoder = {
     static_map_url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview",
-    here_api_key: Rails.application.secrets.geocoder[:here_api_key]
+    here_api_key: Rails.application.credentials.geocoder[:here_api_key]
   }
 ....
 
@@ -357,9 +357,9 @@ xref:services:etherpad.adoc[Etherpad's Decidim docs] in order to set it up.
 [source,ruby]
 ....
   config.etherpad = {
-    server: Rails.application.secrets.etherpad[:server],
-    api_key: Rails.application.secrets.etherpad[:api_key],
-    api_version: Rails.application.secrets.etherpad[:api_version]
+    server: Rails.application.credentials.etherpad[:server],
+    api_key: Rails.application.credentials.etherpad[:api_key],
+    api_version: Rails.application.credentials.etherpad[:api_version]
   }
 ....
 

--- a/docs/modules/develop/pages/maps.adoc
+++ b/docs/modules/develop/pages/maps.adoc
@@ -95,7 +95,7 @@ In order to provide configuration options for the Geocoder gem's lookup, you can
 ----
 config.maps = {
   provider: :your_provider,
-  api_key: Rails.application.secrets.maps[:api_key],
+  api_key: Rails.application.credentials.maps[:api_key],
   geocoding: { extra_option: "value", another_option: "value" }
 }
 ----
@@ -106,7 +106,7 @@ This would equal to configuring the Geocoder gem with the following code:
 ----
 Geocoder.configure(
   your_provider: {
-    api_key: Rails.application.secrets.maps[:api_key],
+    api_key: Rails.application.credentials.maps[:api_key],
     extra_option: "value",
     another_option: "value"
   }
@@ -153,7 +153,7 @@ In order to provide configuration options for the geocoding autocompletion, you 
 ----
 config.maps = {
   provider: :your_provider,
-  api_key: Rails.application.secrets.maps[:api_key],
+  api_key: Rails.application.credentials.maps[:api_key],
   autocomplete: {
     url: "https://photon.example.org/api/"
   }
@@ -353,7 +353,7 @@ In order to provide configuration options for the dynamic maps, you can pass the
 ----
 config.maps = {
   provider: :your_provider,
-  api_key: Rails.application.secrets.maps[:api_key],
+  api_key: Rails.application.credentials.maps[:api_key],
   dynamic: {
     tile_layer: {
       url: "https://tiles.example.org/{z}/{x}/{y}.png?key={apiKey}&{foo}&style={style}",
@@ -376,7 +376,7 @@ This will cause the following options to be available for the builder instance b
   tile_layer: {
     url: "https://tiles.example.org/{z}/{x}/{y}.png?key={apiKey}&{foo}&style={style}",
     configuration: {
-      api_key: Rails.application.secrets.maps[:api_key],
+      api_key: Rails.application.credentials.maps[:api_key],
       foo: "bar=baz",
       style: "bright",
       attribution: %{
@@ -450,7 +450,7 @@ In order to provide configuration options for the static maps, you can pass them
 ----
 config.maps = {
   provider: :your_provider,
-  api_key: Rails.application.secrets.maps[:api_key],
+  api_key: Rails.application.credentials.maps[:api_key],
   static: {
     url: "https://staticmap.example.org/",
     foo: "bar",
@@ -485,7 +485,7 @@ If you want to use the dynamic map replacements for the static map images, do no
 ----
 config.maps = {
   provider: :your_provider,
-  api_key: Rails.application.secrets.maps[:api_key]
+  api_key: Rails.application.credentials.maps[:api_key]
   # static: { ... } # LEAVE THIS OUT
 }
 ----

--- a/docs/modules/services/pages/etherpad.adoc
+++ b/docs/modules/services/pages/etherpad.adoc
@@ -26,9 +26,9 @@ An example snippet in `config/initializers/decidim.rb` may be:
 [source,ruby]
 ----
 config.etherpad = {
-  server: Rails.application.secrets.etherpad[:server],
-  api_key: Rails.application.secrets.etherpad[:api_key],
-  api_version: Rails.application.secrets.etherpad[:api_version]
+  server: Rails.application.credentials.etherpad[:server],
+  api_key: Rails.application.credentials.etherpad[:api_key],
+  api_version: Rails.application.credentials.etherpad[:api_version]
 }
 ----
 

--- a/docs/modules/services/pages/maps.adoc
+++ b/docs/modules/services/pages/maps.adoc
@@ -59,7 +59,7 @@ Use the following configuration for HERE Maps:
 # == HERE Maps ==
 config.maps = {
   provider: :here,
-  api_key: Rails.application.secrets.maps[:api_key],
+  api_key: Rails.application.credentials.maps[:api_key],
   static: { url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview" }
 }
 ----
@@ -94,7 +94,7 @@ Use the following configuration for Open Street Maps based service providers:
 # == OpenStreetMap (OSM) services ==
 config.maps = {
   provider: :osm,
-  api_key: Rails.application.secrets.maps[:api_key],
+  api_key: Rails.application.credentials.maps[:api_key],
   dynamic: {
     tile_layer: {
       url: "https://tiles.example.org/{z}/{x}/{y}.png?key={apiKey}",
@@ -144,7 +144,7 @@ config.maps = {
   provider: :osm,
   dynamic: {
     provider: :here,
-    api_key: Rails.application.secrets.maps[:here_api_key]
+    api_key: Rails.application.credentials.maps[:here_api_key]
   },
   static: { url: "https://staticmap.example.org/" },
   geocoding: { host: "nominatim.example.org", use_https: true },
@@ -181,7 +181,7 @@ For example, if you want to use HERE Maps as your default but disable the static
 ----
 config.maps = {
   provider: :here,
-  api_key: Rails.application.secrets.maps[:api_key],
+  api_key: Rails.application.credentials.maps[:api_key],
   static: false,
   autocomplete: false
 }

--- a/docs/modules/services/pages/social_providers.adoc
+++ b/docs/modules/services/pages/social_providers.adoc
@@ -101,7 +101,7 @@ An example of custom initializer could be written as:
 [source,ruby]
 ----
 #config/initializers/omniauth_myprovider.rb
-if Rails.application.secrets.dig(:omniauth, :myprovider).present?
+if Rails.application.credentials.dig(:omniauth, :myprovider).present?
   Rails.application.config.middleware.use OmniAuth::Builder do
     provider(
       :myprovider,


### PR DESCRIPTION
#### :tophat: What? Why?
This PR converts all `Rails.application.secrets` to `Rails.application.credentials`, in order to avoid displaying deprecation warnings once the upgrade to rails 7.1 is performed. 

#### Testing
1. All the pipeline should be green 
2. Using this branch, create a new development application 
3. Boot the application
4. See everything works as intended. 

:hearts: Thank you!
