### PR TITLE
Public export Proposals for ```votes_count``` hidden

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -40,7 +40,8 @@ module Decidim
           reference: proposal.reference,
           answer: ensure_translatable(proposal.answer),
           answered_at: proposal.answered_at,
-          votes: proposal.proposal_votes_count,
+          votes: (proposal.proposal_votes_count unless
+          proposal.component.current_settings.votes_hidden?),
           endorsements: {
             total_count: proposal.endorsements.size,
             user_endorsements:

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -236,6 +236,15 @@ module Decidim
           end
         end
 
+        context "when the votes are hidden" do
+          let!(:component) { create(:proposal_component, :with_votes_hidden) }
+          let!(:proposal) { create(:proposal, component:) }
+
+          it "does not include total count of votes" do
+            expect(serialized).to include(votes: nil)
+          end
+        end
+
         context "with rich text proposal body" do
           let(:image) { "<img src=\"logo.png\" #{alt_attribute} width=\"407\">" }
           let(:alt_attribute) { "alt=\"Logo alt attribute\"" }


### PR DESCRIPTION
#### :tophat: What? Why?
A fix which is also applicable to Projects within Budgets, which allows CSV exports of the module not to contain ```proposal_vote_count``` due to not enabling the ```show_votes``` (disabling the option). 

#### :pushpin: Related Issues
- Related to #12348
- Related to #13250

#### Testing

### :camera: Screenshots

:hearts: Thank you!
