### PR TITLE
Add exception handling when the versioned model does not exists

### DIFF
--- a/decidim-core/db/migrate/20240722215500_change_object_changes_on_versions.rb
+++ b/decidim-core/db/migrate/20240722215500_change_object_changes_on_versions.rb
@@ -25,6 +25,8 @@ class ChangeObjectChangesOnVersions < ActiveRecord::Migration[6.1]
       end
 
       version.update_columns(old_object_changes: nil, object_changes:) # rubocop:disable Rails/SkipsModelValidations
+    rescue NameError
+      Rails.logger.info "Skipping History of #{version.item_type} with id #{version.item_id}"
     end
 
     PaperTrail::Version.reset_column_information


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the version migrations which raises error when the Versioned entity does not exist. Ex: Decidim::Votings 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12366

#### Testing
1. Create a 0.28 development application 
2. Switch to this branch 
3. Run upgrade steps 
4. See there is no error when migrating `ChangeObjectChangesOnVersions` migration

:hearts: Thank you!
