### PR TITLE
Fixes admin rights loss when added as private user with case-insensitive email

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_participatory_space_private_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_space_private_user.rb
@@ -62,7 +62,7 @@ module Decidim
         return @existing_user if defined?(@existing_user)
 
         @existing_user = User.find_by(
-          email: form.email,
+          email: form.email.downcase,
           organization: private_user_to.organization
         )
 

--- a/decidim-admin/spec/commands/decidim/admin/create_participatory_space_private_user_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/create_participatory_space_private_user_spec.rb
@@ -113,6 +113,21 @@ module Decidim::Admin
         end
       end
 
+      context "when email is input with case-insensitive letters" do
+        let!(:admin) { create(:user, :admin, email: "admin@example.org", organization: privatable_to.organization) }
+        let!(:email) { "Admin@example.org" }
+
+        it "still finds the user" do
+          expect { subject.call }.to broadcast(:ok)
+
+          participatory_space_private_users = Decidim::ParticipatorySpacePrivateUser.where(user: admin)
+          participatory_space_admin = Decidim::User.where(email: "admin@example.org")
+
+          expect(participatory_space_private_users.count).to eq 1
+          expect(participatory_space_admin.first.admin?).to be true
+        end
+      end
+
       context "when the user has not accepted the invitation" do
         before do
           user.invite!

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_space_private_users_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_space_private_users_controller.rb
@@ -3,7 +3,7 @@
 module Decidim
   module ParticipatoryProcesses
     module Admin
-      # Controller that allows managing participatory process privte users
+      # Controller that allows managing participatory process private users
       class ParticipatorySpacePrivateUsersController < Decidim::Admin::ApplicationController
         include Concerns::ParticipatoryProcessAdmin
         include Decidim::Admin::Concerns::HasPrivateUsers


### PR DESCRIPTION
#### :tophat: What? Why?

When an admin user is added to a private process as private user with case-insensitive email input, the user's "admin" -attribute is updated to "false" which leads to loss of admin rights. This happens due to the lack of "downcase" -method so when the user is searched with the case-insensitive email, it doesn't find the user from the database.

Please backport to the previous versions too.

#### :pushpin: Related Issues

- Related to #11575
- Fixes #11575

#### Testing

*Taken from #11575*
1. Go to the Participants > Admins panel in BO
2. Add your email as a global administrator
3. Go to a private users list in a participatory process
4. Click on the 'New private user' button
5. Fill the form with a Name and your email UPPERCASED
6. See that you’ve lost your admins rights

### :camera: Screenshots

*Check #11575*

:hearts: Thank you!
