### PR TITLE
Backport 'Lock @tarekraafat/autocomplete.js version to 10.2.7' to v0.27

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@joeattardi/emoji-button": "^4.6.2",
     "@rails/activestorage": "^6.0.4",
-    "@tarekraafat/autocomplete.js": "^10.2.6",
+    "@tarekraafat/autocomplete.js": "10.2.7",
     "@zeitiger/appendaround": "^1.0.0",
     "axios": "^0.21.4",
     "bootstrap-tagsinput": "^0.7.1",


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #13555 to v0.27

Fixes: #13569

:hearts: Thank you!