### PR TITLE
Allow actions' jobs to be retriggered on first failing

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -118,17 +118,15 @@ jobs:
         name: Parallel tests
         shell: "bash"
         working-directory: ./spec/decidim_dummy_app/
-      - run: |
-          sudo Xvfb -ac $DISPLAY -screen 0 1920x1084x24 > /dev/null 2>&1 & # optional
-          ${{ inputs.test_command }}
-        name: RSpec
-        working-directory: ${{ inputs.working-directory }}
-      - run: |
-          sudo Xvfb -ac $DISPLAY -screen 0 1920x1084x24 > /dev/null 2>&1 & # optional
-          ${{ inputs.test_command }}
-        name: RSpec Retry
-        if: ${{ failure() && github.run_attempt < 2 }}
-        working-directory: ${{ inputs.working-directory }}
+      - uses: nick-fields/retry@v3
+        with:
+          timeout_seconds: 15
+          max_attempts: 3
+          retry_on: error
+          command: |
+            cd ${{ inputs.working-directory }}
+            sudo Xvfb -ac $DISPLAY -screen 0 1920x1084x24 > /dev/null 2>&1 & # optional
+            ${{ inputs.test_command }}
       - uses: codecov/codecov-action@v4
         name: Upload coverage
         with:

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -54,6 +54,19 @@ jobs:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
+      VALIDATOR_HTML_URI: http://localhost:8888/
+      RUBY_VERSION: ${{ inputs.ruby_version }}
+      DECIDIM_MODULE: ${{ inputs.working-directory }}
+      CODECOV_TOKEN: ${{ inputs.codecov_token }}
+      DECIDIM_BULLET_ENABLED: ${{ inputs.bullet_enabled }}
+      DECIDIM_BULLET_N_PLUS_ONE: ${{ inputs.bullet_n_plus_one }}
+      DECIDIM_BULLET_COUNTER_CACHE: ${{ inputs.bullet_counter_cache }}
+      DECIDIM_BULLET_UNUSED_EAGER: ${{ inputs.bullet_unused_eager_loading }}
+      DISPLAY: ":99"
+      CI: "true"
+      SIMPLECOV: "true"
+      SHAKAPACKER_RUNTIME_COMPILE: "false"
+      NODE_ENV: "test"
     services:
       validator:
         image: ghcr.io/validator/validator:latest
@@ -110,20 +123,12 @@ jobs:
           ${{ inputs.test_command }}
         name: RSpec
         working-directory: ${{ inputs.working-directory }}
-        env:
-          VALIDATOR_HTML_URI: http://localhost:8888/
-          RUBY_VERSION: ${{ inputs.ruby_version }}
-          DECIDIM_MODULE: ${{ inputs.working-directory }}
-          CODECOV_TOKEN: ${{ inputs.codecov_token }}
-          DECIDIM_BULLET_ENABLED: ${{ inputs.bullet_enabled }}
-          DECIDIM_BULLET_N_PLUS_ONE: ${{ inputs.bullet_n_plus_one }}
-          DECIDIM_BULLET_COUNTER_CACHE: ${{ inputs.bullet_counter_cache }}
-          DECIDIM_BULLET_UNUSED_EAGER: ${{ inputs.bullet_unused_eager_loading }}
-          DISPLAY: ":99"
-          CI: "true"
-          SIMPLECOV: "true"
-          SHAKAPACKER_RUNTIME_COMPILE: "false"
-          NODE_ENV: "test"
+      - run: |
+          sudo Xvfb -ac $DISPLAY -screen 0 1920x1084x24 > /dev/null 2>&1 & # optional
+          ${{ inputs.test_command }}
+        name: RSpec Retry
+        if: ${{ failure() && github.run_attempt < 2 }}
+        working-directory: ${{ inputs.working-directory }}
       - uses: codecov/codecov-action@v4
         name: Upload coverage
         with:


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the github action that we have introduced in #13443. 
Personally, i have checked with an older version of #13435 in another PR.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13443
- Related to #13491

#### Testing
1. Find a PR that you know is failing
2. Patch the pipeline with the action in this PR 
3. See the Pipeline is still failing ( with both steps being ran - Rspec and Rspec retry ) 

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/7ac51cd1-da24-4ab7-a4f3-7f337ed3d2c0)

:hearts: Thank you!
