### PR TITLE
Fix file type in attachment for S3 files

### DIFF
--- a/decidim-core/app/models/decidim/attachment.rb
+++ b/decidim-core/app/models/decidim/attachment.rb
@@ -74,7 +74,7 @@ module Decidim
     # Returns String.
     def file_type
       if file?
-        url&.split(".")&.last&.downcase
+        url&.split(".")&.last&.split("&")&.first&.downcase
       elsif link?
         "link"
       end

--- a/decidim-core/spec/models/decidim/attachment_spec.rb
+++ b/decidim-core/spec/models/decidim/attachment_spec.rb
@@ -55,6 +55,16 @@ module Decidim
       it "returns the file extension" do
         expect(subject.file_type).to eq("jpeg")
       end
+
+      context "when the url is in S3" do
+        before do
+          allow(subject).to receive(:url).and_return("https://s3.example.com/1234?response-content-disposition=inline&filename=image.jpeg&response-content-type=image%2Fjpeg")
+        end
+
+        it "returns the file extension" do
+          expect(subject.file_type).to eq("jpeg")
+        end
+      end
     end
 
     context "when it has an image" do


### PR DESCRIPTION
#### :tophat: What? Why?

There's a bug where if an attachment is in S3, the file type isn't parsed correctly and shows garbage in the UI. See screenshots below.

This PR fixes it. 

It was detected both in [Metadecidim](https://meta.decidim.org/assemblies/our-governance) (v0.29.0) and also in Decidim Barcelona (v0.28.3)
 
#### Testing

Check the following snippet:

```ruby
# Real-world URL form metadecidim 
url = "https://ajbcn-meta-decidim.s3.eu-west-1.amazonaws.com/1fnb5zj5nfodp9qnd08mzr4vxkpr?response-content-disposition=inline%3B%20filename%3D%22Conveni_Ajuntament_Localret_Decidim_ENGLISH_VERSION.pdf%22%3B%20filename%2A%3DUTF-8%27%27Conveni_Ajuntament_Localret_Decidim_ENGLISH_VERSION.pdf&response-content-type=application%2Fpdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIARXFVQ5FRJEUZE7HY%2F20240926%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20240926T103214Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=db01bb342c4d102c0ded27002b87c4b1dd7864028046d69c838da06958655440"

puts url&.split(".")&.last&.downcase
puts url&.split(".")&.last&.split("&")&.first&.downcase
```

### :camera: Screenshots
 
![Screenshot of the related documents in Metadecidim's assembly, "Our governance"](https://github.com/user-attachments/assets/fe6f1a4f-19ab-49cf-a205-d75e6eb0cd49)

:hearts: Thank you!
