### PR TITLE
Fix proposals' preview spacing

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
@@ -7,7 +7,7 @@
 
   <%= render partial: "wizard_header", locals: { callout_help_text_class: "warning" } %>
 
-  <div class="proposal__container my-10">
+  <div class="proposal__container my-10 flex flex-col gap-4">
     <h2 class="h3 text-secondary"><%= present(@proposal).title(links: true, html_escape: true) %></h2>
 
     <% unless component_settings.participatory_texts_enabled? %>


### PR DESCRIPTION
#### :tophat: What? Why?

While testing the release candidate in Metadecidim, we found that proposals preview has little spacing.

This PR fixes it.
 
#### Testing

1. Log in
2. Create a new proposal
3. See the preview

### :camera: Screenshots

#### Before

![Screenshot with the bug](https://github.com/user-attachments/assets/5b20ff45-c3cb-4a54-a51f-866f2847f173)

#### After

![Screenshot with the fix](https://github.com/user-attachments/assets/5742fe84-6ff7-464f-9121-5924157657ba)

:hearts: Thank you!
