### PR TITLE
Force definitions load in FactoryBot

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/factory_bot.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/factory_bot.rb
@@ -4,4 +4,8 @@ require "factory_bot_rails"
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
+
+  config.before(:suite) do
+    FactoryBot.find_definitions
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

After we merged #13619, we started to see in `develop` some errors related to the loading of FactoryBot definitions. This PR tries to solve this issue by making sure the definitions are in fact loaded. 

#### :pushpin: Related Issues
 
- Related to #13619

#### Testing

Pipeline should be green 

:hearts: Thank you!
