### PR TITLE
Remove flaky test in share tokens preview spec

### DIFF
--- a/decidim-core/app/models/decidim/share_token.rb
+++ b/decidim-core/app/models/decidim/share_token.rb
@@ -24,10 +24,8 @@ module Decidim
     end
 
     def use!(user: nil)
-      puts "ShareToken#use! called with user: #{user} and token: #{token}"
       return raise StandardError, "Share token '#{token}' for '#{token_for_type}' with id = #{token_for_id} has expired." if expired?
 
-      puts "not allowed for registered users" if registered_only? && user.nil?
       return raise StandardError, "Share token '#{token}' for '#{token_for_type}' with id = #{token_for_id} requires a registered user." if registered_only? && user.nil?
 
       update!(times_used: times_used + 1, last_used_at: Time.zone.now)

--- a/decidim-core/app/models/decidim/share_token.rb
+++ b/decidim-core/app/models/decidim/share_token.rb
@@ -25,7 +25,6 @@ module Decidim
 
     def use!(user: nil)
       return raise StandardError, "Share token '#{token}' for '#{token_for_type}' with id = #{token_for_id} has expired." if expired?
-
       return raise StandardError, "Share token '#{token}' for '#{token_for_type}' with id = #{token_for_id} requires a registered user." if registered_only? && user.nil?
 
       update!(times_used: times_used + 1, last_used_at: Time.zone.now)

--- a/decidim-core/app/models/decidim/share_token.rb
+++ b/decidim-core/app/models/decidim/share_token.rb
@@ -24,7 +24,10 @@ module Decidim
     end
 
     def use!(user: nil)
+      puts "ShareToken#use! called with user: #{user} and token: #{token}"
       return raise StandardError, "Share token '#{token}' for '#{token_for_type}' with id = #{token_for_id} has expired." if expired?
+
+      puts "not allowed for registered users" if registered_only? && user.nil?
       return raise StandardError, "Share token '#{token}' for '#{token_for_type}' with id = #{token_for_id} requires a registered user." if registered_only? && user.nil?
 
       update!(times_used: times_used + 1, last_used_at: Time.zone.now)

--- a/decidim-core/lib/decidim/core/test/shared_examples/preview_with_share_token_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/preview_with_share_token_examples.rb
@@ -46,24 +46,22 @@ shared_examples "visit unpublished resource with a share token" do
     end
 
     context "when the token requires the user to be registered" do
-      let(:share_token) { create(:share_token, :with_token, token_for: resource, registered_only: true) }
+      let!(:share_token) { create(:share_token, :with_token, token_for: resource, registered_only: true) }
+      let!(:user) { create(:user, :confirmed, organization:) }
 
       it "does not allow visiting resource" do
         expect(page).to have_content "You are not authorized"
         expect(page).to have_no_current_path(resource_path, ignore_query: true)
       end
 
-      context "when a user is logged" do
-        let(:user) { create(:user, :confirmed, organization:) }
+      it "allows visiting resource to logged users" do
+        login_as user, scope: :user
+        uri = URI(resource_path)
+        uri.query = URI.encode_www_form(params.to_a)
+        visit uri
 
-        it "allows visiting resource" do
-          login_as user, scope: :user
-          uri = URI(resource_path)
-          uri.query = URI.encode_www_form(params.to_a)
-          visit uri
-          expect(page).to have_no_content "You are not authorized"
-          expect(page).to have_current_path(resource_path, ignore_query: true)
-        end
+        expect(page).to have_no_content "You are not authorized"
+        expect(page).to have_current_path(resource_path, ignore_query: true)
       end
     end
   end

--- a/decidim-core/lib/decidim/core/test/shared_examples/preview_with_share_token_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/preview_with_share_token_examples.rb
@@ -56,10 +56,10 @@ shared_examples "visit unpublished resource with a share token" do
 
       it "allows visiting resource to logged users" do
         login_as user, scope: :user
+        sleep 0.5 # add a delay to ensure the user session cookie is set
         uri = URI(resource_path)
         uri.query = URI.encode_www_form(params.to_a)
         visit uri
-        puts "VISITING #{uri}"
         expect(page).to have_no_content "You are not authorized"
         expect(page).to have_current_path(resource_path, ignore_query: true)
       end

--- a/decidim-core/lib/decidim/core/test/shared_examples/preview_with_share_token_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/preview_with_share_token_examples.rb
@@ -13,7 +13,7 @@ shared_examples "visit unpublished resource with a share token" do
   end
 
   context "when a share_token is provided" do
-    let(:share_token) { create(:share_token, :with_token, token_for: resource) }
+    let(:share_token) { create(:share_token, token: "VALID_TOKEN", token_for: resource) }
     let(:params) { { share_token: share_token.token } }
 
     before do
@@ -37,7 +37,7 @@ shared_examples "visit unpublished resource with a share token" do
     end
 
     context "when an invalid share_token is provided" do
-      let(:share_token) { create(:share_token, :with_token, :expired, token_for: resource) }
+      let(:share_token) { create(:share_token, :expired, token: "INVALID_TOKEN_FOR_UNREGISTERED", token_for: resource) }
 
       it "does not allow visiting resource" do
         expect(page).to have_content "You are not authorized"
@@ -46,7 +46,7 @@ shared_examples "visit unpublished resource with a share token" do
     end
 
     context "when the token requires the user to be registered" do
-      let!(:share_token) { create(:share_token, :with_token, token_for: resource, registered_only: true) }
+      let!(:share_token) { create(:share_token, token: "VALID_TOKEN_FOR_REGISTERED", token_for: resource, registered_only: true) }
       let!(:user) { create(:user, :confirmed, organization:) }
 
       it "does not allow visiting resource" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/preview_with_share_token_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/preview_with_share_token_examples.rb
@@ -59,7 +59,9 @@ shared_examples "visit unpublished resource with a share token" do
         uri = URI(resource_path)
         uri.query = URI.encode_www_form(params.to_a)
         visit uri
-
+        # wait and reload to ensure the session is set
+        sleep 0.2
+        visit uri
         expect(page).to have_no_content "You are not authorized"
         expect(page).to have_current_path(resource_path, ignore_query: true)
       end

--- a/decidim-core/lib/decidim/core/test/shared_examples/preview_with_share_token_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/preview_with_share_token_examples.rb
@@ -59,9 +59,7 @@ shared_examples "visit unpublished resource with a share token" do
         uri = URI(resource_path)
         uri.query = URI.encode_www_form(params.to_a)
         visit uri
-        # wait and reload to ensure the session is set
-        sleep 0.2
-        visit uri
+        puts "VISITING #{uri}"
         expect(page).to have_no_content "You are not authorized"
         expect(page).to have_current_path(resource_path, ignore_query: true)
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Looks like #13221 introduced a flaky spec.
This attempts to remove it by decreasing nesting in rspec and creating objects before visiting pages

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13221

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
