### PR TITLE
Remove redundant words in jobs.adoc

### DIFF
--- a/docs/modules/develop/pages/classes/jobs.adoc
+++ b/docs/modules/develop/pages/classes/jobs.adoc
@@ -1,6 +1,6 @@
 = Jobs
 
-Decidim jobs classes are not do not implement anything different than what `ActiveJob` has to offer.
+Decidim jobs classes do not implement anything different than what `ActiveJob` has to offer.
 
 Jobs classes are located in the `app/jobs/decidim/<my_module>` directory, and named: `<my_custom>_job.rb`.
 


### PR DESCRIPTION
Cleaning up two words that seem to have been accidentally left behind.