### PR TITLE
Add text aligned to the left in Components' table

### DIFF
--- a/decidim-admin/app/views/decidim/admin/components/_component_row.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_component_row.html.erb
@@ -3,7 +3,7 @@
     <td class="text-center dragging-handle">
       <%= icon("draggable", class: "dragger") %>
     </td>
-    <td>
+    <td class="!text-left">
       <% if component.manifest.admin_engine %>
         <%= link_to translated_attribute(component.name), manage_component_path(component) %><br>
       <% else %>

--- a/decidim-admin/app/views/decidim/admin/components/_components_table.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_components_table.html.erb
@@ -3,7 +3,7 @@
     <thead>
     <tr>
       <th></th>
-      <th><%= t("index.headers.name", scope: "decidim.admin.components") %></th>
+      <th class="!text-left"><%= t("index.headers.name", scope: "decidim.admin.components") %></th>
       <th><%= t("index.headers.type", scope: "decidim.admin.components") %></th>
       <th><%= t("index.headers.visibility", scope: "decidim.admin.components") %></th>
       <th><%= t("index.headers.actions", scope: "decidim.admin.components") %></th>


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes the alignment of the components names in the components' tables of the admin panel

#### Testing

1. Sign in as admin
2. Go to the components table in a participatory space's admin

### :camera: Screenshots

####  Before

![Screenshot of the bug](https://github.com/user-attachments/assets/7fbb4747-33a1-4367-bbb1-cff9ae54b74b)

#### After

![Screenshot of the fix](https://github.com/user-attachments/assets/ca587e9c-2623-4e89-a841-6b20699ad18e)

:hearts: Thank you!
