### PR TITLE
Removed New Newsletter button from templates

### DIFF
--- a/decidim-admin/app/views/decidim/admin/newsletter_templates/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletter_templates/index.html.erb
@@ -3,7 +3,6 @@
   <div class="item_show__header">
     <h1 class="item_show__header-title">
       <%= t ".title" %>
-      <%= link_to t("actions.newsletter.new", scope: "decidim.admin"), [:newsletter_templates], class: "button button__sm button__secondary expanded small new" %>
     </h1>
   </div>
 


### PR DESCRIPTION
#### :tophat: What? Why?
New Newsletter button existed on the Newsletter template panel which just redirected the user to the same window. This PR removes the button. 

#### :pushpin: Related Issues
- Fixes #13930 

#### Testing
1. Login
2. Go to admin dashboard and head to Newsletters
3. Create a new Newsletter
4. See the new Newsletter button is removed 

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/b12f2422-832d-4de9-adb6-884848ea15f6)

:hearts: Thank you!
