### PR TITLE
Fix redirect path after blocking an user

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/block_user_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/block_user_controller.rb
@@ -22,7 +22,7 @@ module Decidim
         BlockUser.call(@form) do
           on(:ok) do
             flash[:notice] = I18n.t("officializations.block.success", scope: "decidim.admin")
-            redirect_to moderated_users_path(blocked: true), notice:
+            redirect_to moderated_users_path, notice:
           end
 
           on(:invalid) do

--- a/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
@@ -51,9 +51,9 @@
           <% end %>
           <% if allowed_to?(:block, :moderate_users) %>
             <% if moderation.user.blocked? %>
-              <%= icon_link_to "forbid-2-line", user_block_path(user_id: moderation.user.id), t(".actions.unblock"), class: "action-icon action-icon--disabled", method: :delete %>
+              <%= icon_link_to "refresh-line", user_block_path(user_id: moderation.user.id), t(".actions.unblock"), class: "action-icon action-icon--disabled", method: :delete %>
             <% else %>
-              <%= icon_link_to "forbid-2-line", new_user_block_path(user_id: moderation.user.id), t(".actions.block"), class: "action-icon action-icon" %>
+             <%= icon_link_to "lock-2-line", new_user_block_path(user_id: moderation.user.id), t(".actions.block"), class: "action-icon action-icon" %>
             <% end %>
           <% end %>
         </td>

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -25,6 +25,7 @@ module Decidim
       end
 
       initializer "decidim_admin.register_icons" do |_app|
+        Decidim.icons.register(name: "lock-2-line", icon: "lock-2-line", category: "system", description: "Block user icon", engine: :admin)
         Decidim.icons.register(name: "layout-masonry-line", icon: "layout-masonry-line", category: "system", description: "", engine: :admin)
         Decidim.icons.register(name: "service-line", icon: "service-line", category: "system", description: "", engine: :admin)
         Decidim.icons.register(name: "fullscreen-line", icon: "fullscreen-line", category: "system", description: "", engine: :admin)

--- a/decidim-admin/spec/controllers/block_user_controller_spec.rb
+++ b/decidim-admin/spec/controllers/block_user_controller_spec.rb
@@ -75,6 +75,7 @@ module Decidim
 
               expect(flash[:notice]).to be_present
               expect(user.reload.blocked?).to be(true)
+              expect(response).not_to redirect_to(moderated_users_path(blocked: true))
             end
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The `blocked: true` parameter was removed from `moderated_users_path` to avoid redirecting to the "Blocked Users" list after blocking a user.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes https://github.com/decidim/decidim/issues/13425

#### Testing
  1. Log in as an admin.
  2. Go to general search and report a participant (without blocking it).
  3. Go to the admin dashboard.
  4. Go to 'Global Moderations' from the left side.
  5. Go to 'Reported participants'.
  6. Click on the 'Block user' button.
  7. Add a reason for blocking that user.
  8. After blocking a user, check that the admin user remains on the not blocked users list.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
