### PR TITLE
WCAG navigation submenu

### DIFF
--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -10,7 +10,7 @@
   </header>
 
   <div class="vertical-tabs">
-    <nav>
+    <nav role="navigation" aria-label="<%= I18n.t("layouts.decidim.navigation.aria_label", title: translated_attribute(page.title)) %>">
       <button id="dropdown-trigger-pages" data-component="dropdown" data-target="dropdown-menu-pages" data-open-md="true" data-auto-close="true">
         <span>
           <%= translated_attribute(page.title) %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2208,7 +2208,7 @@ en:
       language_chooser:
         choose_language: Choose language
       navigation:
-        aria_label: Navigation menu - %{title}
+        aria_label: Navigation menu- %{title}
       notifications_dashboard:
         mark_all_as_read: Mark all as read
         mark_as_read: Mark as read

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2207,6 +2207,8 @@ en:
         expire_time_html: Your session will expire in <b><span class="minutes">%{minutes}</span> minutes</b>.
       language_chooser:
         choose_language: Choose language
+      navigation:
+        aria_label: Navigation menu - %{title}
       notifications_dashboard:
         mark_all_as_read: Mark all as read
         mark_as_read: Mark as read


### PR DESCRIPTION
#### :tophat: What? 
This PR updates the submenu navigation structure to improve accessibility and ensure compliance with WCAG standards. Changes include:
1. Added dynamic aria-label attributes to navigation menus to provide better context for screen readers, improving compliance with WCAG [1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)(Level A).
2. Added an `aria-label` attribute dynamically generated using the current page title, to provide an accessible and descriptive name for the navigation zone.

#### :tophat: Why?
This issue originates from an accessibility audit funded by the city of Lyon, targeting compliance with RGAA and corresponding WCAG standards. The changes ensure clearer navigation and improved usability for assistive technologies.

#### :pushpin: Related Issues
Related to WCAG [1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).

#### :clipboard: Subtasks
- [x] Update <nav> tags to include dynamic aria-label attributes, addressing WCAG [1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).
- [x] Verify compliance with WCAG standards.
- [ ] Add `CHANGELOG` entry.
- [ ] Add tests for updated accessibility structure.
- [ ] Update documentation if required.

#### Testing

3. **Accessibility Check**:
   - Open the Chrome Developer Tools and go to the **Accessibility** tab: ... /pages/help
   - Inspect the submenu `<nav>` element.
   - Ensure that:
      - The `role="navigation"` attribute is present.
      - Confirm that the `aria-label` contains the appropriate value based on the current page title.

4. **Screen Reader Validation**:
   - Use a screen reader (e.g., VoiceOver on macOS) to navigate the submenu.
   - Confirm that the navigation zone is announced with the correct label from the hidden `<h1>`.

### :camera: Screenshots
<img width="1187" alt="Capture d’écran 2024-12-18 à 17 16 17" src="https://github.com/user-attachments/assets/d57a60d0-1c18-44f5-97d1-d7b7132f869b" />

:hearts: Thank you!
