### PR TITLE
Do not send newsletters to blocked users

### DIFF
--- a/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
+++ b/decidim-admin/app/queries/decidim/admin/newsletter_recipients.rb
@@ -20,11 +20,7 @@ module Decidim
       end
 
       def query
-        recipients = Decidim::User.where(organization: @form.current_organization)
-                                  .where.not(newsletter_notifications_at: nil)
-                                  .where.not(email: nil)
-                                  .where.not(confirmed_at: nil)
-                                  .not_deleted
+        recipients = recipients_base_query
 
         recipients = recipients.interested_in_scopes(@form.scope_ids) if @form.scope_ids.present?
 
@@ -40,6 +36,15 @@ module Decidim
       end
 
       private
+
+      def recipients_base_query
+        Decidim::User.available
+                     .where(organization: @form.current_organization)
+                     .where.not(newsletter_notifications_at: nil)
+                     .where.not(email: nil)
+                     .where.not(confirmed_at: nil)
+                     .not_deleted
+      end
 
       # Return the ids of the ParticipatorySpace selected
       # in form, grouped by type

--- a/decidim-admin/spec/queries/newsletter_recipients_spec.rb
+++ b/decidim-admin/spec/queries/newsletter_recipients_spec.rb
@@ -49,6 +49,14 @@ module Decidim::Admin
             expect(recipients.count).to eq 5
           end
         end
+
+        context "with blocked accounts" do
+          let!(:blocked_recipients) { create_list(:user, 5, :confirmed, :blocked, newsletter_notifications_at: Time.current, organization:) }
+          it "returns all not blocked users" do
+            expect(subject.query).to match_array recipients
+            expect(recipients.count).to eq 5
+          end
+        end
       end
 
       context "when sending to followers" do


### PR DESCRIPTION
#### :tophat: What? Why?
Newsletters are being sent to blocked users. This PR prevents that.

#### Testing
- Create blocked users
- Send a newsletter
- See the newsletter sent to blocked users