### PR TITLE
Retries NPM installation a couple times to prevent network timeouts

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -47,6 +47,9 @@ jobs:
           node-version: ${{ inputs.node_version }}
           cache: 'npm'
           cache-dependency-path: ./package-lock.json
+      - run: npm set fetch-retries 5
+        name: Tune NPM configuration
+        shell: "bash"
       - uses: actions/cache@v4
         id: app-cache
         with:


### PR DESCRIPTION
#### :tophat: What? Why?

Lately we've seen some flaky related to NPM installation in CI. 

This is the stacktrace:

``` 
      create  bin/shakapacker
      create  bin/shakapacker-dev-server
      create  bin/yarn
      create  package.json
npm ERR! code ECONNRESET
npm ERR! errno ECONNRESET
npm ERR! network Invalid response body while trying to fetch https://registry.npmjs.org/@tiptap%2fstarter-kit: aborted
npm ERR! network This is a problem related to network connectivity.
npm ERR! network In most cases you are behind a proxy or have bad network settings.
npm ERR! network 
npm ERR! network If you are behind a proxy, please make sure that the
npm ERR! network 'proxy' config is set properly.  See: 'npm help config'

npm ERR! A complete log of this run can be found in: /home/runner/.npm/_logs/2025-01-10T11_09_24_649Z-debug-0.log

== Command npm i --save-prod ./packages/browserslist-config ./packages/core ./packages/webpacker failed ==
Error: Process completed with exit code 1.
```

#### :pushpin: Related Issues
 
- Related to  https://github.com/decidim/decidim/actions/runs/12708362583/job/35425183500?pr=13827

#### Testing

As the problem is on the build install script (used by most of the other workflows), and the culprit is random network problems,  should just retry those random workflows to see if they happen again.

:hearts: Thank you!
