### PR TITLE
Enable Sidekiq as default for development application

### DIFF
--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -38,6 +38,14 @@ jobs:
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:
+      redis:
+        image: redis
+        ports: ["6379:6379"]
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
       postgres:
         image: postgres:14
         ports: ["5432:5432"]

--- a/decidim-core/lib/decidim/core/seeds.rb
+++ b/decidim-core/lib/decidim/core/seeds.rb
@@ -14,8 +14,6 @@ module Decidim
         Rails.application.reloader.reload! if Rails.application.reloader.check!
         reset_column_information
 
-        ActiveJob::Base.queue_adapter = :inline
-
         organization = create_organization!
 
         if organization.taxonomies.none?
@@ -33,6 +31,7 @@ module Decidim
           3.times do
             create_taxonomy!(name: ::Faker::Lorem.word, parent: sub_taxonomy)
           end
+
           sub_taxonomy = create_taxonomy!(name: "Sectorial", parent: taxonomy)
           5.times do
             create_taxonomy!(name: ::Faker::Lorem.word, parent: sub_taxonomy)

--- a/decidim-core/lib/tasks/decidim_procfile.rake
+++ b/decidim-core/lib/tasks/decidim_procfile.rake
@@ -11,6 +11,12 @@ namespace :decidim do
         shakapacker: bin/shakapacker-dev-server
       RUBY
 
+      if defined?(Sidekiq)
+        actions :append_file, "Procfile.dev", <<~RUBY
+          sidekiq: bundle exec sidekiq -C config/sidekiq.yml
+        RUBY
+      end
+
       actions :create_file, "bin/dev", %(#!/usr/bin/env sh
 
 set -e

--- a/decidim-dev/lib/tasks/generators.rake
+++ b/decidim-dev/lib/tasks/generators.rake
@@ -53,7 +53,8 @@ namespace :decidim do
         "--profiling",
         "--locales",
         "en,ca,es",
-        "--dev_ssl"
+        "--dev_ssl",
+        "--queue=sidekiq"
       )
     end
   end

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -216,20 +216,22 @@ module Decidim
 
         template "sidekiq.yml.erb", "config/sidekiq.yml", force: true
 
+        gsub_file "config/environments/development.rb",
+                  /Rails.application.configure do/,
+                  "Rails.application.configure do\n  config.active_job.queue_adapter = :sidekiq\n"
         gsub_file "config/environments/production.rb",
                   /# config.active_job.queue_adapter     = :resque/,
                   "config.active_job.queue_adapter = ENV['QUEUE_ADAPTER'] if ENV['QUEUE_ADAPTER'].present?"
 
         prepend_file "config/routes.rb", "require \"sidekiq/web\"\n\n"
+
         route <<~RUBY
           authenticate :user, ->(u) { u.admin? } do
             mount Sidekiq::Web => "/sidekiq"
           end
         RUBY
 
-        add_production_gems do
-          gem "sidekiq"
-        end
+        append_file "Gemfile", %(gem "sidekiq")
       end
 
       def add_production_gems(&block)

--- a/decidim-generators/lib/decidim/generators/app_templates/sidekiq.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/sidekiq.yml.erb
@@ -15,4 +15,3 @@
   - [exports, 1]
   - [close_meeting_reminder, 1]
   - [spam_analysis, 1]
-  - [seeds, 1]

--- a/decidim-generators/lib/decidim/generators/app_templates/sidekiq.yml.erb
+++ b/decidim-generators/lib/decidim/generators/app_templates/sidekiq.yml.erb
@@ -15,3 +15,4 @@
   - [exports, 1]
   - [close_meeting_reminder, 1]
   - [spam_analysis, 1]
+  - [seeds, 1]


### PR DESCRIPTION
#### :tophat: What? Why?
In the last weeks we have developed a lot of functionalities that required the queue. We have found ourselves in the situation when we had to configure over and over the queue. 
We also have an issue regarding the creation of development application where we cannot boot up the gitpods due to long time spent seeding the database. 

This PR add Sidekiq and disables the ActiveJob::Base.queue_adapter inline processing when generating seeds. 

Running: `time bundle exec rake development_app` **before** the change, i go the following data:
```
real   37m46.874s
user   22m39.779s
sys    13m4.971s
```

Running: `time bundle exec rake development_app` **after** the change, i go the following data:
```
real   23m16.600s
user   18m29.474s
sys    3m35.191s
```

#### Testing
1. The pipeline is green 
2. Generate a development application 
3. Start the application and see that Procfile also boots Sidekiq. 

:hearts: Thank you!
