### PR TITLE
Add metadata for each resource in the Open Data README

### DIFF
--- a/decidim-core/app/services/decidim/open_data_exporter.rb
+++ b/decidim-core/app/services/decidim/open_data_exporter.rb
@@ -139,6 +139,7 @@ module Decidim
     def readme
       "# #{I18n.t("decidim.open_data.help.core.title", organization: translated_attribute(organization.name))}\n\n
 #{I18n.t("decidim.open_data.help.core.description")}\n\n
+#{I18n.t("decidim.open_data.help.core.generated_on_date", date: I18n.l(Time.current, format: :decidim_short))}\n\n
 #{core_readme}
 #{space_readme}
 #{component_readme}

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1374,6 +1374,7 @@ en:
           components: Components
           description: This ZIP file contains files for studying and researching about this participation platform.
           main: Core
+          resources: resources
           spaces: Spaces
           title: Open Data files for %{organization}
         metrics:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1373,6 +1373,7 @@ en:
         core:
           components: Components
           description: This ZIP file contains files for studying and researching about this participation platform.
+          generated_on_date: Generated on %{date}
           main: Core
           resources: resources
           spaces: Spaces


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds more information to the Open Data README file that's in the zip, to add more information about the resources and the date of generation of the zip itself. 

#### :pushpin: Related Issues
 
- Fixes #13773 

#### Testing

1. Generate the open data ZIP file
2. Check that in the README you have the date of generation and the count of each of the resources

:hearts: Thank you!
