### PR TITLE
Fix the missing meeting calendar in meetings' lists

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
@@ -13,6 +13,11 @@ module Decidim
         "card__calendar-list__reset"
       end
 
+      # Renders the date in the meeting card list
+      def has_image?
+        true
+      end
+
       def image
         render
       end

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_l_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_l_cell_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Meetings
+  describe MeetingLCell, type: :cell do
+    controller Decidim::Meetings::MeetingsController
+    include Decidim::SanitizeHelper
+
+    subject { my_cell.call }
+
+    let!(:meeting) { create(:meeting, :published, start_time: Time.new(2020, 10, 15, 10, 4, 5, 0)) }
+    let(:my_cell) { cell("decidim/meetings/meeting_l", meeting) }
+
+    context "when rendering" do
+      it "renders the card" do
+        expect(subject).to have_css("#meetings__meeting_#{meeting.id}.card__calendar-list__reset")
+      end
+
+      it "shows the start time's month" do
+        expect(subject).to have_css(".card__calendar-month", text: "Oct")
+      end
+
+      it "shows the start time's day" do
+        expect(subject).to have_css(".card__calendar-day", text: "15")
+      end
+
+      it "shows the start time's year" do
+        expect(subject).to have_css(".card__calendar-year", text: "2020")
+      end
+    end
+
+    context "when title contains special html entities" do
+      let!(:original_title) { meeting.title["en"] }
+
+      before do
+        meeting.update!(title: { en: "<strong>#{original_title}</strong> &'<" })
+        meeting.reload
+      end
+
+      it "escapes them correctly" do
+        title = decidim_html_escape(original_title).gsub("&quot;", '"')
+        expect(subject.to_s).to include("&lt;strong&gt;#{title}&lt;/strong&gt; &amp;'&lt;")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

In latest versions we have removed the calendar from the meetings' lists pages. This is at least at: 

- the meetings directory at /meetings
- meeting content block
- the index page of the meeting component

By traveling in time with a great Time Machine called git, I could pin-point the problem at the changes introduced (and backported) with #12576. So, re-adding the `has_image?` method did the trick. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #13523 

#### Testing

1. Go to /meetings (or the other places that I mentioned)

### :camera: Screenshots

#### Before

![Bug](https://github.com/user-attachments/assets/e762d0a8-3c42-4582-87b5-4e11e2612ea9)

#### After

![Fix](https://github.com/user-attachments/assets/5fc68cc4-058c-4024-b550-7b5db43edd35)

:hearts: Thank you!
