### PR TITLE
Patch i18n in seeds

### DIFF
--- a/decidim-debates/lib/decidim/debates/seeds.rb
+++ b/decidim-debates/lib/decidim/debates/seeds.rb
@@ -4,7 +4,7 @@ require "decidim/components/namer"
 
 module Decidim
   module Debates
-    class Seeds
+    class Seeds < Decidim::Seeds
       attr_reader :participatory_space
 
       def initialize(participatory_space:)
@@ -12,11 +12,6 @@ module Decidim
       end
 
       def call
-        admin_user = Decidim::User.find_by(
-          organization: participatory_space.organization,
-          email: "admin@example.org"
-        )
-
         user = Decidim::User.find_by(
           organization: participatory_space.organization,
           email: "user@example.org"

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -87,8 +87,8 @@ module Decidim
         params = {
           component:,
           scope: random_scope(participatory_space:),
-          title: { en: ::Faker::Lorem.sentence(word_count: 2) },
-          body: { en: ::Faker::Lorem.paragraphs(number: 2).join("\n") },
+          title: Decidim::Faker::Localized.sentence(word_count: 2),
+          body: Decidim::Faker::Localized.paragraph(sentence_count: 1),
           proposal_state:,
           answer:,
           answered_at: proposal_state.present? ? Time.current : nil,
@@ -199,8 +199,8 @@ module Decidim
         params = {
           component: proposal.component,
           scope: random_scope(participatory_space:),
-          title: { en: "#{proposal.title["en"]} #{::Faker::Lorem.sentence(word_count: 1)}" },
-          body: { en: "#{proposal.body["en"]} #{::Faker::Lorem.sentence(word_count: 3)}" },
+          title: Decidim::Faker::Localized.literal(proposal.title[I18n.locale]),
+          body: Decidim::Faker::Localized.paragraph(sentence_count: 3),
           proposal_state: Decidim::Proposals::ProposalState.where(component: proposal.component, token: :evaluating).first,
           answer: nil,
           answered_at: Time.current,

--- a/decidim-surveys/lib/decidim/surveys/seeds.rb
+++ b/decidim-surveys/lib/decidim/surveys/seeds.rb
@@ -167,7 +167,7 @@ module Decidim
 
         answer_options.each do |answer_option|
           position = available_positions.sample
-          body = answer_option["en"]
+          body = answer_option[I18n.locale]
 
           Decidim::Forms::AnswerChoice.create!(
             answer:,
@@ -181,7 +181,7 @@ module Decidim
       def create_answer_for_multiple_choice_question_type(options)
         answer = Decidim::Forms::Answer.create!(**options)
         answer_option = options[:question].answer_options.sample
-        body = answer_option["en"]
+        body = answer_option[I18n.locale]
 
         Decidim::Forms::AnswerChoice.create!(
           answer:,
@@ -194,7 +194,7 @@ module Decidim
         answer = Decidim::Forms::Answer.create!(**options)
         answer_option = options[:question].answer_options.sample
         matrix_row = options[:question].matrix_rows.sample
-        body = answer_option["en"]
+        body = answer_option[I18n.locale]
 
         Decidim::Forms::AnswerChoice.create!(
           answer:,


### PR DESCRIPTION
#### :tophat: What? Why?
While investigating #13596, i have noticed that some of the proposals are being created with "en" locale, instead of Catalan. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13596

#### Testing
Given the app has Catalan and Spanish languages set, Catalan being default 
When regenerating the development app, the seeded proposals should have the Catalan. 

:hearts: Thank you!
