### PR TITLE
Remove unnecessary expected spelling variant

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -869,7 +869,6 @@ tailwindcss
 tarekraafat
 taxonomizable
 taxonomization
-taxonomizations
 technopolitical
 templatable
 templateable


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed in another PR that the files changed tab is giving the following warning about an unrelated file for that PR:

> [!WARNING]
> Check warning on line 872 in .github/actions/spelling/expect.txt
>
> **GitHub Actions** / Check Spelling
>
> `taxonomizations` is ignored by check spelling because another more general variant is also in expect. (ignored-expect-variant)

#### Testing
See that the described warning is not longer reported in pull requests.

### :camera: Screenshots
![Warning about the variant in a pull request](https://github.com/user-attachments/assets/f17b63d0-95cf-4362-943a-8569baeb6590)
