### PR TITLE
Add svg icon for comments menu

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -21,7 +21,9 @@
 
       <div class="relative ml-auto">
         <button id="dropdown-trigger-<%= context_menu_id %>" data-component="dropdown" data-target="dropdown-menu-<%= context_menu_id %>" aria-label="<%= t("decidim.components.comment.controls_label") %>">
-          &#8230;
+          <%# NOTE: having two times the icon call is intentional, as that is how the `dropdown` CSS code is done %>
+          <%= icon "more-fill" %>
+          <%= icon "more-fill" %>
         </button>
 
         <div id="dropdown-menu-<%= context_menu_id %>" aria-hidden="true">

--- a/decidim-comments/app/packs/stylesheets/comments.scss
+++ b/decidim-comments/app/packs/stylesheets/comments.scss
@@ -48,6 +48,7 @@
   /* overwrite default dropdown styles */
   [data-target*="dropdown"] {
     @apply md:flex w-auto cursor-pointer text-sm text-secondary;
+
     > svg {
       @apply h-3 w-3;
     }

--- a/decidim-comments/app/packs/stylesheets/comments.scss
+++ b/decidim-comments/app/packs/stylesheets/comments.scss
@@ -48,6 +48,9 @@
   /* overwrite default dropdown styles */
   [data-target*="dropdown"] {
     @apply md:flex w-auto cursor-pointer text-sm text-secondary;
+    > svg {
+      @apply h-3 w-3;
+    }
   }
 
   /* overwrite default dropdown styles */

--- a/decidim-proposals/spec/system/proposal_comment_actions_spec.rb
+++ b/decidim-proposals/spec/system/proposal_comment_actions_spec.rb
@@ -23,7 +23,7 @@ describe "Interact with commenters" do
     context "when the user is the commenter" do
       it "has no actions" do
         within "#comment_#{author_comment.id}" do
-          click_on "…"
+          find("#dropdown-trigger-toggle-context-menu-#{author_comment.id}").click
           expect(page).to have_no_content("Mark as co-author")
         end
       end
@@ -35,7 +35,7 @@ describe "Interact with commenters" do
       it "author can invite" do
         expect(page).to have_content("2 comments")
         within "#comment_#{comment.id}" do
-          click_on "…"
+          find("#dropdown-trigger-toggle-context-menu-#{comment.id}").click
           perform_enqueued_jobs do
             accept_confirm { click_on("Mark as co-author") }
           end
@@ -44,7 +44,7 @@ describe "Interact with commenters" do
         expect(page).to have_content("successfully invited as a co-author")
 
         within "#comment_#{comment.id}" do
-          click_on "…"
+          find("#dropdown-trigger-toggle-context-menu-#{comment.id}").click
           expect(page).to have_link("Cancel co-author invitation")
           expect(page).to have_no_content("Mark as co-author")
         end
@@ -62,7 +62,7 @@ describe "Interact with commenters" do
 
       it "author can cancel invitation" do
         within "#comment_#{comment.id}" do
-          click_on "…"
+          find("#dropdown-trigger-toggle-context-menu-#{comment.id}").click
           perform_enqueued_jobs do
             accept_confirm { click_on("Cancel co-author invitation") }
           end
@@ -71,7 +71,7 @@ describe "Interact with commenters" do
         expect(page).to have_content("Co-author invitation successfully canceled")
 
         within "#comment_#{comment.id}" do
-          click_on "…"
+          find("#dropdown-trigger-toggle-context-menu-#{comment.id}").click
           expect(page).to have_link("Mark as co-author")
           expect(page).to have_no_content("Cancel co-author invitation")
         end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR aligns the comment action button with the rest of the application, by adding a svg icon instead of UTF character.
This was discussed with @andreslucena in this [comment](https://github.com/decidim/decidim/pull/13377#discussion_r1758746362)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13377

#### Testing
1. Green pipeline 
2. Apply patch 
3. Navigate to any page that displays comments 
4. See the look & feel

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
Before:
![image](https://github.com/user-attachments/assets/b4a36389-8a45-44b2-8ea3-0fda3ca22619)
After: 
![image](https://github.com/user-attachments/assets/8840c55c-1f64-475f-ba80-ea4e2327904d)

:hearts: Thank you!
