### PR TITLE
Fix flaky spec on budget projects bulk assignation

### DIFF
--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -52,8 +52,9 @@ describe "Admin manages projects" do
       expect(page).to have_admin_callout "Projects successfully updated"
       expect(page).to have_admin_callout translated(taxonomy.name)
       expect(page).to have_admin_callout translated(another_taxonomy.name)
-      expect(Decidim::Budgets::Project.find(project.id).taxonomies.first).to eq(taxonomy)
-      expect(Decidim::Budgets::Project.find(project2.id).taxonomies.first).to be_nil
+      expect(project.reload.taxonomies).to include(taxonomy)
+      expect(project.taxonomies).to include(another_taxonomy)
+      expect(project2.reload.taxonomies).to be_empty
     end
 
     it "selects projects to implementation" do


### PR DESCRIPTION
#### :tophat: What? Why?
Looks like there's a flaky related to a bulk assignation of taxonomies in budgets.
This PR should solve it.

The flaky failure:
```

Failures:

  1) Admin manages projects bulk actions changes projects taxonomies
     Failure/Error: expect(Decidim::Budgets::Project.find(project.id).taxonomies.first).to eq(taxonomy)

       expected: #<Decidim::Taxonomy id: 38, name: {"en"=>"<script>alert(\"taxonomy_name\");</script> Dolorum aliquam ...: "2024-12-17 09:02:00.206770000 +0000", filters_count: 0, filter_items_count: 1, part_of: [38, 35]>
            got: #<Decidim::Taxonomy id: 37, name: {"ca"=>"<script>alert(\"taxonomy_name\");</script> Adipisci minus p...: "2024-12-17 09:02:00.128647000 +0000", filters_count: 0, filter_items_count: 1, part_of: [37, 36]>

       (compared using ==)

       Diff:





       @@ -1,21 +1,21 @@
       -#<Decidim::Taxonomy:0x00007f54a0a7b6a0
       - id: 38,
       +#<Decidim::Taxonomy:0x00007f54a09ed710
       + id: 37,
         name:
       -  {"en"=>
       -    "<script>alert(\"taxonomy_name\");</script> Dolorum aliquam molestiae. 5680",
       -   "ca"=>
       -    "<script>alert(\"taxonomy_name\");</script> Molestias pariatur totam. 5681",
       +  {"ca"=>
       +    "<script>alert(\"taxonomy_name\");</script> Adipisci minus porro. 5663",
       +   "en"=>
       +    "<script>alert(\"taxonomy_name\");</script> Officia placeat aut. 5662",
           "machine_translations"=>
            {"es"=>
       -      "<script>alert(\"taxonomy_name\");</script> Non qui deleniti. 5682"}},
       +      "<script>alert(\"taxonomy_name\");</script> Aperiam laudantium est. 5664"}},
         decidim_organization_id: 70,
       - parent_id: 35,
       + parent_id: 36,
         weight: 0,
         children_count: 0,
       - taxonomizations_count: 0,
       - created_at: Tue, 17 Dec 2024 09:02:00.192744000 UTC +00:00,
       - updated_at: Tue, 17 Dec 2024 09:02:00.206770000 UTC +00:00,
       + taxonomizations_count: 1,
       + created_at: Tue, 17 Dec 2024 09:02:00.121874000 UTC +00:00,
       + updated_at: Tue, 17 Dec 2024 09:02:00.128647000 UTC +00:00,
         filters_count: 0,
         filter_items_count: 1,
       - part_of: [38, 35]>
       + part_of: [37, 36]>
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
