### PR TITLE
Fix single attachment with title

### DIFF
--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_field.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_field.js
@@ -21,6 +21,7 @@ const updateActiveUploads = (modal) => {
   const files = document.querySelector(`[data-active-uploads=${modal.modal.id}]`)
   const previousId = Array.from(files.querySelectorAll("[type=hidden][id]"))
   const isMultiple = modal.options.multiple
+  const isTitled = modal.options.titled
 
   // fastest way to clean children nodes
   files.textContent = ""
@@ -34,14 +35,14 @@ const updateActiveUploads = (modal) => {
     let hidden = ""
     if (file.hiddenField) {
       // if there is hiddenField, this file is new
-      const fileField = isMultiple
+      const fileField = (isMultiple || isTitled)
         ? `${modal.options.resourceName}[${modal.options.addAttribute}][${ix}][file]`
         : `${modal.options.resourceName}[${modal.options.addAttribute}]`
 
       hidden = `<input type="hidden" name="${fileField}" value="${file.hiddenField}" />`
     } else {
       // otherwise, we keep the attachmentId
-      const fileField = isMultiple
+      const fileField = (isMultiple || isTitled)
         ? `${modal.options.resourceName}[${modal.options.addAttribute}][${ix}][id]`
         : `${modal.options.resourceName}[${modal.options.addAttribute}]`
 
@@ -51,7 +52,7 @@ const updateActiveUploads = (modal) => {
       hidden += `<input type="hidden" name="${fileField}" value="${file.attachmentId}" />`
     }
 
-    if (modal.options.titled) {
+    if (isTitled) {
       const titleValue = modal.modal.querySelectorAll('input[type="text"]')[ix].value
       // NOTE - Renaming the attachment is not supported when multiple uploader is disabled
       const titleField = `${modal.options.resourceName}[${modal.options.addAttribute}][${ix}][title]`

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -388,7 +388,7 @@ module Decidim
     # options      - A Hash with options to build the field. See upload method for
     # more detailed information.
     def attachment(attribute, options = {})
-      object_attachment = object.attachment.present?
+      object_attachment = object.respond_to?(:attachment) && object.attachment.present?
       record = object_attachment ? object.attachment : object
       options = {
         titled: options[:multiple],

--- a/decidim-core/spec/system/form_builder/file_upload_spec.rb
+++ b/decidim-core/spec/system/form_builder/file_upload_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "File upload" do
+  let(:template_class) do
+    Class.new(ActionView::Base) do
+      include Decidim::LayoutHelper
+      include Decidim::DecidimFormHelper
+
+      def protect_against_forgery?
+        false
+      end
+    end
+  end
+  let(:organization) { create(:organization) }
+  let(:current_user) { create(:user, :confirmed, :admin, organization:) }
+  let(:template) { template_class.new(ActionView::LookupContext.new(ActionController::Base.view_paths), {}, []) }
+  let(:options) { {} }
+
+  let(:html_document) do
+    document_inner = html_body.html_safe
+    template.append_stylesheet_pack_tag("decidim_dev")
+    template.instance_eval do
+      <<~HTML.strip
+        <!doctype html>
+        <html lang="en">
+        <head>
+          <title>Form Test</title>
+          #{stylesheet_pack_tag "decidim_core"}
+        </head>
+        <body>
+          <header>
+            <a href="#content">Skip to main content</a>
+          </header>
+          <main id="content">
+            <h1>Form Test</h1>
+            <div class="dev__form">
+              #{document_inner}
+            </div>
+          </main>
+
+          #{javascript_pack_tag "decidim_core", defer: false}
+        </body>
+        </html>
+      HTML
+    end
+  end
+  let(:html_body) { "" }
+
+  let(:form_class) do
+    Class.new(Decidim::Form) do
+      include Decidim::AttachmentAttributes
+
+      attachments_attribute :image
+    end
+  end
+  let(:form) { form_class.new }
+
+  let(:controller) do
+    Class.new(Decidim::ApplicationController) do
+      def self.name
+        "AnonymousController"
+      end
+
+      def endpoint
+        image = images["0"]
+        render html: <<~HTML.html_safe
+          <h1>Form submitted successfully</h1>
+          <div class="image">
+            <span data-blob="#{image["file"]}">
+              #{image["title"]}
+            </span>
+          </div>
+        HTML
+      end
+
+      private
+
+      def images
+        @images ||= params.dig(:form, :add_image)
+      end
+    end
+  end
+
+  before do
+    switch_to_host(organization.host)
+    sign_in current_user
+    Object.const_set(:AnonymousController, controller)
+
+    endpoint = controller.action(:endpoint)
+    final_html = html_document
+    Rails.application.routes.draw do
+      get "/favicon.ico", to: ->(_) { [200, {}, [""]] }
+      get "/offline", to: ->(_) { [200, {}, [""]] }
+      scope ActiveStorage.routes_prefix do
+        get "/disk/:encoded_key/*filename" => "active_storage/disk#show", :as => :rails_disk_service
+        put "/disk/:encoded_token" => "active_storage/disk#update", :as => :update_rails_disk_service
+        post "/direct_uploads" => "active_storage/direct_uploads#create", :as => :rails_direct_uploads
+      end
+
+      post "upload_validations" => "decidim/upload_validations#create", :as => :upload_validations
+      get "test_form", to: ->(_) { [200, {}, [final_html]] }
+      post "endpoint", to: endpoint
+    end
+
+    visit "/test_form"
+  end
+
+  after do
+    Object.send(:remove_const, :AnonymousController)
+
+    expect_no_js_errors
+
+    # Reset the routes back to original
+    Rails.application.reload_routes!
+  end
+
+  context "with a single titled file" do
+    let(:html_body) do
+      record = form
+      template.instance_eval do
+        decidim_form_for(record, url: "/endpoint") do |builder|
+          <<~HTML.strip.html_safe
+            #{builder.attachment(
+              :image,
+              titled: true,
+              multiple: false,
+              label: "Image",
+              button_label: "Add image",
+              button_edit_label: "Edit image",
+              button_class: "button button__lg button__transparent-secondary w-full"
+            )}
+            <button type="submit" class="button">Submit</button>
+          HTML
+        end
+      end
+    end
+
+    it "does not raise an exception when posting the form" do
+      dynamically_attach_file(:form_image, Decidim::Dev.asset("Exampledocument.pdf"), title: "Example doc")
+
+      click_on "Submit"
+
+      within "h1" do
+        expect(page).to have_content("Form submitted successfully")
+      end
+      within "[data-blob]" do
+        expect(page).to have_content("Example doc")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Currently having a single attachment with title breaks the parameters parsing in Rails. The issue is further explained at #13792 and the added spec tests this situation.

#### :pushpin: Related Issues
- Fixes #13792

#### Testing
- Take the spec from this PR and run it against current `develop`
- See the spec fail (`ActionController::BadRequest: Invalid request parameters: expected Hash (got String) for param `add_image'`)
- Take the fix from this branch and recompile the assets
- See the spec pass