### PR TITLE
Add page to export authorizations metadata

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/authorization_exports_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/authorization_exports_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    class AuthorizationExportsController < Decidim::Admin::ApplicationController
+      layout "decidim/admin/users"
+
+      def index
+        enforce_permission_to :index, :authorization_workflow
+
+        @workflows = Decidim::Verifications.workflows.select do |manifest|
+          current_organization.available_authorizations.include?(manifest.name.to_s)
+        end
+
+        @form = form(AuthorizationExportsForm).instance
+      end
+
+      def create
+        AuthorizationExportsJob.perform_later(
+          current_user,
+          authorization_params[:authorization_handler_name],
+          authorization_params[:start_date],
+          authorization_params[:end_date]
+        )
+
+        flash[:notice] = t("decidim.admin.exports.notice")
+
+        redirect_to authorization_exports_path
+      end
+
+      private
+
+      def authorization_params
+        params.require(:authorization_exports).permit(:authorization_handler_name, :start_date, :end_date)
+      end
+    end
+  end
+end

--- a/decidim-admin/app/forms/decidim/admin/authorization_exports_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/authorization_exports_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # A form to validate the date range for authorization exports
+    class AuthorizationExportsForm < Form
+      include TranslatableAttributes
+
+      attribute :start_date, Decidim::Attributes::LocalizedDate
+      attribute :end_date, Decidim::Attributes::LocalizedDate
+      attribute :authorization_handler_name, String
+
+      validates :start_date, presence: true
+      validates :end_date, presence: true
+    end
+  end
+end

--- a/decidim-admin/app/jobs/decidim/admin/authorization_exports_job.rb
+++ b/decidim-admin/app/jobs/decidim/admin/authorization_exports_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    class AuthorizationExportsJob < ApplicationJob
+      queue_as :default
+
+      def perform(user, authorization_handler_name, start_date, end_date)
+        ExportMailer.export(
+          user,
+          export_file_name,
+          export_data(authorization_handler_name, start_date, end_date)
+        ).deliver_now
+      end
+
+      def export_data(authorization_handler_name, start_date, end_date)
+        Decidim::Exporters::CSV.new(
+          collection(authorization_handler_name, start_date, end_date),
+          serializer
+        ).export
+      end
+
+      def export_file_name
+        "authorizations_export"
+      end
+
+      def collection(authorization_handler_name, start_date, end_date)
+        Decidim::Authorization.where(
+          granted_at: start_date..end_date,
+          name: authorization_handler_name
+        )
+      end
+
+      def serializer
+        Decidim::Admin::AuthorizationSerializer
+      end
+    end
+  end
+end

--- a/decidim-admin/app/serializers/decidim/admin/authorization_serializer.rb
+++ b/decidim-admin/app/serializers/decidim/admin/authorization_serializer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    # This class serializes a Authorization so can be exported to CSV
+    class AuthorizationSerializer < Decidim::Exporters::Serializer
+      attr_reader :authorization
+
+      def initialize(authorization)
+        @authorization = authorization
+      end
+
+      def serialize
+        {
+          id: authorization.id,
+          name: authorization.name,
+          granted_at: authorization.granted_at,
+          postal_code: metadata["postal_code"],
+          date_of_birth: metadata["date_of_birth"],
+          gender: metadata["gender"]
+        }
+      end
+
+      private
+
+      def metadata
+        authorization.metadata || {}
+      end
+    end
+  end
+end

--- a/decidim-admin/app/views/decidim/admin/authorization_exports/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/authorization_exports/index.html.erb
@@ -1,0 +1,39 @@
+<% add_decidim_page_title(t("authorization_exports", scope: "decidim.admin.titles")) %>
+
+<div class="item_show__header">
+  <h1 class="item_show__header-title">
+    <%= t("authorization_exports", scope: "decidim.admin.titles") %>
+  </h1>
+</div>
+
+<div class="item__edit item__edit-1col">
+  <div class="item__edit-form">
+    <div class="form__wrapper">
+      <div class="card">
+        <div class="card-section">
+          <div class="row column">
+            <%= decidim_form_for @form, url: authorization_exports_path, multipart: true, html: { class: "form form-defaults" } do |form| %>
+              <div class="row column">
+                <%= form.date_field :start_date, label: t("start_date", scope: "decidim.admin.authorization_exports") %>
+              </div>
+
+              <div class="row column">
+                <%= form.date_field :end_date, label: t("end_date", scope: "decidim.admin.authorization_exports") %>
+              </div>
+
+              <div class="row column">
+                <%= form.select :authorization_handler_name, @workflows.map { |workflow| [workflow.fullname, workflow.name] }, label: t("authorization_handler_name", scope: "decidim.admin.authorization_exports") %>
+              </div>
+
+              <div class="item__edit-sticky">
+                <div class="item__edit-sticky-container">
+                  <%= submit_tag t("submit", scope: "decidim.admin.authorization_exports"), class: "button button__sm button__secondary" %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -286,7 +286,6 @@ en:
       authorization_exports:
         authorization_handler_name: Verification method
         end_date: End date
-        select_date: Select date
         start_date: Start date
         submit: Export verification data
       autocomplete:

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -283,6 +283,12 @@ en:
           success: Attachment updated successfully.
       attachments_privacy_warning:
         message: Be careful when working with attachments in a private space. Any participant could share this document to others.
+      authorization_exports:
+        authorization_handler_name: Verification method
+        end_date: End date
+        select_date: Select date
+        start_date: Start date
+        submit: Export verification data
       autocomplete:
         no_results: No results found
         search_prompt: Type at least three characters to search.
@@ -583,6 +589,7 @@ en:
         appearance: Appearance
         area_types: Area types
         areas: Areas
+        authorization_exports: Export data
         components: Components
         configuration: Configuration
         content: Reported content
@@ -1116,6 +1123,7 @@ en:
         admin_log: Admin log
         area_types: Area types
         areas: Areas
+        authorization_exports: Export verification data
         authorization_workflows: Verification methods
         dashboard: Dashboard
         edit_external_domains: Allowed list of external domains

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -34,6 +34,7 @@ Decidim::Admin::Engine.routes.draw do
     resources :areas, except: [:show]
 
     resources :authorization_workflows, only: :index
+    resources :authorization_exports, only: [:index, :create]
 
     Decidim.authorization_admin_engines.each do |manifest|
       mount manifest.admin_engine, at: "/#{manifest.name}", as: "decidim_admin_#{manifest.name}"

--- a/decidim-admin/lib/decidim/admin/menu.rb
+++ b/decidim-admin/lib/decidim/admin/menu.rb
@@ -42,6 +42,11 @@ module Decidim
                           workflow.admin_root_path,
                           active: is_active_link?(workflow.admin_root_path)
           end
+
+          menu.add_item :authorization_exports,
+                        I18n.t("menu.authorization_exports", scope: "decidim.admin"),
+                        decidim_admin.authorization_exports_path,
+                        active: is_active_link?(decidim_admin.authorization_exports_path)
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

On some occasions, it is necessary to know the sociodemographic data of the participants in a process. Currently, this data can be obtained from the verification form. That is, if you ask for the date of birth, gender, and postal code during the verification, you can then aggregate this data to know the sociodemographic profile of the participants.

#### :pushpin: Related Issues

https://github.com/AjuntamentdeBarcelona/decidim-barcelona/issues/548

#### Testing

- Export verification data given a date range and a verification method https://decidim-lot2.populate.tools/admin/authorization_exports 
- ⚠️ The export will be received by email, so make sure you have access to the admin's email you are using
- ⚠️ Could be that there's no data to export given the range and method you selected. To create data you have to register as a new user and complete a verification method that collects that kind of data. 

### :camera: Screenshots

<img width="1140" alt="Screenshot 2024-09-27 at 16 56 19" src="https://github.com/user-attachments/assets/ac1ed685-49ad-4cdd-b5b9-25e44b970902">


:hearts: Thank you!
