### PR TITLE
Update DownloadYourData exports for decidim-debates

### DIFF
--- a/decidim-debates/app/serializers/decidim/debates/download_your_data_debate_serializer.rb
+++ b/decidim-debates/app/serializers/decidim/debates/download_your_data_debate_serializer.rb
@@ -2,20 +2,13 @@
 
 module Decidim
   module Debates
-    class DownloadYourDataDebateSerializer < Decidim::Exporters::Serializer
-      # Serializes a Debate for download your data
+    class DownloadYourDataDebateSerializer < Decidim::Debates::DebateSerializer
+      # Serializes a Debate for download your data feature
+      #
+      # Remove the author information as it is the same of the user that
+      # requested the data
       def serialize
-        {
-          id: resource.id,
-          title: resource.title,
-          description: resource.description,
-          instructions: resource.instructions,
-          start_time: resource.start_time,
-          end_time: resource.end_time,
-          information_updates: resource.information_updates,
-          reference: resource.reference,
-          component: resource.component.name
-        }
+        super.except!(:author)
       end
     end
   end

--- a/decidim-debates/lib/decidim/debates/debate_serializer.rb
+++ b/decidim-debates/lib/decidim/debates/debate_serializer.rb
@@ -8,64 +8,56 @@ module Decidim
       include Decidim::ApplicationHelper
       include Decidim::ResourceHelper
 
-      # Public: Initializes the serializer with a debate.
-      def initialize(debate)
-        @debate = debate
-      end
-
-      # Public: Exports a hash with the serialized data for this debate.
+      # Public: Exports a hash with the serialized data for this resource.
       def serialize
         {
-          id: debate.id,
+          id: resource.id,
           author: {
             **author_fields
           },
-          title: debate.title,
-          description: debate.description,
-          instructions: debate.instructions,
-          start_time: debate.start_time,
-          end_time: debate.end_time,
-          information_updates: debate.information_updates,
+          title: resource.title,
+          description: resource.description,
+          instructions: resource.instructions,
+          start_time: resource.start_time,
+          end_time: resource.end_time,
+          information_updates: resource.information_updates,
           taxonomies:,
           participatory_space: {
-            id: debate.participatory_space.id,
-            url: Decidim::ResourceLocatorPresenter.new(debate.participatory_space).url
+            id: resource.participatory_space.id,
+            url: Decidim::ResourceLocatorPresenter.new(resource.participatory_space).url
           },
           component: { id: component.id },
-          reference: debate.reference,
-          comments: debate.comments_count,
-          follows_count: debate.follows_count,
+          reference: resource.reference,
+          comments: resource.comments_count,
+          follows_count: resource.follows_count,
           url:,
-          last_comment_at: debate.last_comment_at,
+          last_comment_at: resource.last_comment_at,
           last_comment_by: {
             **last_comment_by_fields
           },
-          comments_enabled: debate.comments_enabled,
-          conclusions: debate.conclusions,
-          closed_at: debate.closed_at,
-          created_at: debate.created_at,
-          updated_at: debate.updated_at,
-          endorsements_count: debate.endorsements_count
+          comments_enabled: resource.comments_enabled,
+          conclusions: resource.conclusions,
+          closed_at: resource.closed_at,
+          created_at: resource.created_at,
+          updated_at: resource.updated_at,
+          endorsements_count: resource.endorsements_count
         }
       end
 
       private
 
-      attr_reader :debate
-      alias resource debate
-
       def last_comment_by_fields
-        return {} unless debate.last_comment_by
+        return {} unless resource.last_comment_by
 
         {
-          id: debate.last_comment_by.id,
-          name: user_name(debate.last_comment_by),
-          url: user_url(debate.last_comment_by)
+          id: resource.last_comment_by.id,
+          name: user_name(resource.last_comment_by),
+          url: user_url(resource.last_comment_by)
         }
       end
 
       def url
-        Decidim::ResourceLocatorPresenter.new(debate).url
+        Decidim::ResourceLocatorPresenter.new(resource).url
       end
 
       def author_fields

--- a/decidim-debates/lib/decidim/debates/debate_serializer.rb
+++ b/decidim-debates/lib/decidim/debates/debate_serializer.rb
@@ -57,6 +57,8 @@ module Decidim
       end
 
       def author_fields
+        return {} if resource.author.respond_to?(:deleted?) && resource.author.deleted?
+
         {
           id: resource.author.id,
           name: user_name(resource.author),

--- a/decidim-debates/lib/decidim/debates/debate_serializer.rb
+++ b/decidim-debates/lib/decidim/debates/debate_serializer.rb
@@ -48,6 +48,7 @@ module Decidim
 
       def last_comment_by_fields
         return {} unless resource.last_comment_by
+        return {} if resource.last_comment_by.respond_to?(:deleted?) && resource.last_comment_by.deleted?
 
         {
           id: resource.last_comment_by.id,

--- a/decidim-debates/lib/decidim/debates/debate_serializer.rb
+++ b/decidim-debates/lib/decidim/debates/debate_serializer.rb
@@ -30,7 +30,7 @@ module Decidim
           reference: resource.reference,
           comments: resource.comments_count,
           follows_count: resource.follows_count,
-          url:,
+          url: Decidim::ResourceLocatorPresenter.new(resource).url,
           last_comment_at: resource.last_comment_at,
           last_comment_by: {
             **last_comment_by_fields
@@ -54,10 +54,6 @@ module Decidim
           name: user_name(resource.last_comment_by),
           url: user_url(resource.last_comment_by)
         }
-      end
-
-      def url
-        Decidim::ResourceLocatorPresenter.new(resource).url
       end
 
       def author_fields

--- a/decidim-debates/spec/lib/decidim/debates/debate_serializer_spec.rb
+++ b/decidim-debates/spec/lib/decidim/debates/debate_serializer_spec.rb
@@ -68,16 +68,8 @@ module Decidim
               let(:author) { create(:user, :deleted, organization: component.organization) }
               let!(:debate) { create(:debate, component:, author:) }
 
-              it "serializes the user id" do
-                expect(serialized[:author]).to include(id: author.id)
-              end
-
-              it "serializes the user name" do
-                expect(serialized[:author]).to include(name: "")
-              end
-
-              it "serializes the link to its profile" do
-                expect(serialized[:author]).to include(url: "")
+              it "does not serialize the fields" do
+                expect(serialized[:author]).to eq({})
               end
             end
           end

--- a/decidim-debates/spec/lib/decidim/debates/debate_serializer_spec.rb
+++ b/decidim-debates/spec/lib/decidim/debates/debate_serializer_spec.rb
@@ -207,7 +207,7 @@ module Decidim
             expect(serialized[:last_comment_by]).to eq(
               id: last_comment_by.id,
               name: "User",
-              url: new_debate.send(:user_url, last_comment_by)
+              url: profile_url(last_comment_by.nickname)
             )
           end
         end

--- a/decidim-debates/spec/lib/decidim/debates/debate_serializer_spec.rb
+++ b/decidim-debates/spec/lib/decidim/debates/debate_serializer_spec.rb
@@ -202,6 +202,28 @@ module Decidim
               url: profile_url(last_comment_by.nickname)
             )
           end
+
+          context "when the last comment is from a user group" do
+            let(:last_comment_by) { create(:user_group, name: "ACME") }
+            let(:debate) { create(:debate, last_comment_by:) }
+
+            it "serializes the last comment by fields" do
+              expect(serialized[:last_comment_by]).to eq(
+                id: last_comment_by.id,
+                name: "ACME",
+                url: profile_url(last_comment_by.nickname)
+              )
+            end
+          end
+
+          context "when the last comment is from a deleted user" do
+            let(:last_comment_by) { create(:user, :deleted) }
+            let(:debate) { create(:debate, last_comment_by:) }
+
+            it "does not serialize the fields" do
+              expect(serialized[:last_comment_by]).to eq({})
+            end
+          end
         end
 
         context "when there is no last comment" do

--- a/decidim-debates/spec/serializers/decidim/debates/download_your_data_debate_serializer_spec.rb
+++ b/decidim-debates/spec/serializers/decidim/debates/download_your_data_debate_serializer_spec.rb
@@ -43,7 +43,7 @@ module Decidim
           end
 
           it "does not serialize the link to its profile" do
-            expect(serialized).not_to include(author: {url: profile_url(debate.author.nickname)})
+            expect(serialized).not_to include(author: { url: profile_url(debate.author.nickname) })
           end
         end
       end

--- a/decidim-debates/spec/serializers/decidim/debates/download_your_data_debate_serializer_spec.rb
+++ b/decidim-debates/spec/serializers/decidim/debates/download_your_data_debate_serializer_spec.rb
@@ -4,47 +4,199 @@ require "spec_helper"
 
 module Decidim
   describe Debates::DownloadYourDataDebateSerializer do
-    subject { described_class.new(resource) }
-    let(:resource) { create(:debate) }
+    subject do
+      described_class.new(debate)
+    end
 
-    let(:serialized) { subject.serialize }
+    let!(:debate) { create(:debate) }
+    let!(:taxonomies) { create_list(:taxonomy, 2, :with_parent, organization: component.organization) }
+    let(:participatory_process) { component.participatory_space }
+    let(:component) { debate.component }
+    let(:new_debate) { described_class.new(debate) }
+    let(:serialized_taxonomies) do
+      { ids: taxonomies.pluck(:id) }.merge(taxonomies.to_h { |t| [t.id, t.name] })
+    end
+
+    before do
+      debate.update!(taxonomies:)
+    end
 
     describe "#serialize" do
-      it "includes the id" do
-        expect(serialized).to include(id: resource.id)
+      let(:serialized) { subject.serialize }
+
+      it "serializes the id" do
+        expect(serialized).to include(id: debate.id)
       end
 
-      it "includes the title" do
-        expect(serialized).to include(title: resource.title)
+      it "serializes the taxonomies" do
+        expect(serialized[:taxonomies]).to eq(serialized_taxonomies)
       end
 
-      it "includes the description" do
-        expect(serialized).to include(description: resource.description)
+      describe "author" do
+        context "when it is a user" do
+          let(:author) { create(:user, name: "John Doe", organization: component.organization) }
+          let(:component) { create(:debates_component) }
+          let!(:debate) { create(:debate, component:, author:) }
+
+          it "does not serialize the user name" do
+            expect(serialized).not_to include(name: "John Doe")
+          end
+
+          it "does not serialize the link to its profile" do
+            expect(serialized).not_to include(author: {url: profile_url(debate.author.nickname)})
+          end
+        end
       end
 
-      it "includes the instructions" do
-        expect(serialized).to include(instructions: resource.instructions)
+      it "serializes the title" do
+        expect(serialized).to include(title: debate.title)
       end
 
-      it "includes the start time" do
-        expect(serialized).to include(start_time: resource.start_time)
+      it "serializes the description" do
+        expect(serialized).to include(description: debate.description)
       end
 
-      it "includes the end time" do
-        expect(serialized).to include(end_time: resource.end_time)
+      it "serializes the start time" do
+        expect(serialized).to include(start_time: debate.start_time)
       end
 
-      it "includes the information updates" do
-        expect(serialized).to include(information_updates: resource.information_updates)
+      it "serializes the end time" do
+        expect(serialized).to include(end_time: debate.end_time)
       end
 
-      it "includes the reference" do
-        expect(serialized).to include(reference: resource.reference)
+      it "serializes the information updates" do
+        expect(serialized).to include(information_updates: debate.information_updates)
       end
 
-      it "includes the component" do
-        expect(serialized).to include(component: resource.component.name)
+      it "serializes the participatory space" do
+        expect(serialized[:participatory_space]).to include(id: participatory_process.id)
+        expect(serialized[:participatory_space][:url]).to include("http", participatory_process.slug)
       end
+
+      it "serializes the component" do
+        expect(serialized[:component]).to include(id: debate.component.id)
+      end
+
+      it "serializes the reference" do
+        expect(serialized).to include(reference: debate.reference)
+      end
+
+      it "serializes the comments" do
+        expect(serialized).to include(comments: debate.comments_count)
+      end
+
+      it "serializes the number of followers" do
+        expect(serialized).to include(follows_count: debate.follows_count)
+      end
+
+      it "serializes the url" do
+        expect(serialized[:url]).to include("http", debate.id.to_s)
+      end
+
+      it "serializes the last comment at" do
+        expect(serialized).to include(last_comment_at: debate.last_comment_at)
+      end
+
+      it "serializes the comments enabled" do
+        expect(serialized).to include(comments_enabled: debate.comments_enabled)
+      end
+
+      it "includes the created at" do
+        expect(serialized).to include(created_at: debate.created_at)
+      end
+
+      it "includes the updated at" do
+        expect(serialized).to include(updated_at: debate.updated_at)
+      end
+
+      it "serializes the endorsements" do
+        expect(serialized).to include(endorsements_count: debate.endorsements_count)
+      end
+
+      describe "conclusions and closed at" do
+        it "does not serializes the conclusion" do
+          expect(serialized[:conclusions]).to be_nil
+        end
+
+        it "does not serializes the closed at" do
+          expect(serialized[:closed_at]).to be_nil
+        end
+
+        context "when the debate is closed" do
+          let!(:debate) { create(:debate, :closed) }
+
+          it "serializes the conclusion" do
+            expect(serialized).to include(conclusions: debate.conclusions)
+          end
+
+          it "serializes the closed at" do
+            expect(serialized).to include(closed_at: debate.closed_at)
+          end
+        end
+
+        context "when the debate is not closed" do
+          let!(:debate) { create(:debate, closed_at: nil) }
+
+          it "does not serialize the conclusion" do
+            expect(serialized[:conclusions]).to be_nil
+          end
+
+          it "does not serialize the closed at" do
+            expect(serialized[:closed_at]).to be_nil
+          end
+        end
+      end
+
+      context "when there is a last comment" do
+        let(:last_comment_by) { create(:user, name: "User") }
+        let(:debate) { create(:debate, last_comment_by:) }
+
+        it "serializes the last comment by fields" do
+          expect(serialized[:last_comment_by]).to eq(
+            id: last_comment_by.id,
+            name: "User",
+            url: profile_url(last_comment_by.nickname)
+          )
+        end
+
+        context "when the last comment is from a user group" do
+          let(:last_comment_by) { create(:user_group, name: "ACME") }
+          let(:debate) { create(:debate, last_comment_by:) }
+
+          it "serializes the last comment by fields" do
+            expect(serialized[:last_comment_by]).to eq(
+              id: last_comment_by.id,
+              name: "ACME",
+              url: profile_url(last_comment_by.nickname)
+            )
+          end
+        end
+
+        context "when the last comment is from a deleted user" do
+          let(:last_comment_by) { create(:user, :deleted) }
+          let(:debate) { create(:debate, last_comment_by:) }
+
+          it "does not serialize the fields" do
+            expect(serialized[:last_comment_by]).to eq({})
+          end
+        end
+      end
+
+      context "when there is no last comment" do
+        let(:debate) { create(:debate, last_comment_by: nil) }
+
+        it "returns no values" do
+          expect(serialized[:last_comment_by]).to eq({})
+        end
+      end
+    end
+
+    def profile_url(nickname)
+      Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:, port: Capybara.server_port)
+    end
+
+    def host
+      debate.organization.host
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR updates the DownloadYourData exports for decidim-debates models.

On this case what I'm doing is: 

- Simplifying DebateSerializer (you can see the reasoning in each commit, I tried to made them granular) 
- Instead of re-implemeting the DebateSerializer (as it was until now), I prefer to just inherit from it, as it is cleaner and there shouldn't be any field that could leak from the admin panel (such as answers/costs in Proposals). I also removed the author information, as we mentioned in https://github.com/decidim/decidim/pull/13859, i don't see any reason to have them (the participant that is requesting these files is the author, so they know who they are) 

#### :pushpin: Related Issues
 
- Related to #13527

#### Testing

- Everything should be green
- There shouldn't be new fields to add here 

:hearts: Thank you!
