### PR TITLE
Fix excessive categories nesting when converting to taxonomies

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -744,6 +744,7 @@ Pujol
 pwa
 QLiterals
 queda
+qux
 railtie
 railties
 randomable

--- a/decidim-core/lib/tasks/decidim_taxonomies.rake
+++ b/decidim-core/lib/tasks/decidim_taxonomies.rake
@@ -94,7 +94,10 @@ namespace :decidim do
 
       data = JSON.parse(File.read(file))
       taxonomies = data["taxonomy_map"]
-      abort "No taxonomies found in the file" unless taxonomies && taxonomies&.any?
+      unless taxonomies && taxonomies&.any?
+        log.warn "No metric (categories) taxonomies found in the file"
+        next
+      end
 
       total = taxonomies.count
       taxonomies.each_with_index do |(id, object_id), index|

--- a/decidim-core/lib/tasks/decidim_taxonomies.rake
+++ b/decidim-core/lib/tasks/decidim_taxonomies.rake
@@ -82,6 +82,7 @@ namespace :decidim do
     task :import_all_plans, [] => :environment do |_task, _args|
       Rails.root.glob("tmp/taxonomies/*_plan.json").each do |file|
         log.info "Importing plan from #{file}"
+        Rake::Task["decidim:taxonomies:import_plan"].reenable
         Rake::Task["decidim:taxonomies:import_plan"].invoke(file)
       end
     end
@@ -112,6 +113,7 @@ namespace :decidim do
     task :update_all_metrics, [] => :environment do |_task, _args|
       Rails.root.glob("tmp/taxonomies/*_result.json").each do |file|
         log.info "Processing metrics from #{file}"
+        Rake::Task["decidim:taxonomies:update_metrics"].reenable
         Rake::Task["decidim:taxonomies:update_metrics"].invoke(file)
       end
     end

--- a/decidim-core/spec/lib/maintenance/import_models/category_spec.rb
+++ b/decidim-core/spec/lib/maintenance/import_models/category_spec.rb
@@ -13,7 +13,7 @@ module Decidim::Maintenance::ImportModels
     # avoid using factories for this test in case old models are removed
     let!(:category) { described_class.create!(name: { "en" => "Category 1", "ca" => "Categoria 1" }, participatory_space: assembly) }
     let!(:subcategory) { described_class.create!(name: { "en" => "Sub Category 1", "ca" => "Subcategoria 1" }, parent: category, participatory_space: assembly) }
-    let!(:sub_subcategory) { described_class.create!(name: { "en" => "Sub Sub Category 1", "ca" => "Sub Subcategoria 1" }, parent: subcategory, participatory_space: assembly) }
+    let!(:sub_subcategory) { described_class.create!(name: { "en" => "Category too deep", "ca" => "Sub Subcategoria 1" }, parent: subcategory, participatory_space: assembly) }
     let!(:another_category) { described_class.create!(name: { "en" => "Another Category 2", "ca" => "Una Altra Categoria 2" }, participatory_space: participatory_process) }
 
     let!(:categorizable) { Categorization.create!(categorizable: dummy_resource, category:) }
@@ -36,9 +36,9 @@ module Decidim::Maintenance::ImportModels
           children: {},
           resources: subcategory.resources
         },
-        "Sub Category 1 > Sub Sub Category 1" => {
+        "Sub Category 1 > Category too deep" => {
           name: {
-            "en" => "Sub Category 1 > Sub Sub Category 1",
+            "en" => "Sub Category 1 > Category too deep",
             "ca" => "Sub Subcategoria 1"
           },
           origin: sub_subcategory.to_global_id.to_s,
@@ -131,7 +131,7 @@ module Decidim::Maintenance::ImportModels
           items: [
             ["Assembly: Assembly", "Category 1"],
             ["Assembly: Assembly", "Category 1", "Sub Category 1"],
-            ["Assembly: Assembly", "Category 1", "Sub Category 1 > Sub Sub Category 1"]
+            ["Assembly: Assembly", "Category 1", "Sub Category 1 > Category too deep"]
           ],
           components: [
             dummy_component.to_global_id.to_s

--- a/decidim-core/spec/lib/maintenance/import_models/category_spec.rb
+++ b/decidim-core/spec/lib/maintenance/import_models/category_spec.rb
@@ -13,6 +13,7 @@ module Decidim::Maintenance::ImportModels
     # avoid using factories for this test in case old models are removed
     let!(:category) { described_class.create!(name: { "en" => "Category 1", "ca" => "Categoria 1" }, participatory_space: assembly) }
     let!(:subcategory) { described_class.create!(name: { "en" => "Sub Category 1", "ca" => "Subcategoria 1" }, parent: category, participatory_space: assembly) }
+    let!(:sub_subcategory) { described_class.create!(name: { "en" => "Sub Sub Category 1", "ca" => "Sub Subcategoria 1" }, parent: subcategory, participatory_space: assembly) }
     let!(:another_category) { described_class.create!(name: { "en" => "Another Category 2", "ca" => "Una Altra Categoria 2" }, participatory_space: participatory_process) }
 
     let!(:categorizable) { Categorization.create!(categorizable: dummy_resource, category:) }
@@ -27,6 +28,25 @@ module Decidim::Maintenance::ImportModels
     let!(:external_category) { described_class.create!(name: { "en" => "External Category" }, participatory_space: external_participatory_process) }
     let!(:external_categorizable) { Categorization.create!(categorizable: external_resource, category: external_category) }
     let(:root_taxonomy_name) { "~ Categories" }
+    let(:common_children) do
+      {
+        "Sub Category 1" => {
+          name: subcategory.name,
+          origin: subcategory.to_global_id.to_s,
+          children: {},
+          resources: subcategory.resources
+        },
+        "Sub Category 1 > Sub Sub Category 1" => {
+          name: {
+            "en" => "Sub Category 1 > Sub Sub Category 1",
+            "ca" => "Sub Subcategoria 1"
+          },
+          origin: sub_subcategory.to_global_id.to_s,
+          children: {},
+          resources: sub_subcategory.resources
+        }
+      }
+    end
 
     before do
       described_class.add_resource_class("Decidim::Dev::DummyResource")
@@ -54,14 +74,7 @@ module Decidim::Maintenance::ImportModels
         expect(subject.taxonomies).to eq(
           name: category.name,
           origin: category.to_global_id.to_s,
-          children: {
-            "Sub Category 1" => {
-              name: subcategory.name,
-              origin: subcategory.to_global_id.to_s,
-              children: {},
-              resources: subcategory.resources
-            }
-          },
+          children: common_children,
           resources: subject.resources
         )
       end
@@ -85,14 +98,7 @@ module Decidim::Maintenance::ImportModels
                                                                   "Category 1" => {
                                                                     name: category.name,
                                                                     origin: category.to_global_id.to_s,
-                                                                    children: {
-                                                                      "Sub Category 1" => {
-                                                                        name: subcategory.name,
-                                                                        origin: subcategory.to_global_id.to_s,
-                                                                        children: {},
-                                                                        resources: {}
-                                                                      }
-                                                                    },
+                                                                    children: common_children,
                                                                     resources: {
                                                                       dummy_resource.to_global_id.to_s => dummy_resource.title[I18n.locale.to_s]
                                                                     }
@@ -124,7 +130,8 @@ module Decidim::Maintenance::ImportModels
           internal_name: "Assembly: Assembly",
           items: [
             ["Assembly: Assembly", "Category 1"],
-            ["Assembly: Assembly", "Category 1", "Sub Category 1"]
+            ["Assembly: Assembly", "Category 1", "Sub Category 1"],
+            ["Assembly: Assembly", "Category 1", "Sub Category 1 > Sub Sub Category 1"]
           ],
           components: [
             dummy_component.to_global_id.to_s
@@ -155,14 +162,7 @@ module Decidim::Maintenance::ImportModels
                                                                     "Category 1" => {
                                                                       name: category.name,
                                                                       origin: category.to_global_id.to_s,
-                                                                      children: {
-                                                                        "Sub Category 1" => {
-                                                                          name: subcategory.name,
-                                                                          origin: subcategory.to_global_id.to_s,
-                                                                          children: {},
-                                                                          resources: {}
-                                                                        }
-                                                                      },
+                                                                      children: common_children,
                                                                       resources: {
                                                                         dummy_resource.to_global_id.to_s => dummy_resource.title[I18n.locale.to_s]
                                                                       }

--- a/decidim-core/spec/tasks/decidim_tasks_taxonomies_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_taxonomies_spec.rb
@@ -7,8 +7,8 @@ describe "Executing Decidim Taxonomy importer tasks" do
   let(:plan_file) { Rails.root.join("tmp/taxonomies/#{organization.host}_plan.json") }
   let(:another_plan_file) { Rails.root.join("tmp/taxonomies/#{another_organization.host}_plan.json") }
 
-  let(:organization) { create(:organization, host: "billie.example.org") }
-  let(:another_organization) { create(:organization, host: "ella.example.org") }
+  let(:organization) { create(:organization, host: "foo.example.org") }
+  let(:another_organization) { create(:organization, host: "bar.example.org") }
 
   let!(:external_scope) { Decidim::Maintenance::ImportModels::Scope.create!(name: { "en" => "External Scope 1" }, code: "3", decidim_organization_id: another_organization.id) }
 

--- a/decidim-core/spec/tasks/decidim_tasks_taxonomies_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_taxonomies_spec.rb
@@ -5,13 +5,14 @@ require "decidim/maintenance"
 
 describe "Executing Decidim Taxonomy importer tasks" do
   let(:plan_file) { Rails.root.join("tmp/taxonomies/#{organization.host}_plan.json") }
-  let(:another_plan_file) { Rails.root.join("tmp/taxonomies/#{another_organization.host}_plan.json") }
+  let(:another_plan_file) { Rails.root.join("tmp/taxonomies/#{external_organization.host}_plan.json") }
 
-  let(:organization) { create(:organization, host: "foo.example.org") }
-  let(:another_organization) { create(:organization, host: "bar.example.org") }
+  let!(:organization) { create(:organization, host: "foo.example.org") }
+  let!(:external_organization) { create(:organization, host: "bar.example.org") }
 
-  let!(:external_scope) { Decidim::Maintenance::ImportModels::Scope.create!(name: { "en" => "External Scope 1" }, code: "3", decidim_organization_id: another_organization.id) }
-
+  let!(:external_scope) { Decidim::Maintenance::ImportModels::Scope.create!(name: { "en" => "External Scope 1" }, code: "3", decidim_organization_id: external_organization.id) }
+  let!(:external_sub_scope) { Decidim::Maintenance::ImportModels::Scope.create!(name: { "en" => "External Scope 1 second level" }, code: "31", decidim_organization_id: external_organization.id, parent: external_scope) }
+  let!(:external_participatory_process) { create(:participatory_process, title: { "en" => "External Process" }, organization: external_organization, decidim_scope_id: external_scope.id) }
   let(:decidim_organization_id) { organization.id }
 
   # avoid using factories for this test in case old models are removed
@@ -208,21 +209,26 @@ describe "Executing Decidim Taxonomy importer tasks" do
   end
 
   describe "rake decidim:taxonomies:import_all_plans", type: :task do
+    let!(:organization) { create(:organization, host: "baz.example.org") }
+    let!(:external_organization) { create(:organization, host: "qux.example.org") }
+
     let(:task) { Rake::Task["decidim:taxonomies:import_all_plans"] }
 
     before do
-      FileUtils.rm_rf(Rails.root.join("tmp/taxonomies/"))
+      FileUtils.rm_f(Rails.root.join("tmp/taxonomies/bar.example.org_plan.json"))
+      FileUtils.rm_f(Rails.root.join("tmp/taxonomies/foo.example.org_plan.json"))
+      sleep(0.1) # Filesystem may need some time to update
       Rake::Task["decidim:taxonomies:make_plan"].reenable
       Rake::Task["decidim:taxonomies:make_plan"].invoke
     end
 
     it "imports the plan for all organizations" do # rubocop:disable RSpec/ExampleLength
-      expect { task.invoke }.to change(Decidim::Taxonomy, :count).by(20)
+      expect { task.invoke }.to change(Decidim::Taxonomy, :count).by(21)
 
       check_message_printed("Importing plan from #{plan_file}")
       check_message_printed("Importing plan from #{another_plan_file}")
       check_message_printed("Importing taxonomies and filters for organization #{decidim_organization_id}")
-      check_message_printed("Importing taxonomies and filters for organization #{another_organization.id}")
+      check_message_printed("Importing taxonomies and filters for organization #{external_organization.id}")
 
       check_message_printed(<<~MSG)
         ...Importing 1 root taxonomies from decidim_participatory_process_types
@@ -374,6 +380,7 @@ describe "Executing Decidim Taxonomy importer tasks" do
 
       Rake::Task["decidim:taxonomies:update_all_metrics"].invoke
       check_message_printed("Updating 1 metrics for category #{subcategory.id} to taxonomy")
+      check_message_printed("No metric (categories) taxonomies found in the file")
       expect(Decidim::Taxonomy.where(organization:).non_roots.pluck(:id)).to include(metric.reload.decidim_taxonomy_id)
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

These PR solve 2 bugs and adds a little improvement when using the rake task `decidim:taxonomies:make_plan` and `decidim:taxonomies:import_all_plans`

- [x] There's a bug when converting categories with more than 2 levels into taxonomies when using the taxonomy importer. This fix converts the last level into a sibling of the previous one.
- [x] This PR also captures more exceptions and gives more info to the user if some import fails.
- [x] The task `import_all_plans` invokes the task `import_plan` for each organization. It needs to be reenabled, otherwise just the first organization is imported.

> This PR should be backported to v0.30

#### :pushpin: Related Issues
This bug has appeared when trying to import the Metadecidim instance that had a tenant with deep categories levels.

:hearts: Thank you!
