### PR TITLE
Fix translation issue on import projects mailer

### DIFF
--- a/decidim-accountability/app/mailers/decidim/accountability/import_projects_mailer.rb
+++ b/decidim-accountability/app/mailers/decidim/accountability/import_projects_mailer.rb
@@ -5,6 +5,9 @@ module Decidim
     # This mailer sends a notification email containing the result of importing
     # Cprojects to the results.
     class ImportProjectsMailer < Decidim::ApplicationMailer
+      include Decidim::TranslatableAttributes
+      helper Decidim::TranslationsHelper
+
       # Public: Sends a notification email with the result of projects import selected projects to Accountability
       #
       # user   - The user to be notified.

--- a/decidim-accountability/app/views/decidim/accountability/import_projects_mailer/import.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/import_projects_mailer/import.html.erb
@@ -1,2 +1,2 @@
-<p><%= t(".success", component_name: @component.name["en"]) %></p>
+<p><%= t(".success", component_name: translated_attribute(@component.name)) %></p>
 <p> <%= t(".added_projects", count: @projects) %></p>


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing #13817, i noticed that we have a template that no matter what, tries to use the english translation. This is not OK, as there are instances where English is not configured ( for example Decidim Barcelona ) 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13817

#### Testing
1. Login to admin
2. Visit a budget component set at least 1 project as selected for implementation
3. Visit the accountability module and import from component 
4. Visit the letter opener and see the text 
5. Apply patch 
6. repeat 2,3,4 
7. See the message remains unchanged.

Alternatively, create a new app, without English language being configured. 
Seed the DB, repeat steps 2,3,4 . I am expecting that step 4 would generate an error as en is not configured.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
