### PR TITLE
Update workflows to use actions/upload-artifact@v3 in release/0.27-stable

### DIFF
--- a/.github/workflows/ci_accountability.yml
+++ b/.github/workflows/ci_accountability.yml
@@ -75,7 +75,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_admin.yml
+++ b/.github/workflows/ci_admin.yml
@@ -66,7 +66,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_admin_system.yml
+++ b/.github/workflows/ci_admin_system.yml
@@ -70,7 +70,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -67,7 +67,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_assemblies.yml
+++ b/.github/workflows/ci_assemblies.yml
@@ -70,7 +70,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_blogs.yml
+++ b/.github/workflows/ci_blogs.yml
@@ -73,7 +73,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_budgets.yml
+++ b/.github/workflows/ci_budgets.yml
@@ -72,7 +72,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_comments.yml
+++ b/.github/workflows/ci_comments.yml
@@ -70,7 +70,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_conferences.yml
+++ b/.github/workflows/ci_conferences.yml
@@ -71,7 +71,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_consultations.yml
+++ b/.github/workflows/ci_consultations.yml
@@ -71,7 +71,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_core_lib.yml
+++ b/.github/workflows/ci_core_lib.yml
@@ -66,7 +66,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-core-lib
           flags: decidim-core-lib
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_core_system.yml
+++ b/.github/workflows/ci_core_system.yml
@@ -73,7 +73,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-core-system
           flags: decidim-core-system
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_core_system_ssl.yml
+++ b/.github/workflows/ci_core_system_ssl.yml
@@ -73,7 +73,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-core-system-ssl
           flags: decidim-core-system-ssl
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_core_tasks.yml
+++ b/.github/workflows/ci_core_tasks.yml
@@ -65,7 +65,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_core_tasks_webpacker.yml
+++ b/.github/workflows/ci_core_tasks_webpacker.yml
@@ -65,7 +65,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_core_unit.yml
+++ b/.github/workflows/ci_core_unit.yml
@@ -65,7 +65,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_debates.yml
+++ b/.github/workflows/ci_debates.yml
@@ -71,7 +71,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_dev_system.yml
+++ b/.github/workflows/ci_dev_system.yml
@@ -64,7 +64,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_forms.yml
+++ b/.github/workflows/ci_forms.yml
@@ -66,7 +66,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -68,7 +68,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_initiatives_system_admin.yml
+++ b/.github/workflows/ci_initiatives_system_admin.yml
@@ -72,7 +72,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-initiatives-system-admin
           flags: decidim-initiatives-system-admin
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_initiatives_system_public.yml
+++ b/.github/workflows/ci_initiatives_system_public.yml
@@ -72,7 +72,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-initiatives-system-public
           flags: decidim-initiatives-system-public
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_meetings_system_admin.yml
+++ b/.github/workflows/ci_meetings_system_admin.yml
@@ -73,7 +73,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-meetings-system-admin
           flags: decidim-meetings-system-admin
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_meetings_system_public.yml
+++ b/.github/workflows/ci_meetings_system_public.yml
@@ -73,7 +73,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-meetings-system-public
           flags: decidim-meetings-system-public
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_meetings_unit_tests.yml
+++ b/.github/workflows/ci_meetings_unit_tests.yml
@@ -69,7 +69,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_pages.yml
+++ b/.github/workflows/ci_pages.yml
@@ -70,7 +70,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_participatory_processes.yml
+++ b/.github/workflows/ci_participatory_processes.yml
@@ -71,7 +71,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_proposals_system_admin.yml
+++ b/.github/workflows/ci_proposals_system_admin.yml
@@ -75,7 +75,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-proposals-system-admin
           flags: decidim-proposals-system-admin
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_proposals_system_public.yml
+++ b/.github/workflows/ci_proposals_system_public.yml
@@ -75,7 +75,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: decidim-proposals-system-public
           flags: decidim-proposals-system-public
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_proposals_unit_tests.yml
+++ b/.github/workflows/ci_proposals_unit_tests.yml
@@ -71,7 +71,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_sortitions.yml
+++ b/.github/workflows/ci_sortitions.yml
@@ -72,7 +72,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_surveys.yml
+++ b/.github/workflows/ci_surveys.yml
@@ -73,7 +73,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -69,7 +69,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_templates.yml
+++ b/.github/workflows/ci_templates.yml
@@ -72,7 +72,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/ci_verifications.yml
+++ b/.github/workflows/ci_verifications.yml
@@ -70,7 +70,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ env.DECIDIM_MODULE }}
           flags: ${{ env.DECIDIM_MODULE }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: screenshots


### PR DESCRIPTION
#### :tophat: What? Why?
While working on [#13498](https://github.com/decidim/decidim/pull/13498). Since **0.27** is still being maintained, i am opening this PR to fix the pipeline issues. 

I have noticed that the pipeline failed with the following error: 

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13498

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![image](https://github.com/user-attachments/assets/f2ef8632-438a-490a-9d23-3ef2be3d3236)

:hearts: Thank you!
