### PR TITLE
Remove host param from url uploader method on Conferences

### DIFF
--- a/decidim-conferences/app/presenters/decidim/conferences/conference_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/conference_presenter.rb
@@ -4,11 +4,11 @@ module Decidim
   module Conferences
     class ConferencePresenter < SimpleDelegator
       def hero_image_url
-        conference.attached_uploader(:hero_image).url(host: conference.organization.host)
+        conference.attached_uploader(:hero_image).url
       end
 
       def banner_image_url
-        conference.attached_uploader(:banner_image).url(host: conference.organization.host)
+        conference.attached_uploader(:banner_image).url
       end
 
       def conference


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing #13436, i have noticed the application failed with the below error after the sync with develop has been made: 
```
(irb):7:in `<main>': unexpected value at params[:host] (ArgumentError)
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13404
- Related to #13313

#### Testing
1. Green pipeline 
2. Having configured the storage to S3 generate the open data file
3. See it fails 

Additionally you can try it on nightly by using the following snippet in the rails console: 
```ruby 
organization = Decidim::Organization.last
organization.open_data_file =nil
organization.save!

path = Rails.root.join("tmp/#{organization.open_data_file_path}")
exporter = Decidim::OpenDataExporter.new(organization, path)
exporter.export
```

Edit the decidim-conference gem and apply the changes suggested by this PR ... and rerun the above snippet.

:hearts: Thank you!
