### PR TITLE
Improve settings options for Related Spaces content block.

### DIFF
--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
@@ -1,3 +1,3 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, (3..30).step(3).to_a, prompt: "", label: %>
+  <%= settings_fields.number_field :max_results, label: %>
 <% end %>

--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
@@ -1,3 +1,3 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, [6, 9, 12], prompt: "", label: %>
+  <%= settings_fields.select :max_results, (3..30).step(3).to_a, prompt: "", label: %>
 <% end %>

--- a/decidim-assemblies/spec/system/admin/admin_manages_assembly_landing_page_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assembly_landing_page_spec.rb
@@ -24,7 +24,7 @@ describe "Admin manages assembly landing page" do
       visit edit_content_block_path(resource, related_assemblies_content_block)
 
       expect(related_assemblies_content_block.settings["max_results"]).to eq(6)
-      select 12, from: :content_block_settings_max_results
+      fill_in :content_block_settings_max_results, with: "12"
       click_on "Update"
 
       expect(page).to have_content("Related assemblies")

--- a/decidim-assemblies/spec/system/homepage_content_blocks_spec.rb
+++ b/decidim-assemblies/spec/system/homepage_content_blocks_spec.rb
@@ -7,9 +7,7 @@ describe "Homepage assemblies content blocks" do
   let!(:promoted_assembly) { create(:assembly, :promoted, organization:) }
   let!(:unpromoted_assembly) { create(:assembly, organization:) }
   let!(:promoted_external_assembly) { create(:assembly, :promoted) }
-  let!(:highlighted_assemblies_content_block) {
-    create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_assemblies)
-  }
+  let!(:highlighted_assemblies_content_block) { create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_assemblies) }
 
   include_context "when admin administrating an assembly"
 
@@ -17,7 +15,6 @@ describe "Homepage assemblies content blocks" do
     switch_to_host(organization.host)
     login_as user, scope: :user
   end
-
 
   it "includes active assemblies to the homepage" do
     visit decidim.root_path

--- a/decidim-assemblies/spec/system/homepage_content_blocks_spec.rb
+++ b/decidim-assemblies/spec/system/homepage_content_blocks_spec.rb
@@ -7,11 +7,17 @@ describe "Homepage assemblies content blocks" do
   let!(:promoted_assembly) { create(:assembly, :promoted, organization:) }
   let!(:unpromoted_assembly) { create(:assembly, organization:) }
   let!(:promoted_external_assembly) { create(:assembly, :promoted) }
+  let!(:highlighted_assemblies_content_block) {
+    create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_assemblies)
+  }
+
+  include_context "when admin administrating an assembly"
 
   before do
-    create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_assemblies)
     switch_to_host(organization.host)
+    login_as user, scope: :user
   end
+
 
   it "includes active assemblies to the homepage" do
     visit decidim.root_path
@@ -20,6 +26,24 @@ describe "Homepage assemblies content blocks" do
       expect(page).to have_i18n_content(promoted_assembly.title)
       expect(page).to have_i18n_content(unpromoted_assembly.title)
       expect(page).not_to have_i18n_content(promoted_external_assembly.title)
+    end
+  end
+
+  it "updates the settings of the content block" do
+    visit decidim_admin.edit_organization_homepage_content_block_path(highlighted_assemblies_content_block)
+
+    expect(find("input[type='number'][name='content_block[settings][max_results]").value).to eq("6")
+
+    fill_in "content_block[settings][max_results]", with: "1"
+    click_on "Update"
+
+    expect(page).to have_content("Highlighted assemblies")
+    expect(highlighted_assemblies_content_block.reload.settings["max_results"]).to eq(1)
+
+    visit decidim.root_path
+
+    within "#highlighted-assemblies" do
+      expect(page).to have_css("a.card__grid", count: 1)
     end
   end
 end

--- a/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
@@ -1,3 +1,3 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, (3..30).step(3).to_a, prompt: "", label: %>
+  <%= settings_fields.number_field :max_results, label: %>
 <% end %>

--- a/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
@@ -1,3 +1,3 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, [6, 9, 12], prompt: "", label: %>
+  <%= settings_fields.select :max_results, (3..30).step(3).to_a, prompt: "", label: %>
 <% end %>

--- a/decidim-conferences/spec/system/homepage_content_blocks_spec.rb
+++ b/decidim-conferences/spec/system/homepage_content_blocks_spec.rb
@@ -8,9 +8,9 @@ describe "Homepage conferences content blocks" do
   let!(:promoted_conference) { create(:conference, :promoted, organization:) }
   let!(:unpromoted_conference) { create(:conference, organization:) }
   let!(:promoted_external_conference) { create(:conference, :promoted) }
+  let!(:highlighted_conferences_content_block) { create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_conferences) }
 
   before do
-    create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_conferences)
     switch_to_host(organization.host)
   end
 
@@ -21,6 +21,33 @@ describe "Homepage conferences content blocks" do
       expect(page).to have_i18n_content(promoted_conference.title)
       expect(page).to have_i18n_content(unpromoted_conference.title)
       expect(page).not_to have_i18n_content(promoted_external_conference.title)
+
+      expect(page).to have_css("a.card__grid", count: 3)
+    end
+  end
+
+  include_context "when admin administrating a conference"
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  it "updates the number of highlighted conferences with a number input field" do
+    visit decidim_admin.edit_organization_homepage_content_block_path(highlighted_conferences_content_block)
+
+    expect(find("input[type='number'][name='content_block[settings][max_results]']").value).to eq("6")
+
+    fill_in "content_block[settings][max_results]", with: "1"
+    click_on "Update"
+
+    expect(page).to have_content("Highlighted conferences")
+    expect(highlighted_conferences_content_block.reload.settings["max_results"]).to eq(1)
+
+    visit decidim.root_path
+
+    within "#highlighted-conferences" do
+      expect(page).to have_css("a.card__grid", count: 1)
     end
   end
 end

--- a/decidim-conferences/spec/system/homepage_content_blocks_spec.rb
+++ b/decidim-conferences/spec/system/homepage_content_blocks_spec.rb
@@ -10,8 +10,11 @@ describe "Homepage conferences content blocks" do
   let!(:promoted_external_conference) { create(:conference, :promoted) }
   let!(:highlighted_conferences_content_block) { create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_conferences) }
 
+  include_context "when admin administrating a conference"
+
   before do
     switch_to_host(organization.host)
+    login_as user, scope: :user
   end
 
   it "includes active conferences to the homepage" do
@@ -24,13 +27,6 @@ describe "Homepage conferences content blocks" do
 
       expect(page).to have_css("a.card__grid", count: 3)
     end
-  end
-
-  include_context "when admin administrating a conference"
-
-  before do
-    switch_to_host(organization.host)
-    login_as user, scope: :user
   end
 
   it "updates the number of highlighted conferences with a number input field" do

--- a/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_settings_form/show.erb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_settings_form/show.erb
@@ -1,4 +1,4 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, [4, 8, 12], prompt: "", label: max_results_label %>
+  <%= settings_fields.select :max_results, (3..30).step(3).to_a, prompt: "", label: max_results_label %>
   <%= settings_fields.select :order, order_select, prompt: "", label: order_label %>
 <% end %>

--- a/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_settings_form/show.erb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_settings_form/show.erb
@@ -1,4 +1,4 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, (3..30).step(3).to_a, prompt: "", label: max_results_label %>
+  <%= settings_fields.number_field :max_results, label: max_results_label %>
   <%= settings_fields.select :order, order_select, prompt: "", label: order_label %>
 <% end %>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
@@ -1,3 +1,3 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, (3..30).step(3).to_a, prompt: "", label: %>
+  <%= settings_fields.number_field :max_results, label: %>
 <% end %>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
@@ -1,3 +1,3 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, [6, 9, 12], prompt: "", label: %>
+  <%= settings_fields.select :max_results, (3..30).step(3).to_a, prompt: "", label: %>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

The selector in highlighted assemblies only allowed to chose between 6,9 and 12, limiting the options of admins. This change allows for a more flexible experience.

This changes allow the administrator of an assembly to have more options to choose from when configuring the "Related Assemblies" content block.

This PR is meant to be as an example for the proposal inside metadecidim. There I also explain another way of dealing with this improvement, and it should also be ported to the highlight of processes. This is not only inside assemblies.

#### :pushpin: Related Issues
- Related to this [proposal in metadecidim](https://meta.decidim.org/processes/roadmap/f/122/proposals/17854?locale=ca)

#### Testing
Access the "Related Assemblies" content block settings and make sure the options now rise up to 30.

### :camera: Screenshots
![new_related_assemblies_setting](https://github.com/user-attachments/assets/4fff49bd-97d0-4d95-b6de-60719406866c)



:hearts: Thank you!
