### PR TITLE
Fix flaky spec in authentication

### DIFF
--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -631,6 +631,10 @@ describe "Authentication" do
             end
           end
 
+          after do
+            user.unlock_access!
+          end
+
           it "when reached maximum failed attempts" do
             within ".new_user" do
               fill_in :session_user_email, with: user.email
@@ -649,6 +653,10 @@ describe "Authentication" do
           user.lock_access!
 
           visit decidim.new_user_unlock_path
+        end
+
+        after do
+          user.unlock_access!
         end
 
         it "resends the unlock instructions" do


### PR DESCRIPTION
#### :tophat: What? Why?

Lately we've seen some flaky related to Authentication happen a lot in CI. 

This is the stacktrace:

```
  1) Authentication when a user is already registered Log Out logs out the user
     Failure/Error:
       within_user_menu do
         click_on("Log out")
       end

     Capybara::ElementNotFound:
       Unable to find id "trigger-dropdown-account" within #<Capybara::Node::Element tag="div" path="/HTML/BODY[1]/DIV[2]/HEADER[1]/DIV[1]/DIV[2]/DIV[1]">

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_authentication_when_a_user_is_already_registered_log_out_logs_out_the_user_563.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_authentication_when_a_user_is_already_registered_log_out_logs_out_the_user_563.html


     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/helpers.rb:16:in `block in within_user_menu'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/helpers.rb:15:in `within_user_menu'
     # ./spec/system/authentication_spec.rb:581:in `block (4 levels) in <top (required)>'
```

I'm not able to reproduce this locally, but I think the problem lies in another example of this same file, as the problem that I saw was that the user wasn't actually logged in in these examples: 

https://github.com/decidim/decidim/blob/da3040b6fdf0da4ee038368b8a616a404d4e7fbd/decidim-core/spec/system/authentication_spec.rb#L404
https://github.com/decidim/decidim/blob/da3040b6fdf0da4ee038368b8a616a404d4e7fbd/decidim-core/spec/system/authentication_spec.rb#L580

My theory is that it wasn't logged in because it was locked in an example before.

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/actions/runs/12680510102/job/35342572566

#### Testing

As it is a flaky that can't be reproduced locally (or at least I can't do it), I'll re-run the relevant job ("[CI] Core - System specs") at least 5 times to see if it happens again.

:hearts: Thank you!
