### PR TITLE
Lock concurrent-ruby to 1.3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ PATH
       cells-erb (~> 0.1.0)
       cells-rails (~> 0.1.3)
       charlock_holmes (~> 0.7)
+      concurrent-ruby (= 1.3.4)
       date_validator (~> 0.12.0)
       devise (~> 4.7)
       devise-i18n (~> 1.2)

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -31,6 +31,9 @@ Gem::Specification.new do |s|
     end
   end
 
+  # Lock Temporarily as it is failing in 0.29 branch. More info: https://github.com/rails/rails/pull/54264
+  s.add_dependency "concurrent-ruby", "= 1.3.4"
+
   s.add_dependency "active_link_to", "~> 1.0"
   s.add_dependency "acts_as_list", "~> 1.0"
   s.add_dependency "batch-loader", "~> 2.0"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -61,6 +61,7 @@ PATH
       cells-erb (~> 0.1.0)
       cells-rails (~> 0.1.3)
       charlock_holmes (~> 0.7)
+      concurrent-ruby (= 1.3.4)
       date_validator (~> 0.12.0)
       devise (~> 4.7)
       devise-i18n (~> 1.2)


### PR DESCRIPTION
#### :tophat: What? Why?
Recently we noticed the pipelines started to fail with the following error: 
![image](https://github.com/user-attachments/assets/fef6ffa0-742e-4873-ba50-12303051099b)

We are locking to concurrent-ruby 1.3.4 in order to have it backported. 

#### Testing
1. Pipeline should be green

:hearts: Thank you!
