### PR TITLE
Remove useless fields from processes and assemblies

### DIFF
--- a/decidim-assemblies/db/migrate/20241108141651_remove_column_show_statistics_from_assemblies.rb
+++ b/decidim-assemblies/db/migrate/20241108141651_remove_column_show_statistics_from_assemblies.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveColumnShowStatisticsFromAssemblies < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :decidim_assemblies, :show_statistics, :string
+  end
+end

--- a/decidim-participatory_processes/db/migrate/20241108141423_remove_column_show_metrics_from_participatory_processes.rb
+++ b/decidim-participatory_processes/db/migrate/20241108141423_remove_column_show_metrics_from_participatory_processes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveColumnShowMetricsFromParticipatoryProcesses < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :decidim_participatory_processes, :show_metrics, :boolean
+  end
+end

--- a/decidim-participatory_processes/db/migrate/20241108141514_remove_column_banner_image_from_participatory_processes.rb
+++ b/decidim-participatory_processes/db/migrate/20241108141514_remove_column_banner_image_from_participatory_processes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveColumnBannerImageFromParticipatoryProcesses < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :decidim_participatory_processes, :banner_image, :string
+  end
+end

--- a/decidim-participatory_processes/db/migrate/20241108141605_remove_column_show_statistics_from_participatory_processes.rb
+++ b/decidim-participatory_processes/db/migrate/20241108141605_remove_column_show_statistics_from_participatory_processes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveColumnShowStatisticsFromParticipatoryProcesses < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :decidim_participatory_processes, :show_statistics, :string
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

In v0.29.0 releases notes, we have the following explanation: 

> ### 2.4. Removal of useless fields
> 
> We are removing some useless fields that are leftovers from the Redesign.
> 
> For the moment we are leaving the information in your database in case that you want to save it, but in v0.30 these fields we'll be fully removed.
> 
> - participatory process table: banner_image. You can read more about this change on PR [#13119](https://github.com/decidim/decidim/pull/13119).
> - assemblies table: show_statistics. You can read more about this change on PR [#13123](https://github.com/decidim/decidim/pull/13123).
> - participatory process table: show_statistics. You can read more about this change on PR [#13123](https://github.com/decidim/decidim/pull/13123).
> - participatory process table: show_metrics. You can read more about this change on PR [#13123](https://github.com/decidim/decidim/pull/13123).

This PR does the removal of these fields for next release (v0.30)  

#### Testing

1. check your `development_app/db/schema.rb` and see these fields
2. run the migrations 
1. check again your `development_app/db/schema.rb` and see that these fields are no longer there 

:hearts: Thank you!
