### PR TITLE
Hide comments when parent resource is hidden

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/hide_resource.rb
+++ b/decidim-admin/app/commands/decidim/admin/hide_resource.rb
@@ -25,7 +25,6 @@ module Decidim
         with_events do
           tool = Decidim::ModerationTools.new(@reportable, @current_user)
           tool.hide!
-          tool.send_notification_to_author
         end
 
         broadcast(:ok, @reportable)

--- a/decidim-core/app/models/decidim/report.rb
+++ b/decidim-core/app/models/decidim/report.rb
@@ -5,7 +5,7 @@ module Decidim
   class Report < ApplicationRecord
     include Decidim::DownloadYourData
 
-    REASONS = %w(spam offensive does_not_belong hidden_during_block).freeze
+    REASONS = %w(spam offensive does_not_belong hidden_during_block parent_hidden).freeze
 
     belongs_to :moderation, foreign_key: "decidim_moderation_id", class_name: "Decidim::Moderation"
     belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1488,6 +1488,8 @@ en:
       create:
         error: There was a problem creating the report. Please, try it again.
         success: The report has been created successfully and it will be reviewed by an admin.
+      parent_hidden:
+        report_details: The parent resource was hidden
     resource:
       controls_label: Resource controls
     resource_endorsements:

--- a/decidim-core/lib/tasks/upgrade/clean_hidden_resources.rake
+++ b/decidim-core/lib/tasks/upgrade/clean_hidden_resources.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :upgrade do
+    namespace :clean do
+      desc "Removes all related resources from hidden resource"
+      task hidden_resources: :environment do
+        logger.info("Removing child resources for hidden parents...")
+        Decidim::Moderation.hidden.find_each do |moderation_for_hidden_resource |
+          reportable = moderation_for_hidden_resource.reportable
+          current_user = reportable.organization.admins.first
+          tool = Decidim::ModerationTools.new(reportable, current_user)
+          tool.hide!
+        rescue NameError => e
+          log_error "Could not hide child resources for reportable id #{moderation_for_hidden_resource.id} because: #{e.message}"
+        end
+      end
+
+      private
+
+      def log_error(msg)
+        puts msg
+        Rails.logger.error(msg)
+      end
+    end
+  end
+end

--- a/decidim-core/spec/tasks/upgrade/clean_hidden_resources_spec.rb
+++ b/decidim-core/spec/tasks/upgrade/clean_hidden_resources_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "rake decidim:upgrade:clean:hidden_resources", type: :task do
+  context "when executing task" do
+    it "does not throw exceptions keys" do
+      expect do
+        Rake::Task[:"decidim:upgrade:clean:hidden_resources"].invoke
+      end.not_to raise_exception
+    end
+  end
+
+  context "when there are no hidings requests" do
+    let!(:searchables) { create_list(:searchable_resource, 8) }
+
+    it "it does not hide any resource" do
+      expect { task.execute }.not_to change(Decidim::SearchableResource, :count)
+    end
+  end
+
+  context "when there was a hiding request" do
+    let!(:searchables) { create_list(:searchable_resource, 8, resource_type: "Decidim::Proposals") }
+
+    it "it hides the reported resource and associated comments from search results" do
+      comments =  Decidim::Comments::Comment.where("decidim_root_commentable_id" => searchables.collect(&:id).sample(1))
+      expect { task.execute }.to change(Decidim::SearchableResource, :count).by(-comments.size)
+    end
+  end
+end
+

--- a/decidim-meetings/spec/system/report_meeting_spec.rb
+++ b/decidim-meetings/spec/system/report_meeting_spec.rb
@@ -6,10 +6,10 @@ describe "Report Meeting" do
   include_context "with a component"
 
   let(:manifest_name) { "meetings" }
-  let!(:meetings) { create_list(:meeting, 3, :published, component:) }
+  let!(:meetings) { create_list(:meeting, 3, :published, component:, author: user) }
   let(:reportable) { meetings.first }
   let(:reportable_path) { resource_locator(reportable).path }
-  let!(:user) { create(:user, :confirmed, organization:) }
+  let!(:user) { create(:user, :admin, :confirmed, organization:) }
 
   let!(:component) do
     create(:meeting_component,
@@ -22,4 +22,6 @@ describe "Report Meeting" do
   end
 
   include_examples "reports"
+
+  include_examples "higher user role hides resource with comments"
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Added a new method `hide_comments!` to search and hide all comments related to the hidden parent resource.
Added a new task ` decidim:upgrade:clean:hidden_resources` to hide all the comments from previously hidden resources.

#### :pushpin: Related Issues
- Related to #?
- Fixes https://github.com/decidim/decidim/issues/13408

#### Testing
1. Log in as an admin user.
2. Create a proposal.
3. Leave some comments -> The comments are now displayed in the user profile/general search section.
4. Report the proposal and hide it.
5. The comments should no longer be displayed in the user profile/general search section.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
