### PR TITLE
Fix deleting a component which has reminders associated with it

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/destroy_component.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_component.rb
@@ -7,6 +7,7 @@ module Decidim
       private
 
       def run_before_hooks
+        Decidim::Reminder.where(component: resource).destroy_all
         resource.manifest.run_hooks(:before_destroy, resource)
       end
 

--- a/decidim-admin/spec/commands/decidim/admin/destroy_component_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/destroy_component_spec.rb
@@ -44,7 +44,7 @@ module Decidim::Admin
     end
 
     context "when the component has a reminder associated with it" do
-      let!(:reminder) { Decidim::Reminder.create!(user: current_user, component:) }
+      let!(:reminder) { create(:reminder, user: current_user, component:) }
 
       it "destroys the component" do
         expect { subject.call }.to broadcast(:ok)

--- a/decidim-admin/spec/commands/decidim/admin/destroy_component_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/destroy_component_spec.rb
@@ -42,5 +42,18 @@ module Decidim::Admin
         expect(result_component).not_to be_persisted
       end
     end
+
+    context "when the component has a reminder associated with it" do
+      let!(:reminder) { Decidim::Reminder.create!(user: current_user, component:) }
+
+      it "destroys the component" do
+        expect { subject.call }.to broadcast(:ok)
+        expect(Decidim::Component.where(id: component.id)).not_to exist
+      end
+
+      it "destroys the associated reminders" do
+        expect { subject.call }.to change(Decidim::Reminder, :count).by(-1)
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed that (budgets) components that have reminders associated with them cannot be deleted.

This fixes the issue.

#### :pushpin: Related Issues
- Related to #8621

#### Testing
- Create a budgets component
- Send reminders against that component (e.g. through the admin panel) or create them manually through the Rails console (`Decidim::Reminder.create!(user: ..., component: ...)`)
- Try to delete the component through the admin panel
- See an error and that the component was not deleted