### PR TITLE
Add Blog posts to Open Data files

### DIFF
--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -97,5 +97,33 @@ en:
           email_outro: You have received this notification because you are following "%{participatory_space_title}". You can unfollow it from the previous link.
           email_subject: New post published in %{participatory_space_title}
           notification_title: The post <a href="%{resource_path}">%{resource_title}</a> has been published in %{participatory_space_title}
+    open_data:
+      help:
+        post_comments:
+          alignment: If this comment was a favour, against or neutral
+          author: The name of the participant that made this comment
+          body: The comment itself
+          commentable_id: The unique id of the commentable
+          commentable_type: The type of the commentable (if it was a result, a proposal, etc.)
+          created_at: The date when this comment was created
+          depth: The place where this comment is in the three of comments (if it is an answer or an answer of an answer)
+          id: The id for this comment
+          locale: The locale (language) that the participant had when leaving this comment
+          root_commentable_url: The URL of the resource that ties to this comment
+          user_group: The name of the user group that made this comment (if any)
+        posts:
+          author: The information of the author
+          body: The body of the post
+          comments_count: The number of comments this post has
+          component: The component that the post belongs to
+          created_at: The date this post was created
+          endorsements_count: The number of endorsements this post has
+          follows_count: The number of follows this post has
+          id: The unique identifier of this post
+          participatory_space: To which space (e.g. Participatory Process, or Assembly) this post belongs to
+          published_at: The date this post was published
+          title: The title of the post
+          updated_at: The last date this post was updated
+          url: The URL for this post
     statistics:
       posts_count: Posts

--- a/decidim-blogs/lib/decidim/blogs.rb
+++ b/decidim-blogs/lib/decidim/blogs.rb
@@ -10,6 +10,7 @@ module Decidim
   # This namespace holds the logic of the `Blogs` component. This component
   # allows the admins to create a custom blog for a participatory process.
   module Blogs
+    autoload :PostSerializer, "decidim/blogs/post_serializer"
     autoload :SchemaOrgBlogPostingPostSerializer, "decidim/blogs/schema_org_blog_posting_post_serializer"
   end
 end

--- a/decidim-blogs/lib/decidim/blogs/component.rb
+++ b/decidim-blogs/lib/decidim/blogs/component.rb
@@ -39,6 +39,31 @@ Decidim.register_component(:blogs) do |component|
     resource.searchable = true
   end
 
+  component.exports :posts do |exports|
+    exports.collection do |component_instance|
+      Decidim::Blogs::Post
+        .not_hidden
+        .where(component: component_instance)
+        .includes(component: { participatory_space: :organization })
+    end
+
+    exports.include_in_open_data = true
+
+    exports.serializer Decidim::Blogs::PostSerializer
+  end
+
+  component.exports :post_comments do |exports|
+    exports.collection do |component_instance|
+      Decidim::Comments::Export.comments_for_resource(
+        Decidim::Blogs::Post, component_instance
+      ).includes(:author, :user_group, root_commentable: { component: { participatory_space: :organization } })
+    end
+
+    exports.include_in_open_data = true
+
+    exports.serializer Decidim::Comments::CommentSerializer
+  end
+
   component.seeds do |participatory_space|
     require "decidim/blogs/seeds"
 

--- a/decidim-blogs/lib/decidim/blogs/component.rb
+++ b/decidim-blogs/lib/decidim/blogs/component.rb
@@ -43,6 +43,7 @@ Decidim.register_component(:blogs) do |component|
     exports.collection do |component_instance|
       Decidim::Blogs::Post
         .not_hidden
+        .published
         .where(component: component_instance)
         .includes(component: { participatory_space: :organization })
     end

--- a/decidim-blogs/lib/decidim/blogs/post_serializer.rb
+++ b/decidim-blogs/lib/decidim/blogs/post_serializer.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Blogs
+    # This class serializes a Post so can be exported to CSV, JSON or other
+    # formats.
+    class PostSerializer < Decidim::Exporters::Serializer
+      include Decidim::ApplicationHelper
+      include Decidim::ResourceHelper
+
+      # Public: Initializes the serializer with a post.
+      def initialize(post)
+        @post = post
+      end
+
+      # Public: Exports a hash with the serialized data for this post.
+      def serialize
+        {
+          id: post.id,
+          author: {
+            **author_fields
+          },
+          title: post.title,
+          body: post.body,
+          created_at: post.created_at,
+          updated_at: post.updated_at,
+          published_at: post.published_at,
+          endorsements_count: post.endorsements_count,
+          comments_count: post.comments_count,
+          follows_count: post.follows_count,
+          participatory_space: {
+            id: post.participatory_space.id,
+            url: Decidim::ResourceLocatorPresenter.new(post.participatory_space).url
+          },
+          component: { id: component.id },
+          url:
+        }
+      end
+
+      private
+
+      attr_reader :post
+      alias resource post
+
+      def component
+        post.component
+      end
+
+      def url
+        Decidim::ResourceLocatorPresenter.new(post).url
+      end
+
+      def author_fields
+        {
+          id: resource.author.id,
+          name: author_name(resource.author),
+          url: author_url(resource.author)
+        }
+      end
+
+      def author_name(author)
+        translated_attribute(author.name)
+      end
+
+      def author_url(author)
+        if author.respond_to?(:nickname)
+          profile_url(author) # is a Decidim::User or Decidim::UserGroup
+        else
+          root_url # is a Decidim::Organization
+        end
+      end
+
+      def profile_url(author)
+        return "" if author.respond_to?(:deleted?) && author.deleted?
+
+        Decidim::Core::Engine.routes.url_helpers.profile_url(author.nickname, host:)
+      end
+
+      def root_url
+        Decidim::Core::Engine.routes.url_helpers.root_url(host:)
+      end
+
+      def host
+        resource.organization.host
+      end
+    end
+  end
+end

--- a/decidim-blogs/spec/lib/decidim/blogs/post_serializer_spec.rb
+++ b/decidim-blogs/spec/lib/decidim/blogs/post_serializer_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Blogs
+    describe PostSerializer do
+      subject do
+        described_class.new(post)
+      end
+
+      let!(:post) { create(:post, component:) }
+      let(:organization) { create(:organization )}
+      let(:participatory_space) { create(:participatory_process, organization:) }
+      let(:component) { create(:post_component, participatory_space:) }
+
+      describe "#serialize" do
+        let(:serialized) { subject.serialize }
+
+        it "serializes the id" do
+          expect(serialized).to include(id: post.id)
+        end
+
+        describe "author" do
+          context "when it is a user" do
+            before do
+              post.author.update!(name: "John Doe")
+              post.reload
+            end
+
+            it "serializes the user name" do
+              expect(serialized[:author]).to include(name: "John Doe")
+            end
+
+            it "serializes the link to its profile" do
+              expect(serialized[:author]).to include(url: profile_url(post.author.nickname))
+            end
+          end
+
+          context "when it is a user group" do
+            let!(:post) { create(:post, author:, component:) }
+            let(:author) { create(:user_group, :verified, organization:) }
+
+            before do
+              post.author.update!(name: "ACME", nickname: "acme")
+              post.reload
+            end
+
+            it "serializes the user name of the user group" do
+              expect(serialized[:author]).to include(name: "ACME")
+            end
+
+            it "serializes the link to the profile of the user group" do
+              expect(serialized[:author]).to include(url: profile_url("acme"))
+            end
+          end
+        end
+
+        it "serializes the title" do
+          expect(serialized).to include(title: post.title)
+        end
+
+        it "serializes the body" do
+          expect(serialized).to include(body: post.body)
+        end
+
+        it "serializes the participatory space" do
+          expect(serialized[:participatory_space]).to include(id: participatory_space.id)
+          expect(serialized[:participatory_space][:url]).to include("http", participatory_space.slug)
+        end
+
+        it "serializes the component" do
+          expect(serialized[:component]).to include(id: post.component.id)
+        end
+
+        it "serializes the comments count" do
+          expect(serialized).to include(comments_count: post.comments_count)
+        end
+
+        it "serializes the endorsements count" do
+          expect(serialized).to include(endorsements_count: post.endorsements_count)
+        end
+
+        it "serializes the follows count" do
+          expect(serialized).to include(follows_count: post.follows_count)
+        end
+
+        it "serializes the url" do
+          expect(serialized[:url]).to include("http", post.id.to_s)
+        end
+      end
+
+      def profile_url(nickname)
+        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:)
+      end
+
+      def root_url
+        Decidim::Core::Engine.routes.url_helpers.root_url(host:)
+      end
+
+      def host
+        post.organization.host
+      end
+    end
+  end
+end

--- a/decidim-blogs/spec/lib/decidim/blogs/post_serializer_spec.rb
+++ b/decidim-blogs/spec/lib/decidim/blogs/post_serializer_spec.rb
@@ -10,7 +10,7 @@ module Decidim
       end
 
       let!(:post) { create(:post, component:) }
-      let(:organization) { create(:organization )}
+      let(:organization) { create(:organization) }
       let(:participatory_space) { create(:participatory_process, organization:) }
       let(:component) { create(:post_component, participatory_space:) }
 

--- a/decidim-blogs/spec/services/decidim/open_data_exporter_spec.rb
+++ b/decidim-blogs/spec/services/decidim/open_data_exporter_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "decidim/core/test/shared_examples/open_data_exporter_examples"
+
+describe Decidim::OpenDataExporter do
+  subject { described_class.new(organization, path) }
+
+  describe "posts" do
+    let(:resource_file_name) { "posts" }
+    let(:component) do
+      create(:post_component, organization:, published_at: Time.current)
+    end
+    let!(:resource) { create(:post, component:) }
+
+    let(:second_component) do
+      create(:post_component, organization:, published_at: Time.current)
+    end
+    let!(:second_resource) { create(:post, component: second_component) }
+
+    let(:resource_title) { "## posts" }
+    let(:help_lines) do
+      [
+        "* id: The unique identifier of this post",
+        "* title: The title of the post"
+      ]
+    end
+    let(:unpublished_component) do
+      create(:post_component, organization:, published_at: nil)
+    end
+    let(:unpublished_resource) { create(:post, component: unpublished_component) }
+
+    it_behaves_like "open data exporter"
+  end
+
+  describe "posts by deleted user" do
+    let(:resource_file_name) { "posts" }
+    let(:component) do
+      create(:post_component, organization:, published_at: Time.current)
+    end
+
+    let!(:deleted_user) { create(:user, :confirmed, :deleted, organization:) }
+    let!(:resource) { create(:post, component:, author: deleted_user) }
+
+    let(:second_component) do
+      create(:post_component, organization:, published_at: Time.current)
+    end
+    let!(:second_resource) { create(:post, component: second_component, author: deleted_user) }
+
+    let(:resource_title) { "## posts" }
+    let(:help_lines) do
+      [
+        "* id: The unique identifier of this post",
+        "* title: The title of the post"
+      ]
+    end
+    let(:unpublished_component) do
+      create(:post_component, organization:, published_at: nil)
+    end
+    let(:unpublished_resource) { create(:post, component: unpublished_component) }
+
+    it_behaves_like "open data exporter"
+  end
+
+  describe "post_comments" do
+    let(:resource_file_name) { "post_comments" }
+    let(:component) do
+      create(:post_component, organization:, published_at: Time.current)
+    end
+    let(:post) { create(:post, component:) }
+    let!(:resource) { create(:comment, commentable: post) }
+    let(:resource_title) { "## post_comments" }
+    let(:help_lines) do
+      [
+        "* id: The id for this comment"
+      ]
+    end
+    let(:unpublished_component) do
+      create(:post_component, organization:, published_at: nil)
+    end
+    let(:unpublished_post) { create(:post, component: unpublished_component) }
+    let(:unpublished_resource) { create(:comment, commentable: unpublished_post) }
+
+    it_behaves_like "open data exporter"
+  end
+end

--- a/decidim-blogs/spec/services/decidim/open_data_exporter_spec.rb
+++ b/decidim-blogs/spec/services/decidim/open_data_exporter_spec.rb
@@ -32,6 +32,12 @@ describe Decidim::OpenDataExporter do
     let(:unpublished_resource) { create(:post, component: unpublished_component) }
 
     it_behaves_like "open data exporter"
+
+    context "with unpublished posts" do
+      let!(:unpublished_resource) { create(:post, published_at: 5.weeks.from_now, component:) }
+
+      it_behaves_like "open data exporter"
+    end
   end
 
   describe "posts by deleted user" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds blogs posts data available to the OpenData files. 

#### :pushpin: Related Issues

- Fixes [#13706](https://github.com/decidim/decidim/issues/13706)

#### Testing

1. Switch to the branch
2. Start app, and export the Open data
3. See the archive contains posts and posts' comments
4. See there is a proper Readme in place

:hearts: Thank you!
