### PR TITLE
Improve url escape

### DIFF
--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -51,7 +51,7 @@ module Decidim
     end
 
     def decidim_url_escape(text)
-      decidim_html_escape(text).sub(/^javascript:/, "")
+      decidim_html_escape(text).sub(/^\s*javascript:/, "")
     end
 
     def decidim_sanitize_translated(text)

--- a/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
@@ -44,6 +44,62 @@ module Decidim
           expect(helper.decidim_sanitize_newsletter(user_input)).to eq(user_input)
         end
       end
+
+      context "when url_escape is invoked" do
+        it "escapes javascript: in the URL" do
+          expect(helper.decidim_url_escape("javascript:alert('hello')")).to eq("alert(&#39;hello&#39;)")
+        end
+
+        it "escapes javascript: prepended by a line break in the URL" do
+          expect(helper.decidim_url_escape("\njavascript:alert('hello')")).to eq("\nalert(&#39;hello&#39;)")
+        end
+      end
+
+      context "when sanitize_text is invoked with dangerous strings" do
+        it "escapes script tags" do
+          expect(helper.decidim_sanitize("<script>alert('hello')</script>", strip_tags: false)).not_to include("<script>")
+        end
+
+        it "removes event handlers from HTML attributes" do
+          expect(helper.decidim_sanitize('<img src="#" onerror="alert(\'XSS\')">', strip_tags: false)).not_to include('onerror')
+        end
+        
+        it "removes nested event handlers in HTML" do
+          expect(helper.decidim_sanitize('<a href="#"><img src="x" onerror="alert(\'XSS\')"></a>', strip_tags: false)).not_to include('onerror')
+        end
+
+        it "removes dangerous CSS in style attributes" do
+          expect(helper.decidim_sanitize('<div style="background-image: url(javascript:alert(\'XSS\'))">', strip_tags: false)).not_to include('javascript:')
+        end
+        
+        it "escapes special characters like &lt; and &gt;" do
+          expect(helper.decidim_sanitize('&lt;script&gt;alert(\'XSS\')&lt;/script&gt;', strip_tags: false)).not_to include('<script>')
+        end
+        
+        it "removes javascript URIs from links" do
+          expect(helper.decidim_sanitize('<a href="javascript:alert(\'XSS\')">click me</a>', strip_tags: false)).not_to include('javascript:')
+        end
+        
+        it "removes event handlers from attributes" do
+          expect(helper.decidim_sanitize('<div id="XSS" onmouseover="alert(\'XSS\')">', strip_tags: false)).not_to include('onmouseover')
+        end
+        
+        it "sanitizes hex-encoded scripts" do
+          expect(helper.decidim_sanitize('&#x3C;script&#x3E;alert(\'XSS\')&#x3C;/script&#x3E;', strip_tags: false)).not_to include('<script>')
+        end
+        
+        it "sanitizes URL-encoded scripts" do
+          expect(helper.decidim_sanitize('%3Cscript%3Ealert(\'XSS\')%3C%2Fscript%3E', strip_tags: false)).not_to include('<script>')
+        end
+        
+        it "removes script inside HTML comments" do
+          expect(helper.decidim_sanitize('<!--<script>alert(\'XSS\')</script>-->', strip_tags: false)).not_to include('<script>')
+        end
+        
+        it "removes base64-encoded scripts" do
+          expect(helper.decidim_sanitize('<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA..." onerror="alert(\'XSS\')">', strip_tags: false)).not_to include('onerror')
+        end        
+      end
     end
   end
 end

--- a/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
@@ -51,7 +51,11 @@ module Decidim
         end
 
         it "escapes javascript: prepended by a line break in the URL" do
-          expect(helper.decidim_url_escape("\njavascript:alert('hello')")).to eq("\nalert(&#39;hello&#39;)")
+          expect(helper.decidim_url_escape("\njavascript:alert('hello')")).to eq("alert(&#39;hello&#39;)")
+        end
+
+        it "escapes javascript: prepended by an empty space in the URL" do
+          expect(helper.decidim_url_escape(" javascript:alert('hello')")).to eq("alert(&#39;hello&#39;)")
         end
       end
 

--- a/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
@@ -65,44 +65,44 @@ module Decidim
         end
 
         it "removes event handlers from HTML attributes" do
-          expect(helper.decidim_sanitize('<img src="#" onerror="alert(\'XSS\')">', strip_tags: false)).not_to include('onerror')
+          expect(helper.decidim_sanitize("<img src=\"#\" onerror=\"alert('XSS')\">", strip_tags: false)).not_to include("onerror")
         end
-        
+
         it "removes nested event handlers in HTML" do
-          expect(helper.decidim_sanitize('<a href="#"><img src="x" onerror="alert(\'XSS\')"></a>', strip_tags: false)).not_to include('onerror')
+          expect(helper.decidim_sanitize("<a href=\"#\"><img src=\"x\" onerror=\"alert('XSS')\"></a>", strip_tags: false)).not_to include("onerror")
         end
 
         it "removes dangerous CSS in style attributes" do
-          expect(helper.decidim_sanitize('<div style="background-image: url(javascript:alert(\'XSS\'))">', strip_tags: false)).not_to include('javascript:')
+          expect(helper.decidim_sanitize("<div style=\"background-image: url(javascript:alert('XSS'))\">", strip_tags: false)).not_to include("javascript:")
         end
-        
+
         it "escapes special characters like &lt; and &gt;" do
-          expect(helper.decidim_sanitize('&lt;script&gt;alert(\'XSS\')&lt;/script&gt;', strip_tags: false)).not_to include('<script>')
+          expect(helper.decidim_sanitize("&lt;script&gt;alert('XSS')&lt;/script&gt;", strip_tags: false)).not_to include("<script>")
         end
-        
+
         it "removes javascript URIs from links" do
-          expect(helper.decidim_sanitize('<a href="javascript:alert(\'XSS\')">click me</a>', strip_tags: false)).not_to include('javascript:')
+          expect(helper.decidim_sanitize("<a href=\"javascript:alert('XSS')\">click me</a>", strip_tags: false)).not_to include("javascript:")
         end
-        
+
         it "removes event handlers from attributes" do
-          expect(helper.decidim_sanitize('<div id="XSS" onmouseover="alert(\'XSS\')">', strip_tags: false)).not_to include('onmouseover')
+          expect(helper.decidim_sanitize("<div id=\"XSS\" onmouseover=\"alert('XSS')\">", strip_tags: false)).not_to include("onmouseover")
         end
-        
+
         it "sanitizes hex-encoded scripts" do
-          expect(helper.decidim_sanitize('&#x3C;script&#x3E;alert(\'XSS\')&#x3C;/script&#x3E;', strip_tags: false)).not_to include('<script>')
+          expect(helper.decidim_sanitize("&#x3C;script&#x3E;alert('XSS')&#x3C;/script&#x3E;", strip_tags: false)).not_to include("<script>")
         end
-        
+
         it "sanitizes URL-encoded scripts" do
-          expect(helper.decidim_sanitize('%3Cscript%3Ealert(\'XSS\')%3C%2Fscript%3E', strip_tags: false)).not_to include('<script>')
+          expect(helper.decidim_sanitize("%3Cscript%3Ealert('XSS')%3C%2Fscript%3E", strip_tags: false)).not_to include("<script>")
         end
-        
+
         it "removes script inside HTML comments" do
-          expect(helper.decidim_sanitize('<!--<script>alert(\'XSS\')</script>-->', strip_tags: false)).not_to include('<script>')
+          expect(helper.decidim_sanitize("<!--<script>alert('XSS')</script>-->", strip_tags: false)).not_to include("<script>")
         end
-        
+
         it "removes base64-encoded scripts" do
-          expect(helper.decidim_sanitize('<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA..." onerror="alert(\'XSS\')">', strip_tags: false)).not_to include('onerror')
-        end        
+          expect(helper.decidim_sanitize('<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA..." onerror="alert(\'XSS\')">', strip_tags: false)).not_to include("onerror")
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

I added more tests for the sanitize_helper to test for possible issues.

The helpers are very robust, but I found one issue with decidim_url_escape. Browsers also interpret "javascript:" URLs, when they start with blank characters, so I improved the regex and also added the according tests.

#### Testing

You can use the new tests in my updated sanitize_helper_spec.rb starting on line 48.
