### PR TITLE
Fix flaky on verifications' code letter system spec

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/warden.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/warden.rb
@@ -10,6 +10,7 @@ module Decidim
     #
     def relogin_as(user, scope: :user)
       logout scope
+      sleep 0.5
 
       login_as user, scope:
     end


### PR DESCRIPTION
#### :tophat: What? Why?

We have a flaky with a particular spec in decidim-verifications. 

On first sight, it looks like a routing problem, but it's actually related to the `logout` method in Warden used in Rspec that isn't working consistently. The best way that I found out as a workaround is to do a sleep to wait until the session is fully logged out. 

#### :pushpin: Related Issues
 
- Related to https://github.com/wardencommunity/warden/issues/163 
- https://github.com/decidim/decidim/actions/runs/10717675828/job/29718053042?pr=13313 

#### Testing

Locally, I could reproduce this by doing:

```bash
bin/rspec decidim-verifications/spec/system/postal_letter/code_request_spec.rb[1:2:1,1:2:2:1]
``` 

And also by just running the spec:

```bash
bin/rspec decidim-verifications/spec/system/postal_letter/code_request_spec.rb -e "shows the address as pending"
```

### :camera: Stacktrace
```

Run options: include {:full_description=>/shows\ the\ address\ as\ pending/}

Randomized with seed 51829

Postal letter code request
  when requesting a code by postal letter
    and getting it sent
2024-09-05 14:58:21 +0200 SEVERE: http://1.lvh.me:6927/admin/postal_letter/ - Failed to load resource: the server responded with a status of 500 (Internal Server Error)
      shows the address as pending (FAILED - 1)

Failures:

  1) Postal letter code request when requesting a code by postal letter and getting it sent shows the address as pending
     Failure/Error: raise ActionController::RoutingError, "No route matches [#{env['REQUEST_METHOD']}] #{env['PATH_INFO'].inspect}"

     ActionController::RoutingError:
       No route matches [GET] "/admin/postal_letter"

     [Screenshot Image]: file:///home/apereira/Work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_postal_letter_code_request_when_requesting_a_code_by_postal_letter_and_getting_it_sent_shows_the_addr
ess_as_pending_237.png

     [Screenshot HTML]: file:///home/apereira/Work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_postal_letter_code_request_when_requesting_a_code_by_postal_letter_and_getting_it_sent_shows_the_addre
ss_as_pending_237.html




     # /home/apereira/Work/decidim/decidim/decidim-dev/lib/decidim/dev/test/map_server.rb:36:in `call'
     # ------------------
     # --- Caused by: ---
     # Capybara::ElementNotFound:
     #   Unable to find css "table"
     #   ./spec/system/postal_letter/code_request_spec.rb:44:in `block (4 levels) in <top (required)>'

Top 1 slowest examples (2.52 seconds, 63.4% of total time):
  Postal letter code request when requesting a code by postal letter and getting it sent shows the address as pending
    2.52 seconds ./spec/system/postal_letter/code_request_spec.rb:43

Finished in 3.97 seconds (files took 3.42 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/system/postal_letter/code_request_spec.rb:43 # Postal letter code request when requesting a code by postal letter and getting it sent shows the address as pending

Randomized with seed 51829

Coverage report generated for RSpec to /home/apereira/Work/decidim/decidim/coverage. 10029 / 89205 LOC (11.24%) covered.
```
 

:hearts: Thank you!
