### PR TITLE
Fix double encoding specific characters with the external links

### DIFF
--- a/decidim-core/app/controllers/decidim/links_controller.rb
+++ b/decidim-core/app/controllers/decidim/links_controller.rb
@@ -41,7 +41,7 @@ module Decidim
     end
 
     def escape_url(external_url)
-      before_fragment, fragment = external_url.split("#", 2)
+      before_fragment, fragment = URI.decode_www_form_component(external_url).split("#", 2)
       escaped_before_fragment = URI::Parser.new.escape(before_fragment)
 
       if fragment

--- a/decidim-core/spec/system/external_domain_warning_spec.rb
+++ b/decidim-core/spec/system/external_domain_warning_spec.rb
@@ -51,6 +51,17 @@ describe "ExternalDomainWarning" do
     end
   end
 
+  context "when the source url has encoded characters" do
+    let(:destination) { "https://example.org/Me%2Cmyself%2Cand%2CI" }
+    let(:url) { "http://#{organization.host}/link?external_url=#{destination}" }
+
+    it "does not show invalid url alert" do
+      visit url
+      expect(page).to have_no_content("Invalid URL")
+      expect(page).to have_content("Me,myself,and,I")
+    end
+  end
+
   context "when url is invalid" do
     let(:invalid_url) { "http://#{organization.host}/link?external_url=foo" }
 


### PR DESCRIPTION
#### :tophat: What? Why?
The external link warning does not work with some links with special encodings. Example (paste this exact encoded link e.g. to proposal):

`https://en.wikipedia.org/wiki/Marcus_Lindberg_%28footballer%2C_born_2000%29`

The comma (`%2C`) will be double encoded with Decidim's external URL warning.

This PR fixes the problem.

#### Testing
1. Enable rich text editor for participants
2. Add proposals component and enable proposal submission
3. Make a new proposal and add the following link in it (exactly as is with encodings): `https://en.wikipedia.org/wiki/Marcus_Lindberg_%28footballer%2C_born_2000%29`
4. Publish the proposal
5. See that the link breaks