### PR TITLE
Fix for liking a resource prompts for groups even though groups are disabled

### DIFF
--- a/decidim-blogs/lib/decidim/blogs/test/factories.rb
+++ b/decidim-blogs/lib/decidim/blogs/test/factories.rb
@@ -14,6 +14,22 @@ FactoryBot.define do
     name { generate_component_name(participatory_space.organization.available_locales, :blogs, skip_injection:) }
     manifest_name { :blogs }
     participatory_space { create(:participatory_process, :with_steps, skip_injection:, organization:) }
+
+    trait :with_endorsements_enabled do
+      step_settings do
+        {
+          participatory_space.active_step.id => { endorsements_enabled: true }
+        }
+      end
+    end
+
+    trait :with_endorsements_disabled do
+      step_settings do
+        {
+          participatory_space.active_step.id => { endorsements_enabled: false }
+        }
+      end
+    end
   end
 
   factory :post, class: "Decidim::Blogs::Post" do

--- a/decidim-blogs/spec/system/endorse_posts_spec.rb
+++ b/decidim-blogs/spec/system/endorse_posts_spec.rb
@@ -6,99 +6,16 @@ describe "endorse posts" do
   include_context "with a component"
   let(:manifest_name) { "blogs" }
   let(:organization) { create(:organization) }
-  let(:author) { create(:user, :confirmed, name: "Tester", organization:) }
-  let!(:post) { create(:post, component:, title: { en: "Blog post title" }) }
+  let!(:post) { create(:post, author: user, component:, title: { en: "Blog post title" }) }
+  let!(:resource) { post }
+  let!(:resource_name) { translated(post.title) }
 
-  before do
-    sign_in author
+  let!(:component) do
+    create(:post_component,
+           *component_traits,
+           manifest:,
+           participatory_space:)
   end
 
-  context "when liking the post without belonging to a user group" do
-    it "likes the post" do
-      visit_component
-      click_on "Blog post title"
-      click_on "Like"
-
-      expect(page).to have_content("Dislike")
-    end
-  end
-
-  context "when liking the post while being a part of a group" do
-    let!(:user_group) do
-      create(
-        :user_group,
-        :verified,
-        name: "Tester's Organization",
-        nickname: "test_org",
-        email: "t.mail.org@example.org",
-        users: [author],
-        organization:
-      )
-    end
-
-    before do
-      visit_component
-      click_on "Blog post title"
-    end
-
-    it "opens a modal where you select identity as a user or a group" do
-      click_on "Like"
-      expect(page).to have_content("Select identity")
-      expect(page).to have_content("Tester's Organization")
-      expect(page).to have_content("Tester")
-    end
-
-    def add_likes
-      click_on "Like"
-      click_on "Tester's Organization"
-      click_on "Tester"
-      click_on "Done"
-      visit current_path
-      click_on "Dislike"
-    end
-
-    context "when both identities picked" do
-      it "likes the post as a group and a user" do
-        add_likes
-
-        within ".identities-modal__list" do
-          expect(page).to have_css(".is-selected", count: 2)
-        end
-      end
-    end
-
-    context "when like cancelled as a user" do
-      it "does not cancel group like" do
-        add_likes
-        find(".is-selected", match: :first).click
-        click_on "Done"
-        visit current_path
-        click_on "Like"
-
-        within ".identities-modal__list" do
-          expect(page).to have_css(".is-selected", count: 1)
-          within ".is-selected" do
-            expect(page).to have_content("Tester's Organization")
-          end
-        end
-      end
-    end
-
-    context "when like cancelled as a group" do
-      it "does not cancel user like" do
-        add_likes
-        page.all(".is-selected")[1].click
-        click_on "Done"
-        visit current_path
-        click_on "Dislike"
-
-        within ".identities-modal__list" do
-          expect(page).to have_css(".is-selected", count: 1)
-          within ".is-selected" do
-            expect(page).to have_text("Tester", exact: true)
-          end
-        end
-      end
-    end
-  end
+  it_behaves_like "Endorse resource system specs"
 end

--- a/decidim-core/app/cells/decidim/endorsement_buttons_cell.rb
+++ b/decidim-core/app/cells/decidim/endorsement_buttons_cell.rb
@@ -69,7 +69,7 @@ module Decidim
     end
 
     def user_has_verified_groups?
-      current_user && Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any?
+      current_user && current_organization.user_groups_enabled? && Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any?
     end
 
     def endorse_translated

--- a/decidim-core/lib/decidim/core/test/shared_examples/system_endorse_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/system_endorse_resource_examples.rb
@@ -165,7 +165,7 @@ shared_examples "Endorse resource system specs" do
         end
 
         before do
-          organization.update(user_groups_enabled: )
+          organization.update(user_groups_enabled:)
           login_as user, scope: :user
           visit_resource
         end
@@ -246,7 +246,6 @@ shared_examples "Endorse resource system specs" do
             end
           end
         end
-
       end
     end
   end

--- a/decidim-core/lib/decidim/core/test/shared_examples/system_endorse_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/system_endorse_resource_examples.rb
@@ -170,7 +170,7 @@ shared_examples "Endorse resource system specs" do
           visit_resource
         end
 
-        context "when organization dissalows user groups" do
+        context "when organization is not allowing user groups" do
           let(:user_groups_enabled) { false }
 
           it "is able to endorse the resource" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/system_endorse_resource_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/system_endorse_resource_examples.rb
@@ -25,7 +25,7 @@ shared_examples "Endorse resource system specs" do
   end
 
   context "when endorsements are not enabled" do
-    let(:component_traits) { [:with_votes_enabled, :with_endorsements_disabled] }
+    let(:component_traits) { [:with_endorsements_disabled] }
 
     context "when the user is not logged in" do
       it "does not show the endorse resource button and counts" do
@@ -51,17 +51,17 @@ shared_examples "Endorse resource system specs" do
 
     it "shows the endorsements count and the endorse button is disabled" do
       visit_resource
-      expect(page).to have_css("[data-buttons] button[disabled='true']")
+      expect(page).to have_css("#resource-#{resource.id}-endorsement-block button[disabled='true']")
     end
   end
 
   context "when endorsements are enabled" do
-    let(:component_traits) { [:with_votes_enabled, :with_endorsements_enabled] }
+    let(:component_traits) { [:with_endorsements_enabled] }
 
     context "when the user is not logged in" do
       it "is given the option to sign in" do
         visit_resource
-        within "[data-buttons]", match: :first do
+        within "#resource-#{resource.id}-endorsement-block" do
           click_on "Like"
         end
 
@@ -77,7 +77,7 @@ shared_examples "Endorse resource system specs" do
       context "when the resource is not endorsed yet" do
         it "is able to endorse the resource" do
           visit_resource
-          within "[data-buttons]" do
+          within "#resource-#{resource.id}-endorsement-block" do
             click_on "Like"
             expect(page).to have_button("Dislike")
           end
@@ -89,7 +89,7 @@ shared_examples "Endorse resource system specs" do
 
         it "is not able to endorse it again" do
           visit_resource
-          within "[data-buttons]" do
+          within "#resource-#{resource.id}-endorsement-block" do
             expect(page).to have_button("Dislike")
             expect(page).to have_no_button("Like")
           end
@@ -97,7 +97,7 @@ shared_examples "Endorse resource system specs" do
 
         it "is able to undo the endorsement" do
           visit_resource
-          within "[data-buttons]" do
+          within "#resource-#{resource.id}-endorsement-block" do
             click_on "Dislike"
             expect(page).to have_button("Like")
           end
@@ -124,7 +124,7 @@ shared_examples "Endorse resource system specs" do
         context "when user is NOT verified" do
           it "is NOT able to endorse" do
             visit_resource
-            within "[data-buttons]", match: :first do
+            within "#resource-#{resource.id}-endorsement-block" do
               click_on "Like"
             end
             expect(page).to have_css("#authorizationModal", visible: :visible)
@@ -142,12 +142,111 @@ shared_examples "Endorse resource system specs" do
 
           it "IS able to endorse", :slow do
             visit_resource
-            within "[data-buttons]", match: :first do
+            within "#resource-#{resource.id}-endorsement-block" do
               click_on "Like"
             end
             expect(page).to have_button("Dislike")
           end
         end
+      end
+
+      context "when user being a part of a group" do
+        let(:component_traits) { [:with_endorsements_enabled] }
+        let!(:user_group) do
+          create(
+            :user_group,
+            :verified,
+            name: "Tester's Organization",
+            nickname: "test_org",
+            email: "t.mail.org@example.org",
+            users: [user],
+            organization:
+          )
+        end
+
+        before do
+          organization.update(user_groups_enabled: )
+          login_as user, scope: :user
+          visit_resource
+        end
+
+        context "when organization dissalows user groups" do
+          let(:user_groups_enabled) { false }
+
+          it "is able to endorse the resource" do
+            within "#resource-#{resource.id}-endorsement-block" do
+              click_on "Like"
+              expect(page).to have_button("Dislike")
+            end
+          end
+        end
+
+        context "when organization allows user groups" do
+          let(:user_groups_enabled) { true }
+
+          it "opens a modal where you select identity as a user or a group" do
+            click_on "Like"
+            expect(page).to have_content("Select identity")
+            expect(page).to have_content("Tester's Organization")
+            expect(page).to have_content(user.name)
+          end
+
+          def add_likes
+            click_on "Like"
+            within "#user-identities" do
+              click_on "Tester's Organization"
+              click_on user.name
+              click_on "Done"
+            end
+            visit_resource
+            click_on "Dislike"
+          end
+
+          context "when both identities picked" do
+            it "likes the post as a group and a user" do
+              add_likes
+
+              within ".identities-modal__list" do
+                expect(page).to have_css(".is-selected", count: 2)
+              end
+            end
+          end
+
+          context "when like cancelled as a user" do
+            it "does not cancel group like" do
+              add_likes
+              find(".is-selected", match: :first).click
+              click_on "Done"
+              visit current_path
+              click_on "Like"
+
+              within ".identities-modal__list" do
+                expect(page).to have_css(".is-selected", count: 1)
+                within ".is-selected" do
+                  expect(page).to have_content("Tester's Organization")
+                end
+              end
+            end
+          end
+
+          context "when like cancelled as a group" do
+            it "does not cancel user like" do
+              add_likes
+              page.all(".is-selected")[1].click
+              click_on "Done"
+              visit current_path
+              click_on "Dislike"
+
+              within ".identities-modal__list" do
+                expect(page).to have_css(".is-selected", count: 1)
+                within ".is-selected" do
+                  expect(page).to have_text(user.name, exact: true)
+                end
+              end
+            end
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
While working on #13373 I have encountered some specs that failed. Upon investigation, i noticed that the select identities pop-up is being fired regardless the organization setting of user_group_enable value. 
Additionally, i have aligned the 3 endorse spec files that i have found to ensure a consistent testing. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to
- Fixes  #13383

#### Testing
1. login as administrator and visit a proposal 
2. press like in a resource and notice the `select identity` pop-up is displayed 
3. Visit admin and uncheck "user group enabled", then save
4. repeat step 2, and see the `select identity` is still being shown 
5. Apply patch 
6. See the elect identity is not being displayed, the like is provided. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
