### PR TITLE
Fix display of short bio in conferences' speaker modal

### DIFF
--- a/decidim-conferences/app/cells/decidim/conferences/conference_speaker_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/conference_speaker_cell.rb
@@ -50,7 +50,7 @@ module Decidim
       def short_bio
         return unless model.short_bio.presence
 
-        decidim_escape_translated model.short_bio
+        decidim_sanitize_editor_admin translated_attribute model.short_bio
       end
 
       def twitter_handle


### PR DESCRIPTION
#### :tophat: What? Why?

While preparing the Decidim Fest 2024, we found a bug in the speakers' bio, where it was getting escaped. 

This PR solves it.

#### :pushpin: Related Issues
 
- Related to https://meta.decidim.org/conferences/DecidimFest24/speakers

#### Testing

1. Go to a conference
2. Click in the speakers link
3. Click in a speaker to open the modal
4. See the short bio

### :camera: Screenshots

#### Before

![Bug](https://github.com/user-attachments/assets/2409979d-7b55-4a9a-b99b-b728feefc473)

#### After

![Fix](https://github.com/user-attachments/assets/47a5079e-1baa-409f-a0d5-0c2b66ec3060)


:hearts: Thank you!
