### PR TITLE
Fix results per page display in pagination

### DIFF
--- a/decidim-core/app/helpers/decidim/paginate_helper.rb
+++ b/decidim-core/app/helpers/decidim/paginate_helper.rb
@@ -11,16 +11,14 @@ module Decidim
     def decidim_paginate(collection, paginate_params = {})
       return if collection.total_pages <= 1
 
+      per_page = (params[:per_page] || paginate_params[:per_page] || Decidim::Paginable::OPTIONS.first).to_i
+
       content_tag :div, class: "flex flex-col-reverse md:flex-row items-center justify-between gap-1 py-8 md:py-16", data: { pagination: "" } do
         template = ""
-        template += render(partial: "decidim/shared/results_per_page", formats: [:html]) if collection.total_pages.positive?
+        template += render(partial: "decidim/shared/results_per_page", locals: { per_page: }, formats: [:html]) if collection.total_pages.positive?
         template += paginate collection, window: 2, outer_window: 1, theme: "decidim", params: paginate_params
         template.html_safe
       end
-    end
-
-    def per_page
-      params[:per_page].to_i || Decidim::Paginable::OPTIONS.first
     end
   end
 end

--- a/decidim-core/spec/system/paginate_spec.rb
+++ b/decidim-core/spec/system/paginate_spec.rb
@@ -36,5 +36,5 @@ describe "Paginate specs" do
 
   it_behaves_like "list pagination", 25
   it_behaves_like "list pagination", 50
-  # it_behaves_like "list pagination", 100
+  it_behaves_like "list pagination", 100
 end

--- a/decidim-core/spec/system/paginate_spec.rb
+++ b/decidim-core/spec/system/paginate_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Paginate specs" do
+  let(:organization) { create(:organization) }
+  let(:component) { create(:component, :published, organization:) }
+  let(:commentable) { create(:dummy_resource, component:) }
+  let(:comment) { create(:comment, commentable:) }
+
+  before do
+    switch_to_host organization.host
+    visit decidim.root_path
+  end
+
+  shared_examples "list pagination" do |per_page|
+    let!(:action_logs) { create_list(:action_log, per_page + 1, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: comment, organization:) }
+
+    it "shows the paginator" do
+      visit decidim.last_activities_path(per_page:)
+
+      expect(page).to have_content("Results per page:")
+      within("details") do
+        within("summary") do
+          expect(page).to have_content(per_page.to_s)
+        end
+
+        within("ul", visible: :all) do
+          expect(page).to have_link("25", href: decidim.last_activities_path(per_page: 25), visible: :all)
+          expect(page).to have_link("50", href: decidim.last_activities_path(per_page: 50), visible: :all)
+          expect(page).to have_link("100", href: decidim.last_activities_path(per_page: 100), visible: :all)
+        end
+      end
+    end
+  end
+
+  it_behaves_like "list pagination", 25
+  it_behaves_like "list pagination", 50
+  # it_behaves_like "list pagination", 100
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the display per page in pagination helper. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to  #12703

#### Testing
1. generate a Development app 
2. Go to notifications and see "Results per page: 0"
3. Apply patch 
4. Refresh and see "Results per page: 25"

### :camera: Screenshots
before in [nightly](https://nightly.decidim.org/search?filter%5Bterm%5D=&filter%5Bwith_resource_type%5D=Decidim%3A%3AMeetings%3A%3AMeeting&filter%5Bwith_scope%5D=) : 
before in [meta](https://meta.decidim.org/search?filter%5Bterm%5D=&filter%5Bwith_resource_type%5D=Decidim%3A%3AProposals%3A%3AProposal&filter%5Bwith_scope%5D=&utf8=%E2%9C%93)

![image](https://github.com/user-attachments/assets/9b3a12ae-f724-4436-b4d0-a125e7c2a69a)

after (dev):
![image](https://github.com/user-attachments/assets/95e9c0be-e7fd-4996-9963-ad596423c17b)


:hearts: Thank you!
