### PR TITLE
Date & Time format in Last Activities

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -11,7 +11,7 @@
         <%== cell("decidim/author", author_presenter) %>
       </span>
       <span class="text-gray-2 text-sm">
-        <%= time_tag created_at, format: :deicidm_short %>
+        <%= time_tag created_at, format: :decidim_short %>
       </span>
       <% if edited? %>
         <span class="label">

--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -11,7 +11,7 @@
         <%== cell("decidim/author", author_presenter) %>
       </span>
       <span class="text-gray-2 text-sm">
-        <%= time_tag created_at, time_ago_in_words(created_at) %>
+        <%= time_tag created_at, format: :deicidm_short %>
       </span>
       <% if edited? %>
         <span class="label">

--- a/decidim-comments/spec/cells/decidim/comments/comment_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comment_cell_spec.rb
@@ -15,6 +15,7 @@ module Decidim::Comments
     let(:component) { create(:component, participatory_space: participatory_process) }
     let(:commentable) { create(:dummy_resource, component:) }
     let(:comment) { create(:comment, commentable:) }
+    let(:created_at) { Time.current }
 
     context "when rendering" do
       it "renders the card" do
@@ -25,7 +26,7 @@ module Decidim::Comments
         expect(subject).to have_css("button[data-dialog-open='loginModal'][title='#{I18n.t("decidim.components.comment.report.action")}']")
         expect(subject).to have_css("a[href='/processes/#{participatory_process.slug}/f/#{component.id}/dummy_resources/#{commentable.id}?commentId=#{comment.id}#comment_#{comment.id}']")
         expect(subject).to have_content(comment.body.values.first)
-        expect(subject).to have_content("less than a minute")
+        expect(subject).to have_content(created_at.strftime("%d/%m/%Y"))
         expect(subject).to have_content(comment.author.name)
 
         expect(subject).to have_no_css(".add-comment")
@@ -86,7 +87,7 @@ module Decidim::Comments
           expect(subject).to have_css("a[href='/processes/#{participatory_process.slug}/f/#{component.id}/dummy_resources/#{commentable.id}?commentId=#{comment.id}#comment_#{comment.id}']")
           expect(subject).to have_content("Edited")
           expect(subject).to have_content(comment.body.values.first)
-          expect(subject).to have_content("less than a minute")
+          expect(subject).to have_content(created_at.strftime("%d/%m/%Y"))
           expect(subject).to have_content(comment.author.name)
 
           expect(subject).to have_no_css(".add-comment")


### PR DESCRIPTION
#### :tophat: What? Why?
Previously the date format in which was printed events such as comments were printed were without dates and only the time to which it took place. This PR extracts a format ```format: :decidim_short``` which takes care of this. 

#### :pushpin: Related Issues
- Fixes #12173 

#### Testing
1. Head over to an installation
2. Click on last activity
3. Find a activity like a comment made on a component and click on it
4. See the date and time printed 

### :camera: Screenshots
BEFORE: 
<img width="844" alt="Screenshot 2024-09-03 at 12 07 01" src="https://github.com/user-attachments/assets/f9148af4-47bf-4b6b-93ad-dbcd3153e46f">

AFTER: 
<img width="860" alt="Screenshot 2024-09-03 at 12 06 31" src="https://github.com/user-attachments/assets/5293b483-915e-4974-a188-448163e84053">

Could @decidim/product verify this is the correct format they wish to display?

:hearts: Thank you!
