### PR TITLE
Make transferable authorization when duplicate user is ephemeral

### DIFF
--- a/decidim-verifications/app/services/decidim/authorization_handler.rb
+++ b/decidim-verifications/app/services/decidim/authorization_handler.rb
@@ -47,7 +47,7 @@ module Decidim
     # @return [Boolean] A boolean indicating whether the authorization can be
     #   transferred.
     def transferrable?
-      duplicate.present? && duplicate.user.deleted?
+      duplicate.present? && (duplicate.user.deleted? || duplicate.user.ephemeral?)
     end
 
     # Defines whether the identity of an ephemeral user with the same authorization

--- a/decidim-verifications/spec/services/decidim/authorization_handler_spec.rb
+++ b/decidim-verifications/spec/services/decidim/authorization_handler_spec.rb
@@ -81,10 +81,16 @@ module Decidim
       context "when a duplicate record exists" do
         include_context "with a duplicate authorization record"
 
-        it { is_expected.to be(false) }
+        it { is_expected.to be_falsey }
 
         context "and the other user is deleted" do
           let(:other_user) { create(:user, :deleted, organization: current_user.organization) }
+
+          it { is_expected.to be(true) }
+        end
+
+        context "and the other user is ephemeral" do
+          let(:other_user) { create(:user, :ephemeral, organization: current_user.organization) }
 
           it { is_expected.to be(true) }
         end

--- a/decidim-verifications/spec/system/ephemeral_action_authorization_spec.rb
+++ b/decidim-verifications/spec/system/ephemeral_action_authorization_spec.rb
@@ -207,4 +207,61 @@ describe "ephemeral action authorization" do
       end
     end
   end
+
+  context "when an ephemeral authorized user exists" do
+    let!(:authorization) { create(:authorization, :granted, user: ephemeral_user, name: "ephemeral_dummy_authorization_handler", unique_id: metadata[:document_number], metadata:) }
+    let(:permissions) do
+      {
+        create: {
+          authorization_handlers: {
+            ephemeral_dummy_authorization_handler: {
+              options: {
+                allowed_postal_codes: "1234, 4567"
+              }
+            }
+          }
+        }
+      }
+    end
+    let(:ephemeral_user) { create(:user, :ephemeral, organization:) }
+    let(:metadata) { { postal_code:, document_number: } }
+    let(:postal_code) { "1234" }
+    let(:document_number) { "012345678X" }
+    let(:birthdate) { 33.years.ago.strftime("%d/%m/%Y") }
+    let(:proposal) { create(:proposal, component:, users: [ephemeral_user]) }
+    let(:user) { create(:user, :confirmed, organization:) }
+
+    context "and a regular user tries to create a new proposal" do
+      before do
+        login_as user, scope: :user
+        visit main_component_path(component)
+        click_on "New proposal"
+      end
+
+      it "redirects to ephemeral verification form" do
+        expect(page).to have_content("We need to verify your identity")
+        expect(page).to have_css("h1", text: "Verify with Ephemeral example authorization")
+      end
+
+      context "and verifies with the same data than an ephemeral user" do
+        before do
+          fill_in :authorization_handler_document_number, with: document_number
+          fill_in :authorization_handler_postal_code, with: postal_code
+          fill_in_datepicker :authorization_handler_birthday_date, with: birthdate
+        end
+
+        it "transfers the authorization" do
+          expect { click_on "Send" }.not_to change(Decidim::Authorization, :count)
+          expect(Decidim::Authorization.where(user: ephemeral_user)).to be_blank
+          expect(authorization.reload.user).to eq(user)
+        end
+
+        it "transfers the authorship of the proposal" do
+          expect(proposal.authors).to contain_exactly(ephemeral_user)
+          click_on "Send"
+          expect(proposal.reload.authors).to contain_exactly(user)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR makes authorizations transferable when they belong to ephemeral users and the destination user is a regular user.

#### :pushpin: Related Issues

- Fixes #13563

#### Testing

Define an ephemeral permission to vote in a budgets component. Create a budgets order as ephemeral user in the component, sign out, enter as a regular user and try to vote in the same component. After verifying the identity with the same data the order should be transferred.

Example done in https://decidim-lot2.populate.tools/processes/branch-highway/f/6/budgets/1/projects

[Screencast from 31-01-25 12:23:08.webm](https://github.com/user-attachments/assets/40ffc611-3a44-42df-acfa-0b62619d0e25)


:hearts: Thank you!
