### PR TITLE
Update supported versions in docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,12 @@
 
 ## Supported Versions
 
-Until we have the version 1.0 we support only the last two minor versions with
+Until we have the version 1.0 we support only the last three minor versions with
 security updates.
 
 | Version  | Supported          |
 | -------- | ------------------ |
+| 0.29.x   | :white_check_mark: |
 | 0.28.x   | :white_check_mark: |
 | 0.27.x   | :white_check_mark: |
 | \<= 0.26 | :x:                |

--- a/docs/modules/install/partials/version_matrix.adoc
+++ b/docs/modules/install/partials/version_matrix.adoc
@@ -2,11 +2,13 @@
 |===
 |Decidim version |Ruby version |Node version | Status
 
-|develop | 3.2.2 | 18.17.x | Unreleased
+|develop | 3.3.4 | 18.17.x | Unreleased
+
+|v0.29 | 3.2.2 | 18.17.x | Bug fixes and security updates
 
 |v0.28 | 3.1.1 | 18.17.x | Bug fixes and security updates
 
-|v0.27 | 3.0.2 | 16.18.x | Bug fixes and security updates
+|v0.27 | 3.0.2 | 16.18.x | Security updates
 
 |v0.26 | 2.7.5+ | 16.9.x | Not maintained
 


### PR DESCRIPTION
#### :tophat: What? Why?

This updates the supported versions of Decidim.

I'm marking this as a fix as I also want to reflect this change in other versions of https://docs.decidim.org as v0.29 is the current default version.

#### :pushpin: Related Issues
 
- Fixes #12923 

#### Testing

Read and check that the versions actually correspond 

:hearts: Thank you!
