### PR TITLE
Make meetings locations longer in seeds

### DIFF
--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -69,8 +69,8 @@ module Decidim
           description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
             Decidim::Faker::Localized.paragraph(sentence_count: 3)
           end,
-          location: Decidim::Faker::Localized.sentence,
-          location_hints: Decidim::Faker::Localized.sentence,
+          location: Decidim::Faker::Localized.sentence(word_count: rand(2..20)),
+          location_hints: Decidim::Faker::Localized.sentence(word_count: rand(2..20)),
           start_time:,
           end_time:,
           address: "#{::Faker::Address.street_address} #{::Faker::Address.zip} #{::Faker::Address.city}",


### PR DESCRIPTION
#### :tophat: What? Why?

While looking at some meetings of https://decidim.barcelona, I saw that there are [a couple that have really long locations](https://www.decidim.barcelona/processes/pressupostos2024/f/6463/meetings/7423). This generates a bug with the display of the date (I'll open another PR). 

This PR improves the randomness of the seeds to make them behave a bit more like the real world scenario. 

#### Testing

Re-seed your database, go to the meetings, see that the address 

### :camera: Screenshots

![image](https://github.com/user-attachments/assets/576a78fd-c1b0-4501-930c-a09133412206)

:hearts: Thank you!
