### PR TITLE
Reduce kebab menu dimensions

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -19,7 +19,7 @@
   }
 
   > svg {
-    @apply w-8 h-8 flex-none text-secondary fill-current;
+    @apply w-6 h-6 flex-none text-secondary fill-current;
   }
 
   &[aria-expanded="false"] > svg:last-of-type,


### PR DESCRIPTION
#### :tophat: What? Why?
The hamburger menu was slightly bigger in dimensions in production than expected. This PR reduces its size ever so slightly.

#### :pushpin: Related Issues
- Fixes #13473

#### Testing
1. Head to a Decidim App
3. Find a component with the hamburger menu (like meetings)
4. Log in if necessary to see details of that meeting
5. See hamburger menu

### :camera: Screenshots
<img width="759" alt="Screenshot 2024-09-30 at 12 42 25" src="https://github.com/user-attachments/assets/887a6cf8-465e-4fc5-932b-ccfff9da4265">

:hearts: Thank you!
