### PR TITLE
Fix CTA button path when displayed somewhere else than the home page

### DIFF
--- a/decidim-core/app/helpers/decidim/cta_button_helper.rb
+++ b/decidim-core/app/helpers/decidim/cta_button_helper.rb
@@ -16,7 +16,7 @@ module Decidim
     # Finds the CTA button path to reuse it in other places.
     def cta_button_path
       if current_organization.cta_button_path.present?
-        current_organization.cta_button_path
+        "/#{current_organization.cta_button_path}"
       elsif Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?
         decidim_participatory_processes.participatory_processes_path
       elsif current_user


### PR DESCRIPTION
#### :tophat: What? Why?
The CTA button path is broken if it is displayed somewhere else than the home page because it does not have the leading slash character. On the home page this works fine as it is at the root path but if this link is displayed somewhere else, it keeps the current path of that URL.

It is displayed e.g. in these places:
https://github.com/decidim/decidim/blob/abb37b7fadbbac268e6cc450abc5350c4a1bd9e8/decidim-verifications/app/views/decidim/verifications/authorizations/new.html.erb#L28
https://github.com/decidim/decidim/blob/abb37b7fadbbac268e6cc450abc5350c4a1bd9e8/decidim-verifications/app/views/decidim/verifications/authorizations/onboarding_pending.html.erb#L36

In the legacy version, it was displayed also on the "first login" page which has been since removed. This is where the bug was noticed initially.

#### Testing
- Try to add a link to the `cta_button_path` in some other page than the home page
- See the link pointing to a 404 page