### PR TITLE
Scroll to form when clicking Comments button

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/add_comment.erb
@@ -1,4 +1,4 @@
-<div class="add-comment">
+<div class="add-comment" id="add-comment-anchor">
   <% if user_signed_in? %>
     <%== cell("decidim/comments/comment_form", model, root_depth:) %>
   <% else %>

--- a/decidim-core/app/cells/decidim/comments_button_cell.rb
+++ b/decidim-core/app/cells/decidim/comments_button_cell.rb
@@ -23,7 +23,7 @@ module Decidim
     end
 
     def path
-      "#comments"
+      "#add-comment-anchor"
     end
 
     def text


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR we are changing the scroll functionality, so that your page gets scrolled to the add comment form. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13328

#### Testing
1. Green pipeline 
2. Apply patch, visit any commentable resource 
3. Click on comment button 
4. See the comment is being scrolled to add comment form

### :camera: Screenshots
N/A

:hearts: Thank you!
