### PR TITLE
Remove obsolete count variable from see_all translation

### DIFF
--- a/decidim-proposals/config/locales/ar-SA.yml
+++ b/decidim-proposals/config/locales/ar-SA.yml
@@ -286,7 +286,7 @@ ar:
           proposals: اقتراحات
     participatory_spaces:
       highlighted_proposals:
-        see_all: شاهد الكل (%{count})
+        see_all: شاهد الكل
     proposals:
       actions:
         answer: إجابة

--- a/decidim-proposals/config/locales/ar.yml
+++ b/decidim-proposals/config/locales/ar.yml
@@ -294,7 +294,7 @@ ar:
         object: أصوات
     participatory_spaces:
       highlighted_proposals:
-        see_all: شاهد الكل (%{count})
+        see_all: شاهد الكل
     proposals:
       actions:
         answer_proposal: الرد على المُقتَرَح

--- a/decidim-proposals/config/locales/cs-CZ.yml
+++ b/decidim-proposals/config/locales/cs-CZ.yml
@@ -287,7 +287,7 @@ cs:
           proposals: Návrhy
     participatory_spaces:
       highlighted_proposals:
-        see_all: Zobrazit všechny (%{count})
+        see_all: Zobrazit všechny
     proposals:
       actions:
         answer: Odpovědět

--- a/decidim-proposals/config/locales/cs.yml
+++ b/decidim-proposals/config/locales/cs.yml
@@ -478,7 +478,7 @@ cs:
     participatory_spaces:
       highlighted_proposals:
         last: Poslední návrhy
-        see_all: Zobrazit všechny (%{count})
+        see_all: Zobrazit všechny
     proposals:
       actions:
         answer_proposal: Odpověď na návrh

--- a/decidim-proposals/config/locales/de.yml
+++ b/decidim-proposals/config/locales/de.yml
@@ -404,7 +404,7 @@ de:
     participatory_spaces:
       highlighted_proposals:
         last: Letzte Vorschläge
-        see_all: Alle anzeigen (%{count})
+        see_all: Alle anzeigen
     proposals:
       actions:
         answer_proposal: Vorschlag beantworten

--- a/decidim-proposals/config/locales/el.yml
+++ b/decidim-proposals/config/locales/el.yml
@@ -292,7 +292,7 @@ el:
         title: Προτάσεις
     participatory_spaces:
       highlighted_proposals:
-        see_all: Δείτε όλες τις προτάσεις (%{count})
+        see_all: Δείτε όλες τις προτάσεις
     proposals:
       actions:
         answer_proposal: Απάντηση σε πρόταση

--- a/decidim-proposals/config/locales/es-MX.yml
+++ b/decidim-proposals/config/locales/es-MX.yml
@@ -470,7 +470,7 @@ es-MX:
     participatory_spaces:
       highlighted_proposals:
         last: Propuestas más recientes
-        see_all: Ver todo (%{count})
+        see_all: Ver todo
     proposals:
       actions:
         answer_proposal: Responder a la propuesta

--- a/decidim-proposals/config/locales/es-PY.yml
+++ b/decidim-proposals/config/locales/es-PY.yml
@@ -470,7 +470,7 @@ es-PY:
     participatory_spaces:
       highlighted_proposals:
         last: Propuestas más recientes
-        see_all: Ver todo (%{count})
+        see_all: Ver todo
     proposals:
       actions:
         answer_proposal: Responder a la propuesta

--- a/decidim-proposals/config/locales/eu.yml
+++ b/decidim-proposals/config/locales/eu.yml
@@ -470,7 +470,7 @@ eu:
     participatory_spaces:
       highlighted_proposals:
         last: Azken proposamenak
-        see_all: Ikusi (%{count}) proposamenak
+        see_all: Ikusi proposamenak
     proposals:
       actions:
         answer_proposal: Erantzun proposamenari

--- a/decidim-proposals/config/locales/fi-pl.yml
+++ b/decidim-proposals/config/locales/fi-pl.yml
@@ -277,7 +277,7 @@ fi-pl:
           proposals: Ehdotukset
     participatory_spaces:
       highlighted_proposals:
-        see_all: Näytä kaikki (%{count})
+        see_all: Näytä kaikki
     proposals:
       actions:
         answer: Vastaa

--- a/decidim-proposals/config/locales/fi-plain.yml
+++ b/decidim-proposals/config/locales/fi-plain.yml
@@ -470,7 +470,7 @@ fi-pl:
     participatory_spaces:
       highlighted_proposals:
         last: Viimeisimmät ehdotukset
-        see_all: Näytä kaikki (%{count})
+        see_all: Näytä kaikki
     proposals:
       actions:
         answer_proposal: Vastaa ehdotukseen

--- a/decidim-proposals/config/locales/fr-CA.yml
+++ b/decidim-proposals/config/locales/fr-CA.yml
@@ -396,7 +396,7 @@ fr-CA:
     participatory_spaces:
       highlighted_proposals:
         last: Dernières propositions
-        see_all: Tout voir (%{count})
+        see_all: Tout voir
     proposals:
       actions:
         answer_proposal: Répondre à la proposition

--- a/decidim-proposals/config/locales/fr-LU.yml
+++ b/decidim-proposals/config/locales/fr-LU.yml
@@ -346,7 +346,7 @@ fr-LU:
         title: Votes
     participatory_spaces:
       highlighted_proposals:
-        see_all: Tout voir (%{count})
+        see_all: Tout voir
     proposals:
       actions:
         answer_proposal: Répondre à la proposition

--- a/decidim-proposals/config/locales/gl.yml
+++ b/decidim-proposals/config/locales/gl.yml
@@ -232,7 +232,7 @@ gl:
         title: Propostas
     participatory_spaces:
       highlighted_proposals:
-        see_all: Ver todos (%{count})
+        see_all: Ver todos
     proposals:
       actions:
         answer_proposal: Responder á proposta

--- a/decidim-proposals/config/locales/hu.yml
+++ b/decidim-proposals/config/locales/hu.yml
@@ -262,7 +262,7 @@ hu:
     participatory_spaces:
       highlighted_proposals:
         last: Legutóbbi javaslatok
-        see_all: Összes (%{count})
+        see_all: Összes
     proposals:
       actions:
         answer_proposal: Javaslat megválaszolása

--- a/decidim-proposals/config/locales/id-ID.yml
+++ b/decidim-proposals/config/locales/id-ID.yml
@@ -169,7 +169,7 @@ id:
         title: Proposal
     participatory_spaces:
       highlighted_proposals:
-        see_all: Lihat semua (%{count})
+        see_all: Lihat semua
     proposals:
       actions:
         edit_proposal: Edit proposal

--- a/decidim-proposals/config/locales/it.yml
+++ b/decidim-proposals/config/locales/it.yml
@@ -251,7 +251,7 @@ it:
         title: proposte
     participatory_spaces:
       highlighted_proposals:
-        see_all: Vedi tutto (%{count})
+        see_all: Vedi tutto
     proposals:
       actions:
         answer_proposal: Proposta di Risposta

--- a/decidim-proposals/config/locales/ja.yml
+++ b/decidim-proposals/config/locales/ja.yml
@@ -458,7 +458,7 @@ ja:
     participatory_spaces:
       highlighted_proposals:
         last: 最近の提案
-        see_all: すべての提案を見る (%{count})
+        see_all: すべての提案を見る
     proposals:
       actions:
         answer_proposal: 提案に回答

--- a/decidim-proposals/config/locales/lt.yml
+++ b/decidim-proposals/config/locales/lt.yml
@@ -299,7 +299,7 @@ lt:
     participatory_spaces:
       highlighted_proposals:
         last: Paskutiniai pasiūlymai
-        see_all: Žiūrėti visus pasiūlymus (%{count})
+        see_all: Žiūrėti visus pasiūlymus
     proposals:
       actions:
         answer_proposal: Atsakyti į pasiūlymą

--- a/decidim-proposals/config/locales/nl.yml
+++ b/decidim-proposals/config/locales/nl.yml
@@ -253,7 +253,7 @@ nl:
         title: voorstellen
     participatory_spaces:
       highlighted_proposals:
-        see_all: Alles zien (%{count})
+        see_all: Alles zien
     proposals:
       actions:
         answer_proposal: Antwoord voorstel

--- a/decidim-proposals/config/locales/no.yml
+++ b/decidim-proposals/config/locales/no.yml
@@ -252,7 +252,7 @@
         title: Forslag
     participatory_spaces:
       highlighted_proposals:
-        see_all: Vis alle (%{count})
+        see_all: Vis alle
     proposals:
       actions:
         answer_proposal: Svar på forslag

--- a/decidim-proposals/config/locales/pl.yml
+++ b/decidim-proposals/config/locales/pl.yml
@@ -356,7 +356,7 @@ pl:
     participatory_spaces:
       highlighted_proposals:
         last: Ostatnie propozycje
-        see_all: Zobacz wszystkie propozycje (%{count})
+        see_all: Zobacz wszystkie propozycje
     proposals:
       actions:
         answer_proposal: Odpowiedz na propozycję

--- a/decidim-proposals/config/locales/pt-BR.yml
+++ b/decidim-proposals/config/locales/pt-BR.yml
@@ -278,7 +278,7 @@ pt-BR:
         title: Votos
     participatory_spaces:
       highlighted_proposals:
-        see_all: Ver todos (%{count})
+        see_all: Ver todos
     proposals:
       actions:
         answer_proposal: Responder proposta

--- a/decidim-proposals/config/locales/pt.yml
+++ b/decidim-proposals/config/locales/pt.yml
@@ -263,7 +263,7 @@ pt:
         title: Propostas
     participatory_spaces:
       highlighted_proposals:
-        see_all: Ver todos (%{count})
+        see_all: Ver todos
     proposals:
       actions:
         answer_proposal: Responder a proposta

--- a/decidim-proposals/config/locales/ro-RO.yml
+++ b/decidim-proposals/config/locales/ro-RO.yml
@@ -266,7 +266,7 @@ ro:
         title: Propuneri
     participatory_spaces:
       highlighted_proposals:
-        see_all: Afișează toate propunerile (%{count})
+        see_all: Afișează toate propunerile
     proposals:
       actions:
         answer_proposal: Răspundeți la propunere

--- a/decidim-proposals/config/locales/sk-SK.yml
+++ b/decidim-proposals/config/locales/sk-SK.yml
@@ -329,7 +329,7 @@ sk:
           proposals: Návrhy
     participatory_spaces:
       highlighted_proposals:
-        see_all: Zobraziť všetky (%{count})
+        see_all: Zobraziť všetky
     proposals:
       actions:
         answer_proposal: Odpoveď na návrh

--- a/decidim-proposals/config/locales/sk.yml
+++ b/decidim-proposals/config/locales/sk.yml
@@ -210,7 +210,7 @@ sk:
         title: Návrhy
     participatory_spaces:
       highlighted_proposals:
-        see_all: Zobraziť všetky (%{count})
+        see_all: Zobraziť všetky
     proposals:
       actions:
         answer_proposal: Odpoveď na návrh

--- a/decidim-proposals/config/locales/tr-TR.yml
+++ b/decidim-proposals/config/locales/tr-TR.yml
@@ -257,7 +257,7 @@ tr:
         title: Teklifler
     participatory_spaces:
       highlighted_proposals:
-        see_all: Tüm teklifleri görün (%{count})
+        see_all: Tüm teklifleri görün
     proposals:
       actions:
         answer_proposal: Cevap önerisi

--- a/decidim-proposals/config/locales/zh-CN.yml
+++ b/decidim-proposals/config/locales/zh-CN.yml
@@ -220,7 +220,7 @@ zh-CN:
         title: 建议
     participatory_spaces:
       highlighted_proposals:
-        see_all: 查看所有建议 (%{count})
+        see_all: 查看所有建议
     proposals:
       actions:
         answer_proposal: 答复建议

--- a/decidim-proposals/config/locales/zh-TW.yml
+++ b/decidim-proposals/config/locales/zh-TW.yml
@@ -283,7 +283,7 @@ zh-TW:
         title: 提案
     participatory_spaces:
       highlighted_proposals:
-        see_all: 檢視所有提案 (%{count})
+        see_all: 檢視所有提案
     proposals:
       actions:
         answer_proposal: 回覆提案


### PR DESCRIPTION
#### :tophat: What? Why?

This removes the obsolete " (%{count})" from a lot of translations. This was already removed in en, es, fi, fr,... but a lot of languages where still missing and therefore showing something like this in the frontend:

<img width="257" alt="image" src="https://github.com/user-attachments/assets/015c6db7-1108-42b3-adc6-e2270636d7bb" />

#### Testing

This change only contains translation updates and can easily be validated manually.
