### PR TITLE
Make confirm page unload compatible with the current unload event standards and newer Chromium

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/headers/browser_feature_permissions.rb
+++ b/decidim-core/app/controllers/concerns/decidim/headers/browser_feature_permissions.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Headers
+    # This module controls the "Permissions-Policy" header to define the
+    # specific sets of browser features that the website is able to use.
+    module BrowserFeaturePermissions
+      extend ActiveSupport::Concern
+
+      included do
+        after_action :define_permissions_policy
+      end
+
+      private
+
+      def define_permissions_policy
+        return if response.media_type != "text/html"
+        return if response.headers["Permissions-Policy"].present?
+
+        # Allow the "unload" and "onbeforeunload" events to be used at the
+        # current domain to prevent the user unintentionally changing the page
+        # when they have something important to do on the page, such as an
+        # unsaved form.
+        #
+        # This header is required because Chrome is phasing this event out due
+        # to some performance issues with the Bfcache feature of the browser.
+        # However, currently there are no alternative events that would allow
+        # preventing accidental page reloads, tab closing or window closing.
+        #
+        # For further information, see:
+        # https://developer.chrome.com/docs/web-platform/deprecating-unload
+        # https://github.com/fergald/docs/blob/master/explainers/permissions-policy-unload.md
+        #
+        # Note that even Google suggests using the "beforeunload" for this
+        # particular use case:
+        # https://developer.chrome.com/docs/web-platform/page-lifecycle-api#events
+        #
+        # beforeunload
+        #   Important: the beforeunload event should only be used to alert the
+        #   user of unsaved changes. Once those changes are saved, the event
+        #   should be removed. It should never be added unconditionally to the
+        #   page, as doing so can hurt performance in some cases.
+        response.headers["Permissions-Policy"] = "unload=(self)"
+      end
+    end
+  end
+end

--- a/decidim-core/app/controllers/concerns/decidim/headers/browser_feature_permissions.rb
+++ b/decidim-core/app/controllers/concerns/decidim/headers/browser_feature_permissions.rb
@@ -25,9 +25,10 @@ module Decidim
         # unsaved form.
         #
         # This header is required because Chrome is phasing this event out due
-        # to some performance issues with the Bfcache feature of the browser.
-        # However, currently there are no alternative events that would allow
-        # preventing accidental page reloads, tab closing or window closing.
+        # to some performance issues with the back/forward cache feature of the
+        # browser. However, currently there are no alternative events that would
+        # allow preventing accidental page reloads, tab closing or window
+        # closing.
         #
         # For further information, see:
         # https://developer.chrome.com/docs/web-platform/deprecating-unload

--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -16,6 +16,7 @@ module Decidim
     include NeedsTosAccepted
     include Headers::HttpCachingDisabler
     include Headers::ContentSecurityPolicy
+    include Headers::BrowserFeaturePermissions
     include ActionAuthorization
     include ForceAuthentication
     include SafeRedirect

--- a/decidim-core/app/packs/src/decidim/configuration.js
+++ b/decidim-core/app/packs/src/decidim/configuration.js
@@ -12,16 +12,6 @@ export default class Configuration {
   }
 
   get(key) {
-    if (typeof key === "string" && key.length > 0) {
-      let currentNode = this.config;
-      for (const part of key.split(".")) {
-        currentNode = currentNode[part];
-        if (!currentNode) {
-          return null;
-        }
-      }
-      return currentNode;
-    }
     return this.config[key];
   }
 }

--- a/decidim-core/app/packs/src/decidim/configuration.js
+++ b/decidim-core/app/packs/src/decidim/configuration.js
@@ -12,6 +12,16 @@ export default class Configuration {
   }
 
   get(key) {
+    if (typeof key === "string" && key.length > 0) {
+      let currentNode = this.config;
+      for (const part of key.split(".")) {
+        currentNode = currentNode[part];
+        if (!currentNode) {
+          return null;
+        }
+      }
+      return currentNode;
+    }
     return this.config[key];
   }
 }

--- a/decidim-core/app/packs/src/decidim/confirm.js
+++ b/decidim-core/app/packs/src/decidim/confirm.js
@@ -10,7 +10,9 @@ const { Rails } = window;
 class ConfirmDialog {
   constructor(sourceElement) {
     this.$modal = $("#confirm-modal");
-    this.$source = sourceElement;
+    if (sourceElement) {
+      this.$source = $(sourceElement);
+    }
     this.$content = $("[data-confirm-modal-content]", this.$modal);
     this.$buttonConfirm = $("[data-confirm-ok]", this.$modal);
     this.$buttonCancel = $("[data-confirm-cancel]", this.$modal);
@@ -29,21 +31,36 @@ class ConfirmDialog {
       this.$buttonConfirm.on("click", (ev) => {
         ev.preventDefault();
 
-        window.Decidim.currentDialogs["confirm-modal"].close()
-        resolve(true);
-        this.$source.focus();
+        this.close(() => resolve(true));
       });
 
       this.$buttonCancel.on("click", (ev) => {
         ev.preventDefault();
 
-        window.Decidim.currentDialogs["confirm-modal"].close()
-        resolve(false);
-        this.$source.focus();
+        this.close(() => resolve(false));
       });
     });
   }
+
+  close(afterClose) {
+    window.Decidim.currentDialogs["confirm-modal"].close()
+    afterClose();
+    if (this.$source) {
+      this.$source.focus();
+    }
+  }
 }
+
+const runConfirm = (message, sourceElement = null) => new Promise((resolve) => {
+  const dialog = new ConfirmDialog(sourceElement);
+  dialog.confirm(message).then((answer) => {
+    let completed = true;
+    if (sourceElement) {
+      completed = Rails.fire(sourceElement, "confirm:complete", [answer]);
+    }
+    resolve(answer && completed);
+  });
+});
 
 // Override the default confirm dialog by Rails
 // See:
@@ -64,37 +81,35 @@ const allowAction = (ev, element) => {
     return false;
   }
 
-  const dialog = new ConfirmDialog(
-    $(element)
-  );
-  dialog.confirm(message).then((answer) => {
-    const completed = Rails.fire(element, "confirm:complete", [answer]);
-    if (answer && completed) {
-      // Allow the event to propagate normally and re-dispatch it without
-      // the confirm data attribute which the Rails internal method is
-      // checking.
-      $(element).data("confirm", null);
-      $(element).removeAttr("data-confirm");
+  runConfirm(message, element).then((answer) => {
+    if (!answer) {
+      return;
+    }
 
-      // The submit button click events will not do anything if they are
-      // dispatched as is. In these cases, just submit the underlying form.
-      if (ev.type === "click" &&
-        (
-          $(element).is('button[type="submit"]') ||
-          $(element).is('input[type="submit"]')
-        )
-      ) {
-        $(element).parents("form").submit();
-      } else {
-        let origEv = ev.originalEvent || ev;
-        let newEv = origEv;
-        if (typeof Event === "function") {
-          // Clone the event because otherwise some click events may not
-          // work properly when re-dispatched.
-          newEv = new origEv.constructor(origEv.type, origEv);
-        }
-        ev.target.dispatchEvent(newEv);
+    // Allow the event to propagate normally and re-dispatch it without
+    // the confirm data attribute which the Rails internal method is
+    // checking.
+    $(element).data("confirm", null);
+    $(element).removeAttr("data-confirm");
+
+    // The submit button click events will not do anything if they are
+    // dispatched as is. In these cases, just submit the underlying form.
+    if (ev.type === "click" &&
+      (
+        $(element).is('button[type="submit"]') ||
+        $(element).is('input[type="submit"]')
+      )
+    ) {
+      $(element).parents("form").submit();
+    } else {
+      let origEv = ev.originalEvent || ev;
+      let newEv = origEv;
+      if (typeof Event === "function") {
+        // Clone the event because otherwise some click events may not
+        // work properly when re-dispatched.
+        newEv = new origEv.constructor(origEv.type, origEv);
       }
+      ev.target.dispatchEvent(newEv);
     }
   });
 
@@ -156,4 +171,4 @@ export const initializeConfirm = () => {
   });
 };
 
-export default ConfirmDialog;
+export default runConfirm;

--- a/decidim-core/app/packs/src/decidim/confirm.js
+++ b/decidim-core/app/packs/src/decidim/confirm.js
@@ -5,7 +5,7 @@
  * it to gain control over the confirm events BEFORE rails-ujs is loaded.
  */
 
-import Rails from "@rails/ujs"
+const { Rails } = window;
 
 class ConfirmDialog {
   constructor(sourceElement) {
@@ -129,26 +129,31 @@ const handleDocumentEvent = (ev, matchSelectors) => {
   });
 };
 
-document.addEventListener("click", (ev) => {
-  return handleDocumentEvent(ev, [
-    Rails.linkClickSelector,
-    Rails.buttonClickSelector,
-    Rails.formInputClickSelector
-  ]);
-});
-document.addEventListener("change", (ev) => {
-  return handleDocumentEvent(ev, [Rails.inputChangeSelector]);
-});
-document.addEventListener("submit", (ev) => {
-  return handleDocumentEvent(ev, [Rails.formSubmitSelector]);
-});
-
-// This is needed for the confirm dialog to work with Foundation Abide.
-// Abide registers its own submit click listeners since Foundation 5.6.x
-// which will be handled before the document listeners above. This would
-// break the custom confirm functionality when used with Foundation Abide.
-document.addEventListener("DOMContentLoaded", function() {
-  $(Rails.formInputClickSelector).on("click.confirm", (ev) => {
-    handleConfirm(ev, getMatchingEventTarget(ev, Rails.formInputClickSelector));
+// Note that this needs to be run **before** Rails.start()
+export const initializeConfirm = () => {
+  document.addEventListener("click", (ev) => {
+    return handleDocumentEvent(ev, [
+      Rails.linkClickSelector,
+      Rails.buttonClickSelector,
+      Rails.formInputClickSelector
+    ]);
   });
-});
+  document.addEventListener("change", (ev) => {
+    return handleDocumentEvent(ev, [Rails.inputChangeSelector]);
+  });
+  document.addEventListener("submit", (ev) => {
+    return handleDocumentEvent(ev, [Rails.formSubmitSelector]);
+  });
+
+  // This is needed for the confirm dialog to work with Foundation Abide.
+  // Abide registers its own submit click listeners since Foundation 5.6.x
+  // which will be handled before the document listeners above. This would
+  // break the custom confirm functionality when used with Foundation Abide.
+  document.addEventListener("DOMContentLoaded", function() {
+    $(Rails.formInputClickSelector).on("click.confirm", (ev) => {
+      handleConfirm(ev, getMatchingEventTarget(ev, Rails.formInputClickSelector));
+    });
+  });
+};
+
+export default ConfirmDialog;

--- a/decidim-core/app/packs/src/decidim/form_remote.js
+++ b/decidim-core/app/packs/src/decidim/form_remote.js
@@ -1,4 +1,4 @@
-import Rails from "@rails/ujs";
+const { Rails } = window;
 
 // Make the remote form submit buttons disabled when the form is being
 // submitted to avoid multiple submits.

--- a/decidim-core/app/packs/src/decidim/impersonation.js
+++ b/decidim-core/app/packs/src/decidim/impersonation.js
@@ -15,7 +15,7 @@ $(() => {
     }, 1000);
 
     // Prevent reload when page is already unloading, otherwise it may cause infinite reloads.
-    window.addEventListener("beforeunload", () => {
+    window.addEventListener("pagehide", () => {
       clearInterval(exitInterval);
       return;
     });

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -41,7 +41,6 @@ import "src/decidim/vizzs"
 import "src/decidim/responsive_horizontal_tabs"
 import "src/decidim/security/selfxss_warning"
 import "src/decidim/session_timeouter"
-import "src/decidim/confirm"
 import "src/decidim/results_listing"
 import "src/decidim/impersonation"
 import "src/decidim/gallery"
@@ -53,6 +52,7 @@ import "src/decidim/sticky_header"
 import "src/decidim/attachments"
 
 // local deps that require initialization
+import ConfirmDialog, { initializeConfirm } from "src/decidim/confirm"
 import formDatePicker from "src/decidim/datepicker/form_datepicker"
 import Configuration from "src/decidim/configuration"
 import ExternalLink from "src/decidim/external_link"
@@ -89,6 +89,7 @@ window.Decidim = window.Decidim || {
   addInputEmoji,
   EmojiButton,
   Dialogs,
+  ConfirmDialog,
   announceForScreenReader
 };
 
@@ -121,6 +122,8 @@ window.initFoundation = (element) => {
   });
 };
 
+// Confirm initialization needs to happen before Rails.start()
+initializeConfirm();
 Rails.start()
 
 /**

--- a/decidim-core/app/packs/src/decidim/session_timeouter.js
+++ b/decidim-core/app/packs/src/decidim/session_timeouter.js
@@ -127,7 +127,7 @@ $(() => {
     setTimer(timeoutInSeconds);
   });
 
-  window.addEventListener("beforeunload", () => {
+  window.addEventListener("pagehide", () => {
     clearInterval(exitInterval);
     return;
   });

--- a/decidim-core/app/packs/src/decidim/utilities/dom.js
+++ b/decidim-core/app/packs/src/decidim/utilities/dom.js
@@ -68,6 +68,7 @@ const createUnloadPreventer = () => {
 
     if (canUnload(ev)) {
       disableBeforeUnload();
+      document.removeEventListener("click", linkClickListener);
       return;
     }
 
@@ -95,6 +96,7 @@ const createUnloadPreventer = () => {
 
     if (canUnload(ev)) {
       disableBeforeUnload();
+      document.removeEventListener("submit", formSubmitListener);
       return;
     }
 

--- a/decidim-core/app/packs/src/decidim/utilities/dom.js
+++ b/decidim-core/app/packs/src/decidim/utilities/dom.js
@@ -1,4 +1,4 @@
-import ConfirmDialog from "src/decidim/confirm"
+import confirmAction from "src/decidim/confirm"
 
 const { Rails } = window;
 
@@ -75,14 +75,14 @@ const createUnloadPreventer = () => {
     ev.preventDefault();
     ev.stopPropagation();
 
-    const dialog = new ConfirmDialog($(link));
-    dialog.confirm(confirmMessage).then((answer) => {
-      const completed = Rails.fire(link, "confirm:complete", [answer]);
-      if (answer && completed) {
-        disableBeforeUnload();
-        document.removeEventListener("click", linkClickListener);
-        link.click();
+    confirmAction(confirmMessage, link).then((answer) => {
+      if (!answer) {
+        return;
       }
+
+      disableBeforeUnload();
+      document.removeEventListener("click", linkClickListener);
+      link.click();
     });
   };
 
@@ -106,14 +106,14 @@ const createUnloadPreventer = () => {
     ev.stopImmediatePropagation();
     ev.stopPropagation();
 
-    const dialog = new ConfirmDialog($(button));
-    dialog.confirm(confirmMessage).then((answer) => {
-      const completed = Rails.fire(button, "confirm:complete", [answer]);
-      if (answer && completed) {
-        disableBeforeUnload();
-        document.removeEventListener("submit", formSubmitListener);
-        source.submit();
+    confirmAction(confirmMessage, button).then((answer) => {
+      if (!answer) {
+        return;
       }
+
+      disableBeforeUnload();
+      document.removeEventListener("submit", formSubmitListener);
+      source.submit();
     });
   };
 

--- a/decidim-core/app/packs/src/decidim/utilities/dom.js
+++ b/decidim-core/app/packs/src/decidim/utilities/dom.js
@@ -43,7 +43,7 @@ const createUnloadPreventer = () => {
   // not work due to the deprecation of the unload APIs in Chromium based
   // browsers and possibly in the web standards in the future.
   //
-  // Accoring to:
+  // According to:
   // https://developer.chrome.com/docs/web-platform/page-lifecycle-api#the_beforeunload_event
   //
   // > Never add a beforeunload listener unconditionally or use it as an

--- a/decidim-core/app/packs/src/decidim/utilities/dom.js
+++ b/decidim-core/app/packs/src/decidim/utilities/dom.js
@@ -1,0 +1,145 @@
+import ConfirmDialog from "src/decidim/confirm"
+
+const { Rails } = window;
+
+const createUnloadPreventer = () => {
+  const preventUnloadConditions = [];
+
+  const confirmMessage = "Are you sure you want to continue?";
+
+  const canUnload = (event) => !preventUnloadConditions.some((condition) => condition(event));
+
+  // TLDR:
+  // The beforeunload event does not work during tests due to the deprecation of
+  // the unload event and ChromeDriver automatically accepting these dialogs.
+  // ---
+  //
+  // Even when there are custom listeners on links and forms, the beforeunload
+  // event is to ensure that the user does not accidentally reload the page or
+  // close the browser or the tab. Note that this does not work during the tests
+  // with ChromeDriver due to the deprecation of the unload event and
+  // ChromeDriver automatically accepting these dialogs. For the time being,
+  // this should work when a real user interacts with the browser along with the
+  // "Permissions-Policy" header set by the backend. For more information about
+  // the header, see Decidim::Headers::BrowserFeaturePermissions).
+  const unloadListener = (event) => {
+    if (canUnload(event)) {
+      return;
+    }
+
+    // According to:
+    // https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event
+    //
+    // > [...] best practice is to trigger the dialog by invoking
+    // > preventDefault() on the event object, while also setting returnValue to
+    // > support legacy cases.
+    event.preventDefault();
+    event.returnValue = true;
+  };
+
+  // The beforeunload event listener has to be registered AFTER a user
+  // interaction which is why it is wrapped around the next click event that
+  // happens after the first unload listener was registered. Otherwise it might
+  // not work due to the deprecation of the unload APIs in Chromium based
+  // browsers and possibly in the web standards in the future.
+  //
+  // Accoring to:
+  // https://developer.chrome.com/docs/web-platform/page-lifecycle-api#the_beforeunload_event
+  //
+  // > Never add a beforeunload listener unconditionally or use it as an
+  // > end-of-session signal. Only add it when a user has unsaved work, and
+  // > remove it as soon as that work has been saved.
+  const registerBeforeUnload = () => {
+    window.removeEventListener("click", registerBeforeUnload);
+    window.addEventListener("beforeunload", unloadListener);
+  };
+
+  const disableBeforeUnload = () => {
+    window.removeEventListener("click", registerBeforeUnload);
+    window.removeEventListener("beforeunload", unloadListener);
+  };
+
+  const linkClickListener = (ev) => {
+    const link = ev.target?.closest("a");
+    if (!link) {
+      return;
+    }
+
+    if (canUnload(ev)) {
+      disableBeforeUnload();
+      return;
+    }
+
+    window.exitUrl = link.href;
+
+    ev.preventDefault();
+    ev.stopPropagation();
+
+    const dialog = new ConfirmDialog($(link));
+    dialog.confirm(confirmMessage).then((answer) => {
+      const completed = Rails.fire(link, "confirm:complete", [answer]);
+      if (answer && completed) {
+        disableBeforeUnload();
+        document.removeEventListener("click", linkClickListener);
+        link.click();
+      }
+    });
+  };
+
+  const formSubmitListener = (ev) => {
+    const source = ev.target?.closest("form");
+    if (!source) {
+      return;
+    }
+
+    if (canUnload(ev)) {
+      disableBeforeUnload();
+      return;
+    }
+
+    const button = source.closest(Rails.formSubmitSelector);
+    if (!button) {
+      return;
+    }
+
+    ev.preventDefault();
+    ev.stopImmediatePropagation();
+    ev.stopPropagation();
+
+    const dialog = new ConfirmDialog($(button));
+    dialog.confirm(confirmMessage).then((answer) => {
+      const completed = Rails.fire(button, "confirm:complete", [answer]);
+      if (answer && completed) {
+        disableBeforeUnload();
+        document.removeEventListener("submit", formSubmitListener);
+        source.submit();
+      }
+    });
+  };
+
+  const registerPreventUnloadListeners = () => {
+    window.addEventListener("click", registerBeforeUnload);
+    document.addEventListener("click", linkClickListener);
+    document.addEventListener("submit", formSubmitListener);
+  };
+
+  return {
+    addPreventCondition: (condition) => {
+      if (typeof condition !== "function") {
+        return;
+      }
+
+      if (preventUnloadConditions.length < 1) {
+        // The unload listeners are global, so only the first call to this
+        // function should result to registering these listeners.
+        registerPreventUnloadListeners();
+      }
+
+      preventUnloadConditions.push(condition);
+    }
+  };
+};
+
+const unloadPreventer = createUnloadPreventer();
+
+export const preventUnload = (condition) => unloadPreventer.addPreventCondition(condition);

--- a/decidim-core/app/packs/src/decidim/utilities/dom.js
+++ b/decidim-core/app/packs/src/decidim/utilities/dom.js
@@ -5,7 +5,7 @@ const { Rails } = window;
 const createUnloadPreventer = () => {
   const preventUnloadConditions = [];
 
-  const confirmMessage = "Are you sure you want to continue?";
+  const confirmMessage = window.Decidim.config.get("messages.confirmUnload") || "Are you sure you want to leave this page?";
 
   const canUnload = (event) => !preventUnloadConditions.some((condition) => condition(event));
 

--- a/decidim-core/app/packs/src/decidim/utilities/dom.js
+++ b/decidim-core/app/packs/src/decidim/utilities/dom.js
@@ -1,11 +1,12 @@
 import confirmAction from "src/decidim/confirm"
+import { getMessages } from "src/decidim/i18n"
 
 const { Rails } = window;
 
 const createUnloadPreventer = () => {
   const preventUnloadConditions = [];
 
-  const confirmMessage = window.Decidim.config.get("messages.confirmUnload") || "Are you sure you want to leave this page?";
+  const confirmMessage = getMessages("confirmUnload") || "Are you sure you want to leave this page?";
 
   const canUnload = (event) => !preventUnloadConditions.some((condition) => condition(event));
 

--- a/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_js_configuration.html.erb
@@ -7,6 +7,7 @@ js_configs = {
     "mentionsModal": {
       "removeRecipient": t("decidim.shared.mentions_modal.remove_recipient", name: "%name%")
     },
+    "confirmUnload": t("decidim.shared.confirm_unload"),
     emojis: I18n.t("emojis").deep_transform_keys { |k| k.to_s.camelize(:lower) },
     editor: I18n.t("editor"),
     date: I18n.t("date"),

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1484,6 +1484,7 @@ en:
         close_modal: Close modal
         ok: OK
         title: Confirm
+      confirm_unload: This page contains unsaved changes. Are you sure you want to leave this page?
       embed:
         title: Embedded video content
       extended_navigation_bar:

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/confirmation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/confirmation_helpers.rb
@@ -47,15 +47,15 @@ module ConfirmationHelpers
   # Used to accept the "onbeforeunload" event's normal browser confirm modal
   # as this cannot be overridden. Original confirm dismiss implementation in
   # Capybara.
-  def accept_page_unload(text = nil, **options, &)
-    page.send(:accept_modal, :confirm, text, options, &)
+  def accept_page_unload(text = nil, **, &)
+    accept_confirm(text, &)
   end
 
   # Used to dismiss the "onbeforeunload" event's normal browser confirm modal
   # as this cannot be overridden. Original confirm dismiss implementation in
   # Capybara.
-  def dismiss_page_unload(text = nil, **options, &)
-    page.send(:dismiss_modal, :confirm, text, options, &)
+  def dismiss_page_unload(text = nil, **, &)
+    dismiss_confirm(text, &)
   end
 end
 

--- a/decidim-forms/app/packs/src/decidim/forms/forms.js
+++ b/decidim-forms/app/packs/src/decidim/forms/forms.js
@@ -46,7 +46,6 @@ $(() => {
     });
   });
 
-  // const $form = $("form.answer-questionnaire");
   const form = document.querySelector("form.answer-questionnaire");
   if (form) {
     const safePath = form.dataset.safePath.split("?")[0];

--- a/decidim-forms/app/packs/src/decidim/forms/forms.js
+++ b/decidim-forms/app/packs/src/decidim/forms/forms.js
@@ -11,6 +11,7 @@ import "dragula/dist/dragula.css";
 import createOptionAttachedInputs from "src/decidim/forms/option_attached_inputs.component"
 import createDisplayConditions from "src/decidim/forms/display_conditions.component"
 import createMaxChoicesAlertComponent from "src/decidim/forms/max_choices_alert.component"
+import { preventUnload } from "src/decidim/utilities/dom"
 
 $(() => {
   $(".js-radio-button-collection, .js-check-box-collection").each((idx, el) => {
@@ -45,30 +46,34 @@ $(() => {
     });
   });
 
-  const $form = $("form.answer-questionnaire");
-  if ($form.length > 0) {
-    $form.find("input, textarea, select").on("change", () => {
-      $form.data("changed", true);
-    });
-
-    const safePath = $form.data("safe-path").split("?")[0];
-    $(document).on("click", "a", (event) => {
-      window.exitUrl = event.currentTarget.href;
-    });
-    $(document).on("submit", "form", (event) => {
-      window.exitUrl = event.currentTarget.action;
-    });
-
-    window.addEventListener("beforeunload", (event) => {
-      const exitUrl = window.exitUrl;
-      const hasChanged = $form.data("changed");
-      window.exitUrl = null;
-
-      if (!hasChanged || (exitUrl && exitUrl.includes(safePath))) {
-        return;
+  // const $form = $("form.answer-questionnaire");
+  const form = document.querySelector("form.answer-questionnaire");
+  if (form) {
+    const safePath = form.dataset.safePath.split("?")[0];
+    let exitUrl = "";
+    document.addEventListener("click", (event) => {
+      const link = event.target?.closest("a");
+      if (link) {
+        exitUrl = link.href;
       }
-
-      event.returnValue = true;
     });
+
+    // The submit listener has to be registered through jQuery because the
+    // custom confirm dialog does not dispatch the "submit" event normally.
+    $(document).on("submit", "form", (event) => {
+      exitUrl = event.currentTarget.action;
+    });
+
+    let hasChanged = false;
+    const controls = form.querySelectorAll("input, textarea, select");
+    const changeListener = () => {
+      if (!hasChanged) {
+        hasChanged = true;
+        controls.forEach((control) => control.removeEventListener("change", changeListener));
+
+        preventUnload(() => !exitUrl.includes(safePath));
+      }
+    };
+    controls.forEach((control) => control.addEventListener("change", changeListener));
   }
 })


### PR DESCRIPTION
#### :tophat: What? Why?
When running under newer Chrome and ChromeDriver (v127+), some of the specs are broken because of the deprecation of the unload event APIs in Chromium:
https://developer.chrome.com/docs/web-platform/deprecating-unload

With the updated APIs, there are some things to consider when using the "beforeunload" event which was put together really well by this article:
https://chriscoyier.net/2023/11/15/careful-about-chrome-119-and-beforeunload-event-listeners/

Changes required:
1. Calling the `preventDefault()` on the event object in addition to setting a truthful `returnValue` according to the [best practices](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event)
2. Registering the `beforeunload` event listener **after** a user interaction (e.g. click on the page)

However, this is not enough to fix the confirm dialogs during the tests because recent versions of the ChromeDriver are set to automatically accept any unload dialogs they see. This has been implemented in the following commit:

https://chromium.googlesource.com/chromium/src/+/5b3168e8f8c4487320c654dd761622b89d548514
https://chromium-review.googlesource.com/c/chromium/src/+/5517510

This still works with the actual browser when considering the backend changes as described in the Chrome developer announcement as well as [on this page](https://github.com/fergald/docs/blob/master/explainers/permissions-policy-unload.md).

On the other hand, for the desired behavior (link clicks, form submits), we can rely on the default confirm dialogs already implemented in Decidim. This makes the default use cases compatible with the newer APIs as well as ChromeDriver during the system specs.

But we may still want to use the `beforeunload` event to prevent accidentally closing the browser window or reloading the page when there are unsaved changes. Even Google states that this is acceptable use of the `beforeunload` event:

> The [`beforeunload`](https://developer.mozilla.org/docs/Web/API/Window/beforeunload_event) event has a slightly different use case to `unload` in that it is a cancellable event. It is often used to warn users of unsaved changes when navigating away. This event is also unreliable as it will not fire if a background tab is killed. It is recommended to limit use of `beforeunload` and [only add it conditionally](https://developer.chrome.com/blog/page-lifecycle-api#the-beforeunload-event). Instead, use the above events for most `unload` replacements.
> 
> https://developer.chrome.com/docs/web-platform/deprecating-unload#alternatives_to_unload_events

And also:

> **The beforeunload event**
> 
> **Caution**: Never add a **`beforeunload`** listener unconditionally or use it as an end-of-session signal. Only add it when a user has unsaved work, and remove it as soon as that work has been saved. 
>
> https://developer.chrome.com/docs/web-platform/page-lifecycle-api#the_beforeunload_event

Therefore, this PR preserves relying on the `beforeunload` event to prevent accidental browser tab closes or page refreshes. Currently there are no alternatives available for these use cases.

Currently I believe this would still work without setting the `Permissions-Policy` header on the backend but as described in the article, this is recommended and I believe will be necessary at some point in the future.

#### :pushpin: Related Issues
- Related to #13277

#### Testing
- Create a meeting
- Enable registrations
- Create a registration form
- Go to register to that meeting
- Make a change on the form
- Try clicking some link away from that page, e.g. to the front page -> you should see the Decidim confirm dialog
- Try closing the tab -> you should see the "beforeunload" browser dialog
- Try reloading the page -> you should see the "beforeunload" browser dialog
- Try to submit the registration form -> (note that it has its own confirm dialog) -> make sure it submits without the unload dialog
- Make sure that when you confirm the dialog action, the desired action happens (e.g. when confirming going to the front page)

### :camera: Screenshots
For any user interaction that can be controlled through JS (link clicks, form submits):
![Custom unload dialog](https://github.com/user-attachments/assets/cf2ad232-ca87-4dc1-ab27-dc10c28d96b8)

For accidental closing of the tab or page refresh when there are unsaved changes in Chrome v127:
![Browser confirm dialog](https://github.com/user-attachments/assets/dca665e6-0a3c-4ca6-8a74-01211284d0a2)