### PR TITLE
Fix ajax update of taxonomy filters in components settings

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/results/_home_taxonomies.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_home_taxonomies.html.erb
@@ -9,12 +9,10 @@
     ) %>
 
     <div>
-      <span class="accountability__grid-title"><%= t("results.home.taxonomies_label", scope: "decidim.accountability") %></span>
       <%= subelements.call %>
     </div>
 
     <div>
-      <span class="accountability__grid-title"><%= t("results.home.sub_taxonomies_label", scope: "decidim.accountability") %></span>
         <% if subelements.has_results? %>
           <div class="accountability__subgrid">
             <% taxonomy.children.where(id: current_component.available_taxonomy_ids).each do |sub_taxonomy| %>

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -277,8 +277,6 @@ en:
         home:
           empty: There are no results yet.
           empty_filters: There are no results with this criteria.
-          sub_taxonomies_label: Subcategories
-          taxonomies_label: Categories
         home_header:
           global_status: Global execution status
         no_results: There are no projects

--- a/decidim-admin/app/controllers/decidim/admin/taxonomy_filters_selector_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/taxonomy_filters_selector_controller.rb
@@ -5,7 +5,7 @@ module Decidim
     class TaxonomyFiltersSelectorController < Decidim::Admin::ApplicationController
       layout "decidim/admin/taxonomy_filters_selector"
 
-      helper_method :root_taxonomy, :taxonomy_filter, :component, :component_filters, :field_name
+      helper_method :root_taxonomy, :taxonomy_filter, :component, :field_name
 
       # ensure component is valid
       before_action do
@@ -63,10 +63,6 @@ module Decidim
 
       def field_name
         "component[settings][taxonomy_filters][]"
-      end
-
-      def component_filters
-        @component_filters ||= root_taxonomy.taxonomy_filters.where(id: component.settings.taxonomy_filters)
       end
 
       def component

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -219,7 +219,7 @@ module Decidim
       def taxonomy_filters(form, name, i18n_scope)
         current_filters = content_tag(:div, class: "js-current-filters") do
           render partial: "decidim/admin/taxonomy_filters_selector/component_table",
-                 locals: { field_name: "#{form.object_name}[#{name}][]", component_filters:, component: @component }
+                 locals: { field_name: "#{form.object_name}[#{name}][]", component: @component }
         end
         add_button = content_tag(:div, class: "mt-2") do
           content_tag(:button,
@@ -238,10 +238,6 @@ module Decidim
         end
 
         label_tag(name, t(name, scope: i18n_scope)) + container + drawer
-      end
-
-      def component_filters
-        @component_filters ||= TaxonomyFilter.for(current_organization).where(id: @component.settings.taxonomy_filters)
       end
     end
   end

--- a/decidim-admin/app/views/decidim/admin/taxonomy_filters_selector/_component_table.html.erb
+++ b/decidim-admin/app/views/decidim/admin/taxonomy_filters_selector/_component_table.html.erb
@@ -7,7 +7,7 @@
     </tr>
   </thead>
   <tbody>
-    <% component_filters.each do |taxonomy_filter| %>
+    <% component.available_taxonomy_filters.each do |taxonomy_filter| %>
         <%= hidden_field_tag(field_name, taxonomy_filter.id) %>
       <tr>
         <td><%= taxonomy_filter.translated_name %></td>

--- a/decidim-admin/lib/decidim/admin/test/manage_taxonomy_filters_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_taxonomy_filters_examples.rb
@@ -13,6 +13,9 @@ shared_examples "manage taxonomy filters in settings" do
   end
 
   context "when taxonomy filter exist" do
+    let!(:another_taxonomy_filter) do
+      create(:taxonomy_filter, internal_name: { en: "Another filter" }, participatory_space_manifests: [participatory_space.manifest.name], root_taxonomy:)
+    end
     before do
       click_on "Configure"
     end
@@ -36,6 +39,22 @@ shared_examples "manage taxonomy filters in settings" do
         expect(page).to have_link("Edit")
       end
       expect(component.reload.settings.taxonomy_filters).to eq([taxonomy_filter.id.to_s])
+
+      click_on "Add filter"
+      within "#taxonomy_filters-dialog-content" do
+        select "A root taxonomy", from: "taxonomy_id"
+        select "Another filter", from: "taxonomy_filter_id"
+        click_on "Save"
+      end
+
+      expect(page).to have_no_css("#taxonomy_filters-dialog-content")
+      within ".js-current-filters" do
+        expect(page).to have_css("td", text: "Internal taxonomy filter name")
+        expect(page).to have_css("td", text: "Public taxonomy filter name")
+        expect(page).to have_css("td", text: "Another filter")
+        expect(page).to have_link("Edit", count: 2)
+      end
+      expect(component.reload.settings.taxonomy_filters).to contain_exactly(taxonomy_filter.id.to_s, another_taxonomy_filter.id.to_s)
 
       click_on "Update"
       click_on "Configure"

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -178,15 +178,13 @@ module Decidim
         let(:choices) { [["A text (0)", taxonomy_filter1.id], ["A text (0)", taxonomy_filter2.id]] }
         let(:options) { { include_blank: "Select a taxonomy filter" } }
         let(:value) { [taxonomy_filter1.id] }
-        let(:component_filters) { Decidim::TaxonomyFilter.where(id: taxonomy_filter1.id) }
 
         before do
           component.update!(settings: { taxonomy_filters: [taxonomy_filter1.id] })
-          allow(view).to receive(:component_filters).and_return(component_filters)
         end
 
         it "is supported" do
-          expect(view).to receive(:render).with(partial: "decidim/admin/taxonomy_filters_selector/component_table", locals: { field_name: "test[test][]", component_filters:, component: })
+          expect(view).to receive(:render).with(partial: "decidim/admin/taxonomy_filters_selector/component_table", locals: { field_name: "test[test][]", component: })
           expect(view).to receive(:render).with(partial: "decidim/admin/components/taxonomy_filters_drawer")
           render_input
         end

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -173,7 +173,7 @@
       <% else %>
         <% @form.taxonomy_filters.each do |filter| %>
           <div class="row column">
-            <%= filter_taxonomy_items_select_field form, :taxonomies, filter, internal: true %>
+            <%= filter_taxonomy_items_select_field form, :taxonomies, filter %>
           </div>
         <% end %>
       <% end %>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
@@ -128,7 +128,7 @@
       <% else %>
         <% @form.taxonomy_filters.each do |filter| %>
           <div class="row column">
-            <%= filter_taxonomy_items_select_field form, :taxonomies, filter, internal: true %>
+            <%= filter_taxonomy_items_select_field form, :taxonomies, filter %>
           </div>
         <% end %>
       <% end %>

--- a/decidim-core/app/helpers/decidim/taxonomies_helper.rb
+++ b/decidim-core/app/helpers/decidim/taxonomies_helper.rb
@@ -7,7 +7,7 @@ module Decidim
     include TranslatableAttributes
 
     def filter_taxonomy_items_select_field(form, name, filter, options = {})
-      label = decidim_sanitize_translated(options.delete(:internal) ? filter.internal_name : filter.name)
+      label = decidim_sanitize_translated(filter.name)
       options = options.merge(include_blank: I18n.t("decidim.taxonomies.prompt")) unless options.has_key?(:include_blank)
       options = options.merge(label:) unless options.has_key?(:label)
       form.select(

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -146,7 +146,7 @@
       <% else %>
         <% @form.taxonomy_filters.each do |filter| %>
           <div class="row column">
-            <%= filter_taxonomy_items_select_field form, :taxonomies, filter, internal: true %>
+            <%= filter_taxonomy_items_select_field form, :taxonomies, filter %>
           </div>
         <% end %>
       <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

When updating the taxonomy filters of a component, only the last item is shown once you close the drawer. 
This PR ensures that all filters are rendered on every update.

This PR also removes the titles "Categories/Subcategories" present in the accountability home page (Small change required by @decidim/product).

Also replaces the internal name by the public one when editing participatory space taxonomies in the admin (request by product).

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13725 
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
