### PR TITLE
Fix diploma PDF rendering

### DIFF
--- a/decidim-conferences/app/mailers/decidim/conferences/admin/send_conference_diploma_mailer.rb
+++ b/decidim-conferences/app/mailers/decidim/conferences/admin/send_conference_diploma_mailer.rb
@@ -43,10 +43,9 @@ module Decidim
             render_to_string(pdf: "conference-diploma",
                              template: "decidim/conferences/admin/send_conference_diploma_mailer/diploma_user",
                              layout: "decidim/diploma"),
-            with_html_string: true,
+            with_html_string: true
           ).to_inline_css
         end
-
       end
     end
   end

--- a/decidim-conferences/app/mailers/decidim/conferences/admin/send_conference_diploma_mailer.rb
+++ b/decidim-conferences/app/mailers/decidim/conferences/admin/send_conference_diploma_mailer.rb
@@ -33,15 +33,20 @@ module Decidim
         private
 
         def add_diploma_attachment
-          diploma = WickedPdf.new.pdf_from_string(
-            render_to_string(pdf: "conference-diploma",
-                             template: "decidim/conferences/admin/send_conference_diploma_mailer/diploma_user",
-                             layout: "decidim/diploma"),
-            orientation: "Landscape"
-          )
+          diploma = WickedPdf.new.pdf_from_string(pdf_content, orientation: "Landscape")
 
           attachments["conference-#{@user.nickname.parameterize}-diploma.pdf"] = diploma
         end
+
+        def pdf_content
+          Premailer.new(
+            render_to_string(pdf: "conference-diploma",
+                             template: "decidim/conferences/admin/send_conference_diploma_mailer/diploma_user",
+                             layout: "decidim/diploma"),
+            with_html_string: true,
+          ).to_inline_css
+        end
+
       end
     end
   end

--- a/decidim-conferences/app/views/decidim/conferences/admin/send_conference_diploma_mailer/diploma_user.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/send_conference_diploma_mailer/diploma_user.html.erb
@@ -5,7 +5,7 @@
         <% logo = @conference.attached_uploader(:main_logo).variant(:thumb) %>
         <% if logo %>
           <div class="diploma__logo">
-            <%= image_tag "data:#{logo.blob.content_type};base64, #{Base64.encode64(logo.download)}" %>
+            <%= image_tag "data:#{logo.blob.content_type};base64, #{Base64.encode64(logo.download.presence || "")}" %>
           </div>
         <% end %>
         <div class="diploma__name">
@@ -18,7 +18,7 @@
           <strong><%= t("decidim.conferences.admin.send_conference_diploma_mailer.diploma_user.attendance_verified_by") %></strong>
           <% signature = @conference.attached_uploader(:signature).variant(:thumb) %>
           <% if signature %>
-            <div><%= image_tag "data:#{signature.blob.content_type};base64, #{Base64.encode64(signature.download)}" %></div>
+            <div><%= image_tag "data:#{signature.blob.content_type};base64, #{Base64.encode64(signature.download.presence || "")}" %></div>
           <% end %>
           <%= l(@conference.sign_date, format: :decidim_short) %>, <%= @conference.signature_name %>
         </div>

--- a/decidim-conferences/app/views/decidim/conferences/admin/send_conference_diploma_mailer/diploma_user.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/send_conference_diploma_mailer/diploma_user.html.erb
@@ -2,10 +2,12 @@
   <div class="diploma__border">
     <div class="diploma__content">
       <div>
-        <div class="diploma__logo">
-          <% logo = @conference.attached_uploader(:main_logo).variant(:thumb) %>
-          <%= image_tag "data:#{logo.blob.content_type};base64, #{Base64.encode64(logo.download)}" %>
-        </div>
+        <% logo = @conference.attached_uploader(:main_logo).variant(:thumb) %>
+        <% if logo %>
+          <div class="diploma__logo">
+            <%= image_tag "data:#{logo.blob.content_type};base64, #{Base64.encode64(logo.download)}" %>
+          </div>
+        <% end %>
         <div class="diploma__name">
           <h2><strong><%= translated_attribute(@conference.title) %></strong></h2>
           <h3><%= t("decidim.conferences.admin.send_conference_diploma_mailer.diploma_user.certificate_of_attendance") %></h3>
@@ -14,10 +16,10 @@
         <hr>
         <div class="diploma__attendance">
           <strong><%= t("decidim.conferences.admin.send_conference_diploma_mailer.diploma_user.attendance_verified_by") %></strong>
-          <div>
-            <% signature = @conference.attached_uploader(:signature).variant(:thumb) %>
-            <%= image_tag "data:#{signature.blob.content_type};base64, #{Base64.encode64(signature.download)}" %>
-          </div>
+          <% signature = @conference.attached_uploader(:signature).variant(:thumb) %>
+          <% if signature %>
+            <div><%= image_tag "data:#{signature.blob.content_type};base64, #{Base64.encode64(signature.download)}" %></div>
+          <% end %>
           <%= l(@conference.sign_date, format: :decidim_short) %>, <%= @conference.signature_name %>
         </div>
       </div>

--- a/decidim-conferences/app/views/decidim/conferences/admin/send_conference_diploma_mailer/diploma_user.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/send_conference_diploma_mailer/diploma_user.html.erb
@@ -3,7 +3,8 @@
     <div class="diploma__content">
       <div>
         <div class="diploma__logo">
-          <%= wicked_pdf_image_tag @conference.attached_uploader(:main_logo).variant_url(:thumb) %>
+          <% logo = @conference.attached_uploader(:main_logo).variant(:thumb) %>
+          <%= image_tag "data:#{logo.blob.content_type};base64, #{Base64.encode64(logo.download)}" %>
         </div>
         <div class="diploma__name">
           <h2><strong><%= translated_attribute(@conference.title) %></strong></h2>
@@ -14,7 +15,8 @@
         <div class="diploma__attendance">
           <strong><%= t("decidim.conferences.admin.send_conference_diploma_mailer.diploma_user.attendance_verified_by") %></strong>
           <div>
-            <%= wicked_pdf_image_tag @conference.attached_uploader(:signature).variant_url(:thumb) %>
+            <% signature = @conference.attached_uploader(:signature).variant(:thumb) %>
+            <%= image_tag "data:#{signature.blob.content_type};base64, #{Base64.encode64(signature.download)}" %>
           </div>
           <%= l(@conference.sign_date, format: :decidim_short) %>, <%= @conference.signature_name %>
         </div>

--- a/decidim-conferences/app/views/layouts/decidim/diploma.html.erb
+++ b/decidim-conferences/app/views/layouts/decidim/diploma.html.erb
@@ -3,7 +3,7 @@
   <head>
       <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
       <meta name="viewport" content="width=device-width">
-      <%= wicked_pdf_stylesheet_pack_tag "decidim_conference_diploma" %>
+      <%= stylesheet_pack_tag "decidim_conference_diploma" %>
     </head>
   <body>
     <%= yield %>

--- a/decidim-conferences/spec/commands/send_conferences_diplomas_spec.rb
+++ b/decidim-conferences/spec/commands/send_conferences_diplomas_spec.rb
@@ -36,6 +36,9 @@ module Decidim::Conferences
         end
 
         it "sends an email with diploma as attachment" do
+          stub_request(:get, %r{/css/decidim_conference_diploma.css}).
+            to_return(status: 200, body: File.read(Rails.root.join("public/packs-test/css/decidim_conference_diploma.css")), headers: {})
+
           perform_enqueued_jobs { command.call }
 
           email = last_email


### PR DESCRIPTION
#### :tophat: What? Why?
While working on #13514, I have noticed that CSS is not being processed as it should. This PR converts the below: 
![image](https://github.com/user-attachments/assets/11de300d-ffe6-453d-af64-0143d20e17a3)

To 

![image](https://github.com/user-attachments/assets/cae52556-6a78-48b2-af11-5f62dad66910)


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13514

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
