### PR TITLE
fix: ux mobile budget page adjustements

### DIFF
--- a/decidim-budgets/app/packs/stylesheets/budgets.scss
+++ b/decidim-budgets/app/packs/stylesheets/budgets.scss
@@ -132,7 +132,7 @@
   }
 
   &__list--header {
-    @apply grid grid-cols-2;
+    @apply flex items-center justify-between;
   }
 
   &-list {


### PR DESCRIPTION
#### :tophat: What? Why?
On Mobile, on a Budget page:

- The layout of this page is not optimal on Mobile
- The dropdown Trier les projets par is on two-line
- The buttons Ajouter don't have the right horizontal padding

#### :pushpin: Related Issues
https://git.octree.ch/decidim/decidim-nightly/-/issues/86

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/ce8bd6dd-0227-4c8b-bb31-7219197918d7)


:hearts: Thank you!
