### PR TITLE
Add proposals geocoding to seeds

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -64,7 +64,8 @@ module Decidim
             vote_limit: 0,
             attachments_allowed: [true, false].sample,
             amendments_enabled: participatory_space.id.odd?,
-            collaborative_drafts_enabled: true
+            collaborative_drafts_enabled: true,
+            geocoding_enabled: [true, false].sample
           },
           step_settings:
         }
@@ -95,6 +96,14 @@ module Decidim
           state_published_at:,
           published_at: Time.current
         }
+
+        if component.settings.geocoding_enabled?
+          params = params.merge({
+                                  address: "#{::Faker::Address.street_address} #{::Faker::Address.zip} #{::Faker::Address.city}",
+                                  latitude: ::Faker::Address.latitude,
+                                  longitude: ::Faker::Address.longitude
+                                })
+        end
 
         proposal = Decidim.traceability.perform_action!(
           "publish",


### PR DESCRIPTION
#### :tophat: What? Why?

In the last participatory budgeting in Decidim Barcelona, we have a performance problem with geocoded proposals. This PR changes the seeds so we sometimes have geocoding enabled in the proposals, which would have make it much more easy to find this problem. 

 
#### Testing

0. Enable geocoding by adding the MAPS_API_KEY and MAPS_PROVIDER env keys
1. Drop the database and run the seeds
2. Browse proposals in a participatory process. See that sometimes you have seeds
 
:hearts: Thank you!
