### PR TITLE
Fix migration of Paperclip::Versions

### DIFF
--- a/decidim-core/db/migrate/20240722215500_change_object_changes_on_versions.rb
+++ b/decidim-core/db/migrate/20240722215500_change_object_changes_on_versions.rb
@@ -9,12 +9,12 @@ class ChangeObjectChangesOnVersions < ActiveRecord::Migration[6.1]
       # This is an adaptation of PaperTrail internal load_changeset method,having in mind that we
       # need to call also the code from PaperTrail::AttributeSerializer::ObjectChangesAttribute
       object_changes = ActiveSupport::HashWithIndifferentAccess.new(YAML.unsafe_load(version.old_object_changes))
-      unless version.item.nil?
+      unless version.item_type.constantize.unscoped.find_by(id: version.item_id).nil?
         # This is the deserialization code from `PaperTrail::AttributeSerializer::ObjectChangesAttribute`
         # where we skip checking the object changeset column type, as we migrate it from YAML to JSON
         changes_to_serialize = object_changes.clone
         if changes_to_serialize.present?
-          serializer = PaperTrail::AttributeSerializers::CastAttributeSerializer.new(version.item.class)
+          serializer = PaperTrail::AttributeSerializers::CastAttributeSerializer.new(version.item_type.constantize)
           changes_to_serialize.each do |key, change|
             # `change` is an Array with two elements, representing before and after.
             object_changes[key] = Array(change).map do |value|


### PR DESCRIPTION
#### :tophat: What? Why?
While working on #13920, i have tried to upgrade a 0.28 app to 0.29, then 0.30.dev. I have noticed there is a migration that has an error: 

Main reason for this error, is that we added paranoia gem back in #13297, which has been applied after #13191 .

```
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

PG::UndefinedColumn: ERROR:  column decidim_participatory_processes.deleted_at does not exist
LINE 1: ...s".* FROM "decidim_participatory_processes" WHERE "decidim_p...
                                                             ^
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094538_change_object_changes_on_versions.decidim.rb:13:in `block in up'
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094538_change_object_changes_on_versions.decidim.rb:9:in `up'
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
-e:1:in `<main>'

Caused by:
ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column decidim_participatory_processes.deleted_at does not exist (ActiveRecord::StatementInvalid)
LINE 1: ...s".* FROM "decidim_participatory_processes" WHERE "decidim_p...
                                                             ^
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094538_change_object_changes_on_versions.decidim.rb:13:in `block in up'
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094538_change_object_changes_on_versions.decidim.rb:9:in `up'
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
-e:1:in `<main>'

Caused by:
PG::UndefinedColumn: ERROR:  column decidim_participatory_processes.deleted_at does not exist (PG::UndefinedColumn)
LINE 1: ...s".* FROM "decidim_participatory_processes" WHERE "decidim_p...
                                                             ^
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094538_change_object_changes_on_versions.decidim.rb:13:in `block in up'
/home/alecslupu/Sites/decidim/decidim/development_app/db/migrate/20250124094538_change_object_changes_on_versions.decidim.rb:9:in `up'
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
-e:1:in `<main>'
Tasks: TOP => db:migrate
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13928
- Fixes #13919

#### Testing
1. Create a 0.28 app, perform upgrade to 0.29, then 0.30
2. See that when running the migrations you will have an error like the one i have posted above
3. Remove error migration, Apply patch , run again decidim:upgrade
4. Migrate , see there are no errors

:hearts: Thank you!
