### PR TITLE
Add open data download for pages

### DIFF
--- a/decidim-pages/config/locales/en.yml
+++ b/decidim-pages/config/locales/en.yml
@@ -17,6 +17,17 @@ en:
             announcement: Announcement
           step:
             announcement: Announcement
+    open_data:
+      help:
+        pages:
+          id: The unique identifier of this page
+          title: The page title
+          body: The body of the page
+          created_at: The date this page was created
+          updated_at: The last date this page was updated
+          participatory_space: To which space (e.g. Participatory Process, or Assembly) this page belongs to
+          component: The component that the page belongs to
+          url: The URL for this page
     pages:
       admin:
         models:

--- a/decidim-pages/lib/decidim/pages.rb
+++ b/decidim-pages/lib/decidim/pages.rb
@@ -10,5 +10,6 @@ module Decidim
   # This namespace holds the logic of the `Pages` component. This component
   # allows the admins to create a custom page for a participatory process.
   module Pages
+    autoload :PageSerializer, "decidim/pages/page_serializer"
   end
 end

--- a/decidim-pages/lib/decidim/pages/component.rb
+++ b/decidim-pages/lib/decidim/pages/component.rb
@@ -49,6 +49,18 @@ Decidim.register_component(:pages) do |component|
     resource.model_class_name = "Decidim::Pages::Page"
   end
 
+  component.exports :pages do |exports|
+    exports.collection do |component_instance|
+      Decidim::Pages::Page
+        .where(component: component_instance)
+        .includes(component: { participatory_space: :organization })
+    end
+
+    exports.include_in_open_data = true
+
+    exports.serializer Decidim::Pages::PageSerializer
+  end
+
   component.seeds do |participatory_space|
     require "decidim/pages/seeds"
 

--- a/decidim-pages/lib/decidim/pages/page_serializer.rb
+++ b/decidim-pages/lib/decidim/pages/page_serializer.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Pages
+    # This class serializes a Page so can be exported to CSV, JSON or other
+    # formats.
+    class PageSerializer < Decidim::Exporters::Serializer
+      include Decidim::ApplicationHelper
+      include Decidim::ResourceHelper
+
+      # Public: Initializes the serializer with a page.
+      def initialize(page)
+        @page = page
+      end
+
+      # Public: Exports a hash with the serialized data for this page.
+      def serialize
+        {
+          id: page.id,
+          title: page.title,
+          body: page.body,
+          created_at: page.created_at,
+          updated_at: page.updated_at,
+          participatory_space: {
+            id: page.participatory_space.id,
+            url: Decidim::ResourceLocatorPresenter.new(page.participatory_space).url
+          },
+          component: { id: component.id },
+          url:
+        }
+      end
+
+      private
+
+      attr_reader :page
+      alias resource page
+
+      def component
+        page.component
+      end
+
+      def url
+        Decidim::ResourceLocatorPresenter.new(page).url
+      end
+
+      def author_fields
+        {
+          id: resource.author.id,
+          name: author_name(resource.author),
+          url: author_url(resource.author)
+        }
+      end
+
+      def author_name(author)
+        translated_attribute(author.name)
+      end
+
+      def author_url(author)
+        if author.respond_to?(:nickname)
+          profile_url(author) # is a Decidim::User or Decidim::UserGroup
+        else
+          root_url # is a Decidim::Organization
+        end
+      end
+
+      def profile_url(author)
+        return "" if author.respond_to?(:deleted?) && author.deleted?
+
+        Decidim::Core::Engine.routes.url_helpers.profile_url(author.nickname, host:)
+      end
+
+      def root_url
+        Decidim::Core::Engine.routes.url_helpers.root_url(host:)
+      end
+
+      def host
+        resource.organization.host
+      end
+    end
+  end
+end

--- a/decidim-pages/spec/lib/decidim/pages/page_serializer_spec.rb
+++ b/decidim-pages/spec/lib/decidim/pages/page_serializer_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Pages
+    describe PageSerializer do
+      subject do
+        described_class.new(page)
+      end
+
+      let!(:page) { create(:page, component:) }
+      let(:organization) { create(:organization) }
+      let(:participatory_space) { create(:participatory_process, organization:) }
+      let(:component) { create(:page_component, participatory_space:) }
+
+      describe "#serialize" do
+        let(:serialized) { subject.serialize }
+
+        it "serializes the id" do
+          expect(serialized).to include(id: page.id)
+        end
+
+        it "serializes the title" do
+          expect(serialized).to include(title: page.title)
+        end
+
+        it "serializes the body" do
+          expect(serialized).to include(body: page.body)
+        end
+
+        it "serializes the participatory space" do
+          expect(serialized[:participatory_space]).to include(id: participatory_space.id)
+          expect(serialized[:participatory_space][:url]).to include("http", participatory_space.slug)
+        end
+
+        it "serializes the component" do
+          expect(serialized[:component]).to include(id: page.component.id)
+        end
+
+        it "serializes the url" do
+          expect(serialized[:url]).to include("http", page.id.to_s)
+        end
+      end
+    end
+  end
+end

--- a/decidim-pages/spec/services/decidim/open_data_exporter_spec.rb
+++ b/decidim-pages/spec/services/decidim/open_data_exporter_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "decidim/core/test/shared_examples/open_data_exporter_examples"
+
+describe Decidim::OpenDataExporter do
+  subject { described_class.new(organization, path) }
+
+  describe "pages" do
+    let(:resource_file_name) { "pages" }
+    let(:component) do
+      create(:page_component, name: "Published page title", organization:, published_at: Time.current)
+    end
+    let!(:resource) { create(:page, component:) }
+
+    let(:second_component) do
+      create(:page_component, name: "Second published page title", organization:, published_at: Time.current)
+    end
+    let!(:second_resource) { create(:page, component: second_component) }
+
+    let(:resource_title) { "## pages" }
+    let(:help_lines) do
+      [
+        "* id: The unique identifier of this page",
+        "* title: The page title"
+      ]
+    end
+    let(:unpublished_component) do
+      create(:page_component, name: "Unpublished page title", organization:, published_at: nil)
+    end
+    let(:unpublished_resource) { create(:page, component: unpublished_component) }
+
+    it_behaves_like "open data exporter"
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds pages data available to the OpenData files. 

#### :pushpin: Related Issues

- Fixes [#13707](https://github.com/decidim/decidim/issues/13707)

#### Testing

1. Switch to the branch
2. Start app, and export the Open data
3. See the archive contains pages
4. See there is a proper Readme in place

:hearts: Thank you!
