### PR TITLE
Fix character counter disposition and spacing with WYSIWYG

### DIFF
--- a/decidim-core/app/packs/src/decidim/input_character_counter.js
+++ b/decidim-core/app/packs/src/decidim/input_character_counter.js
@@ -74,7 +74,7 @@ export default class InputCharacterCounter {
 
       // If input is a hidden for WYSIWYG editor add it at the end
       if (this.$input.parent().is(".editor")) {
-        this.$input.parent().after(this.$target);
+        this.$input.parent().append(container);
       } else {
         const wrapper = document.createElement("span")
         wrapper.className = "input-character-counter"

--- a/decidim-core/app/packs/stylesheets/decidim/editor.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/editor.scss
@@ -21,7 +21,7 @@
 }
 
 .editor-container {
-  @apply editor-props editor-suggestions-props flex flex-col mb-6 border editor-border;
+  @apply editor-props editor-suggestions-props flex flex-col mt-4 border editor-border;
 
   &.editor-disabled {
     .editor-input .ProseMirror {

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -806,7 +806,7 @@ en:
           discard: Discard this draft
           discard_confirmation: Are you sure you want to discard this proposal draft?
           send: Preview
-          title: Edit Proposal Draft
+          title: Edit proposal draft
         edit_form_fields:
           marker_added: Marker added to the map.
         filters:

--- a/decidim-proposals/spec/shared/proposals_wizards_examples.rb
+++ b/decidim-proposals/spec/shared/proposals_wizards_examples.rb
@@ -93,7 +93,7 @@ shared_examples "proposals wizards" do |options|
         end
 
         it "redirects to edit the proposal draft" do
-          expect(page).to have_content("Edit Proposal Draft")
+          expect(page).to have_content("Edit proposal draft")
         end
       end
 
@@ -239,7 +239,7 @@ shared_examples "proposals wizards" do |options|
         end
 
         it "redirects to edit the proposal draft" do
-          expect(page).to have_content("Edit Proposal Draft")
+          expect(page).to have_content("Edit proposal draft")
         end
       end
 

--- a/decidim-proposals/spec/system/new_proposals_spec.rb
+++ b/decidim-proposals/spec/system/new_proposals_spec.rb
@@ -43,9 +43,9 @@ describe "Proposals" do
 
       it "has helper character counter" do
         within "form.new_proposal" do
-          editor = find(".editor")
-          page.scroll_to(editor)
-          expect(editor.sibling("[id^=characters_]:not([id$=_sr])")).to have_content("At least 15 characters", count: 1)
+          within ".editor .input-character-counter__text" do
+            expect(page).to have_content("At least 15 characters", count: 1)
+          end
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

While testing the release candidate in Metadecidim, we found that the character counter wasn't shown correctly with a form with WYSIWYG enabled.

This PR fixes it.

![Screenshot with some remarks on where it is broken exactly](https://github.com/user-attachments/assets/0ad17238-d8e1-4fbd-bdc7-fcd04f03a1b6)

#### Testing

1. Log in as admin
2. Go to  http://localhost:3000/admin/organization/edit
3. Check " Enable rich text editor for participants"
4. Click on "Update"
5. Go to a process, go to a proposal component, click on the "New proposal" button
6. See the form (with and without this patch)

### :camera: Screenshots

#### Before

![Form with spacing problems](https://github.com/user-attachments/assets/54e5ab89-ea79-4aff-90ea-fbb2b675182b)

#### After

![Form with spacing problems fixed](https://github.com/user-attachments/assets/03e63ef3-fa73-407d-905b-995e168345f9)

:hearts: Thank you!
