### PR TITLE
Backport 'Fix google-chrome-stable installation in CI' to v0.29

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -466,6 +466,7 @@ LCell
 legacysupport
 Lesch
 lfo
+libu
 libicu
 libpq
 libreadline
@@ -914,6 +915,7 @@ tzid
 tzip
 uber
 ucw
+udev
 ueee
 ugc
 ujs

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -84,13 +84,15 @@ jobs:
         with:
           ruby-version: ${{ inputs.ruby_version }}
       - run: |
+          sudo apt update
+          sudo apt install libu2f-udev
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{inputs.chrome_version}}-1_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
           rm /tmp/chrome.deb
-        name: Install Chrome version ${{inputs.chrome_version}}
       - uses: nanasess/setup-chromedriver@v2
         with:
           chromedriver-version: ${{inputs.chrome_version}}
+        name: Install Chrome version ${{inputs.chrome_version}}
       - uses: actions/cache@v4
         id: app-cache
         with:


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #13314 to v0.29

:hearts: Thank you!