### PR TITLE
Patch test environment to set cache_classes to false

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -339,6 +339,10 @@ module Decidim
                   "# config.available_locales = Rails.application.secrets.decidim[:available_locales].presence || [:en]"
       end
 
+      def path_test_config
+        gsub_file "config/environments/test.rb", /config\.cache_classes = true$/, "config.cache_classes = false"
+      end
+
       def dev_performance_config
         gsub_file "config/environments/development.rb", /^end\n$/, <<~CONFIG
 


### PR DESCRIPTION
#### :tophat: What? Why?
It was reported on matrix chat that sometimes the test environment cannot be generated, and the generator fails with the following error : 

```
/home/runner/work/decidim-module-kids/decidim-module-kids/vendor/bundle/ruby/3.2.0/gems/spring-4.2.1/lib/spring/application.rb:105:in `block in preload': Spring reloads, and therefore needs the application to have reloading enabled.
Please, set config.cache_classes to false in config/environments/test.rb.
```

I personally could not reproduce it in my stack, but @andra-panaite encountered this issue while working #13575 . 
We had to add the snippet in this PR to the generator to make it run correctly. 
Additional context, extracted from : https://github.com/AjuntamentdeBarcelona/decidim-module-kids/actions/runs/11551918077/job/32149960425?pr=57 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13575 

#### Testing
1. The pipelines should be green 
2. The test app should also be generated correctly, having cache_classes flag set to false. 

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/5789beb1-a567-438b-a8cf-1cc50c4d719e)

:hearts: Thank you!
