### PR TITLE
Fix bundler versions to prevent incompatiblity error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -846,4 +846,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.4.20
+   2.5.22

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -838,4 +838,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.4.20
+   2.5.22


### PR DESCRIPTION
#### :tophat: What? Why?

Some months ago, I changed my development environment and I'm using NixOS/devenv.sh 

The problem is that I'm seeing some errors when using the binstubs, like 

```
$ bin/rake
The running version of Bundler (2.5.22) does not match the version of the specification installed for it (2.4.20). This can be caused by reinstalling Ruby without removing previous installation, leaving around an upgraded default version of Bundler. Reinstalling Ruby from scratch should fix the problem.
```

This PR changes the bundler version so it's compatible with the bundler version of this message and we can keep with the release process.

If this is approved, I'll do the same for v0.28 and v0.29, so I can keep doing the release process. (I'll do this manually as we will need to solve the conflict manually too, as the Gemfile.lock changes a lot between versions) 

#### Testing

Everything should be green and not blow up  

:hearts: Thank you!
