### PR TITLE
Bump erb_lint from 0.4.0 to 0.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ PATH
       decidim-core (= 0.30.0.dev)
       decidim-generators (= 0.30.0.dev)
       decidim-verifications (= 0.30.0.dev)
-      erb_lint (~> 0.4.0)
+      erb_lint (~> 0.6.0)
       factory_bot_rails (~> 6.2)
       faker (~> 3.2)
       i18n-tasks (~> 1.0)
@@ -315,7 +315,7 @@ GEM
     charlock_holmes (0.7.9)
     cmdparse (3.0.7)
     commonmarker (0.23.10)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.4)
     crack (0.4.6)
       bigdecimal
       rexml
@@ -351,12 +351,12 @@ GEM
     doorkeeper (5.6.8)
       railties (>= 5)
     doorkeeper-i18n (4.0.1)
-    erb_lint (0.4.0)
+    erb_lint (0.6.0)
       activesupport
       better_html (>= 2.0.1)
       parser (>= 2.7.1.4)
       rainbow
-      rubocop
+      rubocop (>= 1)
       smart_properties
     erbse (0.1.4)
       temple
@@ -489,7 +489,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
-    minitest (5.24.1)
+    minitest (5.25.1)
     msgpack (1.4.5)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
@@ -505,7 +505,7 @@ GEM
     net-smtp (0.3.4)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.16.6)
+    nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth (1.1.0)
@@ -549,10 +549,10 @@ GEM
     paper_trail (15.1.0)
       activerecord (>= 6.1)
       request_store (~> 1.4)
-    parallel (1.25.1)
+    parallel (1.26.3)
     parallel_tests (4.4.0)
       parallel
-    parser (3.3.4.0)
+    parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
     pg (1.4.6)
@@ -570,7 +570,7 @@ GEM
     public_suffix (6.0.1)
     puma (6.4.2)
       nio4r (~> 2.0)
-    racc (1.8.0)
+    racc (1.8.1)
     rack (2.2.9)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
@@ -637,7 +637,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.2)
+    rexml (3.3.6)
       strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -670,7 +670,7 @@ GEM
     rspec-support (3.13.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.65.0)
+    rubocop (1.65.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -681,7 +681,7 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.3)
+    rubocop-ast (1.32.1)
       parser (>= 3.3.1.0)
     rubocop-capybara (2.21.0)
       rubocop (~> 1.41)

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "bullet", "~> 7.1.6"
   s.add_dependency "byebug", "~> 11.0"
-  s.add_dependency "erb_lint", "~> 0.4.0"
+  s.add_dependency "erb_lint", "~> 0.6.0"
   s.add_dependency "i18n-tasks", "~> 1.0"
   s.add_dependency "nokogiri", "~> 1.16", ">= 1.16.2"
   s.add_dependency "parallel_tests", "~> 4.2"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -116,7 +116,7 @@ PATH
       decidim-core (= 0.30.0.dev)
       decidim-generators (= 0.30.0.dev)
       decidim-verifications (= 0.30.0.dev)
-      erb_lint (~> 0.4.0)
+      erb_lint (~> 0.6.0)
       factory_bot_rails (~> 6.2)
       faker (~> 3.2)
       i18n-tasks (~> 1.0)
@@ -315,7 +315,7 @@ GEM
     charlock_holmes (0.7.9)
     cmdparse (3.0.7)
     commonmarker (0.23.10)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.4)
     crack (0.4.6)
       bigdecimal
       rexml
@@ -351,12 +351,12 @@ GEM
     doorkeeper (5.6.8)
       railties (>= 5)
     doorkeeper-i18n (4.0.1)
-    erb_lint (0.4.0)
+    erb_lint (0.6.0)
       activesupport
       better_html (>= 2.0.1)
       parser (>= 2.7.1.4)
       rainbow
-      rubocop
+      rubocop (>= 1)
       smart_properties
     erbse (0.1.4)
       temple
@@ -443,7 +443,7 @@ GEM
     invisible_captcha (0.13.0)
       rails (>= 3.2.0)
     io-console (0.7.2)
-    json (2.7.1)
+    json (2.7.2)
     jwt (2.8.2)
       base64
     kaminari (1.2.2)
@@ -489,7 +489,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
-    minitest (5.24.1)
+    minitest (5.25.1)
     msgpack (1.4.5)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
@@ -506,7 +506,7 @@ GEM
     net-smtp (0.3.4)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.16.6)
+    nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth (1.1.0)
@@ -550,10 +550,10 @@ GEM
     paper_trail (15.1.0)
       activerecord (>= 6.1)
       request_store (~> 1.4)
-    parallel (1.24.0)
+    parallel (1.26.3)
     parallel_tests (4.4.0)
       parallel
-    parser (3.3.4.0)
+    parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
     pg (1.4.6)
@@ -571,7 +571,7 @@ GEM
     public_suffix (6.0.1)
     puma (6.4.2)
       nio4r (~> 2.0)
-    racc (1.8.0)
+    racc (1.8.1)
     rack (2.2.9)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
@@ -630,7 +630,7 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.6.0)
     redis (4.8.1)
-    regexp_parser (2.9.0)
+    regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
     request_store (1.5.1)
@@ -638,7 +638,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.2)
+    rexml (3.3.6)
       strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -671,7 +671,7 @@ GEM
     rspec-support (3.13.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.65.0)
+    rubocop (1.65.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -682,8 +682,8 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.2)
-      parser (>= 3.3.0.4)
+    rubocop-ast (1.32.1)
+      parser (>= 3.3.1.0)
     rubocop-capybara (2.21.0)
       rubocop (~> 1.41)
     rubocop-factory_bot (2.26.1)


### PR DESCRIPTION
#### :tophat: What? Why?
While working on various PRs, i noticed the following deprecation warning originating from erb_lint 

``
/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/erb_lint-0.4.0/lib/erb_lint/linters/rubocop.rb:152: warning: `Cop.all` is deprecated. Use `Registry.all` instead.
``

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13293

#### Testing
The linter pipeline should not have any deprecation warnings that originates from erb_lint. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![image](https://github.com/user-attachments/assets/4ca8b4de-959f-46a3-96a7-14789ffee942)

:hearts: Thank you!
