### PR TITLE
Improve accountability results visualization

### DIFF
--- a/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
@@ -8,7 +8,7 @@ module Decidim
       helper Decidim::TraceabilityHelper
       helper Decidim::Accountability::BreadcrumbHelper
 
-      helper_method :results, :result, :first_class_taxonomies, :count_calculator
+      helper_method :results, :result, :count_calculator, :selected_root_taxonomy, :selected_taxonomy_children, :selected_taxonomy_grandchildren?
 
       before_action :set_controller_breadcrumb
 
@@ -46,8 +46,22 @@ module Decidim
         }
       end
 
-      def first_class_taxonomies
-        @first_class_taxonomies ||= current_organization.taxonomies.where(parent_id: current_component.available_root_taxonomies, id: current_component.available_taxonomy_ids)
+      def selected_taxonomy_grandchildren?
+        @selected_taxonomy_grandchildren ||= selected_root_taxonomy.all_children.count > selected_taxonomy_children.count
+      end
+
+      def selected_taxonomy_children
+        @selected_taxonomy_children ||= current_organization.taxonomies.where(parent_id: selected_root_taxonomy.id, id: current_component.available_taxonomy_ids)
+      end
+
+      def selected_root_taxonomy
+        @selected_root_taxonomy ||= if params[:root_taxonomy_id] == "list"
+                                      nil
+                                    elsif params[:root_taxonomy_id].blank?
+                                      current_component.available_root_taxonomies.find_by(id: component_settings.default_taxonomy)
+                                    else
+                                      current_component.available_root_taxonomies.find_by(id: params[:root_taxonomy_id])
+                                    end
       end
 
       def count_calculator(taxonomy_id)

--- a/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
@@ -51,6 +51,8 @@ module Decidim
       end
 
       def selected_taxonomy_children
+        return [] if selected_root_taxonomy.blank?
+
         @selected_taxonomy_children ||= current_organization.taxonomies.where(parent_id: selected_root_taxonomy.id, id: current_component.available_taxonomy_ids)
       end
 

--- a/decidim-accountability/app/packs/stylesheets/accountability.scss
+++ b/decidim-accountability/app/packs/stylesheets/accountability.scss
@@ -97,11 +97,18 @@
   }
 
   &__grid {
-    @apply grid md:grid-cols-3 items-start gap-x-10 gap-y-8 md:gap-y-16;
+    @apply grid md:grid-cols-3 items-start gap-x-6 gap-y-6;
 
-    & > :nth-child(even) {
-      @apply grid md:col-span-2;
+    &--one-level {
+      @apply grid;
     }
+
+    &--two-levels {
+      & > :nth-child(even) {
+        @apply grid md:col-span-2;
+      }
+    }
+
 
     /* display the titles only for the first two rows in desktop */
     & > :nth-child(1) &-title,
@@ -170,5 +177,29 @@
 
   &__filters {
     @apply w-full space-y-10;
+  }
+
+  &__taxonomies {
+    @apply w-full;
+
+    ul {
+      @apply flex flex-wrap gap-4 mt-4;
+
+      li {
+        @apply bg-white py-1 px-4 rounded;
+
+        a {
+          @apply text-secondary font-semibold text-sm;
+        }
+
+        &.active {
+          @apply bg-secondary text-white;
+
+          a {
+            @apply text-white;
+          }
+        }
+      }
+    }
   }
 }

--- a/decidim-accountability/app/packs/stylesheets/accountability.scss
+++ b/decidim-accountability/app/packs/stylesheets/accountability.scss
@@ -109,7 +109,6 @@
       }
     }
 
-
     /* display the titles only for the first two rows in desktop */
     & > :nth-child(1) &-title,
     & > :nth-child(2) &-title {

--- a/decidim-accountability/app/views/decidim/accountability/results/_filters.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_filters.html.erb
@@ -1,0 +1,4 @@
+<div class="accountability__filters">
+  <%= render partial: "search" %>
+  <%= render partial: "root_taxonomies_selector" %>
+</div>

--- a/decidim-accountability/app/views/decidim/accountability/results/_home_aside.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_home_aside.html.erb
@@ -1,0 +1,12 @@
+<h1 class="title-decorator"><%= component_name %></h1>
+
+<% if component_settings.display_progress_enabled? %>
+  <%= cell(
+        "decidim/accountability/status",
+        nil,
+        title: t("decidim.accountability.results.home_header.global_status"),
+        progress: progress_calculator(nil).presence,
+        extra_classes: "accountability__status__home"
+      ) %>
+<% end %>
+<%= render partial: "filters" %>

--- a/decidim-accountability/app/views/decidim/accountability/results/_home_taxonomies.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_home_taxonomies.html.erb
@@ -1,32 +1,9 @@
-<div class="accountability__grid">
-  <% first_class_taxonomies.each do |taxonomy| %>
-    <% subelements = cell(
-      "decidim/accountability/status",
-      taxonomy,
-      extra_classes: "accountability__status__background",
-      url: results_path(filter: { taxonomies_part_of_contains: taxonomy }),
-      render_blank: true
-    ) %>
+<h3 class="mb-8 font-semibold text-xl">
+  <%= translated_attribute(selected_root_taxonomy.name) %>
+</h3>
 
-    <div>
-      <%= subelements.call %>
-    </div>
-
-    <div>
-        <% if subelements.has_results? %>
-          <div class="accountability__subgrid">
-            <% taxonomy.children.where(id: current_component.available_taxonomy_ids).each do |sub_taxonomy| %>
-              <%= cell(
-                    "decidim/accountability/status",
-                    sub_taxonomy,
-                    extra_classes: "accountability__status__border",
-                    url: results_path(filter: { taxonomies_part_of_contains: sub_taxonomy })
-                  ) %>
-            <% end %>
-          </div>
-        <% else %>
-          <%= cell("decidim/announcement", t("no_results", scope: "decidim.accountability.results")) %>
-        <% end %>
-      </div>
-  <% end %>
-</div>
+<% if selected_taxonomy_grandchildren? %>
+  <%= render "two_levels_taxonomies" %>
+<% else %>
+  <%= render "one_level_taxonomies" %>
+<% end %>

--- a/decidim-accountability/app/views/decidim/accountability/results/_one_level_taxonomies.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_one_level_taxonomies.html.erb
@@ -1,0 +1,17 @@
+<div class="accountability__grid accountability__grid--one-level">
+  <% selected_taxonomy_children.each do |taxonomy| %>
+    <% subelements = cell(
+      "decidim/accountability/status",
+      taxonomy,
+      extra_classes: "accountability__status__background",
+      url: results_path(filter: { taxonomies_part_of_contains: taxonomy }),
+      render_blank: true
+    ) %>
+
+    <% if subelements.has_results? %>
+      <div>
+        <%= subelements.call %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/decidim-accountability/app/views/decidim/accountability/results/_projects_aside.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_projects_aside.html.erb
@@ -37,6 +37,4 @@
   <% end %>
 </div>
 
-<div class="accountability__filters">
-  <%= render partial: "search" %>
-</div>
+<%= render partial: "filters" %>

--- a/decidim-accountability/app/views/decidim/accountability/results/_root_taxonomies_selector.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_root_taxonomies_selector.html.erb
@@ -1,0 +1,17 @@
+<div class="accountability__taxonomies">
+  <h2 class="accountability__taxonomies__title">
+    <%= t("decidim.accountability.results.root_taxonomies.title") %>
+  </h2>
+  <ul>
+    <% current_component.available_root_taxonomies.each do |taxonomy| %>
+      <% is_selected = selected_root_taxonomy&.id == taxonomy.id %>
+      <li class="<%= "active" if is_selected && action_name == "home" %>">
+        <% if is_selected %>
+          <%= link_to translated_attribute(taxonomy.name), home_results_path(root_taxonomy_id: "list") %>
+        <% else %>
+          <%= link_to translated_attribute(taxonomy.name), home_results_path(root_taxonomy_id: taxonomy.id) %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/decidim-accountability/app/views/decidim/accountability/results/_two_levels_taxonomies.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_two_levels_taxonomies.html.erb
@@ -1,0 +1,30 @@
+<div class="accountability__grid accountability__grid--two-levels">
+  <% selected_taxonomy_children.each do |taxonomy| %>
+    <% subelements = cell(
+      "decidim/accountability/status",
+      taxonomy,
+      extra_classes: "accountability__status__background",
+      url: results_path(filter: { taxonomies_part_of_contains: taxonomy }),
+      render_blank: true
+    ) %>
+
+    <% if subelements.has_results? %>
+      <div>
+        <%= subelements.call %>
+      </div>
+
+      <div>
+        <div class="accountability__subgrid">
+          <% taxonomy.children.where(id: current_component.available_taxonomy_ids).each do |sub_taxonomy| %>
+            <%= cell(
+                  "decidim/accountability/status",
+                  sub_taxonomy,
+                  extra_classes: "accountability__status__border",
+                  url: results_path(filter: { taxonomies_part_of_contains: sub_taxonomy })
+                ) %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/decidim-accountability/app/views/decidim/accountability/results/home.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/home.html.erb
@@ -8,24 +8,10 @@
 <%= append_stylesheet_pack_tag "decidim_accountability" %>
 
 <% content_for :aside do %>
-  <h1 class="title-decorator"><%= component_name %></h1>
-
-  <% if component_settings.display_progress_enabled? %>
-    <%= cell(
-          "decidim/accountability/status",
-          nil,
-          title: t("decidim.accountability.results.home_header.global_status"),
-          progress: progress_calculator(nil).presence,
-          extra_classes: "accountability__status__home"
-        ) %>
-  <% end %>
-  <div class="accountability__filters">
-    <%= render partial: "search" %>
-  </div>
+  <%= render partial: "home_aside" %>
 <% end %>
 
 <%= render layout: "layouts/decidim/shared/layout_two_col" do %>
-
   <% if Decidim::Map.available?(:geocoding, :dynamic) && component_settings.geocoding_enabled? %>
     <div class="accountability__map">
       <%= cell "decidim/map", @all_geocoded_results, metadata_card: "decidim/accountability/result_metadata" %>
@@ -36,14 +22,14 @@
     <div class="editor-content"><%= decidim_sanitize_admin translated_attribute(component_settings.intro) %></div>
   </section>
 
-  <section class="layout-main__section">
-    <% if first_class_taxonomies.empty? %>
-      <%= cell("decidim/announcement",
-               params[:filter].present? ?
-               t("empty_filters", scope: "decidim.accountability.results.home") :
-               t("empty", scope: "decidim.accountability.results.home")) %>
-    <% end %>
-    <%= render partial: "home_taxonomies" %>
-  </section>
-
+  <% if selected_root_taxonomy.present? %>
+    <section class="layout-main__section">
+      <%= render partial: "home_taxonomies" %>
+    </section>
+  <% else %>
+    <section id="results" class="layout-main__section">
+      <%= cell "decidim/accountability/results", results %>
+      <%= decidim_paginate results, order_start_time: params[:order_start_time] %>
+    </section>
+  <% end %>
 <% end %>

--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -274,12 +274,11 @@ en:
           results_count:
             one: 1 result
             other: "%{count} results"
-        home:
-          empty: There are no results yet.
-          empty_filters: There are no results with this criteria.
         home_header:
           global_status: Global execution status
         no_results: There are no projects
+        root_taxonomies:
+          title: 'View by:'
         search:
           search: Search for actions
         show:
@@ -304,6 +303,8 @@ en:
             clear_all: Clear all
             comments_enabled: Comments enabled
             comments_max_length: Comments max length (Leave 0 for default value)
+            default_taxonomy: Default taxonomy
+            default_taxonomy_help: Select which taxonomy you want to show by default. If no taxonomy is selected, the results will be shown in a list format.
             define_taxonomy_filters: Please define some filters for this participatory space before using this setting.
             display_progress_enabled: Display progress
             geocoding_enabled: Maps enabled
@@ -313,6 +314,7 @@ en:
             taxonomy_filters_add: Add filter
           step:
             comments_blocked: Comments blocked
+          visualization: Visualization
     download_your_data:
       show:
         result_comments: Result comments export

--- a/decidim-accountability/lib/decidim/accountability/component.rb
+++ b/decidim-accountability/lib/decidim/accountability/component.rb
@@ -31,6 +31,9 @@ Decidim.register_component(:accountability) do |component|
     settings.attribute :intro, type: :text, translated: true, editor: true
     settings.attribute :display_progress_enabled, type: :boolean, default: true
     settings.attribute :geocoding_enabled, type: :boolean, default: false
+    settings.attribute :default_taxonomy, type: :select, include_blank: true, raw_choices: true, choices: lambda { |context|
+      context[:component].available_root_taxonomies.map { |taxonomy| [taxonomy.name["en"], taxonomy.id] }
+    }
   end
 
   component.register_stat :results_count, primary: true, priority: Decidim::StatsRegistry::HIGH_PRIORITY do |components, _start_at, _end_at|

--- a/decidim-accountability/lib/decidim/accountability/engine.rb
+++ b/decidim-accountability/lib/decidim/accountability/engine.rb
@@ -13,6 +13,10 @@ module Decidim
       routes do
         resources :results, only: [:index, :show] do
           resources :versions, only: [:show]
+
+          collection do
+            get :home
+          end
         end
         root to: "results#home"
       end

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -29,14 +29,13 @@ describe "Explore results", :versioning do
       let(:taxonomy_filter_ids) { [] }
 
       it "shows an empty page with a message" do
-        expect(page).to have_content "There are no results yet"
+        expect(page).to have_content "There are no projects"
       end
     end
 
     context "with a taxonomy" do
       it "shows an empty page with a message" do
         within "main" do
-          expect(page).to have_i18n_content(taxonomy.name)
           expect(page).to have_content "There are no projects"
         end
       end
@@ -85,14 +84,10 @@ describe "Explore results", :versioning do
         expect(page).to have_css(".accountability__map")
       end
 
-      it "shows taxonomies and sub_taxonomies with results for enabled filters" do
-        [taxonomy, sub_taxonomy].each do |item|
-          taxonomy_count = Decidim::Accountability::ResultsCalculator.new(component, item.id).count
-          expect(page).to have_content(translated(item.name)) if taxonomy_count.positive?
+      it "shows root taxonomies filters" do
+        within("aside") do
+          expect(page).to have_content(translated(taxonomy.parent.name))
         end
-
-        expect(page).to have_no_content(translated(other_taxonomy.name))
-        expect(page).to have_no_content(translated(other_sub_taxonomy.name))
       end
 
       it "shows progress" do

--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -91,15 +91,23 @@ module Decidim
       # @param name (see #settings_attribute_input)
       # @param i18n_scope (see #settings_attribute_input)
       # @param options (see #settings_attribute_input)
-      # @option :tabs_prefix (see #settings_attribute_input)
-      # @option :readonly (see #settings_attribute_input)
+      # @option options [String] :tabs_prefix (see #settings_attribute_input)
+      # @option options [Boolean] :readonly (see #settings_attribute_input)
       # @option options [String] :label The label that this field has
       # @option options [String] :help_text The help text shown after the input field
       # @return (see #settings_attribute_input)
       def render_select_form_field(form, attribute, name, i18n_scope, options)
+        choices = attribute.build_choices(component: @component).map do |o|
+          if attribute.raw_choices
+            o
+          else
+            [t("#{name}_options.#{o}", scope: i18n_scope), o]
+          end
+        end
+
         html = form.select(
           name,
-          attribute.build_choices.map { |o| [t("#{name}_options.#{o}", scope: i18n_scope), o] },
+          choices,
           { include_blank: attribute.include_blank, label: options[:label] }
         )
         html << content_tag(:p, options[:help_text], class: "help-text") if options[:help_text]

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -143,7 +143,7 @@ module Decidim
 
         context "when choices is a lambda function" do
           let(:choices) do
-            -> { full_choices.map(&:last) }
+            ->(_context) { full_choices.map(&:last) }
           end
 
           it "is supported" do

--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -76,7 +76,7 @@ Decidim.register_component(:budgets) do |component|
 
   component.settings(:global) do |settings|
     settings.attribute :taxonomy_filters, type: :taxonomy_filters
-    settings.attribute :workflow, type: :enum, default: "one", choices: -> { Decidim::Budgets.workflows.keys.map(&:to_s) }
+    settings.attribute :workflow, type: :enum, default: "one", choices: ->(_context) { Decidim::Budgets.workflows.keys.map(&:to_s) }
     settings.attribute :projects_per_page, type: :integer, default: 12
     settings.attribute :vote_rule_threshold_percent_enabled, type: :boolean, default: true
     settings.attribute :vote_threshold_percent, type: :integer, default: 70

--- a/decidim-core/lib/decidim/settings_manifest.rb
+++ b/decidim-core/lib/decidim/settings_manifest.rb
@@ -129,6 +129,7 @@ module Decidim
       attribute :required_for_authorization, Boolean, default: false
       attribute :readonly
       attribute :choices
+      attribute :raw_choices, Boolean, default: false
       attribute :units
       attribute :include_blank, Boolean, default: false
 
@@ -154,8 +155,8 @@ module Decidim
         default || TYPES[type][:default]
       end
 
-      def build_choices
-        choices.try(:call) || choices
+      def build_choices(context = nil)
+        choices.try(:call, context) || choices
       end
 
       def build_units

--- a/decidim-core/spec/lib/settings_manifest_spec.rb
+++ b/decidim-core/spec/lib/settings_manifest_spec.rb
@@ -91,7 +91,7 @@ module Decidim
         subject.attribute :something, choices: %w(a b c)
         expect(subject.attributes[:something].build_choices).to eq(%w(a b c))
 
-        subject.attribute :something, choices: -> { %w(a b c) }
+        subject.attribute :something, choices: ->(_context) { %w(a b c) }
         expect(subject.attributes[:something].build_choices).to eq(%w(a b c))
       end
 

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -34,12 +34,12 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :minimum_votes_per_user, type: :integer, default: 0, required: true
     settings.attribute :proposal_limit, type: :integer, default: 0, required: true
     settings.attribute :proposal_length, type: :integer, default: 500
-    settings.attribute :proposal_edit_time, type: :enum, default: "limited", choices: -> { %w(infinite limited) }
+    settings.attribute :proposal_edit_time, type: :enum, default: "limited", choices: ->(_context) { %w(infinite limited) }
     settings.attribute :edit_time, type: :integer_with_units, default: [5, "minutes"], required: true, units: %w(minutes hours days)
     settings.attribute :threshold_per_proposal, type: :integer, default: 0, required: true
     settings.attribute :can_accumulate_votes_beyond_threshold, type: :boolean, default: false
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
-    settings.attribute :default_sort_order, type: :select, default: "automatic", choices: -> { POSSIBLE_SORT_ORDERS }
+    settings.attribute :default_sort_order, type: :select, default: "automatic", choices: ->(_context) { POSSIBLE_SORT_ORDERS }
     settings.attribute :official_proposals_enabled, type: :boolean, default: true
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :comments_max_length, type: :integer, required: true
@@ -73,13 +73,13 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
     settings.attribute :publish_answers_immediately, type: :boolean, default: true
     settings.attribute :answers_with_costs, type: :boolean, default: false
-    settings.attribute :default_sort_order, type: :select, include_blank: true, choices: -> { POSSIBLE_SORT_ORDERS }
+    settings.attribute :default_sort_order, type: :select, include_blank: true, choices: ->(_context) { POSSIBLE_SORT_ORDERS }
     settings.attribute :amendment_creation_enabled, type: :boolean, default: true
     settings.attribute :amendment_reaction_enabled, type: :boolean, default: true
     settings.attribute :amendment_promotion_enabled, type: :boolean, default: true
     settings.attribute :amendments_visibility,
                        type: :enum, default: "all",
-                       choices: -> { Decidim.config.amendments_visibility_options }
+                       choices: ->(_context) { Decidim.config.amendments_visibility_options }
     settings.attribute :announcement, type: :text, translated: true, editor: true
     settings.attribute :automatic_hashtags, type: :text, editor: false, required: false
     settings.attribute :suggested_hashtags, type: :text, editor: false, required: false

--- a/docs/modules/develop/pages/components.adoc
+++ b/docs/modules/develop/pages/components.adoc
@@ -140,7 +140,7 @@ Decidim.register_component(:my_component) do |component|
 
   component.settings(:step) do |settings|
     settings.attribute :a_text_setting, type: :text, default: false, required: true, translated: true, editor: true
-    settings.attribute :a_lambda_enum_setting, type: :enum, default: "all", choices: -> { SomeClass.enum_options }
+    settings.attribute :a_lambda_enum_setting, type: :enum, default: "all", choices: ->(_context) { SomeClass.enum_options }
     settings.attribute :a_readonly_setting, type: :string, readonly: ->(context) { SomeClass.readonly?(context[:component]) }
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

As an admin, I want to be able to define how the visualization of results is presented and choose the taxonomy filter that defines the visualization. Moreover, if I not define any taxonomy filter, then, the results list should be displayed.

As a participant, I want to easily switch different views according to the taxonomies applied to that component.

#### :pushpin: Related Issues

- Fixes https://github.com/decidim/decidim/issues/13965

#### Testing

- Results view https://decidim-lot2.populate.tools/processes/branch-highway/f/1/results/home?root_taxonomy_id=1
- Accountability Admin Settings https://decidim-lot2.populate.tools/admin/participatory_processes/branch-highway/components/1/edit

### :camera: Screenshots

![CleanShot 2025-02-12 at 16 49 50@2x](https://github.com/user-attachments/assets/c5fce52e-d2de-4e84-8676-b1e805fb472c)

![CleanShot 2025-02-12 at 16 50 42@2x](https://github.com/user-attachments/assets/d6409a7a-b511-462d-8ece-0cf4bde8c8c9)

![CleanShot 2025-02-12 at 16 51 19@2x](https://github.com/user-attachments/assets/6d61dc35-af09-4fa8-be26-b6f595ecc8bf)


:hearts: Thank you!
