### PR TITLE
Improve the seeded surveys

### DIFF
--- a/decidim-surveys/lib/decidim/surveys/seeds.rb
+++ b/decidim-surveys/lib/decidim/surveys/seeds.rb
@@ -143,57 +143,40 @@ module Decidim
           when "single_option", "multiple_option", "sorting"
             create_answer_for_multiple_choice_question_type(answer_options.merge({ question: }))
           when "matrix_single", "matrix_multiple"
-            create_answer_for_matrix_question_type(answer_options.merge({ question:}))
+            create_answer_for_matrix_question_type(answer_options.merge({ question: }))
           end
         end
       end
 
       def create_answer_for_text_question_type!(options)
-          Decidim::Forms::Answer.create!(
-            user: options[:user],
-            questionnaire: options[:questionnaire],
-            question: options[:question],
-            body: ::Faker::Lorem.paragraph(sentence_count: 1),
-            session_token: options[:session_token],
-            ip_hash: options[:ip_hash]
-          )
+        Decidim::Forms::Answer.create!(
+          **options.merge({ body: ::Faker::Lorem.paragraph(sentence_count: 1) })
+        )
       end
 
       def create_answer_for_multiple_choice_question_type(options)
-        answer = Decidim::Forms::Answer.create!(
-          user: options[:user],
-          questionnaire: options[:questionnaire],
-          question: options[:question],
-          body: nil,
-          session_token: options[:session_token],
-          ip_hash: options[:ip_hash]
-        )
-
+        answer = Decidim::Forms::Answer.create!(**options)
         answer_option = options[:question].answer_options.sample
+        body = answer_option["en"]
+
         Decidim::Forms::AnswerChoice.create!(
           answer:,
           answer_option:,
-          body: answer_option["en"]
+          body:
         )
       end
 
       def create_answer_for_matrix_question_type(options)
-        answer = Decidim::Forms::Answer.create!(
-          user: options[:user],
-          questionnaire: options[:questionnaire],
-          question: options[:question],
-          body: nil,
-          session_token: options[:session_token],
-          ip_hash: options[:ip_hash]
-        )
-
-        matrix_row = options[:question].matrix_rows.sample
+        answer = Decidim::Forms::Answer.create!(**options)
         answer_option = options[:question].answer_options.sample
+        matrix_row = options[:question].matrix_rows.sample
+        body = answer_option["en"]
+
         Decidim::Forms::AnswerChoice.create!(
           answer:,
           answer_option:,
           matrix_row:,
-          body: answer_option["en"]
+          body:
         )
       end
     end

--- a/decidim-surveys/lib/decidim/surveys/seeds.rb
+++ b/decidim-surveys/lib/decidim/surveys/seeds.rb
@@ -20,11 +20,18 @@ module Decidim
       end
 
       def create_component!
+        step_settings = if participatory_space.allows_steps?
+                          { participatory_space.active_step.id => { allow_answers: true } }
+                        else
+                          {}
+                        end
+
         params = {
           name: Decidim::Components::Namer.new(participatory_space.organization.available_locales, :surveys).i18n_name,
           manifest_name: :surveys,
           published_at: Time.current,
-          participatory_space:
+          participatory_space:,
+          step_settings:
         }
 
         Decidim.traceability.perform_action!(

--- a/decidim-surveys/lib/decidim/surveys/seeds.rb
+++ b/decidim-surveys/lib/decidim/surveys/seeds.rb
@@ -114,6 +114,13 @@ module Decidim
             question.matrix_rows.create!(body: Decidim::Faker::Localized.sentence, position:)
           end
         end
+
+        Decidim::Forms::Question.create!(
+          questionnaire:,
+          body: nil,
+          question_type: "separator",
+          position: 3
+        )
       end
     end
   end

--- a/decidim-surveys/lib/decidim/surveys/seeds.rb
+++ b/decidim-surveys/lib/decidim/surveys/seeds.rb
@@ -64,7 +64,7 @@ module Decidim
       end
 
       def create_questions!(questionnaire:)
-        %w(short_answer long_answer).each_with_index do |text_question_type, index|
+        %w(short_answer long_answer files).each_with_index do |text_question_type, index|
           Decidim::Forms::Question.create!(
             questionnaire:,
             body: Decidim::Faker::Localized.paragraph,
@@ -73,7 +73,7 @@ module Decidim
           )
         end
 
-        %w(single_option multiple_option).each_with_index do |multiple_choice_question_type, index|
+        %w(single_option multiple_option sorting).each_with_index do |multiple_choice_question_type, index|
           question = Decidim::Forms::Question.create!(
             questionnaire:,
             body: Decidim::Faker::Localized.paragraph,

--- a/decidim-surveys/lib/decidim/surveys/seeds.rb
+++ b/decidim-surveys/lib/decidim/surveys/seeds.rb
@@ -73,6 +73,7 @@ module Decidim
       def create_questions!(questionnaire:)
         %w(short_answer long_answer files).each_with_index do |text_question_type, index|
           Decidim::Forms::Question.create!(
+            mandatory: text_question_type == "short_answer",
             questionnaire:,
             body: Decidim::Faker::Localized.paragraph,
             question_type: text_question_type,


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing #13617 and also while starting some exploration for #13215, I found that it'd be faster to improve the seeded surveys, as typically for checking out the exports I need to:

1. Go to a surveys component in the admin panel
2. Change the configuration to allow answers
3. Go to the frontend, answer the survey
4. Go back to the admin panel, click in the Export button

With this PR, we can skip the first 3 steps and go directly to the Export button, as there already be some answers available in all the Surveys

Apart from admin the responses, some other changes were made: 

1. Added more question types, to showcase all the different kinds
2. Surveys are open for registered participants
3. The first field is mandatory, to showcase this feature
4. There's a separator (aka different steps in surveys), to showcase this feature

#### :pushpin: Related Issues

- Related to #13617

#### Testing

1. Run the seeds
5. Go to the survey component in the admin
6. See that you have some answers' responses

### :camera: Screenshots
 
![Some surveys' responses in the admin panel](https://github.com/user-attachments/assets/38108ded-fba4-4eff-940f-5d1bd9663c9e)

:hearts: Thank you!
