### PR TITLE
0.27: Fix proposal voting's problem with handling dynamic buttons

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposal_votes/update_buttons_and_counters.js.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposal_votes/update_buttons_and_counters.js.erb
@@ -17,7 +17,7 @@
 <% if vote_limit_enabled? %>
   (function() {
     var $remainingVotesCount = $('#remaining-votes-count');
-    var $notVotedButtons = $('.card__button.button').not('.success');
+    var $notVotedButtons = $('.card__button.button').not('.active');
 
     if(!$remainingVotesCount[0]) { return; }
 
@@ -25,10 +25,10 @@
 
     <% if remaining_votes_count_for(current_user) == 0 %>
       $notVotedButtons.attr('disabled', true);
-      $notVotedButtons.val('<%= t("decidim.proposals.proposals.vote_button.no_votes_remaining") %>');
+      $notVotedButtons.text('<%= t("decidim.proposals.proposals.vote_button.no_votes_remaining") %>');
     <% else %>
       $notVotedButtons.attr('disabled', false);
-      $notVotedButtons.val('<%= t("decidim.proposals.proposals.vote_button.vote") %>');
+      $notVotedButtons.text('<%= t("decidim.proposals.proposals.vote_button.vote") %>');
     <% end %>
   }());
 <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
@@ -7,7 +7,7 @@
     <div id="proposal-<%= proposal.id %>-vote-button" class="button--vote-button">
       <% if !current_user %>
         <% if current_settings.votes_blocked? %>
-          <%= action_authorized_button_to :vote, t("decidim.proposals.proposals.vote_button.votes_blocked"), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), resource: proposal, class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
+          <%= action_authorized_button_to :vote, t("decidim.proposals.proposals.vote_button.votes_blocked"), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), resource: proposal, class: "button #{vote_button_classes(from_proposals_list)}", disabled: true %>
         <% else %>
           <%= action_authorized_button_to :vote, proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), resource: proposal, class: "button #{vote_button_classes(from_proposals_list)}", data: { disable: true, "redirect-url": proposal_path(proposal) } do %>
             <%= t("decidim.proposals.proposals.vote_button.vote") %>
@@ -29,7 +29,8 @@
               "redirect-url": proposal_path(proposal)
             },
             class: "button #{vote_button_classes(from_proposals_list)} active light",
-            id: "vote_button-#{proposal.id}"
+            id: "vote_button-#{proposal.id}",
+            disabled: false
           ) do %>
             <%= icon("check", class: "icon--small") %>
             <%= t("decidim.proposals.proposals.vote_button.already_voted") %>
@@ -37,14 +38,57 @@
           <% end %>
         <% else %>
           <% if proposal.maximum_votes_reached? && !proposal.can_accumulate_supports_beyond_threshold && current_component.participatory_space.can_participate?(current_user) %>
-            <%= content_tag :button, t("decidim.proposals.proposals.vote_button.maximum_votes_reached"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
+            <%= action_authorized_button_to(
+              :vote,
+              proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list),
+              resource: proposal,
+              remote: true,
+              data: { disable: true, "redirect-url": proposal_path(proposal) },
+              class: "button #{vote_button_classes(from_proposals_list)}",
+              disabled: true
+            ) do %>
+              <%= t("decidim.proposals.proposals.vote_button.maximum_votes_reached") %>
+              <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
+            <% end %>
           <% else %>
             <% if vote_limit_enabled? && remaining_votes_count_for(current_user) == 0 %>
-              <%= content_tag :button, t("decidim.proposals.proposals.vote_button.no_votes_remaining"), class: "button #{vote_button_classes(from_proposals_list)}", disabled: true %>
+              <%= action_authorized_button_to(
+                :vote,
+                proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list),
+                resource: proposal,
+                remote: true,
+                data: { disable: true, "redirect-url": proposal_path(proposal) },
+                class: "button #{vote_button_classes(from_proposals_list)}",
+                disabled: true
+              ) do %>
+                <%= t("decidim.proposals.proposals.vote_button.no_votes_remaining") %>
+                <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
+              <% end %>
             <% elsif current_settings.votes_blocked? || !current_component.participatory_space.can_participate?(current_user) %>
-              <%= content_tag :button, t("decidim.proposals.proposals.vote_button.votes_blocked"), class: "button #{vote_button_classes(from_proposals_list)} disabled", disabled: true %>
+              <%= action_authorized_button_to(
+                :vote,
+                proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list),
+                resource: proposal,
+                remote: true,
+                data: { disable: true, "redirect-url": proposal_path(proposal) },
+                class: "button #{vote_button_classes(from_proposals_list)}",
+                disabled: true
+              ) do %>
+                <%= t("decidim.proposals.proposals.vote_button.votes_blocked") %>
+                <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
+               <% end %>
             <% else %>
-              <%= action_authorized_button_to :vote, proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), resource: proposal, remote: true, data: { disable: true, "redirect-url": proposal_path(proposal) }, class: "button #{vote_button_classes(from_proposals_list)}" do %>
+              <%= action_authorized_button_to(
+                :vote,
+                proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list),
+                resource: proposal,
+                remote: true,
+                data: {
+                  disable: true, "redirect-url": proposal_path(proposal)
+                },
+                class: "button #{vote_button_classes(from_proposals_list)}",
+                disabled: false
+              ) do %>
                 <%= t("decidim.proposals.proposals.vote_button.vote") %>
                 <span class="show-for-sr"><%= decidim_html_escape(present(proposal).title) %></span>
               <% end %>

--- a/decidim-proposals/spec/system/vote_proposal_spec.rb
+++ b/decidim-proposals/spec/system/vote_proposal_spec.rb
@@ -287,7 +287,15 @@ describe "Support Proposal", type: :system, slow: true do
           end
 
           it "is not able to vote other proposals" do
-            expect(page).to have_css(".button[disabled]", count: 2)
+            expect(page).to have_css(".button[disabled]", text: "No supports remaining", count: 2)
+          end
+
+          context "when removing the vote from the voted proposal" do
+            it "updates the other proposals' buttons" do
+              click_on "Already supported"
+
+              expect(page).to have_css(".button", text: "Support", count: 3)
+            end
           end
 
           context "when votes are blocked" do


### PR DESCRIPTION
#### :tophat: What? Why?
When proposal voting has a limit, there are problems in how the buttons are handled dynamically. With a support limit of 1 as an example, if you "Support" a proposal, all the other proposals' buttons become disabled, which is correct, but the text is not changed to "No supports remaining". They only update if you refresh the page. Now if you refresh the page everything is correct, the voted proposal's button reads: "Already supported" and the other proposals' buttons read: "No supports remaining" and they are disabled, until you cancel the vote. When you cancel the vote, the canceled proposal's button reads "Support" and the other proposals' buttons still read: "No supports remaining", and they are no longer disabled. Pressing these buttons don't vote for them, because the buttons are lacking the logic to vote. Only after refreshing the page again the website is correct -> All the buttons are enabled and read: "Support".

The buttons should change dynamically as should the text. Now because the rendering of the buttons is only done when the page is loaded, we have to always have a button that is capable of creating a vote, unlike now where based on the capability of voting the button is either a form to vote or a content_tag of a button, and play with the "Disabled" -attribute only, while the text is handled by javascript.

#### Testing
- Create a proposal -component with "Support limit per participant" -value as "1" and "Enable supporting" in the current phase if not by default
- Go to the index page of Proposals
- Vote for any proposal by pressing the "Support" -button and see that the other proposals' buttons only become disabled 
instead of the text changing to "No supports remaining"
- Refresh the page and see it update the page to work as intended
- Press "Already supported" on your voted proposal to cancel the vote and see that the other proposals' buttons become active but the text stay in "No supports remaining", also these buttons don't work to allow you to vote for the other proposals
- Refresh the page and see it update the page to work as intended

### :camera: Screenshots

**After voting:**

![image](https://github.com/user-attachments/assets/7d321846-79a9-4733-95a7-65185610ab7d)

**After refresh:**

![image](https://github.com/user-attachments/assets/8c5ea80e-eb7b-4359-9f73-c686f32b7591)

**After cancelling vote:**

![image](https://github.com/user-attachments/assets/38818c82-b9c9-4456-8687-2fc29c2577de)

**After refresh:**

![image](https://github.com/user-attachments/assets/613b1fb3-895b-431c-b91f-17454ddf5407)


:hearts: Thank you!
