### PR TITLE
Initiative signing through direct verifications

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -169,7 +169,7 @@ end
 
 All the attributes of a workflow are optional except the registered name with which the workflow is registered. A flow without attributes uses default values that generate a direct signature process without steps.
 
-Signature workflows can be defined as ephemeral, in which case users can sign inititives without prior registration. For a workflow of this type to work correctly, an authorization handler form must be defined in `authorization_handler_form` and authorizations saving must not be disabled using the `save_authorizations` setting, in order to ensure that user verifications are saved based on the personal data they provide.
+Signature workflows can be defined as ephemeral, in which case users can sign initiatives without prior registration. For a workflow of this type to work correctly, an authorization handler form must be defined in `authorization_handler_form` and authorizations saving must not be disabled using the `save_authorizations` setting, in order to ensure that user verifications are saved based on the personal data they provide.
 
 To migrate old signature configurations review the One time actions section.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -169,6 +169,8 @@ end
 
 All the attributes of a workflow are optional except the registered name with which the workflow is registered. A flow without attributes uses default values that generate a direct signature process without steps.
 
+Signature workflows can be defined as ephemeral, in which case users can sign inititives without prior registration. For a workflow of this type to work correctly, an authorization handler form must be defined in `authorization_handler_form` and authorizations saving must not be disabled using the `save_authorizations` setting, in order to ensure that user verifications are saved based on the personal data they provide.
+
 To migrate old signature configurations review the One time actions section.
 
 In the process to extract the old initiatives vote form to a base handler a new secret has been added to extract the key used to encrypt the user metadata in the vote. This secret is available in the application calling `Decidim::Initiatives.signature_handler_encryption_secret` and is used in the base class `Decidim::Initiatives::SignatureHandler`.

--- a/decidim-core/app/cells/decidim/onboarding_action_message_cell.rb
+++ b/decidim-core/app/cells/decidim/onboarding_action_message_cell.rb
@@ -25,7 +25,7 @@ module Decidim
     private
 
     def onboarding_path
-      decidim_verifications.onboarding_pending_authorizations_path
+      onboarding_manager.authorization_path || decidim_verifications.onboarding_pending_authorizations_path
     end
 
     def onboarding_manager

--- a/decidim-core/app/commands/decidim/create_ephemeral_user.rb
+++ b/decidim-core/app/commands/decidim/create_ephemeral_user.rb
@@ -41,12 +41,18 @@ module Decidim
         locale: form.locale,
         tos_agreement: true,
         managed: true,
-        extended_data: { ephemeral: true, verified: form.verified }
+        extended_data: { ephemeral: true, verified: form.verified }.merge(onboarding_data)
       )
     end
 
     def confirm_user
       @user.confirm
+    end
+
+    def onboarding_data
+      return {} if form.onboarding_data.blank?
+
+      { OnboardingManager::DATA_KEY => form.onboarding_data.stringify_keys.transform_keys(&:underscore) }
     end
   end
 end

--- a/decidim-core/app/controllers/concerns/decidim/ephemeral_session_checker.rb
+++ b/decidim-core/app/controllers/concerns/decidim/ephemeral_session_checker.rb
@@ -30,7 +30,7 @@ module Decidim
       if onboarding_manager.valid?
         authorizations = action_authorized_to(onboarding_manager.action, **onboarding_manager.action_authorized_resources)
 
-        return redirect_to decidim_verifications.onboarding_pending_authorizations_path unless authorizations_permitted_paths?(authorizations, onboarding_manager)
+        return redirect_to pending_authorizations_path unless authorizations_permitted_paths?(authorizations, onboarding_manager)
 
         if authorizations.global_code == :unauthorized
           flash[:alert] = t("unauthorized", scope: "decidim.core.actions")
@@ -77,11 +77,15 @@ module Decidim
                      []
                    end
       paths_list.prepend(
-        decidim_verifications.onboarding_pending_authorizations_path,
+        pending_authorizations_path,
         decidim.page_path(terms_of_service_page)
       )
 
       paths_list.find { |el| /\A#{URI.parse(el).path}/.match?(request.path) }
+    end
+
+    def pending_authorizations_path
+      onboarding_manager.authorization_path || decidim_verifications.onboarding_pending_authorizations_path
     end
   end
 end

--- a/decidim-core/app/forms/decidim/ephemeral_user_form.rb
+++ b/decidim-core/app/forms/decidim/ephemeral_user_form.rb
@@ -10,6 +10,7 @@ module Decidim
     attribute :nickname
     attribute :organization
     attribute :verified, Boolean, default: false
+    attribute :onboarding_data, Hash, default: {}
 
     def name
       super || I18n.t("decidim.ephemeral_user", locale:)

--- a/decidim-core/app/packs/src/decidim/confirm.js
+++ b/decidim-core/app/packs/src/decidim/confirm.js
@@ -1,3 +1,5 @@
+import icon from "src/decidim/icon"
+
 /**
  * A custom confirm dialog for Decidim based on Foundation reveals.
  *
@@ -15,16 +17,21 @@ class ConfirmDialog {
     }
     this.$content = $("[data-confirm-modal-content]", this.$modal);
     this.$title = $("[data-dialog-title]", this.$modal);
+    this.$iconContainer = $(".confirm-modal-icon", this.$modal);
     this.$buttonConfirm = $("[data-confirm-ok]", this.$modal);
     this.$buttonCancel = $("[data-confirm-cancel]", this.$modal);
 
     window.Decidim.currentDialogs["confirm-modal"].open()
   }
 
-  confirm(message, title) {
+  confirm(message, title, iconName) {
     if (title) {
       this.$title.html(title);
     }
+    if (iconName) {
+      this.$iconContainer.html(icon(iconName, { width: null, height: null }));
+    }
+
     this.$content.html(message);
 
     this.$buttonConfirm.off("click");
@@ -55,9 +62,9 @@ class ConfirmDialog {
   }
 }
 
-const runConfirm = (message, sourceElement = null, title = null) => new Promise((resolve) => {
+const runConfirm = (message, sourceElement = null, opts = {}) => new Promise((resolve) => {
   const dialog = new ConfirmDialog(sourceElement);
-  dialog.confirm(message, title).then((answer) => {
+  dialog.confirm(message, opts.title, opts.iconName).then((answer) => {
     let completed = true;
     if (sourceElement) {
       completed = Rails.fire(sourceElement, "confirm:complete", [answer]);
@@ -77,7 +84,10 @@ const runConfirm = (message, sourceElement = null, title = null) => new Promise(
 // so for the moment this needs to be executed **before** Rails.start()
 const allowAction = (ev, element) => {
   const message = $(element).data("confirm");
-  const title = $(element).data("confirm-title");
+  const opts = {
+    title: $(element).data("confirm-title"),
+    iconName: $(element).data("confirm-icon")
+  };
   if (!message) {
     return true;
   }
@@ -86,7 +96,7 @@ const allowAction = (ev, element) => {
     return false;
   }
 
-  runConfirm(message, element, title).then((answer) => {
+  runConfirm(message, element, opts).then((answer) => {
     if (!answer) {
       return;
     }
@@ -98,6 +108,8 @@ const allowAction = (ev, element) => {
     $(element).removeAttr("data-confirm");
     $(element).data("confirm-title", null);
     $(element).removeAttr("data-confirm-title");
+    $(element).data("confirm-icon", null);
+    $(element).removeAttr("data-confirm-icon");
 
     // The submit button click events will not do anything if they are
     // dispatched as is. In these cases, just submit the underlying form.

--- a/decidim-core/app/packs/src/decidim/confirm.js
+++ b/decidim-core/app/packs/src/decidim/confirm.js
@@ -14,13 +14,17 @@ class ConfirmDialog {
       this.$source = $(sourceElement);
     }
     this.$content = $("[data-confirm-modal-content]", this.$modal);
+    this.$title = $("[data-dialog-title]", this.$modal);
     this.$buttonConfirm = $("[data-confirm-ok]", this.$modal);
     this.$buttonCancel = $("[data-confirm-cancel]", this.$modal);
 
     window.Decidim.currentDialogs["confirm-modal"].open()
   }
 
-  confirm(message) {
+  confirm(message, title) {
+    if (title) {
+      this.$title.html(title);
+    }
     this.$content.html(message);
 
     this.$buttonConfirm.off("click");
@@ -51,9 +55,9 @@ class ConfirmDialog {
   }
 }
 
-const runConfirm = (message, sourceElement = null) => new Promise((resolve) => {
+const runConfirm = (message, sourceElement = null, title = null) => new Promise((resolve) => {
   const dialog = new ConfirmDialog(sourceElement);
-  dialog.confirm(message).then((answer) => {
+  dialog.confirm(message, title).then((answer) => {
     let completed = true;
     if (sourceElement) {
       completed = Rails.fire(sourceElement, "confirm:complete", [answer]);
@@ -73,6 +77,7 @@ const runConfirm = (message, sourceElement = null) => new Promise((resolve) => {
 // so for the moment this needs to be executed **before** Rails.start()
 const allowAction = (ev, element) => {
   const message = $(element).data("confirm");
+  const title = $(element).data("confirm-title");
   if (!message) {
     return true;
   }
@@ -81,7 +86,7 @@ const allowAction = (ev, element) => {
     return false;
   }
 
-  runConfirm(message, element).then((answer) => {
+  runConfirm(message, element, title).then((answer) => {
     if (!answer) {
       return;
     }
@@ -91,6 +96,8 @@ const allowAction = (ev, element) => {
     // checking.
     $(element).data("confirm", null);
     $(element).removeAttr("data-confirm");
+    $(element).data("confirm-title", null);
+    $(element).removeAttr("data-confirm-title");
 
     // The submit button click events will not do anything if they are
     // dispatched as is. In these cases, just submit the underlying form.

--- a/decidim-core/app/packs/src/decidim/icon.js
+++ b/decidim-core/app/packs/src/decidim/icon.js
@@ -20,6 +20,8 @@ export default function icon(iconKey, attributes = {}) {
     const newKey = key.replace(/([A-Z])/g, (ucw) => `-${ucw[0].toLowerCase()}`);
     if (typeof htmlAttributes[key] === "undefined") {
       htmlAttributes[newKey] = iconAttributes[key];
+    } else if (iconAttributes[key] === null) {
+      Reflect.deleteProperty(htmlAttributes, newKey);
     } else {
       htmlAttributes[newKey] = `${htmlAttributes[newKey]} ${iconAttributes[key]}`;
     }

--- a/decidim-core/app/services/decidim/onboarding_manager.rb
+++ b/decidim-core/app/services/decidim/onboarding_manager.rb
@@ -171,6 +171,10 @@ module Decidim
       EngineRouter.main_proxy(component).root_path
     end
 
+    def authorization_path
+      @authorization_path ||= onboarding_data["authorization_path"].presence
+    end
+
     def expired?
       return unless ephemeral?
 

--- a/decidim-core/app/views/decidim/shared/_confirm_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_confirm_modal.html.erb
@@ -1,6 +1,6 @@
 <%= decidim_modal id: "confirm-modal" do %>
   <div data-dialog-container>
-    <%= icon "delete-bin-line" %>
+    <%= icon "delete-bin-line", class: "confirm-modal-icon" %>
     <h2 class="h2" data-dialog-title id="dialog-title-confirm-modal"><%= t("title", scope: "decidim.shared.confirm_modal") %></h2>
 
     <div data-confirm-modal-content></div>

--- a/decidim-core/app/views/layouts/decidim/header/_close_ephemeral_session.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_close_ephemeral_session.html.erb
@@ -5,7 +5,11 @@
         method: :delete,
         class: "main-bar__links-desktop__item",
         "aria-label": t("layouts.decidim.header.close"),
-        data: { close: "", confirm: t("layouts.decidim.header.confirm_close_ephemeral_session") }
+        data: {
+          close: "",
+          confirm: t("layouts.decidim.header.confirm_close_ephemeral_session"),
+          confirm_title: t("layouts.decidim.header.confirm_title_close_ephemeral_session")
+        }
      ) do %>
         <%= icon "close-line" %><span><%= t("layouts.decidim.header.close") %></span>
     <% end %>
@@ -20,6 +24,10 @@
       class: "text-secondary",
       type: :button,
       "aria-label": t("layouts.decidim.header.close"),
-      data: { close: "", confirm: t("layouts.decidim.header.confirm_close_ephemeral_session") }
+      data: {
+        close: "",
+        confirm: t("layouts.decidim.header.confirm_close_ephemeral_session"),
+        confirm_title: t("layouts.decidim.header.confirm_title_close_ephemeral_session")
+      }
     ) %>
 </div>

--- a/decidim-core/app/views/layouts/decidim/header/_close_ephemeral_session.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_close_ephemeral_session.html.erb
@@ -8,7 +8,8 @@
         data: {
           close: "",
           confirm: t("layouts.decidim.header.confirm_close_ephemeral_session"),
-          confirm_title: t("layouts.decidim.header.confirm_title_close_ephemeral_session")
+          confirm_title: t("layouts.decidim.header.confirm_title_close_ephemeral_session"),
+          confirm_icon: "logout-box-line"
         }
      ) do %>
         <%= icon "close-line" %><span><%= t("layouts.decidim.header.close") %></span>
@@ -27,7 +28,8 @@
       data: {
         close: "",
         confirm: t("layouts.decidim.header.confirm_close_ephemeral_session"),
-        confirm_title: t("layouts.decidim.header.confirm_title_close_ephemeral_session")
+        confirm_title: t("layouts.decidim.header.confirm_title_close_ephemeral_session"),
+        confirm_icon: "logout-box-line"
       }
     ) %>
 </div>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2084,7 +2084,8 @@ en:
         terms_of_service: Terms of Service
       header:
         close: Close
-        confirm_close_ephemeral_session: If you navigate out of this page, your session will be closed. Are you sure?
+        confirm_close_ephemeral_session: If you navigate away, your temporary session will be closed. However, all your progress and activity will be saved. If you have finished your activity, click Ok.
+        confirm_title_close_ephemeral_session: Before leaving this page…
         log_in: Log in
         main_menu: Main menu
         user_menu: User menu

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -392,6 +392,7 @@ module Decidim
 
         copy_file "dummy_signature_handler.rb", "app/services/dummy_signature_handler.rb"
         copy_file "dummy_signature_handler_form.html.erb", "app/views/decidim/initiatives/initiative_signatures/dummy_signature/_form.html.erb"
+        copy_file "dummy_signature_handler_form.html.erb", "app/views/decidim/initiatives/initiative_signatures/ephemeral_dummy_signature/_form.html.erb"
         copy_file "dummy_signature_handler_form.html.erb", "app/views/decidim/initiatives/initiative_signatures/dummy_signature_with_personal_data/_form.html.erb"
         copy_file "dummy_sms_mobile_phone_validator.rb", "app/services/dummy_sms_mobile_phone_validator.rb"
         copy_file "initiatives_initializer.rb", "config/initializers/decidim_initiatives.rb"

--- a/decidim-generators/lib/decidim/generators/app_templates/initiatives_initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initiatives_initializer.rb
@@ -9,6 +9,16 @@ Decidim::Initiatives::Signatures.register_workflow(:dummy_signature_handler) do 
   workflow.sms_mobile_phone_validator = "DummySmsMobilePhoneValidator"
 end
 
+Decidim::Initiatives::Signatures.register_workflow(:ephemeral_dummy_signature_handler) do |workflow|
+  workflow.form = "DummySignatureHandler"
+  workflow.ephemeral = true
+  workflow.authorization_handler_form = "DummyAuthorizationHandler"
+  workflow.action_authorizer = "DummySignatureHandler::DummySignatureActionAuthorizer"
+  workflow.promote_authorization_validation_errors = true
+  workflow.sms_verification = true
+  workflow.sms_mobile_phone_validator = "DummySmsMobilePhoneValidator"
+end
+
 Decidim::Initiatives::Signatures.register_workflow(:dummy_signature_with_sms_handler) do |workflow|
   workflow.sms_verification = true
 end

--- a/decidim-initiatives/README.md
+++ b/decidim-initiatives/README.md
@@ -84,6 +84,15 @@ Decidim::Initiatives::Signatures.register_workflow(:dummy_signature_handler) do 
   workflow.sms_mobile_phone_validator = "DummySmsMobilePhoneValidator"
 end
 
+Decidim::Initiatives::Signatures.register_workflow(:ephemeral_dummy_signature_handler) do |workflow|
+  workflow.form = "DummySignatureHandler"
+  workflow.ephemeral = true
+  workflow.authorization_handler_form = "DummyAuthorizationHandler"
+  workflow.action_authorizer = "DummySignatureHandler::DummySignatureActionAuthorizer"
+  workflow.promote_authorization_validation_errors = true
+  workflow.sms_verification = false
+end
+
 Decidim::Initiatives::Signatures.register_workflow(:legacy_signature_handler) do |workflow|
   workflow.form = "Decidim::Initiatives::LegacySignatureHandler"
   workflow.authorization_handler_form = "DummyAuthorizationHandler"
@@ -93,6 +102,8 @@ end
 ```
 
 All the attributes of a workflow are optional except the registered name with which the workflow is registered. A flow without attributes uses default values that generate a direct signature process without steps.
+
+Signature workflows can be defined as ephemeral, in which case users can sign inititives without prior registration. For a workflow of this type to work correctly, an authorization handler form must be defined in `authorization_handler_form` and authorizations saving must not be disabled using the `save_authorizations` setting, in order to ensure that user verifications are saved based on the personal data they provide.
 
 For more information about the definition of a signature workflow read the documentation of `Decidim::Initiatives::SignatureWorkflowManifest` and `Decidim::Initiatives::SignatureHandler`
 

--- a/decidim-initiatives/README.md
+++ b/decidim-initiatives/README.md
@@ -103,7 +103,7 @@ end
 
 All the attributes of a workflow are optional except the registered name with which the workflow is registered. A flow without attributes uses default values that generate a direct signature process without steps.
 
-Signature workflows can be defined as ephemeral, in which case users can sign inititives without prior registration. For a workflow of this type to work correctly, an authorization handler form must be defined in `authorization_handler_form` and authorizations saving must not be disabled using the `save_authorizations` setting, in order to ensure that user verifications are saved based on the personal data they provide.
+Signature workflows can be defined as ephemeral, in which case users can sign initiatives without prior registration. For a workflow of this type to work correctly, an authorization handler form must be defined in `authorization_handler_form` and authorizations saving must not be disabled using the `save_authorizations` setting, in order to ensure that user verifications are saved based on the personal data they provide.
 
 For more information about the definition of a signature workflow read the documentation of `Decidim::Initiatives::SignatureWorkflowManifest` and `Decidim::Initiatives::SignatureHandler`
 

--- a/decidim-initiatives/app/controllers/concerns/decidim/initiatives/has_signature_workflow.rb
+++ b/decidim-initiatives/app/controllers/concerns/decidim/initiatives/has_signature_workflow.rb
@@ -18,10 +18,7 @@ module Decidim
         private
 
         def signature_workflow_manifest
-          @signature_workflow_manifest ||= begin
-            handler_name = current_initiative.type.document_number_authorization_handler
-            Decidim::Initiatives::Signatures.find_workflow_manifest(handler_name) || Decidim::Initiatives::SignatureWorkflowManifest.new
-          end
+          @signature_workflow_manifest ||= current_initiative.type.signature_workflow_manifest || Decidim::Initiatives::SignatureWorkflowManifest.new
         end
 
         def signature_has_steps?

--- a/decidim-initiatives/app/controllers/concerns/decidim/initiatives/has_signature_workflow.rb
+++ b/decidim-initiatives/app/controllers/concerns/decidim/initiatives/has_signature_workflow.rb
@@ -11,9 +11,13 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
-        helper_method :signature_has_steps?
+        helper_method :signature_has_steps?, :ephemeral_signature_workflow?
 
         delegate :signature_form_class, :sms_mobile_phone_form_class, :sms_mobile_phone_validator_class, :sms_code_validator_class, to: :signature_workflow_manifest
+
+        def ephemeral_signature_workflow?
+          signature_workflow_manifest.ephemeral
+        end
 
         private
 

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
@@ -9,7 +9,9 @@ module Decidim
       include Decidim::Initiatives::HasSignatureWorkflow
 
       prepend_before_action :set_wizard_steps
-      before_action :authenticate_user!
+      before_action :authenticate_user!, unless: :ephemeral_signature_workflow?
+      skip_before_action :check_ephemeral_user_session
+
       before_action :authorize_wizard_step, only: [
         :fill_personal_data,
         :store_personal_data,

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
@@ -154,6 +154,8 @@ module Decidim
           check_session_personal_data
         end
 
+        return if @vote_form.blank?
+
         VoteInitiative.call(@vote_form) do
           on(:ok) do
             session[:initiative_vote_form] = {}

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -34,6 +34,7 @@ module Decidim
       helper_method :initiative_type, :available_initiative_types
 
       before_action :authorize_participatory_space, only: [:show]
+      skip_before_action :check_ephemeral_user_session, only: [:index, :show]
 
       # GET /initiatives
       def index

--- a/decidim-initiatives/app/models/decidim/initiatives_type.rb
+++ b/decidim-initiatives/app/models/decidim/initiatives_type.rb
@@ -52,5 +52,9 @@ module Decidim
     def self.log_presenter_class_for(_log)
       Decidim::Initiatives::AdminLog::InitiativesTypePresenter
     end
+
+    def signature_workflow_manifest
+      Decidim::Initiatives::Signatures.find_workflow_manifest(document_number_authorization_handler)
+    end
   end
 end

--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -171,7 +171,7 @@ module Decidim
         can_unvote = initiative.accepts_online_unvotes? &&
                      initiative.organization&.id == user.organization&.id &&
                      initiative.votes.where(author: user).any? &&
-                     authorized?(:vote, resource: initiative, permissions_holder: initiative.type)
+                     vote_authorized?
 
         toggle_allow(can_unvote)
       end

--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -170,8 +170,7 @@ module Decidim
 
         can_unvote = initiative.accepts_online_unvotes? &&
                      initiative.organization&.id == user.organization&.id &&
-                     initiative.votes.where(author: user).any? &&
-                     vote_authorized?
+                     initiative.votes.where(author: user).any?
 
         toggle_allow(can_unvote)
       end
@@ -196,8 +195,7 @@ module Decidim
       def can_vote?
         initiative.votes_enabled? &&
           initiative.organization&.id == user.organization&.id &&
-          initiative.votes.where(author: user).empty? &&
-          vote_authorized?
+          initiative.votes.where(author: user).empty?
       end
 
       def can_user_support?(initiative)
@@ -242,12 +240,6 @@ module Decidim
 
       def authorship_or_admin?
         initiative&.has_authorship?(user) || user.admin?
-      end
-
-      def vote_authorized?
-        return true if user.ephemeral? && ephemeral_signature_workflow?
-
-        authorized?(:vote, resource: initiative, permissions_holder: initiative.type)
       end
 
       def ephemeral_signature_workflow?

--- a/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
+++ b/decidim-initiatives/app/permissions/decidim/initiatives/permissions.rb
@@ -15,6 +15,7 @@ module Decidim
         read_public_initiative?
         search_initiative_types_and_scopes?
         request_membership?
+        ephemeral_vote_initiative?
 
         return permission_action unless user
 
@@ -149,6 +150,14 @@ module Decidim
         toggle_allow(can_vote?)
       end
 
+      def ephemeral_vote_initiative?
+        return unless permission_action.action == :vote &&
+                      permission_action.subject == :initiative &&
+                      user.blank?
+
+        toggle_allow(ephemeral_signature_workflow?)
+      end
+
       def authorized?(permission_action, resource: nil, permissions_holder: nil)
         return unless resource || permissions_holder
 
@@ -188,7 +197,7 @@ module Decidim
         initiative.votes_enabled? &&
           initiative.organization&.id == user.organization&.id &&
           initiative.votes.where(author: user).empty? &&
-          authorized?(:vote, resource: initiative, permissions_holder: initiative.type)
+          vote_authorized?
       end
 
       def can_user_support?(initiative)
@@ -233,6 +242,16 @@ module Decidim
 
       def authorship_or_admin?
         initiative&.has_authorship?(user) || user.admin?
+      end
+
+      def vote_authorized?
+        return true if user.ephemeral? && ephemeral_signature_workflow?
+
+        authorized?(:vote, resource: initiative, permissions_holder: initiative.type)
+      end
+
+      def ephemeral_signature_workflow?
+        initiative.type.signature_workflow_manifest&.ephemeral?
       end
     end
   end

--- a/decidim-initiatives/app/services/decidim/initiatives/signature_handler.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/signature_handler.rb
@@ -172,7 +172,7 @@ module Decidim
       end
 
       def already_voted?
-        Decidim::InitiativesVote.exists?(author: user)
+        Decidim::InitiativesVote.exists?(author: user, initiative:)
       end
 
       private

--- a/decidim-initiatives/app/services/decidim/initiatives/signature_handler.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/signature_handler.rb
@@ -169,6 +169,10 @@ module Decidim
         new.form_attributes.present?
       end
 
+      def already_voted?
+        Decidim::InitiativesVote.exists?(author: user)
+      end
+
       private
 
       # It is expected to validate that no other user has voted with the same

--- a/decidim-initiatives/app/services/decidim/initiatives/signature_handler.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/signature_handler.rb
@@ -24,12 +24,14 @@ module Decidim
       # The initiative to be signed
       attribute :initiative, Decidim::Initiative
 
+      attribute :tos_agreement, if: :ephemeral?
+
       validates :initiative, :user, presence: true
       validate :uniqueness
       validate :valid_metadata
       validate :valid_authorized_scopes
 
-      delegate :promote_authorization_validation_errors, :authorization_handler_form_class, to: :workflow_manifest
+      delegate :promote_authorization_validation_errors, :authorization_handler_form_class, :ephemeral?, to: :workflow_manifest
       delegate :scope, to: :initiative
 
       # A unique ID to be implemented by the signature handler that ensures
@@ -108,7 +110,9 @@ module Decidim
       # Params to be sent to the authorization handler. By default consists on
       # the metadata hash including the signer user
       def authorization_handler_params
-        metadata.merge(user:)
+        params = metadata.merge(user:)
+        params = params.merge(tos_agreement:) if ephemeral?
+        params
       end
 
       # The signature_scope_id can be defined in the signature workflow to be
@@ -144,7 +148,7 @@ module Decidim
       #
       # Returns an Array of Strings.
       def form_attributes
-        attributes.except("id", "user", "initiative").keys
+        attributes.except("id", "user", "initiative", "tos_agreement").keys
       end
 
       # The String partial path so Rails can render the handler as a form. This

--- a/decidim-initiatives/app/services/decidim/initiatives/signature_handler.rb
+++ b/decidim-initiatives/app/services/decidim/initiatives/signature_handler.rb
@@ -26,6 +26,8 @@ module Decidim
 
       attribute :tos_agreement, if: :ephemeral?
 
+      attribute :transfer_status
+
       validates :initiative, :user, presence: true
       validate :uniqueness
       validate :valid_metadata
@@ -148,7 +150,7 @@ module Decidim
       #
       # Returns an Array of Strings.
       def form_attributes
-        attributes.except("id", "user", "initiative", "tos_agreement").keys
+        attributes.except("id", "user", "initiative", "tos_agreement", "transfer_status").keys
       end
 
       # The String partial path so Rails can render the handler as a form. This

--- a/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/fill_personal_data.html.erb
@@ -20,6 +20,10 @@
     </small>
   </div>
 
+  <% if current_user.ephemeral? && !current_user.tos_accepted? %>
+    <%= render partial: "/decidim/verifications/authorizations/tos_acceptance_field", locals: { form: f } %>
+  <% end %>
+
   <div class="form__wrapper">
     <button type="submit" class="button button__lg button__secondary">
       <span><%= t(".continue") %></span>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_new_initiative_button.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_new_initiative_button.html.erb
@@ -1,9 +1,16 @@
 <% if Decidim::Initiatives.creation_enabled %>
   <% if available_initiative_types.size > 1 %>
     <% if current_user %>
-      <%= link_to create_initiative_path(:select_initiative_type), class: "!px-4 title-action__action button button__xl button__secondary w-full" do %>
-        <%= t("new_initiative", scope: "decidim.initiatives.initiatives.index_header") %>
-        <%= icon "add-fill" %>
+      <% if current_user.ephemeral? %>
+        <button class="!px-4 button button__xl button__secondary w-full" disabled>
+          <%= t("new_initiative", scope: "decidim.initiatives.initiatives.index_header") %>
+          <%= icon "add-fill" %>
+        </button>
+      <% else %>
+        <%= link_to create_initiative_path(:select_initiative_type), class: "!px-4 title-action__action button button__xl button__secondary w-full" do %>
+          <%= t("new_initiative", scope: "decidim.initiatives.initiatives.index_header") %>
+          <%= icon "add-fill" %>
+        <% end %>
       <% end %>
     <% else %>
       <% content_for(:redirect_after_login) { create_initiative_url(:select_initiative_type) } %>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -646,6 +646,9 @@ en:
           dummy_signature_with_sms_handler:
             description: Signature which only validates phone number looking for an existing authorization associated and checks SMS code
             name: Dummy Signature Handler With Only SMS
+          ephemeral_dummy_signature_handler:
+            description: Ephemeral signature which takes personal information from user, validates authorization and checks SMS code
+            name: Ephemeral Dummy Signature Handler
           legacy_signature_handler:
             description: Signature handler based on the old signature feature including the collection of personal data, the SMS step and validating the authorization with dummy_authorization_handler. Modify any parameter to adapt to the configuration used
             name: Legacy Signature Handler

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -493,7 +493,7 @@ en:
           invalid_data: Some of the personal data provided to verify your identity is not valid.
         finish:
           back_to_initiative: Back to initiative
-          title: Initiative signature accepted
+          title: You have signed the initiative
         sms_phone_number:
           confirmed_data: You have confirmed your data.
           continue: Sign initiative

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -698,7 +698,6 @@ en:
         actions:
           create: Create an initiative
           title: Actions
-          vote: Sign
   layouts:
     decidim:
       initiative_creation_header:

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -505,6 +505,7 @@ en:
           your_confirmation_code: Your confirmation code
       initiative_votes:
         create:
+          already_voted: Your signature had already been registered with your data.
           error: There was a problem signing the initiative.
           invalid: The data provided to sign the initiative is not valid.
           success_html: Congratulations! The <strong> %{title}</strong> initiative has been successfully signed.

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -32,7 +32,7 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
 
   participatory_space.register_resource(:initiatives_type) do |resource|
     resource.model_class_name = "Decidim::InitiativesType"
-    resource.actions = %w(vote create)
+    resource.actions = %w(create)
   end
 
   participatory_space.model_class_name = "Decidim::Initiative"

--- a/decidim-initiatives/lib/decidim/initiatives/signature_workflow_manifest.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/signature_workflow_manifest.rb
@@ -128,6 +128,15 @@ module Decidim
         authorization_handler_form&.safe_constantize
       end
 
+      # If no authorization handler is set the workflow will not be able to
+      # save the user verification attributes necessary to recover the user
+      # session or transfer their activities
+      def ephemeral?
+        return if authorization_handler_form_class.blank?
+
+        ephemeral
+      end
+
       def sms_mobile_phone_form_class
         return unless sms_verification
 

--- a/decidim-initiatives/lib/decidim/initiatives/signature_workflow_manifest.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/signature_workflow_manifest.rb
@@ -107,6 +107,7 @@ module Decidim
       attribute :sms_code_validator, String, default: nil
 
       validates :name, presence: true
+      validate :ephemeral_configuration
 
       alias key name
 
@@ -154,6 +155,13 @@ module Decidim
         return unless sms_verification
 
         sms_code_validator&.safe_constantize || Decidim::Initiatives::ValidateSmsCode
+      end
+
+      def ephemeral_configuration
+        return unless Rails.env.development?
+        return unless ephemeral
+
+        raise StandardError, "Wrong configuration of ephemeral signature workflow #{fullname}" if !save_authorizations || authorization_handler_form.blank?
       end
     end
   end

--- a/decidim-initiatives/lib/decidim/initiatives/signature_workflow_manifest.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/signature_workflow_manifest.rb
@@ -47,6 +47,14 @@ module Decidim
     #     class Decidim::Initiatives::DefaultSignatureAuthorizer is used,
     #     which inherits from Decidim::Verifications::DefaultActionAuthorizer
     #     and checks the authorization status. (default: true)
+    # - :ephemeral (Boolean) (optional) This option enables the possibility for
+    #     users to sign without prior registration through an ephemeral session.
+    #     To allow ephemeral sessions to be recovered o transferred to regular
+    #     users authorizations must be stored in the process so an
+    #     authorization_handler_form must be defined and the save_authorizations
+    #     option must not be set to false. If those settings are not properly
+    #     configured this option will be ignored and the workflow will not
+    #     allow ephemeral sessions. (default: false)
     # - :promote_authorization_validation_errors (Boolean) (optional) If set
     #     to true, errors in the personal data passed to the authorization
     #     handler form will be displayed next to the corresponding fields

--- a/decidim-initiatives/lib/decidim/initiatives/signature_workflow_manifest.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/signature_workflow_manifest.rb
@@ -128,11 +128,12 @@ module Decidim
         authorization_handler_form&.safe_constantize
       end
 
-      # If no authorization handler is set the workflow will not be able to
-      # save the user verification attributes necessary to recover the user
-      # session or transfer their activities
+      # If no authorization handler is set or the save_authorizations option
+      # is disabled the workflow will not be able to save the user verification
+      # attributes necessary to recover the user session or transfer their
+      # activities
       def ephemeral?
-        return if authorization_handler_form_class.blank?
+        return if authorization_handler_form_class.blank? || !save_authorizations
 
         ephemeral
       end

--- a/decidim-initiatives/lib/decidim/initiatives/validatable_authorizations.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/validatable_authorizations.rb
@@ -44,6 +44,15 @@ module Decidim
 
         def create_authorization
           Decidim::Verifications::AuthorizeUser.call(authorization_handler, initiative.organization) do
+            on(:transferred) do |transfer|
+              self.transfer_status = transfer
+            end
+
+            on(:transfer_user) do |authorized_user|
+              self.user = authorized_user
+              self.transfer_status = :transfer_user
+            end
+
             on(:invalid) do
               return Decidim::Authorization.new
             end

--- a/decidim-initiatives/lib/decidim/initiatives/validatable_authorizations.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/validatable_authorizations.rb
@@ -24,8 +24,9 @@ module Decidim
         def authorization
           return unless user && authorization_handler_form_class
 
-          @authorization ||= if authorization_query.exists? && authorization_query.first.unique_id == authorization_handler.unique_id
-                               authorization_query.first
+          persisted_authorization = authorization_query.first
+          @authorization ||= if persisted_authorization.present? && persisted_authorization.unique_id == authorization_handler.unique_id
+                               persisted_authorization
                              elsif save_authorizations
                                create_authorization
                              else
@@ -62,7 +63,7 @@ module Decidim
         end
 
         def authorization_query
-          @authorization_query ||= Verifications::Authorizations.new(**authorization_params)
+          Verifications::Authorizations.new(**authorization_params)
         end
 
         def new_authorization

--- a/decidim-initiatives/spec/commands/decidim/initiatives/vote_initiative_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/vote_initiative_spec.rb
@@ -272,8 +272,20 @@ module Decidim
               context "when authorization is not fully granted" do
                 let(:granted_at) { nil }
 
-                it "broadcasts invalid" do
-                  expect { command_with_personal_data.call }.to broadcast :invalid
+                context "and the workflow saves authorizations" do
+                  it "renews the authorization" do
+                    expect { command_with_personal_data.call }.to broadcast :ok
+                  end
+                end
+
+                context "and the workflow does not save the authorization" do
+                  before do
+                    allow(workflow_manifest).to receive(:save_authorizations).and_return(false)
+                  end
+
+                  it "does not renew the authorization and broadcasts invalid" do
+                    expect { command_with_personal_data.call }.to broadcast :invalid
+                  end
                 end
               end
             end

--- a/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
+++ b/decidim-initiatives/spec/permissions/decidim/initiatives/permissions_spec.rb
@@ -43,42 +43,6 @@ describe Decidim::Initiatives::Permissions do
 
       it { is_expected.to be false }
     end
-
-    context "when the initiative type has permissions to vote" do
-      before do
-        initiative.type.create_resource_permission(
-          permissions: {
-            "vote" => {
-              "authorization_handlers" => {
-                "dummy_authorization_handler" => { "options" => {} },
-                "another_dummy_authorization_handler" => { "options" => {} }
-              }
-            }
-          }
-        )
-      end
-
-      context "when user is not verified" do
-        it { is_expected.to be false }
-      end
-
-      context "when user is not fully verified" do
-        before do
-          create(:authorization, name: "dummy_authorization_handler", user:, granted_at: 2.seconds.ago)
-        end
-
-        it { is_expected.to be false }
-      end
-
-      context "when user is fully verified" do
-        before do
-          create(:authorization, name: "dummy_authorization_handler", user:, granted_at: 2.seconds.ago)
-          create(:authorization, name: "another_dummy_authorization_handler", user:, granted_at: 2.seconds.ago)
-        end
-
-        it { is_expected.to be true }
-      end
-    end
   end
 
   context "when the action is for the admin part" do

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_type_permissions_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_type_permissions_spec.rb
@@ -15,7 +15,7 @@ describe "Admin manages initiative type permissions" do
   let(:participatory_space_engine) { decidim_admin_initiatives }
   let!(:initiative_type) { create(:initiatives_type, organization:) }
 
-  let(:action) { "vote" }
+  let(:action) { "create" }
 
   let(:index_path) do
     participatory_space_engine.initiatives_types_path

--- a/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
@@ -303,8 +303,6 @@ describe "Initiative signing with ephemeral workflows" do
         end
 
         before do
-          skip "Enable this test after merging https://github.com/decidim/decidim/pull/13981"
-
           login_as regular_user, scope: :user
           visit decidim_initiatives.initiative_path(initiative)
           within ".initiative__aside" do

--- a/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
@@ -331,7 +331,7 @@ describe "Initiative signing with ephemeral workflows" do
     fill_in :dummy_signature_handler_name_and_surname, with: data[:name_and_surname]
     select I18n.t(data[:document_type], scope: "decidim.verifications.id_documents"), from: :dummy_signature_handler_document_type
     fill_in :dummy_signature_handler_document_number, with: data[:document_number]
-    fill_date data[:date_of_birth]
+    fill_signature_date data[:date_of_birth]
     select I18n.t(data[:gender], scope: "decidim.initiatives.initiative_signatures.dummy_signature.form.fields.gender.options"), from: :dummy_signature_handler_gender
     fill_in :dummy_signature_handler_postal_code, with: data[:postal_code]
     select translated_attribute(initiative.scope.name), from: :dummy_signature_handler_scope_id

--- a/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
@@ -1,0 +1,357 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/initiatives/test/initiatives_signatures_test_helpers"
+
+describe "Initiative signing with ephemeral workflows" do
+  let(:organization) { create(:organization, available_authorizations: authorizations) }
+  let(:scoped_type) { create(:initiatives_type_scope, supports_required: 4, type: initiatives_type) }
+  let(:initiative) { create(:initiative, organization:, scoped_type:) }
+  let(:initiatives_type) do
+    create(
+      :initiatives_type,
+      :online_signature_enabled,
+      organization:,
+      document_number_authorization_handler: "dummy_signature_handler"
+    )
+  end
+  let(:authorizations) { %w(dummy_authorization_handler sms) }
+  let(:workflow_attributes) { base_workflow_attributes.merge(extra_workflow_attributes) }
+  let(:base_workflow_attributes) { { ephemeral: true } }
+  let(:extra_workflow_attributes) { {} }
+  let(:test_handler) { Decidim::Initiatives::SignatureWorkflowManifest.new(**workflow_attributes) }
+  let(:document_number) { "012345678X" }
+  let!(:personal_data) do
+    {
+      name_and_surname: "Dan Dan",
+      document_type: "identification_number",
+      document_number:,
+      gender: DummySignatureHandler::AVAILABLE_GENDERS.last,
+      date_of_birth: 30.years.ago.to_date,
+      postal_code: "01234"
+    }
+  end
+  let(:promote_authorization_validation_errors) { false }
+
+  shared_examples "preventing ephemeral session creation" do
+    it "the user is not allowed to sign and no session is created" do
+      expect do
+        expect do
+          within ".initiative__aside" do
+            click_on "Sign"
+          end
+
+          expect(page).to have_no_content "Already signed"
+          expect(page).to have_content "Please log in"
+        end.not_to change(Decidim::InitiativesVote, :count)
+      end.not_to change(Decidim::User, :count)
+    end
+  end
+
+  before do
+    allow(Decidim::Initiatives::Signatures)
+      .to receive(:find_workflow_manifest)
+      .with("dummy_signature_handler")
+      .and_return(test_handler)
+    switch_to_host(organization.host)
+    visit decidim_initiatives.initiative_path(initiative)
+  end
+
+  context "when the workflow only enables the ephemeral feature" do
+    it_behaves_like "preventing ephemeral session creation"
+  end
+
+  context "when the worflow only contains SMS step without personal data collection" do
+    let(:extra_workflow_attributes) do
+      {
+        sms_verification: true,
+        sms_mobile_phone_validator: "DummySmsMobilePhoneValidator",
+        sms_mobile_phone_form: "DummySmsMobilePhoneForm"
+      }
+    end
+
+    it_behaves_like "preventing ephemeral session creation"
+  end
+
+  context "when the workflow collects personal data" do
+    let(:base_workflow_attributes) do
+      {
+        ephemeral: true,
+        form: "DummySignatureHandler"
+      }
+    end
+
+    context "and no authorization hanldler form is defined" do
+      it_behaves_like "preventing ephemeral session creation"
+    end
+
+    context "and an authorization handler form is defined with save_authorizations disabled" do
+      let(:extra_workflow_attributes) do
+        {
+          authorization_handler_form: "DummyAuthorizationHandler",
+          save_authorizations: false
+        }
+      end
+
+      it_behaves_like "preventing ephemeral session creation"
+    end
+
+    context "and an authorization handler form is defined" do
+      let(:extra_workflow_attributes) { { authorization_handler_form: "DummyAuthorizationHandler" } }
+
+      shared_examples "creating ephemeral session" do
+        it "an ephemeral session is created and the user is redirected to fill personal data" do
+          expect do
+            within ".initiative__aside" do
+              click_on "Sign"
+            end
+
+            expect(page).to have_content "Verify with Dummy Signature Handler"
+            expect(page).to have_css("form.new_dummy_signature_handler")
+          end.to change(Decidim::User.ephemeral, :count).by(1)
+        end
+      end
+
+      shared_examples "creating an authorization" do
+        it "displays a mandatory tos acceptance item" do
+          expect(page).to have_content("By verifying your identity you accept the terms of service.")
+
+          expect do
+            expect do
+              fill_personal_data(personal_data)
+              click_on "Validate your data"
+
+              within "#card__tos" do
+                expect(page).to have_content "must be accepted"
+              end
+            end.not_to change(Decidim::InitiativesVote, :count)
+          end.not_to change(Decidim::Authorization, :count)
+        end
+
+        context "when the user fills its personal accepting tos and submits the form" do
+          before do
+            fill_personal_data(personal_data)
+            accept_tos_agreement
+          end
+
+          it "an authorization is created" do
+            user = Decidim::User.ephemeral.last
+            expect do
+              click_on "Validate your data"
+            end.to change(Decidim::Authorization.where(user:, name: "dummy_authorization_handler"), :count).by(1)
+          end
+        end
+      end
+
+      it_behaves_like "creating ephemeral session"
+      it_behaves_like "creating an authorization" do
+        before do
+          within ".initiative__aside" do
+            click_on "Sign"
+          end
+        end
+      end
+
+      context "when filling user personal data and accepting tos" do
+        before do
+          within ".initiative__aside" do
+            click_on "Sign"
+          end
+
+          fill_personal_data(personal_data)
+          accept_tos_agreement
+        end
+
+        let(:user) { Decidim::User.ephemeral.last }
+
+        it "creates a vote on submit" do
+          expect do
+            click_on "Validate your data"
+
+            expect(page).to have_content "Initiative signature accepted"
+          end.to change(Decidim::InitiativesVote.where(author: user), :count).by(1)
+        end
+
+        context "when the worflow includes SMS step" do
+          class DummySmsMobilePhoneForm < Decidim::Verifications::Sms::MobilePhoneForm
+            def generated_code
+              "010203"
+            end
+          end
+
+          let(:extra_workflow_attributes) do
+            {
+              authorization_handler_form: "DummyAuthorizationHandler",
+              sms_verification: true,
+              sms_mobile_phone_validator: "DummySmsMobilePhoneValidator",
+              sms_mobile_phone_form: "DummySmsMobilePhoneForm"
+            }
+          end
+          let(:phone_number) { "111222333" }
+
+          before do
+            click_on "Validate your data"
+          end
+
+          it "the user is redirected to the phone number step" do
+            expect(page).to have_content "Please enter your phone number. You will then receive an SMS with a validation code."
+          end
+
+          it "the SMS step can be completed and the vote created" do
+            user = Decidim::User.ephemeral.last
+
+            fill_phone_number(phone_number)
+
+            click_on "Receive code"
+            expect(page).to have_content "Your confirmation code"
+            fill_sms_code("010203")
+            expect(page).to have_content "Your code is correct"
+
+            expect do
+              click_on "Sign initiative"
+
+              expect(page).to have_content "Initiative signature accepted"
+            end.to change(Decidim::InitiativesVote.where(author: user), :count).by(1)
+          end
+        end
+      end
+    end
+
+    context "with already existing authorizations" do
+      let(:extra_workflow_attributes) { { authorization_handler_form: "DummyAuthorizationHandler" } }
+      let(:regular_user_document_number) { "111222333X" }
+      let(:regular_user_personal_data) do
+        {
+          name_and_surname: "Wang Wang",
+          document_type: "identification_number",
+          document_number: regular_user_document_number,
+          gender: DummySignatureHandler::AVAILABLE_GENDERS.last,
+          date_of_birth: 30.years.ago.to_date,
+          postal_code: "01234"
+        }
+      end
+      let!(:regular_user) { create(:user, :confirmed, name: regular_user_personal_data[:name_and_surname], organization:) }
+      let(:ephemeral_user) { create(:user, :ephemeral, :confirmed, organization:) }
+      let(:other_initiative) { create(:initiative, organization:, scoped_type:) }
+      let!(:signature) { create(:initiative_user_vote, initiative: other_initiative, author: ephemeral_user) }
+
+      context "and ephemeral sessions" do
+        let!(:regular_authorization) do
+          create(
+            :authorization,
+            :granted,
+            name: "dummy_authorization_handler",
+            user: regular_user,
+            unique_id: regular_user_document_number,
+            metadata: regular_user_personal_data.slice(:document_number, :postal_code)
+          )
+        end
+        let!(:ephemeral_user_authorization) do
+          create(
+            :authorization,
+            :granted,
+            name: "dummy_authorization_handler",
+            user: ephemeral_user,
+            unique_id: document_number,
+            metadata: personal_data.slice(:document_number, :postal_code)
+          )
+        end
+
+        before do
+          within ".initiative__aside" do
+            click_on "Sign"
+          end
+        end
+
+        it "an ephemeral user is unable to sign the initiative with the regular user authorization data" do
+          fill_personal_data(regular_user_personal_data)
+          accept_tos_agreement
+
+          expect do
+            expect do
+              click_on "Validate your data"
+
+              expect(page).to have_content "Some of the personal data provided to verify your identity is not valid."
+            end.not_to change(Decidim::Authorization, :count)
+          end.not_to change(Decidim::InitiativesVote, :count)
+        end
+
+        it "an ephemeral user is able to recover the session using the same authorization data" do
+          fill_personal_data(personal_data)
+          accept_tos_agreement
+
+          expect do
+            expect do
+              click_on "Validate your data"
+
+              expect(page).to have_content "Initiative signature accepted"
+            end.not_to change(Decidim::Authorization, :count)
+          end.to change(Decidim::InitiativesVote.where(author: ephemeral_user), :count).by(1)
+        end
+      end
+
+      context "and regular users sessions" do
+        skip "Enable this test after merging https://github.com/decidim/decidim/pull/13981"
+
+        let!(:ephemeral_user_authorization) do
+          create(
+            :authorization,
+            :granted,
+            name: "dummy_authorization_handler",
+            user: ephemeral_user,
+            unique_id: document_number,
+            metadata: personal_data.slice(:document_number, :postal_code)
+          )
+        end
+
+        before do
+          login_as regular_user, scope: :user
+          visit decidim_initiatives.initiative_path(initiative)
+          within ".initiative__aside" do
+            click_on "Sign"
+          end
+        end
+
+        it "a regular user using the authorization data of an ephemeral user gets the ephemeral user activities transferred" do
+          fill_personal_data(personal_data)
+
+          expect do
+            expect do
+              click_on "Validate your data"
+
+              expect(page).to have_content "Initiative signature accepted"
+              expect(page).to have_content "We have recovered the following participation data based on your authorization"
+              expect(page).to have_content "Initiatives vote: 1"
+            end.not_to change(Decidim::Authorization, :count)
+          end.to change(Decidim::InitiativesVote.where(author: regular_user), :count).by(2)
+        end
+      end
+    end
+  end
+
+  def fill_personal_data(data)
+    fill_in :dummy_signature_handler_name_and_surname, with: data[:name_and_surname]
+    select I18n.t(data[:document_type], scope: "decidim.verifications.id_documents"), from: :dummy_signature_handler_document_type
+    fill_in :dummy_signature_handler_document_number, with: data[:document_number]
+    fill_date data[:date_of_birth]
+    select I18n.t(data[:gender], scope: "decidim.initiatives.initiative_signatures.dummy_signature.form.fields.gender.options"), from: :dummy_signature_handler_gender
+    fill_in :dummy_signature_handler_postal_code, with: data[:postal_code]
+    select translated_attribute(initiative.scope.name), from: :dummy_signature_handler_scope_id
+  end
+
+  def accept_tos_agreement
+    within "#card__tos" do
+      check "you accept the terms of service"
+    end
+  end
+
+  def fill_phone_number(number)
+    fill_in :dummy_sms_mobile_phone_mobile_phone_number, with: number
+  end
+
+  def fill_sms_code(code)
+    code.chars.each_with_index do |digit, i|
+      page.find("input[data-verification-code='#{i}']").fill_in(with: digit)
+    end
+  end
+end

--- a/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
@@ -291,8 +291,6 @@ describe "Initiative signing with ephemeral workflows" do
       end
 
       context "and regular users sessions" do
-        skip "Enable this test after merging https://github.com/decidim/decidim/pull/13981"
-
         let!(:ephemeral_user_authorization) do
           create(
             :authorization,
@@ -305,6 +303,8 @@ describe "Initiative signing with ephemeral workflows" do
         end
 
         before do
+          skip "Enable this test after merging https://github.com/decidim/decidim/pull/13981"
+
           login_as regular_user, scope: :user
           visit decidim_initiatives.initiative_path(initiative)
           within ".initiative__aside" do

--- a/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
@@ -61,7 +61,7 @@ describe "Initiative signing with ephemeral workflows" do
     it_behaves_like "preventing ephemeral session creation"
   end
 
-  context "when the worflow only contains SMS step without personal data collection" do
+  context "when the workflow only contains SMS step without personal data collection" do
     let(:extra_workflow_attributes) do
       {
         sms_verification: true,
@@ -81,7 +81,7 @@ describe "Initiative signing with ephemeral workflows" do
       }
     end
 
-    context "and no authorization hanldler form is defined" do
+    context "and no authorization handler form is defined" do
       it_behaves_like "preventing ephemeral session creation"
     end
 
@@ -172,7 +172,7 @@ describe "Initiative signing with ephemeral workflows" do
           end.to change(Decidim::InitiativesVote.where(author: user), :count).by(1)
         end
 
-        context "when the worflow includes SMS step" do
+        context "when the workflow includes SMS step" do
           class DummySmsMobilePhoneForm < Decidim::Verifications::Sms::MobilePhoneForm
             def generated_code
               "010203"

--- a/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
@@ -168,7 +168,7 @@ describe "Initiative signing with ephemeral workflows" do
           expect do
             click_on "Validate your data"
 
-            expect(page).to have_content "Initiative signature accepted"
+            expect(page).to have_content "You have signed the initiative"
           end.to change(Decidim::InitiativesVote.where(author: user), :count).by(1)
         end
 
@@ -210,7 +210,7 @@ describe "Initiative signing with ephemeral workflows" do
             expect do
               click_on "Sign initiative"
 
-              expect(page).to have_content "Initiative signature accepted"
+              expect(page).to have_content "You have signed the initiative"
             end.to change(Decidim::InitiativesVote.where(author: user), :count).by(1)
           end
         end
@@ -284,7 +284,7 @@ describe "Initiative signing with ephemeral workflows" do
             expect do
               click_on "Validate your data"
 
-              expect(page).to have_content "Initiative signature accepted"
+              expect(page).to have_content "You have signed the initiative"
             end.not_to change(Decidim::Authorization, :count)
           end.to change(Decidim::InitiativesVote.where(author: ephemeral_user), :count).by(1)
         end
@@ -319,7 +319,7 @@ describe "Initiative signing with ephemeral workflows" do
             expect do
               click_on "Validate your data"
 
-              expect(page).to have_content "Initiative signature accepted"
+              expect(page).to have_content "You have signed the initiative"
               expect(page).to have_content "We have recovered the following participation data based on your authorization"
               expect(page).to have_content "Initiatives vote: 1"
             end.not_to change(Decidim::Authorization, :count)

--- a/decidim-initiatives/spec/system/initiative_signing_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_spec.rb
@@ -70,67 +70,6 @@ describe "Initiative signing" do
     end
   end
 
-  context "when the initiative type has permissions to vote" do
-    before do
-      initiative.type.create_resource_permission(
-        permissions: {
-          "vote" => {
-            "authorization_handlers" => {
-              "dummy_authorization_handler" => { "options" => {} },
-              "another_dummy_authorization_handler" => { "options" => {} }
-            }
-          }
-        }
-      )
-    end
-
-    context "and has not signed the initiative yet" do
-      context "and is not verified" do
-        it "signin initiative is disabled", :slow do
-          visit decidim_initiatives.initiative_path(initiative)
-
-          within ".initiative__aside" do
-            expect(page).to have_content("Sign")
-            click_on "Sign"
-          end
-
-          expect(page).to have_content("You are almost ready to sign on the #{translated_attribute(initiative.title)} initiative")
-          expect(page).to have_css("a[data-verification]", count: 2)
-        end
-      end
-
-      context "and is verified" do
-        before do
-          create(:authorization, name: "dummy_authorization_handler", user: confirmed_user, granted_at: 2.seconds.ago)
-          create(:authorization, name: "another_dummy_authorization_handler", user: confirmed_user, granted_at: 2.seconds.ago)
-        end
-
-        it "votes as themselves" do
-          vote_initiative
-        end
-      end
-    end
-
-    context "and has signed the initiative" do
-      before do
-        initiative.votes.create(author: confirmed_user, scope: initiative.scope)
-      end
-
-      context "and is not verified" do
-        it "unsigning initiative is disabled" do
-          visit decidim_initiatives.initiative_path(initiative)
-
-          within ".initiative__aside" do
-            expect(page).to have_content(signature_text(1))
-            expect(page).to have_button("Already signed", disabled: true)
-            click_on("Already signed", disabled: true)
-            expect(page).to have_content(signature_text(1))
-          end
-        end
-      end
-    end
-  end
-
   def vote_initiative
     visit decidim_initiatives.initiative_path(initiative)
 

--- a/decidim-initiatives/spec/system/initiative_signing_workflows_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_workflows_spec.rb
@@ -99,13 +99,13 @@ describe "Initiative signing with workflows" do
         expect do
           click_on "Validate your data"
 
-          expect(page).to have_content "Initiative signature accepted"
+          expect(page).to have_content "You have signed the initiative"
         end.to change(Decidim::InitiativesVote, :count).by(1)
       end
 
       it "the vote created stores the provided data in metadata" do
         click_on "Validate your data"
-        expect(page).to have_content "Initiative signature accepted"
+        expect(page).to have_content "You have signed the initiative"
 
         vote = Decidim::InitiativesVote.last
 
@@ -141,7 +141,7 @@ describe "Initiative signing with workflows" do
         expect do
           click_on "Validate your data"
 
-          expect(page).to have_content "Initiative signature accepted"
+          expect(page).to have_content "You have signed the initiative"
         end.not_to change(Decidim::Authorization, :count)
       end
     end
@@ -196,7 +196,7 @@ describe "Initiative signing with workflows" do
           expect do
             click_on "Validate your data"
 
-            expect(page).to have_content "Initiative signature accepted"
+            expect(page).to have_content "You have signed the initiative"
           end.to change(Decidim::Authorization, :count).by(1)
 
           authorization = Decidim::Authorization.last
@@ -243,7 +243,7 @@ describe "Initiative signing with workflows" do
           expect do
             click_on "Validate your data"
 
-            expect(page).to have_content "Initiative signature accepted"
+            expect(page).to have_content "You have signed the initiative"
           end.not_to change(Decidim::Authorization, :count)
         end
       end
@@ -273,7 +273,7 @@ describe "Initiative signing with workflows" do
 
           context "when the authorization status is :ok" do
             it "checks the authorization status and creates the vote" do
-              expect(page).to have_content "Initiative signature accepted"
+              expect(page).to have_content "You have signed the initiative"
               expect(Decidim::InitiativesVote.where(author: confirmed_user)).to be_present
             end
           end
@@ -315,7 +315,7 @@ describe "Initiative signing with workflows" do
             expect do
               click_on "Validate your data"
 
-              expect(page).to have_content "Initiative signature accepted"
+              expect(page).to have_content "You have signed the initiative"
             end.not_to change(Decidim::Authorization, :count)
 
             expect(Decidim::InitiativesVote.where(author: confirmed_user)).to be_present
@@ -331,7 +331,7 @@ describe "Initiative signing with workflows" do
               expect do
                 click_on "Validate your data"
 
-                expect(page).to have_content "Initiative signature accepted"
+                expect(page).to have_content "You have signed the initiative"
               end.not_to change(Decidim::Authorization, :count)
 
               authorization = Decidim::Authorization.where(user: confirmed_user).last
@@ -388,7 +388,7 @@ describe "Initiative signing with workflows" do
               expect do
                 click_on "Validate your data"
 
-                expect(page).to have_content "Initiative signature accepted"
+                expect(page).to have_content "You have signed the initiative"
               end.not_to change(Decidim::Authorization, :count)
 
               expect(Decidim::InitiativesVote.where(author: confirmed_user)).to be_present
@@ -423,7 +423,7 @@ describe "Initiative signing with workflows" do
           fill_personal_data
           click_on "Validate your data"
 
-          expect(page).to have_content "Initiative signature accepted"
+          expect(page).to have_content "You have signed the initiative"
         end
       end
 
@@ -437,7 +437,7 @@ describe "Initiative signing with workflows" do
         end
 
         it "votes directly without additional steps" do
-          expect(page).to have_content "Initiative signature accepted"
+          expect(page).to have_content "You have signed the initiative"
         end
       end
     end
@@ -486,7 +486,7 @@ describe "Initiative signing with workflows" do
           expect(page).to have_content "Your code is correct"
           click_on "Sign initiative"
 
-          expect(page).to have_content "Initiative signature accepted"
+          expect(page).to have_content "You have signed the initiative"
         end
       end
 
@@ -526,7 +526,7 @@ describe "Initiative signing with workflows" do
               expect(page).to have_content "Your code is correct"
               click_on "Sign initiative"
 
-              expect(page).to have_content "Initiative signature accepted"
+              expect(page).to have_content "You have signed the initiative"
             end
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR implements initiatives signatures workflows through direct verifications using ephemeral sessions:
* Changes the permissions system of signatures controller to allow not logged in users to start an ephemeral session and sign providing personal data and validating it to create an authorization.
* Changes the onboarding feature to allow creating ephemeral users with onboarding data and define an alternative authorizations path different of the verifications. This PR changes the authorizations path to be directly the initiatives path
* Adds the tos agreement checkbox in the collect personal data step for for ephemeral users who have not yet accepted the terms.
* Allows transfer of session between ephemeral users and transfer of ephemeral users activities to regular users when the authorization data provided is the same of a previous session
* Adds an example of ephemeral signature workflow to decidim-generators
* Adds documentation of the feature.
* Disables the new initiative button when the user's session is ephemeral and no additional permission is granted.
* Adds the option to pass a title to the confirm modal window. If nothing is passed the default Confirm title is used
* Changes the finished initiative signature message and the close ephemeral session modal title and text.
* Removes the "vote" action from initiatives type and related permissions and tests
* Adds some integration tests

WIP

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #13951

#### Testing

Enable a signature workflow with the ephemeral setting to true. For example:

```ruby
Decidim::Initiatives::Signatures.register_workflow(:ephemeral_dummy_signature_handler) do |workflow|
  workflow.form = "DummySignatureHandler"
  workflow.ephemeral = true
  workflow.authorization_handler_form = "DummyAuthorizationHandler"
  workflow.action_authorizer = "DummySignatureHandler::DummySignatureActionAuthorizer"
  workflow.promote_authorization_validation_errors = true
  workflow.sms_verification = true
  workflow.sms_mobile_phone_validator = "DummySmsMobilePhoneValidator"
  workflow.sms_mobile_phone_form = "DummySmsMobilePhoneForm"
end
```

This workflow has been configured in staging and there is an initiative type using it: https://decidim-lot2.populate.tools/admin/initiatives_types/4/edit and an initiative of the type which can be signed with an ephemeral session: https://decidim-lot2.populate.tools/initiatives/i-41

As a not signed in user start the signature process. The workflow expects a document number ended with X and has enabled the SMS step using always the same dummy code "010203"


##### Edge cases

* An ephemeral user which verified its data can close the session and recover it verifying with the same data  but if it is in the process of voting on an initiative that it has already voted on, it will be redirected as it cannot vote twice on the same initiative.
* If a regular user is verified using the same data of an ephemeral user the ephemeral user resources are transferred to the regular user.

### :camera: Screenshots

Initiative signature with ephemeral session and session recovering to vote another initiative with the same user

[Screencast from 11-02-25 16:42:20.webm](https://github.com/user-attachments/assets/b786703d-5eaa-47f5-b0dc-4cdd948ea545)


:hearts: Thank you!
