### PR TITLE
Fix regression when there's a disabled button in the upload modal

### DIFF
--- a/decidim-admin/spec/system/admin_access_spec.rb
+++ b/decidim-admin/spec/system/admin_access_spec.rb
@@ -15,6 +15,7 @@ describe "AdminAccess" do
 
   context "when the user is a visitor" do
     it "shows the unauthenticated message" do
+      sleep 2
       visit decidim_admin_participatory_processes.edit_participatory_process_path(participatory_process)
 
       expect(page).to have_content "You need to log in or create an account before continuing."

--- a/decidim-core/app/packs/stylesheets/decidim/_buttons.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_buttons.scss
@@ -67,7 +67,7 @@
   }
 
   &.is-hover,
-  &:not([disabled]):not([class*="button__text"]):hover {
+  &:not([disabled]):not([class*="button__text"]):not(label):hover {
     @apply text-white;
 
     background: linear-gradient(0deg, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3)),

--- a/decidim-core/app/packs/stylesheets/decidim/_modal_update.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_modal_update.scss
@@ -6,6 +6,10 @@
       @apply py-14;
     }
 
+    &.is-disabled label.button__secondary {
+      @apply text-gray-2 bg-background-3 border border-gray-2 cursor-not-allowed;
+    }
+
     &-container {
       @apply space-y-4;
     }


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing #11851, I found yet another fix related to the changes introduced in https://github.com/decidim/decidim/pull/12636 

When the upload modal has already an image, and the participant can't add it so they need to remove it first, the button should be disabled as it isn't actionable, but we're showing it as not disabled. This PR fixes it. 

#### :pushpin: Related Issues
 
- Related to #12636

#### Testing

1. Sign in as a participant
2. Go to http://localhost:3000/account
3. In the Avatar field, click in the "Add image" button
4. Click in the "Select file" button
5. Select an image
6. (Without the patch) See that the "Select file" button looks like it's still clickable
6. (With the patch) See that the "Select file" button is disabled

### :camera: Screenshots

#### Before (without the patch)

![Screenshot of the bug](https://github.com/user-attachments/assets/89e0d6c4-b00d-44d0-80f2-566d8018f3ce)

#### After (with the patch)

![Screenshot of the fix](https://github.com/user-attachments/assets/e41785f9-6fe2-47ce-be08-6152ff1f78ed)

:hearts: Thank you!
