### PR TITLE
Spacing on DOB picker in Authorizations

### DIFF
--- a/decidim-verifications/app/views/dummy_authorization/_form.html.erb
+++ b/decidim-verifications/app/views/dummy_authorization/_form.html.erb
@@ -11,7 +11,9 @@
   <%= form.hidden_field :handler_name %>
   <%= form.text_field :document_number %>
   <%= form.text_field :postal_code %>
-  <%= form.date_field :birthday %>
-
+  <div class="row">
+    <%= form.date_field :birthday %>
+  </div>
   <%= scopes_select_field(form, :scope_id) %>
 </div>
+git


### PR DESCRIPTION
#### :tophat: What? Why?
Spacing reduced on the 'date-picker' form within authorizations to coincide form dimensions. 

#### :pushpin: Related Issues
- Fixes #13376 

#### Testing
1. Login into the Decidim application.
2. Head over to account.
3. Click 'Authorizations' and choose an example authorization form. 
4. See the DOB picker with correct spacing.

### :camera: Screenshots
AFTER (correct text and spacing)
<img width="684" alt="Screenshot 2024-09-17 at 11 01 03" src="https://github.com/user-attachments/assets/c352a1e2-9d72-4f36-a927-fc5178fc15ec">

:hearts: Thank you!
