### PR TITLE
Add schema.org Event serializer for Breadcrumb

### DIFF
--- a/decidim-core/app/helpers/decidim/breadcrumb_helper.rb
+++ b/decidim-core/app/helpers/decidim/breadcrumb_helper.rb
@@ -58,7 +58,7 @@ module Decidim
     end
 
     def render_schema_org_breadcrumb_list(breadcrumb_items)
-      exported_breadcrumb_list = Decidim::Exporters::JSON.new([{ breadcrumb_items:, base_url: request.base_url }], Decidim::SchemaOrgBreadcrumbListSerializer).export.read
+      exported_breadcrumb_list = Decidim::Exporters::JSON.new([{ breadcrumb_items:, base_url: request.base_url, organization_name: current_organization_name }], Decidim::SchemaOrgBreadcrumbListSerializer).export.read
       JSON.pretty_generate(JSON.parse(exported_breadcrumb_list).first)
     end
   end

--- a/decidim-core/app/helpers/decidim/breadcrumb_helper.rb
+++ b/decidim-core/app/helpers/decidim/breadcrumb_helper.rb
@@ -58,7 +58,8 @@ module Decidim
     end
 
     def render_schema_org_breadcrumb_list(breadcrumb_items)
-      exported_breadcrumb_list = Decidim::Exporters::JSON.new([{ breadcrumb_items:, base_url: request.base_url, organization_name: current_organization_name }], Decidim::SchemaOrgBreadcrumbListSerializer).export.read
+      exporter_options = { breadcrumb_items:, base_url: request.base_url, organization_name: current_organization_name }
+      exported_breadcrumb_list = Decidim::Exporters::JSON.new([exporter_options], Decidim::SchemaOrgBreadcrumbListSerializer).export.read
       JSON.pretty_generate(JSON.parse(exported_breadcrumb_list).first)
     end
   end

--- a/decidim-core/app/helpers/decidim/breadcrumb_helper.rb
+++ b/decidim-core/app/helpers/decidim/breadcrumb_helper.rb
@@ -56,5 +56,10 @@ module Decidim
         active: active_item.active?
       }
     end
+
+    def render_schema_org_breadcrumb_list(breadcrumb_items)
+      exported_breadcrumb_list = Decidim::Exporters::JSON.new([{ breadcrumb_items:, base_url: request.base_url }], Decidim::SchemaOrgBreadcrumbListSerializer).export.read
+      JSON.pretty_generate(JSON.parse(exported_breadcrumb_list).first)
+    end
   end
 end

--- a/decidim-core/app/serializers/decidim/schema_org_breadcrumb_list_serializer.rb
+++ b/decidim-core/app/serializers/decidim/schema_org_breadcrumb_list_serializer.rb
@@ -10,6 +10,7 @@ module Decidim
     def initialize(options)
       @breadcrumb_items = options[:breadcrumb_items]
       @base_url = options[:base_url]
+      @organization_name = options[:organization_name]
     end
 
     # Serializes a breadcrumb items list for the Schema.org BreadcrumbList type
@@ -22,13 +23,14 @@ module Decidim
       {
         "@context": "https://schema.org",
         "@type": "BreadcrumbList",
+        name: "#{organization_name} breadcrumb",
         itemListElement: breadcrumb_items_serialized
       }
     end
 
     private
 
-    attr_reader :breadcrumb_items, :base_url
+    attr_reader :breadcrumb_items, :base_url, :organization_name
 
     def breadcrumb_items_serialized
       all_items = []

--- a/decidim-core/app/serializers/decidim/schema_org_breadcrumb_list_serializer.rb
+++ b/decidim-core/app/serializers/decidim/schema_org_breadcrumb_list_serializer.rb
@@ -17,6 +17,8 @@ module Decidim
     # @see https://schema.org/BreadcrumbList
     # @see https://developers.google.com/search/docs/appearance/structured-data/breadcrumb?hl=en
     def serialize
+      return {} if breadcrumb_items.none? { |item| item.has_key?(:url) }
+
       {
         "@context": "https://schema.org",
         "@type": "BreadcrumbList",
@@ -32,6 +34,8 @@ module Decidim
       all_items = []
 
       breadcrumb_items.each_with_index do |item, index|
+        next if item.empty?
+
         all_items << {
           "@type": "ListItem",
           position: index + 1,

--- a/decidim-core/app/serializers/decidim/schema_org_breadcrumb_list_serializer.rb
+++ b/decidim-core/app/serializers/decidim/schema_org_breadcrumb_list_serializer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module Decidim
+  class SchemaOrgBreadcrumbListSerializer < Decidim::Exporters::Serializer
+    include Decidim::SanitizeHelper
+
+    # Public: Initializes the serializer with a list of breadcrumb items.
+    def initialize(options)
+      @breadcrumb_items = options[:breadcrumb_items]
+      @base_url = options[:base_url]
+    end
+
+    # Serializes a breadcrumb items list for the Schema.org BreadcrumbList type
+    #
+    # @see https://schema.org/BreadcrumbList
+    # @see https://developers.google.com/search/docs/appearance/structured-data/breadcrumb?hl=en
+    def serialize
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: breadcrumb_items_serialized
+      }
+    end
+
+    private
+
+    attr_reader :breadcrumb_items, :base_url
+
+    def breadcrumb_items_serialized
+      all_items = []
+
+      breadcrumb_items.each_with_index do |item, index|
+        all_items << {
+          "@type": "ListItem",
+          position: index + 1,
+          name: decidim_sanitize_translated(item[:label]),
+          item: URI.join(base_url, item[:url]).to_s
+        }
+      end
+
+      all_items
+    end
+  end
+end

--- a/decidim-core/app/views/layouts/decidim/_schema_org_breadcrumb_list.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_schema_org_breadcrumb_list.html.erb
@@ -1,0 +1,3 @@
+<script type="application/ld+json">
+<%== render_schema_org_breadcrumb_list(breadcrumb_items) %>
+</script>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_items.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_items.html.erb
@@ -30,3 +30,5 @@
     <% end %>
   <% end %>
 <% end %>
+
+<%= render partial: "layouts/decidim/schema_org_breadcrumb_list", locals: { breadcrumb_items: } %>

--- a/decidim-core/spec/helpers/decidim/breadcrumb_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/breadcrumb_helper_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe BreadcrumbHelper do
+    describe "#render_schema_org_breadcrumb_list" do
+      subject { helper.render_schema_org_breadcrumb_list(breadcrumb_items) }
+
+      let(:breadcrumb_items) do
+        [
+          {
+            label: "Processes",
+            url: "/processes",
+            active: true
+          },
+          {
+            label: { ca: "Hola mon", es: "Hola mundo", en: "Hello world" },
+            url: "/processes/hello-world",
+            dropdown_cell: "decidim/participatory_processes/process_dropdown_metadata",
+            resource: participatory_process
+          }
+
+        ]
+      end
+
+      let(:participatory_process) { create(:participatory_process) }
+
+      it "renders a schema.org event" do
+        keys = JSON.parse(subject).keys
+        expect(keys).to include("@context")
+        expect(keys).to include("@type")
+        expect(keys).to include("itemListElement")
+      end
+    end
+  end
+end

--- a/decidim-core/spec/helpers/decidim/breadcrumb_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/breadcrumb_helper_spec.rb
@@ -26,6 +26,10 @@ module Decidim
 
       let(:participatory_process) { create(:participatory_process) }
 
+      before do
+        allow(helper).to receive(:current_organization).and_return(participatory_process.organization)
+      end
+
       it "renders a schema.org event" do
         keys = JSON.parse(subject).keys
         expect(keys).to include("@context")

--- a/decidim-core/spec/serializers/decidim/schema_org_breadcrumb_list_serializer_spec.rb
+++ b/decidim-core/spec/serializers/decidim/schema_org_breadcrumb_list_serializer_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe SchemaOrgBreadcrumbListSerializer do
+    subject do
+      described_class.new({ breadcrumb_items:, base_url: })
+    end
+
+    let(:breadcrumb_items) do
+      [
+        {
+          label: "Processes",
+          url: "/processes",
+          active: true
+        },
+        {
+          label: { ca: "Hola mon", es: "Hola mundo", en: "Hello world" },
+          url: "/processes/hello-world",
+          dropdown_cell: "decidim/participatory_processes/process_dropdown_metadata",
+          resource: participatory_process
+        }
+
+      ]
+    end
+
+    let(:base_url) { "https://example.org" }
+
+    let(:participatory_process) { create(:participatory_process) }
+
+    describe "#serialize" do
+      let(:serialized) { subject.serialize }
+
+      it "serializes the @context" do
+        expect(serialized[:@context]).to eq("https://schema.org")
+      end
+
+      it "serializes the @type" do
+        expect(serialized[:@type]).to eq("BreadcrumbList")
+      end
+
+      it "serializes the breadcrumb items" do
+        expected_items_elements = [
+          { "@type": "ListItem", position: 1, name: "Processes", item: "https://example.org/processes" },
+          { "@type": "ListItem", position: 2, name: "Hello world", item: "https://example.org/processes/hello-world" }
+        ]
+        expect(serialized[:itemListElement]).to eq(expected_items_elements)
+      end
+    end
+  end
+end

--- a/decidim-core/spec/serializers/decidim/schema_org_breadcrumb_list_serializer_spec.rb
+++ b/decidim-core/spec/serializers/decidim/schema_org_breadcrumb_list_serializer_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 module Decidim
   describe SchemaOrgBreadcrumbListSerializer do
     subject do
-      described_class.new({ breadcrumb_items:, base_url: })
+      described_class.new({ breadcrumb_items:, base_url:, organization_name: })
     end
 
     let(:breadcrumb_items) do
@@ -25,8 +25,8 @@ module Decidim
     end
 
     let(:base_url) { "https://example.org" }
-
     let(:participatory_process) { create(:participatory_process) }
+    let(:organization_name) { "ACME Corp" }
 
     describe "#serialize" do
       let(:serialized) { subject.serialize }
@@ -37,6 +37,10 @@ module Decidim
 
       it "serializes the @type" do
         expect(serialized[:@type]).to eq("BreadcrumbList")
+      end
+
+      it "serializes the name" do
+        expect(serialized[:name]).to eq("ACME Corp breadcrumb")
       end
 
       it "serializes the breadcrumb items" do

--- a/decidim-core/spec/serializers/decidim/schema_org_breadcrumb_list_serializer_spec.rb
+++ b/decidim-core/spec/serializers/decidim/schema_org_breadcrumb_list_serializer_spec.rb
@@ -21,7 +21,6 @@ module Decidim
           dropdown_cell: "decidim/participatory_processes/process_dropdown_metadata",
           resource: participatory_process
         }
-
       ]
     end
 
@@ -46,6 +45,48 @@ module Decidim
           { "@type": "ListItem", position: 2, name: "Hello world", item: "https://example.org/processes/hello-world" }
         ]
         expect(serialized[:itemListElement]).to eq(expected_items_elements)
+      end
+
+      context "when there are empty items" do
+        let(:breadcrumb_items) do
+          [
+            {
+              label: "Processes",
+              url: "/processes",
+              active: true
+            },
+            {
+              label: { ca: "Hola mon", es: "Hola mundo", en: "Hello world" },
+              url: "/processes/hello-world",
+              dropdown_cell: "decidim/participatory_processes/process_dropdown_metadata",
+              resource: participatory_process
+            },
+            {}
+          ]
+        end
+
+        it "ignores them" do
+          expected_items_elements = [
+            { "@type": "ListItem", position: 1, name: "Processes", item: "https://example.org/processes" },
+            { "@type": "ListItem", position: 2, name: "Hello world", item: "https://example.org/processes/hello-world" }
+          ]
+          expect(serialized[:itemListElement]).to eq(expected_items_elements)
+        end
+      end
+
+      context "when there are only items without URLs" do
+        let(:breadcrumb_items) do
+          [
+            {
+              label: "Profile",
+              active: true
+            }
+          ]
+        end
+
+        it "returns an empty JSON" do
+          expect(serialized).to eq({})
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR implements the schema.org Event specification in the Breadcrumb, so it's easier for external tools and services (such as Google) to interpret this data. 

I followed  https://developers.google.com/search/docs/appearance/structured-data/breadcrumb?hl=en
 
#### :pushpin: Related Issues 

- Fixes #13247 

#### Testing

1. Go to a page with breadcrumb 
2. Check out the source code of the page and search for "ld+json" 
3. Copy the code and paste it in the "Rich Results Test": https://search.google.com/test/rich-results

Example of the rich results: https://search.google.com/test/rich-results/result/r%2Fbreadcrumbs?id=CoR5PR0cFhcSlA1Xb5uk4Q 

### :camera: Screenshots

![Rich result test (details)](https://github.com/user-attachments/assets/9df4bf93-f8bc-42d5-bcb1-48bd475d8c12)

:hearts: Thank you!
