### PR TITLE
Add authorization to GraphQL 

### DIFF
--- a/decidim-accountability/lib/decidim/api/result_type.rb
+++ b/decidim-accountability/lib/decidim/api/result_type.rb
@@ -26,6 +26,17 @@ module Decidim
       field :parent, Decidim::Accountability::ResultType, "The parent result", null: true
       field :status, Decidim::Accountability::StatusType, "The status for this result", null: true
       field :timeline_entries, [Decidim::Accountability::TimelineEntryType, { null: true }], "The timeline entries for this result", null: true
+
+      def self.authorized?(object, context)
+        context[:debate] = object
+
+        chain = [
+          allowed_to?(:read, :participatory_space, object, context),
+          allowed_to?(:read, :component, object, context)
+        ].all?
+
+        super && chain
+      end
     end
   end
 end

--- a/decidim-accountability/spec/types/integration_schema_spec.rb
+++ b/decidim-accountability/spec/types/integration_schema_spec.rb
@@ -82,6 +82,24 @@ describe "Decidim::Api::QueryType" do
     }
   end
 
+  describe "commentable" do
+    let(:participatory_process_query) do
+      %(
+        commentable(id: "#{result.id}", type: "Decidim::Accountability::Result", locale: "en", toggleTranslations: false) {
+          __typename
+        }
+      )
+    end
+
+    it "executes successfully" do
+      expect { response }.not_to raise_error
+    end
+
+    it do
+      expect(response).to eq({ "commentable" => { "__typename" => "Result" } })
+    end
+  end
+
   describe "valid connection query" do
     let(:component_fragment) do
       %(

--- a/decidim-accountability/spec/types/result_type_spec.rb
+++ b/decidim-accountability/spec/types/result_type_spec.rb
@@ -83,6 +83,38 @@ module Decidim
           expect(response["updatedAt"]).to eq(model.updated_at.to_time.iso8601)
         end
       end
+
+      context "when participatory space is private" do
+        let(:participatory_space) { create(:participatory_process, :with_steps, :private, organization: current_organization) }
+        let(:current_component) { create(:accountability_component, participatory_space:) }
+        let(:model) { create(:result, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when participatory space is not published" do
+        let(:participatory_space) { create(:participatory_process, :with_steps, :unpublished, organization: current_organization) }
+        let(:current_component) { create(:accountability_component, participatory_space:) }
+        let(:model) { create(:result, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when component is not published" do
+        let(:current_component) { create(:accountability_component, :unpublished, organization: current_organization) }
+        let(:model) { create(:result, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
     end
   end
 end

--- a/decidim-api/lib/decidim/api/types/base_object.rb
+++ b/decidim-api/lib/decidim/api/types/base_object.rb
@@ -6,25 +6,55 @@ module Decidim
       class BaseObject < GraphQL::Schema::Object
         field_class Types::BaseField
 
+        # This is a simplified adaptation of allowed_to? from NeedsPermission coneern
+        # @param action [Symbol] The action performed. Most cases the action is :read
+        # @param subject [Symbol] The name of the subject. Ex: :participatory_space, :component
+        # @param object [ActiveModel::Base] The object that is being represented.
+        # @param context [GraphQL::Query::Context] The GraphQL context
+        #
+        # @return Boolean
         def self.allowed_to?(action, subject, object, context)
-          chain = [
-            object.component.manifest.permissions_class,
-            object.participatory_space.manifest.permissions_class,
+          permission_action = Decidim::PermissionAction.new(scope: :public, action:, subject:)
+
+          permission_chain(object).inject(permission_action) do |current_permission_action, permission_class|
+            permission_class.new(
+              context[:current_user],
+              current_permission_action,
+              local_context(object, context)
+            ).permissions
+          end.allowed?
+          # rescue Decidim::PermissionAction::PermissionNotSetError
+          #   false
+        end
+
+        # Injects into context object current_participatory_space and current_component keys as they are needed
+        #
+        # @param object [ActiveModel::Base] The object that is being represented.
+        # @param context [GraphQL::Query::Context] The GraphQL context
+        #
+        # @return Hash
+        def self.local_context(object, context)
+          context[:current_participatory_space] = object.participatory_space if object.respond_to?(:participatory_space)
+          context[:current_component] = object.component if object.respond_to?(:component)
+
+          context.to_h
+        end
+
+        # Creates the permission chain arrau that contains all the permission classes required to authorize a certain resource
+        # We are using unshift as we need the Admin and base permissions to be last in the chain
+        # @param object [ActiveModel::Base] The object that is being represented.
+        #
+        # @return [Decidim::DefaultPermissions]
+        def self.permission_chain(object)
+          permissions = [
             Decidim::Admin::Permissions,
             Decidim::Permissions
           ]
 
-          local_context = context.to_h
-          local_context.merge!({ current_participatory_space: object.try(:participatory_space) })
-          local_context.merge!({ current_component: object.try(:component) })
+          permissions.unshift(object.participatory_space.manifest.permissions_class) if object.respond_to?(:participatory_space)
+          permissions.unshift(object.component.manifest.permissions_class) if object.respond_to?(:component)
 
-          permission_action = Decidim::PermissionAction.new(scope: :public, action:, subject:)
-
-          chain.inject(permission_action) do |current_permission_action, permission_class|
-            permission_class.new(context[:current_user], current_permission_action, local_context).permissions
-          end.allowed?
-        # rescue Decidim::PermissionAction::PermissionNotSetError
-        #   false
+          permissions
         end
       end
     end

--- a/decidim-api/lib/decidim/api/types/base_object.rb
+++ b/decidim-api/lib/decidim/api/types/base_object.rb
@@ -5,6 +5,27 @@ module Decidim
     module Types
       class BaseObject < GraphQL::Schema::Object
         field_class Types::BaseField
+
+        def self.allowed_to?(action, subject, object, context)
+          chain = [
+            object.component.manifest.permissions_class,
+            object.participatory_space.manifest.permissions_class,
+            Decidim::Admin::Permissions,
+            Decidim::Permissions
+          ]
+
+          local_context = context.to_h
+          local_context.merge!({ current_participatory_space: object.try(:participatory_space) })
+          local_context.merge!({ current_component: object.try(:component) })
+
+          permission_action = Decidim::PermissionAction.new(scope: :public, action:, subject:)
+
+          chain.inject(permission_action) do |current_permission_action, permission_class|
+            permission_class.new(context[:current_user], current_permission_action, local_context).permissions
+          end.allowed?
+        # rescue Decidim::PermissionAction::PermissionNotSetError
+        #   false
+        end
       end
     end
   end

--- a/decidim-api/lib/decidim/api/types/base_object.rb
+++ b/decidim-api/lib/decidim/api/types/base_object.rb
@@ -6,7 +6,7 @@ module Decidim
       class BaseObject < GraphQL::Schema::Object
         field_class Types::BaseField
 
-        # This is a simplified adaptation of allowed_to? from NeedsPermission coneern
+        # This is a simplified adaptation of allowed_to? from NeedsPermission concern
         # @param action [Symbol] The action performed. Most cases the action is :read
         # @param subject [Symbol] The name of the subject. Ex: :participatory_space, :component
         # @param object [ActiveModel::Base] The object that is being represented.

--- a/decidim-blogs/lib/decidim/api/post_type.rb
+++ b/decidim-blogs/lib/decidim/api/post_type.rb
@@ -17,6 +17,19 @@ module Decidim
       field :title, Decidim::Core::TranslatedFieldType, "The title for this post", null: true
       field :body, Decidim::Core::TranslatedFieldType, "The body of this post", null: true
       field :published_at, Decidim::Core::DateTimeType, "The time this page was published", null: false
+
+      def self.authorized?(object, context)
+        context[:post] = object
+
+        chain = [
+          allowed_to?(:read, :participatory_space, object, context),
+          allowed_to?(:read, :component, object, context),
+          allowed_to?(:read, :blogpost, object, context),
+          !object.hidden?
+        ].all?
+
+        super && chain
+      end
     end
   end
 end

--- a/decidim-blogs/lib/decidim/blogs/test/factories.rb
+++ b/decidim-blogs/lib/decidim/blogs/test/factories.rb
@@ -52,5 +52,11 @@ FactoryBot.define do
         end
       end
     end
+
+    trait :hidden do
+      after :create do |post, evaluator|
+        create(:moderation, hidden_at: Time.current, reportable: post, skip_injection: evaluator.skip_injection)
+      end
+    end
   end
 end

--- a/decidim-blogs/spec/types/integration_schema_spec.rb
+++ b/decidim-blogs/spec/types/integration_schema_spec.rb
@@ -68,6 +68,24 @@ describe "Decidim::Api::QueryType" do
     }
   end
 
+  describe "commentable" do
+    let(:participatory_process_query) do
+      %(
+        commentable(id: "#{post.id}", type: "Decidim::Blogs::Post", locale: "en", toggleTranslations: false) {
+          __typename
+        }
+      )
+    end
+
+    it "executes successfully" do
+      expect { response }.not_to raise_error
+    end
+
+    it do
+      expect(response).to eq({ "commentable" => { "__typename" => "Post" } })
+    end
+  end
+
   describe "valid connection query" do
     let(:component_fragment) do
       %(

--- a/decidim-blogs/spec/types/post_type_spec.rb
+++ b/decidim-blogs/spec/types/post_type_spec.rb
@@ -44,6 +44,58 @@ module Decidim
           expect(response["body"]["translation"]).to eq(model.body["en"])
         end
       end
+
+      context "when participatory space is private" do
+        let(:participatory_space) { create(:participatory_process, :with_steps, :private, organization: current_organization) }
+        let(:current_component) { create(:post_component, participatory_space:) }
+        let(:model) { create(:post, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when participatory space is not published" do
+        let(:participatory_space) { create(:participatory_process, :with_steps, :unpublished, organization: current_organization) }
+        let(:current_component) { create(:post_component, participatory_space:) }
+        let(:model) { create(:post, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when component is not published" do
+        let(:current_component) { create(:post_component, :unpublished, organization: current_organization) }
+        let(:model) { create(:post, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when is moderated" do
+        let(:model) { create(:post, :hidden) }
+        let(:query) { "{ id }" }
+        let(:root_value) { model.reload }
+
+        it "returns all the required fields" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when post is not published" do
+        let(:current_component) { create(:post_component, :unpublished, organization: current_organization) }
+        let(:model) { create(:post, published_at: nil, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
     end
   end
 end

--- a/decidim-budgets/app/permissions/decidim/budgets/permissions.rb
+++ b/decidim-budgets/app/permissions/decidim/budgets/permissions.rb
@@ -18,6 +18,8 @@ module Decidim
             can_vote?(false) if can_vote_project?(project || order&.projects&.first)
           when :report
             permission_action.allow!
+          when :read
+            toggle_allow(project.visible?)
           end
         end
 

--- a/decidim-budgets/lib/decidim/api/project_type.rb
+++ b/decidim-budgets/lib/decidim/api/project_type.rb
@@ -18,6 +18,19 @@ module Decidim
       field :created_at, Decidim::Core::DateTimeType, "When this project was created", null: true
       field :updated_at, Decidim::Core::DateTimeType, "When this project was updated", null: true
       field :reference, GraphQL::Types::String, "The reference for this project", null: true
+
+      def self.authorized?(object, context)
+        context[:project] = object
+
+        chain = [
+          allowed_to?(:read, :participatory_space, object, context),
+          allowed_to?(:read, :component, object, context),
+          allowed_to?(:read, :project, object, context),
+          object.visible?
+        ].all?
+
+        super && chain
+      end
     end
   end
 end

--- a/decidim-budgets/spec/types/integration_schema_spec.rb
+++ b/decidim-budgets/spec/types/integration_schema_spec.rb
@@ -64,6 +64,24 @@ describe "Decidim::Api::QueryType" do
     }
   end
 
+  describe "commentable" do
+    let(:participatory_process_query) do
+      %(
+        commentable(id: "#{projects.first.id}", type: "Decidim::Budgets::Project", locale: "en", toggleTranslations: false) {
+          __typename
+        }
+      )
+    end
+
+    it "executes successfully" do
+      expect { response }.not_to raise_error
+    end
+
+    it do
+      expect(response).to eq({ "commentable" => { "__typename" => "Project" } })
+    end
+  end
+
   describe "valid connection query" do
     let(:budget_single_result) do
       {

--- a/decidim-budgets/spec/types/project_type_spec.rb
+++ b/decidim-budgets/spec/types/project_type_spec.rb
@@ -91,7 +91,6 @@ module Decidim
         end
       end
 
-
       context "when participatory space is private" do
         let(:participatory_space) { create(:participatory_process, :with_steps, :private, organization: current_organization) }
         let(:current_component) { create(:budgets_component, participatory_space:) }

--- a/decidim-budgets/spec/types/project_type_spec.rb
+++ b/decidim-budgets/spec/types/project_type_spec.rb
@@ -90,6 +90,54 @@ module Decidim
           expect(response["reference"]).to eq(model.reference)
         end
       end
+
+
+      context "when participatory space is private" do
+        let(:participatory_space) { create(:participatory_process, :with_steps, :private, organization: current_organization) }
+        let(:current_component) { create(:budgets_component, participatory_space:) }
+        let(:budget) { create(:budget, component: current_component) }
+        let(:model) { create(:project, budget:) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when participatory space is not published" do
+        let(:participatory_space) { create(:participatory_process, :with_steps, :unpublished, organization: current_organization) }
+        let(:current_component) { create(:budgets_component, participatory_space:) }
+        let(:budget) { create(:budget, component: current_component) }
+        let(:model) { create(:project, budget:) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when component is not published" do
+        let(:current_component) { create(:budgets_component, :unpublished, organization: current_organization) }
+        let(:model) { create(:project, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when is budget is not visible" do
+        let(:current_component) { create(:budgets_component, organization: current_organization) }
+        let(:budget) { create(:budget, component: current_component) }
+        let(:model) { create(:project, budget:) }
+        let(:query) { "{ id }" }
+        let(:root_value) { model.reload }
+
+        it "returns all the required fields" do
+          allow(model).to receive(:visible?).and_return(false)
+          expect(response).to be_nil
+        end
+      end
     end
   end
 end

--- a/decidim-comments/lib/decidim/api/commentable_interface.rb
+++ b/decidim-comments/lib/decidim/api/commentable_interface.rb
@@ -45,6 +45,21 @@ module Decidim
       def user_allowed_to_comment
         object.commentable? && object.user_allowed_to_comment?(context[:current_user])
       end
+
+      definition_methods do
+        def resolve_type(object, _context)
+          GraphQL::Types.const_get("#{object.class.name}Type")
+        end
+
+        def self.authorized?(object, context)
+          super && (
+            !object.hidden? && object.component.published? && object.participatory_space.published? &&
+              (!object.participatory_space.private_space? || (object.participatory_space.private_space? && object.participatory_space.try(:is_transparent?)) )
+          )
+        end
+
+      end
+
     end
   end
 end

--- a/decidim-comments/lib/decidim/api/commentable_interface.rb
+++ b/decidim-comments/lib/decidim/api/commentable_interface.rb
@@ -50,16 +50,7 @@ module Decidim
         def resolve_type(object, _context)
           GraphQL::Types.const_get("#{object.class.name}Type")
         end
-
-        def self.authorized?(object, context)
-          super && (
-            !object.hidden? && object.component.published? && object.participatory_space.published? &&
-              (!object.participatory_space.private_space? || (object.participatory_space.private_space? && object.participatory_space.try(:is_transparent?)) )
-          )
-        end
-
       end
-
     end
   end
 end

--- a/decidim-comments/lib/decidim/comments/query_extensions.rb
+++ b/decidim-comments/lib/decidim/comments/query_extensions.rb
@@ -11,7 +11,7 @@ module Decidim
       #
       # Returns nothing.
       def self.included(type)
-        type.field :commentable, CommentableType, null: false do
+        type.field :commentable, Decidim::Comments::CommentableInterface do
           argument :id, GraphQL::Types::String, "The commentable's ID", required: true
           argument :type, GraphQL::Types::String, "The commentable's class name. i.e. `Decidim::ParticipatoryProcess`", required: true
           argument :locale, GraphQL::Types::String, "The locale for which to get the comments text", required: true

--- a/decidim-debates/app/permissions/decidim/debates/permissions.rb
+++ b/decidim-debates/app/permissions/decidim/debates/permissions.rb
@@ -13,6 +13,8 @@ module Decidim
         case permission_action.action
         when :create
           toggle_allow(can_create_debate?)
+        when :read
+          toggle_allow(!debate.hidden?)
         when :report
           allow!
         when :edit

--- a/decidim-debates/lib/decidim/api/debate_type.rb
+++ b/decidim-debates/lib/decidim/api/debate_type.rb
@@ -28,7 +28,7 @@ module Decidim
         chain = [
           allowed_to?(:read, :participatory_space, object, context),
           allowed_to?(:read, :component, object, context),
-          allowed_to?(:read, :debate, object, context),
+          allowed_to?(:read, :debate, object, context)
         ].all?
 
         super && chain

--- a/decidim-debates/lib/decidim/api/debate_type.rb
+++ b/decidim-debates/lib/decidim/api/debate_type.rb
@@ -21,6 +21,18 @@ module Decidim
       field :updated_at, Decidim::Core::DateTimeType, "When this debate was updated", null: true
       field :information_updates, Decidim::Core::TranslatedFieldType, "The information updates for this debate", null: true
       field :reference, GraphQL::Types::String, "The reference for this debate", null: true
+
+      def self.authorized?(object, context)
+        context[:debate] = object
+
+        chain = [
+          allowed_to?(:read, :participatory_space, object, context),
+          allowed_to?(:read, :component, object, context),
+          allowed_to?(:read, :debate, object, context),
+        ].all?
+
+        super && chain
+      end
     end
   end
 end

--- a/decidim-debates/lib/decidim/debates/test/factories.rb
+++ b/decidim-debates/lib/decidim/debates/test/factories.rb
@@ -46,6 +46,12 @@ FactoryBot.define do
       end
     end
 
+    trait :hidden do
+      after :create do |debate, evaluator|
+        create(:moderation, hidden_at: Time.current, reportable: debate, skip_injection: evaluator.skip_injection)
+      end
+    end
+
     trait :closed do
       closed_at { Time.current }
       conclusions { generate_localized_description(:debate_conclusions, skip_injection:) }

--- a/decidim-debates/spec/types/debate_type_spec.rb
+++ b/decidim-debates/spec/types/debate_type_spec.rb
@@ -97,6 +97,48 @@ module Decidim
           expect(response).to include("reference" => model.reference.to_s)
         end
       end
+
+      context "when participatory space is private" do
+        let(:participatory_space) { create(:participatory_process, :with_steps, :private, organization: current_organization) }
+        let(:current_component) { create(:debates_component, participatory_space:) }
+        let(:model) { create(:debate, :open_ama, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when participatory space is not published" do
+        let(:participatory_space) { create(:participatory_process, :with_steps, :unpublished, organization: current_organization) }
+        let(:current_component) { create(:debates_component, participatory_space:) }
+        let(:model) { create(:debate, :open_ama, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when component is not published" do
+        let(:current_component) { create(:debates_component, :unpublished, organization: current_organization) }
+        let(:model) { create(:debate, :open_ama, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when is moderated" do
+        let(:model) { create(:debate, :open_ama, :hidden) }
+        let(:query) { "{ id }" }
+        let(:root_value) { model.reload }
+
+        it "returns all the required fields" do
+          expect(response).to be_nil
+        end
+      end
     end
   end
 end

--- a/decidim-debates/spec/types/integration_schema_spec.rb
+++ b/decidim-debates/spec/types/integration_schema_spec.rb
@@ -53,6 +53,24 @@ describe "Decidim::Api::QueryType" do
     }
   end
 
+  describe "commentable" do
+    let(:participatory_process_query) do
+      %(
+        commentable(id: "#{debate.id}", type: "Decidim::Debates::Debate", locale: "en", toggleTranslations: false) {
+          __typename
+        }
+      )
+    end
+
+    it "executes successfully" do
+      expect { response }.not_to raise_error
+    end
+
+    it do
+      expect(response).to eq({ "commentable" => { "__typename" => "Debate" } })
+    end
+  end
+
   describe "valid connection query" do
     let(:component_fragment) do
       %(

--- a/decidim-forms/spec/types/questionnaire_type_spec.rb
+++ b/decidim-forms/spec/types/questionnaire_type_spec.rb
@@ -54,7 +54,7 @@ module Decidim
 
       describe "forEntity" do
         let(:query) { "{ forEntity { id } }" }
-        let(:meeting) { create(:meeting) }
+        let(:meeting) { create(:meeting, :published) }
 
         before do
           model.update(questionnaire_for: meeting)

--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -4,6 +4,8 @@ module Decidim
   module Initiatives
     class Permissions < Decidim::DefaultPermissions
       def permissions
+        return permission_action if initiative && !initiative.is_a?(Decidim::Initiative)
+
         # Delegate the admin permission checks to the admin permissions class
         return Decidim::Initiatives::Admin::Permissions.new(user, permission_action, context).permissions if permission_action.scope == :admin
         return permission_action if permission_action.scope != :public

--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -41,6 +41,8 @@ module Decidim
             toggle_allow(can_register_invitation_meeting?)
           when :reply_poll
             toggle_allow(can_reply_poll?)
+          when :read
+            toggle_allow(!meeting.hidden?)
           end
         when :poll
           case permission_action.action

--- a/decidim-meetings/lib/decidim/api/meeting_type.rb
+++ b/decidim-meetings/lib/decidim/api/meeting_type.rb
@@ -77,6 +77,21 @@ module Decidim
       field :type_of_meeting, GraphQL::Types::String, "The type of the meeting (online or in-person)", null: false
       field :online_meeting_url, GraphQL::Types::String, "The URL of the meeting (when the type is online)", null: false
       field :iframe_embed_type, GraphQL::Types::String, "The type of displaying of the online meeting URL", null: true
+
+
+      def self.authorized?(object, context)
+        context[:meeting] = object
+
+        chain = [
+          allowed_to?(:read, :participatory_space, object, context),
+          allowed_to?(:read, :component, object, context),
+          allowed_to?(:read, :meeting, object, context),
+          object.published?,
+          object.current_user_can_visit_meeting?(context[:current_user]),
+        ].all?
+
+        super && chain
+      end
     end
   end
 end

--- a/decidim-meetings/lib/decidim/api/meeting_type.rb
+++ b/decidim-meetings/lib/decidim/api/meeting_type.rb
@@ -78,7 +78,6 @@ module Decidim
       field :online_meeting_url, GraphQL::Types::String, "The URL of the meeting (when the type is online)", null: false
       field :iframe_embed_type, GraphQL::Types::String, "The type of displaying of the online meeting URL", null: true
 
-
       def self.authorized?(object, context)
         context[:meeting] = object
 
@@ -87,7 +86,7 @@ module Decidim
           allowed_to?(:read, :component, object, context),
           allowed_to?(:read, :meeting, object, context),
           object.published?,
-          object.current_user_can_visit_meeting?(context[:current_user]),
+          object.current_user_can_visit_meeting?(context[:current_user])
         ].all?
 
         super && chain

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -64,6 +64,12 @@ FactoryBot.define do
       type_of_meeting { :in_person }
     end
 
+    trait :hidden do
+      after :create do |meeting, evaluator|
+        create(:moderation, hidden_at: Time.current, reportable: meeting, skip_injection: evaluator.skip_injection)
+      end
+    end
+
     trait :online do
       type_of_meeting { :online }
       online_meeting_url { "https://decidim.org" }

--- a/decidim-meetings/spec/types/integration_schema_spec.rb
+++ b/decidim-meetings/spec/types/integration_schema_spec.rb
@@ -84,6 +84,24 @@ describe "Decidim::Api::QueryType" do
     }
   end
 
+  describe "commentable" do
+    let(:participatory_process_query) do
+      %(
+        commentable(id: "#{meeting.id}", type: "Decidim::Meetings::Meeting", locale: "en", toggleTranslations: false) {
+          __typename
+        }
+      )
+    end
+
+    it "executes successfully" do
+      expect { response }.not_to raise_error
+    end
+
+    it do
+      expect(response).to eq({ "commentable" => { "__typename" => "Meeting" } })
+    end
+  end
+
   describe "valid connection query" do
     let(:component_fragment) do
       %(

--- a/decidim-meetings/spec/types/meeting_type_spec.rb
+++ b/decidim-meetings/spec/types/meeting_type_spec.rb
@@ -331,12 +331,13 @@ module Decidim
       end
 
       context "when is private but transparent" do
-        let(:model) { create(:meeting, private_meeting: true, transparent: true) }
+        let(:model) { create(:meeting, :not_official, :published, private_meeting: true, transparent: true) }
+        let(:current_user) { model.author }
         let(:query) { "{ id }" }
         let(:root_value) { model.reload }
 
         it "returns all the required fields" do
-          expect(response).to be_nil
+          expect(response["id"]).to eq(model.id.to_s)
         end
       end
 

--- a/decidim-meetings/spec/types/meeting_type_spec.rb
+++ b/decidim-meetings/spec/types/meeting_type_spec.rb
@@ -7,15 +7,16 @@ require "decidim/core/test/shared_examples/scopable_interface_examples"
 require "decidim/core/test/shared_examples/attachable_interface_examples"
 require "decidim/core/test/shared_examples/authorable_interface_examples"
 require "decidim/core/test/shared_examples/timestamps_interface_examples"
-require "shared/services_interface_examples"
-require "shared/linked_resources_interface_examples"
+require_relative "../shared/services_interface_examples"
+require_relative "../shared/linked_resources_interface_examples"
 
 module Decidim
   module Meetings
     describe MeetingType, type: :graphql do
       include_context "with a graphql class type"
-      let(:component) { create(:meeting_component) }
-      let(:model) { create(:meeting, component:) }
+      let(:current_component) { create(:meeting_component) }
+      let(:component) { current_component }
+      let(:model) { create(:meeting, :published, component: ) }
 
       include_examples "authorable interface"
       include_examples "categorizable interface"
@@ -77,7 +78,7 @@ module Decidim
         let(:query) { "{ isWithdrawn }" }
 
         context "when meetings is withdrawn" do
-          let(:model) { create(:meeting, :withdrawn, component:) }
+          let(:model) { create(:meeting, :published, :withdrawn, component:) }
 
           it "returns true" do
             expect(response["isWithdrawn"]).to be true
@@ -85,7 +86,7 @@ module Decidim
         end
 
         context "when meetings is not withdrawn" do
-          let(:model) { create(:meeting, component:) }
+          let(:model) { create(:meeting, :published, component:) }
 
           it "returns false" do
             expect(response["isWithdrawn"]).to be false
@@ -97,7 +98,7 @@ module Decidim
         let(:query) { "{ closed closingReport { translation(locale: \"ca\") } }" }
 
         context "when closed" do
-          let(:model) { create(:meeting, :closed, component:) }
+          let(:model) { create(:meeting, :published, :closed, component:) }
 
           it "returns true" do
             expect(response["closed"]).to be true
@@ -110,7 +111,7 @@ module Decidim
         end
 
         context "when closed with minutes" do
-          let(:model) { create(:meeting, :closed_with_minutes, closing_visible:, component:) }
+          let(:model) { create(:meeting, :published, :closed_with_minutes, closing_visible:, component:) }
           let(:query) { "{ closed closingReport { translation(locale: \"ca\") } }" }
 
           context "and closing_visible is true" do
@@ -140,7 +141,7 @@ module Decidim
         end
 
         context "when open" do
-          let(:model) { create(:meeting, component:) }
+          let(:model) { create(:meeting, :published, component:) }
 
           it "returns false" do
             expect(response["closed"]).to be false
@@ -168,7 +169,7 @@ module Decidim
       end
 
       context "with registrations open" do
-        let(:model) { create(:meeting, :with_registrations_enabled, component:) }
+        let(:model) { create(:meeting, :published, :with_registrations_enabled, component:) }
 
         describe "registrationsEnabled" do
           let(:query) { "{ registrationsEnabled }" }
@@ -271,11 +272,8 @@ module Decidim
       end
 
       context "when meeting is private" do
+        let(:model) { create(:meeting, :published, :not_official, :with_registrations_enabled, component:, private_meeting: true, transparent: true) }
         let(:query) { "{ privateMeeting }" }
-
-        before do
-          model.update(private_meeting: true, transparent: false)
-        end
 
         it "returns true" do
           expect(response["privateMeeting"]).to be true
@@ -287,6 +285,78 @@ module Decidim
 
         it "returns true" do
           expect(response["transparent"]).to be true
+        end
+      end
+
+
+      context "when participatory space is private" do
+        let(:participatory_space) { create(:participatory_process, :with_steps, :private, organization: current_organization) }
+        let(:current_component) { create(:meeting_component, participatory_space:) }
+        let(:model) { create(:meeting, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when participatory space is not published" do
+        let(:participatory_space) { create(:participatory_process, :with_steps, :unpublished, organization: current_organization) }
+        let(:current_component) { create(:meeting_component, participatory_space:) }
+        let(:model) { create(:meeting, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when component is not published" do
+        let(:current_component) { create(:meeting_component, :unpublished, organization: current_organization) }
+        let(:model) { create(:meeting, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when is moderated" do
+        let(:model) { create(:meeting, :hidden) }
+        let(:query) { "{ id }" }
+        let(:root_value) { model.reload }
+
+        it "returns all the required fields" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when is private but transparent" do
+        let(:model) { create(:meeting, private_meeting: true) }
+        let(:query) { "{ id }" }
+        let(:root_value) { model.reload }
+
+        it "returns all the required fields" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when is private" do
+        let(:model) { create(:meeting, private_meeting: true) }
+        let(:query) { "{ id }" }
+        let(:root_value) { model.reload }
+
+        it "returns all the required fields" do
+          expect(response).to be_nil
+        end
+      end
+      context "when is not published" do
+        let(:model) { create(:meeting, published_at: nil) }
+        let(:query) { "{ id }" }
+        let(:root_value) { model.reload }
+
+        it "returns all the required fields" do
+          expect(response).to be_nil
         end
       end
     end

--- a/decidim-meetings/spec/types/meeting_type_spec.rb
+++ b/decidim-meetings/spec/types/meeting_type_spec.rb
@@ -16,7 +16,7 @@ module Decidim
       include_context "with a graphql class type"
       let(:current_component) { create(:meeting_component) }
       let(:component) { current_component }
-      let(:model) { create(:meeting, :published, component: ) }
+      let(:model) { create(:meeting, :published, component:) }
 
       include_examples "authorable interface"
       include_examples "categorizable interface"
@@ -288,7 +288,6 @@ module Decidim
         end
       end
 
-
       context "when participatory space is private" do
         let(:participatory_space) { create(:participatory_process, :with_steps, :private, organization: current_organization) }
         let(:current_component) { create(:meeting_component, participatory_space:) }
@@ -332,7 +331,7 @@ module Decidim
       end
 
       context "when is private but transparent" do
-        let(:model) { create(:meeting, private_meeting: true) }
+        let(:model) { create(:meeting, private_meeting: true, transparent: true) }
         let(:query) { "{ id }" }
         let(:root_value) { model.reload }
 
@@ -350,6 +349,7 @@ module Decidim
           expect(response).to be_nil
         end
       end
+
       context "when is not published" do
         let(:model) { create(:meeting, published_at: nil) }
         let(:query) { "{ id }" }

--- a/decidim-proposals/app/permissions/decidim/proposals/permissions.rb
+++ b/decidim-proposals/app/permissions/decidim/proposals/permissions.rb
@@ -12,7 +12,11 @@ module Decidim
 
         case permission_action.subject
         when :proposal
-          apply_proposal_permissions(permission_action)
+          if permission_action.action == :read
+            toggle_allow(!proposal.hidden?)
+          else
+            apply_proposal_permissions(permission_action)
+          end
         when :collaborative_draft
           apply_collaborative_draft_permissions(permission_action)
         when :proposal_coauthor_invites

--- a/decidim-proposals/lib/decidim/api/proposal_type.rb
+++ b/decidim-proposals/lib/decidim/api/proposal_type.rb
@@ -55,6 +55,20 @@ module Decidim
         current_component = object.component
         object.proposal_votes_count unless current_component.current_settings.votes_hidden?
       end
+
+      def self.authorized?(object, context)
+        context[:proposal] = object
+
+        chain = [
+          allowed_to?(:read, :participatory_space, object, context),
+          allowed_to?(:read, :component, object, context),
+          allowed_to?(:read, :proposal, object, context),
+          object.published?,
+        ].all?
+
+        super && chain
+      end
+
     end
   end
 end

--- a/decidim-proposals/lib/decidim/api/proposal_type.rb
+++ b/decidim-proposals/lib/decidim/api/proposal_type.rb
@@ -63,12 +63,11 @@ module Decidim
           allowed_to?(:read, :participatory_space, object, context),
           allowed_to?(:read, :component, object, context),
           allowed_to?(:read, :proposal, object, context),
-          object.published?,
+          object.published?
         ].all?
 
         super && chain
       end
-
     end
   end
 end

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -380,8 +380,8 @@ FactoryBot.define do
     trait :official_meeting do
       after :build do |proposal, evaluator|
         proposal.coauthorships.clear
-        component = build(:meeting_component, participatory_space: proposal.component.participatory_space, skip_injection: evaluator.skip_injection)
-        proposal.coauthorships.build(author: build(:meeting, component:, skip_injection: evaluator.skip_injection))
+        component = build(:meeting_component, :published, participatory_space: proposal.component.participatory_space, skip_injection: evaluator.skip_injection)
+        proposal.coauthorships.build(author: build(:meeting, :published, component:, skip_injection: evaluator.skip_injection))
       end
     end
 

--- a/decidim-proposals/spec/types/integration_schema_spec.rb
+++ b/decidim-proposals/spec/types/integration_schema_spec.rb
@@ -90,6 +90,24 @@ describe "Decidim::Api::QueryType" do
     }
   end
 
+  describe "commentable" do
+    let(:participatory_process_query) do
+      %(
+        commentable(id: "#{proposal.id}", type: "Decidim::Proposals::Proposal", locale: "en", toggleTranslations: false) {
+          __typename
+        }
+      )
+    end
+
+    it "executes successfully" do
+      expect { response }.not_to raise_error
+    end
+
+    it do
+      expect(response).to eq({ "commentable" => { "__typename" => "Proposal" } })
+    end
+  end
+
   describe "valid connection query" do
     let(:component_fragment) do
       %(

--- a/decidim-proposals/spec/types/proposal_type_spec.rb
+++ b/decidim-proposals/spec/types/proposal_type_spec.rb
@@ -171,6 +171,48 @@ module Decidim
           expect(response["meeting"]["title"]["translation"]).to eq(model.authors.first.title["en"])
         end
       end
+
+      context "when participatory space is private" do
+        let(:participatory_space) { create(:participatory_process, :with_steps, :private, organization: current_organization) }
+        let(:current_component) { create(:proposal_component, participatory_space:) }
+        let(:model) { create(:proposal, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when participatory space is not published" do
+        let(:participatory_space) { create(:participatory_process, :with_steps, :unpublished, organization: current_organization) }
+        let(:current_component) { create(:proposal_component, participatory_space:) }
+        let(:model) { create(:proposal, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when component is not published" do
+        let(:current_component) { create(:proposal_component, :unpublished, organization: current_organization) }
+        let(:model) { create(:proposal, component: current_component) }
+        let(:query) { "{ id }" }
+
+        it "returns nothing" do
+          expect(response).to be_nil
+        end
+      end
+
+      context "when is moderated" do
+        let(:model) { create(:proposal, :hidden) }
+        let(:query) { "{ id }" }
+        let(:root_value) { model.reload }
+
+        it "returns all the required fields" do
+          expect(response).to be_nil
+        end
+      end
     end
   end
 end

--- a/decidim-sortitions/lib/decidim/api/sortition_type.rb
+++ b/decidim-sortitions/lib/decidim/api/sortition_type.rb
@@ -25,14 +25,13 @@ module Decidim
       field :cancelled_by_user, Decidim::Core::UserType, "Who cancelled this sortition", null: true
       field :candidate_proposals, [GraphQL::Types::Int, { null: true }], "The candidate proposal for this sortition", null: true
 
-
       def self.authorized?(object, context)
         context[:sortition] = object
 
         chain = [
           allowed_to?(:read, :participatory_space, object, context),
           allowed_to?(:read, :component, object, context),
-          object.visible?,
+          object.visible?
         ].all?
 
         super && chain

--- a/decidim-sortitions/lib/decidim/api/sortition_type.rb
+++ b/decidim-sortitions/lib/decidim/api/sortition_type.rb
@@ -24,6 +24,19 @@ module Decidim
       field :cancelled_on, Decidim::Core::DateType, "When this sortition was cancelled", null: true
       field :cancelled_by_user, Decidim::Core::UserType, "Who cancelled this sortition", null: true
       field :candidate_proposals, [GraphQL::Types::Int, { null: true }], "The candidate proposal for this sortition", null: true
+
+
+      def self.authorized?(object, context)
+        context[:sortition] = object
+
+        chain = [
+          allowed_to?(:read, :participatory_space, object, context),
+          allowed_to?(:read, :component, object, context),
+          object.visible?,
+        ].all?
+
+        super && chain
+      end
     end
   end
 end

--- a/decidim-sortitions/spec/types/integration_schema_spec.rb
+++ b/decidim-sortitions/spec/types/integration_schema_spec.rb
@@ -57,6 +57,24 @@ describe "Decidim::Api::QueryType" do
     }
   end
 
+  describe "commentable" do
+    let(:participatory_process_query) do
+      %(
+        commentable(id: "#{sortition.id}", type: "Decidim::Sortitions::Sortition", locale: "en", toggleTranslations: false) {
+          __typename
+        }
+      )
+    end
+
+    it "executes successfully" do
+      expect { response }.not_to raise_error
+    end
+
+    it do
+      expect(response).to eq({ "commentable" => { "__typename" => "Sortition" } })
+    end
+  end
+
   describe "valid connection query" do
     let(:component_fragment) do
       %(

--- a/decidim-sortitions/spec/types/sortition_type_spec.rb
+++ b/decidim-sortitions/spec/types/sortition_type_spec.rb
@@ -133,6 +133,50 @@ module Decidim
             expect(response["cancelledByUser"]["name"]).to eq(model.cancelled_by_user.name)
           end
         end
+
+        context "when participatory space is private" do
+          let(:participatory_space) { create(:participatory_process, :with_steps, :private, organization: current_organization) }
+          let(:current_component) { create(:sortition_component, participatory_space:) }
+          let(:model) { create(:sortition, component: current_component) }
+          let(:query) { "{ id }" }
+
+          it "returns nothing" do
+            expect(response).to be_nil
+          end
+        end
+
+        context "when participatory space is not published" do
+          let(:participatory_space) { create(:participatory_process, :with_steps, :unpublished, organization: current_organization) }
+          let(:current_component) { create(:sortition_component, participatory_space:) }
+          let(:model) { create(:sortition, component: current_component) }
+          let(:query) { "{ id }" }
+
+          it "returns nothing" do
+            expect(response).to be_nil
+          end
+        end
+
+        context "when component is not published" do
+          let(:current_component) { create(:sortition_component, :unpublished, organization: current_organization) }
+          let(:model) { create(:sortition, component: current_component) }
+          let(:query) { "{ id }" }
+
+          it "returns nothing" do
+            expect(response).to be_nil
+          end
+        end
+
+        context "when is sortition is not visible" do
+          let(:current_component) { create(:sortition_component, organization: current_organization) }
+          let(:model) { create(:sortition, component: current_component) }
+          let(:query) { "{ id }" }
+          let(:root_value) { model.reload }
+
+          it "returns all the required fields" do
+            allow(model).to receive(:visible?).and_return(false)
+            expect(response).to be_nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
We are adding basic authorization to GraphQL, so that we avoid displaying unpublished entries. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
Browse the API, and see that you can request or view deleted or moderated content. 

:hearts: Thank you!
