### PR TITLE
Lock uri to ~> 0.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "decidim-initiatives", path: "."
 gem "decidim-templates", path: "."
 
 gem "bootsnap", "~> 1.4"
+gem "uri", "~> 0.11"
 
 gem "puma", ">= 6.3.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -765,6 +765,7 @@ GEM
     uber (0.1.0)
     unicode-display_width (2.4.2)
     uniform_notifier (1.16.0)
+    uri (0.13.1)
     valid_email2 (4.0.6)
       activemodel (>= 3.2)
       mail (~> 2.5)
@@ -829,6 +830,7 @@ DEPENDENCIES
   net-smtp (~> 0.3.1)
   parallel_tests (~> 4.2)
   puma (>= 6.3.1)
+  uri (~> 0.11)
   web-console (~> 4.2)
 
 RUBY VERSION

--- a/decidim-generators/Gemfile
+++ b/decidim-generators/Gemfile
@@ -12,6 +12,7 @@ gem "decidim-initiatives", path: ".."
 gem "decidim-templates", path: ".."
 
 gem "bootsnap", "~> 1.3"
+gem "uri", "~> 0.11"
 
 gem "puma", ">= 6.3.1"
 

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -765,6 +765,7 @@ GEM
     uber (0.1.0)
     unicode-display_width (2.4.2)
     uniform_notifier (1.16.0)
+    uri (0.13.1)
     valid_email2 (4.0.6)
       activemodel (>= 3.2)
       mail (~> 2.5)
@@ -828,6 +829,7 @@ DEPENDENCIES
   net-pop (~> 0.1.1)
   net-smtp (~> 0.3.1)
   puma (>= 6.3.1)
+  uri (~> 0.11)
   web-console (~> 4.2)
   wicked_pdf (~> 2.1)
 

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -147,6 +147,7 @@ module Decidim
           append_file "Gemfile", %(\ngem "net-imap", "~> 0.2.3", group: :development)
           append_file "Gemfile", %(\ngem "net-pop", "~> 0.1.1", group: :development)
           append_file "Gemfile", %(\ngem "net-smtp", "~> 0.3.1", group: :development)
+          append_file "Gemfile", %(\ngem "uri", "~> 0.11")
           get "#{target_gemfile}.lock", "Gemfile.lock", force: true
         else
           copy_file target_gemfile, "Gemfile", force: true


### PR DESCRIPTION
#### :tophat: What? Why?
This PR is semantically locking `uri` to `~> 0.11` as recently there was a release or uri 1.0.0, which made the pipeline to fail. 

This aim to fix the following stacktrace:

```
       NameError: uninitialized constant URI::REGEXP
       Did you mean?  Regexp
       /home/runner/work/decidim/decidim/decidim-generators/spec/generator_test_app/config/application.rb:7:in `<top (required)>'
       /home/runner/work/decidim/decidim/decidim-generators/spec/generator_test_app/Rakefile:4:in `<top (required)>'
       bin/rails:5:in `<main>'
       (See full trace by running task with --trace)
       Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
       Coverage report generated for (1/4) to /home/runner/work/decidim/decidim/coverage/coverage.xml. 212 / 273 LOC (77.66%) covered
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13621


#### Testing
pipeline should be green 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![image](https://github.com/user-attachments/assets/f14c071f-c59d-456d-aecc-c1823dafe376)

:hearts: Thank you!
