### PR TITLE
Upgrade check-spelling action

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
     - name: check-spelling
       id: spelling
-      uses: check-spelling/check-spelling@v0.0.22
+      uses: check-spelling/check-spelling@v0.0.24
       with:
         suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
         checkout: true
@@ -143,7 +143,7 @@ jobs:
       cancel-in-progress: false
     steps:
     - name: apply spelling updates
-      uses: check-spelling/check-spelling@v0.0.22
+      uses: check-spelling/check-spelling@v0.0.24
       with:
         experimental_apply_changes_via_bot: 1
         checkout: true


### PR DESCRIPTION
#### :tophat: What? Why?
I have noticed there is a pipeline issue in #13767 ( Crowdin ), and went to check. I have noticed the spelchecked died with the following error: 
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/download-artifact: v3`. Learn more: [https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

The issue is fixed by 0.0.23, but we upgrade to the latest version so we have all the possible fixes.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13767

#### Testing
The pipeline should be green

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
