### PR TITLE
Fix display proposals in sortitions when votes enabled

### DIFF
--- a/decidim-sortitions/app/views/decidim/sortitions/sortitions/_proposal.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/sortitions/_proposal.html.erb
@@ -1,1 +1,1 @@
-<%= card_for proposal, url_extra_params: { included_in: sortition.to_gid } %>
+<%= card_for proposal, hide_voting: true, url_extra_params: { included_in: sortition.to_gid } %>

--- a/decidim-sortitions/spec/system/decidim/sortitions/show_spec.rb
+++ b/decidim-sortitions/spec/system/decidim/sortitions/show_spec.rb
@@ -38,6 +38,17 @@ describe "show" do
       find("#sortitions .card__list").click
     end
 
+    context "when votes are enabled" do
+      let!(:decidim_proposals_component) { create(:proposal_component, :with_votes_enabled, organization: component.organization) }
+      let!(:sortition) { create(:sortition, component:, decidim_proposals_component:) }
+
+      it "shows all selected proposals" do
+        sortition.proposals.each do |p|
+          expect(page).to have_content(translated(p.title))
+        end
+      end
+    end
+
     it "there are selected proposals" do
       expect(sortition.selected_proposals).not_to be_empty
     end


### PR DESCRIPTION
#### :tophat: What? Why?
While working on the QR implementation ([#14086](https://github.com/decidim/decidim/pull/14086)), i have noticed the survey proposals page is raising an error. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13883

#### Testing
1. Visit a proposal component admin panel 
2. Enable voting for the respective component 
3. Visit the sortition component & create a sortition
4. Visit public sortition page
5. See the error 
6. Apply patch 
7. Refresh 
8. See the error is gone

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
