### PR TITLE
Change preview icon on sortitions

### DIFF
--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
@@ -38,7 +38,7 @@
               <span class="action-space icon"></span>
             <% end %>
 
-            <%= icon_link_to "eye-line", sortition_path(sortition), t("actions.show", scope: "decidim.sortitions.admin"), class: "action-icon--preview", target: "_blank", data: { "external-link": false } %>
+            <%= icon_link_to "fullscreen-line", sortition_path(sortition), t("actions.show", scope: "decidim.sortitions.admin"), class: "action-icon--preview", target: "_blank", data: { "external-link": false } %>
 
             <%= resource_permissions_link(sortition) %>
 


### PR DESCRIPTION
#### :tophat: What? Why?
Previously the preview icon was the ```eye-line```. This is now changed in the Sortitions component within Processes to the correct icon ```fullscreen-line```.

#### :pushpin: Related Issues
- Fixes #13936 

#### Testing
1. Login
2. Create a sortition from a process 
3. Go to the index of sortitions
4. See the preview icon change to ```fullscreen-line```.

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/83080388-8b03-48fa-986c-7a26ab23a48c)

:hearts: Thank you!
