### PR TITLE
Fix `GraphQL/UnnecessaryFieldAlias` rubocop offenses

### DIFF
--- a/decidim-accountability/lib/decidim/api/accountability_type.rb
+++ b/decidim-accountability/lib/decidim/api/accountability_type.rb
@@ -8,12 +8,12 @@ module Decidim
 
       field :results, Decidim::Accountability::ResultType.connection_type, null: true, connection: true
 
-      def results
-        Result.where(component: object).includes(:component)
-      end
-
       field :result, Decidim::Accountability::ResultType, null: true do
         argument :id, ID, required: true
+      end
+
+      def results
+        Result.where(component: object).includes(:component)
       end
 
       def result(**args)

--- a/decidim-budgets/lib/decidim/api/budgets_type.rb
+++ b/decidim-budgets/lib/decidim/api/budgets_type.rb
@@ -8,12 +8,12 @@ module Decidim
 
       field :budgets, Decidim::Budgets::BudgetType.connection_type, null: true, connection: true
 
-      def budgets
-        Budget.where(component: object).includes(:component)
-      end
-
       field :budget, Decidim::Budgets::BudgetType, null: true do
         argument :id, GraphQL::Types::ID, required: true
+      end
+
+      def budgets
+        Budget.where(component: object).includes(:component)
       end
 
       def budget(**args)

--- a/decidim-comments/lib/decidim/api/comment_mutation_type.rb
+++ b/decidim-comments/lib/decidim/api/comment_mutation_type.rb
@@ -8,12 +8,13 @@ module Decidim
 
       field :id, GraphQL::Types::ID, "The Comment's unique ID", null: false
 
+      field :down_vote, Decidim::Comments::CommentType, null: true
+
       field :up_vote, Decidim::Comments::CommentType, null: true
       def up_vote(args: {})
         VoteCommentResolver.new(weight: 1).call(object, args, context)
       end
 
-      field :down_vote, Decidim::Comments::CommentType, null: true
       def down_vote(args: {})
         VoteCommentResolver.new(weight: -1).call(object, args, context)
       end

--- a/decidim-comments/lib/decidim/api/comment_type.rb
+++ b/decidim-comments/lib/decidim/api/comment_type.rb
@@ -15,19 +15,19 @@ module Decidim
 
       field :sgid, GraphQL::Types::String, "The Comment's signed global id", null: false
 
-      field :body, GraphQL::Types::String, "The comment message", null: false
+      field :body, GraphQL::Types::String, "The comment message", null: false, method: :translated_body
 
       field :formatted_body, GraphQL::Types::String, "The comment message ready to display (it is expected to include HTML)", null: false
 
-      field :formatted_created_at, GraphQL::Types::String, "The creation date of the comment in relative format", null: false
+      field :formatted_created_at, GraphQL::Types::String, "The creation date of the comment in relative format", null: false, method: :friendly_created_at
 
       field :alignment, GraphQL::Types::Int, "The comment's alignment. Can be 0 (neutral), 1 (in favor) or -1 (against)'", null: true
 
-      field :up_votes, GraphQL::Types::Int, "The number of comment's upVotes", null: false
+      field :up_votes, GraphQL::Types::Int, "The number of comment's upVotes", null: false, method: :up_votes_count
 
       field :up_voted, GraphQL::Types::Boolean, "Check if the current user has upvoted the comment", null: false
 
-      field :down_votes, GraphQL::Types::Int, "The number of comment's downVotes", null: false
+      field :down_votes, GraphQL::Types::Int, "The number of comment's downVotes", null: false, method: :down_votes_count
 
       field :down_voted, GraphQL::Types::Boolean, "Check if the current user has downvoted the comment", null: false
 
@@ -45,24 +45,8 @@ module Decidim
         object.to_sgid.to_s
       end
 
-      def body
-        object.translated_body
-      end
-
-      def formatted_created_at
-        object.friendly_created_at
-      end
-
-      def up_votes
-        object.up_votes_count
-      end
-
       def up_voted
         object.up_voted_by?(context[:current_user])
-      end
-
-      def down_votes
-        object.down_votes_count
       end
 
       def down_voted

--- a/decidim-core/lib/decidim/api/interfaces/author_interface.rb
+++ b/decidim-core/lib/decidim/api/interfaces/author_interface.rb
@@ -9,6 +9,9 @@ module Decidim
       description "An author"
 
       field :id, ID, "The author ID", null: false
+
+      field :deleted, Boolean, "Whether the author's account has been deleted or not", null: false
+
       field :name, String, "The author's name", null: false
       field :nickname, String, "The author's nickname", null: false
 
@@ -20,8 +23,6 @@ module Decidim
       def organization_name
         object.organization.name
       end
-
-      field :deleted, Boolean, "Whether the author's account has been deleted or not", null: false
 
       def self.resolve_type(obj, _ctx)
         return Decidim::Core::UserType if obj.is_a? Decidim::User

--- a/decidim-core/lib/decidim/api/interfaces/coauthorable_interface.rb
+++ b/decidim-core/lib/decidim/api/interfaces/coauthorable_interface.rb
@@ -12,6 +12,11 @@ module Decidim
             description: "The total amount of co-authors that contributed to the entity. Note that this field may include also non-user authors like meetings or the organization",
             null: true
 
+      field :authors, [Decidim::Core::AuthorInterface, { null: true }],
+            method: :user_identities,
+            description: "The resource co-authors. Include only users or groups of users",
+            null: false
+
       field :author, Decidim::Core::AuthorInterface,
             description: "The resource author. Note that this can be null on official proposals or meeting-proposals",
             null: true
@@ -20,11 +25,6 @@ module Decidim
         author = object.creator_identity
         author if author.is_a?(Decidim::User) || author.is_a?(Decidim::UserGroup)
       end
-
-      field :authors, [Decidim::Core::AuthorInterface, { null: true }],
-            method: :user_identities,
-            description: "The resource co-authors. Include only users or groups of users",
-            null: false
     end
   end
 end

--- a/decidim-core/lib/decidim/api/interfaces/endorsable_interface.rb
+++ b/decidim-core/lib/decidim/api/interfaces/endorsable_interface.rb
@@ -9,11 +9,11 @@ module Decidim
 
       field :endorsements, [Decidim::Core::AuthorInterface, { null: true }], "The endorsements of this object.", null: false
 
+      field :endorsements_count, Integer, description: "The total amount of endorsements the object has received", null: true
+
       def endorsements
         object.endorsements.map(&:normalized_author)
       end
-
-      field :endorsements_count, Integer, description: "The total amount of endorsements the object has received", null: true
     end
   end
 end

--- a/decidim-core/lib/decidim/api/interfaces/participatory_space_interface.rb
+++ b/decidim-core/lib/decidim/api/interfaces/participatory_space_interface.rb
@@ -9,6 +9,13 @@ module Decidim
 
       field :id, GraphQL::Types::ID, "The participatory space's unique ID", null: false
 
+      field :components, [ComponentInterface, { null: true }], null: true, description: "Lists the components this space contains." do
+        argument :filter, ComponentInputFilter, "Provides several methods to filter the results", required: false
+        argument :order, ComponentInputSort, "Provides several methods to order the results", required: false
+      end
+
+      field :stats, [Decidim::Core::StatisticType, { null: true }], null: true
+
       field :title, TranslatedFieldType, "The graphql_name of this participatory space.", null: false
 
       field :type, String, description: "The participatory space class name. i.e. Decidim::ParticipatoryProcess", null: false
@@ -23,16 +30,9 @@ module Decidim
         ParticipatorySpaceManifestPresenter.new(object.manifest, object.organization)
       end
 
-      field :components, [ComponentInterface, { null: true }], null: true, description: "Lists the components this space contains." do
-        argument :filter, ComponentInputFilter, "Provides several methods to filter the results", required: false
-        argument :order, ComponentInputSort, "Provides several methods to order the results", required: false
-      end
-
       def components(filter: {}, order: {})
         ComponentList.new.call(object, { filter:, order: }, context)
       end
-
-      field :stats, [Decidim::Core::StatisticType, { null: true }], null: true
 
       def stats
         return if object.respond_to?(:show_statistics) && !object.show_statistics

--- a/decidim-core/lib/decidim/api/types/taxonomy_type.rb
+++ b/decidim-core/lib/decidim/api/types/taxonomy_type.rb
@@ -7,15 +7,9 @@ module Decidim
 
       field :id, GraphQL::Types::ID, null: false
       field :name, Decidim::Core::TranslatedFieldType, "The name of this taxonomy.", null: false
-      field :is_root, Boolean, "Whether this taxonomy is a root taxonomy (root taxonomies have no parents).", null: false
+      field :is_root, Boolean, "Whether this taxonomy is a root taxonomy (root taxonomies have no parents).", null: false, method: :root?
       field :children, [Decidim::Core::TaxonomyType], "The children of this taxonomy.", null: false
       field :parent, Decidim::Core::TaxonomyType, "The parent of this taxonomy.", null: true
-
-      # rubocop:disable Naming/PredicateName
-      def is_root
-        object.root?
-      end
-      # rubocop:enable Naming/PredicateName
     end
   end
 end

--- a/decidim-core/lib/decidim/api/types/user_group_type.rb
+++ b/decidim-core/lib/decidim/api/types/user_group_type.rb
@@ -16,7 +16,7 @@ module Decidim
       field :organization_name, Decidim::Core::TranslatedFieldType, "The user group's organization name", null: false
       field :deleted, GraphQL::Types::Boolean, "Whether the user group's has been deleted or not", null: false
       field :badge, GraphQL::Types::String, "A badge for the user group", null: false
-      field :members, [Decidim::Core::UserType, { null: true }], "Members of this group", null: false
+      field :members, [Decidim::Core::UserType, { null: true }], "Members of this group", null: false, method: :accepted_users
       field :members_count, GraphQL::Types::Int, "Number of members in this group", null: false
 
       def nickname
@@ -41,10 +41,6 @@ module Decidim
 
       def badge
         object.presenter.badge
-      end
-
-      def members
-        object.accepted_users
       end
 
       def members_count

--- a/decidim-core/lib/decidim/api/types/user_type.rb
+++ b/decidim-core/lib/decidim/api/types/user_type.rb
@@ -29,7 +29,7 @@ module Decidim
 
       field :badge, GraphQL::Types::String, "A badge for the user group", null: false
 
-      field :groups, [Decidim::Core::UserGroupType, { null: true }], "Groups where this user belongs", null: false
+      field :groups, [Decidim::Core::UserGroupType, { null: true }], "Groups where this user belongs", null: false, method: :accepted_user_groups
 
       def nickname
         object.presenter.nickname
@@ -57,10 +57,6 @@ module Decidim
 
       def badge
         object.presenter.badge
-      end
-
-      def groups
-        object.accepted_user_groups
       end
 
       def self.authorized?(object, context)

--- a/decidim-debates/lib/decidim/api/debates_type.rb
+++ b/decidim-debates/lib/decidim/api/debates_type.rb
@@ -8,12 +8,12 @@ module Decidim
 
       field :debates, Decidim::Debates::DebateType.connection_type, null: true, connection: true
 
-      def debates
-        Debate.where(component: object).includes(:component)
-      end
-
       field :debate, Decidim::Debates::DebateType, null: true do
         argument :id, GraphQL::Types::ID, required: true
+      end
+
+      def debates
+        Debate.where(component: object).includes(:component)
       end
 
       def debate(**args)

--- a/decidim-dev/config/rubocop/graphql.yml
+++ b/decidim-dev/config/rubocop/graphql.yml
@@ -35,5 +35,3 @@ GraphQL/PrepareMethod:
 GraphQL/ArgumentDescription:
   Enabled: false
 
-GraphQL/UnnecessaryFieldAlias:
-  Enabled: false

--- a/decidim-dev/config/rubocop/graphql.yml
+++ b/decidim-dev/config/rubocop/graphql.yml
@@ -11,13 +11,7 @@ GraphQL:
 GraphQL/FieldDescription:
   Enabled: false
 
-GraphQL/FieldDefinitions:
-  Enabled: false
-
 GraphQL/OrderedFields:
-  Enabled: false
-
-GraphQL/FieldMethod:
   Enabled: false
 
 GraphQL/OrderedArguments:

--- a/decidim-initiatives/lib/decidim/api/initiative_api_type.rb
+++ b/decidim-initiatives/lib/decidim/api/initiative_api_type.rb
@@ -17,7 +17,7 @@ module Decidim
       field :minimum_committee_members, GraphQL::Types::Int, "Minimum of committee members", null: true
       field :validate_sms_code_on_votes, GraphQL::Types::Boolean, "Add SMS code validation step to signature process", null: true
       field :undo_online_signatures_enabled, GraphQL::Types::Boolean, "Enable participants to undo their online signatures", null: true
-      field :promoting_committee_enabled, GraphQL::Types::Boolean, "If promoting committee is enabled", method: :promoting_committee_enabled, null: true
+      field :promoting_committee_enabled, GraphQL::Types::Boolean, "If promoting committee is enabled", null: true
       field :signature_type, GraphQL::Types::String, "Signature type of the initiative", null: true
 
       field :initiatives, [Decidim::Initiatives::InitiativeType, { null: true }], "The initiatives that have this type", null: false

--- a/decidim-initiatives/lib/decidim/api/initiative_type.rb
+++ b/decidim-initiatives/lib/decidim/api/initiative_type.rb
@@ -13,6 +13,9 @@ module Decidim
       description "A initiative"
 
       field :description, Decidim::Core::TranslatedFieldType, "The description of this initiative.", null: true
+
+      field :committee_members, [Decidim::Initiatives::InitiativeCommitteeMemberType, { null: true }], null: true
+
       field :slug, GraphQL::Types::String, null: false
       field :hashtag, GraphQL::Types::String, "The hashtag for this initiative", null: true
       field :published_at, Decidim::Core::DateTimeType, "The time this initiative was published", null: false
@@ -26,7 +29,7 @@ module Decidim
       field :initiative_votes_count, GraphQL::Types::Int,
             description: "The number of votes in this initiative",
             deprecation_reason: "initiativeVotesCount has been collapsed in onlineVotes parameter",
-            null: true
+            null: true, method: :online_votes_count
       field :initiative_supports_count, GraphQL::Types::Int,
             description: "The number of supports in this initiative",
             method: :online_votes_count,
@@ -35,15 +38,9 @@ module Decidim
 
       field :author, Decidim::Core::AuthorInterface, "The initiative author", null: false
 
-      def initiative_votes_count
-        object.online_votes_count
-      end
-
       def author
         object.user_group || object.author
       end
-
-      field :committee_members, [Decidim::Initiatives::InitiativeCommitteeMemberType, { null: true }], null: true
     end
   end
 end

--- a/decidim-initiatives/lib/decidim/api/initiative_type_interface.rb
+++ b/decidim-initiatives/lib/decidim/api/initiative_type_interface.rb
@@ -8,11 +8,7 @@ module Decidim
       include Decidim::Api::Types::BaseInterface
       description "An interface that can be used in Initiative objects."
 
-      field :initiative_type, Decidim::Initiatives::InitiativeApiType, "The object's initiative type", null: true
-
-      def initiative_type
-        object.type
-      end
+      field :initiative_type, Decidim::Initiatives::InitiativeApiType, "The object's initiative type", null: true, method: :type
     end
   end
 end

--- a/decidim-meetings/lib/decidim/api/meetings_type.rb
+++ b/decidim-meetings/lib/decidim/api/meetings_type.rb
@@ -8,12 +8,12 @@ module Decidim
 
       field :meetings, Decidim::Meetings::MeetingType.connection_type, null: true, connection: true
 
-      def meetings
-        Meeting.published.visible.where(component: object).includes(:component)
-      end
-
       field :meeting, Decidim::Meetings::MeetingType, null: true do
         argument :id, GraphQL::Types::ID, required: true
+      end
+
+      def meetings
+        Meeting.published.visible.where(component: object).includes(:component)
       end
 
       def meeting(**args)

--- a/decidim-pages/lib/decidim/api/pages_type.rb
+++ b/decidim-pages/lib/decidim/api/pages_type.rb
@@ -8,12 +8,12 @@ module Decidim
 
       field :pages, Decidim::Pages::PageType.connection_type, null: true, connection: true
 
-      def pages
-        Page.where(component: object).includes(:component)
-      end
-
       field :page, Decidim::Pages::PageType, null: true do
         argument :id, GraphQL::Types::ID, required: true
+      end
+
+      def pages
+        Page.where(component: object).includes(:component)
       end
 
       def page(**args)

--- a/decidim-sortitions/lib/decidim/api/sortitions_type.rb
+++ b/decidim-sortitions/lib/decidim/api/sortitions_type.rb
@@ -8,12 +8,12 @@ module Decidim
 
       field :sortitions, Decidim::Sortitions::SortitionType.connection_type, null: true, connection: true
 
-      def sortitions
-        Sortition.where(component: object).includes(:component)
-      end
-
       field :sortition, Decidim::Sortitions::SortitionType, null: true do
         argument :id, GraphQL::Types::ID, required: true
+      end
+
+      def sortitions
+        Sortition.where(component: object).includes(:component)
       end
 
       def sortition(**args)

--- a/decidim-surveys/lib/decidim/api/surveys_type.rb
+++ b/decidim-surveys/lib/decidim/api/surveys_type.rb
@@ -8,12 +8,12 @@ module Decidim
 
       field :surveys, Decidim::Surveys::SurveyType.connection_type, null: true, connection: true
 
-      def surveys
-        Survey.where(component: object).includes(:component)
-      end
-
       field :survey, Decidim::Surveys::SurveyType, null: true do
         argument :id, GraphQL::Types::ID, required: true
+      end
+
+      def surveys
+        Survey.where(component: object).includes(:component)
       end
 
       def survey(**args)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes `GraphQL/UnnecessaryFieldAlias` rubocop offenses

#### :pushpin: Related Issues
*Link your PR to an issue*
- Requires #14000 to be merged before

#### Testing
1. Pipeline is green

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
