### PR TITLE
Remove additional space from general search for comments that contain links

### DIFF
--- a/decidim-core/app/cells/decidim/card_s/show.erb
+++ b/decidim-core/app/cells/decidim/card_s/show.erb
@@ -1,10 +1,10 @@
-<%= link_to resource_path, class: "card__search", id: dom_id(resource) do %>
-  <%= content_tag title_tag, class: "h4 card__search-title" do %>
+<%= content_tag title_tag, class: "h4 card__search-title" do %>
+  <%= link_to resource_path, class: "card__search", id: dom_id(resource) do %>
     <%= title %>
   <% end %>
-  <% if metadata_cell.present? %>
-    <div class="card__search-metadata">
-      <%= cell metadata_cell, resource, links: false %>
-    </div>
-  <% end %>
+<% end %>
+<% if metadata_cell.present? %>
+  <div class="card__search-metadata">
+    <%= cell metadata_cell, resource, links: false %>
+  </div>
 <% end %>

--- a/decidim-core/app/cells/decidim/card_s/show.erb
+++ b/decidim-core/app/cells/decidim/card_s/show.erb
@@ -1,4 +1,4 @@
-<%= content_tag :div, id: dom_id(resource) do %>
+<%= content_tag :div, id: dom_id(resource), class: "card__search" do %>
   <%= content_tag title_tag, class: "h4 card__search-title" do %>
     <%= link_to resource_path, class: "card__search" do %>
       <%= title %>

--- a/decidim-core/app/cells/decidim/card_s/show.erb
+++ b/decidim-core/app/cells/decidim/card_s/show.erb
@@ -1,10 +1,12 @@
-<%= content_tag title_tag, class: "h4 card__search-title" do %>
-  <%= link_to resource_path, class: "card__search", id: dom_id(resource) do %>
-    <%= title %>
+<%= content_tag :div, id: dom_id(resource) do %>
+  <%= content_tag title_tag, class: "h4 card__search-title" do %>
+    <%= link_to resource_path, class: "card__search" do %>
+      <%= title %>
+    <% end %>
   <% end %>
-<% end %>
-<% if metadata_cell.present? %>
-  <div class="card__search-metadata">
-    <%= cell metadata_cell, resource, links: false %>
-  </div>
+  <% if metadata_cell.present? %>
+    <div class="card__search-metadata">
+     <%= cell metadata_cell, resource, links: false %>
+    </div>
+  <% end %>
 <% end %>

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_s_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_s_cell_spec.rb
@@ -13,7 +13,7 @@ module Decidim::Meetings
 
     context "when rendering" do
       it "renders the card" do
-        expect(subject).to have_css("#meeting_#{meeting.id}.card__search")
+        expect(subject).to have_css("div#meeting_#{meeting.id}")
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
I have removed the additional <a> tag that appeared above the comment title.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes https://github.com/decidim/decidim/issues/13582

#### Testing
1. Go to a proposal/meeting.
2. Add a comment.
3. Go to the general search.
4. Observe the extra space above the comments containing links.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
