### PR TITLE
Make the address card shown long locations with the time

### DIFF
--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -13,7 +13,7 @@
     }
 
     &-container {
-      @apply grid grid-cols-[auto_1fr] md:grid-cols-[auto_1fr_1fr] items-center gap-0 md:gap-x-5 border-4 border-background rounded md:h-[140px] overflow-hidden;
+      @apply grid grid-cols-[auto_1fr] md:grid-cols-[auto_1fr_1fr] items-center gap-0 md:gap-x-5 border-4 border-background rounded overflow-hidden;
 
       > *:nth-child(2) {
         @apply p-4 md:p-0;
@@ -28,7 +28,7 @@
       }
 
       > *:nth-child(3) {
-        @apply order-1 md:order-2 h-[135px] md:h-full;
+        @apply order-1 md:order-2 h-[135px];
       }
     }
 


### PR DESCRIPTION
#### :tophat: What? Why?

When you have maps enabled and a long location in a Meeting, the start and end time aren't shown in some resolutions, as the address cell gets cut. 

I noticed this bug in production: https://www.decidim.barcelona/processes/pressupostos2024/f/6463/meetings/7423 

This PR fixes it. 

#### :pushpin: Related Issues
 
- Related to #13538 

#### Testing

1. Enable maps in your development app
2. Seed the database with the seeds from #13538 (or just create a really long location in a meeting) 
3. Go to this meeting 
4. (Before the patch) see that you loose the start and end time when resizing/changing the size of the fonts
4. (After the patch) see that you don't lose the start and end time when resizing/changing the size of the fonts

### :camera: Screenshots

#### Before 

![Bug](https://github.com/user-attachments/assets/619c6fab-95b2-4522-a3b9-5ce6b5788e40)

#### After

![Fix](https://github.com/user-attachments/assets/10a25a07-18fb-47f5-8378-cd371178bbee)

:hearts: Thank you!
