### PR TITLE
Dropdown select scopes on Newsletters 

### DIFF
--- a/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
@@ -60,12 +60,7 @@
             </div>
             <div class="card-section">
               <div class="cell small-12 medium-6 m-4">
-                <%= f.select(
-                      :scope_ids,
-                      ordered_scopes_descendants_for_select(false),
-                      { include_blank: false },
-                      { class: "chosen-select", multiple: true, size: 5 }
-                    ) %>
+                <%= scopes_select_field f, :scope_ids, options: { include_blank: false }, html_options: { class: "chosen-select", multiple: true, size: 5 } %>
                 <span class="help-text"> <%= t(".scopes_help") %> </span>
               </div>
             </div>

--- a/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
@@ -60,7 +60,8 @@
             </div>
             <div class="card-section">
               <div class="row column">
-                <%= scopes_picker_filter f, :scope_ids, help_text: t(".scopes_help") %>
+                <%= scopes_select_field f, :scope_ids %>
+                <%= t(".scopes_help") %>
               </div>
             </div>
           </div>

--- a/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
@@ -54,13 +54,18 @@
         </div>
 
         <% if current_user.admin? %>
-          <div class="card">
+          <div class="card mb-2">
             <div class="card-divider">
               <h2 class="card-title"><%= t ".select_scopes" %></h2>
             </div>
             <div class="card-section">
-              <div class="row column">
-                <%= scopes_select_field f, :scope_ids %>
+              <div class="cell small-12 medium-6 m-4">
+                <%= f.select(
+                      :scope_ids,
+                      ordered_scopes_descendants_for_select(false),
+                      { include_blank: false },
+                      { class: "chosen-select", multiple: true, size: 5 }
+                    ) %>
                 <span class="help-text"> <%= t(".scopes_help") %> </span>
               </div>
             </div>

--- a/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/select_recipients_to_deliver.html.erb
@@ -61,7 +61,7 @@
             <div class="card-section">
               <div class="row column">
                 <%= scopes_select_field f, :scope_ids %>
-                <%= t(".scopes_help") %>
+                <span class="help-text"> <%= t(".scopes_help") %> </span>
               </div>
             </div>
           </div>

--- a/decidim-admin/spec/forms/selective_newsletter_form_spec.rb
+++ b/decidim-admin/spec/forms/selective_newsletter_form_spec.rb
@@ -121,6 +121,12 @@ module Decidim
           end
         end
       end
+
+      context "when a scope is selectable", type: :b do
+        let(:scope) { create(:scope, organization:) }
+
+        it { is_expected.to be_valid }
+      end
     end
   end
 end

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -163,7 +163,7 @@ module Decidim
         let(:options) { { include_blank: "Select a scope" } }
 
         it "is supported" do
-          expect(form).to receive(:select).with(:test, choices, options)
+          expect(form).to receive(:select).with(:test, choices, options, {})
           render_input
         end
       end

--- a/decidim-core/app/helpers/decidim/scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/scopes_helper.rb
@@ -53,13 +53,14 @@ module Decidim
     # options       - An optional Hash with options:
     #
     # Returns nothing.
-    def scopes_select_field(form, name, root: false, options: {})
+    def scopes_select_field(form, name, root: false, options: {}, html_options: {})
       options = options.merge(include_blank: I18n.t("decidim.scopes.prompt")) unless options.has_key?(:include_blank)
 
       form.select(
         name,
         ordered_scopes_descendants_for_select(root),
-        options
+        options,
+        html_options
       )
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The select dropdown for Newsletters was not migrated properly. This PR utilises the ``` scopes_select_field ``` to fix that issue.

#### :pushpin: Related Issues
- Fixes #13421

#### Testing
1. Log in 
2. Head to edit and newsletters
3. Create a newsletter
4. Select send to receipts
5. See the scopes dropdown on the bottom of page working. 

### :camera: Screenshots

<img width="1212" alt="Screenshot 2024-09-25 at 14 40 17" src="https://github.com/user-attachments/assets/d116d6a8-a68d-4ec8-9206-94c398b05757">

:hearts: Thank you!
