### PR TITLE
Hide help buttons if no help content is given in admin-side

### DIFF
--- a/decidim-core/app/helpers/decidim/participatory_space_helpers.rb
+++ b/decidim-core/app/helpers/decidim/participatory_space_helpers.rb
@@ -28,7 +28,7 @@ module Decidim
     end
 
     def participatory_space_floating_help
-      return if help_section.blank?
+      return if help_section.blank? || strip_tags(translated_attribute(help_section).html_safe).blank?
 
       floating_help(help_id) { translated_attribute(help_section).html_safe }
     end

--- a/decidim-core/app/views/decidim/shared/_floating_help.html.erb
+++ b/decidim-core/app/views/decidim/shared/_floating_help.html.erb
@@ -1,16 +1,18 @@
-<div id="floating-helper-tip" data-floating-help>
-  <button class="button button__xs button__text-secondary py-1" data-dialog-open="floating-helper-block">
-    <%= icon "question-line" %>
-    <span><%= t("help", scope: "decidim.shared.floating_help") %></span>
-  </button>
-</div>
-
-<%= decidim_modal id: "floating-helper-block" do %>
-  <div data-dialog-container>
-    <%= icon "question-line" %>
-    <h3 id="dialog-title-floating-helper-block" data-dialog-title><%= t("help", scope: "decidim.shared.floating_help") %></h3>
-    <div class="editor-content">
-      <%= content %>
-    </div>
+<% if strip_tags(content).present? %>
+  <div id="floating-helper-tip" data-floating-help>
+    <button class="button button__xs button__text-secondary py-1" data-dialog-open="floating-helper-block">
+      <%= icon "question-line" %>
+      <span><%= t("help", scope: "decidim.shared.floating_help") %></span>
+    </button>
   </div>
+
+  <%= decidim_modal id: "floating-helper-block" do %>
+    <div data-dialog-container>
+      <%= icon "question-line" %>
+      <h3 id="dialog-title-floating-helper-block" data-dialog-title><%= t("help", scope: "decidim.shared.floating_help") %></h3>
+      <div class="editor-content">
+        <%= content %>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/decidim-core/app/views/decidim/shared/_floating_help.html.erb
+++ b/decidim-core/app/views/decidim/shared/_floating_help.html.erb
@@ -1,18 +1,16 @@
-<% if strip_tags(content).present? %>
-  <div id="floating-helper-tip" data-floating-help>
-    <button class="button button__xs button__text-secondary py-1" data-dialog-open="floating-helper-block">
-      <%= icon "question-line" %>
-      <span><%= t("help", scope: "decidim.shared.floating_help") %></span>
-    </button>
-  </div>
+<div id="floating-helper-tip" data-floating-help>
+  <button class="button button__xs button__text-secondary py-1" data-dialog-open="floating-helper-block">
+    <%= icon "question-line" %>
+    <span><%= t("help", scope: "decidim.shared.floating_help") %></span>
+  </button>
+</div>
 
-  <%= decidim_modal id: "floating-helper-block" do %>
-    <div data-dialog-container>
-      <%= icon "question-line" %>
-      <h3 id="dialog-title-floating-helper-block" data-dialog-title><%= t("help", scope: "decidim.shared.floating_help") %></h3>
-      <div class="editor-content">
-        <%= content %>
-      </div>
+<%= decidim_modal id: "floating-helper-block" do %>
+  <div data-dialog-container>
+    <%= icon "question-line" %>
+    <h3 id="dialog-title-floating-helper-block" data-dialog-title><%= t("help", scope: "decidim.shared.floating_help") %></h3>
+    <div class="editor-content">
+      <%= content %>
     </div>
-  <% end %>
+  </div>
 <% end %>

--- a/decidim-core/spec/helpers/decidim/participatory_space_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/participatory_space_helper_spec.rb
@@ -33,7 +33,7 @@ module Decidim
           }
         end
 
-        it "does not show help sections" do
+        it "does not display any help section" do
           expect(subject).to be_blank
         end
       end
@@ -45,7 +45,7 @@ module Decidim
           }
         end
 
-        it "display a help sections" do
+        it "displays a help sections" do
           expect(subject).to include("participatory processes are")
         end
       end

--- a/decidim-core/spec/helpers/decidim/participatory_space_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/participatory_space_helper_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe ParticipatorySpaceHelpers do
+    let(:helper) do
+      Class.new(ActionView::Base) do
+        include ParticipatorySpaceHelpers
+        include SanitizeHelper
+        include TranslatableAttributes
+        include ContextualHelpHelper
+        include Decidim::IconHelper
+
+        def compiled_method_container
+          self.class
+        end
+      end.new(ActionView::LookupContext.new(ActionController::Base.view_paths), {}, [])
+    end
+
+    describe "#participatory_space_floating_help" do
+      subject { helper.participatory_space_floating_help }
+
+      before do
+        allow(helper).to receive(:help_section).and_return(help_section)
+        allow(helper).to receive(:help_id).and_return("participatory_processes")
+      end
+
+      context "when help_section is an empty paragraph" do
+        let(:help_section) do
+          {
+            en: "<p></p>"
+          }
+        end
+
+        it "does not show help sections" do
+          expect(subject).to be_blank
+        end
+      end
+
+      context "when help_section is not blank" do
+        let(:help_section) do
+          {
+            en: "<p>participatory processes are ...</p>"
+          }
+        end
+
+        it "display a help sections" do
+          expect(subject).to include("participatory processes are")
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/helpers/decidim/participatory_space_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/participatory_space_helper_spec.rb
@@ -26,10 +26,32 @@ module Decidim
         allow(helper).to receive(:help_id).and_return("participatory_processes")
       end
 
+      context "when help_section is empty" do
+        let(:help_section) do
+          {}
+        end
+
+        it "does not display any help section" do
+          expect(subject).to be_blank
+        end
+      end
+
+      context "when help_section is blank" do
+        let(:help_section) do
+          {
+            en: ""
+          }
+        end
+
+        it "does not display any help section" do
+          expect(subject).to be_blank
+        end
+      end
+
       context "when help_section is an empty paragraph" do
         let(:help_section) do
           {
-            en: "<p></p>"
+            en: "<p><strong> </strong></p>"
           }
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*
This PR hide help button and related modal if content saved admin-side is empty. 
To do such, we strip first the HTML tags (as the WYSIWYG editor save `<p></p>` as empty string). 
 
#### :pushpin: Related Issues

- Fixes #13929

#### Testing
*Describe the best way to test or validate your PR.*
1. In the admin panel, Settings > Help Sections, define no Content for Participatory Process
2. Go as a visitor to see "all participatory processes"
3. You should not see a help button, nor the modal
4. Go as visitor to see "all assemblies"
5. You should see a help button and a modal on click. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![image](https://github.com/user-attachments/assets/8487dc37-9a98-4e76-8265-096f5d8f67cc)

![image](https://github.com/user-attachments/assets/1b6f7fd9-7de1-4bb3-b795-84d29cdcace4)

![image](https://github.com/user-attachments/assets/cb9b8898-2b44-4ed8-9ebd-fcec9b1608d2)


:hearts: Thank you!
