### PR TITLE
Fix flaky spec in geocoder

### DIFF
--- a/decidim-core/spec/lib/map/geocoding_spec.rb
+++ b/decidim-core/spec/lib/map/geocoding_spec.rb
@@ -18,10 +18,6 @@ module Decidim
         let(:utility_class) { Provider::Geocoding::Test }
       end
 
-      after do
-        Geocoder::Lookup::Test.reset
-      end
-
       describe "#initialize" do
         let(:config) { { foo: "bar" } }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Lately we've seen some flaky related to Geocoding happen a lot in CI. 

This is the stacktrace:

```

  1) Decidim::Geocodable calls the Decidim geocoding utility and geocodes the resource
     Failure/Error: Geocoder.search(query, options)

     WebMock::NetConnectNotAllowedError:
       Real HTTP connections are disabled. Unregistered request: GET https://nominatim.openstreetmap.org/search?accept-language=en&addressdetails=1&format=json&q=Carrer%20del%20Pare%20Llaurador,%20113 with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Referer'=>'44.lvh.me', 'User-Agent'=>'Decidim/0.30.0.dev (My Application Name)'}

       You can stub this request with the following snippet:

       stub_request(:get, "https://nominatim.openstreetmap.org/search?accept-language=en&addressdetails=1&format=json&q=Carrer%20del%20Pare%20Llaurador,%20113").
         with(
           headers: {
       	  'Accept'=>'*/*',
       	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
       	  'Referer'=>'44.lvh.me',
       	  'User-Agent'=>'Decidim/0.30.0.dev (My Application Name)'
           }).
         to_return(status: 200, body: "", headers: {})

       ============================================================
     # ./lib/decidim/geocodable.rb:65:in `search'
     # ./lib/decidim/geocodable.rb:39:in `block in do_lookup'
     # ./lib/decidim/geocodable.rb:48:in `with_record'
     # ./lib/decidim/geocodable.rb:38:in `do_lookup'
     # ./spec/lib/geocodable_spec.rb:37:in `block (2 levels) in <module:Decidim>'

  2) Decidim::Geocodable when the address is invalid calls the Decidim geocoding utility and try to geocode the resource, but the result is [NaN,NaN]
     Failure/Error: Geocoder.search(query, options)

     WebMock::NetConnectNotAllowedError:
       Real HTTP connections are disabled. Unregistered request: GET https://nominatim.openstreetmap.org/search?accept-language=en&addressdetails=1&format=json&q=aaa with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Referer'=>'44.lvh.me', 'User-Agent'=>'Decidim/0.30.0.dev (My Application Name)'}

       You can stub this request with the following snippet:

       stub_request(:get, "https://nominatim.openstreetmap.org/search?accept-language=en&addressdetails=1&format=json&q=aaa").
         with(
           headers: {
       	  'Accept'=>'*/*',
       	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
       	  'Referer'=>'44.lvh.me',
       	  'User-Agent'=>'Decidim/0.30.0.dev (My Application Name)'
           }).
         to_return(status: 200, body: "", headers: {})

       ============================================================
     # ./lib/decidim/geocodable.rb:65:in `search'
     # ./lib/decidim/geocodable.rb:39:in `block in do_lookup'
     # ./lib/decidim/geocodable.rb:48:in `with_record'
     # ./lib/decidim/geocodable.rb:38:in `do_lookup'
     # ./spec/lib/geocodable_spec.rb:57:in `block (3 levels) in <module:Decidim>'

```

~~I'm not able to reproduce this locally, but I think the problem lies in the User-Agent, where it's looking for the string "Ruby" and finding other string ("Decidim/XXX"). This PR tries to fix this flaky by relaxing this check.~~

A new theory! I think the problem lies in another file, as we're resetting the Geocoder mocks, and that makes that this other stub is disabled. Let's see what the CI says 🤞🏽 

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/actions/runs/12689290873/job/35367852392
 

#### Testing

As it is a flaky that can't be reproduced locally (or at least I can't do it), I'll re-run the relevant job ("[CI] Core - Libs") at least 5 times to see if it happens again.

:hearts: Thank you!
