### PR TITLE
Adjust PR Labels workflow

### DIFF
--- a/.github/workflows/add_pr_labels.yml
+++ b/.github/workflows/add_pr_labels.yml
@@ -1,9 +1,5 @@
 name: "Pull Request Labeler"
 on:
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
-    types: [ opened, edited, synchronize, reopened, labeled, unlabeled ]
   pull_request_target:
     branches-ignore:
       - "chore/l10n*"
@@ -23,6 +19,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/labeler@v5
         with:
-          sync-labels: 'true'
           dot: 'true'
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
#### :tophat: What? Why?
This PR changes slightly the Add PR labels introduced in #13726

- We remove sync option, so that labels are not removed. 
- Remove `pull_request` target workflow, to allow green pipelines in external PRs

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13726

#### Testing
Pipeline should be green 

:hearts: Thank you!
