### PR TITLE
Revert "Allow actions' jobs to be retriggered on first failing (#13443)"

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -54,19 +54,6 @@ jobs:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
-      VALIDATOR_HTML_URI: http://localhost:8888/
-      RUBY_VERSION: ${{ inputs.ruby_version }}
-      DECIDIM_MODULE: ${{ inputs.working-directory }}
-      CODECOV_TOKEN: ${{ inputs.codecov_token }}
-      DECIDIM_BULLET_ENABLED: ${{ inputs.bullet_enabled }}
-      DECIDIM_BULLET_N_PLUS_ONE: ${{ inputs.bullet_n_plus_one }}
-      DECIDIM_BULLET_COUNTER_CACHE: ${{ inputs.bullet_counter_cache }}
-      DECIDIM_BULLET_UNUSED_EAGER: ${{ inputs.bullet_unused_eager_loading }}
-      DISPLAY: ":99"
-      CI: "true"
-      SIMPLECOV: "true"
-      SHAKAPACKER_RUNTIME_COMPILE: "false"
-      NODE_ENV: "test"
     services:
       validator:
         image: ghcr.io/validator/validator:latest
@@ -123,13 +110,20 @@ jobs:
           ${{ inputs.test_command }}
         name: RSpec
         working-directory: ${{ inputs.working-directory }}
-        continue-on-error: true
-      - run: |
-          sudo Xvfb -ac $DISPLAY -screen 0 1920x1084x24 > /dev/null 2>&1 & # optional
-          ${{ inputs.test_command }}
-        name: RSpec Retry
-        if: failure() && github.run_attempt < 2
-        working-directory: ${{ inputs.working-directory }}
+        env:
+          VALIDATOR_HTML_URI: http://localhost:8888/
+          RUBY_VERSION: ${{ inputs.ruby_version }}
+          DECIDIM_MODULE: ${{ inputs.working-directory }}
+          CODECOV_TOKEN: ${{ inputs.codecov_token }}
+          DECIDIM_BULLET_ENABLED: ${{ inputs.bullet_enabled }}
+          DECIDIM_BULLET_N_PLUS_ONE: ${{ inputs.bullet_n_plus_one }}
+          DECIDIM_BULLET_COUNTER_CACHE: ${{ inputs.bullet_counter_cache }}
+          DECIDIM_BULLET_UNUSED_EAGER: ${{ inputs.bullet_unused_eager_loading }}
+          DISPLAY: ":99"
+          CI: "true"
+          SIMPLECOV: "true"
+          SHAKAPACKER_RUNTIME_COMPILE: "false"
+          NODE_ENV: "test"
       - uses: codecov/codecov-action@v4
         name: Upload coverage
         with:


### PR DESCRIPTION
#### :tophat: What? Why?

While working with #13435, I found some specs that should be failing in the CI and weren't. 

The problem is that with #13443 we misinterpreted how countinue-with-error and rspec retry would work. 

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error

So, it's better to just undo that change. 

This reverts commit af7c9d6ca10c18bfd830deaa8e4aaa1d46982a6a.

#### :pushpin: Related Issues

- Related to #13443
- Related to #13445 

#### Testing

First I'll let it run to see if we have any failing spec from the last couple of days that we didn't detected
 

:hearts: Thank you!
