### PR TITLE
Increase generator pipeline timeout

### DIFF
--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -54,7 +54,7 @@ jobs:
     name: ${{ matrix.test.name }}
     runs-on: ubuntu-22.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
-    timeout-minutes: 60
+    timeout-minutes: 90
     services:
       postgres:
         image: postgres:14


### PR DESCRIPTION
#### :tophat: What? Why?
Starting with the changes done in #13786 and #13838 we have started to see a lot of generator pipeline failures caused by timeouts. 
This PR increases the generator timeout to 90 mins as a workaround on the issue. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13786
- Related to #13838

#### Testing
1. Pipeline should be green without any retries on CI Generator jobs

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/271989ac-be32-4ad7-989d-c4ef9d7f5bba)
![image](https://github.com/user-attachments/assets/5c7b0c00-a70b-466f-97fb-cc5bbabdc13d)


:hearts: Thank you!
