### PR TITLE
Fix initiative form is not taking into account the scope selected

### DIFF
--- a/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/create_initiative.rb
@@ -98,7 +98,7 @@ module Decidim
       end
 
       def scoped_type
-        InitiativesTypeScope.order(:id).find_by(type: form.type)
+        InitiativesTypeScope.order(:id).find_by(type: form.type, scope: form.scope)
       end
 
       def signature_end_date


### PR DESCRIPTION
#### :tophat: What? Why?
Fix the scope saved when creating an initiative. 

#### :pushpin: Related Issues
- Fixes #13597

#### Testing
1. Create a new initiative selecting a specific scope.
2. See that the initiative created has the scope selected in the form.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Creating a new initiative with the correct scope](https://github.com/user-attachments/assets/6bbf7a85-0359-4808-9d82-02be6ee176f9)





:hearts: Thank you!
