### PR TITLE
Sort valuator selectors by valuator name

### DIFF
--- a/decidim-core/lib/decidim/participatory_space_user.rb
+++ b/decidim-core/lib/decidim/participatory_space_user.rb
@@ -47,6 +47,10 @@ module Decidim
         []
       end
 
+      def self.order_by_name
+        includes(:user).order("decidim_users.name ASC")
+      end
+
       private
 
       # Private: check if the process and the user have the same organization

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/admin/filterable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/admin/filterable.rb
@@ -51,7 +51,7 @@ module Decidim
           end
 
           def valuator_role_ids
-            current_participatory_space.user_roles(:valuator).pluck(:id)
+            current_participatory_space.user_roles(:valuator).order_by_name.pluck(:id)
           end
 
           def translated_valuator_role_ids_has(valuator_role_id)

--- a/decidim-proposals/app/forms/decidim/proposals/admin/valuation_assignment_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/valuation_assignment_form.rb
@@ -16,7 +16,10 @@ module Decidim
         end
 
         def valuator_roles
-          @valuator_roles ||= current_component.participatory_space.user_roles(:valuator).where(id: valuator_role_ids)
+          @valuator_roles ||= current_component.participatory_space
+                                               .user_roles(:valuator)
+                                               .order_by_name
+                                               .where(id: valuator_role_ids)
         end
 
         def same_participatory_space

--- a/decidim-proposals/app/helpers/decidim/proposals/admin/proposal_bulk_actions_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/admin/proposal_bulk_actions_helper.rb
@@ -35,7 +35,7 @@ module Decidim
 
         # find the valuators for the current space.
         def find_valuators_for_select(participatory_space, current_user)
-          valuator_roles = participatory_space.user_roles(:valuator)
+          valuator_roles = participatory_space.user_roles(:valuator).order_by_name
           valuators = Decidim::User.where(id: valuator_roles.pluck(:decidim_user_id)).to_a
 
           filtered_valuator_roles = valuator_roles.filter do |role|


### PR DESCRIPTION
Fixes https://github.com/decidim/decidim/issues/13594

Sorts valuator' selectors and filters by valuator name (instead of defaults' user role id).

Test: https://decidim-lot2.populate.tools/admin/participatory_processes/branch-highway/components/4/manage/proposals?q%5Bs%5D=translated_title+asc