### PR TITLE
Fix for creating an amendment in proposals is not cloning the category 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ bundle update decidim
 bin/rails decidim:upgrade
 bin/rails db:migrate
 bin/rails decidim:upgrade:clean:invalid_records
+bin/rails decidim_proposals:upgrade:set_categories
 ```
 
 ### 1.3. Follow the steps and commands detailed in these notes
@@ -98,6 +99,16 @@ end
 ```
 
 You can read more about this change on PR [#13196](https://github.com/decidim/decidim/pull/13196).
+
+### 2.6. Amendments category fix
+
+We have identified a bug in the filtering system, as the amendments created did not share the category with the proposal it amended. This fix aims to fix historic data. To fix it, you need to run:
+
+```shell
+bin/rails decidim_proposals:upgrade:set_categories
+```
+
+You can read more about this change on PR [#13395](https://github.com/decidim/decidim/pull/13395).
 
 ## 3. One time actions
 

--- a/decidim-core/app/commands/decidim/amendable/create_draft.rb
+++ b/decidim-core/app/commands/decidim/amendable/create_draft.rb
@@ -42,7 +42,6 @@ module Decidim
       # A first version will be created in step 4: publish
       # for diff rendering in the amendment control version
       def create_emendation!
-        raise "FOO BAR"
         PaperTrail.request(enabled: false) do
           @emendation = Decidim.traceability.perform_action!(
             :create,
@@ -55,6 +54,7 @@ module Decidim
             emendation.body = { I18n.locale => form.emendation_params.with_indifferent_access[:body] }
             emendation.component = amendable.component
             emendation.add_author(current_user, user_group)
+            emendation.category = amendable.category if amendable.respond_to?(:category)
             emendation.save!
             emendation
           end

--- a/decidim-core/app/commands/decidim/amendable/create_draft.rb
+++ b/decidim-core/app/commands/decidim/amendable/create_draft.rb
@@ -42,6 +42,7 @@ module Decidim
       # A first version will be created in step 4: publish
       # for diff rendering in the amendment control version
       def create_emendation!
+        raise "FOO BAR"
         PaperTrail.request(enabled: false) do
           @emendation = Decidim.traceability.perform_action!(
             :create,

--- a/decidim-proposals/lib/tasks/proposals/upgrade/decidim_proposals_upgrade_tasks.rake
+++ b/decidim-proposals/lib/tasks/proposals/upgrade/decidim_proposals_upgrade_tasks.rake
@@ -2,6 +2,19 @@
 
 namespace :decidim_proposals do
   namespace :upgrade do
+    desc "Assigns category to emendations based on amendable category"
+    task set_categories: :environment do
+      Decidim::Proposals::Proposal.includes(:category).find_each do |proposal|
+        next if proposal.category.blank?
+        next unless proposal.amendable?
+
+        proposal.emendations.each do |emendation|
+          emendation.category = proposal.category
+          emendation.save(validate: false)
+        end
+      end
+    end
+
     desc "Removes all proposal valuator records of which the role assignment does not exists"
     task remove_valuator_orphan_records: :environment do
       if Decidim.module_installed?("participatory_processes")

--- a/decidim-proposals/spec/commands/decidim/proposals/amendable/create_amendment_draft_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/amendable/create_amendment_draft_spec.rb
@@ -44,8 +44,8 @@ module Decidim
 
           amendable.reload
 
-          expect(Decidim::Amendment.last.draft?).to be_true
-          expect(amendable.class.last.published?).to be_false
+          expect(Decidim::Amendment.last).to be_draft
+          expect(amendable.class.last).not_to be_published
           expect(amendable.emendations.count).to eq(1)
           expect(amendable.category.id).to eq(category.id)
           expect(amendable.emendations.first.category.id).to eq(category.id)

--- a/decidim-proposals/spec/commands/decidim/proposals/amendable/create_amendment_draft_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/amendable/create_amendment_draft_spec.rb
@@ -30,6 +30,27 @@ module Decidim
       let(:command) { described_class.new(form) }
 
       include_examples "create amendment draft"
+
+      context "when proposal has a category association" do
+        let(:category) { create(:category, participatory_space: component.participatory_space) }
+        let!(:amendable) { create(:proposal, component:, category:) }
+
+        it "copies the Proposal category" do
+          expect { command.call }
+            .to change(Decidim::Amendment, :count)
+            .by(1)
+            .and change(amendable.class, :count)
+            .by(1)
+
+          amendable.reload
+
+          expect(Decidim::Amendment.last.draft?).to be_true
+          expect(amendable.class.last.published?).to be_false
+          expect(amendable.emendations.count).to eq(1)
+          expect(amendable.category.id).to eq(category.id)
+          expect(amendable.emendations.first.category.id).to eq(category.id)
+        end
+      end
     end
   end
 end

--- a/decidim-proposals/spec/lib/tasks/upgrade/set_categories_spec.rb
+++ b/decidim-proposals/spec/lib/tasks/upgrade/set_categories_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "rake decidim_proposals:upgrade:set_categories", type: :task do
+  context "when executing task" do
+    it "does not throw an exception" do
+      expect { task.execute }.not_to raise_exception
+    end
+  end
+
+  context "when there are no errors" do
+    let!(:component) { create(:proposal_component, :with_amendments_enabled) }
+
+    let(:category) { create(:category, participatory_space: component.participatory_space) }
+    let(:proposal) { create(:proposal, component:, category:) }
+    let!(:proposal_amendment) { create_list(:proposal_amendment, 2, amendable: proposal) }
+
+    it "sets the category" do
+      expect { task.execute }.to change(Decidim::Categorization, :count).by(2)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When i go to the proposals page and select a proposal having a category associated, when i click on "amend" and following the instructions, the amendments get created, but the category is not associated. Therefore, when filtering by a specific category, the amendments for those proposals are not visible. 

Confirmed with @carolromero that the amendents should be visible there.  

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #13382 

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
