### PR TITLE
Fix login modal rgaa

### DIFF
--- a/decidim-core/app/helpers/decidim/modal_helper.rb
+++ b/decidim-core/app/helpers/decidim/modal_helper.rb
@@ -24,7 +24,7 @@ module Decidim
                    type: :button,
                    data: { dialog_close: opts[:id] || "", dialog_closable: "" },
                    "aria-label": t("close_modal", scope: "decidim.shared.confirm_modal"),
-                   "aria-describedby": opts[:id] || "",
+                   "aria-describedby": opts[:id] || ""
                  )
                end
 

--- a/decidim-core/app/helpers/decidim/modal_helper.rb
+++ b/decidim-core/app/helpers/decidim/modal_helper.rb
@@ -23,7 +23,8 @@ module Decidim
                    "&times".html_safe,
                    type: :button,
                    data: { dialog_close: opts[:id] || "", dialog_closable: "" },
-                   "aria-label": t("close_modal", scope: "decidim.shared.confirm_modal")
+                   "aria-label": t("close_modal", scope: "decidim.shared.confirm_modal"),
+                   "aria-describedby": opts[:id] || "",
                  )
                end
 

--- a/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -12,6 +12,6 @@
     <% end %>
   </div>
   <%- if current_organization.sign_in_enabled? %>
-    <span class="login__omniauth-separator"><%= t(".or") %></span>
+    <p class="login__omniauth-separator"><%= t(".or") %></p>
   <%- end %>
 <% end %>

--- a/decidim-core/app/views/decidim/shared/_login_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_login_modal.html.erb
@@ -40,7 +40,7 @@
 
     <% if current_organization.sign_in_enabled? %>
       <div data-dialog-actions>
-        <button type="button" class="button button__lg button__transparent-secondary" data-dialog-close="loginModal">
+        <button type="button" class="button button__lg button__transparent-secondary" data-dialog-close="loginModal" aria-describedby="loginModal">
           <%= t("cancel", scope: "decidim.admin.actions") %>
         </button>
         <button type="submit" class="button button__lg button__secondary">

--- a/decidim-core/app/views/decidim/shared/_login_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_login_modal.html.erb
@@ -19,6 +19,9 @@
           <% end %>
 
           <div class="form__wrapper">
+            <div>
+              <p><%= t('.required_fields') %></p>
+            </div>
             <%= f.email_field :email, autocomplete: "email", placeholder: t("placeholder_email", scope: "decidim.devise.shared"), required: true %>
 
             <%= render partial: "decidim/account/password_fields", locals: { form: f } %>

--- a/decidim-core/app/views/decidim/shared/_login_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_login_modal.html.erb
@@ -20,7 +20,7 @@
 
           <div class="form__wrapper">
             <div>
-              <p><%= t('.required_fields') %></p>
+              <p><%= t(".required_fields") %></p>
             </div>
             <%= f.email_field :email, autocomplete: "email", placeholder: t("placeholder_email", scope: "decidim.devise.shared"), required: true %>
 

--- a/decidim-core/app/views/decidim/shared/_login_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_login_modal.html.erb
@@ -19,7 +19,7 @@
           <% end %>
 
           <div class="form__wrapper">
-            <%= f.email_field :email, autocomplete: "email", placeholder: t("placeholder_email", scope: "decidim.devise.shared") %>
+            <%= f.email_field :email, autocomplete: "email", placeholder: t("placeholder_email", scope: "decidim.devise.shared"), required: true %>
 
             <%= render partial: "decidim/account/password_fields", locals: { form: f } %>
           </div>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1663,6 +1663,7 @@ en:
         log_in_before_follow: Please log in before performing this action
       login_modal:
         please_log_in: Please log in
+        required_fields: All fields are required
         sign_up: Create an account
       mentions_modal:
         remove_recipient: Remove recipient %{name}


### PR DESCRIPTION
#### :tophat: What? Why?
In omniauth modal, add aria on close button, change span for p, and add explanation on mandatory fields before the form.

#### :pushpin: Related Issues
*Link your PR to an issue*
Related to #https://github.com/decidim/decidim/issues/13722

#### Testing
Without being logged, go to a process
Click on follow button
The omniauth modal appears
Check that you can fully navigate with the keyboard in the modal

### :camera: Screenshots
<img width="900" alt="391947089-5f4edee9-1abc-4116-b35c-bc6ed6890e7b" src="https://github.com/user-attachments/assets/7b818b98-e95c-4cd8-8faa-27362b059ea7">


:hearts: Thank you!
