### PR TITLE
Fix disordered columns in survey export

### DIFF
--- a/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
+++ b/decidim-forms/lib/decidim/forms/user_answers_serializer.rb
@@ -42,7 +42,7 @@ module Decidim
         questionnaire_id = @answers.first&.decidim_questionnaire_id
         return {} unless questionnaire_id
 
-        questions = Decidim::Forms::Question.where(decidim_questionnaire_id: questionnaire_id)
+        questions = Decidim::Forms::Question.where(decidim_questionnaire_id: questionnaire_id).order(:position)
         return {} if questions.none?
 
         questions.each.inject({}) do |serialized, question|

--- a/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
+++ b/decidim-forms/spec/serializers/decidim/forms/user_answers_serializer_spec.rb
@@ -219,6 +219,13 @@ module Decidim
           end
         end
       end
+
+      describe "questions_hash" do
+        it "generates a hash of questions ordered by position" do
+          questions.shuffle!
+          expect(subject.instance_eval { questions_hash }.keys.map { |key| key[0].to_i }.uniq).to eq(questions.sort_by(&:position).map { |question| question.position + 1 })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When we export the answers to a survey, the questions are now ordered by position to avoid wrong order.

#### :pushpin: Related Issues
- Related to #https://github.com/decidim/decidim/issues/13201

#### Testing

1. As an admin, go to a process, and add a new survey component (allow answers and multiple answers).
2. Go to the edit of the survey and add questions, separators, titles and description... and save at the end.
3. After save, modify the order of questions, add a new question..and save again.
4. Publish the survey
5. As a user, answer the survey.
6. As an admin, go back to the edit of the survey and export the answers.
7. See in the file that the columns are in good order.

:hearts: Thank you!
