### PR TITLE
Fix `GraphQL/ArgumentDescription` rubocop offenses

### DIFF
--- a/decidim-accountability/lib/decidim/api/accountability_type.rb
+++ b/decidim-accountability/lib/decidim/api/accountability_type.rb
@@ -9,7 +9,7 @@ module Decidim
       field :results, Decidim::Accountability::ResultType.connection_type, "A collection of Results", null: true, connection: true
 
       field :result, Decidim::Accountability::ResultType, "A single Result object", null: true do
-        argument :id, ID, required: true
+        argument :id, ID, "The id of the Result requested", required: true
       end
 
       def results

--- a/decidim-budgets/lib/decidim/api/budgets_type.rb
+++ b/decidim-budgets/lib/decidim/api/budgets_type.rb
@@ -9,7 +9,7 @@ module Decidim
       field :budgets, Decidim::Budgets::BudgetType.connection_type, "A collection of Budgets", null: true, connection: true
 
       field :budget, Decidim::Budgets::BudgetType, "A single Budget object", null: true do
-        argument :id, GraphQL::Types::ID, required: true
+        argument :id, GraphQL::Types::ID, "The id of the Budget requested", required: true
       end
 
       def budgets

--- a/decidim-debates/lib/decidim/api/debates_type.rb
+++ b/decidim-debates/lib/decidim/api/debates_type.rb
@@ -9,7 +9,7 @@ module Decidim
       field :debates, Decidim::Debates::DebateType.connection_type, "A collection of Debates", null: true, connection: true
 
       field :debate, Decidim::Debates::DebateType, "A single Debate object", null: true do
-        argument :id, GraphQL::Types::ID, required: true
+        argument :id, GraphQL::Types::ID, "The id of the Debate requested", required: true
       end
 
       def debates

--- a/decidim-dev/config/rubocop/graphql.yml
+++ b/decidim-dev/config/rubocop/graphql.yml
@@ -22,7 +22,3 @@ GraphQL/ExtractType:
 
 GraphQL/PrepareMethod:
   Enabled: false
-
-GraphQL/ArgumentDescription:
-  Enabled: false
-

--- a/decidim-meetings/lib/decidim/api/meetings_type.rb
+++ b/decidim-meetings/lib/decidim/api/meetings_type.rb
@@ -9,7 +9,7 @@ module Decidim
       field :meetings, Decidim::Meetings::MeetingType.connection_type, "A collection of Meetings", null: true, connection: true
 
       field :meeting, Decidim::Meetings::MeetingType, "A single Meeting object", null: true do
-        argument :id, GraphQL::Types::ID, required: true
+        argument :id, GraphQL::Types::ID, "The id of the Meeting requested", required: true
       end
 
       def meetings

--- a/decidim-pages/lib/decidim/api/pages_type.rb
+++ b/decidim-pages/lib/decidim/api/pages_type.rb
@@ -9,7 +9,7 @@ module Decidim
       field :pages, Decidim::Pages::PageType.connection_type, "A collection of Pages", null: true, connection: true
 
       field :page, Decidim::Pages::PageType, "A single Page object", null: true do
-        argument :id, GraphQL::Types::ID, required: true
+        argument :id, GraphQL::Types::ID, "The id of the Page requested", required: true
       end
 
       def pages

--- a/decidim-sortitions/lib/decidim/api/sortitions_type.rb
+++ b/decidim-sortitions/lib/decidim/api/sortitions_type.rb
@@ -9,7 +9,7 @@ module Decidim
       field :sortitions, Decidim::Sortitions::SortitionType.connection_type, "A collection of Sortitions", null: true, connection: true
 
       field :sortition, Decidim::Sortitions::SortitionType, "A single Sortition object", null: true do
-        argument :id, GraphQL::Types::ID, required: true
+        argument :id, GraphQL::Types::ID, "The id of the Sortition requested", required: true
       end
 
       def sortitions

--- a/decidim-surveys/lib/decidim/api/surveys_type.rb
+++ b/decidim-surveys/lib/decidim/api/surveys_type.rb
@@ -9,7 +9,7 @@ module Decidim
       field :surveys, Decidim::Surveys::SurveyType.connection_type, "A collection of Surveys", null: true, connection: true
 
       field :survey, Decidim::Surveys::SurveyType, "A single Survey object", null: true do
-        argument :id, GraphQL::Types::ID, required: true
+        argument :id, GraphQL::Types::ID, "The id of the Survey requested", required: true
       end
 
       def surveys


### PR DESCRIPTION
This PR fixes `GraphQL/ArgumentDescription` rubocop offenses

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14001

#### Testing
1. Green pipeline