### PR TITLE
Fix shebangs for bash in internal scripts

### DIFF
--- a/.github/run_erblint.sh
+++ b/.github/run_erblint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 shopt -s globstar
 

--- a/.github/run_spelling_check.sh
+++ b/.github/run_spelling_check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! command -v yq &> /dev/null; then
   echo "The yq command is not available on this system."

--- a/.github/workflows/dependencies.sh
+++ b/.github/workflows/dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script gathers all the dependencies for each decidim module in the repository.
 # Run it located on the root folder of the repo to get the list of paths to add to each workflow.


### PR DESCRIPTION
#### :tophat: What? Why?

During the release process, I have some problems with the execution of the spellchecker script as it doesn't have a valid shebang for my operating system (I use NixOS BTW 😎)

This PR fixes it and makes the bash agnostic to where is it (i.e. its path) 

#### Testing

These script should work in all the GNU/Linux/UNIX/POSIX based OS (like in your machine xD)

:hearts: Thank you!
