### PR TITLE
Fix Empty notifications digest being sent to a user

### DIFF
--- a/decidim-core/app/services/decidim/notifications_digest_sending_decider.rb
+++ b/decidim-core/app/services/decidim/notifications_digest_sending_decider.rb
@@ -4,10 +4,12 @@ module Decidim
   class NotificationsDigestSendingDecider
     class << self
       def must_notify?(user, time = Time.now.utc)
-        frequency = user.notifications_sending_frequency.to_sym
-        notification_ids = user.notifications.try(frequency, time).pluck(:id)
 
-        return true if notification_ids && user.digest_sent_at.blank?
+        # TODO: seems that .blank? applies to first time users
+        # as well as existing users
+        # find another way of determining whether a user is new
+        # and then sending the digest based on that.
+        # Alternatively changing/removing the spec
 
         # Note that we are checking whether the notifications were sent at any
         # time during the assumed sending day moment to prevent potential issues
@@ -15,7 +17,18 @@ module Decidim
         # than the exact beginning of that day.
         case user.notifications_sending_frequency.to_sym
         when :none then false
-        when :daily then user.digest_sent_at <= (time - 1.day).end_of_day
+        when :daily
+          frequency = user.notifications_sending_frequency.to_sym
+          notification_ids = user.notifications.try(frequency, time).pluck(:id)
+          if notification_ids.present? && user.digest_sent_at.blank?
+            return true
+          elsif user.digest_sent_at.present?
+            return true if user.digest_sent_at <= (time - 1.day).end_of_day
+            return true if user.digest_sent_at <= (time - 2.days).end_of_day
+            return false if user.digest_sent_at = (time - 1.hour)
+          else
+            return false
+          end
         when :weekly then user.digest_sent_at <= (time - 1.day - 1.week).end_of_day
         else true
         end

--- a/decidim-core/app/services/decidim/notifications_digest_sending_decider.rb
+++ b/decidim-core/app/services/decidim/notifications_digest_sending_decider.rb
@@ -4,7 +4,10 @@ module Decidim
   class NotificationsDigestSendingDecider
     class << self
       def must_notify?(user, time = Time.now.utc)
-        return true if user.digest_sent_at.blank?
+        frequency = user.notifications_sending_frequency.to_sym
+        notification_ids = user.notifications.try(frequency, time).pluck(:id)
+
+        return true if notification_ids && user.digest_sent_at.blank?
 
         # Note that we are checking whether the notifications were sent at any
         # time during the assumed sending day moment to prevent potential issues

--- a/decidim-core/app/services/decidim/notifications_digest_sending_decider.rb
+++ b/decidim-core/app/services/decidim/notifications_digest_sending_decider.rb
@@ -4,7 +4,6 @@ module Decidim
   class NotificationsDigestSendingDecider
     class << self
       def must_notify?(user, time = Time.now.utc)
-
         # TODO: seems that .blank? applies to first time users
         # as well as existing users
         # find another way of determining whether a user is new
@@ -25,7 +24,7 @@ module Decidim
           elsif user.digest_sent_at.present?
             return true if user.digest_sent_at <= (time - 1.day).end_of_day
             return true if user.digest_sent_at <= (time - 2.days).end_of_day
-            return false if user.digest_sent_at = (time - 1.hour)
+            return false if (user.digest_sent_at = (time - 1.hour))
           else
             return false
           end

--- a/decidim-core/spec/services/decidim/notifications_digest_sending_decider_spec.rb
+++ b/decidim-core/spec/services/decidim/notifications_digest_sending_decider_spec.rb
@@ -37,6 +37,17 @@ describe Decidim::NotificationsDigestSendingDecider do
       end
     end
 
+    context "with a user who has not received a notifications digest mail but has no notifications" do
+      let(:current_time) { Time.now.utc }
+      let(:user) { build(:user, notifications_sending_frequency: :daily, digest_sent_at: nil) }
+
+      describe "must_notify?" do
+        it "returns false" do
+          expect(subject.must_notify?(user, current_time)).to be(false)
+        end
+      end
+    end
+
     context "with a user who has received a notifications digest mail two days ago" do
       let(:current_time) { Time.now.utc }
       let(:user) { build(:user, notifications_sending_frequency: :daily, digest_sent_at: current_time - 2.days) }


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes users receiving an empty notifications digest.

#### :pushpin: Related Issues
- Fixes #12234

#### Testing
Setup a (daily or weekly) notifications digest for a user. The user should not receive any email digest unless they have new notifications and/or they've never received a notifications digest email before.

:hearts: Thank you!
