### PR TITLE
Backport 'Lock @tarekraafat/autocomplete.js version to 10.2.7' to v0.28

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@picmo/popup-picker": "^5.8.4",
     "@rails/activestorage": "^6.0.4",
-    "@tarekraafat/autocomplete.js": "^10.2.6",
+    "@tarekraafat/autocomplete.js": "10.2.7",
     "@tiptap/core": "2.1.13",
     "@tiptap/extension-blockquote": "2.1.13",
     "@tiptap/extension-bold": "2.1.13",


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #13555 to v0.28

:hearts: Thank you!