### PR TITLE
Backport 'Retries NPM installation a couple times to prevent network timeouts' to v0.29

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -513,6 +513,7 @@ marydoe
 Massot
 matrixmultiple
 matutes
+maxtimeout
 mcdoggo
 mcell
 medios
@@ -537,6 +538,7 @@ Milhouse
 millor
 Millora
 minicard
+mintimeout
 minuscat
 misogi
 mlat

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -46,6 +46,9 @@ jobs:
           node-version: ${{ inputs.node_version }}
           cache: 'npm'
           cache-dependency-path: ./package-lock.json
+      - run: npm config set fetch-retries 5 && npm config set fetch-retry-mintimeout 20000 && npm config set fetch-retry-maxtimeout 120000
+        name: Tune NPM configuration
+        shell: "bash"
       - uses: actions/cache@v4
         id: app-cache
         with:


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #13831 to v0.29

:hearts: Thank you!