### PR TITLE
Lock Chrome and ChromeDriver to 126.0.6478.182

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -24,6 +24,7 @@ AGPL
 Ajuntament
 Ajuntamentde
 alabs
+amd
 amendables
 AMR
 andreslucena

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -38,6 +38,11 @@ on:
         required: false
         default: true
         type: boolean
+      chrome_version:
+        description: 'Chrome & Chromedriver version'
+        required: false
+        default: "126.0.6478.182"
+        type: string
 
 jobs:
   build_app:
@@ -78,7 +83,14 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby_version }}
+      - run: |
+          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{inputs.chrome_version}}-1_amd64.deb
+          sudo dpkg -i /tmp/chrome.deb
+          rm /tmp/chrome.deb
+        name: Install Chrome version ${{inputs.chrome_version}}
       - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: ${{inputs.chrome_version}}
       - uses: actions/cache@v4
         id: app-cache
         with:


### PR DESCRIPTION
#### :tophat: What? Why?
This PR is locking the chrome & chromedriver to a specific version. Apparently the chrome team is working on removing / improving the unload/beforeunload handlers, and the fixes provided are not stable. 

Fixes the error:
![image](https://github.com/user-attachments/assets/dc084837-c924-415f-abbd-8700d4e180a4)


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12159
- Related to https://issues.chromium.org/issues/351858989
- Related to https://issues.chromium.org/issues/42323840

#### Testing
Make sure the pipeline is green 

:hearts: Thank you!
