### PR TITLE
Patch RELEASE_NOTES

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,7 @@ sudo apt install p7zip # or the alternative installation process for your operat
 sudo apt install wkhtmltopdf # or the alternative installation process for your operating system. See "2.7. wkhtmltopdf binary change"
 bundle remove spring spring-watcher-listen
 bundle update decidim
+rm config/initializers/carrierwave.rb
 bin/rails decidim:upgrade
 bin/rails db:migrate
 bin/rails decidim:upgrade:clean:invalid_records


### PR DESCRIPTION
#### :tophat: What? Why?
While investigating #13535 i had to upgrade an app from 0.28 to 0.29. While performing the upgrade steps, i got hit by an error: 
```
NameError: uninitialized constant CarrierWave (NameError)
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13535

#### Testing
1. Create a decidim 0.28 application 
2. Follow 0.29 upgrade steps 
3. Apply patch and repeat 

:hearts: Thank you!
