### PR TITLE
Fix DOMSubtreeModified deprecation warning

### DIFF
--- a/decidim-core/app/packs/src/decidim/attachments/file_or_link_tabs.js
+++ b/decidim-core/app/packs/src/decidim/attachments/file_or_link_tabs.js
@@ -36,10 +36,14 @@ const initializeTabs = (container) => {
     updateTabsState(container);
   });
 
-  uploadsContainer.addEventListener("DOMSubtreeModified", () => {
-    updateTabsState(container);
-    console.log("DOMSubtreeModified");
+  const observer = new MutationObserver((mutationsList) => {
+    mutationsList.forEach((mutation) => {
+      if (mutation.type === "childList") {
+        updateTabsState(container);
+      }
+    });
   });
+  observer.observe(uploadsContainer, {childList: true, subtree: true});
 
   updateTabsState(container);
 };


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes a jsvascript deprecation warning that can be found in most of the pipelines (tested against develop on Accountability pipeline)

```javascript
2024-08-29 13:51:26 +0000 WARNING: http://194.lvh.me:6809/packs-test/js/decidim_core.js 8 Listener added for a 'DOMSubtreeModified' mutation event. This event type is deprecated, and will be removed from this browser VERY soon. Usage of this event listener will cause performance issues today, and represents a large risk of imminent site breakage. Consider using MutationObserver instead. See https://chromestatus.com/feature/5083947249172480 for more information.
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12917

#### Testing
1. The pipeline should not contain the JS 
2. Switching the branch when uploading an attachment still works as intended (both file and link)

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![image](https://github.com/user-attachments/assets/c0930f57-be2f-488d-857f-8bbf949d5568)

:hearts: Thank you!
