### PR TITLE
Fix component draggable order in admin panel

### DIFF
--- a/decidim-admin/app/views/decidim/admin/components/_components_table.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_components_table.html.erb
@@ -2,13 +2,14 @@
   <table class="table-list">
     <thead>
     <tr>
+      <th></th>
       <th><%= t("index.headers.name", scope: "decidim.admin.components") %></th>
       <th><%= t("index.headers.type", scope: "decidim.admin.components") %></th>
       <th><%= t("index.headers.visibility", scope: "decidim.admin.components") %></th>
       <th><%= t("index.headers.actions", scope: "decidim.admin.components") %></th>
     </tr>
     </thead>
-    <tbody>
+    <tbody class="draggable-table" data-sort-url="<%= reorder_components_path %>" data-draggable-table>
     <% components.each do |component| %>
       <%= render partial: "component_row", locals: { component:, view: } %>
     <% end %>

--- a/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
@@ -211,7 +211,6 @@ shared_examples "assembly admin manage assembly components" do
   end
 
   describe "reorders a component" do
-    let(:participatory_space) { assembly }
     let!(:component1) { create(:component, name: { en: "Component 1" }, participatory_space:) }
     let!(:component2) { create(:component, name: { en: "Component 2" }, participatory_space:) }
     let!(:component3) { create(:component, name: { en: "Component 3" }, participatory_space:) }

--- a/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
@@ -210,6 +210,29 @@ shared_examples "assembly admin manage assembly components" do
     end
   end
 
+  describe "reorders a component" do
+    let(:participatory_space) { assembly }
+    let!(:component1) { create(:component, name: { en: "Component 1" }, participatory_space:) }
+    let!(:component2) { create(:component, name: { en: "Component 2" }, participatory_space:) }
+    let!(:component3) { create(:component, name: { en: "Component 3" }, participatory_space:) }
+
+    before do
+      visit participatory_space_components_path(participatory_space)
+    end
+
+    it "changes the order of the components" do
+      expect(page.text.index("Component 1")).to be < page.text.index("Component 2")
+      expect(page.text.index("Component 2")).to be < page.text.index("Component 3")
+
+      first("td.dragging-handle").drag_to(find("tbody.draggable-table tr:last-child"))
+
+      visit current_path
+
+      expect(page.text.index("Component 2")).to be < page.text.index("Component 1")
+      expect(page.text.index("Component 1")).to be < page.text.index("Component 3")
+    end
+  end
+
   def participatory_space
     assembly
   end

--- a/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
@@ -217,7 +217,6 @@ shared_examples "manage assembly components" do
   end
 
   describe "reorders a component" do
-    let(:participatory_space) { assembly }
     let!(:component1) { create(:component, name: { en: "Component 1" }, participatory_space:) }
     let!(:component2) { create(:component, name: { en: "Component 2" }, participatory_space:) }
     let!(:component3) { create(:component, name: { en: "Component 3" }, participatory_space:) }

--- a/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
@@ -216,6 +216,29 @@ shared_examples "manage assembly components" do
     end
   end
 
+  describe "reorders a component" do
+    let(:participatory_space) { assembly }
+    let!(:component1) { create(:component, name: { en: "Component 1" }, participatory_space:) }
+    let!(:component2) { create(:component, name: { en: "Component 2" }, participatory_space:) }
+    let!(:component3) { create(:component, name: { en: "Component 3" }, participatory_space:) }
+
+    before do
+      visit participatory_space_components_path(participatory_space)
+    end
+
+    it "changes the order of the components" do
+      expect(page.text.index("Component 1")).to be < page.text.index("Component 2")
+      expect(page.text.index("Component 2")).to be < page.text.index("Component 3")
+
+      first("td.dragging-handle").drag_to(find("tbody.draggable-table tr:last-child"))
+
+      visit current_path
+
+      expect(page.text.index("Component 2")).to be < page.text.index("Component 1")
+      expect(page.text.index("Component 1")).to be < page.text.index("Component 3")
+    end
+  end
+
   def participatory_space
     assembly
   end

--- a/decidim-conferences/spec/shared/manage_conference_components_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_components_examples.rb
@@ -216,6 +216,29 @@ shared_examples "manage conference components" do
     end
   end
 
+  describe "reorders a component" do
+    let(:participatory_space) { conference }
+    let!(:component1) { create(:component, name: { en: "Component 1" }, participatory_space:) }
+    let!(:component2) { create(:component, name: { en: "Component 2" }, participatory_space:) }
+    let!(:component3) { create(:component, name: { en: "Component 3" }, participatory_space:) }
+
+    before do
+      visit participatory_space_components_path(participatory_space)
+    end
+
+    it "changes the order of the components" do
+      expect(page.text.index("Component 1")).to be < page.text.index("Component 2")
+      expect(page.text.index("Component 2")).to be < page.text.index("Component 3")
+
+      first("td.dragging-handle").drag_to(find("tbody.draggable-table tr:last-child"))
+
+      visit current_path
+
+      expect(page.text.index("Component 2")).to be < page.text.index("Component 1")
+      expect(page.text.index("Component 1")).to be < page.text.index("Component 3")
+    end
+  end
+
   def participatory_space
     conference
   end

--- a/decidim-conferences/spec/shared/manage_conference_components_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_components_examples.rb
@@ -217,7 +217,6 @@ shared_examples "manage conference components" do
   end
 
   describe "reorders a component" do
-    let(:participatory_space) { conference }
     let!(:component1) { create(:component, name: { en: "Component 1" }, participatory_space:) }
     let!(:component2) { create(:component, name: { en: "Component 2" }, participatory_space:) }
     let!(:component3) { create(:component, name: { en: "Component 3" }, participatory_space:) }

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
@@ -231,6 +231,28 @@ describe "Admin manages initiative components" do
     end
   end
 
+  describe "reorders a component" do
+    let!(:component1) { create(:component, name: { en: "Component 1" }, participatory_space:) }
+    let!(:component2) { create(:component, name: { en: "Component 2" }, participatory_space:) }
+    let!(:component3) { create(:component, name: { en: "Component 3" }, participatory_space:) }
+
+    before do
+      visit participatory_space_components_path(participatory_space)
+    end
+
+    it "changes the order of the components" do
+      expect(page.text.index("Component 1")).to be < page.text.index("Component 2")
+      expect(page.text.index("Component 2")).to be < page.text.index("Component 3")
+
+      first("td.dragging-handle").drag_to(find("tbody.draggable-table tr:last-child"))
+
+      visit current_path
+
+      expect(page.text.index("Component 2")).to be < page.text.index("Component 1")
+      expect(page.text.index("Component 1")).to be < page.text.index("Component 3")
+    end
+  end
+
   def participatory_space
     initiative
   end

--- a/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
@@ -333,6 +333,29 @@ shared_examples "manage process components" do
     end
   end
 
+  describe "reorders a component" do
+    let(:participatory_space) { participatory_process }
+    let!(:component1) { create(:component, name: { en: "Component 1" }, participatory_space:) }
+    let!(:component2) { create(:component, name: { en: "Component 2" }, participatory_space:) }
+    let!(:component3) { create(:component, name: { en: "Component 3" }, participatory_space:) }
+
+    before do
+      visit participatory_space_components_path(participatory_space)
+    end
+
+    it "changes the order of the components" do
+      expect(page.text.index("Component 1")).to be < page.text.index("Component 2")
+      expect(page.text.index("Component 2")).to be < page.text.index("Component 3")
+
+      first("td.dragging-handle").drag_to(find("tbody.draggable-table tr:last-child"))
+
+      visit current_path
+
+      expect(page.text.index("Component 2")).to be < page.text.index("Component 1")
+      expect(page.text.index("Component 1")).to be < page.text.index("Component 3")
+    end
+  end
+
   def participatory_space
     participatory_process
   end

--- a/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
@@ -334,7 +334,6 @@ shared_examples "manage process components" do
   end
 
   describe "reorders a component" do
-    let(:participatory_space) { participatory_process }
     let!(:component1) { create(:component, name: { en: "Component 1" }, participatory_space:) }
     let!(:component2) { create(:component, name: { en: "Component 2" }, participatory_space:) }
     let!(:component3) { create(:component, name: { en: "Component 3" }, participatory_space:) }


### PR DESCRIPTION
#### :tophat: What? Why?

After #13297, we lost the capabilities for sorting components in the admin from #13074. 

The thing is that we didn't have the proper testing for actually detecting this feature in the UI.

This PR fixes the problem and adds the specs. 

#### :pushpin: Related Issues
 
- Related to #13074 and #13297
 

#### Testing

1. Sign in as admin
2. Go to components in a space
3. Change order of the components by drag and dropping
4. See that the order has changed
5. Reload the page
6. See that the order still has changed

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/ca49993a-9781-4b18-9cef-a4d21417ce9e)

:hearts: Thank you!
