### PR TITLE
Create a content block for open debates on the home of a space

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -238,6 +238,7 @@ ignore_unused:
   - decidim.participatory_processes.content_blocks.*.name
   - decidim.participatory_process_groups.content_blocks.*.name
   - decidim.assemblies.content_blocks.*.name
+  - decidim.debates.content_blocks.*.name
   - decidim.initiatives.content_blocks.*.name
   - decidim.meetings.content_blocks.*.name
   - decidim.blogs.content_blocks.*.name

--- a/decidim-assemblies/lib/decidim/assemblies/content_blocks/registry_manager.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/content_blocks/registry_manager.rb
@@ -111,11 +111,27 @@ module Decidim
             content_block.public_name_key = "decidim.application.photos.related_photos"
           end
 
+          register_highlighted_debates
           register_highlighted_meetings
           register_highlighted_posts
           register_highlighted_proposals
           register_highlighted_results
           register_related_processes
+        end
+
+        def self.register_highlighted_debates
+          return unless Decidim.module_installed?(:debates)
+
+          Decidim.content_blocks.register(:assembly_homepage, :highlighted_debates) do |content_block|
+            content_block.cell = "decidim/debates/content_blocks/highlighted_debates"
+            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_for_component_settings_form"
+            content_block.public_name_key = "decidim.debates.content_blocks.highlighted_debates.name"
+            content_block.component_manifest_name = "debates"
+
+            content_block.settings do |settings|
+              settings.attribute :component_id, type: :select, default: nil
+            end
+          end
         end
 
         def self.register_highlighted_meetings

--- a/decidim-assemblies/lib/decidim/assemblies/content_blocks/registry_manager.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/content_blocks/registry_manager.rb
@@ -124,13 +124,8 @@ module Decidim
 
           Decidim.content_blocks.register(:assembly_homepage, :highlighted_debates) do |content_block|
             content_block.cell = "decidim/debates/content_blocks/highlighted_debates"
-            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_for_component_settings_form"
             content_block.public_name_key = "decidim.debates.content_blocks.highlighted_debates.name"
             content_block.component_manifest_name = "debates"
-
-            content_block.settings do |settings|
-              settings.attribute :component_id, type: :select, default: nil
-            end
           end
         end
 

--- a/decidim-blogs/app/cells/decidim/blogs/content_blocks/highlighted_posts_cell.rb
+++ b/decidim-blogs/app/cells/decidim/blogs/content_blocks/highlighted_posts_cell.rb
@@ -4,9 +4,6 @@ module Decidim
   module Blogs
     module ContentBlocks
       class HighlightedPostsCell < Decidim::ContentBlocks::HighlightedElementsCell
-        include Decidim::ComponentPathHelper
-        include Decidim::CardHelper
-
         def show
           render unless posts_count.zero?
         end

--- a/decidim-core/app/cells/decidim/content_blocks/highlighted_elements_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/highlighted_elements_cell.rb
@@ -4,6 +4,8 @@ module Decidim
   module ContentBlocks
     class HighlightedElementsCell < BaseCell
       include Decidim::ContentBlocks::HasRelatedComponents
+      include Decidim::ComponentPathHelper
+      include Decidim::CardHelper
 
       def published_components
         @published_components ||= if model.settings.try(:component_id).present?

--- a/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates/content.erb
+++ b/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates/content.erb
@@ -1,0 +1,16 @@
+<div class="content-block__title">
+  <h2 class="h2 decorator"><%= single_component ? translated_attribute(single_component.name) : t("name", scope: "decidim.components.debates") %></h2>
+  <div class="label text-lg"><%= debates_count %></div>
+  <% if single_component %>
+    <%= link_to decidim_debates.root_path, class: "button button__sm button__text-secondary" do %>
+      <span><%= t("decidim.debates.content_blocks.highlighted_debates.see_all") %></span>
+      <%= icon "arrow-right-line" %>
+    <% end %>
+  <% end %>
+</div>
+
+<div class="participatory-space__block-grid">
+  <% debates_to_render.each do |debate| %>
+    <%= cell "decidim/debates/debate_g", debate %>
+  <% end %>
+</div>

--- a/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates/content.erb
+++ b/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates/content.erb
@@ -1,6 +1,6 @@
 <div class="content-block__title">
   <h2 class="h2 decorator"><%= single_component ? translated_attribute(single_component.name) : t("name", scope: "decidim.components.debates") %></h2>
-  <div class="label text-lg"><%= debates_count %></div>
+  <div class="label text-lg"><%= items_count %></div>
   <% if single_component %>
     <%= link_to decidim_debates.root_path, class: "button button__sm button__text-secondary" do %>
       <span><%= t("decidim.debates.content_blocks.highlighted_debates.see_all") %></span>

--- a/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates_cell.rb
@@ -5,7 +5,7 @@ module Decidim
     module ContentBlocks
       class HighlightedDebatesCell < Decidim::ContentBlocks::HighlightedElementsCell
         def show
-          render unless debates_count.zero?
+          render unless items_count.zero?
         end
 
         private
@@ -28,8 +28,8 @@ module Decidim
           @debates_to_render ||= debates.includes([:author, :component]).limit(limit)
         end
 
-        def debates_count
-          @debates_count ||= debates.size
+        def items_count
+          debates_to_render.size
         end
 
         def cache_hash
@@ -38,10 +38,6 @@ module Decidim
           hash << debates.cache_key_with_version
           hash << I18n.locale.to_s
           hash.join(Decidim.cache_key_separator)
-        end
-
-        def items_count
-          debates_count
         end
 
         def limit

--- a/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates_cell.rb
@@ -14,7 +14,7 @@ module Decidim
         private
 
         def debates
-          @debates ||= Decidim::Debates::Debate.open.where(component: published_components).created_at_desc
+          @debates ||= Decidim::Debates::Debate.open.where(component: published_components).updated_at_desc
         end
 
         def decidim_debates

--- a/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates_cell.rb
@@ -5,7 +5,7 @@ module Decidim
     module ContentBlocks
       class HighlightedDebatesCell < Decidim::ContentBlocks::HighlightedElementsCell
         def show
-          render unless items_count.zero?
+          render unless debates_count.zero?
         end
 
         private
@@ -41,6 +41,10 @@ module Decidim
         end
 
         def items_count
+          debates_count
+        end
+
+        def limit
           3
         end
       end

--- a/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates_cell.rb
@@ -5,7 +5,7 @@ module Decidim
     module ContentBlocks
       class HighlightedDebatesCell < Decidim::ContentBlocks::HighlightedElementsCell
         def show
-          render unless debates_count.zero?
+          render unless items_count.zero?
         end
 
         private
@@ -40,7 +40,7 @@ module Decidim
           hash.join(Decidim.cache_key_separator)
         end
 
-        def limit
+        def items_count
           3
         end
       end

--- a/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates_cell.rb
@@ -4,9 +4,6 @@ module Decidim
   module Debates
     module ContentBlocks
       class HighlightedDebatesCell < Decidim::ContentBlocks::HighlightedElementsCell
-        include Decidim::ComponentPathHelper
-        include Decidim::CardHelper
-
         def show
           render unless debates_count.zero?
         end

--- a/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/content_blocks/highlighted_debates_cell.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Debates
+    module ContentBlocks
+      class HighlightedDebatesCell < Decidim::ContentBlocks::HighlightedElementsCell
+        include Decidim::ComponentPathHelper
+        include Decidim::CardHelper
+
+        def show
+          render unless debates_count.zero?
+        end
+
+        private
+
+        def debates
+          @debates ||= Decidim::Debates::Debate.open.where(component: published_components).created_at_desc
+        end
+
+        def decidim_debates
+          return unless single_component
+
+          Decidim::EngineRouter.main_proxy(single_component)
+        end
+
+        def single_component
+          @single_component ||= published_components.one? ? published_components.first : nil
+        end
+
+        def debates_to_render
+          @debates_to_render ||= debates.includes([:author, :component]).limit(limit)
+        end
+
+        def debates_count
+          @debates_count ||= debates.size
+        end
+
+        def cache_hash
+          hash = []
+          hash << "decidim/debates/content_blocks/highlighted_debates"
+          hash << debates.cache_key_with_version
+          hash << I18n.locale.to_s
+          hash.join(Decidim.cache_key_separator)
+        end
+
+        def limit
+          3
+        end
+      end
+    end
+  end
+end

--- a/decidim-debates/app/cells/decidim/debates/debate_g/show.erb
+++ b/decidim-debates/app/cells/decidim/debates/debate_g/show.erb
@@ -1,0 +1,12 @@
+<%= link_to resource_path, class: classes[:default], id: resource_id do %>
+  <div class="<%= classes[:text] %>">
+    <%= content_tag title_tag, title, class: title_class %>
+    <%= description if show_description? %>
+
+    <% if metadata_cell.present? %>
+      <div class="<%= classes[:metadata] %>">
+        <%= cell metadata_cell, resource, links: false, **options %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/decidim-debates/app/cells/decidim/debates/debate_g_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/debate_g_cell.rb
@@ -5,7 +5,6 @@ module Decidim
     # This cell renders the Grid (:g) debate card
     # for a given instance of a Debate
     class DebateGCell < Decidim::CardGCell
-
       def show
         render
       end

--- a/decidim-debates/app/cells/decidim/debates/debate_g_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/debate_g_cell.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Debates
+    # This cell renders the Grid (:g) debate card
+    # for a given instance of a Debate
+    class DebateGCell < Decidim::CardGCell
+
+      def show
+        render
+      end
+
+      private
+
+      def show_description?
+        true
+      end
+
+      def metadata_cell
+        "decidim/debates/debate_metadata_g"
+      end
+    end
+  end
+end

--- a/decidim-debates/app/cells/decidim/debates/debate_metadata_g_cell.rb
+++ b/decidim-debates/app/cells/decidim/debates/debate_metadata_g_cell.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Debates
+    # This cell renders metadata for an instance of a Debate
+    class DebateMetadataGCell < Decidim::Debates::DebateCardMetadataCell
+      private
+
+      def debate_items
+        [author_item, comments_count_item]
+      end
+    end
+  end
+end

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -42,6 +42,7 @@ module Decidim
                         index_on_create: ->(debate) { debate.visible? },
                         index_on_update: ->(debate) { debate.visible? })
 
+      scope :created_at_desc, -> { order(arel_table[:created_at].desc) }
       scope :open, -> { where(closed_at: nil) }
       scope :closed, -> { where.not(closed_at: nil) }
       scope :authored_by, ->(author) { where(author:) }

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -42,7 +42,7 @@ module Decidim
                         index_on_create: ->(debate) { debate.visible? },
                         index_on_update: ->(debate) { debate.visible? })
 
-      scope :created_at_desc, -> { order(arel_table[:created_at].desc) }
+      scope :updated_at_desc, -> { order(arel_table[:updated_at].desc) }
       scope :open, -> { where(closed_at: nil) }
       scope :closed, -> { where.not(closed_at: nil) }
       scope :authored_by, ->(author) { where(author:) }

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -87,6 +87,10 @@ en:
           close: "%{user_name} closed the %{resource_name} debate on the %{space_name} space"
           create: "%{user_name} created the %{resource_name} debate on the %{space_name} space"
           update: "%{user_name} updated the %{resource_name} debate on the %{space_name} space"
+      content_blocks:
+        highlighted_debates:
+          name: Debates
+          see_all: See all debates
       debate_m:
         commented_time_ago: Commented %{time} ago
       debates:

--- a/decidim-debates/spec/cells/decidim/debates/content_blocks/highlighted_debates_cell_spec.rb
+++ b/decidim-debates/spec/cells/decidim/debates/content_blocks/highlighted_debates_cell_spec.rb
@@ -9,7 +9,7 @@ describe Decidim::Debates::ContentBlocks::HighlightedDebatesCell, type: :cell do
 
   let(:organization) { create(:organization) }
   let(:participatory_space) { create(:participatory_process, organization:) }
-  let(:component) { create(:debates_component, participatory_space:, manifest_name: "debates") }
+  let(:component) { create(:debates_component, participatory_space) }
   let(:manifest_name) { :highlighted_debates }
   let(:scope_name) { :participatory_process_homepage }
   let(:content_block) { create(:content_block, organization:, manifest_name:, scope_name:, scoped_resource_id: participatory_space.id) }

--- a/decidim-debates/spec/cells/decidim/debates/content_blocks/highlighted_debates_cell_spec.rb
+++ b/decidim-debates/spec/cells/decidim/debates/content_blocks/highlighted_debates_cell_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Debates::ContentBlocks::HighlightedDebatesCell, type: :cell do
+  subject { cell("decidim/debates/content_blocks/highlighted_debates", content_block).call }
+
+  controller Decidim::Debates::DebatesController
+
+  let(:organization) { create(:organization) }
+  let(:participatory_space) { create(:participatory_process, organization:) }
+  let(:component) { create(:debates_component, participatory_space:, manifest_name: "debates") }
+  let(:manifest_name) { :highlighted_debates }
+  let(:scope_name) { :participatory_process_homepage }
+  let(:content_block) { create(:content_block, organization:, manifest_name:, scope_name:, scoped_resource_id: participatory_space.id) }
+
+  context "with 1 open debate" do
+    let!(:debate) { create(:debate, title: { en: "Debate title" }, component:) }
+
+    it "renders the open debate" do
+      expect(subject).to have_content("Debate title")
+      expect(subject).to have_css(".card__grid", count: 1)
+    end
+  end
+
+  context "with 4 debates (3 open, 1 closed)" do
+    let!(:debate_old) { create(:debate, title: { en: "Old Debate" }, component:, created_at: 1.year.ago, updated_at: 1.year.ago, closed_at: nil) }
+    let!(:debate1) { create(:debate, title: { en: "Recent Debate 1" }, component:, created_at: 3.days.ago, updated_at: 3.days.ago) }
+    let!(:debate2) { create(:debate, title: { en: "Recent Debate 2" }, component:, created_at: 2.days.ago, updated_at: 2.days.ago) }
+    let!(:debate3) { create(:debate, title: { en: "Recent Debate 3" }, component:, created_at: 1.day.ago, updated_at: 1.day.ago) }
+    let!(:debate_closed) { create(:debate, title: { en: "Closed Debate" }, component:, closed_at: 1.day.ago) }
+
+    it "renders only 3 most recent open debates" do
+      expect(subject).to have_no_content("Closed Debate")
+
+      expect(subject).to have_no_content("Old Debate")
+
+      expect(subject).to have_css(".card__grid", count: 3)
+      expect(subject).to have_content("Recent Debate 1")
+      expect(subject).to have_content("Recent Debate 2")
+      expect(subject).to have_content("Recent Debate 3")
+    end
+  end
+
+  context "with no debates" do
+    it "renders nothing" do
+      expect(subject).to have_no_content("Debate title")
+      expect(subject).to have_no_css(".card__grid", count: 1)
+    end
+  end
+end

--- a/decidim-debates/spec/cells/decidim/debates/content_blocks/highlighted_debates_cell_spec.rb
+++ b/decidim-debates/spec/cells/decidim/debates/content_blocks/highlighted_debates_cell_spec.rb
@@ -9,7 +9,7 @@ describe Decidim::Debates::ContentBlocks::HighlightedDebatesCell, type: :cell do
 
   let(:organization) { create(:organization) }
   let(:participatory_space) { create(:participatory_process, organization:) }
-  let(:component) { create(:debates_component, participatory_space) }
+  let(:component) { create(:debates_component, participatory_space:) }
   let(:manifest_name) { :highlighted_debates }
   let(:scope_name) { :participatory_process_homepage }
   let(:content_block) { create(:content_block, organization:, manifest_name:, scope_name:, scoped_resource_id: participatory_space.id) }

--- a/decidim-debates/spec/cells/decidim/debates/debate_g_cell_spec.rb
+++ b/decidim-debates/spec/cells/decidim/debates/debate_g_cell_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Debates
+  describe DebateGCell, type: :cell do
+    controller Decidim::Debates::DebatesController
+
+    subject { cell_html }
+
+    let(:my_cell) { cell("decidim/debates/debate_g", debate) }
+    let(:cell_html) { my_cell.call }
+    let(:created_at) { 1.month.ago }
+    let(:component) { create(:debates_component) }
+    let!(:debate) { create(:debate, description: { en: "Description for test" }, component:, created_at:) }
+    let(:model) { debate }
+    let(:user) { create(:user, organization: debate.participatory_space.organization) }
+
+    before do
+      allow(controller).to receive(:current_user).and_return(user)
+    end
+
+    context "when rendering" do
+      it "renders the grid card" do
+        expect(subject).to have_css("[id^='debates__debate']")
+      end
+
+      it "renders the description" do
+        expect(subject).to have_content("Description for test")
+      end
+
+      it "renders the title" do
+        expect(subject).to have_content(translated_attribute(model.title))
+      end
+
+      context "when the description has a link" do
+        let!(:debate) { create(:debate, description:, component:, created_at:) }
+        let(:description) { { en: "This is a description with a link to <a href='http://example.org'>example.org</a>" } }
+
+        it "renders the description" do
+          expect(subject).to have_content("This is a description with a link to example.org")
+        end
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/content_blocks/registry_manager.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/content_blocks/registry_manager.rb
@@ -166,12 +166,12 @@ module Decidim
             end
           end
 
+          register_highlighted_debates
           register_highlighted_meetings
           register_highlighted_posts
           register_highlighted_proposals
           register_highlighted_results
           register_related_assemblies
-          register_highlighted_debates
         end
 
         def self.register_highlighted_debates
@@ -179,13 +179,8 @@ module Decidim
 
           Decidim.content_blocks.register(:participatory_process_homepage, :highlighted_debates) do |content_block|
             content_block.cell = "decidim/debates/content_blocks/highlighted_debates"
-            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_for_component_settings_form"
             content_block.public_name_key = "decidim.debates.content_blocks.highlighted_debates.name"
             content_block.component_manifest_name = "debates"
-
-            content_block.settings do |settings|
-              settings.attribute :component_id, type: :select, default: nil
-            end
           end
         end
 

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/content_blocks/registry_manager.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/content_blocks/registry_manager.rb
@@ -171,6 +171,22 @@ module Decidim
           register_highlighted_proposals
           register_highlighted_results
           register_related_assemblies
+          register_highlighted_debates
+        end
+
+        def self.register_highlighted_debates
+          return unless Decidim.module_installed?(:debates)
+
+          Decidim.content_blocks.register(:participatory_process_homepage, :highlighted_debates) do |content_block|
+            content_block.cell = "decidim/debates/content_blocks/highlighted_debates"
+            content_block.settings_form_cell = "decidim/content_blocks/highlighted_elements_for_component_settings_form"
+            content_block.public_name_key = "decidim.debates.content_blocks.highlighted_debates.name"
+            content_block.component_manifest_name = "debates"
+
+            content_block.settings do |settings|
+              settings.attribute :component_id, type: :select, default: nil
+            end
+          end
         end
 
         def self.register_highlighted_meetings


### PR DESCRIPTION
#### :tophat: What? Why?
This pull request introduces a new content block that allows administrators to highlight a maximum of 3 open debates on the homepage of a participation space.

The content block will:
- Display titles, descriptions, and a link to view the full debate.
- Only show open debates (debates without a `closed_at` value).
- Automatically hide if there are no open debates to display.

#### :pushpin: Related Issues
- Fixes #13478

#### Testing
To test this feature:
1. As an admin, go to the landing page configuration of a participation space.
2. Add the new "Debates" content block to the page.
3. Ensure that up to 3 open debates are displayed with titles, descriptions, and links to the full debate.
4. Verify that closed debates are not displayed.
5. Check that the block hides if there are no open debates.

### :camera: Screenshots
<img width="600" alt="2024-10-09 в 15 01 17" src="https://github.com/user-attachments/assets/d13d858f-27b2-47eb-8167-acb40a4d507e">
<img width="600" alt="2024-10-09 в 15 02 15" src="https://github.com/user-attachments/assets/60954273-0910-4673-8abc-e5efd51ca7c4">

:hearts: Thank you!

