### PR TITLE
Disable search engine choice window for ChromeDriver in system specs

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -58,6 +58,7 @@ Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.args << "--explicitly-allowed-ports=#{Capybara.server_port}"
   options.args << "--headless=new"
+  options.args << "--disable-search-engine-choice-screen" # Prevents closing the window normally
   # Do not limit browser resources
   options.args << "--disable-dev-shm-usage"
   options.args << "--no-sandbox"


### PR DESCRIPTION
#### :tophat: What? Why?
With the latest stable Chrome and ChromeDriver (127.0.6533.99) started to see the following errors in the console when trying to run any system specs:

```
     Got 0 failures and 2 other errors:

     1.1) Failure/Error: Unable to infer file and line number from backtrace
          
          Selenium::WebDriver::Error::UnknownError:
            unknown error: failed to close window in 20 seconds
              (Session info: chrome=127.0.6533.99)

     1.2) Failure/Error: Unable to infer file and line number from backtrace
          
          Selenium::WebDriver::Error::UnknownError:
            unknown error: failed to close window in 20 seconds
              (Session info: chrome=127.0.6533.99)
```

Tried running the same spec in visual mode by disabling the headless mode of ChromeDriver, i.e. commenting out this line:
https://github.com/decidim/decidim/blob/2596f591b04366dd450f332e6c408a102c6929b3/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb#L60

And I saw the search engine selection screen on top of the window which prevents the screen from being closed (see the attached screenshot).

#### Testing
- Update Chrome and ChromeDriver to latest stable (127.0.6533.99 or newer)
- Try to run any system specs
- See the errors presented in the description without the fix
- Re-run the same spec with the fix and see that the error is gone

### :camera: Screenshots

![Search engine selector on top of the Chrome window](https://github.com/user-attachments/assets/f7e72f24-386a-4076-a7ab-1bc7b29d535c)