### PR TITLE
Backport 'Fix google-chrome-stable installation in CI' to v0.28

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -89,11 +89,13 @@ jobs:
           ruby-version: ${{ inputs.ruby_version }}
           bundler-cache: true
       - run: |
+          sudo apt update
+          sudo apt install libu2f-udev
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{inputs.chrome_version}}-1_amd64.deb
           sudo dpkg -i /tmp/chrome.deb
           rm /tmp/chrome.deb
-        name: Install Chrome version ${{inputs.chrome_version}}
       - uses: nanasess/setup-chromedriver@v2
+        name: Install Chrome version ${{inputs.chrome_version}}
         with:
           chromedriver-version: ${{inputs.chrome_version}}
       - uses: actions/cache@v3


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #13314 to v0.28

:hearts: Thank you!