### PR TITLE
Update DownloadYourData exports for decidim-conferences

### DIFF
--- a/decidim-conferences/app/serializers/decidim/conferences/download_your_data_conference_invite_serializer.rb
+++ b/decidim-conferences/app/serializers/decidim/conferences/download_your_data_conference_invite_serializer.rb
@@ -10,15 +10,14 @@ module Decidim
           sent_at: resource.sent_at,
           accepted_at: resource.accepted_at,
           rejected_at: resource.rejected_at,
-          user: {
-            name: resource.user.name,
-            email: resource.user.email
-          },
+          created_at: resource.created_at,
+          updated_at: resource.updated_at,
           registration_type: {
             title: resource.registration_type.title,
             price: resource.registration_type.price
           },
           conference: {
+            url: Decidim::EngineRouter.main_proxy(resource.conference).conference_url(resource.conference),
             title: resource.conference.title,
             reference: resource.conference.reference,
             slogan: resource.conference.slogan,

--- a/decidim-conferences/app/serializers/decidim/conferences/download_your_data_conference_registration_serializer.rb
+++ b/decidim-conferences/app/serializers/decidim/conferences/download_your_data_conference_registration_serializer.rb
@@ -7,15 +7,15 @@ module Decidim
       def serialize
         {
           id: resource.id,
-          user: {
-            name: resource.user.name,
-            email: resource.user.email
-          },
+          created_at: resource.created_at,
+          updated_at: resource.updated_at,
+          confirmed_at: resource.confirmed_at,
           registration_type: {
             title: resource.registration_type.title,
             price: resource.registration_type.price
           },
           conference: {
+            url: Decidim::EngineRouter.main_proxy(resource.conference).conference_url(resource.conference),
             title: resource.conference.title,
             reference: resource.conference.reference,
             slogan: resource.conference.slogan,

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -548,8 +548,8 @@ en:
           id: The unique identifier of the conference invitation
           registration_type: The type of the registration for this conference that was sent
           rejected_at: The date when the conference invitation was rejected
-          updated_at: The date when this invitation was updated for the last time
           sent_at: The date when this conference invitation was sent
+          updated_at: The date when this invitation was updated for the last time
         conference_registrations:
           conference: The conference that this belongs to
           confirmed_at: The date when this registration was confirmed

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -543,16 +543,20 @@ en:
         conference_invites:
           accepted_at: The date when the conference invitation was accepted
           conference: The conference where this invitation was sent
+          confirmed_at: The date when this invitation was confirmed
+          created_at: The date when this invitation was created
           id: The unique identifier of the conference invitation
           registration_type: The type of the registration for this conference that was sent
           rejected_at: The date when the conference invitation was rejected
+          updated_at: The date when this invitation was updated for the last time
           sent_at: The date when this conference invitation was sent
-          user: The unique identifier of the user that the invitation was sent
         conference_registrations:
           conference: The conference that this belongs to
+          confirmed_at: The date when this registration was confirmed
+          created_at: The date when this registration was created
           id: The unique identifier of the conference regisrations
           registration_type: The type of registration that this belongs to
-          user: The unique identifier of the user for this registration
+          updated_at: The date when this registration was updated for the last time
     events:
       conferences:
         conference_registration_confirmed:

--- a/decidim-conferences/spec/serializers/decidim/conferences/download_your_data_conference_invite_serializer_spec.rb
+++ b/decidim-conferences/spec/serializers/decidim/conferences/download_your_data_conference_invite_serializer_spec.rb
@@ -18,15 +18,8 @@ module Decidim::Conferences
         expect(subject.serialize).to include(sent_at: resource.sent_at)
         expect(subject.serialize).to include(accepted_at: resource.accepted_at)
         expect(subject.serialize).to include(rejected_at: resource.rejected_at)
-      end
-
-      it "includes the user" do
-        serialized_user = subject.serialize[:user]
-
-        expect(serialized_user).to be_a(Hash)
-
-        expect(serialized_user).to include(name: resource.user.name)
-        expect(serialized_user).to include(email: resource.user.email)
+        expect(subject.serialize).to include(created_at: resource.created_at)
+        expect(subject.serialize).to include(updated_at: resource.updated_at)
       end
 
       it "includes the registration_type" do
@@ -43,6 +36,7 @@ module Decidim::Conferences
 
         expect(serialized_conference).to be_a(Hash)
 
+        expect(serialized_conference).to include(url: Decidim::EngineRouter.main_proxy(resource.conference).conference_url(resource.conference))
         expect(serialized_conference).to include(title: resource.conference.title)
         expect(serialized_conference).to include(slogan: resource.conference.slogan)
         expect(serialized_conference).to include(description: resource.conference.description)

--- a/decidim-conferences/spec/serializers/decidim/conferences/download_your_data_conference_registration_serializer_spec.rb
+++ b/decidim-conferences/spec/serializers/decidim/conferences/download_your_data_conference_registration_serializer_spec.rb
@@ -9,17 +9,11 @@ module Decidim::Conferences
     subject { described_class.new(resource) }
 
     describe "#serialize" do
-      it "includes the id" do
+      it "includes the registration metadata" do
         expect(subject.serialize).to include(id: resource.id)
-      end
-
-      it "includes the user" do
-        expect(subject.serialize[:user]).to(
-          include(name: resource.user.name)
-        )
-        expect(subject.serialize[:user]).to(
-          include(email: resource.user.email)
-        )
+        expect(subject.serialize).to include(created_at: resource.created_at)
+        expect(subject.serialize).to include(updated_at: resource.updated_at)
+        expect(subject.serialize).to include(confirmed_at: resource.confirmed_at)
       end
 
       it "includes the registration_type" do
@@ -32,6 +26,10 @@ module Decidim::Conferences
       end
 
       it "includes the conference" do
+        expect(subject.serialize[:conference]).to(
+          include(url: Decidim::EngineRouter.main_proxy(resource.conference).conference_url(resource.conference))
+        )
+
         expect(subject.serialize[:conference]).to(
           include(title: resource.conference.title)
         )

--- a/decidim-core/lib/decidim/core/test/shared_examples/download_your_data_shared_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/download_your_data_shared_examples.rb
@@ -8,7 +8,7 @@ shared_examples_for "a download your data entity" do
   end
 
   it "does not have any missing translation" do
-    expect(data).not_to include("Translation missing")
+    expect(data).not_to include("Translation missing"), data
   end
 
   it "has the correct help definition" do


### PR DESCRIPTION
#### :tophat: What? Why?

This PR updates the DownloadYourData exports for decidim-conferences models.

On this case:

- I added the URL for the related conference, to ease-up the review of the metadata
- Added some missing fields (`created_at`, `updated_at`, and `confirmed_at` in the case of Registrations). 

#### :pushpin: Related Issues
 
- Related to #13527

#### Testing

- Everything should be green
- There shouldn't be new fields to add here 

:hearts: Thank you!
