### PR TITLE
Fix editors with only images

### DIFF
--- a/decidim-core/app/packs/src/decidim/editor.js
+++ b/decidim-core/app/packs/src/decidim/editor.js
@@ -25,7 +25,7 @@ export default function createQuillEditor(container) {
   const toolbar = $(container).data("toolbar");
   const disabled = $(container).data("disabled");
 
-  const allowedEmptyContentSelector = "iframe";
+  const allowedEmptyContentSelector = "iframe,img";
   let quillToolbar = [
     ["bold", "italic", "underline", "linebreak"],
     [{ list: "ordered" }, { list: "bullet" }],


### PR DESCRIPTION
#### :tophat: What? Why?
There's a little bug in the Quill editor. If you add only and image it is not detected as content and it is removed.

Only for the 0.27 series.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
In the admin, in some HTML editor, upload  and image, and only an image. 
Save
Edit again, the image has disapeared

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
