### PR TITLE
Add links to the updated releases notes in the release branch

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+NOTE: This is the draft for the releases notes. If you are an implementer or someone that is upgrading a Decidim installation, we recommend
+checking out the last version of this document in the GitHub page for the releases of this branch:
+
+- https://github.com/decidim/decidim/releases/tag/v0.29.0
+- https://github.com/decidim/decidim/releases/tag/v0.29.1
+
 ## 1. Upgrade notes
 
 As usual, we recommend that you have a full backup, of the database, application code and static files.


### PR DESCRIPTION
#### :tophat: What? Why?

We've been discussing about the duplication between the GH releases tags pages and the Releases Notes files in the branches.

This is my proposals for pointing to the single source of truth of the already released versions. 

#### :pushpin: Related Issues
 
- Related to #13911

#### Testing

Read the text

:hearts: Thank you!
