### PR TITLE
Backport 'Remove `personal_url` and `about` fields when users are deleted' to v0.29

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -122,7 +122,7 @@ bin/rails decidim_proposals:upgrade:set_categories
 
 You can read more about this change on PR [#13395](https://github.com/decidim/decidim/pull/13395).
 
-### 2.7. wkhtmltopdf binary change
+### 2.9. wkhtmltopdf binary change
 
 For improving the support with latest versions of Ubuntu, and keeping a low size in Heroku/Docker images, we removed the `wkhtmltopdf-binary` gem dependency. This means that your package manager should have the `wkhtmltopdf` binary installed.
 
@@ -133,6 +133,16 @@ sudo apt install wkhtmltopdf
 ```
 
 You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).
+
+### 2.10. Clean deleted user records `decidim:upgrade:clean:clean_deleted_users` task
+
+When a user deleted their account, we mistakenly retained some metadata, such as the personal_url and about fields. Going forward, these fields will be automatically cleared upon deletion. To fix this issue for previously deleted accounts, we've added a new rake task that should be run on your production database.
+
+```ruby
+bin/rails decidim:upgrade:clean:clean_deleted_users
+```
+
+You can read more about this change on PR [#13624](https://github.com/decidim/decidim/pull/13624).
 
 ## 3. One time actions
 

--- a/decidim-core/app/commands/decidim/destroy_account.rb
+++ b/decidim-core/app/commands/decidim/destroy_account.rb
@@ -37,6 +37,8 @@ module Decidim
       current_user.name = ""
       current_user.nickname = ""
       current_user.email = ""
+      current_user.personal_url = ""
+      current_user.about = ""
       current_user.delete_reason = @form.delete_reason
       current_user.admin = false if current_user.admin?
       current_user.deleted_at = Time.current

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -218,8 +218,15 @@ FactoryBot.define do
     end
 
     trait :deleted do
+      name { "" }
+      nickname { "" }
       email { "" }
+      delete_reason { "I want to delete my account" }
+      admin { false }
       deleted_at { Time.current }
+      avatar { nil }
+      personal_url { "" }
+      about { "" }
     end
 
     trait :admin_terms_accepted do

--- a/decidim-core/lib/tasks/upgrade/decidim_fix_categorization.rake
+++ b/decidim-core/lib/tasks/upgrade/decidim_fix_categorization.rake
@@ -8,8 +8,17 @@ namespace :decidim do
         :"decidim:upgrade:clean:searchable_resources",
         :"decidim:upgrade:clean:notifications",
         :"decidim:upgrade:clean:follows",
-        :"decidim:upgrade:clean:action_logs"
+        :"decidim:upgrade:clean:action_logs",
+        :"decidim:upgrade:clean:action_logs",
+        :"decidim:upgrade:clean:clean_deleted_users"
       ]
+
+      desc "Remove data from deleted users"
+      task clean_deleted_users: :environment do
+        logger = Logger.new($stdout)
+        logger.info("=== Removing extra data from deleted users")
+        Decidim::User.where.not(deleted_at: nil).update_all(personal_url: "", about: "") # rubocop:disable Rails/SkipsModelValidations
+      end
 
       desc "Removes any action logs belonging to invalid resources"
       task :action_logs, [] => :environment do

--- a/decidim-core/spec/commands/decidim/destroy_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/destroy_account_spec.rb
@@ -51,11 +51,14 @@ module Decidim
         expect(user.reload.deleted_at).not_to be_nil
       end
 
-      it "set name, nickname and email to blank string" do
+      it "set name, nickname, personal_url, about and email to blank string" do
         command.call
-        expect(user.reload.name).to eq("")
-        expect(user.reload.nickname).to eq("")
-        expect(user.reload.email).to eq("")
+        user.reload
+        expect(user.name).to eq("")
+        expect(user.nickname).to eq("")
+        expect(user.email).to eq("")
+        expect(user.personal_url).to eq("")
+        expect(user.about).to eq("")
       end
 
       it "destroys the current user avatar" do

--- a/decidim-core/spec/tasks/upgrade/clean_deleted_users_spec.rb
+++ b/decidim-core/spec/tasks/upgrade/clean_deleted_users_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "rake decidim:upgrade:clean:clean_deleted_users", type: :task do
+  context "when executing task" do
+    let!(:organization) { create(:organization) }
+    let!(:user) { create(:user, organization:, about: "This is my description", personal_url: "http://example.com") }
+    let!(:deleted_user) { create(:user, :deleted, organization:, about: "This is my description", personal_url: "http://example.com") }
+
+    it "updates the correct user" do
+      task.execute
+
+      expect(user.reload.about).to eq("This is my description")
+      expect(user.reload.personal_url).to eq("http://example.com")
+      expect(deleted_user.reload.about).to eq("")
+      expect(deleted_user.reload.personal_url).to eq("")
+    end
+
+    it "avoid removing entries" do
+      expect { task.execute }.not_to change(Decidim::User, :count)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #13624 to v0.29

:hearts: Thank you!