### PR TITLE
Add overwrite parameter to upload-artifact

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -122,3 +122,4 @@ jobs:
           name: screenshots
           path: ./spec/decidim_dummy_app/tmp/screenshots
           if-no-files-found: ignore
+          overwrite: true


### PR DESCRIPTION
#### :tophat: What? Why?
This PR aims to fix the flacky `upload-artifact` job, which often fails with the following error: 
```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

#### Testing
1. The pipeline should be green with no retries on caused by this error.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
