### PR TITLE
Clarify license identificator (AGPL-3.0-or-later)

### DIFF
--- a/decidim-accountability/decidim-accountability.gemspec
+++ b/decidim-accountability/decidim-accountability.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Accountability.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-admin/decidim-admin.gemspec
+++ b/decidim-admin/decidim-admin.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Admin.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-ai/decidim-ai.gemspec
+++ b/decidim-ai/decidim-ai.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Ai.version
   s.authors = ["Alexandru-Emil Lupu"]
   s.email = ["contact@alecslupu.ro"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-api/decidim-api.gemspec
+++ b/decidim-api/decidim-api.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Api.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-assemblies/decidim-assemblies.gemspec
+++ b/decidim-assemblies/decidim-assemblies.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Assemblies.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-blogs/decidim-blogs.gemspec
+++ b/decidim-blogs/decidim-blogs.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Blogs.version
   s.authors = ["Isaac Massot Gil"]
   s.email = ["isaac.mg@coditramuntana.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-budgets/decidim-budgets.gemspec
+++ b/decidim-budgets/decidim-budgets.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Budgets.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-comments/decidim-comments.gemspec
+++ b/decidim-comments/decidim-comments.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Comments.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-conferences/decidim-conferences.gemspec
+++ b/decidim-conferences/decidim-conferences.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Conferences.version
   s.authors = ["Isaac Massot Gil"]
   s.email = ["isaac.mg@coditramuntana.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   }
   s.summary = "The core of the Decidim framework."
   s.description = "Adds core features so other engines can hook into the framework."
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.required_ruby_version = "~> 3.3.0"
 
   s.files = Dir.chdir(__dir__) do

--- a/decidim-debates/decidim-debates.gemspec
+++ b/decidim-debates/decidim-debates.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Debates.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva", "Genis Matutes Pujol"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com", "genis.matutes@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-design/decidim-design.gemspec
+++ b/decidim-design/decidim-design.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Design.version
   s.authors = ["Decidim Team"]
   s.email = ["hola@decidim.org"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Dev.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-forms/decidim-forms.gemspec
+++ b/decidim-forms/decidim-forms.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Forms.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva", "Rubén González Valero"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com", "rbngzlv@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-generators/decidim-generators.gemspec
+++ b/decidim-generators/decidim-generators.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Generators.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-generators/lib/decidim/generators/component_templates/decidim-component.gemspec.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/decidim-component.gemspec.erb
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::<%= component_module_name %>.version
   s.authors = ["<%= %x[git config user.name].chomp %>"]
   s.email = ["<%= %x[git config user.email].chomp %>"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-generators/lib/decidim/generators/component_templates/package.json.erb
+++ b/decidim-generators/lib/decidim/generators/component_templates/package.json.erb
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": <%= JSON.generate(component_description || "") %>,
   "private": true,
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-or-later",
   "scripts": {
     "lint": "eslint -c .eslintrc.json --no-error-on-unmatched-pattern --ignore-pattern app/packs/vendor --ext .js app/packs",
     "stylelint": "stylelint app/packs/**/*.scss"

--- a/decidim-generators/spec/runtime/component_generator_spec.rb
+++ b/decidim-generators/spec/runtime/component_generator_spec.rb
@@ -23,7 +23,7 @@ module Decidim
           "version" => "0.0.1",
           "description" => "",
           "private" => true,
-          "license" => "AGPL-3.0",
+          "license" => "AGPL-3.0-or-later",
           "scripts" => {
             "lint" => "eslint -c .eslintrc.json --no-error-on-unmatched-pattern --ignore-pattern app/packs/vendor --ext .js app/packs",
             "stylelint" => "stylelint app/packs/**/*.scss"

--- a/decidim-generators/spec/runtime/path_flag_spec.rb
+++ b/decidim-generators/spec/runtime/path_flag_spec.rb
@@ -41,7 +41,7 @@ module Decidim
           "version" => "0.0.1",
           "description" => "",
           "private" => true,
-          "license" => "AGPL-3.0",
+          "license" => "AGPL-3.0-or-later",
           "scripts" => {
             "lint" => "eslint -c .eslintrc.json --no-error-on-unmatched-pattern --ignore-pattern app/packs/vendor --ext .js app/packs",
             "stylelint" => "stylelint app/packs/**/*.scss"

--- a/decidim-initiatives/decidim-initiatives.gemspec
+++ b/decidim-initiatives/decidim-initiatives.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Initiatives.version
   s.authors = ["Juan Salvador Perez Garcia"]
   s.email = ["jsperezg@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-meetings/decidim-meetings.gemspec
+++ b/decidim-meetings/decidim-meetings.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Meetings.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-pages/decidim-pages.gemspec
+++ b/decidim-pages/decidim-pages.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Pages.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-participatory_processes/decidim-participatory_processes.gemspec
+++ b/decidim-participatory_processes/decidim-participatory_processes.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::ParticipatoryProcesses.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-proposals/decidim-proposals.gemspec
+++ b/decidim-proposals/decidim-proposals.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Proposals.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-sortitions/decidim-sortitions.gemspec
+++ b/decidim-sortitions/decidim-sortitions.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Sortitions.version
   s.authors = ["Juan Salvador Perez Garcia"]
   s.email = ["jsperezg@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-surveys/decidim-surveys.gemspec
+++ b/decidim-surveys/decidim-surveys.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Surveys.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-system/decidim-system.gemspec
+++ b/decidim-system/decidim-system.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::System.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-templates/decidim-templates.gemspec
+++ b/decidim-templates/decidim-templates.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = Decidim::Templates.version
   s.authors = ["Vera Rojman"]
   s.email = ["vrojman@protonmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/decidim-verifications/decidim-verifications.gemspec
+++ b/decidim-verifications/decidim-verifications.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.summary = "Decidim verifications module"
   s.description = "Several verification methods for your decidim instance"
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
 
   s.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").select do |f|

--- a/decidim.gemspec
+++ b/decidim.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.version = Decidim.version
   s.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.license = "AGPL-3.0"
+  s.license = "AGPL-3.0-or-later"
   s.homepage = "https://decidim.org"
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/decidim/decidim/issues",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20988,16 +20988,16 @@
     "packages/browserslist-config": {
       "name": "@decidim/browserslist-config",
       "version": "0.30.0-dev",
-      "license": "AGPL-3.0"
+      "license": "AGPL-3.0-or-later"
     },
     "packages/core": {
       "name": "@decidim/core",
       "version": "0.30.0-dev",
-      "license": "AGPL-3.0",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@rails/activestorage": "^7.0.8",
-        "@tarekraafat/autocomplete.js": "^10.2.6",
+        "@tarekraafat/autocomplete.js": "10.2.7",
         "@tiptap/core": "2.1.13",
         "@tiptap/extension-blockquote": "2.1.13",
         "@tiptap/extension-bold": "2.1.13",
@@ -21070,7 +21070,7 @@
       "name": "@decidim/dev",
       "version": "0.30.0-dev",
       "dev": true,
-      "license": "AGPL-3.0",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@linthtml/linthtml": "^0.9.6",
         "axe-core": "^4.7.2",
@@ -21081,7 +21081,7 @@
       "name": "@decidim/eslint-config",
       "version": "0.30.0-dev",
       "dev": true,
-      "license": "AGPL-3.0",
+      "license": "AGPL-3.0-or-later",
       "peerDependencies": {
         "eslint": "^8.7.0",
         "eslint-config-airbnb": "^19.0.4",
@@ -21099,7 +21099,7 @@
       "name": "@decidim/prettier-config",
       "version": "0.30.0-dev",
       "dev": true,
-      "license": "AGPL-3.0",
+      "license": "AGPL-3.0-or-later",
       "peerDependencies": {
         "prettier": "^2.3.2"
       }
@@ -21108,7 +21108,7 @@
       "name": "@decidim/stylelint-config",
       "version": "0.30.0-dev",
       "dev": true,
-      "license": "AGPL-3.0",
+      "license": "AGPL-3.0-or-later",
       "peerDependencies": {
         "stylelint": "^15.3.0",
         "stylelint-prettier": "^3.0.0"
@@ -21117,7 +21117,7 @@
     "packages/webpacker": {
       "name": "@decidim/webpacker",
       "version": "0.30.0-dev",
-      "license": "AGPL-3.0",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@rails/ujs": "^6.1.7",
         "@tailwindcss/typography": "^0.5.2",

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -8,6 +8,6 @@
     "directory": "packages/browserslist-config"
   },
   "author": "Decidim Contributors",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-or-later",
   "main": "index.js"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/core"
   },
   "author": "Decidim Contributors",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-or-later",
   "dependencies": {
     "emoji-mart": "^5.5.2",
     "@emoji-mart/data": "^1.1.2",

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/dev"
   },
   "author": "Decidim Contributors",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@linthtml/linthtml": "^0.9.6",
     "axe-core": "^4.7.2",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/eslint-config"
   },
   "author": "Decidim Contributors",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-or-later",
   "main": "index.js",
   "peerDependencies": {
     "eslint": "^8.7.0",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/prettier-config"
   },
   "author": "Decidim Contributors",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-or-later",
   "main": "index.js",
   "peerDependencies": {
     "prettier": "^2.3.2"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/stylelint-config"
   },
   "author": "Decidim Contributors",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-or-later",
   "main": "index.js",
   "peerDependencies": {
     "stylelint": "^15.3.0",

--- a/packages/webpacker/package.json
+++ b/packages/webpacker/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/webpacker"
   },
   "author": "Decidim Contributors",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-or-later",
   "main": "index.js",
   "dependencies": {
     "@rails/ujs": "^6.1.7",


### PR DESCRIPTION
#### :tophat: What? Why?

We have some warnings when generating releases and also in CI: 

> WARNING:  License identifier 'AGPL-3.0' is deprecated. Use an identifier from
https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
or set it to nil if you don't want to specify a license.
Did you mean 'AFL-3.0', 'APL-1.0'?

Source: https://github.com/decidim/decidim/actions/runs/12272320971/job/34240857529  (from the "[CI] Generators - FullAppGenerator" job)

According to the social contract (https://decidim.org/contract) we have "or later":

> The code of the platform, along with the modules, libraries or any other code that is developed for its functioning and deployment, will always be Free Open Source Software with an [Affero GPLv3 license or later versions](https://www.gnu.org/licenses/agpl-3.0.en.html) whenever the code is newly developed and with licenses that are compatible with the above one when code re-used.

So, this PR clarifies this. 

#### :pushpin: Related Issues
 
- Fixes  #12586 
- See valid SPDX identifiers at https://spdx.org/licenses/ 

#### Testing

Going to the same CI log ("[CI] Generators - FullAppGenerator") it should not show this warning 

 
  
:hearts: Thank you!
