### PR TITLE
Hide the public export for Projects votes

### DIFF
--- a/decidim-budgets/lib/decidim/budgets/project_serializer.rb
+++ b/decidim-budgets/lib/decidim/budgets/project_serializer.rb
@@ -29,7 +29,8 @@ module Decidim
           description: project.description,
           budget: { id: project.budget.id },
           budget_amount: project.budget_amount,
-          confirmed_votes: project.confirmed_orders_count,
+          confirmed_votes: (project.confirmed_orders_count if
+            project.component.current_settings.show_votes?),
           comments: project.comments_count,
           created_at: project.created_at,
           url: project.polymorphic_resource_url({}),

--- a/decidim-budgets/spec/serializers/project_serializer_spec.rb
+++ b/decidim-budgets/spec/serializers/project_serializer_spec.rb
@@ -4,13 +4,14 @@ require "spec_helper"
 
 module Decidim::Budgets
   describe ProjectSerializer do
-    let(:budget) { create(:budget) }
+    let(:budget) { create(:budget, component:) }
     let(:serialized) { subject.run }
     let(:attachment) { create(:attachment, attached_to: project) }
     let(:proposals_component) { create(:component, manifest_name: "proposals", participatory_space: project.participatory_space) }
     let(:proposals) { create_list(:proposal, 3, component: proposals_component) }
     let(:taxonomies) { create_list(:taxonomy, 2, :with_parent, organization: budget.component.organization) }
     let(:project) { create(:project, budget:, taxonomies:) }
+    let(:component) { create(:budgets_component) }
 
     subject { described_class.new(project) }
 
@@ -111,6 +112,20 @@ module Decidim::Budgets
 
       it "includes new field" do
         expect(serialized[:test_field]).to eq("Resource class: Decidim::Budgets::Project")
+      end
+    end
+
+    context "when show votes is disabled" do
+      it "does not include count of confirmed votes" do
+        expect(serialized[:confirmed_votes]).to be_nil
+      end
+    end
+
+    context "when show votes is enabled" do
+      let(:component) { create(:budgets_component, :with_show_votes_enabled) }
+
+      it "includes count of confirmed votes" do
+        expect(serialized[:confirmed_votes]).to eq(project.confirmed_orders_count)
       end
     end
   end

--- a/decidim-budgets/spec/serializers/project_serializer_spec.rb
+++ b/decidim-budgets/spec/serializers/project_serializer_spec.rb
@@ -53,10 +53,6 @@ module Decidim::Budgets
         expect(serialized[:budget_amount]).to eq(project.budget_amount)
       end
 
-      it "includes count of confirmed votes" do
-        expect(serialized[:confirmed_votes]).to eq(project.confirmed_orders_count)
-      end
-
       it "includes comment count" do
         expect(serialized[:comments]).to eq(project.comments.count)
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Inspired fix from [here](https://github.com/decidim/decidim/compare/develop...DominikPeters:decidim:feature/budget_projects_and_votes_export) and #13739, the Projects component now hides ```show_votes```, when the user disabled the option, allowing exportable data not to display the information.

Should be merged directly after: https://github.com/decidim/decidim/pull/13675 

#### :pushpin: Related Issues

- Related to #13739
- Fixes #12348

#### Testing

```decidim-budgets/spec/serializers/project_serializer_spec.rb```

### :camera: Screenshots

:hearts: Thank you!
