### PR TITLE
Fix flacky spec on budgets' open data export

### DIFF
--- a/decidim-budgets/spec/services/decidim/open_data_exporter_spec.rb
+++ b/decidim-budgets/spec/services/decidim/open_data_exporter_spec.rb
@@ -23,5 +23,21 @@ describe Decidim::OpenDataExporter do
   end
   let(:unpublished_resource) { create(:project, component: unpublished_component) }
 
+  before do
+    I18n.backend.reload!
+    I18n.backend.store_translations(
+      :en,
+      decidim: {
+        open_data: {
+          help: {
+            projects: {
+              test_field: "Test field for projects serializer subscription"
+            }
+          }
+        }
+      }
+    )
+  end
+
   it_behaves_like "open data exporter"
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR attempts to fix the flaky spec on the budget. Since this cannot be tested on local, i have test it in our repo, and seems that is working as it should. 

#### Testing
1. Pipeline should be green

:hearts: Thank you!
