### PR TITLE
Update DownloadYourData exports for `decidim-initiatives`

### DIFF
--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -14,6 +14,7 @@ module Decidim
     include Decidim::HasAttachmentCollections
     include Decidim::Traceable
     include Decidim::Loggable
+    include Decidim::DownloadYourData
     include Decidim::Initiatives::InitiativeSlug
     include Decidim::Resourceable
     include Decidim::HasReference
@@ -156,6 +157,10 @@ module Decidim
                       index_on_create: ->(_initiative) { false },
                       # is Resourceable instead of ParticipatorySpaceResourceable so we cannot use `visible?`
                       index_on_update: ->(initiative) { initiative.published? })
+
+    def self.export_serializer
+      Decidim::Initiatives::DownloadYourDataInitiativeSerializer
+    end
 
     def self.log_presenter_class_for(_log)
       Decidim::Initiatives::AdminLog::InitiativePresenter

--- a/decidim-initiatives/app/serializers/decidim/initiatives/download_your_data_initiative_serializer.rb
+++ b/decidim-initiatives/app/serializers/decidim/initiatives/download_your_data_initiative_serializer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Initiatives
+    class DownloadYourDataInitiativeSerializer < OpenDataInitiativeSerializer
+      # Serializes a Debate for download your data feature
+      #
+      # Remove the author information as it is the same of the user that
+      # requested the data
+      def serialize
+        super.except!(:author)
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/serializers/decidim/initiatives/download_your_data_initiative_serializer.rb
+++ b/decidim-initiatives/app/serializers/decidim/initiatives/download_your_data_initiative_serializer.rb
@@ -8,7 +8,7 @@ module Decidim
       # Remove the author information as it is the same of the user that
       # requested the data
       def serialize
-        super.except!(:author)
+        super.except!(:authors)
       end
     end
   end

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -38,6 +38,10 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
   participatory_space.model_class_name = "Decidim::Initiative"
   participatory_space.permissions_class_name = "Decidim::Initiatives::Permissions"
 
+  participatory_space.data_portable_entities = [
+    "Decidim::Initiative"
+  ]
+
   participatory_space.exports :initiatives do |export|
     export.collection do
       Decidim::Initiative.public_spaces

--- a/decidim-initiatives/spec/serializers/download_your_data_initiative_serializer_spec.rb
+++ b/decidim-initiatives/spec/serializers/download_your_data_initiative_serializer_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Initiatives
+  describe DownloadYourDataInitiativeSerializer do
+    subject { described_class.new(initiative) }
+
+    let(:initiative) { create(:initiative, :with_area) }
+    let(:serialized) { subject.serialize }
+
+    describe "#serialize" do
+      it "includes the reference" do
+        expect(serialized).to include(reference: initiative.reference)
+      end
+
+      it "includes the title" do
+        expect(serialized).to include(title: initiative.title)
+      end
+
+      it "includes the url" do
+        expect(serialized).to include(url: "http://#{initiative.organization.host}:#{Capybara.server_port}/initiatives/i-#{initiative.id}")
+      end
+
+      it "includes the description" do
+        expect(serialized).to include(description: initiative.description)
+      end
+
+      it "includes the state" do
+        expect(serialized).to include(state: initiative.state)
+      end
+
+      it "includes the created_at timestamp" do
+        expect(serialized).to include(created_at: initiative.created_at)
+      end
+
+      it "includes the updated_at timestamp" do
+        expect(serialized).to include(updated_at: initiative.updated_at)
+      end
+
+      it "includes the published_at timestamp" do
+        expect(serialized).to include(published_at: initiative.published_at)
+      end
+
+      it "includes the signature_start_date" do
+        expect(serialized).to include(signature_start_date: initiative.signature_start_date)
+      end
+
+      it "includes the signature_end_date" do
+        expect(serialized).to include(signature_end_date: initiative.signature_end_date)
+      end
+
+      it "includes the signature_type" do
+        expect(serialized).to include(signature_type: initiative.signature_type)
+      end
+
+      it "includes the number of signatures (supports)" do
+        expect(serialized).to include(signatures: initiative.supports_count)
+      end
+
+      it "includes the answer" do
+        expect(serialized).to include(answer: initiative.answer)
+      end
+
+      it "includes the answered_at" do
+        expect(serialized).to include(answered_at: initiative.answered_at)
+      end
+
+      it "includes the answer_url" do
+        expect(serialized).to include(answer_url: initiative.answer_url)
+      end
+
+      it "includes the hashtag" do
+        expect(serialized).to include(hashtag: initiative.hashtag)
+      end
+
+      it "includes the first_progress_notification_at timestamp" do
+        expect(serialized).to include(first_progress_notification_at: initiative.first_progress_notification_at)
+      end
+
+      it "includes the second_progress_notification_at timestamp" do
+        expect(serialized).to include(second_progress_notification_at: initiative.second_progress_notification_at)
+      end
+
+      it "includes the online_votes" do
+        expect(serialized).to include(online_votes: initiative.online_votes)
+      end
+
+      it "includes the offline_votes" do
+        expect(serialized).to include(offline_votes: initiative.offline_votes)
+      end
+
+      it "includes the comments_count" do
+        expect(serialized).to include(comments_count: initiative.comments_count)
+      end
+
+      it "includes the follows_count" do
+        expect(serialized).to include(follows_count: initiative.follows_count)
+      end
+
+      it "includes the scope id" do
+        expect(serialized[:scope]).to include(id: initiative.scope.id)
+      end
+
+      it "includes the scope name" do
+        expect(serialized[:scope]).to include(name: initiative.scope.name)
+      end
+
+      it "includes the type id" do
+        expect(serialized[:type]).to include(id: initiative.type.id)
+      end
+
+      it "includes the type title" do
+        expect(serialized[:type]).to include(title: initiative.type.title)
+      end
+
+      it "includes the authors' ids" do
+        expect(serialized[:authors]).to include(id: initiative.author_users.map(&:id))
+      end
+
+      it "includes the authors' names" do
+        expect(serialized[:authors]).to include(name: initiative.author_users.map(&:name))
+      end
+
+      it "includes the area id" do
+        expect(serialized[:area]).to include(id: initiative.area.id)
+      end
+
+      it "includes the area name" do
+        expect(serialized[:area]).to include(name: initiative.area.name)
+      end
+    end
+  end
+end

--- a/decidim-initiatives/spec/serializers/download_your_data_initiative_serializer_spec.rb
+++ b/decidim-initiatives/spec/serializers/download_your_data_initiative_serializer_spec.rb
@@ -114,12 +114,8 @@ module Decidim::Initiatives
         expect(serialized[:type]).to include(title: initiative.type.title)
       end
 
-      it "includes the authors' ids" do
-        expect(serialized[:authors]).to include(id: initiative.author_users.map(&:id))
-      end
-
-      it "includes the authors' names" do
-        expect(serialized[:authors]).to include(name: initiative.author_users.map(&:name))
+      it "excludes the authors" do
+        expect(serialized).not_to have_key(:authors)
       end
 
       it "includes the area id" do

--- a/decidim-initiatives/spec/services/decidim/download_your_data_exporter_spec.rb
+++ b/decidim-initiatives/spec/services/decidim/download_your_data_exporter_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/core/test/shared_examples/download_your_data_shared_examples"
+
+module Decidim
+  describe DownloadYourDataExporter do
+    subject { DownloadYourDataExporter.new(user, "download-your-data", "CSV") }
+
+    let(:user) { create(:user, :confirmed, organization:) }
+    let(:organization) { create(:organization) }
+
+    describe "#readme" do
+      context "when the user has an initiative" do
+        let(:initiatives_type) { create(:initiatives_type, organization:) }
+        let(:scope) { create(:initiatives_type_scope, type: initiatives_type) }
+        let!(:initiative) { create(:initiative, author: user, organization:, scoped_type: scope) }
+
+        let(:help_definition_string) { "The title of the initiative" }
+
+        it_behaves_like "a download your data entity"
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR updates the DownloadYourData exports for decidim-initiatives models.

On this case what I'm doing is: 

- Doing the same strategy as in #13895, I inherit the Serializer with the DownloadYourDataSerializer to make it more maintainable 

#### :pushpin: Related Issues
 
- Related to #13527

#### Testing

- Everything should be green
- There shouldn't be new fields to add here 

:hearts: Thank you!
