### PR TITLE
Fix flaky on share token feature

### DIFF
--- a/decidim-core/app/models/decidim/share_token.rb
+++ b/decidim-core/app/models/decidim/share_token.rb
@@ -52,7 +52,7 @@ module Decidim
     end
 
     def self.ransackable_attributes(_auth_object = nil)
-      %w(token expires_at last_used_at registered_only)
+      %w(token expires_at last_used_at registered_only times_used)
     end
 
     def self.ransackable_associations(_auth_object = nil)


### PR DESCRIPTION
#### :tophat: What? Why?
While working on different PRs like : #13883, #13999, #13995, i have noticed that some specs in the participatory process, Assemblies and conferences were failing with the following output : 

```
2) Admin manages participatory process share tokens when the user is a process admin behaves like manage participatory space share tokens behaves like manage resource share tokens when there are tokens when ordering can be ordered by token and other attributes
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
       expected to find visible css "tbody tr:first-child" with text "1" within #<Capybara::Node::Element tag="div" path="/HTML/BODY[1]/MAIN[1]/DIV[1]/DIV[2]/DIV[2]/DIV[4]/DIV[1]/DIV[2]/DIV[1]"> but there were no matches. Also found "b 03/02/2025 23:29 Yes 3", which matched the selector but not all filters. 

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_participatory_process_share_tokens_when_the_user_is_a_process_admin_behaves_like_manage_participatory_space_share_tokens_behaves_like_manage_resource_share_tokens_w_747.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_participatory_process_share_tokens_when_the_user_is_a_process_admin_behaves_like_manage_participatory_space_share_tokens_behaves_like_manage_resource_share_tokens_w_747.html


     Shared Example Group: "manage resource share tokens" called from /home/runner/work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/manage_share_tokens_examples.rb:236
     Shared Example Group: "manage participatory space share tokens" called from ./spec/system/admin/admin_manages_participatory_process_share_tokens_spec.rb:17
     # /home/runner/work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/manage_share_tokens_examples.rb:109:in `block (5 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/manage_share_tokens_examples.rb:93:in `block (4 levels) in <top (required)>'
```



```
rspec './spec/system/admin/admin_manages_participatory_process_share_tokens_spec.rb[1:1:1:2:3:1]' # Admin manages participatory process share tokens behaves like manage participatory space share tokens behaves like manage resource share tokens when there are tokens when ordering can be ordered by token and other attributes
rspec './spec/system/admin/admin_manages_participatory_process_share_tokens_spec.rb[1:2:1:1:2:3:1]' # Admin manages participatory process share tokens when the user is a process admin behaves like manage participatory space share tokens behaves like manage resource share tokens when there are tokens when ordering can be ordered by token and other attributes
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/ade3746a-445c-40b7-be29-5273a029a555)

:hearts: Thank you!
