### PR TITLE
Prevent malformed URLs in online/hybrid meetings

### DIFF
--- a/decidim-core/app/cells/decidim/address/online.erb
+++ b/decidim-core/app/cells/decidim/address/online.erb
@@ -5,8 +5,8 @@
       <div class="address">
         <div class="address__location"><%= t(model.type_of_meeting, scope: "decidim.meetings.meetings.filters.type_values") %></div>
         <% if display_online_meeting_url? %>
-          <a href="<%= model.online_meeting_url %>" target="_blank" rel="noopener noreferrer" class="address__hints underline break-all">
-            <%= model.online_meeting_url %>
+          <a href="<%= online_meeting_url %>" target="_blank" rel="noopener noreferrer" class="address__hints underline break-all">
+            <%= online_meeting_url %>
           <% end %>
           </a>
       </div>

--- a/decidim-core/app/cells/decidim/address_cell.rb
+++ b/decidim-core/app/cells/decidim/address_cell.rb
@@ -43,6 +43,10 @@ module Decidim
       HTML
     end
 
+    def online_meeting_url
+      URI::Parser.new.escape(model.online_meeting_url)
+    end
+
     def display_online_meeting_url?
       return true unless model.respond_to?(:online?)
       return true unless model.respond_to?(:iframe_access_level_allowed_for_user?)


### PR DESCRIPTION
#### :tophat: What? Why?

We have detected a problem with online/hybrid meetings where it can show malformed URLs. This PR fixes it.  

#### Testing

1. Save a malformed URL in the online meeting field
2. Visit the page
 
:hearts: Thank you!
