### PR TITLE
Fix for sticky button CTAs

### DIFF
--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -49,6 +49,7 @@ import "src/decidim/data_consent"
 import "src/decidim/abide_form_validator_fixer"
 import "src/decidim/sw"
 import "src/decidim/sticky_header"
+import "src/decidim/sticky_footer"
 import "src/decidim/attachments"
 
 // local deps that require initialization

--- a/decidim-core/app/packs/src/decidim/sticky_footer.js
+++ b/decidim-core/app/packs/src/decidim/sticky_footer.js
@@ -7,26 +7,15 @@
 // 
 
 const footer = document.querySelector("footer");
-const stickyButtons = document.querySelectorAll("[data-sticky-buttons]");
-
-const isElementInViewport = (element) => {
-  const rect = element.getBoundingClientRect();
-  return rect.top >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight);
-};
+const stickyButtons = document.querySelector("[data-sticky-buttons]");
 
 const adjustCtasButtons = () => {
-  if (!stickyButtons || !stickyButtons.length) {
+  if (!stickyButtons) {
     return;
   }
 
-  let visibleButtons = Array.from(stickyButtons).filter(isElementInViewport);
-
-  if (visibleButtons.length > 0) {
-    const marginBottom = Math.max(...visibleButtons.map((ctasButton) => ctasButton.offsetHeight));
-    footer.style.marginBottom = `${marginBottom}px`;
-  } else {
-    footer.style.marginBottom = 0;
-  }
+  const marginBottom = stickyButtons.offsetHeight;
+  footer.style.marginBottom = `${marginBottom}px`;
 };
 
 if (stickyButtons) {

--- a/decidim-core/app/packs/src/decidim/sticky_footer.js
+++ b/decidim-core/app/packs/src/decidim/sticky_footer.js
@@ -1,10 +1,10 @@
 // This script add margin to the footer when the sticky CTA Buttons are shown on mobile devices,
 // so the footer is always visible.
-// 
+//
 // The sticky buttons show some of the main Call to Actions (CTAs) so that they remain accessible on the
 // screen as the participant scrolls through the detailed view of the Meetings, Proposals, Surveys, and Budgets
 // components.
-// 
+//
 
 const footer = document.querySelector("footer");
 const stickyButtons = document.querySelector("[data-sticky-buttons]");

--- a/decidim-core/app/packs/src/decidim/sticky_footer.js
+++ b/decidim-core/app/packs/src/decidim/sticky_footer.js
@@ -1,0 +1,40 @@
+// This script add margin to the footer when the sticky CTA Buttons are shown on mobile devices,
+// so the footer is always visible.
+// 
+// The sticky buttons show some of the main Call to Actions (CTAs) so that they remain accessible on the
+// screen as the participant scrolls through the detailed view of the Meetings, Proposals, Surveys, and Budgets
+// components.
+// 
+
+const footer = document.querySelector("footer");
+const stickyButtons = document.querySelectorAll("[data-sticky-buttons]");
+
+const isElementInViewport = (element) => {
+  const rect = element.getBoundingClientRect();
+  return rect.top >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight);
+};
+
+const adjustCtasButtons = () => {
+  if (!stickyButtons || !stickyButtons.length) {
+    return;
+  }
+
+  let visibleButtons = Array.from(stickyButtons).filter(isElementInViewport);
+
+  if (visibleButtons.length > 0) {
+    const marginBottom = Math.max(...visibleButtons.map((ctasButton) => ctasButton.offsetHeight));
+    footer.style.marginBottom = `${marginBottom}px`;
+  } else {
+    footer.style.marginBottom = 0;
+  }
+};
+
+if (stickyButtons) {
+  document.addEventListener("scroll", () => {
+    adjustCtasButtons();
+  });
+
+  document.addEventListener("on:toggle", () => {
+    adjustCtasButtons();
+  });
+}

--- a/decidim-core/app/packs/src/decidim/sticky_header.js
+++ b/decidim-core/app/packs/src/decidim/sticky_header.js
@@ -1,33 +1,14 @@
-// This script implements the sticky header and the sticky buttons. The sticky header hides when participants scroll down and shows when they scroll up.
-// Sticky headers allow users to quickly access the navigation, search, and utility-navigation elements without scrolling up to the top of the page. They increase the discoverability of the elements in the header.
-// The sticky buttons in the other hand, those are some of the main Call to Actions (CTAs) that remain accessible on the screen as the user scrolls through the detailed view of the Meetings, Proposals, Surveys, and Budgets components.
+// This script implements the sticky header on mobile devices.
+//
+// The sticky header hides when participants scroll down and shows when they scroll up.
+// Sticky headers allow users to quickly access the navigation, search, and utility-navigation
+// elements without scrolling up to the top of the page. They increase the discoverability of the elements in the header.
+//
 
 import { screens } from "tailwindcss/defaultTheme"
 
 let prevScroll = window.scrollY;
 const stickyHeader = document.querySelector("[data-sticky-header]");
-const footer = document.querySelector("footer");
-const stickyButtons = document.querySelectorAll("[data-sticky-buttons]");
-
-const isElementInViewport = (element) => {
-  const rect = element.getBoundingClientRect();
-  return rect.top >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight);
-};
-
-const adjustCtasButtons = () => {
-  if (!stickyButtons || !stickyButtons.length) {
-    return;
-  }
-
-  let visibleButtons = Array.from(stickyButtons).filter(isElementInViewport);
-
-  if (visibleButtons.length > 0) {
-    const marginBottom = Math.max(...visibleButtons.map((ctasButton) => ctasButton.offsetHeight));
-    footer.style.marginBottom = `${marginBottom}px`;
-  } else {
-    footer.style.marginBottom = 0;
-  }
-};
 
 // Fix the menu bar container margin top when there are multiple elements in the sticky header
 // As there could be different heights and we cannot know beforehand, we need to adjust this in a dynamic way
@@ -76,12 +57,6 @@ if (stickyHeader) {
         }
         prevScroll = currentScroll;
       }
-
-      adjustCtasButtons();
     }
-  });
-
-  document.addEventListener("on:toggle", () => {
-    adjustCtasButtons();
   });
 };

--- a/decidim-core/app/packs/stylesheets/decidim/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_layout.scss
@@ -137,7 +137,7 @@
 }
 
 .layout-aside__ctas-buttons {
-  @apply md:relative inset-x-0 bottom-0 z-30 md:z-0 flex flex-row-reverse md:flex-col items-center md:items-stretch last:[&>button]:font-semibold first:[&>button]:text-lg justify-around bg-white md:bg-transparent gap-4 md:gap-0 p-4 md:p-0 shadow-inner md:shadow-none first:[&>*]:grow md:first:[&>*]:grow-0 last:[&>*]:w-1/2 md:last:[&>*]:w-auto h-20 md:h-fit first:[&>button]:py-3;
+  @apply fixed md:relative inset-x-0 bottom-0 z-30 md:z-0 flex flex-row-reverse md:flex-col items-center md:items-stretch last:[&>button]:font-semibold first:[&>button]:text-lg justify-around bg-white md:bg-transparent gap-4 md:gap-0 p-4 md:p-0 shadow-inner md:shadow-none first:[&>*]:grow md:first:[&>*]:grow-0 last:[&>*]:w-1/2 md:last:[&>*]:w-auto h-20 md:h-fit first:[&>button]:py-3;
 
   .meeting__aside-progress,
   .proposals__aside-progress {

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -120,7 +120,7 @@ Capybara.register_driver :iphone do |app|
   options.args << "--no-sandbox"
   # Do not limit browser resources
   options.args << "--disable-dev-shm-usage"
-  options.add_emulation(device_name: "iPhone 6")
+  options.add_emulation(device_name: "iPhone XR")
 
   Capybara::Selenium::Driver.new(
     app,


### PR DESCRIPTION
#### :tophat: What? Why?

On https://github.com/decidim/decidim/pull/13127 we did a bad merge and break the  "Sticky CTAs" feature. This PR fixes it. 

I also did some clean-up on its JS code: splitting it to its own file and making the code simpler.

#### :pushpin: Related Issues
 
- Related to #13002 and #13127
- Fixes #13488

#### Testing

Sadly you need to do it manually. I tried to work on some specs but I could not made them work locally.

This is my proof of concept with the spec (that doesn't work):

```diff
diff --git a/decidim-meetings/spec/system/meeting_registrations_spec.rb b/decidim-meetings/spec/system/meeting_registrations_spec.rb
index 6366ffcf58..e665117f6e 100644
--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -152,6 +152,27 @@ describe "Meeting registrations" do
             end
           end
         end
+
+        context "and the device is a mobile" do
+          # Make the description really long so the button would be actually below
+          let!(:meeting) { create(:meeting, :published, description: { en: Faker::Lorem.paragraphs(number: 100).join }, component:, questionnaire:) }
+
+          before do
+            driven_by(:iphone)
+            visit_meeting
+          end
+
+          it "always show the registration sticky button" do
+            within "#dc-dialog-wrapper" do
+              click_on "Accept all"
+            end
+
+            expect(find("Register").visible?).to be_truthy
+
+            page.scroll_to(find("footer"))
+            expect(find("Register").visible?).to be_truthy
+          end
+        end
       end

       context "and the user is logged in" do
```

### :camera: Screenshots

#### Before

![Page with a register button (no sticky)](https://github.com/user-attachments/assets/feef0e6f-f70e-4200-853e-699c8d237a6b)

#### After
 
![Page with a register button (sticky)](https://github.com/user-attachments/assets/3d966ff5-e621-4beb-90e5-eb0e68cede4b)



:hearts: Thank you!
