### PR TITLE
Spacing on DOB picker in Authorizations 

### DIFF
--- a/decidim-admin/spec/system/admin_access_spec.rb
+++ b/decidim-admin/spec/system/admin_access_spec.rb
@@ -15,6 +15,7 @@ describe "AdminAccess" do
 
   context "when the user is a visitor" do
     it "shows the unauthenticated message" do
+      sleep 2
       visit decidim_admin_participatory_processes.edit_participatory_process_path(participatory_process)
 
       expect(page).to have_content "You need to log in or create an account before continuing."

--- a/decidim-assemblies/app/serializers/decidim/assemblies/open_data_assembly_serializer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/open_data_assembly_serializer.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Assemblies
+    # This class serializes an Assembly so it can be exported to CSV for the Open Data feature.
+    class OpenDataAssemblySerializer < Decidim::Exporters::ParticipatorySpaceSerializer
+      # Public: Exports a hash with the serialized data for this assembly.
+      #
+      def serialize
+        super.merge(
+          {
+            subtitle: resource.subtitle,
+            remote_hero_image_url: Decidim::ParticipatoryProcesses::ParticipatoryProcessPresenter.new(resource).hero_image_url,
+            remote_banner_image_url: Decidim::Assemblies::AssemblyPresenter.new(resource).banner_image_url,
+            announcement: resource.announcement,
+            developer_group: resource.developer_group,
+            local_area: resource.local_area,
+            meta_scope: resource.meta_scope,
+            participatory_scope: resource.participatory_scope,
+            purpose_of_action: resource.purpose_of_action,
+            composition: resource.composition,
+            duration: resource.duration,
+            participatory_structure: resource.participatory_structure,
+            target: resource.target,
+            reference: resource.reference,
+            decidim_scope_id: resource.decidim_scope_id,
+            area: {
+              id: resource.area.try(:id),
+              name: resource.area.try(:name) || empty_translatable
+            },
+            scope: {
+              id: resource.scope.try(:id),
+              name: resource.scope.try(:name) || empty_translatable
+            },
+            scopes_enabled: resource.scopes_enabled,
+            included_at: resource.included_at,
+            closing_date: resource.closing_date,
+            created_by: resource.created_by,
+            creation_date: resource.creation_date,
+            closing_date_reason: resource.closing_date_reason,
+            internal_organisation: resource.internal_organisation,
+            is_transparent: resource.is_transparent,
+            special_features: resource.special_features,
+            twitter_handler: resource.twitter_handler,
+            instagram_handler: resource.instagram_handler,
+            facebook_handler: resource.facebook_handler,
+            youtube_handler: resource.youtube_handler,
+            github_handler: resource.github_handler,
+            created_by_other: resource.created_by_other,
+            assembly_type: {
+              id: resource.assembly_type.try(:id),
+              title: resource.assembly_type.try(:title) || empty_translatable
+            }
+          }
+        )
+      end
+    end
+  end
+end

--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -32,11 +32,16 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
   end
 
   participatory_space.exports :assemblies do |export|
-    export.collection do |assembly|
-      Decidim::Assembly.where(id: assembly.id).includes(:area, :scope, :attachment_collections, :categories)
+    export.collection do
+      Decidim::Assembly
+        .public_spaces
+        .includes(:area, :scope, :attachment_collections, :categories)
     end
 
+    export.include_in_open_data = true
+
     export.serializer Decidim::Assemblies::AssemblySerializer
+    export.open_data_serializer Decidim::Assemblies::OpenDataAssemblySerializer
   end
 
   participatory_space.register_on_destroy_account do |user|

--- a/decidim-assemblies/spec/serializers/decidim/assemblies/open_data_assembly_serializer_spec.rb
+++ b/decidim-assemblies/spec/serializers/decidim/assemblies/open_data_assembly_serializer_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module Decidim::Assemblies
-  describe AssemblySerializer do
+  describe OpenDataAssemblySerializer do
     let(:resource) { create(:assembly) }
 
     subject { described_class.new(resource) }
@@ -19,7 +19,6 @@ module Decidim::Assemblies
         expect(serialized).to include(hashtag: resource.hashtag)
         expect(serialized).to include(title: resource.title)
         expect(serialized).to include(subtitle: resource.subtitle)
-        expect(serialized).to include(weight: resource.weight)
         expect(serialized).to include(short_description: resource.short_description)
         expect(serialized).to include(description: resource.description)
         expect(serialized[:remote_hero_image_url]).to be_blob_url(resource.hero_image.blob)
@@ -33,7 +32,6 @@ module Decidim::Assemblies
         expect(serialized).to include(participatory_scope: resource.participatory_scope)
         expect(serialized).to include(participatory_structure: resource.participatory_structure)
         expect(serialized).to include(scopes_enabled: resource.scopes_enabled)
-        expect(serialized).to include(private_space: resource.private_space)
         expect(serialized).to include(reference: resource.reference)
         expect(serialized).to include(purpose_of_action: resource.purpose_of_action)
         expect(serialized).to include(composition: resource.composition)
@@ -53,7 +51,6 @@ module Decidim::Assemblies
         expect(serialized).to include(youtube_handler: resource.youtube_handler)
         expect(serialized).to include(github_handler: resource.github_handler)
         expect(serialized).to include(created_by_other: resource.created_by_other)
-        expect(serialized).to include(announcement: resource.announcement)
       end
 
       context "when assembly has area" do
@@ -107,52 +104,6 @@ module Decidim::Assemblies
 
           expect(serialized_assembly_type).to include(id: resource.assembly_type.id)
           expect(serialized_assembly_type).to include(title: resource.assembly_type.title)
-        end
-      end
-
-      context "when assembly has categories" do
-        let!(:category) { create(:category, participatory_space: resource) }
-
-        it "includes the categories" do
-          serialized_assembly_categories = subject.serialize[:categories].first
-          expect(serialized_assembly_categories).to be_a(Hash)
-
-          expect(serialized_assembly_categories).to include(id: category.id)
-          expect(serialized_assembly_categories).to include(name: category.name)
-          expect(serialized_assembly_categories).to include(description: category.description)
-          expect(serialized_assembly_categories).to include(parent_id: category.parent_id)
-        end
-
-        context "when category has subcategories" do
-          let!(:subcategory) { create(:subcategory, parent: category, participatory_space: resource) }
-
-          it "includes the categories" do
-            serialized_assembly_categories = subject.serialize[:categories].first
-
-            expect(serialized_assembly_categories).to be_a(Hash)
-
-            expect(serialized_assembly_categories).to include(id: category.id)
-            expect(serialized_assembly_categories).to include(name: category.name)
-            expect(serialized_assembly_categories).to include(description: category.description)
-            expect(serialized_assembly_categories).to include(parent_id: category.parent_id)
-          end
-        end
-      end
-
-      context "when assembly has attachments" do
-        let!(:attachment_collection) { create(:attachment_collection, collection_for: resource) }
-        let!(:attachment) { create(:attachment, attached_to: resource, attachment_collection:) }
-
-        it "includes the attachment" do
-          serialized_assembly_attachment = subject.serialize[:attachments][:files].first
-
-          expect(serialized_assembly_attachment).to be_a(Hash)
-
-          expect(serialized_assembly_attachment).to include(id: attachment.id)
-          expect(serialized_assembly_attachment).to include(title: attachment.title)
-          expect(serialized_assembly_attachment).to include(weight: attachment.weight)
-          expect(serialized_assembly_attachment).to include(description: attachment.description)
-          expect(serialized_assembly_attachment[:remote_file_url]).to be_blob_url(resource.attachments.first.file.blob)
         end
       end
     end

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -145,7 +145,7 @@ describe "Assemblies" do
     end
   end
 
-  it_behaves_like "followable content for users" do
+  it_behaves_like "followable space content for users" do
     let(:assembly) { base_assembly }
     let!(:user) { create(:user, :confirmed, organization:) }
     let(:followable) { assembly }

--- a/decidim-assemblies/spec/system/download_open_data_files_spec.rb
+++ b/decidim-assemblies/spec/system/download_open_data_files_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/core/test/shared_examples/download_open_data_shared_context"
+require "decidim/core/test/shared_examples/download_open_data_shared_examples"
+
+describe "Download Open Data files", download: true do
+  let(:organization) { create(:organization) }
+
+  include_context "when downloading open data files"
+
+  it "lets the users download open data files" do
+    download_open_data_file
+
+    expect(File.basename(download_path)).to include("open-data.zip")
+    Zip::File.open(download_path) do |zipfile|
+      expect(zipfile.glob("*open-data-assemblies.csv").length).to eq(1)
+    end
+  end
+
+  describe "assemblies" do
+    let(:file_name) { "open-data-assemblies.csv" }
+
+    context "when there is none" do
+      it "returns an empty file" do
+        download_open_data_file
+        content = extract_content_from_zip(download_path, file_name)
+        expect(content).to eq("\n")
+      end
+    end
+
+    context "when the assembly is unpublished" do
+      let!(:assembly) { create(:assembly, :unpublished, organization:) }
+      let(:participatory_space_title) { translated_attribute(assembly.title).gsub('"', '""') }
+
+      it_behaves_like "does not include it in the open data file"
+    end
+
+    context "when the assembly is published and not private" do
+      let!(:assembly) { create(:assembly, :published, organization:, private_space: false) }
+      let(:participatory_space_title) { translated_attribute(assembly.title).gsub('"', '""') }
+
+      it_behaves_like "includes it in the open data file"
+    end
+
+    context "when the assembly is published, private and transparent" do
+      let!(:assembly) { create(:assembly, :published, organization:, private_space: true, is_transparent: true) }
+      let(:participatory_space_title) { translated_attribute(assembly.title).gsub('"', '""') }
+
+      it_behaves_like "includes it in the open data file"
+    end
+
+    context "when the assembly is published, private and not transparent" do
+      let!(:assembly) { create(:assembly, :published, organization:, private_space: true, is_transparent: false) }
+      let(:participatory_space_title) { translated_attribute(assembly.title).gsub('"', '""') }
+
+      it_behaves_like "does not include it in the open data file"
+    end
+  end
+end

--- a/decidim-blogs/app/views/decidim/blogs/posts/_actions.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/_actions.html.erb
@@ -8,10 +8,7 @@
   </div>
 
   <div class="blog__actions-right">
-    <%= follow_button_for(post, false, button_classes: "button button__sm button__text-secondary") %>
-
     <%= cell "decidim/share_button", nil %>
-    <%= cell "decidim/report_button", post %>
   </div>
 </div>
 

--- a/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
@@ -32,7 +32,12 @@
     <% end %>
 
     <div class="layout-author">
-      <%= cell "decidim/author", post_presenter.author, from: post, context_actions: [:date], layout: :compact %>
+      <div class="relative flex items-center justify-center w-full">
+        <div class="w-10/12 flex items-center gap-4">
+          <%= cell "decidim/author", post_presenter.author, from: post, context_actions: [:date], layout: :compact %>
+        </div>
+        <%= render "decidim/shared/resource_actions", resource: post %>
+      </div>
     </div>
   </section>
 

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -37,9 +37,17 @@ edit_link(
         </div>
       <% end %>
       <%= cell("decidim/budgets/project_selected_status", project, as_label: true) %>
-      <h1 class="h1 decorator budget__definition-project__title editor-content">
-        <%= decidim_sanitize translated_attribute project.title %>
-      </h1>
+
+      <div class="layout-author">
+        <div class="relative flex items-center justify-center w-full">
+          <div class="w-10/12 flex items-center gap-4">
+            <h1 class="h1 decorator budget__definition-project__title editor-content">
+              <%= decidim_sanitize translated_attribute project.title %>
+            </h1>
+          </div>
+          <%= render "decidim/shared/resource_actions", resource: project, skip_report: true %>
+        </div>
+      </div>
     </section>
     <section class="layout-main__section">
       <div class="editor-content">
@@ -89,7 +97,6 @@ edit_link(
         </div>
       </section>
       <section class="layout-aside__section actions__secondary">
-        <%= render partial: "decidim/shared/follow_button", class: "text-center", locals: { followable: project, large: false } %>
         <%= cell "decidim/share_button", nil %>
       </section>
     <% end %>

--- a/decidim-conferences/app/cells/decidim/conference_activity_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conference_activity_cell.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A cell to display when a conference has been created.
+  class ConferenceActivityCell < ActivityCell
+    def title
+      I18n.t("decidim.conferences.last_activity.new_conference")
+    end
+  end
+end

--- a/decidim-conferences/app/presenters/decidim/conferences/conference_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/conference_presenter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Conferences
+    class ConferencePresenter < SimpleDelegator
+      def hero_image_url
+        conference.attached_uploader(:hero_image).url(host: conference.organization.host)
+      end
+
+      def banner_image_url
+        conference.attached_uploader(:banner_image).url(host: conference.organization.host)
+      end
+
+      def conference
+        __getobj__
+      end
+    end
+  end
+end

--- a/decidim-conferences/app/serializers/decidim/conferences/conference_serializer.rb
+++ b/decidim-conferences/app/serializers/decidim/conferences/conference_serializer.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module Decidim
-  module Assemblies
-    # This class serializes an Assembly so it can be exported to CSV, JSON or other formats.
-    class AssemblySerializer < Decidim::Assemblies::OpenDataAssemblySerializer
-      # Public: Exports a hash with the serialized data for this assembly.
+  module Conferences
+    # This class serializes a Conference so it can be exported to CSV, JSON or other formats.
+    class ConferenceSerializer < Decidim::Conferences::OpenDataConferenceSerializer
+      # Public: Exports a hash with the serialized data for this conference.
       def serialize
         super.merge(
           {
@@ -13,7 +13,6 @@ module Decidim
               attachment_collections: serialize_attachment_collections,
               files: serialize_attachments
             },
-            private_space: resource.private_space,
             weight: resource.weight,
             components: serialize_components
           }

--- a/decidim-conferences/app/serializers/decidim/conferences/open_data_conference_serializer.rb
+++ b/decidim-conferences/app/serializers/decidim/conferences/open_data_conference_serializer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Conferences
+    # This class serializes a Conference so it can be exported to CSV for the Open Data feature.
+    class OpenDataConferenceSerializer < Decidim::Exporters::ParticipatorySpaceSerializer
+      # Public: Exports a hash with the serialized data for this conference.
+      def serialize
+        super.merge(
+          {
+            slogan: resource.slogan,
+            reference: resource.reference,
+            remote_hero_image_url: Decidim::Conferences::ConferencePresenter.new(resource).hero_image_url,
+            remote_banner_image_url: Decidim::Conferences::ConferencePresenter.new(resource).banner_image_url,
+            location: resource.location,
+            objectives: resource.objectives,
+            start_date: resource.start_date,
+            end_date: resource.end_date,
+            scopes_enabled: resource.scopes_enabled,
+            decidim_scope_id: resource.decidim_scope_id,
+            scope: {
+              id: resource.scope.try(:id),
+              name: resource.scope.try(:name) || empty_translatable
+            }
+          }
+        )
+      end
+    end
+  end
+end

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -474,6 +474,8 @@ en:
           name: Highlighted conferences
       index:
         title: Conferences
+      last_activity:
+        new_conference: 'New conference:'
       mailer:
         conference_registration_mailer:
           confirmation:

--- a/decidim-conferences/lib/decidim/conferences/participatory_space.rb
+++ b/decidim-conferences/lib/decidim/conferences/participatory_space.rb
@@ -36,6 +36,19 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
     context.layout = "layouts/decidim/admin/conference"
   end
 
+  participatory_space.exports :conferences do |export|
+    export.collection do
+      Decidim::Conference
+        .public_spaces
+        .includes(:scope, :attachment_collections, :categories)
+    end
+
+    export.include_in_open_data = true
+
+    export.serializer Decidim::Conferences::ConferenceSerializer
+    export.open_data_serializer Decidim::Conferences::OpenDataConferenceSerializer
+  end
+
   participatory_space.register_on_destroy_account do |user|
     Decidim::ConferenceUserRole.where(user:).destroy_all
     Decidim::ConferenceSpeaker.where(user:).destroy_all

--- a/decidim-conferences/lib/decidim/conferences/seeds.rb
+++ b/decidim-conferences/lib/decidim/conferences/seeds.rb
@@ -17,7 +17,7 @@ module Decidim
         )
 
         2.times do |_n|
-          conference = Decidim::Conference.create!(
+          params = {
             title: Decidim::Faker::Localized.sentence(word_count: 5),
             slogan: Decidim::Faker::Localized.sentence(word_count: 2),
             slug: Decidim::Faker::Internet.unique.slug(words: nil, glue: "-"),
@@ -43,7 +43,16 @@ module Decidim
             registration_terms: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
               Decidim::Faker::Localized.paragraph(sentence_count: 3)
             end
-          )
+          }
+
+          conference = Decidim.traceability.perform_action!(
+            "publish",
+            Decidim::Conference,
+            organization.users.first,
+            visibility: "all"
+          ) do
+            Decidim::Conference.create!(params)
+          end
           conference.add_to_index_as_search_resource
 
           # Create users with specific roles

--- a/decidim-conferences/spec/presenters/decidim/conferences/conference_presenter_spec.rb
+++ b/decidim-conferences/spec/presenters/decidim/conferences/conference_presenter_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Conferences::ConferencePresenter do
+    subject { described_class.new(conference) }
+
+    let!(:conference) { create(:conference) }
+    let(:organization_host) { conference.organization.host }
+
+    describe "when no images were uploaded" do
+      before do
+        conference.hero_image.purge
+        conference.banner_image.purge
+      end
+
+      it "return nil for hero_image_url" do
+        expect(subject.hero_image_url).to be_nil
+      end
+
+      it "return nil for banner_image_url" do
+        expect(subject.banner_image_url).to be_nil
+      end
+    end
+
+    describe "when images are attached" do
+      it "resolves hero_image_url" do
+        expect(subject.hero_image_url).to be_blob_url(conference.hero_image.blob)
+      end
+
+      it "resolves banner_image_url" do
+        expect(subject.banner_image_url).to be_blob_url(conference.banner_image.blob)
+      end
+    end
+  end
+end

--- a/decidim-conferences/spec/serializers/decidim/conferences/conference_serializer_spec.rb
+++ b/decidim-conferences/spec/serializers/decidim/conferences/conference_serializer_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Conferences
+  describe ConferenceSerializer do
+    let(:resource) { create(:conference) }
+
+    subject { described_class.new(resource) }
+
+    describe "#serialize" do
+      it "includes the conference data" do
+        serialized = subject.serialize
+
+        expect(serialized).to be_a(Hash)
+
+        expect(serialized).to include(id: resource.id)
+        expect(serialized).to include(slug: resource.slug)
+        expect(serialized).to include(hashtag: resource.hashtag)
+        expect(serialized).to include(title: resource.title)
+        expect(serialized).to include(slogan: resource.slogan)
+        expect(serialized).to include(reference: resource.reference)
+        expect(serialized).to include(weight: resource.weight)
+        expect(serialized).to include(short_description: resource.short_description)
+        expect(serialized).to include(description: resource.description)
+        expect(serialized[:remote_hero_image_url]).to be_blob_url(resource.hero_image.blob)
+        expect(serialized[:remote_banner_image_url]).to be_blob_url(resource.banner_image.blob)
+        expect(serialized).to include(location: resource.location)
+        expect(serialized).to include(promoted: resource.promoted)
+        expect(serialized).to include(objectives: resource.objectives)
+        expect(serialized).to include(start_date: resource.start_date)
+        expect(serialized).to include(end_date: resource.end_date)
+        expect(serialized).to include(scopes_enabled: resource.scopes_enabled)
+        expect(serialized).to include(decidim_scope_id: resource.decidim_scope_id)
+      end
+
+      context "when conference has scope" do
+        let(:scope) { create(:scope, organization: resource.organization) }
+
+        before do
+          resource.scope = scope
+          resource.save
+        end
+
+        it "includes the scope" do
+          serialized_scope = subject.serialize[:scope]
+
+          expect(serialized_scope).to be_a(Hash)
+
+          expect(serialized_scope).to include(id: resource.scope.id)
+          expect(serialized_scope).to include(name: resource.scope.name)
+        end
+      end
+
+      context "when conference has categories" do
+        let!(:category) { create(:category, participatory_space: resource) }
+
+        it "includes the categories" do
+          serialized_conference_categories = subject.serialize[:categories].first
+          expect(serialized_conference_categories).to be_a(Hash)
+
+          expect(serialized_conference_categories).to include(id: category.id)
+          expect(serialized_conference_categories).to include(name: category.name)
+          expect(serialized_conference_categories).to include(description: category.description)
+          expect(serialized_conference_categories).to include(parent_id: category.parent_id)
+        end
+
+        context "when category has subcategories" do
+          let!(:subcategory) { create(:subcategory, parent: category, participatory_space: resource) }
+
+          it "includes the categories" do
+            serialized_conference_categories = subject.serialize[:categories].first
+
+            expect(serialized_conference_categories).to be_a(Hash)
+
+            expect(serialized_conference_categories).to include(id: category.id)
+            expect(serialized_conference_categories).to include(name: category.name)
+            expect(serialized_conference_categories).to include(description: category.description)
+            expect(serialized_conference_categories).to include(parent_id: category.parent_id)
+          end
+        end
+      end
+
+      context "when conference has attachments" do
+        let!(:attachment_collection) { create(:attachment_collection, collection_for: resource) }
+        let!(:attachment) { create(:attachment, attached_to: resource, attachment_collection:) }
+
+        it "includes the attachment" do
+          serialized_conference_attachments = subject.serialize[:attachments][:files].first
+
+          expect(serialized_conference_attachments).to be_a(Hash)
+
+          expect(serialized_conference_attachments).to include(id: attachment.id)
+          expect(serialized_conference_attachments).to include(title: attachment.title)
+          expect(serialized_conference_attachments).to include(weight: attachment.weight)
+          expect(serialized_conference_attachments).to include(description: attachment.description)
+          expect(serialized_conference_attachments[:remote_file_url]).to be_blob_url(resource.attachments.first.file.blob)
+        end
+      end
+    end
+  end
+end

--- a/decidim-conferences/spec/serializers/decidim/conferences/open_data_conference_serializer_spec.rb
+++ b/decidim-conferences/spec/serializers/decidim/conferences/open_data_conference_serializer_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Conferences
+  describe OpenDataConferenceSerializer do
+    let(:resource) { create(:conference) }
+
+    subject { described_class.new(resource) }
+
+    describe "#serialize" do
+      it "includes the conference data" do
+        serialized = subject.serialize
+
+        expect(serialized).to be_a(Hash)
+
+        expect(serialized).to include(id: resource.id)
+        expect(serialized).to include(slug: resource.slug)
+        expect(serialized).to include(hashtag: resource.hashtag)
+        expect(serialized).to include(title: resource.title)
+        expect(serialized).to include(slogan: resource.slogan)
+        expect(serialized).to include(reference: resource.reference)
+        expect(serialized).to include(short_description: resource.short_description)
+        expect(serialized).to include(description: resource.description)
+        expect(serialized[:remote_hero_image_url]).to be_blob_url(resource.hero_image.blob)
+        expect(serialized[:remote_banner_image_url]).to be_blob_url(resource.banner_image.blob)
+        expect(serialized).to include(location: resource.location)
+        expect(serialized).to include(promoted: resource.promoted)
+        expect(serialized).to include(objectives: resource.objectives)
+        expect(serialized).to include(start_date: resource.start_date)
+        expect(serialized).to include(end_date: resource.end_date)
+        expect(serialized).to include(scopes_enabled: resource.scopes_enabled)
+        expect(serialized).to include(decidim_scope_id: resource.decidim_scope_id)
+      end
+
+      context "when conference has scope" do
+        let(:scope) { create(:scope, organization: resource.organization) }
+
+        before do
+          resource.scope = scope
+          resource.save
+        end
+
+        it "includes the scope" do
+          serialized_scope = subject.serialize[:scope]
+
+          expect(serialized_scope).to be_a(Hash)
+
+          expect(serialized_scope).to include(id: resource.scope.id)
+          expect(serialized_scope).to include(name: resource.scope.name)
+        end
+      end
+    end
+  end
+end

--- a/decidim-conferences/spec/system/admin/admin_manages_conferences_publication_spec.rb
+++ b/decidim-conferences/spec/system/admin/admin_manages_conferences_publication_spec.rb
@@ -11,4 +11,23 @@ describe "Admin manages conference publication" do
   let!(:participatory_space) { conference }
 
   it_behaves_like "manage participatory space publications"
+
+  it "displays the entry in last activities" do
+    participatory_space.update(title: { en: title })
+    participatory_space.unpublish!
+    participatory_space.reload
+
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit admin_page_path
+    click_on "Publish"
+
+    visit decidim.last_activities_path
+    expect(page).to have_content("New conference: #{title}")
+
+    within "#filters" do
+      find("a", class: "filter", text: "Conference", match: :first).click
+    end
+    expect(page).to have_content("New conference: #{title}")
+  end
 end

--- a/decidim-conferences/spec/system/conferences_spec.rb
+++ b/decidim-conferences/spec/system/conferences_spec.rb
@@ -129,7 +129,7 @@ describe "Conferences" do
     end
   end
 
-  it_behaves_like "followable content for users" do
+  it_behaves_like "followable space content for users" do
     let(:conference) { base_conference }
     let!(:user) { create(:user, :confirmed, organization:) }
     let(:followable) { conference }

--- a/decidim-conferences/spec/system/download_open_data_files_spec.rb
+++ b/decidim-conferences/spec/system/download_open_data_files_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/core/test/shared_examples/download_open_data_shared_context"
+require "decidim/core/test/shared_examples/download_open_data_shared_examples"
+
+describe "Download Open Data files", download: true do
+  let(:organization) { create(:organization) }
+
+  include_context "when downloading open data files"
+
+  it "lets the users download open data files" do
+    download_open_data_file
+
+    expect(File.basename(download_path)).to include("open-data.zip")
+    Zip::File.open(download_path) do |zipfile|
+      expect(zipfile.glob("*open-data-conferences.csv").length).to eq(1)
+    end
+  end
+
+  describe "conferences" do
+    let(:file_name) { "open-data-conferences.csv" }
+
+    context "when there is none" do
+      it "returns an empty file" do
+        download_open_data_file
+        content = extract_content_from_zip(download_path, file_name)
+        expect(content).to eq("\n")
+      end
+    end
+
+    context "when the conference is unpublished" do
+      let!(:conference) { create(:conference, :unpublished, organization:) }
+      let(:participatory_space_title) { translated_attribute(conference.title).gsub('"', '""') }
+
+      it_behaves_like "does not include it in the open data file"
+    end
+
+    context "when the conference is published" do
+      let!(:conference) { create(:conference, :published, organization:) }
+      let(:participatory_space_title) { translated_attribute(conference.title).gsub('"', '""') }
+
+      it_behaves_like "includes it in the open data file"
+    end
+  end
+end

--- a/decidim-core/app/models/decidim/action_log.rb
+++ b/decidim-core/app/models/decidim/action_log.rb
@@ -138,6 +138,7 @@ module Decidim
         Decidim::Proposals::Proposal
         Decidim::Surveys::Survey
         Decidim::Assembly
+        Decidim::Conference
         Decidim::Initiative
         Decidim::ParticipatoryProcess
       ).select do |klass|

--- a/decidim-core/app/packs/src/decidim/datepicker/form_datepicker.js
+++ b/decidim-core/app/packs/src/decidim/datepicker/form_datepicker.js
@@ -32,8 +32,8 @@ export default function formDatePicker(input) {
   helpTextContainer.setAttribute("class", "datepicker__help-text-container");
 
   const helpTextDate = document.createElement("span");
-  helpTextDate.setAttribute("class", "help-text datepicker__help-date");
-  helpTextDate.innerText = i18nDateHelp.date_format;
+  helpTextContainer.setAttribute("class", "birthday__wrapper-text");
+  helpTextContainer.innerText = i18nDateHelp.date_format;
 
   const helpTextTime = document.createElement("span");
   helpTextTime.setAttribute("class", "help-text datepicker__help-time");

--- a/decidim-core/app/packs/src/decidim/datepicker/form_datepicker.js
+++ b/decidim-core/app/packs/src/decidim/datepicker/form_datepicker.js
@@ -32,7 +32,7 @@ export default function formDatePicker(input) {
   helpTextContainer.setAttribute("class", "datepicker__help-text-container");
 
   const helpTextDate = document.createElement("span");
-  helpTextContainer.setAttribute("class", "birthday__wrapper-text");
+  helpTextContainer.setAttribute("class", "help-text datepicker__help-date");
   helpTextContainer.innerText = i18nDateHelp.date_format;
 
   const helpTextTime = document.createElement("span");

--- a/decidim-core/app/packs/src/decidim/datepicker/form_datepicker.js
+++ b/decidim-core/app/packs/src/decidim/datepicker/form_datepicker.js
@@ -32,8 +32,8 @@ export default function formDatePicker(input) {
   helpTextContainer.setAttribute("class", "datepicker__help-text-container");
 
   const helpTextDate = document.createElement("span");
-  helpTextContainer.setAttribute("class", "help-text datepicker__help-date");
-  helpTextContainer.innerText = i18nDateHelp.date_format;
+  helpTextDate.setAttribute("class", "help-text datepicker__help-date");
+  helpTextDate.innerText = i18nDateHelp.date_format;
 
   const helpTextTime = document.createElement("span");
   helpTextTime.setAttribute("class", "help-text datepicker__help-time");
@@ -55,7 +55,7 @@ export default function formDatePicker(input) {
   };
 
   if (!input.getAttribute("hide_help")) {
-    row.before(helpTextContainer);
+    label.appendChild(helpTextContainer);
   };
 
   if (formats.time === 12) {

--- a/decidim-core/app/packs/stylesheets/decidim/_buttons.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_buttons.scss
@@ -67,7 +67,7 @@
   }
 
   &.is-hover,
-  &:not([disabled]):not([class*="button__text"]):hover {
+  &:not([disabled]):not([class*="button__text"]):not(label):hover {
     @apply text-white;
 
     background: linear-gradient(0deg, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3)),

--- a/decidim-core/app/packs/stylesheets/decidim/_datepicker.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_datepicker.scss
@@ -179,7 +179,7 @@
   }
 
   &__help-date {
-    @apply w-1/2 relative inline-block;
+    @apply w-1/2 relative inline-block -mt-8;
   }
 
   &__help-time {

--- a/decidim-core/app/packs/stylesheets/decidim/_datepicker.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_datepicker.scss
@@ -57,7 +57,7 @@
 
   &__date-column,
   &__time-column {
-    @apply flex-1 w-1/2 relative;
+    @apply flex-1 w-1/2 -mt-6 relative;
 
     > input {
       @apply h-9;

--- a/decidim-core/app/packs/stylesheets/decidim/_datepicker.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_datepicker.scss
@@ -48,7 +48,7 @@
   }
 
   &__datepicker-row {
-    @apply flex gap-4;
+    @apply flex gap-4 -mt-8;
   }
 
   &__time-row {

--- a/decidim-core/app/packs/stylesheets/decidim/_forms.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_forms.scss
@@ -78,6 +78,14 @@
   @apply block text-sm text-gray-2 font-normal prose-a:text-secondary prose-a:underline;
 }
 
+.birthday__wrapper {
+  @apply flex text-sm text-gray-2 font-normal prose-a:text-secondary prose-a:underline;
+
+  &-text {
+    @apply flex -mt-8;
+  }
+}
+
 .form__wrapper {
   @apply flex flex-col py-10 gap-10 last:pb-0;
 

--- a/decidim-core/app/packs/stylesheets/decidim/_forms.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_forms.scss
@@ -78,14 +78,6 @@
   @apply block text-sm text-gray-2 font-normal prose-a:text-secondary prose-a:underline;
 }
 
-.birthday__wrapper {
-  @apply flex text-sm text-gray-2 font-normal prose-a:text-secondary prose-a:underline;
-
-  &-text {
-    @apply flex -mt-8;
-  }
-}
-
 .form__wrapper {
   @apply flex flex-col py-10 gap-10 last:pb-0;
 
@@ -104,10 +96,6 @@
   & label:not(&-checkbox-label),
   &-block label:not(&-checkbox-label) {
     @apply font-semibold text-lg;
-  }
-
-  .help-text {
-    @apply mt-4;
   }
 
   input[type="date"],

--- a/decidim-core/app/packs/stylesheets/decidim/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_layout.scss
@@ -96,6 +96,24 @@
 
 .layout-author {
   @apply flex items-center gap-4;
+
+  /* overwrite default dropdown styles */
+  [data-target*="dropdown"] {
+    @apply w-auto cursor-pointer text-secondary text-2xl flex;
+  }
+
+  /* overwrite default dropdown styles */
+  [id*="dropdown-menu"][aria-hidden="true"] {
+    @apply md:hidden;
+  }
+
+  .dropdown__bottom {
+    @apply [&>li]:pl-0;
+
+    .button {
+      @apply [&>svg]:order-1 [&>span]:order-2;
+    }
+  }
 }
 
 .layout-aside__buttons {

--- a/decidim-core/app/packs/stylesheets/decidim/_modal_update.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_modal_update.scss
@@ -6,6 +6,10 @@
       @apply py-14;
     }
 
+    &.is-disabled label.button__secondary {
+      @apply text-gray-2 bg-background-3 border border-gray-2 cursor-not-allowed;
+    }
+
     &-container {
       @apply space-y-4;
     }

--- a/decidim-core/app/queries/decidim/last_activity.rb
+++ b/decidim-core/app/queries/decidim/last_activity.rb
@@ -68,7 +68,12 @@ module Decidim
                         SQL
                       ).to_s
                     else
-                      Arel.sql("decidim_action_logs.participatory_space_type = '#{manifest.model_class_name}'").to_s
+                      Arel.sql(
+                        [
+                          "decidim_action_logs.resource_type = '#{manifest.model_class_name}'",
+                          "decidim_action_logs.participatory_space_type = '#{manifest.model_class_name}'"
+                        ].join(" OR ")
+                      ).to_s
                     end
 
         conditions << "(#{condition})"

--- a/decidim-core/app/serializers/decidim/exporters/participatory_space_serializer.rb
+++ b/decidim-core/app/serializers/decidim/exporters/participatory_space_serializer.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Exporters
+    # This class serves as the base class for the serializers that export
+    # participatory spaces.
+    class ParticipatorySpaceSerializer < Decidim::Exporters::Serializer
+      include Decidim::ApplicationHelper
+      include Decidim::ResourceHelper
+      include Decidim::TranslationsHelper
+
+      # Public: Initializes the serializer with a resource
+      def initialize(resource)
+        @resource = resource
+      end
+
+      # Public: Exports a hash with the serialized data for this resource.
+      def serialize
+        {
+          id: resource.id,
+          title: resource.title,
+          slug: resource.slug,
+          hashtag: resource.hashtag,
+          short_description: resource.short_description,
+          description: resource.description,
+          promoted: resource.promoted
+        }
+      end
+
+      private
+
+      attr_reader :resource
+
+      def serialize_categories
+        return unless resource.categories.first_class.any?
+
+        resource.categories.first_class.map do |category|
+          {
+            id: category.try(:id),
+            name: category.try(:name),
+            description: category.try(:description),
+            parent_id: category.try(:parent_id),
+            subcategories: serialize_subcategories(category.subcategories)
+          }
+        end
+      end
+
+      def serialize_subcategories(subcategories)
+        return unless subcategories.any?
+
+        subcategories.map do |subcategory|
+          {
+            id: subcategory.try(:id),
+            name: subcategory.try(:name),
+            description: subcategory.try(:description),
+            parent_id: subcategory.try(:parent_id)
+          }
+        end
+      end
+
+      def serialize_attachment_collections
+        return unless resource.attachment_collections.any?
+
+        resource.attachment_collections.map do |collection|
+          {
+            id: collection.try(:id),
+            name: collection.try(:name),
+            weight: collection.try(:weight),
+            description: collection.try(:description)
+          }
+        end
+      end
+
+      def serialize_attachments
+        return unless resource.attachments.any?
+
+        resource.attachments.map do |attachment|
+          {
+            id: attachment.try(:id),
+            title: attachment.try(:title),
+            weight: attachment.try(:weight),
+            description: attachment.try(:description),
+            attachment_collection: {
+              name: attachment.attachment_collection.try(:name),
+              weight: attachment.attachment_collection.try(:weight),
+              description: attachment.attachment_collection.try(:description)
+            },
+            remote_file_url: Decidim::AttachmentPresenter.new(attachment).attachment_file_url
+          }
+        end
+      end
+
+      def serialize_components
+        serializer = Decidim::Exporters::ParticipatorySpaceComponentsSerializer.new(resource)
+        serializer.run
+      end
+    end
+  end
+end

--- a/decidim-core/app/services/decidim/open_data_exporter.rb
+++ b/decidim-core/app/services/decidim/open_data_exporter.rb
@@ -47,10 +47,10 @@ module Decidim
       ActiveRecord::Base.uncached do
         components.where(manifest_name: export_manifest.manifest.name).find_each do |component|
           export_manifest.collection.call(component).find_in_batches(batch_size: 100) do |batch|
-            exporter = Decidim::Exporters::CSV.new(batch, export_manifest.serializer)
+            serializer = export_manifest.open_data_serializer.nil? ? export_manifest.serializer : export_manifest.open_data_serializer
+            exporter = Decidim::Exporters::CSV.new(batch, serializer)
             headers.push(*exporter.headers)
             exported = exporter.export
-
             tmpdir = Dir::Tmpname.create(export_manifest.name.to_s) do
               # just get an empty file name
             end
@@ -79,8 +79,9 @@ module Decidim
       collection = participatory_spaces.filter { |space| space.manifest.name == export_manifest.manifest.name }.flat_map do |participatory_space|
         export_manifest.collection.call(participatory_space)
       end
+      serializer = export_manifest.open_data_serializer.nil? ? export_manifest.serializer : export_manifest.open_data_serializer
 
-      Decidim::Exporters::CSV.new(collection, export_manifest.serializer).export
+      Decidim::Exporters::CSV.new(collection, serializer).export
     end
 
     def add_file_to_output(output, file_name, data)

--- a/decidim-core/app/views/decidim/shared/_resource_actions.html.erb
+++ b/decidim-core/app/views/decidim/shared/_resource_actions.html.erb
@@ -1,0 +1,21 @@
+<div class="relative ml-auto">
+  <button id="dropdown-trigger-resource-<%= resource.id %>"
+          data-component="dropdown"
+          data-target="dropdown-menu-resource-<%= resource.id %>"
+          aria-label="<%= t("decidim.resource.controls_label") %>">
+    <span class="sr-only"><%= t("decidim.resource.controls_label") %></span>
+    <%# NOTE: having two times the icon call is intentional, as that is how the `dropdown` CSS code is done %>
+    <%= icon "more-2-fill" %>
+    <%= icon "more-2-fill" %>
+  </button>
+  <div id="dropdown-menu-resource-<%= resource.id %>" aria-hidden="true">
+    <ul class="dropdown dropdown__bottom divide-y divide-gray-3 px-4" role="menu">
+      <%= yield %>
+      <% unless defined?(skip_report) && skip_report %>
+        <li role="menuitem"><%= cell "decidim/report_button", resource %></li>
+      <% end %>
+      <li role="menuitem">
+        <%= cell "decidim/follow_button", resource, large: false %></li>
+    </ul>
+  </div>
+</div>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1449,6 +1449,8 @@ en:
       create:
         error: There was a problem creating the report. Please, try it again.
         success: The report has been created successfully and it will be reviewed by an admin.
+    resource:
+      controls_label: Resource controls
     resource_endorsements:
       create:
         error: There was a problem during the endorsement action.

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -55,7 +55,8 @@ module Decidim
 
       initializer "decidim_core.register_icons", after: "decidim_core.add_social_share_services" do
         Decidim.icons.register(name: "phone-line", icon: "phone-line", category: "system", description: "", engine: :core)
-
+        Decidim.icons.register(name: "more-2-fill", icon: "more-2-fill", category: "system", description: "Resource Action button", engine: :core)
+        Decidim.icons.register(name: "more-fill", icon: "more-fill", category: "system", description: "Resource Action button", engine: :core)
         Decidim.icons.register(name: "upload-cloud-2-line", icon: "upload-cloud-2-line", category: "system",
                                description: "Upload cloud 2 line used in attachments form", engine: :core)
         Decidim.icons.register(name: "arrow-right-line", icon: "arrow-right-line", category: "system",

--- a/decidim-core/lib/decidim/core/test/shared_examples/download_open_data_shared_context.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/download_open_data_shared_context.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "when downloading open data files" do
+  # Workaround to ignore Bullet warnings in these examples, until we found a way to actually fix these issues
+  before do
+    Bullet.n_plus_one_query_enable = false
+    Bullet.unused_eager_loading_enable = false
+  end
+
+  after do
+    Bullet.n_plus_one_query_enable = Decidim::Env.new("DECIDIM_BULLET_N_PLUS_ONE", "false").present?
+    Bullet.unused_eager_loading_enable = Decidim::Env.new("DECIDIM_BULLET_UNUSED_EAGER", "false").present?
+  end
+
+  def download_open_data_file
+    # Prevent using the same cached file
+    open_data_file = Rails.root.join("tmp/#{organization.open_data_file_path}")
+    FileUtils.rm_f(open_data_file)
+    Decidim::OpenDataJob.perform_now(organization)
+    switch_to_host(organization.host)
+    visit decidim.root_path
+
+    click_on "Download Open Data files"
+  end
+
+  def extract_content_from_zip(download_path, file_name)
+    Zip::File.open(download_path) do |zipfile|
+      entry = zipfile.select { |an_entry| an_entry.name.match?(/.*#{file_name}/) }.first
+      content = entry.get_input_stream.read
+
+      return content
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core/test/shared_examples/download_open_data_shared_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/download_open_data_shared_examples.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "decidim/core/test/shared_examples/download_open_data_shared_context"
+
+RSpec.shared_examples "includes it in the open data file" do
+  include_context "when downloading open data files"
+
+  it do
+    download_open_data_file
+    content = extract_content_from_zip(download_path, file_name)
+    expect(content).to include(participatory_space_title)
+  end
+end
+
+RSpec.shared_examples "does not include it in the open data file" do
+  include_context "when downloading open data files"
+
+  it do
+    download_open_data_file
+    content = extract_content_from_zip(download_path, file_name)
+    expect(content).not_to include(participatory_space_title)
+  end
+end

--- a/decidim-core/lib/decidim/core/test/shared_examples/follows_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/follows_examples.rb
@@ -14,6 +14,8 @@ shared_examples "followable content for users" do
     context "when user clicks the Follow button" do
       it "makes the user follow the followable" do
         visit followable_path
+        find("#dropdown-trigger-resource-#{followable.id}").click
+
         expect do
           click_on "Follow"
           expect(page).to have_content "Stop following"
@@ -30,6 +32,45 @@ shared_examples "followable content for users" do
     context "when user clicks the Follow button" do
       it "makes the user follow the followable" do
         visit followable_path
+        find("#dropdown-trigger-resource-#{followable.id}").click
+
+        expect do
+          click_on "Stop following"
+          expect(page).to have_content "Follow"
+        end.to change(Decidim::Follow, :count).by(-1)
+      end
+    end
+  end
+end
+
+shared_examples "followable space content for users" do
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  context "when not following the followable" do
+    context "when user clicks the Follow button" do
+      it "makes the user follow the followable" do
+        visit followable_path
+
+        expect do
+          click_on "Follow"
+          expect(page).to have_content "Stop following"
+        end.to change(Decidim::Follow, :count).by(1)
+      end
+    end
+  end
+
+  context "when the user is following the followable" do
+    before do
+      create(:follow, followable:, user:)
+    end
+
+    context "when user clicks the Follow button" do
+      it "makes the user follow the followable" do
+        visit followable_path
+
         expect do
           click_on "Stop following"
           expect(page).to have_content "Follow"
@@ -51,6 +92,8 @@ shared_examples "followable content for users with a component" do
     context "when user clicks the Follow button" do
       it "makes the user follow the followable" do
         visit followable_path
+        find("#dropdown-trigger-resource-#{followable.id}").click
+
         expect do
           click_on "Follow"
           expect(page).to have_content "Stop following"

--- a/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
@@ -9,7 +9,7 @@ shared_examples "logged in user reports content" do
     context "and the user has not reported the resource yet" do
       it "reports the resource" do
         visit reportable_path
-
+        find("#dropdown-trigger-resource-#{reportable.id}").click
         expect(page).to have_css(%(button[data-dialog-open="flagModal"]))
         find(%(button[data-dialog-open="flagModal"])).click
         expect(page).to have_css(".flag-modal", visible: :visible)
@@ -44,6 +44,7 @@ shared_examples "higher user role hides" do
     it "reports the resource" do
       visit reportable_path
 
+      find("#dropdown-trigger-resource-#{reportable.id}").click
       expect(page).to have_css(%(button[data-dialog-open="flagModal"]))
       find(%(button[data-dialog-open="flagModal"])).click
       expect(page).to have_css(".flag-modal", visible: :visible)
@@ -67,6 +68,7 @@ shared_examples "higher user role does not have hide" do
     it "reports the resource" do
       visit reportable_path
 
+      find("#dropdown-trigger-resource-#{reportable.id}").click
       expect(page).to have_css(%(button[data-dialog-open="flagModal"]))
       find(%(button[data-dialog-open="flagModal"])).click
       expect(page).to have_css(".flag-modal", visible: :visible)
@@ -85,6 +87,7 @@ shared_examples "reports" do
 
       expect(page).to have_no_css("html.is-disabled")
 
+      find("#dropdown-trigger-resource-#{reportable.id}").click
       click_on "Report"
 
       expect(page).to have_css("html.is-disabled")
@@ -103,6 +106,7 @@ shared_examples "reports" do
     it "cannot report it twice" do
       visit reportable_path
 
+      find("#dropdown-trigger-resource-#{reportable.id}").click
       expect(page).to have_css(%(button[data-dialog-open="flagModal"]))
       find(%(button[data-dialog-open="flagModal"])).click
       expect(page).to have_css(".flag-modal", visible: :visible)

--- a/decidim-core/lib/decidim/exporters/export_manifest.rb
+++ b/decidim-core/lib/decidim/exporters/export_manifest.rb
@@ -14,6 +14,12 @@ module Decidim
 
       # A setting to choose if the collection exported by this manifest should
       # be included in the open data export available for all users.
+      #
+      # Optionally, you can define a specific serializer using the `open_data_serializer` method
+      # to have a granular control on which fields are added to the open data export.
+      # This is specially useful for ParticipatorySpaces, as the serializer is used for the
+      # export/import feature, and we do not want to publish some of the data available there
+      # (as the components settings).
       attribute :include_in_open_data, Boolean, default: false
 
       attr_reader :name, :manifest
@@ -71,6 +77,14 @@ module Decidim
       # `Decidim::Exporters::Serializer` as a default implementation.
       def serializer(serializer = nil)
         @serializer ||= serializer || Decidim::Exporters::Serializer
+      end
+
+      # Public: Sets the open data serializer when an argument is provided, returns the
+      # stored serializer otherwise.
+      #
+      # See more information in the `serializer` method.
+      def open_data_serializer(serializer = nil)
+        @open_data_serializer ||= serializer || nil
       end
 
       DEFAULT_FORMATS = %w(CSV JSON Excel).freeze

--- a/decidim-core/spec/lib/exporters/export_manifest_spec.rb
+++ b/decidim-core/spec/lib/exporters/export_manifest_spec.rb
@@ -45,6 +45,22 @@ module Decidim
       end
     end
 
+    describe "#open_data_serializer" do
+      context "when no serializer is specified" do
+        it "returns nil" do
+          expect(subject.open_data_serializer).to be_nil
+        end
+      end
+
+      context "when a serializer is set" do
+        it "returns the serializer" do
+          klass = Class.new
+          subject.open_data_serializer klass
+          expect(subject.open_data_serializer).to eq(klass)
+        end
+      end
+    end
+
     describe "#formats" do
       context "when no formats are specified" do
         it "returns the default formats array" do

--- a/decidim-core/spec/system/download_open_data_files_spec.rb
+++ b/decidim-core/spec/system/download_open_data_files_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/core/test/shared_examples/download_open_data_shared_context"
+
+describe "Download Open Data files", download: true do
+  let(:organization) { create(:organization) }
+
+  include_context "when downloading open data files"
+
+  it "lets the users download open data files" do
+    download_open_data_file
+
+    expect(File.basename(download_path)).to include("open-data.zip")
+    Zip::File.open(download_path) do |zipfile|
+      expect(zipfile.glob("*open-data-meeting_comments.csv").length).to eq(1)
+      expect(zipfile.glob("*open-data-meetings.csv").length).to eq(1)
+      expect(zipfile.glob("*open-data-projects.csv").length).to eq(1)
+      expect(zipfile.glob("*open-data-proposal_comments.csv").length).to eq(1)
+      expect(zipfile.glob("*open-data-proposals.csv").length).to eq(1)
+      expect(zipfile.glob("*open-data-result_comments.csv").length).to eq(1)
+      expect(zipfile.glob("*open-data-results.csv").length).to eq(1)
+    end
+  end
+end

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -515,24 +515,6 @@ describe "Homepage" do
         end
       end
 
-      context "when downloading open data", download: true do
-        before do
-          Decidim::OpenDataJob.perform_now(organization)
-          switch_to_host(organization.host)
-          visit decidim.root_path
-        end
-
-        it "lets the users download open data files" do
-          click_on "Download Open Data files"
-          expect(File.basename(download_path)).to include("open-data.zip")
-          Zip::File.open(download_path) do |zipfile|
-            expect(zipfile.glob("*open-data-proposals.csv").length).to eq(1)
-            expect(zipfile.glob("*open-data-results.csv").length).to eq(1)
-            expect(zipfile.glob("*open-data-meetings.csv").length).to eq(1)
-          end
-        end
-      end
-
       describe "footer message" do
         context "when the organization does not have a description" do
           let(:organization) { create(:organization, description: { en: nil }) }

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -28,12 +28,17 @@ edit_link(
 
     <% debate_presenter = Decidim::Debates::DebatePresenter.new(debate) %>
     <div class="layout-author">
-      <%= cell "decidim/author", debate_presenter.author, skip_profile_link: true %>
-      <% if debate.closed? %>
-        <span class="success label">
-          <%= t("debate_closed", scope: "decidim.debates.debates.show") %>
-        </span>
-      <% end %>
+      <div class="relative flex items-center justify-center w-full">
+        <div class="w-10/12 flex items-center gap-4">
+          <%= cell "decidim/author", debate_presenter.author, skip_profile_link: true %>
+          <% if debate.closed? %>
+            <span class="success label">
+              <%= t("debate_closed", scope: "decidim.debates.debates.show") %>
+            </span>
+          <% end %>
+        </div>
+        <%= render "decidim/shared/resource_actions", resource: debate %>
+      </div>
     </div>
   </section>
 
@@ -116,9 +121,7 @@ edit_link(
     </div>
   </section>
   <section class="layout-aside__section actions__secondary">
-    <%= follow_button_for(debate) %>
     <%= cell "decidim/share_button", nil %>
-    <%= cell "decidim/report_button", debate %>
   </section>
 
   <% end %>

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -67,6 +67,7 @@ module Decidim
 
           PublishInitiative.call(current_initiative, current_user) do
             on(:ok) do
+              flash[:notice] = I18n.t("initiatives.publish.success", scope: "decidim.initiatives.admin")
               redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
             end
           end
@@ -78,6 +79,7 @@ module Decidim
 
           UnpublishInitiative.call(current_initiative, current_user) do
             on(:ok) do
+              flash[:notice] = I18n.t("initiatives.unpublish.success", scope: "decidim.initiatives.admin")
               redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
             end
           end
@@ -88,6 +90,7 @@ module Decidim
           enforce_permission_to :discard, :initiative, initiative: current_initiative
           DiscardInitiative.call(current_initiative, current_user) do
             on(:ok) do
+              flash[:notice] = I18n.t("initiatives.discard.success", scope: "decidim.initiatives.admin")
               redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
             end
           end
@@ -98,6 +101,7 @@ module Decidim
           enforce_permission_to :accept, :initiative, initiative: current_initiative
           AcceptInitiative.call(current_initiative, current_user) do
             on(:ok) do
+              flash[:notice] = I18n.t("initiatives.accept.success", scope: "decidim.initiatives.admin")
               redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
             end
           end
@@ -108,6 +112,7 @@ module Decidim
           enforce_permission_to :reject, :initiative, initiative: current_initiative
           RejectInitiative.call(current_initiative, current_user) do
             on(:ok) do
+              flash[:notice] = I18n.t("initiatives.reject.success", scope: "decidim.initiatives.admin")
               redirect_to decidim_admin_initiatives.edit_initiative_path(current_initiative)
             end
           end

--- a/decidim-initiatives/app/serializers/decidim/initiatives/initiative_serializer.rb
+++ b/decidim-initiatives/app/serializers/decidim/initiatives/initiative_serializer.rb
@@ -2,33 +2,14 @@
 
 module Decidim
   module Initiatives
-    class InitiativeSerializer < Decidim::Exporters::Serializer
+    class InitiativeSerializer < Decidim::Initiatives::OpenDataInitiativeSerializer
       # Serializes an initiative
       def serialize
-        {
-          id: resource.id,
-          title: resource.title,
-          description: resource.description,
-          state: resource.state,
-          created_at: resource.created_at,
-          published_at: resource.published_at,
-          signature_end_date: resource.signature_end_date,
-          signature_type: resource.signature_type,
-          signatures: resource.supports_count,
-          scope: {
-            name: resource.scope&.name
-          },
-          type: {
-            title: resource.type&.title
-          },
-          authors: {
-            id: resource.author_users.map(&:id),
-            name: resource.author_users.map(&:name)
-          },
-          area: {
-            name: resource.area&.name
+        super.merge(
+          {
+            components: serialize_components
           }
-        }
+        )
       end
     end
   end

--- a/decidim-initiatives/app/serializers/decidim/initiatives/open_data_initiative_serializer.rb
+++ b/decidim-initiatives/app/serializers/decidim/initiatives/open_data_initiative_serializer.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    class OpenDataInitiativeSerializer < Decidim::Exporters::ParticipatorySpaceSerializer
+      # Public: Exports a hash with the serialized data for this initiative.
+      #
+      # Note that we do not merge the original serialize method here, as the Initiative
+      # model does not have the same attributes as the other Spaces models.
+      def serialize
+        {
+          reference: resource.reference,
+          title: resource.title,
+          description: resource.description,
+          state: resource.state,
+          created_at: resource.created_at,
+          published_at: resource.published_at,
+          signature_start_date: resource.signature_start_date,
+          signature_end_date: resource.signature_end_date,
+          signature_type: resource.signature_type,
+          signatures: resource.supports_count,
+          answer: resource.answer,
+          answered_at: resource.answered_at,
+          answer_url: resource.answer_url,
+          hashtag: resource.hashtag,
+          first_progress_notification_at: resource.first_progress_notification_at,
+          second_progress_notification_at: resource.second_progress_notification_at,
+          scope: {
+            id: resource.scope.try(:id),
+            name: resource.scope.try(:name) || empty_translatable
+          },
+          type: {
+            id: resource.type&.id,
+            title: resource.type&.title
+          },
+          authors: {
+            id: resource.author_users.map(&:id),
+            name: resource.author_users.map(&:name)
+          },
+          area: {
+            id: resource.area.try(:id),
+            name: resource.area.try(:name) || empty_translatable
+          }
+        }
+      end
+    end
+  end
+end

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -242,6 +242,10 @@ en:
             alert_html: "<p>You must create at least one initiative type so participants can start creating initiatives.</p><p> %{link}</p>"
             button: New initiative type
         initiatives:
+          accept:
+            success: The initiative has been successfully accepted.
+          discard:
+            success: The initiative has been successfully discarded.
           edit:
             accept: Accept initiative
             confirm: Are you sure?
@@ -265,6 +269,12 @@ en:
             edit: Edit
             new: New
             photos: Photos
+          publish:
+            success: The initiative has been successfully published.
+          reject:
+            success: The initiative has been successfully rejected.
+          unpublish:
+            success: The initiative has been successfully unpublished.
           update:
             error: There was a problem updating the initiative.
             success: The initiative has been successfully updated.

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -40,10 +40,13 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
 
   participatory_space.exports :initiatives do |export|
     export.collection do
-      Decidim::Initiative
+      Decidim::Initiative.public_spaces
     end
 
+    export.include_in_open_data = true
+
     export.serializer Decidim::Initiatives::InitiativeSerializer
+    export.open_data_serializer Decidim::Initiatives::OpenDataInitiativeSerializer
   end
 
   participatory_space.seeds do

--- a/decidim-initiatives/spec/serializers/open_data_initiative_serializer_spec.rb
+++ b/decidim-initiatives/spec/serializers/open_data_initiative_serializer_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module Decidim::Initiatives
-  describe InitiativeSerializer do
+  describe OpenDataInitiativeSerializer do
     subject { described_class.new(initiative) }
 
     let(:initiative) { create(:initiative, :with_area) }

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_publication_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_publication_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages initiative publication" do
+  let!(:user) { create(:user, :admin, :confirmed, organization:) }
+  let(:organization) { create(:organization) }
+
+  # To be published, the initiative needs to be in the :validating state
+  let!(:initiative) { create(:initiative, :validating, organization:) }
+
+  let(:admin_page_path) { decidim_admin_initiatives.edit_initiative_path(participatory_space) }
+  let(:public_collection_path) { decidim_initiatives.initiatives_path }
+  let(:title) { "My space" }
+  let(:participatory_space) { initiative }
+
+  # We cannot use the shared example "manage participatory space publications"
+  # as Initiatives have some differences in comparison with the other spaces:
+  #
+  # - Initiatives are not published/unpublished, they are validated
+  # - There is a modal to confirm the publish/unpublish
+  # - The public collection path is still visible even though there are not initiatives
+  # - The initiative is visible for administrators even when it is unpublished
+  #
+  # That is why I copied and adapted that shared example to this file.
+
+  describe "manage initiative publications" do
+    before do
+      participatory_space.update(title: { en: title })
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+    end
+
+    context "when the participatory space is unpublished" do
+      before do
+        participatory_space.unpublish!
+        participatory_space.reload
+        visit admin_page_path
+      end
+
+      it "publishes it" do
+        click_on "Publish"
+
+        within "#confirm-modal" do
+          click_on "OK"
+        end
+
+        expect(page).to have_content("successfully")
+
+        visit public_collection_path
+
+        expect(page).to have_content title
+      end
+    end
+
+    context "when the participatory space is published" do
+      before do
+        allow(Rails.application).to \
+          receive(:env_config).with(no_args).and_wrap_original do |m, *|
+            m.call.merge(
+              "action_dispatch.show_exceptions" => true,
+              "action_dispatch.show_detailed_exceptions" => false
+            )
+          end
+        participatory_space.publish!
+        participatory_space.reload
+        visit admin_page_path
+      end
+
+      it "unpublishes it" do
+        # we cannot use "a 404 page" shared example as we want to check it
+        # inside an example
+        click_on "Unpublish"
+
+        within "#confirm-modal" do
+          click_on "OK"
+        end
+
+        expect(page).to have_content("successfully")
+
+        visit public_collection_path
+
+        expect(page).to have_no_content title
+      end
+    end
+  end
+
+  it "displays the entry in last activities" do
+    participatory_space.update(title: { en: title })
+
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit admin_page_path
+    click_on "Publish"
+
+    within "#confirm-modal" do
+      click_on "OK"
+    end
+
+    visit decidim.last_activities_path
+    expect(page).to have_content("New initiative: #{title}")
+
+    within "#filters" do
+      find("a", class: "filter", text: "Initiative", match: :first).click
+    end
+    expect(page).to have_content("New initiative: #{title}")
+  end
+end

--- a/decidim-initiatives/spec/system/download_open_data_files_spec.rb
+++ b/decidim-initiatives/spec/system/download_open_data_files_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/core/test/shared_examples/download_open_data_shared_context"
+require "decidim/core/test/shared_examples/download_open_data_shared_examples"
+
+describe "Download Open Data files", download: true do
+  let(:organization) { create(:organization) }
+
+  include_context "when downloading open data files"
+
+  it "lets the users download open data files" do
+    download_open_data_file
+
+    expect(File.basename(download_path)).to include("open-data.zip")
+    Zip::File.open(download_path) do |zipfile|
+      expect(zipfile.glob("*open-data-initiatives.csv").length).to eq(1)
+    end
+  end
+
+  describe "initiatives" do
+    let(:file_name) { "open-data-initiatives.csv" }
+
+    context "when there is none" do
+      it "returns an empty file" do
+        download_open_data_file
+        content = extract_content_from_zip(download_path, file_name)
+        expect(content).to eq("\n")
+      end
+    end
+
+    context "when the initiative is in state 'created'" do
+      let!(:initiative) { create(:initiative, :created, organization:) }
+      let(:participatory_space_title) { translated_attribute(initiative.title).gsub('"', '""') }
+
+      it_behaves_like "does not include it in the open data file"
+    end
+
+    context "when the initiative is in state 'validating'" do
+      let!(:initiative) { create(:initiative, :validating, organization:) }
+      let(:participatory_space_title) { translated_attribute(initiative.title).gsub('"', '""') }
+
+      it_behaves_like "does not include it in the open data file"
+    end
+
+    context "when the initiative is in state 'open'" do
+      let!(:initiative) { create(:initiative, :open, organization:) }
+      let(:participatory_space_title) { translated_attribute(initiative.title).gsub('"', '""') }
+
+      it_behaves_like "includes it in the open data file"
+    end
+
+    context "when the initiative is in state 'accepted'" do
+      let!(:initiative) { create(:initiative, :accepted, organization:) }
+      let(:participatory_space_title) { translated_attribute(initiative.title).gsub('"', '""') }
+
+      it_behaves_like "includes it in the open data file"
+    end
+
+    context "when the initiative is in state 'rejected'" do
+      let!(:initiative) { create(:initiative, :rejected, organization:) }
+      let(:participatory_space_title) { translated_attribute(initiative.title).gsub('"', '""') }
+
+      it_behaves_like "includes it in the open data file"
+    end
+
+    context "when the initiative is in state 'discarded'" do
+      let!(:initiative) { create(:initiative, :discarded, organization:) }
+      let(:participatory_space_title) { translated_attribute(initiative.title).gsub('"', '""') }
+
+      it_behaves_like "includes it in the open data file"
+    end
+  end
+end

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -221,7 +221,7 @@ describe "Initiative" do
     end
   end
 
-  it_behaves_like "followable content for users" do
+  it_behaves_like "followable space content for users" do
     let(:initiative) { base_initiative }
     let!(:user) { create(:user, :confirmed, organization:) }
     let(:followable) { initiative }

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
@@ -6,7 +6,12 @@
     <%= render partial: "meeting_poll_actions", locals: { mobile: true } %>
 
     <div class="layout-author">
-      <%= cell "decidim/author", author_presenter_for(meeting.normalized_author), from: meeting, context_actions: nil, layout: :compact %>
+      <div class="relative flex items-center justify-center w-full">
+        <div class="w-10/12 flex items-center gap-4">
+          <%= cell "decidim/author", author_presenter_for(meeting.normalized_author), from: meeting, context_actions: nil, layout: :compact %>
+        </div>
+        <%= render "decidim/shared/resource_actions", resource: meeting %>
+      </div>
 
       <% if meeting.private_meeting? %>
         <span class="<%= meeting_type_badge_css_class("private") %> label">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
@@ -93,7 +93,5 @@
 
 <section class="layout-aside__section actions__secondary">
   <%= cell "decidim/meetings/cancel_registration_meeting_button", meeting %>
-  <%= follow_button_for(meeting) %>
   <%= cell "decidim/share_button", nil %>
-  <%= cell "decidim/report_button", meeting %>
 </section>

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -187,6 +187,8 @@ describe "Meeting registrations" do
 
             expect(page).to have_css(".button", text: "Cancel your registration")
             expect(page).to have_text("19 slots remaining")
+            find("#dropdown-trigger-resource-#{meeting.id}").click
+
             expect(page).to have_text("Stop following")
             expect(page).to have_no_text("Participants")
             expect(page).to have_no_css("#panel-participants")
@@ -207,6 +209,7 @@ describe "Meeting registrations" do
             expect(page).to have_content("successfully")
 
             expect(page).to have_text("19 slots remaining")
+            find("#dropdown-trigger-resource-#{meeting.id}").click
             expect(page).to have_text("Stop following")
             expect(page).to have_text("Participants")
             within "#panel-participants" do
@@ -234,6 +237,7 @@ describe "Meeting registrations" do
 
             expect(page).to have_css(".button", text: "Cancel your registration")
             expect(page).to have_text("19 slots remaining")
+            find("#dropdown-trigger-resource-#{meeting.id}").click
             expect(page).to have_text("Stop following")
           end
         end

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/open_data_participatory_process_serializer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/open_data_participatory_process_serializer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    # This class serializes a ParticipatoryProcess so it can be exported to CSV for the Open Data feature.
+    class OpenDataParticipatoryProcessSerializer < Decidim::Exporters::ParticipatorySpaceSerializer
+      # Public: Exports a hash with the serialized data for this resource.
+      def serialize
+        super.merge(
+          {
+            subtitle: resource.subtitle,
+            remote_hero_image_url: Decidim::ParticipatoryProcesses::ParticipatoryProcessPresenter.new(resource).hero_image_url,
+            announcement: resource.announcement,
+            start_date: resource.start_date,
+            end_date: resource.end_date,
+            developer_group: resource.developer_group,
+            local_area: resource.local_area,
+            meta_scope: resource.meta_scope,
+            participatory_scope: resource.participatory_scope,
+            participatory_structure: resource.participatory_structure,
+            target: resource.target,
+            area: {
+              id: resource.area.try(:id),
+              name: resource.area.try(:name) || empty_translatable
+            },
+            participatory_process_group: {
+              id: resource.participatory_process_group.try(:id),
+              title: resource.participatory_process_group.try(:title) || empty_translatable,
+              description: resource.participatory_process_group.try(:description) || empty_translatable,
+              remote_hero_image_url: Decidim::ParticipatoryProcesses::ParticipatoryProcessGroupPresenter.new(resource.participatory_process_group).hero_image_url
+            },
+            scope: {
+              id: resource.scope.try(:id),
+              name: resource.scope.try(:name) || empty_translatable
+            },
+            scopes_enabled: resource.scopes_enabled,
+            participatory_process_type: {
+              id: resource.participatory_process_type.try(:id),
+              title: resource.participatory_process_type.try(:title) || empty_translatable
+            }
+          }
+        )
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
@@ -4,76 +4,30 @@ module Decidim
   module ParticipatoryProcesses
     # This class serializes a ParticipatoryProcesses so can be exported to CSV, JSON or other
     # formats.
-    class ParticipatoryProcessSerializer < Decidim::Exporters::Serializer
-      include Decidim::ApplicationHelper
-      include Decidim::ResourceHelper
-      include Decidim::TranslationsHelper
-
-      # Public: Initializes the serializer with a participatory_process.
-      def initialize(participatory_process)
-        @participatory_process = participatory_process
-      end
-
+    class ParticipatoryProcessSerializer < Decidim::ParticipatoryProcesses::OpenDataParticipatoryProcessSerializer
       # Public: Exports a hash with the serialized data for this participatory_process.
       def serialize
-        {
-          id: participatory_process.id,
-          title: participatory_process.title,
-          subtitle: participatory_process.subtitle,
-          slug: participatory_process.slug,
-          hashtag: participatory_process.hashtag,
-          short_description: participatory_process.short_description,
-          description: participatory_process.description,
-          announcement: participatory_process.announcement,
-          start_date: participatory_process.start_date,
-          end_date: participatory_process.end_date,
-          remote_hero_image_url: Decidim::ParticipatoryProcesses::ParticipatoryProcessPresenter.new(participatory_process).hero_image_url,
-          developer_group: participatory_process.developer_group,
-          local_area: participatory_process.local_area,
-          meta_scope: participatory_process.meta_scope,
-          participatory_scope: participatory_process.participatory_scope,
-          participatory_structure: participatory_process.participatory_structure,
-          target: participatory_process.target,
-          area: {
-            id: participatory_process.area.try(:id),
-            name: participatory_process.area.try(:name) || empty_translatable
-          },
-          participatory_process_group: {
-            id: participatory_process.participatory_process_group.try(:id),
-            title: participatory_process.participatory_process_group.try(:title) || empty_translatable,
-            description: participatory_process.participatory_process_group.try(:description) || empty_translatable,
-            remote_hero_image_url: Decidim::ParticipatoryProcesses::ParticipatoryProcessGroupPresenter.new(participatory_process.participatory_process_group).hero_image_url
-          },
-          scope: {
-            id: participatory_process.scope.try(:id),
-            name: participatory_process.scope.try(:name) || empty_translatable
-          },
-          private_space: participatory_process.private_space,
-          promoted: participatory_process.promoted,
-          scopes_enabled: participatory_process.scopes_enabled,
-          participatory_process_type: {
-            id: participatory_process.participatory_process_type.try(:id),
-            title: participatory_process.participatory_process_type.try(:title) || empty_translatable
-          },
-          participatory_process_steps: serialize_participatory_process_steps,
-          participatory_process_categories: serialize_categories,
-          attachments: {
-            attachment_collections: serialize_attachment_collections,
-            files: serialize_attachments
-          },
-          components: serialize_components
-        }
+        super.merge(
+          {
+            categories: serialize_categories,
+            attachments: {
+              attachment_collections: serialize_attachment_collections,
+              files: serialize_attachments
+            },
+            private_space: resource.private_space,
+            weight: resource.weight,
+            components: serialize_components,
+            participatory_process_steps: serialize_participatory_process_steps
+          }
+        )
       end
 
       private
 
-      attr_reader :participatory_process
-      alias resource participatory_process
-
       def serialize_participatory_process_steps
-        return unless participatory_process.steps.any?
+        return unless resource.steps.any?
 
-        participatory_process.steps.map do |step|
+        resource.steps.map do |step|
           {
             id: step.try(:id),
             title: step.try(:title),
@@ -86,70 +40,6 @@ module Decidim
             position: step.position
           }
         end
-      end
-
-      def serialize_categories
-        return unless participatory_process.categories.first_class.any?
-
-        participatory_process.categories.first_class.map do |category|
-          {
-            id: category.try(:id),
-            name: category.try(:name),
-            description: category.try(:description),
-            parent_id: category.try(:parent_id),
-            subcategories: serialize_subcategories(category.subcategories)
-          }
-        end
-      end
-
-      def serialize_subcategories(subcategories)
-        return unless subcategories.any?
-
-        subcategories.map do |subcategory|
-          {
-            id: subcategory.try(:id),
-            name: subcategory.try(:name),
-            description: subcategory.try(:description),
-            parent_id: subcategory.try(:parent_id)
-          }
-        end
-      end
-
-      def serialize_attachment_collections
-        return unless participatory_process.attachment_collections.any?
-
-        participatory_process.attachment_collections.map do |collection|
-          {
-            id: collection.try(:id),
-            name: collection.try(:name),
-            weight: collection.try(:weight),
-            description: collection.try(:description)
-          }
-        end
-      end
-
-      def serialize_attachments
-        return unless participatory_process.attachments.any?
-
-        participatory_process.attachments.map do |attachment|
-          {
-            id: attachment.try(:id),
-            title: attachment.try(:title),
-            weight: attachment.try(:weight),
-            description: attachment.try(:description),
-            attachment_collection: {
-              name: attachment.attachment_collection.try(:name),
-              weight: attachment.attachment_collection.try(:weight),
-              description: attachment.attachment_collection.try(:description)
-            },
-            remote_file_url: Decidim::AttachmentPresenter.new(attachment).attachment_file_url
-          }
-        end
-      end
-
-      def serialize_components
-        serializer = Decidim::Exporters::ParticipatorySpaceComponentsSerializer.new(@participatory_process)
-        serializer.run
       end
     end
   end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -45,11 +45,14 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
   end
 
   participatory_space.exports :participatory_processes do |export|
-    export.collection do |participatory_process|
-      Decidim::ParticipatoryProcess.where(id: participatory_process.id)
+    export.collection do
+      Decidim::ParticipatoryProcess.public_spaces
     end
 
+    export.include_in_open_data = true
+
     export.serializer Decidim::ParticipatoryProcesses::ParticipatoryProcessSerializer
+    export.open_data_serializer Decidim::ParticipatoryProcesses::OpenDataParticipatoryProcessSerializer
   end
 
   participatory_space.register_on_destroy_account do |user|

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/open_data_participatory_process_serializer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/open_data_participatory_process_serializer_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 module Decidim::ParticipatoryProcesses
-  describe ParticipatoryProcessSerializer do
+  describe OpenDataParticipatoryProcessSerializer do
     let(:resource) { create(:participatory_process) }
 
     subject { described_class.new(resource) }
@@ -31,7 +31,6 @@ module Decidim::ParticipatoryProcesses
         expect(serialized).to include(participatory_scope: resource.participatory_scope)
         expect(serialized).to include(participatory_structure: resource.participatory_structure)
         expect(serialized).to include(target: resource.target)
-        expect(serialized).to include(private_space: resource.private_space)
         expect(serialized).to include(promoted: resource.promoted)
         expect(serialized).to include(scopes_enabled: resource.scopes_enabled)
       end
@@ -107,77 +106,6 @@ module Decidim::ParticipatoryProcesses
           expect(serialized_participatory_process_group).to include(title: resource.participatory_process_group.title)
           expect(serialized_participatory_process_group).to include(description: resource.participatory_process_group.description)
           expect(serialized_participatory_process_group[:remote_hero_image_url]).to be_blob_url(resource.participatory_process_group.hero_image.blob)
-        end
-      end
-
-      context "when process has steps" do
-        let(:step) { create(:participatory_process_step) }
-
-        before do
-          resource.steps << step
-          resource.save
-        end
-
-        it "includes the participatory_process_steps" do
-          serialized_participatory_process_steps = subject.serialize[:participatory_process_steps].first
-
-          expect(serialized_participatory_process_steps).to be_a(Hash)
-
-          expect(serialized_participatory_process_steps).to include(id: step.id)
-          expect(serialized_participatory_process_steps).to include(title: step.title)
-          expect(serialized_participatory_process_steps).to include(description: step.description)
-          expect(serialized_participatory_process_steps).to include(start_date: step.start_date)
-          expect(serialized_participatory_process_steps).to include(end_date: step.end_date)
-          expect(serialized_participatory_process_steps).to include(cta_path: step.cta_path)
-          expect(serialized_participatory_process_steps).to include(cta_text: step.cta_text)
-          expect(serialized_participatory_process_steps).to include(active: step.active)
-          expect(serialized_participatory_process_steps).to include(position: step.position)
-        end
-      end
-
-      context "when process has categories" do
-        let!(:category) { create(:category, participatory_space: resource) }
-
-        it "includes the categories" do
-          serialized_participatory_process_categories = subject.serialize[:categories].first
-          expect(serialized_participatory_process_categories).to be_a(Hash)
-
-          expect(serialized_participatory_process_categories).to include(id: category.id)
-          expect(serialized_participatory_process_categories).to include(name: category.name)
-          expect(serialized_participatory_process_categories).to include(description: category.description)
-          expect(serialized_participatory_process_categories).to include(parent_id: category.parent_id)
-        end
-
-        context "when category has subcategories" do
-          let!(:subcategory) { create(:subcategory, parent: category, participatory_space: resource) }
-
-          it "includes the categories" do
-            serialized_participatory_process_categories = subject.serialize[:categories].first
-
-            expect(serialized_participatory_process_categories).to be_a(Hash)
-
-            expect(serialized_participatory_process_categories).to include(id: category.id)
-            expect(serialized_participatory_process_categories).to include(name: category.name)
-            expect(serialized_participatory_process_categories).to include(description: category.description)
-            expect(serialized_participatory_process_categories).to include(parent_id: category.parent_id)
-          end
-        end
-      end
-
-      context "when process has attachments" do
-        let!(:attachment_collection) { create(:attachment_collection, collection_for: resource) }
-        let!(:attachment) { create(:attachment, attached_to: resource, attachment_collection:) }
-
-        it "includes the attachment" do
-          serialized_participatory_process_attachment = subject.serialize[:attachments][:files].first
-
-          expect(serialized_participatory_process_attachment).to be_a(Hash)
-
-          expect(serialized_participatory_process_attachment).to include(id: attachment.id)
-          expect(serialized_participatory_process_attachment).to include(title: attachment.title)
-          expect(serialized_participatory_process_attachment).to include(weight: attachment.weight)
-          expect(serialized_participatory_process_attachment).to include(description: attachment.description)
-          expect(serialized_participatory_process_attachment[:remote_file_url]).to be_blob_url(resource.attachments.first.file.blob)
         end
       end
     end

--- a/decidim-participatory_processes/spec/system/download_open_data_files_spec.rb
+++ b/decidim-participatory_processes/spec/system/download_open_data_files_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/core/test/shared_examples/download_open_data_shared_context"
+require "decidim/core/test/shared_examples/download_open_data_shared_examples"
+
+describe "Download Open Data files", download: true do
+  let(:organization) { create(:organization) }
+
+  include_context "when downloading open data files"
+
+  it "lets the users download open data files" do
+    download_open_data_file
+
+    expect(File.basename(download_path)).to include("open-data.zip")
+    Zip::File.open(download_path) do |zipfile|
+      expect(zipfile.glob("*open-data-participatory_processes.csv").length).to eq(1)
+    end
+  end
+
+  describe "participatory processes" do
+    let(:file_name) { "open-data-participatory_processes.csv" }
+
+    context "when there is none" do
+      it "returns an empty file" do
+        download_open_data_file
+        content = extract_content_from_zip(download_path, file_name)
+        expect(content).to eq("\n")
+      end
+    end
+
+    context "when the participatory process is unpublished" do
+      let!(:participatory_process) { create(:participatory_process, :unpublished, organization:) }
+      let(:participatory_space_title) { translated_attribute(participatory_process.title).gsub('"', '""') }
+
+      it_behaves_like "does not include it in the open data file"
+    end
+
+    context "when the participatory process is published and not private" do
+      let!(:participatory_process) { create(:participatory_process, :published, organization:, private_space: false) }
+      let(:participatory_space_title) { translated_attribute(participatory_process.title).gsub('"', '""') }
+
+      it_behaves_like "includes it in the open data file"
+    end
+
+    context "when the participatory process is published and private" do
+      let!(:participatory_process) { create(:participatory_process, :published, organization:, private_space: true) }
+      let(:participatory_space_title) { translated_attribute(participatory_process.title).gsub('"', '""') }
+
+      it_behaves_like "does not include it in the open data file"
+    end
+  end
+end

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -202,7 +202,7 @@ describe "Participatory Processes" do
     end
   end
 
-  it_behaves_like "followable content for users" do
+  it_behaves_like "followable space content for users" do
     let!(:participatory_process) { base_process }
     let!(:user) { create(:user, :confirmed, organization:) }
     let(:followable) { participatory_process }

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_collaborative_draft_aside.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/_collaborative_draft_aside.html.erb
@@ -47,7 +47,5 @@
 </section>
 
 <section class="layout-aside__section actions__secondary">
-  <%= follow_button_for(@collaborative_draft) %>
   <%= cell "decidim/share_button", nil %>
-  <%= cell "decidim/report_button", @collaborative_draft %>
 </section>

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
@@ -26,13 +26,18 @@
     <% end %>
 
     <div class="layout-author">
-      <%= cell "decidim/coauthorships", @collaborative_draft, context_actions: [] %>
+      <div class="relative flex items-center justify-center w-full">
+        <div class="w-10/12 flex items-center gap-4">
+          <%= cell "decidim/coauthorships", @collaborative_draft, context_actions: [] %>
 
-      <% if @collaborative_draft.state %>
-        <span class="<%= collaborative_drafts_state_class(@collaborative_draft.state) %> label">
-          <%= humanize_collaborative_draft_state(@collaborative_draft.state) %>
-        </span>
-      <% end %>
+          <% if @collaborative_draft.state %>
+            <span class="<%= collaborative_drafts_state_class(@collaborative_draft.state) %> label">
+              <%= humanize_collaborative_draft_state(@collaborative_draft.state) %>
+            </span>
+          <% end %>
+        </div>
+        <%= render "decidim/shared/resource_actions", resource: @collaborative_draft %>
+      </div>
     </div>
   </section>
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_aside.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_aside.html.erb
@@ -36,7 +36,5 @@
 </section>
 
 <section class="layout-aside__section actions__secondary">
-  <%= follow_button_for(@proposal) %>
   <%= cell "decidim/share_button", nil %>
-  <%= cell "decidim/report_button", @proposal %>
 </section>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -47,11 +47,16 @@ extra_admin_link(
 
     <% unless component_settings.participatory_texts_enabled? %>
       <div class="layout-author">
-        <%= cell "decidim/coauthorships", @proposal, context_actions: [:date] %>
+        <div class="relative flex items-center justify-center w-full">
+          <div class="w-10/12 flex items-center gap-4">
+            <%= cell "decidim/coauthorships", @proposal, context_actions: [:date] %>
 
-        <% if not ["section","subsection"].include? @proposal.participatory_text_level %>
-          <%= cell("decidim/proposals/proposal_metadata", @proposal).state_item&.dig(:text) %>
-        <% end %>
+            <% if not ["section","subsection"].include? @proposal.participatory_text_level %>
+              <%= cell("decidim/proposals/proposal_metadata", @proposal).state_item&.dig(:text) %>
+            <% end %>
+          </div>
+          <%= render "decidim/shared/resource_actions", resource: @proposal %>
+        </div>
       </div>
     <% end %>
   </section>

--- a/decidim-proposals/spec/system/report_proposal_spec.rb
+++ b/decidim-proposals/spec/system/report_proposal_spec.rb
@@ -27,6 +27,7 @@ describe "Report Proposal" do
 
     it "reports the resource" do
       visit reportable_path
+      find("#dropdown-trigger-resource-#{reportable.id}").click
 
       expect(page).to have_css(%(button[data-dialog-open="flagModal"]))
       find(%(button[data-dialog-open="flagModal"])).click

--- a/decidim-verifications/app/views/dummy_authorization/_form.html.erb
+++ b/decidim-verifications/app/views/dummy_authorization/_form.html.erb
@@ -11,7 +11,8 @@
   <%= form.hidden_field :handler_name %>
   <%= form.text_field :document_number %>
   <%= form.text_field :postal_code %>
-  <%= form.date_field :birthday %>
-
+  <div class="row">
+    <%= form.date_field :birthday %>
+  </div>
   <%= scopes_select_field(form, :scope_id) %>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Spacing reduced on the 'date-picker' form within authorizations to coincide form dimensions. 

#### :pushpin: Related Issues
- Fixes #13376 

#### Testing
1. Login into the Decidim application.
2. Head over to account.
3. Click 'Authorizations' and choose an example authorization form. 
4. See the DOB picker with correct spacing.

### :camera: Screenshots
AFTER (correct text and spacing)
<img width="684" alt="Screenshot 2024-09-17 at 11 01 03" src="https://github.com/user-attachments/assets/c352a1e2-9d72-4f36-a927-fc5178fc15ec">

:hearts: Thank you!
