### PR TITLE
Fix issues with customized Omniauth callback handling

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/devise_authentication_methods.rb
+++ b/decidim-core/app/controllers/concerns/decidim/devise_authentication_methods.rb
@@ -12,7 +12,7 @@ module Decidim
         if user.present? && user.blocked?
           check_user_block_status(user)
         elsif user.needs_password_update?
-          change_password_path
+          decidim.change_password_path
         elsif first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user)
           decidim_verifications.first_login_authorizations_path
         else

--- a/decidim-core/app/views/decidim/devise/omniauth_registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/omniauth_registrations/new.html.erb
@@ -13,7 +13,7 @@
     <%= form_required_explanation %>
   </div>
 
-  <%= decidim_form_for(@form, namespace: "registration", as: resource_name, url: omniauth_registrations_path(resource_name), html: { id: "omniauth-register-form" }) do |f| %>
+  <%= decidim_form_for(@form, namespace: "registration", as: resource_name, url: decidim.omniauth_registrations_path(resource_name), html: { id: "omniauth-register-form" }) do |f| %>
 
     <div class="form__wrapper">
       <%= f.text_field :name, help_text: t("decidim.devise.omniauth_registrations.new.username_help"), autocomplete: "name", placeholder: "John Doe" %>

--- a/decidim-core/app/views/decidim/devise/omniauth_registrations/new_tos_fields.html.erb
+++ b/decidim-core/app/views/decidim/devise/omniauth_registrations/new_tos_fields.html.erb
@@ -3,7 +3,7 @@
     <h1 class="title-decorator my-12"><%= t("decidim.devise.omniauth_registrations.new_tos_fields.sign_up_title") %></h1>
   </div>
 
-  <%= decidim_form_for(@form, namespace: "registration", as: resource_name, url: omniauth_registrations_path(resource_name), html: { id: "omniauth-register-form" }) do |f| %>
+  <%= decidim_form_for(@form, namespace: "registration", as: resource_name, url: decidim.omniauth_registrations_path(resource_name), html: { id: "omniauth-register-form" }) do |f| %>
 
     <div class="form__wrapper">
       <%= f.hidden_field :name %>

--- a/decidim-core/app/views/decidim/devise/shared/_tos_fields.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_tos_fields.html.erb
@@ -7,7 +7,7 @@
     <% end %>
   </div>
 
-  <%= form.check_box :tos_agreement, label: t("decidim.devise.registrations.new.tos_agreement", link: link_to(t("decidim.devise.registrations.new.terms"), page_path("terms-of-service"))), label_options: { class: "form__wrapper-checkbox-label" } %>
+  <%= form.check_box :tos_agreement, label: t("decidim.devise.registrations.new.tos_agreement", link: link_to(t("decidim.devise.registrations.new.terms"), decidim.page_path("terms-of-service"))), label_options: { class: "form__wrapper-checkbox-label" } %>
 </div>
 
 <div id="card__newsletter" class="form__wrapper-block">

--- a/decidim-dev/spec/controllers/third_party_omniauth_registrations_controller_spec.rb
+++ b/decidim-dev/spec/controllers/third_party_omniauth_registrations_controller_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Dev
+  class OmniauthCallbacksController < Decidim::Devise::OmniauthRegistrationsController
+    def callback; end
+  end
+end
+
+describe "ThirdPartyOmniauthRegistrationsController" do
+  routes { Decidim::Dev::Engine.routes }
+
+  let(:organization) { create(:organization) }
+
+  controller(Decidim::Dev::OmniauthCallbacksController) {}
+
+  before do
+    request.env["decidim.current_organization"] = organization
+    request.env["devise.mapping"] = Devise.mappings[:user]
+  end
+
+  describe "POST callback" do
+    let(:provider) { "custom" }
+    let(:uid) { "12345" }
+    let(:email) { "user@custom.example.org" }
+    let!(:user) { create(:user, organization:, email:) }
+
+    before do
+      request.env["omniauth.auth"] = {
+        provider:,
+        uid:,
+        info: {
+          name: "Custom Auth",
+          nickname: "custom_auth",
+          email:
+        }
+      }
+    end
+
+    describe "after_sign_in_path_for" do
+      subject { controller.after_sign_in_path_for(user) }
+
+      context "when the user is admin who has a pending password change" do
+        let(:user) { build(:user, :admin, organization:, sign_in_count: 1, password_updated_at: 1.year.ago) }
+
+        it { is_expected.to eq("/change_password") }
+      end
+    end
+  end
+end

--- a/decidim-dev/spec/requests/third_party_omniauth_callback_spec.rb
+++ b/decidim-dev/spec/requests/third_party_omniauth_callback_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Dev
+  # This controller simulates a customized Omniauth callback flow that would be
+  # used by 3rd party login providers. Such providers may need to customize how
+  # the login callback is handled based on conditions returned by the Omniauth
+  # provider. Customizing the Omniauth strategy is not enough when the login
+  # provider needs access to the Decidim context.
+  class OmniauthCallbacksController < Decidim::Devise::OmniauthRegistrationsController
+    def dev_callback
+      create
+    end
+  end
+end
+
+RSpec.describe "Omniauth callback" do
+  subject { response.body }
+
+  let(:organization) { create(:organization) }
+
+  let(:user) { create(:user, :confirmed, organization:, email: "user@example.org", password: "decidim123456789") }
+
+  let(:oauth_hash) do
+    {
+      provider: "dev",
+      uid:,
+      info: {
+        name: "Custom Auth",
+        nickname: "custom_auth",
+        email:
+      }
+    }
+  end
+
+  before do
+    host! organization.host
+  end
+
+  describe "POST callback" do
+    let(:request_path) { "/users/auth/dev/callback" }
+
+    let(:uid) { "12345" }
+    let(:email) { "user@custom.example.org" }
+
+    context "with a new user" do
+      it "shows the create an account form" do
+        get(request_path, env: { "omniauth.auth" => oauth_hash })
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Create an account")
+        expect(response.body).to include("Terms of Service")
+      end
+    end
+
+    context "with existing user" do
+      let!(:user) { create(:user, organization:, email:) }
+
+      it "redirects to root" do
+        get(request_path, env: { "omniauth.auth" => oauth_hash })
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to("/")
+      end
+    end
+
+    context "when the user is admin with a pending password change" do
+      let!(:user) { create(:user, :confirmed, :admin, organization:, email:, sign_in_count: 1, password_updated_at: 1.year.ago) }
+
+      it "redirects to the /change_password path" do
+        get(request_path, env: { "omniauth.auth" => oauth_hash })
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to("/change_password")
+      end
+    end
+  end
+end

--- a/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb
@@ -169,6 +169,9 @@ test:
       enabled: true
       client_id:
       client_secret:
+    dev:
+      enabled: true
+      icon: tools-line
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.


### PR DESCRIPTION
#### :tophat: What? Why?
If a 3rd party Decidim authentication module customizes the Omniauth callback flow by extending the
`OmniauthRegistrationsController`, it would cause exceptions/errors due to the assumptions made that the core controller is the only one handling the callback flow.

The initial problem was the login failure if an admin user's password had expired, in this situation the redirect to the password change path fails and the user will see a message that "you need to login before accessing this page" (or that was in the original bug report).

While fixing this (and writing the spec), I also noticed some other issues caused by the assumptions regarding the `OmniauthRegistrationsController` being the only controller handling this flow. If the controller is in a different engine than `Decidim::Core`, the calls to the `_path` methods would fail.

The added spec should pinpoint the problems this is fixing.

#### Testing
- Copy the added spec from this PR and run it against the current core -> See it fail
- Run the spec again with the fixes in this PR -> See it pass

Note that when running the specs, you need to regenerate the dummy app or copy the changes to the already generated dummy app's `secrets.yml`.