### PR TITLE
Backport 'Lock Chrome and ChromeDriver to 126.0.6478.182' to v0.29

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -24,6 +24,7 @@ AGPL
 Ajuntament
 Ajuntamentde
 alabs
+amd
 amendables
 AMR
 andreslucena

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -38,6 +38,11 @@ on:
         required: false
         default: true
         type: boolean
+      chrome_version:
+        description: 'Chrome & Chromedriver version'
+        required: false
+        default: "126.0.6478.182"
+        type: string
 
 jobs:
   build_app:
@@ -78,7 +83,14 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby_version }}
+      - run: |
+          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{inputs.chrome_version}}-1_amd64.deb
+          sudo dpkg -i /tmp/chrome.deb
+          rm /tmp/chrome.deb
+        name: Install Chrome version ${{inputs.chrome_version}}
       - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: ${{inputs.chrome_version}}
       - uses: actions/cache@v4
         id: app-cache
         with:


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #13277 to v0.29

:hearts: Thank you!