### PR TITLE
Fix editing the assembly content block "related assemblies"

### DIFF
--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_landing_page_content_blocks_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_landing_page_content_blocks_controller.rb
@@ -10,6 +10,8 @@ module Decidim
 
         layout "decidim/admin/assemblies"
 
+        helper_method :parent_assembly
+
         private
 
         def content_block_scope
@@ -28,6 +30,12 @@ module Decidim
 
         def resource_landing_page_content_block_path
           assembly_landing_page_content_block_path(scoped_resource, params[:id])
+        end
+
+        alias current_participatory_space current_assembly
+
+        def parent_assembly
+          current_assembly.parent
         end
       end
     end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_landing_page_content_blocks_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_landing_page_content_blocks_controller.rb
@@ -32,10 +32,8 @@ module Decidim
           assembly_landing_page_content_block_path(scoped_resource, params[:id])
         end
 
-        alias current_participatory_space current_assembly
-
         def parent_assembly
-          current_assembly.parent
+          scoped_resource.parent
         end
       end
     end

--- a/decidim-assemblies/spec/system/admin/admin_manages_assembly_landing_page_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assembly_landing_page_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages assembly landing page" do
+  include_context "when admin administrating an assembly"
+  let!(:resource) { assembly }
+  let(:scope_name) { :assembly_homepage }
+  let(:edit_landing_page_path) { decidim_admin_assemblies.edit_assembly_landing_page_path(resource) }
+
+  def edit_content_block_path(resource, content_block)
+    decidim_admin_assemblies.edit_assembly_landing_page_content_block_path(resource, content_block)
+  end
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  context "when editing related assemblies" do
+    let!(:related_assemblies_content_block) { create(:content_block, organization:, scope_name: "assembly_homepage", manifest_name: "related_assemblies", scoped_resource_id: resource.id, settings: { "max_results" => "6" }) }
+
+    it "updates the related assemblies content block" do
+      visit edit_content_block_path(resource, related_assemblies_content_block)
+
+      expect(related_assemblies_content_block.settings["max_results"]).to eq(6)
+      select 12, from: :content_block_settings_max_results
+      click_on "Update"
+
+      expect(page).to have_content("Related assemblies")
+      expect(related_assemblies_content_block.reload.settings["max_results"]).to eq(12)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
The "related assemblies" content block crashed the application if you want to edit the number of items.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to  #13509
- Fixes #13499

#### Testing
Add the content block "related assemblies"
try to edit it
This affects v0.28 onwards

### :camera: Screenshots
![imatge](https://github.com/user-attachments/assets/78863344-54b1-4dba-ad0c-409ebd7d8a8b)

Before:

![imatge](https://github.com/user-attachments/assets/46528743-6ca2-4a27-88a1-62a6bd4094f4)

After:

![imatge](https://github.com/user-attachments/assets/e08aba67-d1ea-49ea-b685-32e23e60b606)

:hearts: Thank you!
