### PR TITLE
Fix label width

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_labels.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_labels.scss
@@ -6,7 +6,7 @@
   --warning: #ad4910;
   --bg-warning: #ffeebd;
 
-  @apply bg-background text-gray-2 rounded flex h-min items-center gap-1 px-2 py-1 font-semibold text-sm;
+  @apply bg-background text-gray-2 rounded inline-flex h-min items-center gap-1 px-2 py-1 font-semibold text-sm;
 
   &.success {
     @apply bg-[var(--bg-success)] text-[var(--success)];


### PR DESCRIPTION
#### :tophat: What? Why?
After #13841 i have noticed that the admin labels are displayed in flex, meaning they get the full width of the cell. This fixes the issue. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13841

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

Before:
![image](https://github.com/user-attachments/assets/e2c91705-51db-46c2-bcc2-dbd0c8f7b52b)

After:
![image](https://github.com/user-attachments/assets/9bedd016-fa85-4f2e-a3b7-2b0417ab7006)


:hearts: Thank you!
