### PR TITLE
Lock Ubuntu to 22.04 in github actions

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -50,7 +50,7 @@ jobs:
           - decidim-system
           - decidim-templates
           - decidim-verifications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: ${{ matrix.working-directory }}
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build_app:
     name: Build app
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     env:

--- a/.github/workflows/ci_backporter.yml
+++ b/.github/workflows/ci_backporter.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   backport:
     name: "Backporter"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     # the below IF structure checks:
     #  - PR repository must be the official Decidim repository ( decidim/decidim )

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -52,7 +52,7 @@ jobs:
           - command: bundle exec parallel_test --type rspec --pattern spec/lib/
             name: Lib
     name: ${{ matrix.test.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:

--- a/.github/workflows/ci_javascript.yml
+++ b/.github/workflows/ci_javascript.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:

--- a/.github/workflows/ci_production_check.yml
+++ b/.github/workflows/ci_production_check.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -34,7 +34,7 @@ jobs:
           - ./.github/run_spelling_check.sh
           - npm run linthtml
     name: Lint code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     steps:

--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   check_title:
     name: Check PR title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:

--- a/.github/workflows/lint_pr_labels.yml
+++ b/.github/workflows/lint_pr_labels.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   check_label:
     name: Check PR labels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
         with:

--- a/.github/workflows/on_docs_update.yml
+++ b/.github/workflows/on_docs_update.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   trigger_documentation_build:
     name: Trigger decidim/documentation build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
     - name: Send dispatch for trigger_build workflow

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   trigger_docker_build:
     name: Trigger decidim/docker build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
     - name: Send dispatch for Docker Hub build

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -83,7 +83,7 @@ jobs:
       security-events: write
     outputs:
       followup: ${{ steps.spelling.outputs.followup }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ contains(github.event_name, 'pull_request') || github.event_name == 'push' }}
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}
@@ -131,7 +131,7 @@ jobs:
       contents: write
       pull-requests: write
       actions: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{
         github.repository_owner != 'decidim' &&
         github.event_name == 'issue_comment' &&

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   build_app:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     env:

--- a/decidim-generators/lib/decidim/generators/component_templates/github/ci.yml.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/github/ci.yml.erb
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     services:
       postgres:


### PR DESCRIPTION
#### :tophat: What? Why?
While working on #13511, i have noticed the pipeline started to fail suddently with ` fail MiniMagick::Error, "You must have ImageMagick or GraphicsMagick installed"` error. 

On a closer look, i have noticed that the develop pipeline was using Ubuntu 22.04.5 LTS, while my branch was using Ubuntu  24.04.1. 

The specified Ubuntu version has an additional issue, as it does not suport wkhtmltopdf binary gem. 

```
    Error: PDF could not be generated!
        Command Error: pid 7370 exit 1
       /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/wkhtmltopdf-binary-0.12.6.6/bin/wkhtmltopdf:69:in `<main>': Invalid platform, must be running on Ubuntu 16.04/18.04/20.04/22.04, CentOS 6/7/8, Debian 9/10, Archlinux amd64, or Intel-based Cocoa macOS (missing binary: /opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/wkhtmltopdf-binary-0.12.6.6/bin/wkhtmltopdf_ubuntu_24.04_amd64). (RuntimeError)
```

https://github.com/actions/runner-images


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
