### PR TITLE
Fix meeting view when maps are disabled

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/dates_and_map/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/dates_and_map/show.erb
@@ -15,9 +15,11 @@
     </div>
   </div>
 
-  <%= static_map %>
-
-  <% if online? %>
+  <% if display_map? %>
+    <%= static_map %>
+  <% elsif online? %>
     <%= cell("decidim/address", meeting, online: true) %>
+  <% else %>
+    <%= cell("decidim/address", meeting) %>
   <% end %>
 </div>

--- a/decidim-meetings/app/cells/decidim/meetings/dates_and_map_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/dates_and_map_cell.rb
@@ -14,7 +14,7 @@ module Decidim
       delegate :snippets, to: :controller
 
       def static_map
-        return render :static_map if display_map?
+        return render :static_map
       end
 
       def year

--- a/decidim-meetings/spec/system/meeting_spec.rb
+++ b/decidim-meetings/spec/system/meeting_spec.rb
@@ -107,10 +107,11 @@ describe "Meeting", download: true do
     context "and meeting is in_person" do
       let(:meeting) { create(:meeting, :published, :with_services, component:) }
 
-      it "hides the map section" do
+      it "hides the map section but displays address" do
         visit_meeting
 
         expect(page).to have_no_css("div.meeting__calendar-container .static-map")
+        expect(page).to have_css("div.meeting__calendar-container .address__container")
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fix "In person" meeting view when maps are configured but not enabled for that component.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #13646 

#### Testing
1. Go to a meeting in a component with the maps enabled and see how you can see the meeting details on the meeting page.
2. Go to the admin page and change the component configuration disabling the maps.
3. Go back to the meeting page and see how the meeting details are still present. 

### :camera: Screenshots
"In person" meeting with maps configured and enabled for the component:
![3109f436-f7d5-4896-94d1-9e88af1c3d43](https://github.com/user-attachments/assets/641c9f3c-4124-4d58-a4d8-31fadd1b592d)

"In person" meeting with maps configured but disabled for the component (fixed view):
![1d90a7c4-8cbb-4475-aeec-06aea30aca26](https://github.com/user-attachments/assets/5472bc38-ce2d-4107-b115-a3fd9267a5c6)

"Online" meetings configured and maps enabled for the component. Same screenshot for meetings configured and maps disabled:

![8578be46-3051-4afe-b053-8240a6d8c46e](https://github.com/user-attachments/assets/e50ba6ca-97dd-406c-b66e-6e5b6733432d)




:hearts: Thank you!
