### PR TITLE
Remove host param from url uploader method

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -152,7 +152,7 @@ describe "Admin manages organization" do
       context "when the admin terms of service content has an image with an alt tag" do
         let(:another_organization) { create(:organization) }
         let(:image) { create(:attachment, attached_to: another_organization) }
-        let(:image_url) { image.attached_uploader(:file).url(host: organization_host) }
+        let(:image_url) { image.attached_uploader(:file).url }
         let(:organization_host) { "example.lvh.me" }
         let(:organization) do
           create(

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -177,9 +177,9 @@ describe "Admin manages organization" do
                 <button type="button" aria-label="Resize image (bottom left corner)" data-image-resizer-control="bottom-left"></button>
                 <button type="button" aria-label="Resize image (bottom right corner)" data-image-resizer-control="bottom-right"></button>
                 <div data-image-resizer-dimensions="">
-                  <span data-image-resizer-dimension="width" data-image-resizer-dimension-value="512"></span>
+                  <span data-image-resizer-dimension="width" data-image-resizer-dimension-value=""></span>
                   ×
-                  <span data-image-resizer-dimension="height" data-image-resizer-dimension-value="342"></span></div>
+                  <span data-image-resizer-dimension="height" data-image-resizer-dimension-value=""></span></div>
                 <div class="editor-content-image" data-image=""><img src="#{image_url}" alt="foo bar"></div>
               </div>
             </div>

--- a/decidim-assemblies/app/presenters/decidim/assemblies/assembly_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/assembly_presenter.rb
@@ -6,11 +6,11 @@ module Decidim
       include Decidim::TranslationsHelper
 
       def hero_image_url
-        assembly.attached_uploader(:hero_image).url(host: assembly.organization.host)
+        assembly.attached_uploader(:hero_image).url
       end
 
       def banner_image_url
-        assembly.attached_uploader(:banner_image).url(host: assembly.organization.host)
+        assembly.attached_uploader(:banner_image).url
       end
 
       def area_name

--- a/decidim-core/app/cells/decidim/newsletter_templates/image_text_cta_cell.rb
+++ b/decidim-core/app/cells/decidim/newsletter_templates/image_text_cta_cell.rb
@@ -50,7 +50,7 @@ module Decidim
       end
 
       def main_image_url
-        newsletter.template.images_container.attached_uploader(:main_image).url(host: organization.host)
+        newsletter.template.images_container.attached_uploader(:main_image).url
       end
 
       def organization_primary_color

--- a/decidim-core/app/controllers/decidim/doorkeeper/credentials_controller.rb
+++ b/decidim-core/app/controllers/decidim/doorkeeper/credentials_controller.rb
@@ -28,7 +28,7 @@ module Decidim
       end
 
       def avatar_url
-        avatar_url = current_resource_owner.attached_uploader(:avatar).url(host: current_resource_owner.organization.host)
+        avatar_url = current_resource_owner.attached_uploader(:avatar).url
         return unless avatar_url
 
         unless %r{^https?://}.match? avatar_url

--- a/decidim-core/app/presenters/decidim/attachment_presenter.rb
+++ b/decidim-core/app/presenters/decidim/attachment_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
   #
   class AttachmentPresenter < SimpleDelegator
     def attachment_file_url
-      attachment.attached_uploader(:file).url(host: attached_to.organization.host)
+      attachment.attached_uploader(:file).url
     end
 
     def attachment

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_group_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_group_presenter.rb
@@ -6,7 +6,7 @@ module Decidim
       def hero_image_url
         return if process_group.blank?
 
-        process_group.attached_uploader(:hero_image).url(host: process_group.organization.host)
+        process_group.attached_uploader(:hero_image).url
       end
 
       def process_group

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -4,7 +4,7 @@ module Decidim
   module ParticipatoryProcesses
     class ParticipatoryProcessPresenter < SimpleDelegator
       def hero_image_url
-        process.attached_uploader(:hero_image).url(host: process.organization.host)
+        process.attached_uploader(:hero_image).url
       end
 
       def area_name

--- a/decidim-proposals/app/services/decidim/proposals/proposal_builder.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_builder.rb
@@ -117,7 +117,7 @@ module Decidim
           if attachment.file.attached?
             new_attachment.file = attachment.file.blob
           else
-            new_attachment.attached_uploader(:file).remote_url = attachment.attached_uploader(:file).url(host: original_proposal.organization.host)
+            new_attachment.attached_uploader(:file).remote_url = attachment.attached_uploader(:file).url
           end
 
           new_attachment.save!


### PR DESCRIPTION
#### :tophat: What? Why?

Remove `host` param from `url` uploader method. As it was causing an error while using a S3 storage provider.

#### :pushpin: Related Issues

- Related to #12576
- Fixes #13403

#### Testing

You need an instance with the S3 storage configuration with newsletters with images uploaded while running decidim <= 0.28.2. Then, update decidim to 0.29, go to the preview page of the newsletter on the admin page, and see how it works

:hearts: Thank you!
