### PR TITLE
Randomize the proposals seeds amendments configuration

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -20,10 +20,13 @@ module Decidim
         5.times do |n|
           proposal = create_proposal!(component:)
 
-          emendation = create_emendation!(proposal:) if proposal.state.nil?
+          if proposal.state.nil? && component.settings.amendments_enabled?
+            emendation = create_emendation!(proposal:)
+            create_proposal_votes!(proposal: emendation)
+          end
 
           (n % 3).times do |_m|
-            create_proposal_votes!(proposal:, emendation:)
+            create_proposal_votes!(proposal:)
           end
 
           (n % 3).times do
@@ -60,6 +63,7 @@ module Decidim
           settings: {
             vote_limit: 0,
             attachments_allowed: [true, false].sample,
+            amendments_enabled: [true, false].sample,
             collaborative_drafts_enabled: true
           },
           step_settings:
@@ -218,11 +222,10 @@ module Decidim
         emendation
       end
 
-      def create_proposal_votes!(proposal:, emendation: nil)
+      def create_proposal_votes!(proposal:)
         author = find_or_initialize_user_by(email: random_email(suffix: "vote"))
 
         Decidim::Proposals::ProposalVote.create!(proposal:, author:) unless proposal.published_state? && proposal.rejected?
-        Decidim::Proposals::ProposalVote.create!(proposal: emendation, author:) if emendation
       end
 
       def create_proposal_notes!(proposal:)

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -63,7 +63,7 @@ module Decidim
           settings: {
             vote_limit: 0,
             attachments_allowed: [true, false].sample,
-            amendments_enabled: [true, false].sample,
+            amendments_enabled: participatory_space.id.odd?,
             collaborative_drafts_enabled: true
           },
           step_settings:


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing with #13395, I noticed that the current seeds don't make much sense: proposals with amendments are shown even though the component does not have the "Amendments enabled" component setting checked. 

This PR fixes it by taking by adding this setting in seeds configuration and showing or not amendments depending on this.  

 
#### Testing

1. Run `rm -rf development_app/public/decidim-packs/ && bin/rails db:drop db:create db:migrate assets:precompile db:seed`
2. Check out the proposals components configuration. See that you have the "Amendments enabled" checked on components that have amendments, and when the "Amendments enabled" isn't checked, the component does not have amendments.  

:hearts: Thank you!
