### PR TITLE
Avoid server error when accepting a proposal without giving it a cost

### DIFF
--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_answers_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_answers_controller.rb
@@ -7,6 +7,7 @@ module Decidim
       class ProposalAnswersController < Admin::ApplicationController
         include ActionView::Helpers::SanitizeHelper
         include Decidim::Proposals::Admin::NeedsInterpolations
+        include Decidim::Proposals::Admin::Filterable
 
         helper_method :proposal
 
@@ -77,6 +78,10 @@ module Decidim
 
         def proposals
           @proposals ||= Proposal.where(component: current_component).where(id: params[:proposal_ids])
+        end
+
+        def collection
+          @collection ||= Proposal.where(component: current_component).not_hidden.published
         end
 
         def template

--- a/decidim-proposals/spec/controllers/decidim/proposals/admin/proposal_answers_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals/admin/proposal_answers_controller_spec.rb
@@ -7,6 +7,8 @@ module Decidim
   module Proposals
     module Admin
       describe ProposalAnswersController do
+        include Decidim::ApplicationHelper
+
         let(:user) { create(:user, :confirmed, :admin, organization: component.organization) }
         let(:component) { create(:proposal_component, :with_creation_enabled, :with_attachments_allowed) }
         let!(:emendation) { create(:proposal, component:) }
@@ -24,6 +26,7 @@ module Decidim
         let(:context) do
           {
             current_organization: component.organization,
+            current_participatory_space: component.participatory_space,
             current_component: component,
             current_user: user
           }
@@ -32,7 +35,39 @@ module Decidim
         before do
           sign_in user
           request.env["decidim.current_organization"] = component.organization
+          request.env["decidim.current_participatory_space"] = component.participatory_space
           request.env["decidim.current_component"] = component
+        end
+
+        describe "PUT update" do
+          let(:params) do
+            {
+              id: proposal1.id,
+              internal_state: "accepted",
+              component_id: component.id,
+              participatory_process_slug: component.participatory_space.slug
+            }
+          end
+
+          context "when cost is required" do
+            before do
+              component.update!(
+                step_settings: {
+                  component.participatory_space.active_step.id => {
+                    answers_with_costs: true
+                  }
+                }
+              )
+            end
+
+            context "when update fails" do
+              it "renders ProposalsController#show view" do
+                post :update, params: params
+                expect(response).to have_http_status(:ok)
+                expect(subject).to render_template("decidim/proposals/admin/proposals/show")
+              end
+            end
+          end
         end
 
         describe "POST update_multiple_answers" do

--- a/decidim-proposals/spec/system/admin/admin_answers_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_answers_proposal_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin answers proposals" do
+  let(:manifest_name) { "proposals" }
+  let(:proposal_answering_enabled?) { true }
+  let(:proposal_answers_with_costs?) { false }
+  let!(:component) { create(:proposal_component, participatory_space:) }
+  let!(:proposals) { create_list(:proposal, 3, component:, cost_report: {}) }
+
+  include_context "when managing a component as an admin"
+
+  before do
+    visit current_path
+  end
+
+  context "when proposals answering is enabled" do
+    before do 
+      component.update!(
+        settings: { proposal_answering_enabled: true },
+        step_settings: {
+          component.participatory_space.active_step.id => {
+            proposal_answering_enabled: proposal_answering_enabled?,
+            answers_with_costs: proposal_answers_with_costs?
+          }
+        }
+      )
+      visit current_path
+    end
+
+    it "can accept the proposal" do
+      find("a.action-icon--show-proposal", match: :first).click
+      find("label[for='proposal_answer_internal_state_accepted']").click
+      fill_in_i18n_editor(
+        :proposal_answer_answer,
+        "#proposal_answer-answer-tabs",
+        en: "An accepted answer"
+      )
+      find("button[name=commit]", match: :first).click
+      expect(page).to have_css(".flash", text: "Proposal successfully answered.")
+    end
+
+    context "with costs enabled" do
+      let(:proposal_answers_with_costs?) { true }
+
+      it "when accepting, a cost value and cost report are required" do
+        find("a.action-icon--show-proposal", match: :first).click
+        find("input#proposal_answer_internal_state_accepted").click
+        fill_in_i18n_editor(
+          :proposal_answer_answer,
+          "#proposal_answer-answer-tabs",
+          en: "An accepted answer"
+        )
+        find("button[name=commit]", match: :first).click
+        expect(find("label[for=proposal_answer_cost_report]")).to have_content("Required field")
+        expect(find("label[for=proposal_answer_cost]")).to have_content("Required field")
+        expect(page).to have_css(".flash", text: "There was a problem answering this proposal.")
+
+      end
+
+      it "rejects without any cost value or cost report" do
+        find("a.action-icon--show-proposal", match: :first).click
+        find("input#proposal_answer_internal_state_rejected").click
+        fill_in_i18n_editor(
+          :proposal_answer_answer,
+          "#proposal_answer-answer-tabs",
+          en: "A Rejected answer"
+        )
+        find("button[name=commit]", match: :first).click
+        expect(page).to have_css(".flash", text: "Proposal successfully answered.")
+      end
+
+      it "accepts with a cost value and cost report" do
+        find("a.action-icon--show-proposal", match: :first).click
+        find("input#proposal_answer_internal_state_accepted").click
+        fill_in_i18n_editor(
+          :proposal_answer_answer,
+          "#proposal_answer-answer-tabs",
+          en: "An accepted answer with cost report"
+        )
+        fill_in_i18n_editor(
+          :proposal_answer_cost_report,
+          "#proposal_answer-cost_report-tabs",
+          en: "Cost report on the "
+        )
+        fill_in :proposal_answer_cost, with: "50"
+
+        find("button[name=commit]", match: :first).click
+        expect(page).to have_css(".flash", text: "Proposal successfully answered.")
+      end
+    end
+
+    
+  end
+
+
+
+end

--- a/decidim-proposals/spec/system/admin/admin_answers_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_answers_proposal_spec.rb
@@ -4,7 +4,6 @@ require "spec_helper"
 
 describe "Admin answers proposals" do
   let(:manifest_name) { "proposals" }
-  let(:proposal_answering_enabled?) { true }
   let(:proposal_answers_with_costs?) { false }
   let!(:component) { create(:proposal_component, participatory_space:) }
   let!(:proposals) { create_list(:proposal, 3, component:, cost_report: {}) }
@@ -21,7 +20,7 @@ describe "Admin answers proposals" do
         settings: { proposal_answering_enabled: true },
         step_settings: {
           component.participatory_space.active_step.id => {
-            proposal_answering_enabled: proposal_answering_enabled?,
+            proposal_answering_enabled: true,
             answers_with_costs: proposal_answers_with_costs?
           }
         }
@@ -29,13 +28,13 @@ describe "Admin answers proposals" do
       visit current_path
     end
 
-    it "can accept the proposal" do
+    it "when accepting, can submit answer with a text answer" do
       find("a.action-icon--show-proposal", match: :first).click
       find("label[for='proposal_answer_internal_state_accepted']").click
       fill_in_i18n_editor(
         :proposal_answer_answer,
         "#proposal_answer-answer-tabs",
-        en: "An accepted answer"
+        en: "An accepted answer without costs"
       )
       find("*[type=submit][name=commit]", match: :first).click
       expect(page).to have_css(".flash", text: "Proposal successfully answered.")
@@ -44,44 +43,35 @@ describe "Admin answers proposals" do
     context "with costs enabled" do
       let(:proposal_answers_with_costs?) { true }
 
-      it "when accepting, a cost value and cost report are required" do
+      before do
         find("a.action-icon--show-proposal", match: :first).click
-        find("input#proposal_answer_internal_state_accepted").click
         fill_in_i18n_editor(
           :proposal_answer_answer,
           "#proposal_answer-answer-tabs",
-          en: "An accepted answer"
+          en: "A text answer that is long enough to be valid"
         )
+      end
+
+      it "when accepting, a cost value and cost report are required" do
+        find("input#proposal_answer_internal_state_accepted").click
         find("*[type=submit][name=commit]", match: :first).click
         expect(find("label[for=proposal_answer_cost_report]")).to have_content("Required field")
         expect(find("label[for=proposal_answer_cost]")).to have_content("Required field")
         expect(page).to have_css(".flash", text: "There was a problem answering this proposal.")
       end
 
-      it "rejects without any cost value or cost report" do
-        find("a.action-icon--show-proposal", match: :first).click
+      it "when rejecting, do not require a cost value or cost report" do
         find("input#proposal_answer_internal_state_rejected").click
-        fill_in_i18n_editor(
-          :proposal_answer_answer,
-          "#proposal_answer-answer-tabs",
-          en: "A Rejected answer"
-        )
         find("*[type=submit][name=commit]", match: :first).click
         expect(page).to have_css(".flash", text: "Proposal successfully answered.")
       end
 
-      it "accepts with a cost value and cost report" do
-        find("a.action-icon--show-proposal", match: :first).click
+      it "when accepting, can submit answer with a cost value and cost report" do
         find("input#proposal_answer_internal_state_accepted").click
-        fill_in_i18n_editor(
-          :proposal_answer_answer,
-          "#proposal_answer-answer-tabs",
-          en: "An accepted answer with cost report"
-        )
         fill_in_i18n_editor(
           :proposal_answer_cost_report,
           "#proposal_answer-cost_report-tabs",
-          en: "Cost report on the "
+          en: "Cost report on the proposal"
         )
         fill_in :proposal_answer_cost, with: "50"
 

--- a/decidim-proposals/spec/system/admin/admin_answers_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_answers_proposal_spec.rb
@@ -16,7 +16,7 @@ describe "Admin answers proposals" do
   end
 
   context "when proposals answering is enabled" do
-    before do 
+    before do
       component.update!(
         settings: { proposal_answering_enabled: true },
         step_settings: {
@@ -37,7 +37,7 @@ describe "Admin answers proposals" do
         "#proposal_answer-answer-tabs",
         en: "An accepted answer"
       )
-      find("button[name=commit]", match: :first).click
+      find("*[type=submit][name=commit]", match: :first).click
       expect(page).to have_css(".flash", text: "Proposal successfully answered.")
     end
 
@@ -52,11 +52,10 @@ describe "Admin answers proposals" do
           "#proposal_answer-answer-tabs",
           en: "An accepted answer"
         )
-        find("button[name=commit]", match: :first).click
+        find("*[type=submit][name=commit]", match: :first).click
         expect(find("label[for=proposal_answer_cost_report]")).to have_content("Required field")
         expect(find("label[for=proposal_answer_cost]")).to have_content("Required field")
         expect(page).to have_css(".flash", text: "There was a problem answering this proposal.")
-
       end
 
       it "rejects without any cost value or cost report" do
@@ -67,7 +66,7 @@ describe "Admin answers proposals" do
           "#proposal_answer-answer-tabs",
           en: "A Rejected answer"
         )
-        find("button[name=commit]", match: :first).click
+        find("*[type=submit][name=commit]", match: :first).click
         expect(page).to have_css(".flash", text: "Proposal successfully answered.")
       end
 
@@ -86,14 +85,9 @@ describe "Admin answers proposals" do
         )
         fill_in :proposal_answer_cost, with: "50"
 
-        find("button[name=commit]", match: :first).click
+        find("*[type=submit][name=commit]", match: :first).click
         expect(page).to have_css(".flash", text: "Proposal successfully answered.")
       end
     end
-
-    
   end
-
-
-
 end


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*
This PR fix the invalid render of the ProposalAnswerController. 
https://github.com/decidim/decidim/blob/develop/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_answers_controller.rb#L36

The controller will render a view `decidim/proposals/admin/proposals/show` that needs : 
- a collection method
- filter helpers included

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #13938

#### Testing
*Describe the best way to test or validate your PR.*

    1. Go to a proposal component
    2. In the component configuration, check "Enable costs on proposal answers"
    3. Go to the answer proposal form
    4. See that there is no indication that the fields are mandatory
    5. Give the accepted state and an answer to the proposal
    6. Save and see the fields Cost, Cost Report, Execution Period in red. No error 500
    

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Fields with error ](https://github.com/user-attachments/assets/f13cd296-38b8-4ae5-8dce-f676673d4c41)

:hearts: Thank you!
