### PR TITLE
Fix calendar failing specs

### DIFF
--- a/decidim-core/spec/system/date_picker/date_picker_spec.rb
+++ b/decidim-core/spec/system/date_picker/date_picker_spec.rb
@@ -94,6 +94,7 @@ describe "Datepicker" do
       it "fills the field correctly" do
         find(".datepicker__calendar-button").click
         find('span > input[name="year"]').set("1994")
+        find('select[name="month"]').find(:option, "January").select_option
         find(".wc-datepicker__next-month-button").click
         month = find('select[name="month"]').value
         formatted_month = format("%02d", month)
@@ -501,6 +502,7 @@ describe "Datepicker" do
       it "fills the field correctly" do
         find(".datepicker__calendar-button").click(x: 5, y: 10)
         find('span > input[name="year"]').set("1994")
+        find('select[name="month"]').find(:option, "January").select_option
         find(".wc-datepicker__next-month-button").click
         month = find('select[name="month"]').value
         formatted_month = format("%02d", month)
@@ -756,6 +758,7 @@ describe "Datepicker" do
       it "fills the field correctly" do
         find(".datepicker__calendar-button").click(x: 5, y: 10)
         find('span > input[name="year"]').set("1994")
+        find('select[name="month"]').find(:option, "January").select_option
         find(".wc-datepicker__next-month-button").click
         month = find('select[name="month"]').value
         formatted_month = format("%02d", month)


### PR DESCRIPTION
#### :tophat: What? Why?
Starting December 1st we started to see that the core pipeline started to fail. This PR fixes this.

<details>
<summary>Details</summary>

```
Failures:

  1) Datepicker when date format dd.mm.yyyy and clock format 24 when filling form datetime input with datepicker fills the field correctly
     Failure/Error: expect(page).to have_field("example_input_date", with: "20/#{formatted_month}/1994")
       expected to find visible field "example_input_date" that is not disabled with value "20/01/1994" but there were no matches. Also found "", which matched the selector but not all filters. Expected value to be "20/01/1994" but was "20/01/1995"

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_datepicker_when_date_format_dd_mm_yyyy_and_clock_format24_when_filling_form_datetime_input_with_datepicker_fills_the_field_correctly_90.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_datepicker_when_date_format_dd_mm_yyyy_and_clock_format24_when_filling_form_datetime_input_with_datepicker_fills_the_field_correctly_90.html


     # ./spec/system/date_picker/date_picker_spec.rb:110:in `block (4 levels) in <top (required)>'

  2) Datepicker when date format yyyy.mm.dd when filling form datetime input with datepicker fills the field correctly
     Failure/Error: expect(page).to have_field("example_input_date", with: "1994/#{formatted_month}/20")
       expected to find visible field "example_input_date" that is not disabled with value "1994/01/20" but there were no matches. Also found "", which matched the selector but not all filters. Expected value to be "1994/01/20" but was "1995/01/20"

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_datepicker_when_date_format_yyyy_mm_dd_when_filling_form_datetime_input_with_datepicker_fills_the_field_correctly_733.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_datepicker_when_date_format_yyyy_mm_dd_when_filling_form_datetime_input_with_datepicker_fills_the_field_correctly_733.html


     # ./spec/system/date_picker/date_picker_spec.rb:771:in `block (4 levels) in <top (required)>'

  3) Datepicker when date format mm/dd/yyyy and clock format 12 when filling form datetime input with datepicker fills the field correctly
     Failure/Error: expect(page).to have_field("example_input_date", with: "#{formatted_month}/20/1994")
       expected to find visible field "example_input_date" that is not disabled with value "01/20/1994" but there were no matches. Also found "", which matched the selector but not all filters. Expected value to be "01/20/1994" but was "01/20/1995"

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_datepicker_when_date_format_mm_dd_yyyy_and_clock_format12_when_filling_form_datetime_input_with_datepicker_fills_the_field_correctly_299.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_datepicker_when_date_format_mm_dd_yyyy_and_clock_format12_when_filling_form_datetime_input_with_datepicker_fills_the_field_correctly_299.html


     # ./spec/system/date_picker/date_picker_spec.rb:515:in `block (4 levels) in <top (required)>'
```


</details>


![image](https://github.com/user-attachments/assets/e1ab5fd2-ec99-47a6-bea2-cdcb8ad6ca49)


#### Testing

Pipelines should be green 

:hearts: Thank you!
