### PR TITLE
Fix edgecase in upgrade migration task

### DIFF
--- a/decidim-core/lib/tasks/upgrade/migrations.rake
+++ b/decidim-core/lib/tasks/upgrade/migrations.rake
@@ -54,8 +54,8 @@ namespace :decidim do
 
       target_file = Rails.root.glob("db/migrate/**_#{migration_file_base}.*.rb").first
       return if target_file.blank?
-
-      scope = target_file.split(".")[-2]
+      
+      scope = target_file.to_s.split(".")[-2]
 
       source = File.binread(file_path)
 

--- a/decidim-core/lib/tasks/upgrade/migrations.rake
+++ b/decidim-core/lib/tasks/upgrade/migrations.rake
@@ -54,7 +54,7 @@ namespace :decidim do
 
       target_file = Rails.root.glob("db/migrate/**_#{migration_file_base}.*.rb").first
       return if target_file.blank?
-      
+
       scope = target_file.to_s.split(".")[-2]
 
       source = File.binread(file_path)


### PR DESCRIPTION
#### :tophat: What? Why?
When i was trying to boot up the server, i got the below error.  I am adding this PR to ensure the target_file is always a string, and not a PathName

```
The Gemfile's dependencies are satisfied
rails aborted!
ArgumentError: wrong number of arguments (given 1, expected 0) (ArgumentError)

      scope = target_file.split(".")[-2]
                                ^^^
/home/alecslupu/Sites/decidim/redesign/development_app/bin/rails:5:in `<top (required)>'
/home/alecslupu/Sites/decidim/redesign/development_app/bin/spring:12:in `block in <top (required)>'
/home/alecslupu/Sites/decidim/redesign/development_app/bin/spring:9:in `<top (required)>'
Tasks: TOP => decidim:upgrade => decidim:upgrade:migrations
(See full trace by running task with --trace)
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13690

#### Testing
*Describe the best way to test or validate your PR.*
1. Cleanup all the unused gems 
2. Run bundle install against develop 
3. Try to start the server using `/bin/dev`
4. See if you get the error
5. Apply patch 
6. See you do not get the error 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
