### PR TITLE
Set correct method for `secret_key_base`

### DIFF
--- a/decidim-core/app/forms/decidim/omniauth_registration_form.rb
+++ b/decidim-core/app/forms/decidim/omniauth_registration_form.rb
@@ -21,7 +21,7 @@ module Decidim
     validates :uid, presence: true
 
     def self.create_signature(provider, uid)
-      Digest::MD5.hexdigest("#{provider}-#{uid}-#{Rails.application.secrets.secret_key_base}")
+      Digest::MD5.hexdigest("#{provider}-#{uid}-#{Rails.application.secret_key_base}")
     end
 
     def normalized_nickname

--- a/decidim-core/lib/decidim/attribute_encryptor.rb
+++ b/decidim-core/lib/decidim/attribute_encryptor.rb
@@ -21,7 +21,7 @@ module Decidim
     def self.cryptor
       @cryptor ||= begin
         key = ActiveSupport::KeyGenerator.new("attribute").generate_key(
-          Rails.application.secrets.secret_key_base, ActiveSupport::MessageEncryptor.key_len
+          Rails.application.secret_key_base, ActiveSupport::MessageEncryptor.key_len
         )
         ActiveSupport::MessageEncryptor.new(key)
       end

--- a/decidim-core/lib/decidim/newsletter_encryptor.rb
+++ b/decidim-core/lib/decidim/newsletter_encryptor.rb
@@ -14,7 +14,7 @@ module Decidim
 
     def self.crypt_data
       key = ActiveSupport::KeyGenerator.new("sent_at").generate_key(
-        Rails.application.secrets.secret_key_base, ActiveSupport::MessageEncryptor.key_len
+        Rails.application.secret_key_base, ActiveSupport::MessageEncryptor.key_len
       )
       ActiveSupport::MessageEncryptor.new(key)
     end

--- a/decidim-core/lib/decidim/paddable.rb
+++ b/decidim-core/lib/decidim/paddable.rb
@@ -66,7 +66,7 @@ module Decidim
           return tokenizer.hex_digest(id)
         end
 
-        Digest::MD5.hexdigest("#{id}-#{Rails.application.secrets.secret_key_base}")
+        Digest::MD5.hexdigest("#{id}-#{Rails.application.secret_key_base}")
       end
 
       def build_pad_url(id)

--- a/decidim-core/spec/lib/paddable_spec.rb
+++ b/decidim-core/spec/lib/paddable_spec.rb
@@ -111,7 +111,7 @@ module Decidim
       end
 
       def unsecure_hash(id)
-        Digest::MD5.hexdigest("#{id}-#{Rails.application.secrets.secret_key_base}")
+        Digest::MD5.hexdigest("#{id}-#{Rails.application.secret_key_base}")
       end
 
       def secure_hash(id)

--- a/decidim-forms/db/migrate/20190315203056_add_session_token_to_decidim_forms_answers.rb
+++ b/decidim-forms/db/migrate/20190315203056_add_session_token_to_decidim_forms_answers.rb
@@ -10,7 +10,7 @@ class AddSessionTokenToDecidimFormsAnswers < ActiveRecord::Migration[5.2]
     add_index :decidim_forms_answers, :session_token
 
     Answer.find_each do |answer|
-      answer.session_token = Digest::MD5.hexdigest("#{answer.decidim_user_id}-#{Rails.application.secrets.secret_key_base}")
+      answer.session_token = Digest::MD5.hexdigest("#{answer.decidim_user_id}-#{Rails.application.secret_key_base}")
       answer.save!
     end
   end

--- a/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/vote_form.rb
@@ -48,7 +48,7 @@ module Decidim
           [
             initiative.id,
             document_number || signer.id,
-            Rails.application.secrets.secret_key_base
+            Rails.application.secret_key_base
           ].compact.join("-")
         )
       end

--- a/decidim-initiatives/app/services/decidim/initiatives/data_encryptor.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/data_encryptor.rb
@@ -9,7 +9,7 @@ module Decidim
       def initialize(args = {})
         @secret = args.fetch(:secret) || "default"
         @key = ActiveSupport::KeyGenerator.new(secret).generate_key(
-          Rails.application.secrets.secret_key_base, ActiveSupport::MessageEncryptor.key_len
+          Rails.application.secret_key_base, ActiveSupport::MessageEncryptor.key_len
         )
         @encryptor = ActiveSupport::MessageEncryptor.new(@key)
       end

--- a/decidim-system/app/cells/decidim/system/system_checks_cell.rb
+++ b/decidim-system/app/cells/decidim/system/system_checks_cell.rb
@@ -23,7 +23,7 @@ module Decidim
       end
 
       def correct_secret_key_base?
-        Rails.application.secrets.secret_key_base&.length == 128
+        Rails.application.secret_key_base&.length == 128
       end
 
       def generated_secret_key

--- a/decidim-system/app/forms/decidim/system/base_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/base_organization_form.rb
@@ -114,7 +114,7 @@ module Decidim
       # We need a valid secret key base for encrypting the SMTP password with it
       # It is also necessary for other things in Rails (like Cookies encryption)
       def validate_secret_key_base_for_encryption
-        return if Rails.application.secrets.secret_key_base&.length == 128
+        return if Rails.application.secret_key_base&.length == 128
 
         errors.add(:password, I18n.t("activemodel.errors.models.organization.attributes.password.secret_key"))
       end

--- a/decidim-verifications/app/forms/decidim/verifications/sms/mobile_phone_form.rb
+++ b/decidim-verifications/app/forms/decidim/verifications/sms/mobile_phone_form.rb
@@ -18,7 +18,7 @@ module Decidim
         # A mobile phone can only be verified once but it should be private.
         def unique_id
           Digest::MD5.hexdigest(
-            "#{mobile_phone_number}-#{Rails.application.secrets.secret_key_base}"
+            "#{mobile_phone_number}-#{Rails.application.secret_key_base}"
           )
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
While investigating the possibility of moving away from Rails secrets, i have found out that rails recommends using `Rails.application.secret_key_base` as the source of the secrets_key_base. 
According to the [documentation](https://api.rubyonrails.org/classes/Rails/Application.html#method-i-secret_key_base), 
when using this method, in production will check for the existance of ENV['SECRET_KEY_BASE'], `credentials.secret_key_base` and finally for `secrets.secret_key_base`. 
In lower environments will either check if is defined, or it will generate a new one in 'tmp/' folder.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to  #13220

#### Testing
Everything should be green

:hearts: Thank you!
