### PR TITLE
Backport 'Fix datetime fields on forms when the organization has a timezone specified' to v0.28

### DIFF
--- a/.spelling.yml
+++ b/.spelling.yml
@@ -3,6 +3,7 @@ exclude_paths:
   - config/locales/((?!en).)*\.yml
   - decidim-dev/lib/decidim/dev/assets/participatory_text.md
   - decidim-core/lib/decidim/db/common-passwords.txt
+  - decidim-core/spec/lib/attributes/time_with_timezone_spec.rb
   - decidim-initiatives/spec/types/initiative_type_spec.rb
   - decidim-proposals/app/packs/documents/decidim/proposals/participatory_texts/participatory_text.md
 

--- a/decidim-core/lib/decidim/attributes/time_with_zone.rb
+++ b/decidim-core/lib/decidim/attributes/time_with_zone.rb
@@ -5,6 +5,15 @@ module Decidim
     # Custom attributes value to parse a String representing a Time using
     # the app TimeZone.
     class TimeWithZone < ActiveModel::Type::DateTime
+      # Date format: 2020-06-20T, 2020-06-20, 20/06/2020T or 20/06/2020
+      # Time format: 10:20, 10:20:30 or 10:20:30.123456
+      ISO_DATETIME_WITHOUT_TIMEZONE = %r{
+        \A
+        ((\d{4})-(\d\d)-(\d\d)|(\d\d)/(\d\d)/(\d{4}))(?:T|\s)
+        (\d\d):(\d\d)(:(\d\d)(?:\.(\d{1,6})\d*)?)?
+        \z
+      }x
+
       def type
         :"decidim/attributes/time_with_zone"
       end
@@ -18,8 +27,9 @@ module Decidim
       rescue ArgumentError
         fallback = super
         return fallback unless fallback.is_a?(Time)
+        return Time.zone.parse(fallback.strftime("%F %T")) if ISO_DATETIME_WITHOUT_TIMEZONE.match?(value)
 
-        Time.zone.parse(fallback.strftime("%F %T"))
+        ActiveSupport::TimeWithZone.new(fallback, Time.zone)
       end
     end
   end

--- a/decidim-core/spec/lib/attributes/time_with_timezone_spec.rb
+++ b/decidim-core/spec/lib/attributes/time_with_timezone_spec.rb
@@ -25,42 +25,82 @@ module Decidim
         context "and timezone offset" do
           it "parses the String in the correct timezone" do
             Time.use_zone("CET") do
-              expect(subject.utc.to_s).to eq("2017-02-01 14:00:00 UTC")
+              expect(subject.utc.to_s).to eq(expected_time_with_offset)
             end
           end
         end
 
         context "and no timezone offset" do
           it "parses the String in the correct timezone" do
-            expect(subject.utc.to_s).to eq("2017-02-01 15:00:00 UTC")
+            expect(subject.utc.to_s).to eq(expected_time_without_offset)
           end
         end
       end
 
       context "when given a String" do
         context "with formatted DateTime" do
-          context "when d/m/Y" do
-            let(:value) { "01/02/2017 15:00" }
+          let(:expected_time_without_offset) { "2017-02-01 15:00:00 UTC" }
 
-            include_context "with date and time parsing"
+          context "without specifying the timezone" do
+            let(:expected_time_with_offset) { "2017-02-01 14:00:00 UTC" }
+
+            context "when d/m/Y HH:mm" do
+              let(:value) { "01/02/2017 15:00" }
+
+              include_context "with date and time parsing"
+            end
+
+            context "when Y-m-d HH:MM" do
+              let(:value) { "2017-02-01 15:00" }
+
+              include_context "with date and time parsing"
+            end
+
+            context "when Y-m-d HH:MM:SS" do
+              let(:value) { "2017-02-01 15:00:00" }
+
+              include_context "with date and time parsing"
+            end
+
+            context "when Y-m-d HH:MM:SS.N" do
+              let(:value) { "2017-02-01 15:00:00.000000" }
+
+              include_context "with date and time parsing"
+            end
+
+            context "when Y-m-dTHH:MM" do
+              let(:value) { "2017-02-01T15:00" }
+
+              include_context "with date and time parsing"
+            end
+
+            context "when Y-m-dTHH:MM:SS" do
+              let(:value) { "2017-02-01T15:00:00" }
+
+              include_context "with date and time parsing"
+            end
+
+            context "when Y-m-dTHH:MM:SS.N" do
+              let(:value) { "2017-02-01T15:00:00.000000" }
+
+              include_context "with date and time parsing"
+            end
           end
 
-          context "when Y-m-d HH:MM" do
-            let(:value) { "2017-02-01 15:00" }
+          context "with specifying the timezone" do
+            let(:expected_time_with_offset) { "2017-02-01 15:00:00 UTC" }
 
-            include_context "with date and time parsing"
-          end
+            context "when Y-m-d HH:MM:SS TZ" do
+              let(:value) { "2017-02-01 16:00:00 +01:00" }
 
-          context "when Y-m-d HH:MM:SS TZ" do
-            let(:value) { "2017-02-01 16:00:00 +01:00" }
+              include_context "with date and time parsing"
+            end
 
-            include_context "with date and time parsing"
-          end
+            context "when %Y-%m-%d %H:%M:%S.%N %z" do
+              let(:value) { "2017-02-01 16:00:00.000000000 +0100" }
 
-          context "when %Y-%m-%d %H:%M:%S.%N %z" do
-            let(:value) { "2017-02-01 16:00:00.000000000 +0100" }
-
-            include_context "with date and time parsing"
+              include_context "with date and time parsing"
+            end
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #13577 to v0.28

:hearts: Thank you!