### PR TITLE
Enable pgcrypto extension for Postgres

### DIFF
--- a/decidim-core/db/migrate/20241022002600_create_private_exports.rb
+++ b/decidim-core/db/migrate/20241022002600_create_private_exports.rb
@@ -2,6 +2,8 @@
 
 class CreatePrivateExports < ActiveRecord::Migration[7.0]
   def change
+    enable_extension "pgcrypto"
+
     create_table :decidim_private_exports, id: :uuid do |t|
       t.string :export_type, null: false
       t.string :attached_to_type


### PR DESCRIPTION
#### :tophat: What? Why?

While working on the v0.30.0.rc1 update in Metadecidim, I had this error in CI: 

> ActiveRecord::StatementInvalid: PG::UndefinedFunction: ERROR:  function gen_random_uuid() does not exist (ActiveRecord::StatementInvalid) 

This is because in #13571 we introduced a UUID column type, and when it is generated by Rails in the db/schema.rb uses this function that comes from the extension pgcrypto and some environments (as posgtres image in GH Actions) do not have it enabled by default (or this is my theory at least xD)

https://github.com/decidim/metadecidim/blob/30228052b479e737fd661e7c8f260a9d0e4f9d14/db/schema.rb#L1542 

#### :pushpin: Related Issues
 
- Related to #13571
- Related to https://github.com/decidim/metadecidim/pull/141 

#### Testing

Check the CI errors in https://github.com/decidim/metadecidim/pull/141  

--

This should only be backported to v0.30 as in v0.29 and below we didn't have this feature.

:hearts: Thank you!
