### PR TITLE
Fix migration of survey component's `published_at`

### DIFF
--- a/decidim-surveys/db/migrate/20240925124312_add_settings_to_decidim_surveys_surveys.rb
+++ b/decidim-surveys/db/migrate/20240925124312_add_settings_to_decidim_surveys_surveys.rb
@@ -20,7 +20,7 @@ class AddSettingsToDecidimSurveysSurveys < ActiveRecord::Migration[7.0]
         add_index :decidim_surveys_surveys, :published_at
 
         Survey.where(published_at: nil).find_each do |survey|
-          published_at = survey.component.published_at
+          published_at = survey.component&.published_at
           next if published_at.nil?
 
           survey.update(published_at:)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes an edge case with surveys migrations, in which the survey cannot have any associated component. It happened to me while i was working on #13920, and encountered the below error


```
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

undefined method `published_at' for nil
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094566_add_settings_to_decidim_surveys_surveys.decidim_surveys.rb:24:in `block (3 levels) in change'
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094566_add_settings_to_decidim_surveys_surveys.decidim_surveys.rb:23:in `block (2 levels) in change'
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094566_add_settings_to_decidim_surveys_surveys.decidim_surveys.rb:13:in `block in change'
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094566_add_settings_to_decidim_surveys_surveys.decidim_surveys.rb:12:in `change'
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
-e:1:in `<main>'

Caused by:
NoMethodError: undefined method `published_at' for nil (NoMethodError)

          published_at = survey.component.published_at
                                         ^^^^^^^^^^^^^
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094566_add_settings_to_decidim_surveys_surveys.decidim_surveys.rb:24:in `block (3 levels) in change'
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094566_add_settings_to_decidim_surveys_surveys.decidim_surveys.rb:23:in `block (2 levels) in change'
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094566_add_settings_to_decidim_surveys_surveys.decidim_surveys.rb:13:in `block in change'
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094566_add_settings_to_decidim_surveys_surveys.decidim_surveys.rb:12:in `change'
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
-e:1:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)

```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #13919

#### Testing
1. in order to reach to this error, you will need first to apply #13935
2. Create a 0.28 app, perform upgrade to 0.29, then 0.30 
3. See that when running the migrations you will have a survey related error
4. remove error migration, Apply patch , run again decidim:upgrade
5. migrate , see there are no errors 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
