### PR TITLE
Add schema.org Event serializer for Meetings

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -22,6 +22,7 @@ linters:
     allowed_types:
       - text/javascript
       - text/template
+      - application/ld+json
 
   DeprecatedClasses:
     enabled: true

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -426,6 +426,7 @@ describe "Explore results", :versioning do
         let(:meeting) { meetings.first }
 
         before do
+          stub_geocoding_coordinates([meeting.latitude, meeting.longitude])
           result.link_resources(meetings, "meetings_through_proposals")
           visit current_path
         end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/geocoder.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/geocoder.rb
@@ -14,6 +14,19 @@ module GeocoderHelpers
     )
   end
 
+  def stub_geocoding_coordinates(coordinates)
+    geocoder_request_url = "https://nominatim.openstreetmap.org/reverse?accept-language=en&addressdetails=1&format=json&lat=#{coordinates[0]}&lon=#{coordinates[1]}"
+    geocoder_response = File.read(Decidim::Dev.asset("geocoder_result_here.json"))
+
+    stub_request(:get, geocoder_request_url).with(
+      headers: {
+        "Accept" => "*/*",
+        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+        "User-Agent" => "Ruby"
+      }
+    ).to_return(body: geocoder_response)
+  end
+
   # Waits for the front-end geocoding request to finish in order to ensure there
   # are no pending requests when proceeding.
   def fill_in_geocoding(attribute, options = {})

--- a/decidim-meetings/app/helpers/decidim/meetings/meetings_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/meetings_helper.rb
@@ -142,6 +142,11 @@ module Decidim
         base_url = "https://calendar.google.com/calendar/u/0/r/eventedit"
         "#{base_url}?#{params.to_param}"
       end
+
+      def render_schema_org_event_meeting(meeting)
+        exported_meeting = Decidim::Exporters::JSON.new([meeting], Decidim::Meetings::SchemaOrgEventMeetingSerializer).export.read
+        JSON.pretty_generate(JSON.parse(exported_meeting).first)
+      end
     end
   end
 end

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
@@ -1,4 +1,7 @@
 <%= render layout: "layouts/decidim/shared/layout_item" do %>
+
+  <%= render partial: "schema_org_event_meeting" %>
+
   <section class="layout-main__section layout-main__heading">
     <h1 class="h2 decorator"><%= present(meeting).title(links: true, html_escape: true ) %></h1>
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_schema_org_event_meeting.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_schema_org_event_meeting.html.erb
@@ -1,0 +1,3 @@
+<script type="application/ld+json">
+<%== render_schema_org_event_meeting(meeting) %>
+</script>

--- a/decidim-meetings/lib/decidim/meetings.rb
+++ b/decidim-meetings/lib/decidim/meetings.rb
@@ -16,6 +16,7 @@ module Decidim
     autoload :MeetingSerializer, "decidim/meetings/meeting_serializer"
     autoload :UserAnswersSerializer, "decidim/meetings/user_answers_serializer"
     autoload :DownloadYourDataUserAnswersSerializer, "decidim/meetings/download_your_data_user_answers_serializer"
+    autoload :SchemaOrgEventMeetingSerializer, "decidim/meetings/schema_org_event_meeting_serializer"
 
     include ActiveSupport::Configurable
 

--- a/decidim-meetings/lib/decidim/meetings/schema_org_event_meeting_serializer.rb
+++ b/decidim-meetings/lib/decidim/meetings/schema_org_event_meeting_serializer.rb
@@ -97,17 +97,20 @@ module Decidim
       end
 
       def location_postal_address
+        address = {
+          "@type": "PostalAddress",
+          streetAddress: translated_attribute(meeting.address)
+        }
+
+        address = address.merge({ addressLocality: geocoder_city }) if geocoder_city.present?
+        address = address.merge({ addressRegion: geocoder_state }) if geocoder_state.present?
+        address = address.merge({ postalCode: geocoder_postal_code }) if geocoder_postal_code.present?
+        address = address.merge({ addressCountry: geocoder_country }) if geocoder_country.present?
+
         {
           "@type": "Place",
           name: translated_attribute(meeting.location),
-          address: {
-            "@type": "PostalAddress",
-            streetAddress: translated_attribute(meeting.address),
-            addressLocality: geocoder_city,
-            addressRegion: geocoder_state,
-            postalCode: geocoder_postal_code,
-            addressCountry: geocoder_country
-          }
+          address:
         }
       end
 

--- a/decidim-meetings/lib/decidim/meetings/schema_org_event_meeting_serializer.rb
+++ b/decidim-meetings/lib/decidim/meetings/schema_org_event_meeting_serializer.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    class SchemaOrgEventMeetingSerializer < Decidim::Exporters::Serializer
+      include Decidim::TranslationsHelper
+      include ActionView::Helpers::UrlHelper
+
+      # Public: Initializes the serializer with a meeting.
+      def initialize(meeting)
+        @meeting = meeting
+      end
+
+      # Serializes a meeting for the Schema.org Event type
+      #
+      # @see https://schema.org/Event
+      # @see https://developers.google.com/search/docs/appearance/structured-data/event?hl=en
+      def serialize
+        attributes = {
+          "@context": "https://schema.org",
+          "@type": "Event",
+          name: translated_attribute(meeting.title),
+          description: translated_attribute(meeting.description),
+          startDate: meeting.start_time.iso8601,
+          endDate: meeting.end_time.iso8601,
+          organizer:,
+          eventAttendanceMode: event_attendance_mode,
+          eventStatus: "https://schema.org/EventScheduled",
+          location:
+        }
+
+        attributes = attributes.merge(image:) if meeting.photos.any?
+        attributes
+      end
+
+      private
+
+      attr_reader :meeting
+
+      def organizer
+        return organizer_user_group if meeting.decidim_user_group_id?
+
+        case meeting.author.class.name
+        when "Decidim::Organization"
+          organizer_organization
+        when "Decidim::User"
+          organizer_user
+        end
+      end
+
+      def organizer_user_group
+        {
+          "@type": "Organization",
+          name: meeting.author.name,
+          url: EngineRouter.new("decidim", router_options).profile_url(meeting.user_group.nickname)
+        }
+      end
+
+      def organizer_organization
+        {
+          "@type": "Organization",
+          name: translated_attribute(meeting.author.name),
+          url: EngineRouter.new("decidim", router_options).root_url
+        }
+      end
+
+      def organizer_user
+        {
+          "@type": "Person",
+          name: meeting.author.name,
+          url: EngineRouter.new("decidim", router_options).profile_url(meeting.author.nickname)
+        }
+      end
+
+      def router_options = { host: meeting.organization.host }
+
+      def event_attendance_mode
+        case meeting.type_of_meeting
+        when "online"
+          "https://schema.org/OnlineEventAttendanceMode"
+        when "hybrid"
+          "https://schema.org/MixedEventAttendanceMode"
+        else
+          "https://schema.org/OfflineEventAttendanceMode"
+        end
+      end
+
+      def location
+        case meeting.type_of_meeting
+        when "online"
+          location_virtual
+        when "hybrid"
+          [location_postal_address, location_virtual]
+        else
+          location_postal_address
+        end
+      end
+
+      def location_postal_address
+        {
+          "@type": "Place",
+          name: translated_attribute(meeting.location),
+          address: {
+            "@type": "PostalAddress",
+            streetAddress: translated_attribute(meeting.address),
+            addressLocality: geocoder_city,
+            addressRegion: geocoder_state,
+            postalCode: geocoder_postal_code,
+            addressCountry: geocoder_country
+          }
+        }
+      end
+
+      def location_virtual
+        {
+          "@type": "VirtualLocation",
+          url: meeting.online_meeting_url
+        }
+      end
+
+      def geocoder
+        return if meeting.latitude.blank? || meeting.longitude.blank?
+
+        @geocoder ||= Geocoder.search([meeting.latitude, meeting.longitude]).first
+      end
+
+      def geocoder_city
+        @geocoder_city ||= geocoder&.city
+      end
+
+      def geocoder_state
+        @geocoder_state ||= geocoder&.state
+      end
+
+      def geocoder_postal_code
+        @geocoder_postal_code ||= geocoder&.postal_code
+      end
+
+      def geocoder_country
+        @geocoder_country ||= geocoder&.country
+      end
+
+      def image = meeting.photos.map(&:thumbnail_url)
+    end
+  end
+end

--- a/decidim-meetings/lib/decidim/meetings/schema_org_event_meeting_serializer.rb
+++ b/decidim-meetings/lib/decidim/meetings/schema_org_event_meeting_serializer.rb
@@ -4,6 +4,7 @@ module Decidim
   module Meetings
     class SchemaOrgEventMeetingSerializer < Decidim::Exporters::Serializer
       include Decidim::TranslationsHelper
+      include Decidim::SanitizeHelper
       include ActionView::Helpers::UrlHelper
 
       # Public: Initializes the serializer with a meeting.
@@ -19,8 +20,8 @@ module Decidim
         attributes = {
           "@context": "https://schema.org",
           "@type": "Event",
-          name: translated_attribute(meeting.title),
-          description: translated_attribute(meeting.description),
+          name: decidim_escape_translated(meeting.title),
+          description: decidim_escape_translated(meeting.description),
           startDate: meeting.start_time.iso8601,
           endDate: meeting.end_time.iso8601,
           organizer:,
@@ -59,7 +60,7 @@ module Decidim
       def organizer_organization
         {
           "@type": "Organization",
-          name: translated_attribute(meeting.author.name),
+          name: decidim_escape_translated(meeting.author.name),
           url: EngineRouter.new("decidim", router_options).root_url
         }
       end
@@ -67,7 +68,7 @@ module Decidim
       def organizer_user
         {
           "@type": "Person",
-          name: meeting.author.name,
+          name: decidim_escape_translated(meeting.author.name),
           url: EngineRouter.new("decidim", router_options).profile_url(meeting.author.nickname)
         }
       end
@@ -99,7 +100,7 @@ module Decidim
       def location_postal_address
         address = {
           "@type": "PostalAddress",
-          streetAddress: translated_attribute(meeting.address)
+          streetAddress: decidim_escape_translated(meeting.address)
         }
 
         address = address.merge({ addressLocality: geocoder_city }) if geocoder_city.present?
@@ -109,7 +110,7 @@ module Decidim
 
         {
           "@type": "Place",
-          name: translated_attribute(meeting.location),
+          name: decidim_escape_translated(meeting.location),
           address:
         }
       end

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -67,6 +67,8 @@ FactoryBot.define do
     trait :online do
       type_of_meeting { :online }
       online_meeting_url { "https://decidim.org" }
+      latitude { nil }
+      longitude { nil }
     end
 
     trait :hybrid do

--- a/decidim-meetings/spec/helpers/meetings_helper_spec.rb
+++ b/decidim-meetings/spec/helpers/meetings_helper_spec.rb
@@ -5,14 +5,14 @@ require "spec_helper"
 module Decidim
   module Meetings
     describe MeetingsHelper do
-      describe "meeting_description" do
+      describe "#meeting_description" do
         it "truncates meeting description respecting the html tags" do
           meeting = create(:meeting, description: { "en" => "<p>This is a long description with some <b>bold text</b></p>" })
           expect(helper.meeting_description(meeting, 40)).to match("<p>This is a long description with some <b>bol</b>...")
         end
       end
 
-      describe "google_calendar_event_url" do
+      describe "#google_calendar_event_url" do
         it "generates a valid url containing title and start and end time" do
           meeting = create(:meeting, title: { "en" => "My title" }, start_time: "2001-01-01T01:01", end_time: "2002-02-02T02:02")
           uri = URI.parse(helper.google_calendar_event_url(meeting))
@@ -23,6 +23,42 @@ module Decidim
           expect(params["dates"].join).to include("20010101T0101")
           expect(params["dates"].join).to include("20020202T0202")
           expect(params["text"].join).to eq("My title")
+        end
+      end
+
+      describe "#render_schema_org_event_meeting" do
+        subject { helper.render_schema_org_event_meeting(meeting) }
+
+        let!(:meeting) { create(:meeting, :published, latitude:, longitude:) }
+        let(:latitude) { 40.7504928941818 }
+        let(:longitude) { -73.993466492276 }
+
+        let(:geocoder_request_url) { "https://nominatim.openstreetmap.org/reverse?accept-language=en&addressdetails=1&format=json&lat=#{latitude}&lon=#{longitude}" }
+        let(:geocoder_query) { "Madison Square Garden, 4 Penn Plaza, New York, NY" }
+        let(:geocoder_response) { File.read(Decidim::Dev.asset("geocoder_result_osm.json")) }
+
+        before do
+          stub_request(:get, geocoder_request_url).with(
+            headers: {
+              "Accept" => "*/*",
+              "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+              "User-Agent" => "Ruby"
+            }
+          ).to_return(body: geocoder_response)
+        end
+
+        it "renders a schema.org event" do
+          keys = JSON.parse(subject).keys
+          expect(keys).to include("@context")
+          expect(keys).to include("@type")
+          expect(keys).to include("name")
+          expect(keys).to include("description")
+          expect(keys).to include("startDate")
+          expect(keys).to include("endDate")
+          expect(keys).to include("organizer")
+          expect(keys).to include("eventAttendanceMode")
+          expect(keys).to include("eventStatus")
+          expect(keys).to include("location")
         end
       end
     end

--- a/decidim-meetings/spec/lib/decidim/meetings/schema_org_event_meeting_serializer_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/schema_org_event_meeting_serializer_spec.rb
@@ -39,11 +39,11 @@ module Decidim::Meetings
       end
 
       it "serializes the name" do
-        expect(serialized).to include(name: meeting.title["en"])
+        expect(serialized).to include(name: decidim_escape_translated(meeting.title))
       end
 
       it "serializes the description" do
-        expect(serialized).to include(description: meeting.description["en"])
+        expect(serialized).to include(description: decidim_escape_translated(meeting.description))
       end
 
       it "serializes the startDate" do
@@ -94,7 +94,7 @@ module Decidim::Meetings
 
           it "serializes the location" do
             expect(serialized[:location][:@type]).to eq("Place")
-            expect(serialized[:location][:name]).to eq(translated_attribute(meeting.location))
+            expect(serialized[:location][:name]).to eq(decidim_escape_translated(meeting.location))
             expect(serialized[:location][:address][:@type]).to eq("PostalAddress")
             expect(serialized[:location][:address][:streetAddress]).to eq(translated_attribute(meeting.address))
             expect(serialized[:location][:address][:addressLocality]).to eq("New York City")
@@ -117,7 +117,7 @@ module Decidim::Meetings
 
             it "returns the location without the address details" do
               expect(serialized[:location][:address][:@type]).to eq("PostalAddress")
-              expect(serialized[:location][:address][:streetAddress]).to eq(translated_attribute(meeting.address))
+              expect(serialized[:location][:address][:streetAddress]).to eq(decidim_escape_translated(meeting.address))
               expect(serialized[:location][:address].keys).to eq([:@type, :streetAddress])
             end
           end
@@ -145,9 +145,9 @@ module Decidim::Meetings
 
           it "serializes both locations" do
             expect(serialized[:location].first[:@type]).to eq("Place")
-            expect(serialized[:location].first[:name]).to eq(translated_attribute(meeting.location))
+            expect(serialized[:location].first[:name]).to eq(decidim_escape_translated(meeting.location))
             expect(serialized[:location].first[:address][:@type]).to eq("PostalAddress")
-            expect(serialized[:location].first[:address][:streetAddress]).to eq(translated_attribute(meeting.address))
+            expect(serialized[:location].first[:address][:streetAddress]).to eq(decidim_escape_translated(meeting.address))
             expect(serialized[:location].first[:address][:addressLocality]).to eq("New York City")
             expect(serialized[:location].first[:address][:addressRegion]).to eq("New York")
             expect(serialized[:location].first[:address][:postalCode]).to eq("10001")

--- a/decidim-meetings/spec/lib/decidim/meetings/schema_org_event_meeting_serializer_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/schema_org_event_meeting_serializer_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Meetings
+  describe SchemaOrgEventMeetingSerializer do
+    subject do
+      described_class.new(meeting)
+    end
+
+    let!(:meeting) { create(:meeting, :published, latitude:, longitude:) }
+    let(:organization) { meeting.component.organization }
+
+    let(:latitude) { 40.7504928941818 }
+    let(:longitude) { -73.993466492276 }
+    let(:geocoder_request_url) { "https://nominatim.openstreetmap.org/reverse?accept-language=en&addressdetails=1&format=json&lat=#{latitude}&lon=#{longitude}" }
+    let(:geocoder_query) { "Madison Square Garden, 4 Penn Plaza, New York, NY" }
+    let(:geocoder_response) { File.read(Decidim::Dev.asset("geocoder_result_osm.json")) }
+
+    before do
+      stub_request(:get, geocoder_request_url).with(
+        headers: {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "User-Agent" => "Ruby"
+        }
+      ).to_return(body: geocoder_response)
+    end
+
+    describe "#serialize" do
+      let(:serialized) { subject.serialize }
+
+      it "serializes the @context" do
+        expect(serialized[:@context]).to eq("https://schema.org")
+      end
+
+      it "serializes the @type" do
+        expect(serialized[:@type]).to eq("Event")
+      end
+
+      it "serializes the name" do
+        expect(serialized).to include(name: meeting.title["en"])
+      end
+
+      it "serializes the description" do
+        expect(serialized).to include(description: meeting.description["en"])
+      end
+
+      it "serializes the startDate" do
+        expect(serialized).to include(startDate: meeting.start_time.iso8601)
+      end
+
+      it "serializes the endDate" do
+        expect(serialized).to include(endDate: meeting.end_time.iso8601)
+      end
+
+      describe "authors" do
+        context "with official author" do
+          let!(:meeting) { create(:meeting, :official, :published, latitude:, longitude:) }
+
+          it "serializes the organizer" do
+            expect(serialized[:organizer][:@type]).to eq("Organization")
+            expect(serialized[:organizer][:name]).to eq(translated_attribute(meeting.author.name))
+            expect(serialized[:organizer][:url]).to eq("http://#{organization.host}:#{Capybara.server_port}/")
+          end
+        end
+
+        context "with participant author" do
+          let!(:meeting) { create(:meeting, :participant_author, :published, latitude:, longitude:) }
+
+          it "serializes the organizer" do
+            expect(serialized[:organizer][:@type]).to eq("Person")
+            expect(serialized[:organizer][:name]).to eq(meeting.author.name)
+            expect(serialized[:organizer][:url]).to eq("http://#{organization.host}:#{Capybara.server_port}/profiles/#{meeting.author.nickname}")
+          end
+        end
+
+        context "with user group author" do
+          let!(:meeting) { create(:meeting, :user_group_author, :published, latitude:, longitude:) }
+
+          it "serializes the organizer" do
+            expect(serialized[:organizer][:@type]).to eq("Organization")
+            expect(serialized[:organizer][:name]).to eq(meeting.author.name)
+            expect(serialized[:organizer][:url]).to eq("http://#{organization.host}:#{Capybara.server_port}/profiles/#{meeting.user_group.nickname}")
+          end
+        end
+      end
+
+      describe "types of meetings" do
+        context "with in-person meeting" do
+          it "serializes the eventAttendanceMode" do
+            expect(serialized).to include(eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode")
+          end
+
+          it "serializes the location" do
+            expect(serialized[:location][:@type]).to eq("Place")
+            expect(serialized[:location][:name]).to eq(translated_attribute(meeting.location))
+            expect(serialized[:location][:address][:@type]).to eq("PostalAddress")
+            expect(serialized[:location][:address][:streetAddress]).to eq(translated_attribute(meeting.address))
+            expect(serialized[:location][:address][:addressLocality]).to eq("New York City")
+            expect(serialized[:location][:address][:addressRegion]).to eq("New York")
+            expect(serialized[:location][:address][:postalCode]).to eq("10001")
+            expect(serialized[:location][:address][:addressCountry]).to eq("United States of America")
+          end
+        end
+
+        context "with online meeting" do
+          let(:meeting) { create(:meeting, :published, :online) }
+
+          it "serializes the eventAttendanceMode" do
+            expect(serialized).to include(eventAttendanceMode: "https://schema.org/OnlineEventAttendanceMode")
+          end
+
+          it "serializes the location" do
+            expect(serialized[:location][:@type]).to eq("VirtualLocation")
+            expect(serialized[:location][:url]).to eq(meeting.online_meeting_url)
+          end
+        end
+
+        context "with hybrid meeting" do
+          let(:meeting) { create(:meeting, :published, :hybrid, latitude:, longitude:) }
+
+          it "serializes the eventAttendanceMode" do
+            expect(serialized).to include(eventAttendanceMode: "https://schema.org/MixedEventAttendanceMode")
+          end
+
+          it "serializes both locations" do
+            expect(serialized[:location].first[:@type]).to eq("Place")
+            expect(serialized[:location].first[:name]).to eq(translated_attribute(meeting.location))
+            expect(serialized[:location].first[:address][:@type]).to eq("PostalAddress")
+            expect(serialized[:location].first[:address][:streetAddress]).to eq(translated_attribute(meeting.address))
+            expect(serialized[:location].first[:address][:addressLocality]).to eq("New York City")
+            expect(serialized[:location].first[:address][:addressRegion]).to eq("New York")
+            expect(serialized[:location].first[:address][:postalCode]).to eq("10001")
+            expect(serialized[:location].first[:address][:addressCountry]).to eq("United States of America")
+
+            expect(serialized[:location].second[:@type]).to eq("VirtualLocation")
+            expect(serialized[:location].second[:url]).to eq(meeting.online_meeting_url)
+          end
+        end
+      end
+
+      describe "images" do
+        context "without images" do
+          it "does not has the attribute" do
+            expect(serialized).not_to include(:image)
+          end
+        end
+
+        context "with one image" do
+          let!(:attachment) { create(:attachment, :with_image, attached_to: meeting, file: attachment_file) }
+          let!(:attachment_file) { Decidim::Dev.test_file("city3.jpeg", "image/jpeg") }
+
+          it "serializes the image" do
+            expect(serialized[:image]).to include(attachment.thumbnail_url)
+          end
+        end
+
+        context "with multiple images" do
+          let!(:attachment1) { create(:attachment, :with_image, attached_to: meeting, file: attachment1_file) }
+          let!(:attachment1_file) { Decidim::Dev.test_file("city3.jpeg", "image/jpeg") }
+          let!(:attachment2) { create(:attachment, :with_image, attached_to: meeting, file: attachment2_file) }
+          let!(:attachment2_file) { Decidim::Dev.test_file("city3.jpeg", "image/jpeg") }
+
+          it "serializes the images" do
+            expect(serialized[:image]).to include(attachment1.thumbnail_url)
+            expect(serialized[:image]).to include(attachment2.thumbnail_url)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/lib/decidim/meetings/schema_org_event_meeting_serializer_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/schema_org_event_meeting_serializer_spec.rb
@@ -102,6 +102,25 @@ module Decidim::Meetings
             expect(serialized[:location][:address][:postalCode]).to eq("10001")
             expect(serialized[:location][:address][:addressCountry]).to eq("United States of America")
           end
+
+          context "when the geocoder does not work" do
+            let(:geocoder_response) do
+              [
+                {
+                  lat: "40.7504928941818",
+                  lon: "-73.993466492276",
+                  display_name: "Madison Square Garden, West 31st Street, Long Island City, New York City, New York, 10001, United States of America",
+                  type: "stadium"
+                }
+              ]
+            end
+
+            it "returns the location without the address details" do
+              expect(serialized[:location][:address][:@type]).to eq("PostalAddress")
+              expect(serialized[:location][:address][:streetAddress]).to eq(translated_attribute(meeting.address))
+              expect(serialized[:location][:address].keys).to eq([:@type, :streetAddress])
+            end
+          end
         end
 
         context "with online meeting" do

--- a/decidim-meetings/spec/shared/manage_invites_examples.rb
+++ b/decidim-meetings/spec/shared/manage_invites_examples.rb
@@ -50,6 +50,10 @@ def invite_existing_user(user)
 end
 
 shared_examples "manage invites" do
+  before do
+    stub_geocoding_coordinates([meeting.latitude, meeting.longitude])
+  end
+
   describe "inviting an attendee" do
     context "when registrations are not enabled" do
       it "cannot invite people to join a meeting" do

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -525,6 +525,10 @@ describe "Admin manages meetings", serves_geocoding_autocomplete: true, serves_m
     end
     let!(:proposals) { create_list(:proposal, 3, component: proposal_component) }
 
+    before do
+      stub_geocoding_coordinates([meeting.latitude, meeting.longitude])
+    end
+
     it "closes a meeting with a report" do
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
         page.click_on "Close"

--- a/decidim-meetings/spec/system/comments_spec.rb
+++ b/decidim-meetings/spec/system/comments_spec.rb
@@ -19,6 +19,10 @@ describe "Comments" do
 
   let(:resource_path) { resource_locator(commentable).path }
 
+  before do
+    stub_geocoding_coordinates([commentable.latitude, commentable.longitude])
+  end
+
   include_examples "comments"
 
   context "with comments blocked" do

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -435,7 +435,7 @@ describe "Explore meetings", :slow do
         start_time: date.beginning_of_day,
         end_time: date.end_of_day
       )
-
+      stub_geocoding_coordinates([meeting.latitude, meeting.longitude])
       visit resource_locator(meeting).path
     end
 

--- a/decidim-meetings/spec/system/explore_versions_spec.rb
+++ b/decidim-meetings/spec/system/explore_versions_spec.rb
@@ -26,6 +26,7 @@ describe "Explore versions", versioning: true do
   end
 
   before do
+    stub_geocoding_coordinates([meeting.latitude, meeting.longitude])
     Decidim.traceability.update!(
       meeting,
       "test suite",

--- a/decidim-meetings/spec/system/follow_meetings_spec.rb
+++ b/decidim-meetings/spec/system/follow_meetings_spec.rb
@@ -11,5 +11,9 @@ describe "Follow meetings" do
 
   let(:followable_path) { resource_locator(followable).path }
 
+  before do
+    stub_geocoding_coordinates([followable.latitude, followable.longitude])
+  end
+
   include_examples "followable content for users with a component"
 end

--- a/decidim-meetings/spec/system/meeting_agenda_spec.rb
+++ b/decidim-meetings/spec/system/meeting_agenda_spec.rb
@@ -14,6 +14,10 @@ describe "Meeting agenda" do
     visit resource_locator(meeting).path
   end
 
+  before do
+    stub_geocoding_coordinates([meeting.latitude, meeting.longitude])
+  end
+
   context "when meeting agenda is not visible" do
     let(:visible) { false }
 

--- a/decidim-meetings/spec/system/meeting_questions_administrate_spec.rb
+++ b/decidim-meetings/spec/system/meeting_questions_administrate_spec.rb
@@ -49,6 +49,10 @@ describe "Meeting poll administration" do
   let!(:poll) { create(:poll, meeting:) }
   let!(:questionnaire) { create(:meetings_poll_questionnaire, questionnaire_for: poll) }
 
+  before do
+    stub_geocoding_coordinates([meeting.latitude, meeting.longitude])
+  end
+
   context "when all questions are unpublished" do
     let!(:question_multiple_option) { create(:meetings_poll_question, :unpublished, questionnaire:, body: body_multiple_option_question, question_type: "multiple_option") }
     let!(:question_single_option) { create(:meetings_poll_question, :unpublished, questionnaire:, body: body_single_option_question, question_type: "single_option") }

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -31,6 +31,7 @@ describe "Meeting registrations" do
   end
 
   before do
+    stub_geocoding_coordinates([meeting.latitude, meeting.longitude])
     meeting.update!(
       registrations_enabled:,
       registration_form_enabled:,

--- a/decidim-meetings/spec/system/meeting_spec.rb
+++ b/decidim-meetings/spec/system/meeting_spec.rb
@@ -13,6 +13,10 @@ describe "Meeting", download: true do
     visit resource_locator(meeting).path
   end
 
+  before do
+    stub_geocoding_coordinates([meeting.latitude, meeting.longitude])
+  end
+
   it "has a link to download the meeting in ICS format" do
     visit_meeting
     click_on "Add to calendar"

--- a/decidim-meetings/spec/system/meetings_social_share_spec.rb
+++ b/decidim-meetings/spec/system/meetings_social_share_spec.rb
@@ -26,6 +26,7 @@ describe "Social shares" do
   let(:resource) { meeting }
 
   before do
+    stub_geocoding_coordinates([meeting.latitude, meeting.longitude])
     if content_block
       content_block.images_container.background_image = block_attachment_file
       content_block.save!

--- a/decidim-meetings/spec/system/private_meetings_spec.rb
+++ b/decidim-meetings/spec/system/private_meetings_spec.rb
@@ -36,6 +36,7 @@ describe "Private meetings" do
             switch_to_host(organization.host)
             login_as user, scope: :user
             visit_component
+            stub_geocoding_coordinates([private_meeting.latitude, private_meeting.longitude])
           end
 
           it "lists all meetings that are transparent" do
@@ -98,6 +99,7 @@ describe "Private meetings" do
             switch_to_host(organization.host)
             login_as other_user, scope: :user
             visit_component
+            stub_geocoding_coordinates([private_meeting.latitude, private_meeting.longitude])
           end
 
           it "lists private meetings" do

--- a/decidim-meetings/spec/system/report_meeting_spec.rb
+++ b/decidim-meetings/spec/system/report_meeting_spec.rb
@@ -17,5 +17,9 @@ describe "Report Meeting" do
            participatory_space: participatory_process)
   end
 
+  before do
+    stub_geocoding_coordinates([reportable.latitude, reportable.longitude])
+  end
+
   include_examples "reports"
 end

--- a/decidim-meetings/spec/system/show_spec.rb
+++ b/decidim-meetings/spec/system/show_spec.rb
@@ -9,6 +9,7 @@ describe "show" do
   let!(:meeting) { create(:meeting, :published, component:) }
 
   before do
+    stub_geocoding_coordinates([meeting.latitude, meeting.longitude])
     visit_component
     click_on meeting.title[I18n.locale.to_s]
   end

--- a/decidim-meetings/spec/system/user_close_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_close_meeting_spec.rb
@@ -24,6 +24,7 @@ describe "User edit meeting" do
   end
 
   before do
+    stub_geocoding_coordinates([meeting.latitude, meeting.longitude])
     switch_to_host user.organization.host
   end
 

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -86,6 +86,7 @@ describe "User creates meeting" do
 
         it "creates a new meeting", :slow do
           stub_geocoding(meeting_address, [latitude, longitude])
+          stub_geocoding_coordinates([latitude, longitude])
           visit_component
 
           click_on "New meeting"
@@ -130,6 +131,7 @@ describe "User creates meeting" do
             address_field: :meeting_address
           ) do
             before do
+              stub_geocoding_coordinates([3.345, 4.456])
               # Prepare the view for submission (other than the address field)
               visit_component
 
@@ -156,6 +158,7 @@ describe "User creates meeting" do
 
           it "creates a new meeting", :slow do
             stub_geocoding(meeting_address, [latitude, longitude])
+            stub_geocoding_coordinates([latitude, longitude])
 
             visit_component
 
@@ -194,6 +197,7 @@ describe "User creates meeting" do
 
           it "creates a new meeting with registrations on this platform", :slow do
             stub_geocoding(meeting_address, [latitude, longitude])
+            stub_geocoding_coordinates([latitude, longitude])
 
             visit_component
 

--- a/decidim-meetings/spec/system/user_edit_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_edit_meeting_spec.rb
@@ -19,6 +19,7 @@ describe "User edit meeting" do
 
   before do
     switch_to_host user.organization.host
+    stub_geocoding_coordinates([meeting.latitude, meeting.longitude])
     stub_geocoding(meeting.address, [latitude, longitude])
   end
 
@@ -59,6 +60,7 @@ describe "User edit meeting" do
         let(:geocoded_address_coordinates) { [latitude, longitude] }
 
         before do
+          stub_geocoding_coordinates([latitude, longitude])
           # Prepare the view for submission (other than the address field)
           visit_component
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR implements the schema.org Event specification in Meetings, so it's easier for external tools and services (such as Google) to interpret this data. 

I followed is in https://developers.google.com/search/docs/appearance/structured-data/event?hl=en 

Note that there are a few warnings of optional fields:

- **performer**: it does not apply to Decidim use case
- **offers**: it does not apply to Decidim use case
- **image**: I implemented it but even if I add attachments images, it still gives a warning as the URL is invalid in localhost. 

#### :pushpin: Related Issues 

- Fixes [#13245](https://github.com/decidim/decidim/issues/13245)

#### Testing

1. Create three meetings of different types: in person, online and hybrid
2. Check out the source code of the page and search for "ld+json" 
3. Copy the code and paste it in the "Rich Results Test": https://search.google.com/test/rich-results

Example of the rich results: https://search.google.com/test/rich-results/result/r%2Fevents?id=xmfa3OtCoI2dlGCPFUnViw

### :camera: Screenshots

![Source code](https://github.com/user-attachments/assets/664726d8-0ffc-4c55-8acf-d4aeb9f4c66b)
![Rich Results Test](https://github.com/user-attachments/assets/e0db807d-e417-4691-a3de-93eed7573f3b)
![Rich Results Test (details)](https://github.com/user-attachments/assets/c873b500-fb72-4447-931f-3b1ecf4a29d9)

:hearts: Thank you!
