### PR TITLE
Improve generic error messages

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -203,7 +203,7 @@ en:
         verify: Verify
       admin_terms_of_service:
         accept:
-          error: There was an error while accepting the admin terms of service.
+          error: There was a problem while accepting the admin terms of service.
           success: Great! You have accepted the admin terms of service.
         actions:
           accept: I agree with the terms
@@ -367,7 +367,7 @@ en:
         user_name: User
       content_blocks:
         create:
-          error: There was an error while creating the content block.
+          error: There was a problem while creating the content block.
           success: Content block successfully created.
         destroy:
           error: There was a problem trying to delete this content block.
@@ -790,7 +790,7 @@ en:
           success: Newsletter updated successfully. Please review it before sending.
       officializations:
         block:
-          error: There was an error blocking the participant.
+          error: There was a problem blocking the participant.
           success: Participant successfully blocked.
         create:
           success: Participant successfully officialized.
@@ -824,7 +824,7 @@ en:
           show: Show
           title: Show participant's email address
         unblock:
-          error: There was an error unblocking the participant.
+          error: There was a problem unblocking the participant.
           success: Participant successfully unblocked.
       organization:
         edit:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -294,11 +294,11 @@ en:
       dismiss: Dismiss notification
     amendments:
       accepted:
-        error: An error ocurred while accepting the amendment.
+        error: There was a problem accepting the amendment.
         success: The amendment has been accepted successfully.
       amendable:
         button: Amend %{model_name}
-        error: There has been an error amending this resource.
+        error: There was a problem amending this resource.
         promote_button: Promote to %{model_name}
         promote_confirm_text: Are you sure you want to promote this emendation?
         promote_help_text: You can promote this emendation and publish it as an independent %{model_name}.
@@ -307,7 +307,7 @@ en:
           one: "%{count} amendment"
           other: "%{count} amendments"
       created:
-        error: An error ocurred while creating the amendment draft.
+        error: There was a problem creating the amendment draft.
         success: Amendment draft has been created successfully.
       destroy_draft:
         error: There was a problem deleting the amendment draft.
@@ -359,7 +359,7 @@ en:
         error: There was a problem updating the amendment draft.
         success: Amendment draft successfully updated.
       withdraw:
-        error: An error ocurred while withdrawing the amendment.
+        error: There was a problem withdrawing the amendment.
         success: The amendment has been withdrawn successfully.
       wizard_step_form:
         steps:
@@ -1437,7 +1437,7 @@ en:
         subject: A resource has been reported
     reports:
       create:
-        error: An error ocurred while creating the report. Please, try it again.
+        error: There was a problem creating the report. Please, try it again.
         success: The report has been created successfully and it will be reviewed by an admin.
     resource_endorsements:
       create:
@@ -1874,7 +1874,7 @@ en:
       not_found: could not be found. Have you created an account previously?
       not_locked: was not locked
       not_saved:
-        one: 'There''s been an error processing your request:'
+        one: 'There has been an error processing your request:'
         other: 'There were multiple errors when processing your request:'
       too_many_marks: is using too many consecutive punctuation marks (e.g. ! and ?)
       too_much_caps: is using too many capital letters (over 25% of the text)

--- a/decidim-forms/config/locales/en.yml
+++ b/decidim-forms/config/locales/en.yml
@@ -24,7 +24,7 @@ en:
               missing: are not complete
               too_many: You can choose a maximum of %{count}.
         questionnaire:
-          request_invalid: There was an error handling the request. Please try again.
+          request_invalid: There was a problem handling the request. Please try again.
   decidim:
     forms:
       admin:

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -101,7 +101,7 @@ en:
           title_or_description_or_id_string_or_author_name_or_author_nickname_cont: Search %{collection} by title, description, ID or author name.
       initiatives_settings:
         update:
-          error: An error has occurred.
+          error: There was a problem updating the initiatives settings.
           success: The initiatives settings have been successfully updated.
       menu:
         attachments: Attachments
@@ -266,7 +266,7 @@ en:
             new: New
             photos: Photos
           update:
-            error: An error has occurred.
+            error: There was a problem updating the initiative.
             success: The initiative has been successfully updated.
         initiatives_settings:
           edit:
@@ -280,7 +280,7 @@ en:
             title: Settings for initiatives
         initiatives_type_scopes:
           create:
-            error: An error has occurred.
+            error: There was a problem creating a new scope for the given initiative.
             success: A new scope for the given initiative type has been created.
           destroy:
             success: The scope has been successfully removed.
@@ -291,11 +291,11 @@ en:
             create: Create
             title: Create initiative type scope
           update:
-            error: An error has occurred.
+            error: There was a problem updating the scope.
             success: The scope has been successfully updated.
         initiatives_types:
           create:
-            error: An error has occurred.
+            error: There was a problem creating the initiative type.
             success: A new initiative type has been successfully created. You need to define at least one scope for this initiative type so it can be used.
           destroy:
             success: The initiative type has been successfully removed.
@@ -312,7 +312,7 @@ en:
             create: Create
             title: New initiative type
           update:
-            error: An error has occurred.
+            error: There was a problem updating the initiative type.
             success: The initiative type has been successfully updated.
       admin_log:
         initiative:
@@ -587,7 +587,7 @@ en:
         expired: Expired
       unavailable_scope: Unavailable scope
       update:
-        error: An error has occurred.
+        error: There was a problem updating the initiative.
         success: The initiative has been successfully updated.
     menu:
       initiatives: Initiatives

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
@@ -181,7 +181,7 @@ describe Decidim::Initiatives::InitiativesController do
             expect(flash[:alert]).not_to be_empty
             expect(response).to have_http_status(:ok)
             expect(subject).to render_template(:edit)
-            expect(response.body).to include("An error has occurred")
+            expect(response.body).to include("There was a problem updating the initiative.")
           end
         end
       end

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -664,7 +664,7 @@ en:
         transparent: Transparent
         withdraw: Withdrawn
       withdraw:
-        error: An error ocurred while withdrawing the meeting.
+        error: There was a problem withdrawing the meeting.
         success: The meeting has been withdrawn successfully.
     metrics:
       meetings:

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -176,7 +176,7 @@ en:
           title: Duplicate participatory process
       participatory_process_groups:
         destroy:
-          error: There was an error while destroying the Participatory process group.
+          error: There was a problem while destroying the Participatory process group.
           success: Participatory process group successfully deleted.
         edit:
           title: Edit process group

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -544,10 +544,10 @@ en:
           answer:
             bulk_answer_error: Proposals with IDs [%{proposals}] could not be answered due errors applying the template "%{template}". You can check that the answer template matches the expected format for this component by applying it individually.
             bulk_answer_success: '%{count} proposals will be answered using the template "%{template}". Please wait a few minutes and refresh the page to see the updates.'
-            invalid: There has been a problem answering this proposal.
+            invalid: There was a problem answering this proposal.
             success: Proposal successfully answered.
           create:
-            invalid: There has been a problem creating this proposal.
+            invalid: There was a problem creating this proposal.
             success: Proposal successfully created.
           edit:
             title: Update proposal
@@ -629,18 +629,18 @@ en:
             title: Import proposals from another component
         proposals_merges:
           create:
-            invalid: 'There has been a problem merging the selected proposals because some of them:'
+            invalid: 'There was a problem merging the selected proposals because some of them:'
             success: Successfully merged the proposals into a new one.
         proposals_splits:
           create:
-            invalid: 'There has been a problem splitting the selected proposals because some of them:'
+            invalid: 'There was a problem splitting the selected proposals because some of them:'
             success: Successfully splitted the proposals into new ones.
         valuation_assignments:
           create:
-            invalid: There was an error assigning proposals to a valuator.
+            invalid: There was a problem assigning proposals to a valuator.
             success: Proposals assigned to a valuator successfully.
           delete:
-            invalid: There was an error unassigning proposals from a valuator.
+            invalid: There was a problem unassigning proposals from a valuator.
             success: Valuator unassigned from proposals successfully.
       admin_log:
         proposal:

--- a/decidim-proposals/spec/shared/merge_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/merge_proposals_examples.rb
@@ -73,7 +73,7 @@ shared_examples "merge proposals" do
 
             it "does not create a new proposal and displays a validation fail message" do
               expect(page).to have_css(".table-list tbody tr", count: 3)
-              expect(page).to have_content("There has been a problem merging the selected proposals")
+              expect(page).to have_content("There was a problem merging the selected proposals")
               expect(page).to have_content("Are not official")
               expect(page).to have_content("Have received votes or endorsements")
             end

--- a/decidim-proposals/spec/shared/split_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/split_proposals_examples.rb
@@ -58,7 +58,7 @@ shared_examples "split proposals" do
             let!(:proposals) { create_list(:proposal, 3, :with_endorsements, :with_votes, component: current_component) }
 
             it "does not create a new proposal and displays a validation fail message" do
-              expect(page).to have_content("There has been a problem splitting the selected proposals")
+              expect(page).to have_content("There was a problem splitting the selected proposals")
               expect(page).to have_content("Are not official")
               expect(page).to have_content("Have received votes or endorsements")
             end

--- a/decidim-proposals/spec/system/amendable/amend_proposal_spec.rb
+++ b/decidim-proposals/spec/system/amendable/amend_proposal_spec.rb
@@ -255,7 +255,7 @@ describe "Amend Proposal", versioning: true do
             end
 
             it "is shown the Error Flash" do
-              expect(page).to have_css("[data-alert-box].alert", text: "An error ocurred while creating the amendment")
+              expect(page).to have_css("[data-alert-box].alert", text: "There was a problem creating the amendment")
             end
 
             it "is shown the field error message" do

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
           destroy:
             confirm: Revoke before date authorizations cannot be undone. Are you sure you want to continue?
             confirm_all: Revoke all the authorizations cannot be undone. Are you sure you want to continue?
-          destroy_nok: There has been a problem while revoking authorizations.
+          destroy_nok: There was a problem while revoking authorizations.
           destroy_ok: All matched authorizations have been revocated successfully.
           info: There are a total of %{count} verified participants.
           no_data: No verified participants.
@@ -158,7 +158,7 @@ en:
         admin:
           census:
             create:
-              error: There was an error importing census.
+              error: There was a problem importing census.
               success: Successfully imported %{count} items (%{errors} errors).
             destroy_all:
               success: All census data have been deleted.


### PR DESCRIPTION
#### :tophat: What? Why?
While working on the translations, I noticed that the generic error messages are written in multiple ways across the different modules and translation files. Also some generic error messages in the initiatives module do not specify what went wrong, they only state a very generic error message.

This PR improves these messages and brings consistency to the way these terms are written.

#### Testing
- See the changed translations and check their writing
- See that CI is green (so that the terminology changes are also reflected to the tests)