### PR TITLE
Fix private admin create new assembly 

### DIFF
--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
@@ -90,10 +90,10 @@ module Decidim
         def parent_assembly_id
           # Return the parent_id from Ransack parameters if it exists
           return ransack_params[:parent_id_eq] if ransack_params[:parent_id_eq].present?
-          
+
           # If the assembly parameter is present, return its parent_id
           return assembly_parent_id if params[:assembly].present?
-          
+
           # Otherwise, return the parent_id from the params hash
           return params[:parent_id]
         end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
@@ -17,13 +17,13 @@ module Decidim
         end
 
         def new
-          enforce_permission_to :create, :assembly, assembly: collection.find_by(id: params[:parent_id])
+          enforce_permission_to :create, :assembly, assembly: parent_assembly
           @form = form(AssemblyForm).instance
           @form.parent_id = params[:parent_id]
         end
 
         def create
-          enforce_permission_to :create, :assembly, assembly: collection.find_by(id: params[:assembly][:parent_id])
+          enforce_permission_to :create, :assembly, assembly: parent_assembly
           @form = form(AssemblyForm).from_params(params)
 
           CreateAssembly.call(@form) do
@@ -84,7 +84,22 @@ module Decidim
         alias current_participatory_space current_assembly
 
         def parent_assembly
-          @parent_assembly ||= collection.find_by(id: ransack_params[:parent_id_eq])
+          @parent_assembly ||= collection.find_by(id: parent_assembly_id)
+        end
+
+        def parent_assembly_id
+          # Return the parent_id from Ransack parameters if it exists
+          return ransack_params[:parent_id_eq] if ransack_params[:parent_id_eq].present?
+          
+          # If the assembly parameter is present, return its parent_id
+          return assembly_parent_id if params[:assembly].present?
+          
+          # Otherwise, return the parent_id from the params hash
+          return params[:parent_id]
+        end
+
+        def assembly_parent_id
+          params[:assembly][:parent_id]
         end
 
         def assembly_params

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
@@ -17,13 +17,13 @@ module Decidim
         end
 
         def new
-          enforce_permission_to :create, :assembly
+          enforce_permission_to :create, :assembly, assembly: collection.find_by(id: params[:parent_id])
           @form = form(AssemblyForm).instance
           @form.parent_id = params[:parent_id]
         end
 
         def create
-          enforce_permission_to :create, :assembly
+          enforce_permission_to :create, :assembly, assembly: collection.find_by(id: params[:assembly][:parent_id])
           @form = form(AssemblyForm).from_params(params)
 
           CreateAssembly.call(@form) do
@@ -66,7 +66,7 @@ module Decidim
         end
 
         def copy
-          enforce_permission_to :create, :assembly
+          enforce_permission_to :create, :assembly, assembly: collection.find_by(id: params[:parent_id])
         end
 
         private

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
@@ -9,12 +9,12 @@ module Decidim
         include Concerns::AssemblyAdmin
 
         def new
-          enforce_permission_to :create, :assembly
+          enforce_permission_to :create, :assembly, assembly: collection.find_by(id: params[:parent_id]) 
           @form = form(AssemblyCopyForm).from_model(current_assembly)
         end
 
         def create
-          enforce_permission_to :create, :assembly
+          enforce_permission_to :create, :assembly, assembly: collection.find_by(id: params[:assembly][:parent_id]) 
           @form = form(AssemblyCopyForm).from_params(params)
 
           CopyAssembly.call(@form, current_assembly, current_user) do

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
@@ -9,12 +9,12 @@ module Decidim
         include Concerns::AssemblyAdmin
 
         def new
-          enforce_permission_to :create, :assembly, assembly: collection.find_by(id: params[:parent_id])
+          enforce_permission_to :create, :assembly
           @form = form(AssemblyCopyForm).from_model(current_assembly)
         end
 
         def create
-          enforce_permission_to :create, :assembly, assembly: collection.find_by(id: params[:assembly][:parent_id])
+          enforce_permission_to :create, :assembly
           @form = form(AssemblyCopyForm).from_params(params)
 
           CopyAssembly.call(@form, current_assembly, current_user) do

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
@@ -9,12 +9,12 @@ module Decidim
         include Concerns::AssemblyAdmin
 
         def new
-          enforce_permission_to :create, :assembly, assembly: collection.find_by(id: params[:parent_id]) 
+          enforce_permission_to :create, :assembly, assembly: collection.find_by(id: params[:parent_id])
           @form = form(AssemblyCopyForm).from_model(current_assembly)
         end
 
         def create
-          enforce_permission_to :create, :assembly, assembly: collection.find_by(id: params[:assembly][:parent_id]) 
+          enforce_permission_to :create, :assembly, assembly: collection.find_by(id: params[:assembly][:parent_id])
           @form = form(AssemblyCopyForm).from_params(params)
 
           CopyAssembly.call(@form, current_assembly, current_user) do

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -176,7 +176,7 @@ module Decidim
         return unless permission_action.action == :create &&
                       permission_action.subject == :assembly
 
-        toggle_allow(user.admin?)
+        toggle_allow(user.admin? || admin_assembly?)
       end
 
       def user_can_export_assembly?

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -176,7 +176,7 @@ module Decidim
         return unless permission_action.action == :create &&
                       permission_action.subject == :assembly
 
-        toggle_allow(user.admin? || admin_assembly? || user_role == "admin")
+        toggle_allow(user.admin?)
       end
 
       def user_can_export_assembly?

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -77,10 +77,14 @@
                <% else %>
                  <span class="action-space icon"></span>
                <% end %>
-               <%= icon_link_to "government-line",
-                                url_for(query_params_with(parent_id_eq: assembly.id)),
-                                t("decidim.admin.titles.assemblies"),
-                                class: "action-icon--dial #{"highlighted" if assembly.children.count.positive?}" %>
+               <% if assembly.children.count.positive? || allowed_to?(:read, :assembly, assembly:) %>
+                <%= icon_link_to "government-line",
+                                  url_for(query_params_with(parent_id_eq: assembly.id)),
+                                  t("decidim.admin.titles.assemblies"),
+                                  class: "action-icon--dial #{"highlighted" if assembly.children.count.positive?}" %>
+               <% else %>
+                 <span class="action-space icon"></span>
+               <% end %>
                <% if allowed_to? :copy, :assembly, assembly: assembly %>
                 <%= icon_link_to "file-copy-line", new_assembly_copy_path(assembly), t("actions.duplicate", scope: "decidim.admin"), class: "action-icon--copy" %>
               <% else %>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -85,7 +85,7 @@
                <% else %>
                  <span class="action-space icon"></span>
                <% end %>
-               <% if allowed_to? :copy, :assembly, assembly: assembly %>
+               <% if allowed_to? :copy, :assembly, assembly: assembly, assembly: parent_assembly %>
                 <%= icon_link_to "file-copy-line", new_assembly_copy_path(assembly), t("actions.duplicate", scope: "decidim.admin"), class: "action-icon--copy" %>
               <% else %>
                 <span class="action-space icon"></span>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -77,15 +77,11 @@
                <% else %>
                  <span class="action-space icon"></span>
                <% end %>
-               <% if assembly.children.count.positive? || allowed_to?(:create, :assembly) %>
-                 <%= icon_link_to "government-line",
-                                  url_for(query_params_with(parent_id_eq: assembly.id)),
-                                  t("decidim.admin.titles.assemblies"),
-                                  class: "action-icon--dial #{"highlighted" if assembly.children.count.positive?}" %>
-               <% else %>
-                 <span class="action-space icon"></span>
-               <% end %>
-              <% if allowed_to? :copy, :assembly, assembly: assembly %>
+               <%= icon_link_to "government-line",
+                                url_for(query_params_with(parent_id_eq: assembly.id)),
+                                t("decidim.admin.titles.assemblies"),
+                                class: "action-icon--dial #{"highlighted" if assembly.children.count.positive?}" %>
+               <% if allowed_to? :copy, :assembly, assembly: assembly %>
                 <%= icon_link_to "file-copy-line", new_assembly_copy_path(assembly), t("actions.duplicate", scope: "decidim.admin"), class: "action-icon--copy" %>
               <% else %>
                 <span class="action-space icon"></span>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -78,7 +78,7 @@
                  <span class="action-space icon"></span>
                <% end %>
                <% if assembly.children.count.positive? || allowed_to?(:read, :assembly, assembly:) %>
-                <%= icon_link_to "government-line",
+                 <%= icon_link_to "government-line",
                                   url_for(query_params_with(parent_id_eq: assembly.id)),
                                   t("decidim.admin.titles.assemblies"),
                                   class: "action-icon--dial #{"highlighted" if assembly.children.count.positive?}" %>

--- a/decidim-assemblies/app/views/layouts/decidim/admin/assemblies.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/admin/assemblies.html.erb
@@ -1,6 +1,6 @@
 <% content_for :breadcrumb_context_menu do %>
   <div class="process-title-content-breadcrumb-container-right">
-    <% if allowed_to? :create, :assembly %>
+    <% if allowed_to? :create, :assembly, assembly: parent_assembly %>
       <% link = defined?(parent_assembly) ? new_assembly_path(parent_id: parent_assembly&.id) : new_assembly_path %>
       <%= link_to link, class: "button button__sm button__transparent process-title-content-breadcrumb-container-right-link" do %>
         <%= icon "add-line", class: "w-4 h-4" %>

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -288,7 +288,7 @@ describe Decidim::Assemblies::Permissions do
     it_behaves_like(
       "access for roles",
       org_admin: true,
-      admin: true,
+      admin: false,
       collaborator: false,
       moderator: false,
       valuator: false


### PR DESCRIPTION
#### :tophat: What? Why?
PR to prevent regular users who are only admins for a specific assembly, and not general admins, from creating new assemblies.


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13279 
- Fixes #13279 

#### Testing
* Create an Assembly Meetups.
* In Meetup, create a sub-asssembly Europe. 
* In Europe, create a sub-assembly France
* In France Assembly, go in “Assembly Admins” tab and click “New Assembly Admin”
* Invite then a user that has:
  * No previous admin rights
  * Exists, and has already confirmed his email
  * **Expected**: The invited user **can't** see the button “New Assembly” in the assemblies table /admin/assemblies.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![image](https://github.com/user-attachments/assets/d287e78c-04fb-46fc-a8f4-c42e5a0f740f)


:hearts: Thank you!
