### PR TITLE
Fix error in external domain allowlist

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/organization_external_domain_allowlist_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_external_domain_allowlist_controller.rb
@@ -18,7 +18,7 @@ module Decidim
         enforce_permission_to :update, :organization, organization: current_organization
         @form = form(OrganizationExternalDomainAllowlistForm).from_params(params)
 
-        UpdateExternalDomainAllowlist.call(@form, current_organization, current_user) do
+        UpdateExternalDomainAllowlist.call(@form, current_organization) do
           on(:ok) do
             flash[:notice] = t("domain_allowlist.update.success", scope: "decidim.admin")
             redirect_to edit_organization_external_domain_allowlist_path

--- a/decidim-admin/spec/system/admin_manages_external_domains_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_external_domains_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+describe "Admin manages external domain list" do
+  let!(:admin) { create(:user, :admin, :confirmed, organization:) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as admin, scope: :user
+    visit decidim_admin.edit_organization_external_domain_allowlist_path
+  end
+
+  context "when there are items in allowed list" do
+    let(:organization) { create(:organization, external_domain_allowlist: ["example.org", "twitter.com", "facebook.com", "youtube.com", "github.com", "mytesturl.me"]) }
+
+    it "displays all the allowed domains in the list" do
+      inputs = page.all(".external-domains-list input[type=text]")
+      expect(inputs.count).to eq(6)
+    end
+
+    it "removes items from the allowed domain list" do
+      buttons = page.all(".external-domains-list button.remove-external-domain")
+
+      within ".external-domains-list" do
+        buttons[0].click
+      end
+
+      click_on "Update"
+
+      organization.reload
+      expect(organization.external_domain_allowlist).not_to include("example.org")
+    end
+
+    it "reorders the elements in the list" do
+      down_buttons = page.all(".external-domains-list button.move-down-question")
+      up_buttons = page.all(".external-domains-list button.move-up-question")
+      within ".external-domains-list" do
+        down_buttons[0].click
+        up_buttons[2].click # there are 6 elements in the list, but only 5 buttons of "move up", first element is on the second input
+        down_buttons[4].click # there are 6 elements in the list, but only 5 buttons of "move down", last element is on the 5th input
+      end
+
+      click_on "Update"
+      organization.reload
+      expect(organization.external_domain_allowlist).to eq(["twitter.com", "example.org", "youtube.com", "facebook.com", "mytesturl.me", "github.com"])
+    end
+  end
+
+  context "when there are no items in allowed list" do
+    let(:organization) { create(:organization, external_domain_allowlist: []) }
+
+    it "updates the external domains list" do
+      expect(page).to have_content("Add to allowed list")
+      click_on "Add to allowed list"
+      within ".external-domains-list" do
+        find(:css, "input[type=text]").set("example.org")
+      end
+
+      click_on "Update"
+
+      organization.reload
+      expect(organization.external_domain_allowlist).to include("example.org")
+    end
+
+    it "updates the list when having multiple allowed domains" do
+      expect(page).to have_content("Add to allowed list")
+      click_on "Add to allowed list"
+      click_on "Add to allowed list"
+
+      inputs = page.all(".external-domains-list input[type=text]")
+      within ".external-domains-list" do
+        inputs[0].set("example.org")
+        inputs[1].set("decidim.org")
+      end
+
+      click_on "Update"
+
+      organization.reload
+      expect(organization.external_domain_allowlist).to include("example.org", "decidim.org")
+    end
+
+    it "reorders the list" do
+      expect(page).to have_content("Add to allowed list")
+      click_on "Add to allowed list"
+      click_on "Add to allowed list"
+
+      inputs = page.all(".external-domains-list input[type=text]")
+      buttons = page.all(".external-domains-list button.move-down-question")
+
+      within ".external-domains-list" do
+        inputs[0].set("example.org")
+        buttons[0].click
+        inputs[1].set("decidim.org")
+      end
+
+      click_on "Update"
+
+      organization.reload
+      expect(organization.external_domain_allowlist).to eq(["decidim.org", "example.org"])
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When updating the external domain allowlist, we get a 500 error in the update controller.

![image](https://github.com/user-attachments/assets/9614b661-5ba7-41e0-a7ac-e725b874ecdf)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #12983

#### Testing
Scenario 1:
1. Make sure the admin related pipeline is green
2. Take the spec added by this PR, and run it against develop. 

Scenario 2:
1. Using Develop branch, login as admin user 
2. visit admin panel and navigate to Settins / External domain allow list 
3. Add / remove a value
4. Click update 
5. See the error 
6. Apply the patch, repeat 2, 3, 4 
7. See there is no error.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
