### PR TITLE
Add Open Data page with explanations

### DIFF
--- a/decidim-core/app/controllers/decidim/open_data_controller.rb
+++ b/decidim-core/app/controllers/decidim/open_data_controller.rb
@@ -2,6 +2,8 @@
 
 module Decidim
   class OpenDataController < Decidim::ApplicationController
+    def index; end
+
     def download
       if uploader.attached?
         redirect_to uploader.path

--- a/decidim-core/app/packs/stylesheets/decidim/_open_data.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_open_data.scss
@@ -1,0 +1,31 @@
+.page__container-open_data {
+  .card {
+    @apply border-b border-gray-3 mt-6;
+
+    .card-title {
+      @apply text-primary font-semibold text-xl inline-block;
+    }
+
+    .card-divider-button {
+      @apply flex items-center justify-between items-end w-full;
+
+      svg {
+        @apply inline-block w-6 h-6 fill-primary;
+      }
+
+      &[aria-expanded="true"] {
+        svg {
+          @apply rotate-180 transition-transform;
+        }
+      }
+    }
+
+    .card-section {
+      @apply pb-8;
+
+      ul {
+        @apply mb-0;
+      }
+    }
+  }
+}

--- a/decidim-core/app/packs/stylesheets/decidim/application.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/application.scss
@@ -75,6 +75,7 @@
 @import "stylesheets/decidim/_home.scss";
 @import "stylesheets/decidim/_search.scss";
 @import "stylesheets/decidim/_cookies.scss";
+@import "stylesheets/decidim/_open_data.scss";
 // participatory spaces are quite similar between processes and assemblies (different modules), so their stylesheets are placed in the core
 @import "stylesheets/decidim/_participatory_spaces.scss";
 @import "stylesheets/decidim/_omnipresent_banner.scss";

--- a/decidim-core/app/views/decidim/open_data/_section.html.erb
+++ b/decidim-core/app/views/decidim/open_data/_section.html.erb
@@ -1,0 +1,16 @@
+<% scope = "decidim.open_data.index.#{i18n_scope}" %>
+
+<div class="card" data-component="accordion">
+  <div class="card-divider">
+    <button class="card-divider-button" data-open="false" data-controls="panel-title--<%= i18n_scope %>" type="button">
+      <h2 class="card-title" id="title">
+        <%= t("title", scope:) %>
+      </h2>
+      <%= icon "arrow-up-s-line", class: "mb-4" %>
+    </button>
+  </div>
+
+  <div id="panel-title--<%= i18n_scope %>" class="card-section" aria-hidden="true">
+    <%= yield %>
+  </div>
+</div>

--- a/decidim-core/app/views/decidim/open_data/index.html.erb
+++ b/decidim-core/app/views/decidim/open_data/index.html.erb
@@ -1,0 +1,49 @@
+<% add_decidim_meta_tags(
+  title: t(".title"),
+  description: t(".description")
+) %>
+
+<%= render layout:"layouts/decidim/shared/layout_center" do %>
+
+  <div class="text-center py-12">
+    <h1 class="h1 decorator inline-block text-left">
+      <%= t("title", scope: "decidim.open_data.index") %>
+    </h1>
+  </div>
+
+  <div class="page__container page__container-open_data">
+    <div class="editor-content">
+      <p>
+      <%= t("description", scope: "decidim.open_data.index", organization_name: current_organization_name) %>
+      </p>
+
+      <%# i18n-tasks-use t("decidim.open_data.index.explanation.title") %>
+      <%= render layout: "decidim/open_data/section", locals: { i18n_scope: "explanation" } do %>
+        <p> <%= t("body_1", scope: "decidim.open_data.index.explanation", organization_name: current_organization_name) %> </p>
+        <p> <%= t("body_2", scope: "decidim.open_data.index.explanation") %> </p>
+      <% end %>
+
+      <%# i18n-tasks-use t("decidim.open_data.index.how_to.title") %>
+      <%# i18n-tasks-use t("decidim.open_data.index.how_to.step_1.title") %>
+      <%# i18n-tasks-use t("decidim.open_data.index.how_to.step_1.body_html") %>
+      <%# i18n-tasks-use t("decidim.open_data.index.how_to.step_2.title") %>
+      <%# i18n-tasks-use t("decidim.open_data.index.how_to.step_2.body_html") %>
+      <%# i18n-tasks-use t("decidim.open_data.index.how_to.step_3.title") %>
+      <%# i18n-tasks-use t("decidim.open_data.index.how_to.step_3.body_html") %>
+      <%= render layout: "decidim/open_data/section", locals: { i18n_scope: "how_to" } do %>
+        <% (1..3).each do |step_number| %>
+          <% scope = "decidim.open_data.index.how_to.step_#{step_number}" %>
+          <div class="row column">
+            <h3 class="text-lg pt-8"><%= t("title", scope:) %></h3>
+            <%= t("body_html", scope:) %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="mt-4 flex flex-col items-center">
+      <%= link_to t("download_open_data", scope: "decidim.open_data.index"), decidim.open_data_download_path, class: "button button__primary button__xl" %>
+    </div>
+  </div>
+
+<% end %>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
@@ -24,7 +24,7 @@
     <% if Decidim.module_installed?(:meetings) %>
       <li class="font-semibold underline"><%= link_to t("decidim.pages.home.extended.meetings"), Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path %></li>
     <% end %>
-    <li class="font-semibold underline"><%= link_to t("layouts.decidim.footer.download_open_data"), decidim.open_data_download_path %></li>
+    <li class="font-semibold underline"><%= link_to t("layouts.decidim.footer.open_data"), decidim.open_data_path %></li>
   </ul>
 </nav>
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1324,6 +1324,35 @@ en:
         message_2: Please, try again later.
         retry: Retry
     open_data:
+      index:
+        description: Welcome to the %{organization_name} Open Data page. Here, you will find data files that are regularly generated from various deliberative and governance processes within %{organization_name}. These files are made available to promote transparency, accessibility, and collaboration. Below, you will find detailed information on what these files are, how to open and work with them, and a description of the content and structure of each file.
+        download_open_data: Download all the Open Data files
+        explanation:
+          body_1: These files are datasets exported from %{organization_name}'s participatory processes, such as proposals, comments, and meetings. They provide raw, structured data that can be used for analysis, research, or integration with other tools. The data is updated automatically every 24 hours, ensuring that you have access to the most recent information.
+          body_2: These files are in CSV (Comma-Separated Values) format, which is a widely-used file format that can be opened and processed by a variety of software applications, including spreadsheet programs, text editors, and data analysis tools.
+          title: What are these files?
+        how_to:
+          step_1:
+            body_html: Click on the links provided below to download the CSV files to your computer.
+            title: 1. Download the files
+          step_2:
+            body_html: |-
+              <ul>
+                <li><b>Spreadsheet Applications</b>: You can open CSV files using applications like Microsoft Excel, Google Sheets, or LibreOffice Calc. Simply open the application, then select "Open" from the File menu, and choose the downloaded CSV file.</li>
+                <li><b>Text Editors</b>: CSV files can also be opened in any text editor, such as Notepad or Sublime Text. This will display the raw data, with each line representing a row and each value separated by a comma.</li>
+                <li><b>Data Analysis Tools</b>: If you are familiar with data analysis tools like Python (with pandas), R, or SQL databases, you can import these CSV files directly for processing and analysis.</li>
+              </ul>
+            title: 2. Open the files
+          step_3:
+            body_html: |-
+              <ul>
+                <li><b>Filtering and Sorting</b>: In spreadsheet applications, you can filter and sort the data to focus on specific subsets of information.</li>
+                <li><b>Analysis</b>: Use the data to perform various analyses, such as counting the number of proposals, analyzing trends in comments, or evaluating participation in meetings.</li>
+                <li><b>Visualization</b>: You can create charts, graphs, and other visualizations to help interpret the data.</li>
+              </ul>
+            title: 3. Working with the data
+          title: How to open and work with these files
+        title: Open Data
       not_available_yet: The Open Data files are not yet available, please try again in a few minutes.
     pad_iframe:
       disclaimer: The contents of this pad are written by registered users and express their opinions. %{organization} cannot be held responsible for its contents.
@@ -1972,9 +2001,9 @@ en:
         data_consent_settings: Cookie settings
         decidim_logo: Decidim Logo
         decidim_title: Decidim
-        download_open_data: Download Open Data files
         log_in: Log in
         made_with_open_source: Website made with <a target="_blank" href="https://github.com/decidim/decidim">free software</a>.
+        open_data: Open Data
         resources: Resources
         sign_up: Create an account
         terms_of_service: Terms of Service

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -159,6 +159,7 @@ Decidim::Core::Engine.routes.draw do
   match "/404", to: "errors#not_found", via: :all
   match "/500", to: "errors#internal_server_error", via: :all
 
+  get "/open-data", to: "open_data#index", as: :open_data
   get "/open-data/download", to: "open_data#download", as: :open_data_download
 
   resource :follow, only: [:create, :destroy]

--- a/decidim-core/lib/decidim/core/test/shared_examples/download_open_data_shared_context.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/download_open_data_shared_context.rb
@@ -20,7 +20,8 @@ RSpec.shared_context "when downloading open data files" do
     switch_to_host(organization.host)
     visit decidim.root_path
 
-    click_on "Download Open Data files"
+    click_on "Open Data"
+    click_on "Download all the Open Data files"
   end
 
   def extract_content_from_zip(download_path, file_name)


### PR DESCRIPTION
#### :tophat: What? Why?

Currently the Open Data feature doesn't give much information about how to work with the files, and having only a README inside of a ZIP file can be scary for people that are not well versed technically. 

This PR implements an explanation page with instructions on how to work with this file. This will be the basis for other developments (such as adding a link for each file and having the explanation of the fields in this page). 

#### :pushpin: Related Issues
 
- Related to #13252

#### Testing

1. Go to the footer
2. Click in the "Open data" link

### :camera: Screenshots

![Screenshot of this page](https://github.com/user-attachments/assets/9b8d7507-d021-4dfa-b360-d13d73067416)

:hearts: Thank you!
