### PR TITLE
Fix flaky spec in autocomplete

### DIFF
--- a/decidim-core/lib/decidim/map/autocomplete.rb
+++ b/decidim-core/lib/decidim/map/autocomplete.rb
@@ -87,14 +87,6 @@ module Decidim
             organization: @template.current_organization
           )
 
-          if Rails.env.test?
-            pp "No autocomplete_utility defined"
-            pp options
-            pp geocoding_options
-            pp attribute
-            pp @autocomplete_utility
-          end
-
           return text_field(attribute, options) unless @autocomplete_utility
 
           # Decidim::Map::Autocomplete::Builder

--- a/decidim-core/lib/decidim/map/autocomplete.rb
+++ b/decidim-core/lib/decidim/map/autocomplete.rb
@@ -82,11 +82,21 @@ module Decidim
       #     <%= form.geocoding_field(:address) %>
       #   <% end %>
       module FormBuilder
-        def geocoding_field(attribute, options = {}, geocoding_options = {})
+        def  geocoding_field(attribute, options = {}, geocoding_options = {})
           @autocomplete_utility ||= Decidim::Map.autocomplete(
             organization: @template.current_organization
           )
-          return text_field(attribute, options) unless @autocomplete_utility
+
+          unless @autocomplete_utility
+            if Rails.env.test?
+              pp "No autocomplete_utility defined"
+              pp options
+              pp geocoding_options
+              pp attribute
+              pp @autocomplete_utility
+            end
+            return text_field(attribute, options)
+          end
 
           # Decidim::Map::Autocomplete::Builder
           builder = @autocomplete_utility.create_builder(

--- a/decidim-core/lib/decidim/map/autocomplete.rb
+++ b/decidim-core/lib/decidim/map/autocomplete.rb
@@ -82,21 +82,20 @@ module Decidim
       #     <%= form.geocoding_field(:address) %>
       #   <% end %>
       module FormBuilder
-        def  geocoding_field(attribute, options = {}, geocoding_options = {})
+        def geocoding_field(attribute, options = {}, geocoding_options = {})
           @autocomplete_utility ||= Decidim::Map.autocomplete(
             organization: @template.current_organization
           )
 
-          unless @autocomplete_utility
-            if Rails.env.test?
-              pp "No autocomplete_utility defined"
-              pp options
-              pp geocoding_options
-              pp attribute
-              pp @autocomplete_utility
-            end
-            return text_field(attribute, options)
+          if Rails.env.test?
+            pp "No autocomplete_utility defined"
+            pp options
+            pp geocoding_options
+            pp attribute
+            pp @autocomplete_utility
           end
+
+          return text_field(attribute, options) unless @autocomplete_utility
 
           # Decidim::Map::Autocomplete::Builder
           builder = @autocomplete_utility.create_builder(

--- a/decidim-core/spec/lib/geocodable_spec.rb
+++ b/decidim-core/spec/lib/geocodable_spec.rb
@@ -30,6 +30,8 @@ module Decidim
     let(:longitude) { 2.1234 }
 
     before do
+      Decidim::Map.reset_utility_configuration!
+      GeocoderHelpers.configure_maps
       stub_geocoding(address, [latitude, longitude])
     end
 

--- a/decidim-core/spec/lib/map/autocomplete_spec.rb
+++ b/decidim-core/spec/lib/map/autocomplete_spec.rb
@@ -7,6 +7,12 @@ require "decidim/core/test/shared_examples/form_builder_examples"
 module Decidim
   module Map
     describe Autocomplete do
+
+      before(:each) do
+        Decidim::Map.reset_utility_configuration!
+        GeocoderHelpers.configure_maps
+      end
+
       include_context "with map utility" do
         subject { utility }
       end

--- a/decidim-core/spec/lib/map/autocomplete_spec.rb
+++ b/decidim-core/spec/lib/map/autocomplete_spec.rb
@@ -7,8 +7,7 @@ require "decidim/core/test/shared_examples/form_builder_examples"
 module Decidim
   module Map
     describe Autocomplete do
-
-      before(:each) do
+      before do
         Decidim::Map.reset_utility_configuration!
         GeocoderHelpers.configure_maps
       end


### PR DESCRIPTION
#### :tophat: What? Why?
While running the specs, we noticed that from time to time, we get some random failures on `spec/lib/map/autocomplete_spec.rb`. 
![image](https://github.com/user-attachments/assets/99aaebdb-be66-4ce2-95a6-bcf7e74f39e2)

While investigating, i have reached in `Decidim::Map::Autocoplete::FormBuilder` module, where the method `geocoding_field` can return a plain text field if the autocomplete utility is not properly configured.

https://github.com/decidim/decidim/blob/878c5124f46be6cd0e316ee001fd54cd69a2bccb/decidim-core/lib/decidim/map/autocomplete.rb#L85-L106

#### Testing
1. This is kind of a test that is impossible to test locally, by just running the file, as the issue is being generated by runtime map configuration that is not coming from this file. 
2. You can see in the pipeline that the spec has not been failing for 10 times while i have tested. ( please note the [pipeline](https://github.com/decidim/decidim/actions/runs/12917368230/job/36044198128?pr=13901) was still marked as failing as at the same time the download flacky spec kicked in, and i did not bother to fix ) 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
