### PR TITLE
Fix 'Conference media link creation form has wrong title'

### DIFF
--- a/decidim-conferences/app/views/decidim/conferences/admin/media_links/new.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/media_links/new.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_page_title(t("media_links.new.title", scope: "decidim.admin")) %>
 <div class="item_show__header">
   <h1 class="item_show__header-title">
-    <%= t("conference_speakers.new.title", scope: "decidim.admin") %>
+    <%= t("media_links.new.title", scope: "decidim.admin") %>
   </h1>
 </div>
 <div class="item__edit item__edit-1col">

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -193,7 +193,7 @@ en:
           media_links_title: Media Links
         new:
           create: Create
-          title: Create media link.
+          title: Create media link
         update:
           error: There was a problem updating this media link.
           success: Media Link successfully updated.

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -193,7 +193,7 @@ en:
           media_links_title: Media Links
         new:
           create: Create
-          title: Media Link
+          title: Create media link.
         update:
           error: There was a problem updating this media link.
           success: Media Link successfully updated.


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the wrong label in the media links conference page. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #13931

#### Testing
1. Go to the admin panel
2. Go to a Conference
3. Click on "Media links"
4. Click on "New media link"
5. See title of the form is "New conference speaker."
6. Apply patch 
7. See the title being changed

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
