### PR TITLE
Fix exporting of the open data file

### DIFF
--- a/decidim-core/app/services/decidim/open_data_exporter.rb
+++ b/decidim-core/app/services/decidim/open_data_exporter.rb
@@ -51,13 +51,14 @@ module Decidim
             headers.push(*exporter.headers)
             exported = exporter.export
 
-            tmpfile = Tempfile.new("#{export_manifest.name}-#{component.id}-")
-            tmpfile.write(exported.read)
-            # Do not delete the file when the reference is deleted
-            ObjectSpace.undefine_finalizer(tmpfile)
-            tmpfile.close
+            tmpdir = Dir::Tmpname.create(export_manifest.name.to_s) do
+              # just get an empty file name
+            end
+            filename = File.join(tmpdir, "#{component.id}.csv")
+            Dir.mkdir(tmpdir)
+            File.write(filename, exported.read)
 
-            collection.push(tmpfile.path)
+            collection.push(filename)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

While working on #13248, I found a bug that prevented downloading the open data files in some cases. This PR fixes it. 

#### :pushpin: Related Issues
 
- Related to #13248

#### Testing

1. Click on the "Download Open Data files" in the footer.
2. See the flash message that is being generated.
3. Click again the same link
4. See the flash message that is being generated.
5. Check your logs to see the exception 

### :camera: Stacktrace

```
2024-08-27T10:42:57.644Z pid=371679 tid=6g5r WARN: {"context":"Job raised exception","job":{"retry":true,"queue":"exports","class":"ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper","wrapped":"Decidim::OpenDa
taJob","args":[{"job_class":"Decidim::OpenDataJob","job_id":"c42e9aa3-9e14-4e72-8d8c-08b00d4086b2","provider_job_id":null,"queue_name":"exports","priority":null,"arguments":[{"_aj_globalid":"gid://decidim-develop
ment-app/Decidim::Organization/1"}],"executions":0,"exception_executions":{},"locale":"en","timezone":"UTC","enqueued_at":"2024-08-27T10:42:56Z"}],"jid":"482403ecb3aec9808dfde83f","created_at":1724755376.854259,"
enqueued_at":1724755376.85429}}
2024-08-27T10:42:57.644Z pid=371679 tid=6g5r WARN: Errno::ENOENT: No such file or directory @ rb_sysopen - /tmp/results-1-20240827-371679-a96f3e
2024-08-27T10:42:57.644Z pid=371679 tid=6g5r WARN:
```

:hearts: Thank you!
