### PR TITLE
Fix admin proposals filters and sortings

### DIFF
--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -404,19 +404,15 @@ module Decidim
       end
 
       def self.ransackable_scopes(auth_object = nil)
-        base = [:with_any_origin, :with_any_state, :state_eq, :voted_by, :coauthored_by, :related_to, :with_any_taxonomies]
-        return base unless auth_object&.admin?
-
-        # Add extra scopes for admins for the admin panel searches
-        base + [:valuator_role_ids_has]
+        [:with_any_origin, :with_any_state, :state_eq, :voted_by, :coauthored_by, :related_to, :with_any_taxonomies, :valuator_role_ids_has]
       end
 
       # Create i18n ransackers for :title and :body.
       # Create the :search_text ransacker alias for searching from both of these.
       ransacker_i18n_multi :search_text, [:title, :body]
 
-      def self.ransackable_attributes(_auth_object = nil)
-        %w(id_string search_text title body is_emendation)
+      def self.ransackable_attributes(auth_object = nil)
+        %w(id_string search_text title body is_emendation comments_count proposal_votes_count published_at proposal_notes_count)
       end
 
       def self.ransackable_associations(_auth_object = nil)

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -403,7 +403,7 @@ module Decidim
         where(query, value:)
       end
 
-      def self.ransackable_scopes(auth_object = nil)
+      def self.ransackable_scopes(_auth_object = nil)
         [:with_any_origin, :with_any_state, :state_eq, :voted_by, :coauthored_by, :related_to, :with_any_taxonomies, :valuator_role_ids_has]
       end
 
@@ -411,7 +411,7 @@ module Decidim
       # Create the :search_text ransacker alias for searching from both of these.
       ransacker_i18n_multi :search_text, [:title, :body]
 
-      def self.ransackable_attributes(auth_object = nil)
+      def self.ransackable_attributes(_auth_object = nil)
         %w(id_string search_text title body is_emendation comments_count proposal_votes_count published_at proposal_notes_count)
       end
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -25,7 +25,7 @@
             <%= check_box_tag "proposals_bulk", "all", false, class: "js-check-all" %>
           </th>
           <th class="!text-left">
-            <%= sort_link(query, :title, t("models.proposal.fields.title", scope: "decidim.proposals") ) %>
+            <%= sort_link(query, :translated_title, t("models.proposal.fields.title", scope: "decidim.proposals") ) %>
           </th>
           <th>
             <%= sort_link(query, :published_at, t("models.proposal.fields.published_at", scope: "decidim.proposals") ) %>
@@ -58,7 +58,7 @@
           </th>
 
           <th>
-            <%= sort_link(query, :state, [:state, :is_emendation], t("models.proposal.fields.state", scope: "decidim.proposals") ) %>
+            <%= t("models.proposal.fields.state", scope: "decidim.proposals") %>
           </th>
 
           <th><%= t("actions.title", scope: "decidim.proposals") %></th>


### PR DESCRIPTION
#### :tophat: What? Why?

Currently, the admin / proposals list page have two issues:

- Most sortable columns don't work nor the default sorting (by title).
- When using that page as a non-admin (like as an "admin" UserRole), the "Assigned to valuator" filter doesn't work. 

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/13594
- Fixes https://github.com/decidim/decidim/issues/13583

#### Testing

- Process admin can filter by valuator in the admin proposals view: https://decidim-lot2.populate.tools/admin/participatory_processes/branch-highway/components/4/manage/proposals
- Proposals can be sorted alphabetically: https://decidim-lot2.populate.tools/admin/participatory_processes/branch-highway/components/4/manage/proposals 

### :camera: Screenshots

![Screenshot 2024-11-04 at 17 17 31](https://github.com/user-attachments/assets/11a7b639-238f-4d82-a8be-8dad331cc9f5)
