### PR TITLE
Lock @tarekraafat/autocomplete.js version to 10.2.7

### DIFF
--- a/decidim-core/app/packs/src/decidim/autocomplete.js
+++ b/decidim-core/app/packs/src/decidim/autocomplete.js
@@ -1,6 +1,6 @@
 /* eslint max-lines: ["error", 350] */
 
-import * as AutoCompleteJS from "@tarekraafat/autocomplete.js";
+import AutoCompleteJS from "@tarekraafat/autocomplete.js";
 // Styles from node_modules/@tarekraafat/autocomplete.js
 // It needs to be done in JS because postcss-import does not find files in node_modules/
 import "@tarekraafat/autocomplete.js/dist/css/autoComplete.02.css";

--- a/decidim-core/app/packs/src/decidim/autocomplete.js
+++ b/decidim-core/app/packs/src/decidim/autocomplete.js
@@ -1,6 +1,6 @@
 /* eslint max-lines: ["error", 350] */
 
-import AutoCompleteJS from "@tarekraafat/autocomplete.js";
+import * as AutoCompleteJS from "@tarekraafat/autocomplete.js";
 // Styles from node_modules/@tarekraafat/autocomplete.js
 // It needs to be done in JS because postcss-import does not find files in node_modules/
 import "@tarekraafat/autocomplete.js/dist/css/autoComplete.02.css";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "emoji-mart": "^5.5.2",
     "@emoji-mart/data": "^1.1.2",
     "@rails/activestorage": "^7.0.8",
-    "@tarekraafat/autocomplete.js": "^10.2.6",
+    "@tarekraafat/autocomplete.js": "10.2.7",
     "@tiptap/core": "2.1.13",
     "@tiptap/extension-blockquote": "2.1.13",
     "@tiptap/extension-bold": "2.1.13",


### PR DESCRIPTION
#### :tophat: What? Why?
This issue fixes the `@tarekraafat/autocomplete.js` error in pipeline. On October 16th [@tarekraafat/autocomplete.js](https://www.npmjs.com/package/@tarekraafat/autocomplete.js) version 10.2.8 has been released. We are locking the version to 10.2.7, hoping to allocate time at a later date for upgrade. 

```
LOG from InjectManifest
<i> The service worker at ../sw.js will precache
<i>         185 URLs, totaling 9.61 MB.

ERROR in ../../decidim-core/app/packs/src/decidim/autocomplete.js 89:28-42
export 'default' (imported as 'AutoCompleteJS') was not found in '@tarekraafat/autocomplete.js' (module has no exports)
 @ ../../decidim-admin/app/packs/src/decidim/admin/admin_autocomplete.js 20:0-52 59:17-29
 @ ../../decidim-admin/app/packs/entrypoints/decidim_admin.js 15:0-46
```

#### Testing
Pipelines should be green

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![image](https://github.com/user-attachments/assets/474f6607-58a0-4745-86df-b5209d43ea55)

:hearts: Thank you!
