### PR TITLE
Signature count in Initiative cards

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_progress-bar.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_progress-bar.scss
@@ -29,7 +29,7 @@
   }
 
   &__sm {
-    @apply w-16;
+    @apply w-16 pt-2;
   }
 
   &__sm &__number {


### PR DESCRIPTION
#### :tophat: What? Why?
The initiative signature count in the Initiative cards were not aligned with the rest of the items in the card (Date etc). This PR adds padding to correct this CSS.

#### :pushpin: Related Issues
- Fixes #13934

#### Testing
1. Go to the initiatives index in front end of an Decidim Installation
2. See the initiative count on the cards aligned properly

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/2cd9f641-ba74-46b7-9da9-32913eb76670)

:hearts: Thank you!
