### PR TITLE
Fix videos disappearing from admin editors without cookie consent

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -453,7 +453,7 @@ describe "Admin manages organization", type: :system do
       context "when the admin terms of use content has only a video" do
         let(:organization) { create(:organization, admin_terms_of_use_body: {}) }
 
-        it "saves the content correctly with the video" do
+        before do
           within ".editor" do
             within ".editor .ql-toolbar" do
               find("button.ql-video").click
@@ -463,8 +463,28 @@ describe "Admin manages organization", type: :system do
               find("a.ql-action").click
             end
           end
+        end
+
+        it "saves the content correctly with the video" do
+          click_button "Update"
+
+          organization.reload
+          expect(translated(organization.admin_terms_of_use_body)).to eq(
+            %(<iframe class="ql-video" frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/f6JMgJAQ2tc?showinfo=0"></iframe>)
+          )
+        end
+
+        it "does not remove the video" do
+          click_button "Update"
+          expect(page).to have_content("Organization updated successfully")
+
+          # Close the callout for the new update to initiate the callout again
+          within ".callout-wrapper .callout.success" do
+            click_button "×"
+          end
 
           click_button "Update"
+          expect(page).to have_content("Organization updated successfully")
 
           organization.reload
           expect(translated(organization.admin_terms_of_use_body)).to eq(

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -949,7 +949,11 @@ module Decidim
     # WYSIWYG editor
     #
     def sanitize_editor_value(value)
-      sanitized_value = decidim_sanitize_editor_admin(value)
+      # Do not call the `decidim_sanitize_editor_admin` here because it would
+      # disable the iframe elements from the editable areas that are shown to
+      # admins causing all videos to be removed in case the admin has not given
+      # full consent to cookies.
+      sanitized_value = decidim_sanitize_editor(value, { scrubber: Decidim::AdminInputScrubber.new })
 
       sanitized_value == %(<div class="ql-editor-display"></div>) ? "" : sanitized_value
     end


### PR DESCRIPTION
#### :tophat: What? Why?
When the admin user has not given their full cookie consent, any videos embedded into the rich text editors will disappear when they edit these sections.

This bug only exists in versions 0.27.7-0.27.9 and was introduced by #12925 which is why this PR is for 0.27 only.

#### :pushpin: Related Issues
- Related to #12925
- Fixes #13727

#### Testing
- Make sure you have only essential cookies enabled
- Login as admin
- Go to the admin panel
- Edit any rich text field in there
- Add a video to the field
- Save the page
- Wait for reload (or go back to the same edit view) and see that the video disappears within the content element
- Re-save the page
- The video has now been removed also from the content stored in the database