### PR TITLE
Do not disclose Decidim version through the API

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -74,7 +74,19 @@ You can read more about this change on PR [#XXXX](https://github.com/decidim/dec
 
 ## 5. Changes in APIs
 
-### 5.1. [[TITLE OF THE CHANGE]]
+### 5.1. Decidim version number no longer disclosed through the GraphQL API by default
+
+In previous Decidim versions, you could request the running Decidim version through the following API query against the GraphQL API:
+
+```graphql
+query { decidim { version } }
+```
+
+This no longer returns the running Decidim version by default and instead it will result to `null` being reported as the version number.
+
+If you would like to re-enable exposing the Decidim version number through the GraphQL API, you may do so by setting the `DECIDIM_API_DISCLOSE_SYSTEM_VERSION` environment variable to `true`. However, this is highly discouraged but may be required for some automation or integrations.
+
+### 5.2. [[TITLE OF THE CHANGE]]
 
 In order to [[REASONING (e.g. improve the maintenance of the code base)]] we have changed...
 

--- a/decidim-api/lib/decidim/api.rb
+++ b/decidim-api/lib/decidim/api.rb
@@ -24,6 +24,10 @@ module Decidim
       15
     end
 
+    config_accessor :disclose_system_version do
+      %w(1 true yes).include?(ENV.fetch("DECIDIM_API_DISCLOSE_SYSTEM_VERSION", nil))
+    end
+
     # This declares all the types an interface or union can resolve to. This needs
     # to be done in order to be able to have them found. This is a shortcoming of
     # graphql-ruby and the way it deals with loading types, in combination with

--- a/decidim-core/lib/decidim/api/types/decidim_type.rb
+++ b/decidim-core/lib/decidim/api/types/decidim_type.rb
@@ -6,8 +6,12 @@ module Decidim
     class DecidimType < Decidim::Api::Types::BaseObject
       description "Decidim's framework-related properties."
 
-      field :version, GraphQL::Types::String, "The current decidim's version of this deployment.", null: false
+      field :version, GraphQL::Types::String, "The current decidim's version of this deployment.", null: true
       field :application_name, GraphQL::Types::String, "The current installation's name.", null: false
+
+      def version
+        object.version if Decidim::Api.disclose_system_version
+      end
     end
   end
 end

--- a/decidim-core/spec/lib/query_extensions_spec.rb
+++ b/decidim-core/spec/lib/query_extensions_spec.rb
@@ -34,8 +34,18 @@ module Decidim
       describe "decidim" do
         let(:query) { %({ decidim { version }}) }
 
-        it "returns the right version" do
-          expect(response["decidim"]).to include("version" => Decidim.version)
+        it "returns nil" do
+          expect(response["decidim"]).to include("version" => nil)
+        end
+
+        context "when disclosing system version is enabled" do
+          before do
+            allow(Decidim::Api).to receive(:disclose_system_version).and_return(true)
+          end
+
+          it "returns the right version" do
+            expect(response["decidim"]).to include("version" => Decidim.version)
+          end
         end
       end
 

--- a/decidim-core/spec/types/decidim_spec.rb
+++ b/decidim-core/spec/types/decidim_spec.rb
@@ -28,8 +28,18 @@ describe "Decidim::Api::QueryType" do
     it "has decidim" do
       expect(response["decidim"]).to eq({
                                           "applicationName" => "My Application Name",
-                                          "version" => Decidim::Core.version
+                                          "version" => nil
                                         })
+    end
+
+    context "when disclosing system version is enabled" do
+      before do
+        allow(Decidim::Api).to receive(:disclose_system_version).and_return(true)
+      end
+
+      it "discloses the version number" do
+        expect(response["decidim"]).to include("version" => Decidim::Core.version)
+      end
     end
   end
 end

--- a/decidim-core/spec/types/decidim_type_spec.rb
+++ b/decidim-core/spec/types/decidim_type_spec.rb
@@ -18,7 +18,17 @@ module Decidim
         let(:query) { "{ version }" }
 
         it "returns the version" do
-          expect(response).to eq("version" => Decidim.version)
+          expect(response).to eq("version" => nil)
+        end
+
+        context "when disclosing system version is enabled" do
+          before do
+            allow(Decidim::Api).to receive(:disclose_system_version).and_return(true)
+          end
+
+          it "returns the version" do
+            expect(response).to eq("version" => Decidim.version)
+          end
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
According to OWASP Application Security Verification Standard v4.0.3, applications should not disclose detailed version information of system components.

> **14.3.3** Verify that the HTTP headers or any part of the HTTP response do not expose detailed version information of system components.

https://owasp.org/www-project-application-security-verification-standard/

This PR hides the version number from the GraphQL API by default and adds the ability to disclose it by defining the environment variable `DECIDIM_API_DISCLOSE_SYSTEM_VERSION=true`.

It also means a change in the API as the `Decidim` type's `version` field now allows a `null` value.

#### Testing
- Start Decidim server
- Perform the following request: `curl 'http://localhost:3000/api' -H 'Content-Type: application/json' --data-raw '{"query":"{decidim{version}}"}'`
- See that version number is reported as `null`
- Add `DECIDIM_API_DISCLOSE_SYSTEM_VERSION=true` to the environment variables
- Restart Decidim server
- Perform the same query and you should now see the version number disclosed