### PR TITLE
Revert "Backport 'Patch test environment to set cache_classes to false' to v0.29"

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -339,10 +339,6 @@ module Decidim
                   "# config.available_locales = Rails.application.secrets.decidim[:available_locales].presence || [:en]"
       end
 
-      def path_test_config
-        gsub_file "config/environments/test.rb", /config\.cache_classes = true$/, "config.cache_classes = false"
-      end
-
       def dev_performance_config
         gsub_file "config/environments/development.rb", /^end\n$/, <<~CONFIG
 


### PR DESCRIPTION
#### :tophat: What? Why?

Earlier today we have added #13628, which fixes some installations, but breaks the CI. We need to revert this, as this may actually break even more things ( installations, modules etc) 

#### :pushpin: Related Issues

- Related to #13628