### PR TITLE
Refactor API objects to use `Decidim::Core::TimestampsInterface`

### DIFF
--- a/decidim-accountability/lib/decidim/api/result_type.rb
+++ b/decidim-accountability/lib/decidim/api/result_type.rb
@@ -4,6 +4,7 @@ module Decidim
   module Accountability
     class ResultType < Decidim::Api::Types::BaseObject
       implements Decidim::Core::TaxonomizableInterface
+      implements Decidim::Core::TimestampsInterface
       implements Decidim::Comments::CommentableInterface
 
       description "A result"
@@ -15,8 +16,6 @@ module Decidim
       field :start_date, Decidim::Core::DateType, "The start date for this result", null: true
       field :end_date, Decidim::Core::DateType, "The end date for this result", null: true
       field :progress, GraphQL::Types::Float, "The progress for this result", null: true
-      field :created_at, Decidim::Core::DateTimeType, "When this result was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, "When this result was updated", null: true
       field :children_count, GraphQL::Types::Int, "The number of children results", null: true
       field :weight, GraphQL::Types::Int, "The order of this result", null: false
       field :external_id, GraphQL::Types::String, "The external ID for this result", null: true

--- a/decidim-accountability/lib/decidim/api/status_type.rb
+++ b/decidim-accountability/lib/decidim/api/status_type.rb
@@ -3,13 +3,13 @@
 module Decidim
   module Accountability
     class StatusType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+
       description "A status"
 
       field :id, GraphQL::Types::ID, "The internal ID for this status", null: false
       field :key, GraphQL::Types::String, "The key for this status", null: true
       field :name, Decidim::Core::TranslatedFieldType, "The name for this status", null: true
-      field :created_at, Decidim::Core::DateType, "When this status was created", null: true
-      field :updated_at, Decidim::Core::DateType, "When this status was updated", null: true
       field :description, Decidim::Core::TranslatedFieldType, "The description for this status", null: true
       field :progress, GraphQL::Types::Int, "The progress for this status", null: true
 

--- a/decidim-accountability/lib/decidim/api/timeline_entry_type.rb
+++ b/decidim-accountability/lib/decidim/api/timeline_entry_type.rb
@@ -3,14 +3,14 @@
 module Decidim
   module Accountability
     class TimelineEntryType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+
       description "A Timeline Entry"
 
       field :id, GraphQL::Types::ID, "The internal ID for this timeline entry", null: false
       field :entry_date, Decidim::Core::DateType, "The entry date for this timeline entry", null: true
       field :title, Decidim::Core::TranslatedFieldType, "The title for this timeline entry", null: true
       field :description, Decidim::Core::TranslatedFieldType, "The description for this timeline entry", null: true
-      field :created_at, Decidim::Core::DateTimeType, "When this timeline entry was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, "When this timeline entry was updated", null: true
 
       field :result, Decidim::Accountability::ResultType, "The result for this timeline entry", null: true
     end

--- a/decidim-accountability/spec/types/integration_schema_spec.rb
+++ b/decidim-accountability/spec/types/integration_schema_spec.rb
@@ -105,24 +105,24 @@ describe "Decidim::Api::QueryType" do
       "reference" => result.reference,
       "startDate" => result.start_date.to_s,
       "status" => {
-        "createdAt" => result.status.created_at.to_date.to_s,
+        "createdAt" => result.status.created_at.to_time.iso8601,
         "description" => { "translation" => result.status.description[locale] },
         "id" => result.status.id.to_s,
         "key" => result.status.key,
         "name" => { "translation" => result.status.name[locale] },
         "progress" => result.status.progress,
         "results" => [{ "id" => result.id.to_s }],
-        "updatedAt" => result.status.updated_at.to_date.to_s
+        "updatedAt" => result.status.updated_at.to_time.iso8601
       },
       "timelineEntries" => [
         {
-          "createdAt" => result.timeline_entries.first.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+          "createdAt" => result.timeline_entries.first.created_at.to_time.iso8601,
           "title" => { "translation" => result.timeline_entries.first.title[locale] },
           "description" => { "translation" => result.timeline_entries.first.description[locale] },
           "entryDate" => result.timeline_entries.first.entry_date.to_s,
           "id" => result.timeline_entries.first.id.to_s,
           "result" => { "id" => result.id.to_s },
-          "updatedAt" => result.timeline_entries.first.updated_at.iso8601.to_s.gsub("Z", "+00:00")
+          "updatedAt" => result.timeline_entries.first.updated_at.to_time.iso8601
         }
       ],
       "title" => { "translation" => result.title[locale] },

--- a/decidim-accountability/spec/types/integration_schema_spec.rb
+++ b/decidim-accountability/spec/types/integration_schema_spec.rb
@@ -94,7 +94,7 @@ describe "Decidim::Api::QueryType" do
       "comments" => [],
       "commentsHaveAlignment" => result.comments_have_alignment?,
       "commentsHaveVotes" => result.comments_have_votes?,
-      "createdAt" => result.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => result.created_at.to_time.iso8601,
       "description" => { "translation" => result.description[locale] },
       "endDate" => result.end_date.to_s,
       "externalId" => result.external_id,
@@ -128,7 +128,7 @@ describe "Decidim::Api::QueryType" do
       "title" => { "translation" => result.title[locale] },
       "totalCommentsCount" => result.comments_count,
       "type" => "Decidim::Accountability::Result",
-      "updatedAt" => result.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "updatedAt" => result.updated_at.to_time.iso8601,
       "userAllowedToComment" => result.user_allowed_to_comment?(current_user),
       "weight" => result.weight.to_i
     }

--- a/decidim-accountability/spec/types/status_type_spec.rb
+++ b/decidim-accountability/spec/types/status_type_spec.rb
@@ -46,7 +46,7 @@ module Decidim
         let(:query) { "{ createdAt }" }
 
         it "returns the createdAt" do
-          expect(response["createdAt"]).to eq(model.created_at.to_date.iso8601)
+          expect(response["createdAt"]).to eq(model.created_at.to_time.iso8601)
         end
       end
 
@@ -54,7 +54,7 @@ module Decidim
         let(:query) { "{ updatedAt }" }
 
         it "returns the updatedAt" do
-          expect(response["updatedAt"]).to eq(model.updated_at.to_date.iso8601)
+          expect(response["updatedAt"]).to eq(model.updated_at.to_time.iso8601)
         end
       end
 

--- a/decidim-assemblies/lib/decidim/api/assembly_type.rb
+++ b/decidim-assemblies/lib/decidim/api/assembly_type.rb
@@ -9,6 +9,7 @@ module Decidim
       implements Decidim::Core::ParticipatorySpaceResourceableInterface
       implements Decidim::Core::TaxonomizableInterface
       implements Decidim::Core::CategoriesContainerInterface
+      implements Decidim::Core::TimestampsInterface
 
       description "An assembly"
 
@@ -18,8 +19,6 @@ module Decidim
       field :description, Decidim::Core::TranslatedFieldType, "The description of this assembly", null: true
       field :slug, String, "The slug of this assembly", null: false
       field :hashtag, String, "The hashtag for this assembly", null: true
-      field :created_at, Decidim::Core::DateTimeType, "The time this assembly was created", null: false
-      field :updated_at, Decidim::Core::DateTimeType, "The time this assembly was updated", null: false
       field :published_at, Decidim::Core::DateTimeType, "The time this assembly was published", null: false
       field :reference, String, "Reference for this assembly", null: false
 

--- a/decidim-assemblies/spec/types/integration_schema_spec.rb
+++ b/decidim-assemblies/spec/types/integration_schema_spec.rb
@@ -18,10 +18,10 @@ describe "Decidim::Api::QueryType" do
       "area" => nil,
       "assemblyType" => {
         "assemblies" => assembly.assembly_type.assemblies.map { |a| { "id" => a.id.to_s } },
-        "createdAt" => assembly.assembly_type.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+        "createdAt" => assembly.assembly_type.created_at.to_time.iso8601,
         "id" => assembly.assembly_type.id.to_s,
         "title" => { "translation" => assembly.assembly_type.title[locale] },
-        "updatedAt" => assembly.assembly_type.updated_at.iso8601.to_s.gsub("Z", "+00:00")
+        "updatedAt" => assembly.assembly_type.updated_at.to_time.iso8601
       },
       "attachments" => [],
       "categories" => [],
@@ -31,7 +31,7 @@ describe "Decidim::Api::QueryType" do
       "closingDateReason" => { "translation" => assembly.closing_date_reason[locale] },
       "components" => [],
       "composition" => { "translation" => assembly.composition[locale] },
-      "createdAt" => assembly.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => assembly.created_at.to_time.iso8601,
       "createdBy" => assembly.created_by,
       "createdByOther" => { "translation" => assembly.created_by_other[locale] },
       "creationDate" => assembly.creation_date.to_date.to_s,
@@ -55,7 +55,7 @@ describe "Decidim::Api::QueryType" do
       "participatoryStructure" => { "translation" => assembly.participatory_structure[locale] },
       "privateSpace" => assembly.private_space?,
       "promoted" => assembly.promoted?,
-      "publishedAt" => assembly.published_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "publishedAt" => assembly.published_at.to_time.iso8601,
       "purposeOfAction" => { "translation" => assembly.purpose_of_action[locale] },
       "reference" => assembly.reference,
       "taxonomies" => [{ "id" => taxonomy.id.to_s, "name" => { "translation" => taxonomy.name[locale] }, "parent" => { "id" => taxonomy.parent_id.to_s }, "children" => taxonomy.children.map { |child| { "id" => child.id.to_s } } }],
@@ -67,7 +67,7 @@ describe "Decidim::Api::QueryType" do
       "title" => { "translation" => assembly.title[locale] },
       "twitterHandler" => assembly.twitter_handler,
       "type" => assembly.class.name,
-      "updatedAt" => assembly.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "updatedAt" => assembly.updated_at.to_time.iso8601,
       "youtubeHandler" => assembly.youtube_handler
 
     }

--- a/decidim-blogs/spec/types/integration_schema_spec.rb
+++ b/decidim-blogs/spec/types/integration_schema_spec.rb
@@ -73,7 +73,7 @@ describe "Decidim::Api::QueryType" do
       "comments" => [],
       "commentsHaveAlignment" => true,
       "commentsHaveVotes" => true,
-      "createdAt" => post.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => post.created_at.to_time.iso8601,
       "endorsements" => post.endorsements.map do |endo|
         {
           "__typename" => "User",
@@ -93,7 +93,7 @@ describe "Decidim::Api::QueryType" do
       "title" => { "translation" => post.title[locale] },
       "totalCommentsCount" => 0,
       "type" => "Decidim::Blogs::Post",
-      "updatedAt" => post.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "updatedAt" => post.updated_at.to_time.iso8601,
       "userAllowedToComment" => post.user_allowed_to_comment?(current_user),
       "versions" => [],
       "versionsCount" => 0

--- a/decidim-budgets/lib/decidim/api/budget_type.rb
+++ b/decidim-budgets/lib/decidim/api/budget_type.rb
@@ -3,6 +3,7 @@
 module Decidim
   module Budgets
     class BudgetType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
       implements Decidim::Core::TraceableInterface
 
       description "A budget"
@@ -11,8 +12,6 @@ module Decidim
       field :title, Decidim::Core::TranslatedFieldType, "The title for this budget", null: false
       field :description, Decidim::Core::TranslatedFieldType, "The description for this budget", null: false
       field :total_budget, GraphQL::Types::Int, "The total budget", null: false, camelize: false
-      field :created_at, Decidim::Core::DateTimeType, "When this budget was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, "When this budget was updated", null: true
 
       field :projects, [Decidim::Budgets::ProjectType, { null: true }], "The projects for this budget", null: false
 

--- a/decidim-budgets/lib/decidim/api/project_type.rb
+++ b/decidim-budgets/lib/decidim/api/project_type.rb
@@ -3,6 +3,7 @@
 module Decidim
   module Budgets
     class ProjectType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
       implements Decidim::Core::TaxonomizableInterface
       implements Decidim::Core::AttachableInterface
       implements Decidim::Comments::CommentableInterface
@@ -14,8 +15,6 @@ module Decidim
       field :description, Decidim::Core::TranslatedFieldType, "The description for this project", null: true
       field :budget_amount, GraphQL::Types::Int, "The budget amount for this project", null: true, camelize: false
       field :selected, GraphQL::Types::Boolean, "Whether this proposal is selected or not", method: :selected?, null: true
-      field :created_at, Decidim::Core::DateTimeType, "When this project was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, "When this project was updated", null: true
       field :reference, GraphQL::Types::String, "The reference for this project", null: true
 
       def self.authorized?(object, context)

--- a/decidim-budgets/spec/types/integration_schema_spec.rb
+++ b/decidim-budgets/spec/types/integration_schema_spec.rb
@@ -57,7 +57,7 @@ describe "Decidim::Api::QueryType" do
 
   let(:budget_single_result) do
     {
-      "createdAt" => budget.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => budget.created_at.to_time.iso8601,
       "description" => { "translation" => budget.description[locale] },
       "id" => budget.id.to_s,
       "projects" => budget.projects.map do |project|
@@ -69,7 +69,7 @@ describe "Decidim::Api::QueryType" do
           "comments" => [],
           "commentsHaveAlignment" => project.comments_have_alignment?,
           "commentsHaveVotes" => project.comments_have_votes?,
-          "createdAt" => project.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+          "createdAt" => project.created_at.to_time.iso8601,
           "description" => { "translation" => project.description[locale] },
           "hasComments" => project.comment_threads.size.positive?,
           "id" => project.id.to_s,
@@ -78,13 +78,13 @@ describe "Decidim::Api::QueryType" do
           "title" => { "translation" => project.title[locale] },
           "totalCommentsCount" => project.comments_count,
           "type" => "Decidim::Budgets::Project",
-          "updatedAt" => project.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+          "updatedAt" => project.updated_at.to_time.iso8601,
           "userAllowedToComment" => project.user_allowed_to_comment?(current_user)
         }
       end,
       "title" => { "translation" => budget.title[locale] },
       "total_budget" => budget.total_budget,
-      "updatedAt" => budget.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "updatedAt" => budget.updated_at.to_time.iso8601,
       "versions" => [],
       "versionsCount" => 0
     }
@@ -129,13 +129,13 @@ describe "Decidim::Api::QueryType" do
   describe "valid connection query" do
     let(:budget_single_result) do
       {
-        "createdAt" => budget.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+        "createdAt" => budget.created_at.to_time.iso8601,
         "description" => { "translation" => budget.description[locale] },
         "id" => budget.id.to_s,
         "projects" => budget.projects.map { |project| { "id" => project.id.to_s } },
         "title" => { "translation" => budget.title[locale] },
         "total_budget" => budget.total_budget,
-        "updatedAt" => budget.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+        "updatedAt" => budget.updated_at.to_time.iso8601,
         "versions" => [],
         "versionsCount" => 0
       }
@@ -195,7 +195,7 @@ describe "Decidim::Api::QueryType" do
     let(:lookout_key) { "budget" }
     let(:query_result) do
       {
-        "createdAt" => budget.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+        "createdAt" => budget.created_at.to_time.iso8601,
         "description" => { "translation" => budget.description[locale] },
         "id" => budget.id.to_s,
         "projects" => budget.projects.map do |project|
@@ -207,7 +207,7 @@ describe "Decidim::Api::QueryType" do
             "comments" => [],
             "commentsHaveAlignment" => project.comments_have_alignment?,
             "commentsHaveVotes" => project.comments_have_votes?,
-            "createdAt" => project.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+            "createdAt" => project.created_at.to_time.iso8601,
             "description" => { "translation" => project.description[locale] },
             "hasComments" => project.comment_threads.size.positive?,
             "id" => project.id.to_s,
@@ -216,13 +216,13 @@ describe "Decidim::Api::QueryType" do
             "title" => { "translation" => project.title[locale] },
             "totalCommentsCount" => project.comments_count,
             "type" => "Decidim::Budgets::Project",
-            "updatedAt" => project.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+            "updatedAt" => project.updated_at.to_time.iso8601,
             "userAllowedToComment" => project.user_allowed_to_comment?(current_user)
           }
         end,
         "title" => { "translation" => budget.title[locale] },
         "total_budget" => budget.total_budget,
-        "updatedAt" => budget.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+        "updatedAt" => budget.updated_at.to_time.iso8601,
         "versions" => [],
         "versionsCount" => 0
       }

--- a/decidim-comments/lib/decidim/api/comment_type.rb
+++ b/decidim-comments/lib/decidim/api/comment_type.rb
@@ -4,9 +4,11 @@ module Decidim
   module Comments
     # This type represents a comment on a commentable object.
     class CommentType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+      implements Decidim::Comments::CommentableInterface
+
       description "A comment"
 
-      implements Decidim::Comments::CommentableInterface
       field :author, Decidim::Core::AuthorInterface, "The resource author", null: false
 
       field :id, GraphQL::Types::ID, "The Comment's unique ID", null: false
@@ -16,8 +18,6 @@ module Decidim
       field :body, GraphQL::Types::String, "The comment message", null: false
 
       field :formatted_body, GraphQL::Types::String, "The comment message ready to display (it is expected to include HTML)", null: false
-
-      field :created_at, GraphQL::Types::String, "The creation date of the comment", null: false
 
       field :formatted_created_at, GraphQL::Types::String, "The creation date of the comment in relative format", null: false
 
@@ -47,10 +47,6 @@ module Decidim
 
       def body
         object.translated_body
-      end
-
-      def created_at
-        object.created_at.iso8601
       end
 
       def formatted_created_at

--- a/decidim-comments/lib/decidim/api/commentable_interface.rb
+++ b/decidim-comments/lib/decidim/api/commentable_interface.rb
@@ -8,39 +8,28 @@ module Decidim
       description "A commentable interface"
 
       field :id, GraphQL::Types::ID, "The commentable's ID", null: false
-
       field :type, GraphQL::Types::String, "The commentable's class name. i.e. `Decidim::ParticipatoryProcess`", method: :commentable_type, null: false
-
       field :accepts_new_comments, GraphQL::Types::Boolean, "Whether the object can have new comments or not", method: :accepts_new_comments?, null: false
-
       field :comments_have_alignment, GraphQL::Types::Boolean, "Whether the object comments have alignment or not", method: :comments_have_alignment?, null: false
-
       field :comments_have_votes, GraphQL::Types::Boolean, "Whether the object comments have votes or not", method: :comments_have_votes?, null: false
+      field :total_comments_count, GraphQL::Types::Int, description: "The number of comments in all levels this resource holds", method: :comments_count, null: false
+      field :has_comments, GraphQL::Types::Boolean, "Check if the commentable has comments", null: false
+      field :user_allowed_to_comment, GraphQL::Types::Boolean, "Check if the current user can comment", null: false
 
       field :comments, [Decidim::Comments::CommentType, { null: false }], null: false do
         argument :order_by, GraphQL::Types::String, "Order the comments", required: false
         argument :single_comment_id, GraphQL::Types::String, "ID of the single comment to look at", required: false
       end
 
-      field :total_comments_count, GraphQL::Types::Int, description: "The number of comments in all levels this resource holds", null: false
-
       def comments(order_by: nil, single_comment_id: nil)
         SortedComments.for(object, order_by:, id: single_comment_id).not_hidden
       end
-
-      def total_comments_count
-        object.comments_count
-      end
-
-      field :has_comments, GraphQL::Types::Boolean, "Check if the commentable has comments", null: false
 
       # rubocop:disable Naming/PredicateName
       def has_comments
         object.comment_threads.not_hidden.size.positive?
       end
       # rubocop:enable Naming/PredicateName
-
-      field :user_allowed_to_comment, GraphQL::Types::Boolean, "Check if the current user can comment", null: false
 
       def user_allowed_to_comment
         object.commentable? && object.user_allowed_to_comment?(context[:current_user])

--- a/decidim-comments/spec/types/comment_type_spec.rb
+++ b/decidim-comments/spec/types/comment_type_spec.rb
@@ -142,7 +142,7 @@ module Decidim
         let(:query) { "{ createdAt }" }
 
         it "returns its created_at field to iso format" do
-          expect(response).to include("createdAt" => model.created_at.iso8601)
+          expect(response).to include("createdAt" => model.created_at.to_time.iso8601)
         end
       end
 

--- a/decidim-conferences/lib/decidim/api/conference_media_link_type.rb
+++ b/decidim-conferences/lib/decidim/api/conference_media_link_type.rb
@@ -4,6 +4,8 @@ module Decidim
   module Conferences
     # This type represents a conference.
     class ConferenceMediaLinkType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+
       description "A conference media link"
 
       field :id, GraphQL::Types::ID, "Internal ID for this media link", null: false
@@ -11,8 +13,6 @@ module Decidim
       field :link, GraphQL::Types::String, "URL for this media link", null: true
       field :date, Decidim::Core::DateType, "Relevant date for the media link", null: true
       field :weight, GraphQL::Types::Int, "Order of appearance in which it should be presented", null: true
-      field :created_at, Decidim::Core::DateTimeType, "The time this entry was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, "The time this entry was updated", null: true
     end
   end
 end

--- a/decidim-conferences/lib/decidim/api/conference_partner_type.rb
+++ b/decidim-conferences/lib/decidim/api/conference_partner_type.rb
@@ -4,6 +4,8 @@ module Decidim
   module Conferences
     # This type represents a conference.
     class ConferencePartnerType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+
       description "A conference partner"
 
       field :id, GraphQL::Types::ID, "ID of the resource", null: false
@@ -12,8 +14,6 @@ module Decidim
       field :weight, GraphQL::Types::Int, "Order of appearance in which it should be presented", null: true
       field :link, GraphQL::Types::String, "Relevant URL for this partner", null: true
       field :logo, GraphQL::Types::String, "Link to the partner's logo", null: true
-      field :created_at, Decidim::Core::DateTimeType, "The time this partner was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, "The time this partner was updated", null: true
 
       def logo
         object.attached_uploader(:logo).url

--- a/decidim-conferences/lib/decidim/api/conference_speaker_type.rb
+++ b/decidim-conferences/lib/decidim/api/conference_speaker_type.rb
@@ -4,6 +4,8 @@ module Decidim
   module Conferences
     # This type represents a conference.
     class ConferenceSpeakerType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+
       description "A conference speaker"
 
       field :id, GraphQL::Types::ID, "Internal ID of the speaker", null: false
@@ -15,9 +17,6 @@ module Decidim
       field :personal_url, GraphQL::Types::String, "Personal URL of the speaker", null: true
       field :avatar, GraphQL::Types::String, "Avatar of the speaker", null: true
       field :user, Decidim::Core::UserType, "Decidim user corresponding to this speaker", null: true
-
-      field :created_at, Decidim::Core::DateTimeType, "The time this member was created ", null: true
-      field :updated_at, Decidim::Core::DateTimeType, "The time this member was updated", null: true
 
       def avatar
         object.attached_uploader(:avatar).url

--- a/decidim-conferences/lib/decidim/api/conference_type.rb
+++ b/decidim-conferences/lib/decidim/api/conference_type.rb
@@ -8,6 +8,7 @@ module Decidim
       implements Decidim::Core::ScopableInterface
       implements Decidim::Core::AttachableInterface
       implements Decidim::Core::TaxonomizableInterface
+      implements Decidim::Core::TimestampsInterface
       implements Decidim::Core::CategoriesContainerInterface
 
       description "A conference"
@@ -19,8 +20,6 @@ module Decidim
       field :hashtag, GraphQL::Types::String, "The hashtag for this conference", null: true
       field :slogan, Decidim::Core::TranslatedFieldType, "The slogan of the conference", null: true
       field :location, String, "The location of this conference", null: true
-      field :created_at, Decidim::Core::DateTimeType, "The time this conference was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, "The time this conference was updated", null: true
       field :published_at, Decidim::Core::DateTimeType, "The time this conference was published", null: true
       field :reference, GraphQL::Types::String, "Reference prefix for this conference", null: true
 

--- a/decidim-conferences/spec/types/integration_schema_spec.rb
+++ b/decidim-conferences/spec/types/integration_schema_spec.rb
@@ -18,7 +18,7 @@ describe "Decidim::Api::QueryType" do
       "availableSlots" => conference.available_slots,
       "categories" => [],
       "components" => [],
-      "createdAt" => conference.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => conference.created_at.to_time.iso8601,
       "description" => { "translation" => conference.description[locale] },
       "endDate" => conference.end_date.to_s,
       "hashtag" => conference.hashtag,
@@ -28,7 +28,7 @@ describe "Decidim::Api::QueryType" do
       "objectives" => { "translation" => conference.objectives[locale] },
       "partners" => [],
       "promoted" => conference.promoted?,
-      "publishedAt" => conference.published_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "publishedAt" => conference.published_at.to_time.iso8601,
       "reference" => conference.reference,
       "registrationTerms" => { "translation" => conference.registration_terms[locale] },
       "registrationsEnabled" => conference.registrations_enabled?,
@@ -41,7 +41,7 @@ describe "Decidim::Api::QueryType" do
       "startDate" => conference.start_date.to_date.to_s,
       "title" => { "translation" => conference.title[locale] },
       "type" => conference.class.name,
-      "updatedAt" => conference.updated_at.iso8601.to_s.gsub("Z", "+00:00")
+      "updatedAt" => conference.updated_at.to_time.iso8601
     }
   end
 

--- a/decidim-core/lib/decidim/api/types/area_api_type.rb
+++ b/decidim-core/lib/decidim/api/types/area_api_type.rb
@@ -3,14 +3,14 @@
 module Decidim
   module Core
     class AreaApiType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+
       graphql_name "Area"
       description "An area."
 
       field :id, GraphQL::Types::ID, "Internal ID for this area", null: false
       field :name, Decidim::Core::TranslatedFieldType, "The graphql_name of this area.", null: false
       field :area_type, Decidim::Core::AreaTypeType, "The area type of this area", null: true
-      field :created_at, Decidim::Core::DateTimeType, "The time this assembly was created", null: false
-      field :updated_at, Decidim::Core::DateTimeType, "The time this assembly was updated", null: false
     end
   end
 end

--- a/decidim-core/lib/decidim/api/types/session_type.rb
+++ b/decidim-core/lib/decidim/api/types/session_type.rb
@@ -7,12 +7,11 @@ module Decidim
       description "The current session"
 
       field :user, UserType, "The current user", null: true
+      field :verified_user_groups, [UserGroupType], "The current user verified user groups", null: false
 
       def user
         object
       end
-
-      field :verified_user_groups, [UserGroupType], "The current user verified user groups", null: false
 
       def verified_user_groups
         Decidim::UserGroups::ManageableUserGroups.for(object).verified

--- a/decidim-core/lib/decidim/api/types/trace_version_type.rb
+++ b/decidim-core/lib/decidim/api/types/trace_version_type.rb
@@ -8,12 +8,12 @@ module Decidim
       field :id, GraphQL::Types::ID, "The ID of the version", null: false
       field :created_at, Decidim::Core::DateTimeType, description: "The date and time this version was created", null: true
       field :editor, Decidim::Core::AuthorInterface, description: "The editor/author of this version", null: true
+      field :changeset, GraphQL::Types::JSON, description: "Object with the changes in this version", null: true
 
       def editor
         author = Decidim.traceability.version_editor(object)
         author if author.is_a?(Decidim::User) || author.is_a?(Decidim::UserGroup)
       end
-      field :changeset, GraphQL::Types::JSON, description: "Object with the changes in this version", null: true
 
       delegate :changeset, to: :object
     end

--- a/decidim-core/lib/decidim/api/types/user_group_type.rb
+++ b/decidim-core/lib/decidim/api/types/user_group_type.rb
@@ -9,52 +9,43 @@ module Decidim
       implements Decidim::Core::AuthorInterface
 
       field :id, GraphQL::Types::ID, "The user group's id", null: false
-
       field :name, GraphQL::Types::String, "The user group's name", null: false
-
       field :nickname, GraphQL::Types::String, "The user group nickname", null: false
+      field :avatar_url, GraphQL::Types::String, "The user's avatar url", null: false
+      field :profile_path, GraphQL::Types::String, "The user group's profile url", null: false
+      field :organization_name, Decidim::Core::TranslatedFieldType, "The user group's organization name", null: false
+      field :deleted, GraphQL::Types::Boolean, "Whether the user group's has been deleted or not", null: false
+      field :badge, GraphQL::Types::String, "A badge for the user group", null: false
+      field :members, [Decidim::Core::UserType, { null: true }], "Members of this group", null: false
+      field :members_count, GraphQL::Types::Int, "Number of members in this group", null: false
 
       def nickname
         object.presenter.nickname
       end
 
-      field :avatar_url, GraphQL::Types::String, "The user's avatar url", null: false
-
       def avatar_url
         object.presenter.avatar_url
       end
-
-      field :profile_path, GraphQL::Types::String, "The user group's profile url", null: false
 
       def profile_path
         object.presenter.profile_path
       end
 
-      field :organization_name, Decidim::Core::TranslatedFieldType, "The user group's organization name", null: false
-
       def organization_name
         object.organization.name
       end
-
-      field :deleted, GraphQL::Types::Boolean, "Whether the user group's has been deleted or not", null: false
 
       def deleted
         object.presenter.deleted?
       end
 
-      field :badge, GraphQL::Types::String, "A badge for the user group", null: false
-
       def badge
         object.presenter.badge
       end
 
-      field :members, [Decidim::Core::UserType, { null: true }], "Members of this group", null: false
-
       def members
         object.accepted_users
       end
-
-      field :members_count, GraphQL::Types::Int, "Number of members in this group", null: false
 
       def members_count
         object.accepted_memberships.count

--- a/decidim-debates/lib/decidim/api/debate_type.rb
+++ b/decidim-debates/lib/decidim/api/debate_type.rb
@@ -6,6 +6,7 @@ module Decidim
       implements Decidim::Core::TaxonomizableInterface
       implements Decidim::Comments::CommentableInterface
       implements Decidim::Core::AuthorableInterface
+      implements Decidim::Core::TimestampsInterface
 
       description "A debate"
 
@@ -16,8 +17,6 @@ module Decidim
       field :start_time, Decidim::Core::DateTimeType, "The start time for this debate", null: true
       field :end_time, Decidim::Core::DateTimeType, "The end time for this debate", null: true
       field :image, GraphQL::Types::String, "The image of this debate", null: true
-      field :created_at, Decidim::Core::DateTimeType, "When this debate was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, "When this debate was updated", null: true
       field :information_updates, Decidim::Core::TranslatedFieldType, "The information updates for this debate", null: true
       field :reference, GraphQL::Types::String, "The reference for this debate", null: true
 

--- a/decidim-debates/spec/types/integration_schema_spec.rb
+++ b/decidim-debates/spec/types/integration_schema_spec.rb
@@ -63,7 +63,7 @@ describe "Decidim::Api::QueryType" do
       "comments" => [],
       "commentsHaveAlignment" => debate.comments_have_alignment?,
       "commentsHaveVotes" => debate.comments_have_votes?,
-      "createdAt" => debate.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => debate.created_at.to_time.iso8601,
       "description" => { "translation" => debate.description[locale] },
       "endTime" => debate.end_time,
       "hasComments" => debate.comment_threads.size.positive?,
@@ -76,7 +76,7 @@ describe "Decidim::Api::QueryType" do
       "title" => { "translation" => debate.title[locale] },
       "totalCommentsCount" => debate.comments_count,
       "type" => "Decidim::Debates::Debate",
-      "updatedAt" => debate.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "updatedAt" => debate.updated_at.to_time.iso8601,
       "userAllowedToComment" => debate.user_allowed_to_comment?(current_user)
     }
   end

--- a/decidim-initiatives/lib/decidim/api/initiative_api_type.rb
+++ b/decidim-initiatives/lib/decidim/api/initiative_api_type.rb
@@ -3,14 +3,14 @@
 module Decidim
   module Initiatives
     class InitiativeApiType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+
       graphql_name "InitiativeType"
       description "An initiative type"
 
       field :id, GraphQL::Types::ID, "The internal ID for this initiative type", null: false
       field :title, Decidim::Core::TranslatedFieldType, "Initiative type name", null: true
       field :description, Decidim::Core::TranslatedFieldType, "This is the initiative type description", null: true
-      field :created_at, Decidim::Core::DateTimeType, "The date this initiative type was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, "The date this initiative type was updated", null: true
       field :banner_image, GraphQL::Types::String, "Banner image", null: true
       field :collect_user_extra_fields, GraphQL::Types::Boolean, "Collect participant personal data on signature", null: true
       field :extra_fields_legal_information, GraphQL::Types::String, "Legal information about the collection of personal data", null: true

--- a/decidim-initiatives/lib/decidim/api/initiative_committee_member_type.rb
+++ b/decidim-initiatives/lib/decidim/api/initiative_committee_member_type.rb
@@ -4,6 +4,8 @@ module Decidim
   module Initiatives
     # This type represents an initiative committee member.
     class InitiativeCommitteeMemberType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+
       graphql_name "InitiativeCommitteeMemberType"
       description "An initiative committee member"
 
@@ -11,8 +13,6 @@ module Decidim
       field :user, Decidim::Core::UserType, "The decidim user for this initiative committee member", null: true
 
       field :state, GraphQL::Types::String, "Type of the committee member", null: true
-      field :created_at, Decidim::Core::DateTimeType, "The date this initiative committee member was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, "The date this initiative committee member was updated", null: true
     end
   end
 end

--- a/decidim-initiatives/spec/types/integration_schema_spec.rb
+++ b/decidim-initiatives/spec/types/integration_schema_spec.rb
@@ -17,21 +17,21 @@ describe "Decidim::Api::QueryType" do
       "author" => { "id" => initiative.author.id.to_s },
       "committeeMembers" => initiative.committee_members.map do |cm|
         {
-          "createdAt" => cm.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+          "createdAt" => cm.created_at.to_time.iso8601,
           "id" => cm.id.to_s,
           "state" => cm.state,
-          "updatedAt" => cm.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+          "updatedAt" => cm.updated_at.to_time.iso8601,
           "user" => { "id" => cm.decidim_users_id.to_s }
         }
       end,
       "components" => [],
-      "createdAt" => initiative.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => initiative.created_at.to_time.iso8601,
       "description" => { "translation" => initiative.description[locale] },
       "hashtag" => initiative.hashtag,
       "id" => initiative.id.to_s,
       "offlineVotes" => initiative.offline_votes_count,
       "onlineVotes" => initiative.online_votes_count,
-      "publishedAt" => initiative.published_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "publishedAt" => initiative.published_at.to_time.iso8601,
       "reference" => initiative.reference,
       "scope" => { "id" => initiative.scope.id.to_s },
       "signatureEndDate" => initiative.signature_end_date.to_date.to_s,
@@ -41,14 +41,14 @@ describe "Decidim::Api::QueryType" do
       "state" => initiative.state,
       "title" => { "translation" => initiative.title[locale] },
       "type" => initiative.class.name,
-      "updatedAt" => initiative.updated_at.iso8601.to_s.gsub("Z", "+00:00")
+      "updatedAt" => initiative.updated_at.to_time.iso8601
 
     }
   end
   let(:initiative_type_data) do
     {
       "collectUserExtraFields" => initiative.type.collect_user_extra_fields?,
-      "createdAt" => initiative.type.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => initiative.type.created_at.to_time.iso8601,
       "description" => { "translation" => initiative.type.description[locale] },
       "extraFieldsLegalInformation" => initiative.type.extra_fields_legal_information,
       "id" => initiative.type.id.to_s,
@@ -58,7 +58,7 @@ describe "Decidim::Api::QueryType" do
       "signatureType" => initiative.type.signature_type,
       "title" => { "translation" => initiative.type.title[locale] },
       "undoOnlineSignaturesEnabled" => initiative.type.undo_online_signatures_enabled,
-      "updatedAt" => initiative.type.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "updatedAt" => initiative.type.updated_at.to_time.iso8601,
       "validateSmsCodeOnVotes" => initiative.type.validate_sms_code_on_votes
     }
   end

--- a/decidim-meetings/lib/decidim/api/agenda_item_type.rb
+++ b/decidim-meetings/lib/decidim/api/agenda_item_type.rb
@@ -3,6 +3,8 @@
 module Decidim
   module Meetings
     class AgendaItemType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+
       graphql_name "MeetingAgendaItem"
       description "A meeting agenda item"
 
@@ -14,9 +16,6 @@ module Decidim
       field :agenda, Decidim::Meetings::AgendaType, "Belonging agenda", null: true
       field :duration, GraphQL::Types::Int, "Duration in number of minutes for this item in this agenda", null: false
       field :position, GraphQL::Types::Int, "Order position for this agenda item", null: false
-
-      field :created_at, Decidim::Core::DateTimeType, description: "The date and time this agenda item was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, description: "The date and time this agenda item was updated", null: true
     end
   end
 end

--- a/decidim-meetings/lib/decidim/api/agenda_type.rb
+++ b/decidim-meetings/lib/decidim/api/agenda_type.rb
@@ -3,6 +3,8 @@
 module Decidim
   module Meetings
     class AgendaType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+
       graphql_name "MeetingAgenda"
       description "A meeting agenda"
 
@@ -11,9 +13,6 @@ module Decidim
       field :items, [Decidim::Meetings::AgendaItemType, { null: true }], "Items and sub-items of the agenda", method: :agenda_items, null: false
       # probably useful in the future, when handling user permissions
       # field :visible, !types.Boolean, "Whether this minutes is public or not", property: :visible
-
-      field :created_at, Decidim::Core::DateTimeType, description: "The date and time this agenda was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, description: "The date and time this agenda was updated", null: true
     end
   end
 end

--- a/decidim-meetings/lib/decidim/api/meeting_type.rb
+++ b/decidim-meetings/lib/decidim/api/meeting_type.rb
@@ -22,15 +22,41 @@ module Decidim
       field :end_time, Decidim::Core::DateTimeType, "The time this meeting ends", null: false
       field :agenda, Decidim::Meetings::AgendaType, "Agenda for this meeting, if available", null: true
 
-      def agenda
-        object.agenda if object.agenda&.visible?
-      end
-
       field :closed, GraphQL::Types::Boolean, "Whether this meeting is closed or not.", method: :closed?, null: false
       field :isWithdrawn, GraphQL::Types::Boolean, "Whether this meeting is withdrawn or not.", method: :withdrawn?, null: false
       field :closing_report, Decidim::Core::TranslatedFieldType, "The closing report of this meeting.", null: true
       field :video_url, GraphQL::Types::String, "URL for the video of the session, if any", null: true
       field :audio_url, GraphQL::Types::String, "URL for the audio of the session, if any", null: true
+
+      field :withdrawn_at, Decidim::Core::DateTimeType, description: "The date and time this meeting was withdrawn", null: true
+      field :withdrawn, GraphQL::Types::Boolean, "Whether this meeting has been withdrawn or not", method: :withdrawn?, null: true
+
+      field :attending_organizations, GraphQL::Types::String, "list of attending organizations", null: true
+      field :attendee_count, GraphQL::Types::Int, "Amount of attendees to this meeting", method: :attendees_count, null: true
+      field :contribution_count, GraphQL::Types::Int, "Amount of contributions to this meeting", method: :contributions_count, null: true
+
+      field :private_meeting, GraphQL::Types::Boolean, "Whether the meeting is private or not (it can only be true if transparent)", null: false
+      field :transparent, GraphQL::Types::Boolean, "For private meetings, information is public if transparent", null: false
+      field :registrations_enabled, GraphQL::Types::Boolean, "Whether the registrations are enabled or not", null: false
+      field :registration_terms, Decidim::Core::TranslatedFieldType, "The registration terms", null: true
+      field :remaining_slots, GraphQL::Types::Int, "Amount of slots available for this meeting", null: true
+      field :registration_form_enabled, GraphQL::Types::Boolean, "Whether the registrations have a form or not", null: false
+      field :registration_form, Decidim::Forms::QuestionnaireType, description: "If registration requires to fill a form, this is the questionnaire", null: true
+      field :location, Decidim::Core::TranslatedFieldType, "The location of this meeting (free format)", null: true
+      field :location_hints, Decidim::Core::TranslatedFieldType, "The location of this meeting (free format)", null: true
+      field :address, GraphQL::Types::String, "The physical address of this meeting (used for geolocation)", null: true
+      field :coordinates, Decidim::Core::CoordinatesType, "Physical coordinates for this meeting", null: true
+      field :type_of_meeting, GraphQL::Types::String, "The type of the meeting (online or in-person)", null: false
+      field :online_meeting_url, GraphQL::Types::String, "The URL of the meeting (when the type is online)", null: false
+      field :iframe_embed_type, GraphQL::Types::String, "The type of displaying of the online meeting URL", null: true
+
+      def registration_form
+        object.questionnaire if object.registration_form_enabled?
+      end
+
+      def agenda
+        object.agenda if object.agenda&.visible?
+      end
 
       def closing_report
         object.closing_report if object.closing_visible?
@@ -44,38 +70,9 @@ module Decidim
         object.audio_url if object.closing_visible?
       end
 
-      field :withdrawn_at, Decidim::Core::DateTimeType, description: "The date and time this meeting was withdrawn", null: true
-      field :withdrawn, GraphQL::Types::Boolean, "Whether this meeting has been withdrawn or not", method: :withdrawn?, null: true
-
-      field :created_at, Decidim::Core::DateTimeType, description: "The date and time this minutes was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, description: "The date and time this minutes was updated", null: true
-
-      field :attending_organizations, GraphQL::Types::String, "list of attending organizations", null: true
-      field :attendee_count, GraphQL::Types::Int, "Amount of attendees to this meeting", method: :attendees_count, null: true
-      field :contribution_count, GraphQL::Types::Int, "Amount of contributions to this meeting", method: :contributions_count, null: true
-
-      field :private_meeting, GraphQL::Types::Boolean, "Whether the meeting is private or not (it can only be true if transparent)", null: false
-      field :transparent, GraphQL::Types::Boolean, "For private meetings, information is public if transparent", null: false
-      field :registrations_enabled, GraphQL::Types::Boolean, "Whether the registrations are enabled or not", null: false
-      field :registration_terms, Decidim::Core::TranslatedFieldType, "The registration terms", null: true
-      field :remaining_slots, GraphQL::Types::Int, "Amount of slots available for this meeting", null: true
-      field :registration_form_enabled, GraphQL::Types::Boolean, "Whether the registrations have a form or not", null: false
-      field :registration_form, Decidim::Forms::QuestionnaireType, description: "If registration requires to fill a form, this is the questionnaire", null: true
-
-      def registration_form
-        object.questionnaire if object.registration_form_enabled?
-      end
-      field :location, Decidim::Core::TranslatedFieldType, "The location of this meeting (free format)", null: true
-      field :location_hints, Decidim::Core::TranslatedFieldType, "The location of this meeting (free format)", null: true
-      field :address, GraphQL::Types::String, "The physical address of this meeting (used for geolocation)", null: true
-      field :coordinates, Decidim::Core::CoordinatesType, "Physical coordinates for this meeting", null: true
-
       def coordinates
         [object.latitude, object.longitude]
       end
-      field :type_of_meeting, GraphQL::Types::String, "The type of the meeting (online or in-person)", null: false
-      field :online_meeting_url, GraphQL::Types::String, "The URL of the meeting (when the type is online)", null: false
-      field :iframe_embed_type, GraphQL::Types::String, "The type of displaying of the online meeting URL", null: true
 
       def self.authorized?(object, context)
         context[:meeting] = object

--- a/decidim-meetings/spec/types/integration_schema_spec.rb
+++ b/decidim-meetings/spec/types/integration_schema_spec.rb
@@ -119,9 +119,9 @@ describe "Decidim::Api::QueryType" do
         "latitude" => meeting.latitude.to_f,
         "longitude" => meeting.longitude.to_f
       },
-      "createdAt" => meeting.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => meeting.created_at.to_time.iso8601,
       "description" => { "translation" => meeting.description[locale] },
-      "endTime" => meeting.end_time.iso8601.to_s.gsub("Z", "+00:00"),
+      "endTime" => meeting.end_time.to_time.iso8601,
       "hasComments" => meeting.comment_threads.size.positive?,
       "id" => meeting.id.to_s,
       "location" => { "translation" => meeting.location[locale] },
@@ -139,12 +139,12 @@ describe "Decidim::Api::QueryType" do
           "title" => { "translation" => s.title[locale] }
         }
       end,
-      "startTime" => meeting.start_time.iso8601.to_s.gsub("Z", "+00:00"),
+      "startTime" => meeting.start_time.to_time.iso8601,
       "title" => { "translation" => meeting.title[locale] },
       "totalCommentsCount" => meeting.comments_count,
       "transparent" => meeting.transparent?,
       "type" => "Decidim::Meetings::Meeting",
-      "updatedAt" => meeting.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "updatedAt" => meeting.updated_at.to_time.iso8601,
       "userAllowedToComment" => meeting.user_allowed_to_comment?(current_user)
     }
   end

--- a/decidim-pages/lib/decidim/api/page_type.rb
+++ b/decidim-pages/lib/decidim/api/page_type.rb
@@ -3,13 +3,13 @@
 module Decidim
   module Pages
     class PageType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+
       description "A page"
 
       field :id, GraphQL::Types::ID, null: false
       field :title, Decidim::Core::TranslatedFieldType, "The title of this page (same as the component name).", null: false
       field :body, Decidim::Core::TranslatedFieldType, "The body of this page.", null: true
-      field :created_at, Decidim::Core::DateTimeType, "The time this page was created", null: false
-      field :updated_at, Decidim::Core::DateTimeType, "The time this page was updated", null: false
     end
   end
 end

--- a/decidim-pages/spec/types/integration_schema_spec.rb
+++ b/decidim-pages/spec/types/integration_schema_spec.rb
@@ -30,10 +30,10 @@ describe "Decidim::Api::QueryType" do
   let(:page_single_result) do
     {
       "body" => { "translation" => page.body[locale] },
-      "createdAt" => page.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => page.created_at.to_time.iso8601,
       "id" => page.id.to_s,
       "title" => { "translation" => page.title[locale] },
-      "updatedAt" => page.updated_at.iso8601.to_s.gsub("Z", "+00:00")
+      "updatedAt" => page.updated_at.to_time.iso8601
     }
   end
 

--- a/decidim-participatory_processes/lib/decidim/api/participatory_process_type.rb
+++ b/decidim-participatory_processes/lib/decidim/api/participatory_process_type.rb
@@ -7,6 +7,7 @@ module Decidim
       implements Decidim::Core::ParticipatorySpaceInterface
       implements Decidim::Core::ParticipatorySpaceResourceableInterface
       implements Decidim::Core::TaxonomizableInterface
+      implements Decidim::Core::TimestampsInterface
       implements Decidim::Core::AttachableInterface
       implements Decidim::Core::CategoriesContainerInterface
 
@@ -15,8 +16,6 @@ module Decidim
       field :id, GraphQL::Types::ID, "The internal ID for this participatory process", null: false
       field :slug, GraphQL::Types::String, null: false
       field :hashtag, GraphQL::Types::String, "The hashtag for this participatory process", null: true
-      field :created_at, Decidim::Core::DateTimeType, "The time this page was created", null: false
-      field :updated_at, Decidim::Core::DateTimeType, "The time this page was updated", null: false
       field :published_at, Decidim::Core::DateTimeType, "The time this page was published", null: false
       field :subtitle, Decidim::Core::TranslatedFieldType, "The subtitle of this participatory process.", null: true
       field :description, Decidim::Core::TranslatedFieldType, "The description of this participatory process.", null: true

--- a/decidim-participatory_processes/lib/decidim/api/participatory_process_type_type.rb
+++ b/decidim-participatory_processes/lib/decidim/api/participatory_process_type_type.rb
@@ -4,12 +4,12 @@ module Decidim
   module ParticipatoryProcesses
     # This type represents a ParticipatoryProcessType.
     class ParticipatoryProcessTypeType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+
       description "A participatory process type"
 
       field :id, GraphQL::Types::ID, "Unique ID of this participatory process type", null: false
       field :title, Decidim::Core::TranslatedFieldType, "The title of this participatory process type", null: true
-      field :created_at, Decidim::Core::DateTimeType, "The time this participatory process type was created", null: false
-      field :updated_at, Decidim::Core::DateTimeType, "The time this participatory process type was updated", null: false
       field :processes, [Decidim::ParticipatoryProcesses::ParticipatoryProcessType, { null: true }],
             description: "Lists all the participatory processes belonging to this type", null: false
     end

--- a/decidim-participatory_processes/spec/types/integration_schema_spec.rb
+++ b/decidim-participatory_processes/spec/types/integration_schema_spec.rb
@@ -158,7 +158,7 @@ describe "Decidim::Api::QueryType" do
       "attachments" => [],
       "categories" => [],
       "components" => components,
-      "createdAt" => participatory_process.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => participatory_process.created_at.to_time.iso8601,
       "description" => { "translation" => participatory_process.description[locale] },
       "developerGroup" => { "translation" => participatory_process.developer_group[locale] },
       "endDate" => participatory_process.end_date.to_s,
@@ -171,7 +171,7 @@ describe "Decidim::Api::QueryType" do
       "participatoryScope" => { "translation" => participatory_process.participatory_scope[locale] },
       "participatoryStructure" => { "translation" => participatory_process.participatory_structure[locale] },
       "promoted" => false,
-      "publishedAt" => participatory_process.published_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "publishedAt" => participatory_process.published_at.to_time.iso8601,
       "reference" => participatory_process.reference,
       "taxonomies" => [{ "id" => taxonomy.id.to_s, "name" => { "translation" => taxonomy.name[locale] }, "parent" => { "id" => taxonomy.parent_id.to_s }, "children" => taxonomy.children.map { |child| { "id" => child.id.to_s } } }],
       "shortDescription" => { "translation" => participatory_process.short_description[locale] },
@@ -182,7 +182,7 @@ describe "Decidim::Api::QueryType" do
       "target" => { "translation" => participatory_process.target[locale] },
       "title" => { "translation" => participatory_process.title[locale] },
       "type" => "Decidim::ParticipatoryProcess",
-      "updatedAt" => participatory_process.updated_at.iso8601.to_s.gsub("Z", "+00:00")
+      "updatedAt" => participatory_process.updated_at.to_time.iso8601
     }
   end
   let(:query) do

--- a/decidim-proposals/lib/decidim/api/proposal_type.rb
+++ b/decidim-proposals/lib/decidim/api/proposal_type.rb
@@ -22,10 +22,6 @@ module Decidim
       field :address, GraphQL::Types::String, "The physical address (location) of this proposal", null: true
       field :coordinates, Decidim::Core::CoordinatesType, "Physical coordinates for this proposal", null: true
 
-      def coordinates
-        [object.latitude, object.longitude]
-      end
-
       field :reference, GraphQL::Types::String, "This proposal's unique reference", null: true
       field :state, GraphQL::Types::String, "The answer status in which proposal is in", null: true
       field :answer, Decidim::Core::TranslatedFieldType, "The answer feedback for the status for this proposal", null: true
@@ -44,11 +40,15 @@ module Decidim
       field :withdrawn_at, Decidim::Core::DateTimeType, description: "The date and time this proposal was withdrawn", null: true
       field :withdrawn, GraphQL::Types::Boolean, "Whether this proposal has been withdrawn or not", method: :withdrawn?, null: true
 
+      field :vote_count, GraphQL::Types::Int, description: "The total amount of votes the proposal has received", null: true
+
+      def coordinates
+        [object.latitude, object.longitude]
+      end
+
       def meeting
         object.authors.first if object.official_meeting?
       end
-
-      field :vote_count, GraphQL::Types::Int, description: "The total amount of votes the proposal has received", null: true
 
       def vote_count
         current_component = object.component

--- a/decidim-proposals/spec/types/integration_schema_spec.rb
+++ b/decidim-proposals/spec/types/integration_schema_spec.rb
@@ -134,7 +134,7 @@ describe "Decidim::Api::QueryType" do
       "commentsHaveAlignment" => proposal.comments_have_alignment?,
       "commentsHaveVotes" => proposal.comments_have_votes?,
       "coordinates" => { "latitude" => proposal.latitude, "longitude" => proposal.longitude },
-      "createdAt" => proposal.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => proposal.created_at.to_time.iso8601,
       "createdInMeeting" => proposal.created_in_meeting?,
       "endorsements" => proposal.endorsements.map do |e|
         { "deleted" => e.author.deleted?,
@@ -152,19 +152,19 @@ describe "Decidim::Api::QueryType" do
       "official" => proposal.official?,
       "participatoryTextLevel" => proposal.participatory_text_level,
       "position" => proposal.position,
-      "publishedAt" => proposal.published_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "publishedAt" => proposal.published_at.to_time.iso8601,
       "reference" => proposal.reference,
       "state" => proposal.state,
       "title" => { "translation" => proposal.title[locale] },
       "totalCommentsCount" => proposal.comments_count,
       "type" => "Decidim::Proposals::Proposal",
-      "updatedAt" => proposal.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "updatedAt" => proposal.updated_at.to_time.iso8601,
       "userAllowedToComment" => proposal.user_allowed_to_comment?(current_user),
       "versions" => [],
       "versionsCount" => 0,
       "voteCount" => proposal.votes.size,
       "withdrawn" => proposal.withdrawn?,
-      "withdrawnAt" => proposal.withdrawn_at&.iso8601&.to_s&.gsub("Z", "+00:00")
+      "withdrawnAt" => proposal.withdrawn_at&.to_time&.iso8601
     }
   end
 

--- a/decidim-sortitions/lib/decidim/api/sortition_type.rb
+++ b/decidim-sortitions/lib/decidim/api/sortition_type.rb
@@ -6,6 +6,7 @@ module Decidim
       implements Decidim::Core::AuthorableInterface
       implements Decidim::Comments::CommentableInterface
       implements Decidim::Core::TaxonomizableInterface
+      implements Decidim::Core::TimestampsInterface
 
       description "A sortition"
 
@@ -14,8 +15,6 @@ module Decidim
       field :target_items, GraphQL::Types::Int, "The target items for this sortition", null: true
       field :request_timestamp, Decidim::Core::DateType, "The request time stamp for this request", null: true
       field :selected_proposals, [GraphQL::Types::Int, { null: true }], "The selected proposals for this sortition", null: true
-      field :created_at, Decidim::Core::DateTimeType, "When this sortition was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, "When this sortition was updated", null: true
       field :witnesses, Decidim::Core::TranslatedFieldType, "The witnesses for this sortition", null: true
       field :additional_info, Decidim::Core::TranslatedFieldType, "The additional info for this sortition", null: true
       field :reference, GraphQL::Types::String, "The reference for this sortition", null: true

--- a/decidim-sortitions/spec/types/integration_schema_spec.rb
+++ b/decidim-sortitions/spec/types/integration_schema_spec.rb
@@ -59,7 +59,7 @@ describe "Decidim::Api::QueryType" do
       "comments" => [],
       "commentsHaveAlignment" => sortition.comments_have_alignment?,
       "commentsHaveVotes" => sortition.comments_have_votes?,
-      "createdAt" => sortition.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => sortition.created_at.to_time.iso8601,
       "dice" => sortition.dice,
       "hasComments" => sortition.comment_threads.size.positive?,
       "id" => sortition.id.to_s,
@@ -70,7 +70,7 @@ describe "Decidim::Api::QueryType" do
       "title" => { "translation" => sortition.title[locale] },
       "totalCommentsCount" => sortition.comments_count,
       "type" => "Decidim::Sortitions::Sortition",
-      "updatedAt" => sortition.updated_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "updatedAt" => sortition.updated_at.to_time.iso8601,
       "userAllowedToComment" => sortition.user_allowed_to_comment?(current_user),
       "witnesses" => { "translation" => sortition.witnesses[locale] }
     }

--- a/decidim-surveys/lib/decidim/api/survey_type.rb
+++ b/decidim-surveys/lib/decidim/api/survey_type.rb
@@ -3,11 +3,11 @@
 module Decidim
   module Surveys
     class SurveyType < Decidim::Api::Types::BaseObject
+      implements Decidim::Core::TimestampsInterface
+
       description "A survey"
 
       field :id, GraphQL::Types::ID, "The internal ID for this survey", null: false
-      field :created_at, Decidim::Core::DateTimeType, "The time this survey was created", null: true
-      field :updated_at, Decidim::Core::DateTimeType, "The time this survey was updated", null: true
       field :questionnaire, Decidim::Forms::QuestionnaireType, "The questionnaire for this survey", null: true
 
       def self.authorized?(object, context)

--- a/decidim-surveys/spec/types/integration_schema_spec.rb
+++ b/decidim-surveys/spec/types/integration_schema_spec.rb
@@ -58,10 +58,10 @@ describe "Decidim::Api::QueryType" do
   let(:survey_single_result) do
     survey.reload
     {
-      "createdAt" => survey.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+      "createdAt" => survey.created_at.to_time.iso8601,
       "id" => survey.id.to_s,
       "questionnaire" => {
-        "createdAt" => survey.questionnaire.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+        "createdAt" => survey.questionnaire.created_at.to_time.iso8601,
         "description" => { "translation" => survey.questionnaire.description[locale] },
         "forType" => "Decidim::Surveys::Survey",
         "id" => survey.questionnaire.id.to_s,
@@ -75,21 +75,21 @@ describe "Decidim::Api::QueryType" do
               }
             end,
             "body" => { "translation" => q.body[locale] },
-            "createdAt" => q.created_at.iso8601.to_s.gsub("Z", "+00:00"),
+            "createdAt" => q.created_at.to_time.iso8601,
             "description" => { "translation" => q.description[locale] },
             "id" => q.id.to_s,
             "mandatory" => q.mandatory?,
             "maxChoices" => q.max_choices,
             "position" => q.position,
             "questionType" => q.question_type,
-            "updatedAt" => q.updated_at.iso8601.to_s.gsub("Z", "+00:00")
+            "updatedAt" => q.updated_at.to_time.iso8601
           }
         end,
         "title" => { "translation" => survey.questionnaire.title[locale] },
         "tos" => { "translation" => survey.questionnaire.tos[locale] },
-        "updatedAt" => survey.questionnaire.updated_at.iso8601.to_s.gsub("Z", "+00:00")
+        "updatedAt" => survey.questionnaire.updated_at.to_time.iso8601
       },
-      "updatedAt" => survey.updated_at.iso8601.to_s.gsub("Z", "+00:00")
+      "updatedAt" => survey.updated_at.to_time.iso8601
     }
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am setting all the updated_at & created_at to the same format by ensuring that we are using already defined `Decidim::Core::TimestampsInterface`. 

#### Testing
1. Pipeline is green

:hearts: Thank you!
