### PR TITLE
Fix answer choices default order

### DIFF
--- a/decidim-forms/app/models/decidim/forms/answer_choice.rb
+++ b/decidim-forms/app/models/decidim/forms/answer_choice.rb
@@ -17,6 +17,8 @@ module Decidim
                  optional: true
 
       validates :matrix_row, presence: true, if: -> { answer.question.matrix? }
+
+      default_scope { left_outer_joins(:matrix_row).order(arel_table[:position].asc, Decidim::Forms::QuestionMatrixRow.arel_table[:position].asc, arel_table[:id].asc) }
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

When application serializes answers to questions of sorting or matrix types there is not a default order defined and the database may return records with ids in reverse order causing misinterpretation of the results. This PR:

* Defines a default scope in `Decidim::Forms::AnswerChoice` model, in ascending order first by position, then by position of matrix_row if any (used on matrix_single and matrix_multiple questions) and finally by id.
* Adds some tests forcing positions not correlated with ids of records

#### Testing

Usually the database returns answer choices ordered by id and then errors do not occur. Try this with a database that does the opposite

### :camera: Screenshots

![Screenshot from 2025-01-27 21-16-40](https://github.com/user-attachments/assets/f51b7a7e-c3ca-4615-ae8a-b0844df7577f)



:hearts: Thank you!
![Screenshot from 2025-01-27 21-17-08](https://github.com/user-attachments/assets/7473e28e-53d6-4553-994f-be3a552273b0)
