### PR TITLE
Add proposal state label in diff renderer

### DIFF
--- a/decidim-proposals/app/services/decidim/proposals/diff_renderer.rb
+++ b/decidim-proposals/app/services/decidim/proposals/diff_renderer.rb
@@ -15,13 +15,14 @@ module Decidim
           address: :string,
           latitude: :string,
           longitude: :string,
-          decidim_proposals_proposal_state_id: :string
+          decidim_proposals_proposal_state_id: :state
         }
       end
 
       # Parses the values before parsing the changeset.
       def parse_changeset(attribute, values, type, diff)
         return parse_scope_changeset(attribute, values, type, diff) if type == :scope
+        return parse_state_changeset(attribute, values, type, diff) if type == :state
 
         values = parse_values(attribute, values)
         old_value = values[0]
@@ -33,6 +34,22 @@ module Decidim
             label: I18n.t(attribute, scope: i18n_scope),
             old_value:,
             new_value:
+          }
+        )
+      end
+
+      def parse_state_changeset(attribute, values, type, diff)
+        return unless diff
+
+        old_scope = Decidim::Proposals::ProposalState.find_by(id: values[0])
+        new_scope = Decidim::Proposals::ProposalState.find_by(id: values[1])
+
+        diff.update(
+          attribute => {
+            type:,
+            label: I18n.t(attribute, scope: i18n_scope),
+            old_value: old_scope ? translated_attribute(old_scope.title) : "",
+            new_value: new_scope ? translated_attribute(new_scope.title) : ""
           }
         )
       end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
         automatic_hashtags: Hashtags automatically added
         body: Body
         category_id: Category
+        decidim_proposals_proposal_state_id: State
         decidim_scope_id: Scope
         has_address: Has address
         scope_id: Scope

--- a/decidim-proposals/spec/system/proposals_versions_spec.rb
+++ b/decidim-proposals/spec/system/proposals_versions_spec.rb
@@ -102,5 +102,31 @@ describe "Explore versions", versioning: true do
         end
       end
     end
+
+    it "show the correct state" do
+      form_params = {
+        internal_state: "evaluating",
+        answer: { en: "Foo" },
+        cost: 2000,
+        cost_report: { en: "Cost report" },
+        execution_period: { en: "Execution period" }
+      }
+      form = Decidim::Proposals::Admin::ProposalAnswerForm.from_params(form_params).with_context(
+        current_user: proposal.authors.first,
+        current_component: proposal.component,
+        current_organization: proposal.component.organization
+      )
+      Decidim::Proposals::Admin::AnswerProposal.call(form, proposal)
+
+      visit current_path
+      click_on("Version 3 of 3")
+
+      within "#diff-for-state" do
+        expect(page).to have_content("State")
+        within ".diff > ul > .ins" do
+          expect(page).to have_content("Evaluating")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Add a label for diff attributes.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes  #12658

#### Testing
1. Login as admin, visit any proposals page 
2. Answer the proposal and change the state 
3. Visit the proposal changeset ( diff render) 
4. See the attribute title is displayed like `Translation missing: ...`
5. Apply the page 
6. Refresh the page

### :camera: Screenshots
![image](https://github.com/decidim/decidim/assets/105683/94413942-3d89-4847-b184-592c4315771a)

![image](https://github.com/user-attachments/assets/5a8e9555-4c37-4d87-ab5f-3d088064c950)


:hearts: Thank you!
