### PR TITLE
Generalize the term "Geocoding enabled"

### DIFF
--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -329,7 +329,7 @@ en:
               errors:
                 budget_voting_rule_only_one: Only one voting rule must be enabled.
                 budget_voting_rule_required: One voting rule is required.
-            geocoding_enabled: Geocoding enabled
+            geocoding_enabled: Maps enabled
             landing_page_content: Budgets landing page
             more_information_modal: More information modal
             projects_per_page: Projects per page

--- a/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
+++ b/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
@@ -49,7 +49,7 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
       Decidim::Component.build_settings(manifest, name, data, organization)
     end
 
-    describe "with geocoding enabled" do
+    describe "with maps enabled" do
       let(:geocoding_enabled) { true }
       # One budget rule must me activated
       let(:percent_enabled) { true }

--- a/decidim-core/spec/types/component_input_filter_spec.rb
+++ b/decidim-core/spec/types/component_input_filter_spec.rb
@@ -61,11 +61,11 @@ module Decidim
         end
       end
 
-      context "when searching components with geocoding enabled" do
+      context "when searching components with maps enabled" do
         let!(:model_with_geocoding_enabled) { create(:proposal_component, :published, :with_geocoding_enabled, participatory_space: model) }
         let(:query) { "{ components(filter: { withGeolocationEnabled: true} ) { id } }" }
 
-        it "returns the component with geocoding enabled" do
+        it "returns the component with maps enabled" do
           ids = response["components"].map { |component| component["id"].to_i }
           expect(ids).to include(*model_with_geocoding_enabled.id)
         end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -176,7 +176,7 @@ en:
               days: Days
               hours: Hours
               minutes: Minutes
-            geocoding_enabled: Geocoding enabled
+            geocoding_enabled: Maps enabled
             minimum_votes_per_user: Minimum votes per user
             new_proposal_body_template: New proposal body template
             new_proposal_body_template_help: You can define prefilled text that the new Proposals will have

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -186,7 +186,7 @@ describe "Edit proposals" do
       end
     end
 
-    context "with geocoding enabled" do
+    context "with maps enabled" do
       let(:component) { create(:proposal_component, :with_geocoding_enabled, participatory_space: participatory_process) }
       let(:address) { "6 Villa des Nymphéas 75020 Paris" }
       let(:new_address) { "6 rue Sorbier 75020 Paris" }

--- a/docs/modules/services/pages/maps.adoc
+++ b/docs/modules/services/pages/maps.adoc
@@ -241,8 +241,8 @@ As of April 2017, only proposals and meetings have maps and geocoding.
 
 === Proposals
 
-In order to enable geocoding for proposals you will need to edit the component configuration and turn on "Geocoding enabled" configuration.
-This works for that specific component, so you can have geocoding enabled for proposals in a participatory process, and disabled for another proposals component in the same participatory process.
+In order to enable maps for proposals you will need to edit the component configuration and turn on "Maps enabled" configuration.
+This works for that specific component, so you can have maps enabled for proposals in a participatory process, and disabled for another proposals component in the same participatory process.
 
 === Meetings
 


### PR DESCRIPTION
#### :tophat: What? Why?
Currently there are two differently named component settings that basically mean the same:
- Geocoding enabled (proposals and budgets)
- Maps enabled (meetings)

I would like to generalize these terms to the same format "Maps enabled" for all components.

Another reason is that for most admin users the word "geocoding" does not mean anything and they do not necessarily understand that. The wording "maps enabled" is much more understandable for a regular admin user.

#### Testing
- Go to edit a proposals component -> see the setting "Maps enabled"
- Go to edit a budgets component -> see the setting "Maps enabled"