### PR TITLE
Fix related assemblies content block

### DIFF
--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_landing_page_content_blocks_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_landing_page_content_blocks_controller.rb
@@ -8,6 +8,8 @@ module Decidim
         include Decidim::Admin::ContentBlocks::LandingPageContentBlocks
         include Concerns::AssemblyAdmin
 
+        helper_method :parent_assembly
+
         layout "decidim/admin/assemblies"
 
         private
@@ -28,6 +30,10 @@ module Decidim
 
         def resource_landing_page_content_block_path
           assembly_landing_page_content_block_path(scoped_resource, params[:id])
+        end
+
+        def parent_assembly
+          @parent_assembly ||= scoped_resource.parent
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the Content block settings page. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #13499

#### Testing
1. Go to the assembly admin module
2. Edit an assembly
3. Go to the landing page
4. Add the "Related assemblies"
5. See the error
6. Apply patch
7. See the error is gone
8. 
:hearts: Thank you!
