### PR TITLE
Fix flaky spec with follow button in participatory spaces

### DIFF
--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -145,6 +145,13 @@ describe "Assemblies" do
     end
   end
 
+  it_behaves_like "followable content for users" do
+    let(:assembly) { base_assembly }
+    let!(:user) { create(:user, :confirmed, organization:) }
+    let(:followable) { assembly }
+    let(:followable_path) { decidim_assemblies.assembly_path(assembly) }
+  end
+
   describe "when going to the assembly page" do
     let!(:assembly) { base_assembly }
     let!(:proposals_component) { create(:component, :published, participatory_space: assembly, manifest_name: :proposals) }
@@ -162,14 +169,6 @@ describe "Assemblies" do
     context "and requesting the assembly path with main data and type and duration blocks active" do
       before do
         visit decidim_assemblies.assembly_path(assembly)
-      end
-
-      describe "follow button" do
-        let!(:user) { create(:user, :confirmed, organization:) }
-        let(:followable) { assembly }
-        let(:followable_path) { decidim_assemblies.assembly_path(assembly) }
-
-        include_examples "follows"
       end
 
       context "when hero, main_data extra_data, metadata and dates_metadata blocks are enabled" do

--- a/decidim-budgets/spec/system/follow_projects_spec.rb
+++ b/decidim-budgets/spec/system/follow_projects_spec.rb
@@ -12,5 +12,5 @@ describe "Follow projects" do
 
   let(:followable_path) { resource_locator([budget, followable]).path }
 
-  include_examples "follows with a component"
+  include_examples "followable content for users with a component"
 end

--- a/decidim-conferences/spec/system/conferences_spec.rb
+++ b/decidim-conferences/spec/system/conferences_spec.rb
@@ -129,6 +129,13 @@ describe "Conferences" do
     end
   end
 
+  it_behaves_like "followable content for users" do
+    let(:conference) { base_conference }
+    let!(:user) { create(:user, :confirmed, organization:) }
+    let(:followable) { conference }
+    let(:followable_path) { decidim_conferences.conference_path(conference) }
+  end
+
   describe "when going to the conference page" do
     let!(:conference) { base_conference }
     let!(:proposals_component) { create(:component, :published, participatory_space: conference, manifest_name: :proposals) }
@@ -143,14 +150,6 @@ describe "Conferences" do
 
     it "has a sidebar" do
       expect(page).to have_css(".conference__nav-container")
-    end
-
-    describe "follow button" do
-      let!(:user) { create(:user, :confirmed, organization:) }
-      let(:followable) { conference }
-      let(:followable_path) { decidim_conferences.conference_path(conference) }
-
-      include_examples "follows"
     end
 
     describe "conference venues" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/follows_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/follows_examples.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
-shared_examples "follows" do
+# When using these shared examples, make sure there are no prior requests within
+# the same group of examples where this is included. Otherwise you may end up
+# in race conditions that cause these to fail as explained at:
+# https://github.com/decidim/decidim/pull/6161
+shared_examples "followable content for users" do
   before do
+    switch_to_host(organization.host)
     login_as user, scope: :user
   end
 
@@ -34,9 +39,9 @@ shared_examples "follows" do
   end
 end
 
-shared_examples "follows with a component" do
+shared_examples "followable content for users with a component" do
   include_context "with a component"
-  include_examples "follows"
+  include_examples "followable content for users"
 
   context "when the user is following the followable's participatory space" do
     before do

--- a/decidim-debates/spec/system/follow_debate_spec.rb
+++ b/decidim-debates/spec/system/follow_debate_spec.rb
@@ -11,5 +11,5 @@ describe "Follow debates" do
 
   let(:followable_path) { resource_locator(followable).path }
 
-  include_examples "follows with a component"
+  include_examples "followable content for users with a component"
 end

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -219,14 +219,13 @@ describe "Initiative" do
         it_behaves_like "initiative does not show send to technical validation"
       end
     end
+  end
 
-    describe "follow button" do
-      let!(:user) { create(:user, :confirmed, organization:) }
-      let(:followable) { initiative }
-      let(:followable_path) { decidim_initiatives.initiative_path(initiative) }
-
-      include_examples "follows"
-    end
+  it_behaves_like "followable content for users" do
+    let(:initiative) { base_initiative }
+    let!(:user) { create(:user, :confirmed, organization:) }
+    let(:followable) { initiative }
+    let(:followable_path) { decidim_initiatives.initiative_path(initiative) }
   end
 
   describe "initiative components" do

--- a/decidim-meetings/spec/system/follow_meetings_spec.rb
+++ b/decidim-meetings/spec/system/follow_meetings_spec.rb
@@ -11,5 +11,5 @@ describe "Follow meetings" do
 
   let(:followable_path) { resource_locator(followable).path }
 
-  include_examples "follows with a component"
+  include_examples "followable content for users with a component"
 end

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -202,6 +202,13 @@ describe "Participatory Processes" do
     end
   end
 
+  it_behaves_like "followable content for users" do
+    let!(:participatory_process) { base_process }
+    let!(:user) { create(:user, :confirmed, organization:) }
+    let(:followable) { participatory_process }
+    let(:followable_path) { decidim_participatory_processes.participatory_process_path(participatory_process) }
+  end
+
   context "when going to the participatory process page" do
     let!(:participatory_process) { base_process }
     let!(:proposals_component) { create(:component, :published, participatory_space: participatory_process, manifest_name: :proposals) }
@@ -232,14 +239,6 @@ describe "Participatory Processes" do
           create(:content_block, organization:, scope_name: :participatory_process_homepage, manifest_name:, scoped_resource_id: participatory_process.id)
         end
         visit decidim_participatory_processes.participatory_process_path(participatory_process)
-      end
-
-      describe "follow button" do
-        let!(:user) { create(:user, :confirmed, organization:) }
-        let(:followable) { participatory_process }
-        let(:followable_path) { decidim_participatory_processes.participatory_process_path(participatory_process) }
-
-        include_examples "follows"
       end
 
       context "when requesting the process path" do

--- a/decidim-proposals/spec/system/follow_proposals_spec.rb
+++ b/decidim-proposals/spec/system/follow_proposals_spec.rb
@@ -11,5 +11,5 @@ describe "Follow proposals" do
 
   let(:followable_path) { resource_locator(followable).path }
 
-  include_examples "follows with a component"
+  include_examples "followable content for users with a component"
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes a flaky with the follow button in spaces. 

The culprit is the same as explained in https://github.com/decidim/decidim/pull/6161, so the solution is the same: to keep the example in a top level so we don't have race conditions. 

#### Related issues

https://github.com/decidim/decidim/actions/runs/10557574658/job/29245582038?pr=13299 (as it's a CI log, this will be deleted in a couple days) 

#### Testing

Before the fix, to reproduce to bug, run:
`for i in $(seq 1 100); do echo $i ;  bin/rspec decidim-participatory_processes/spec/system/participatory_processes_spec.rb -e "follow button"   || break ; done`

After the fix, run:
`for i in $(seq 1 100); do echo $i ;  bin/rspec decidim-participatory_processes/spec/system/participatory_processes_spec.rb -e  "followable content for users"  || break ; done`

### Stacktrace

```
Failures:

  1) Assemblies when going to the assembly page and requesting the assembly path with main data and type and duration blocks active follow button when the user is following the followable when user clicks the Follow button makes the user follow the followable
     Failure/Error: raise Capybara::ElementNotFound, "Unable to find #{query.applied_description}" if result.empty?

     Capybara::ElementNotFound:
       Unable to find link or button "Stop following"

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_assemblies_when_going_to_the_assembly_page_and_requesting_the_assembly_path_with_main_data_and_type_and_duration_blocks_active_follow_button_when_the_user_is_following_the_follow_87.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_assemblies_when_going_to_the_assembly_page_and_requesting_the_assembly_path_with_main_data_and_type_and_duration_blocks_active_follow_button_when_the_user_is_following_the_follow_87.html


     Shared Example Group: "follows" called from ./spec/system/assemblies_spec.rb:172
     # /home/runner/work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/follows_examples.rb:29:in `block (5 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/follows_examples.rb:28:in `block (4 levels) in <top (required)>'
 
(...)

Finished in 9 minutes 45 seconds (files took 19.26 seconds to load)
210 examples, 1 failure

Failed examples:

rspec './spec/system/assemblies_spec.rb[1:6:2:1:2:1:1]' # Assemblies when going to the assembly page and requesting the assembly path with main data and type and duration blocks active follow button when the user is following the followable when user clicks the Follow button makes the user follow the followable
```


### :camera: Screenshots

![imatge](https://github.com/user-attachments/assets/731b9d87-37f1-4983-b401-471221972f33)


:hearts: Thank you!
