### PR TITLE
Import proposals from one component to another in the background

### DIFF
--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_imports_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_imports_controller.rb
@@ -16,8 +16,8 @@ module Decidim
           @form = form(Admin::ProposalsImportForm).from_params(params)
 
           Admin::ImportProposals.call(@form) do
-            on(:ok) do |proposals|
-              flash[:notice] = I18n.t("proposals_imports.create.success", scope: "decidim.proposals.admin", number: proposals.length)
+            on(:ok) do
+              flash[:notice] = I18n.t("proposals_imports.create.success", scope: "decidim.proposals.admin")
               redirect_to EngineRouter.admin_proxy(current_component).root_path
             end
 

--- a/decidim-proposals/app/jobs/decidim/proposals/admin/import_proposals_job.rb
+++ b/decidim-proposals/app/jobs/decidim/proposals/admin/import_proposals_job.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      class ImportProposalsJob < ApplicationJob
+        queue_as :default
+
+        def perform(form)
+          @form = form
+          ActiveRecord::Base.transaction do
+            proposals.map do |original_proposal|
+              next if proposal_already_copied?(original_proposal, target_component)
+
+              Decidim::Proposals::ProposalBuilder.copy(
+                original_proposal,
+                author: proposal_author,
+                action_user: current_user,
+                extra_attributes: {
+                  "component" => target_component
+                }.merge(proposal_answer_attributes(original_proposal))
+              )
+            end
+          end
+          ImportProposalsMailer.notify_success(current_user, origin_component, target_component, proposals.count).deliver_now
+        rescue ActiveRecord::RecordNotFound, NoMethodError
+          ImportProposalsMailer.notify_failure(current_user, origin_component, target_component).deliver_now
+        end
+
+        private
+
+        def proposals
+          proposals = Decidim::Proposals::Proposal.where(component: origin_component)
+
+          if @form["states"].include?("not_answered")
+            proposals.not_answered.or(proposals.where(id: proposals.only_status(@form["states"]).pluck(:id)))
+          else
+            proposals.only_status(@form["states"])
+          end
+        end
+
+        def origin_component
+          @origin_component ||= Decidim::Component.find(@form["origin_component_id"])
+        end
+
+        def target_component
+          @target_component ||= Decidim::Component.find(@form["current_component_id"])
+        end
+
+        def current_user
+          @current_user ||= Decidim::User.find(@form["current_user_id"])
+        end
+
+        def current_organization
+          @current_organization ||= Decidim::Organization.find(@form["current_organization_id"])
+        end
+
+        def proposal_already_copied?(original_proposal, target_component)
+          # Note: we are including also proposals from unpublished components
+          # because otherwise duplicates could be created until the component is
+          # published.
+          original_proposal.linked_resources(:proposals, "copied_from_component", component_published: false).any? do |proposal|
+            proposal.component == target_component
+          end
+        end
+
+        def proposal_author
+          @form["keep_authors"] ? nil : current_organization
+        end
+
+        def proposal_answer_attributes(original_proposal)
+          return {} unless @form["keep_answers"]
+
+          state = Decidim::Proposals::ProposalState.where(component: target_component, token: original_proposal.state).first
+
+          {
+            answer: original_proposal.answer,
+            answered_at: original_proposal.answered_at,
+            proposal_state: state,
+            state_published_at: original_proposal.state_published_at
+          }
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/mailers/decidim/proposals/admin/import_proposals_mailer.rb
+++ b/decidim-proposals/app/mailers/decidim/proposals/admin/import_proposals_mailer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module Admin
+      class ImportProposalsMailer < Decidim::ApplicationMailer
+        def notify_success(user, origin_component, target_component, count)
+          @organization = user.organization
+          @origin_component = origin_component
+          @target_component = target_component
+          @count = count
+
+          with_user(user) do
+            mail(to: user.email, subject: t(".subject"))
+          end
+        end
+
+        def notify_failure(user, origin_component, target_component)
+          @organization = user.organization
+          @origin_component = origin_component
+          @target_component = target_component
+
+          with_user(user) do
+            mail(to: user.email, subject: t(".subject"))
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/views/decidim/proposals/admin/import_proposals_mailer/notify_failure.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/import_proposals_mailer/notify_failure.html.erb
@@ -1,0 +1,1 @@
+<p><%= t(".body", origin_component_name: translated_attribute(@origin_component.name), target_component_name: translated_attribute(@target_component.name)) %></p>

--- a/decidim-proposals/app/views/decidim/proposals/admin/import_proposals_mailer/notify_success.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/import_proposals_mailer/notify_success.html.erb
@@ -1,0 +1,2 @@
+<p><%= t(".body", origin_component_name: translated_attribute(@origin_component.name), target_component_name: translated_attribute(@target_component.name)) %></p>
+<p><%= t(".added_proposals", count: @count) %></p>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -518,6 +518,17 @@ en:
         exports:
           proposal_comments: Comments
           proposals: Proposals
+        import_proposals_mailer:
+          notify_success:
+            added_proposals:
+              one: One proposal was imported.
+              other: "%{count} proposals were imported."
+            subject: The proposals have been imported successfully
+            body: Successful imported proposals from the %{origin_component_name} component to the %{target_component_name} component. You can review the results in the
+              administration interface.
+          notify_failure:
+            subject: There was an error importing proposals
+            body: There was a problem while importing proposals from the %{origin_component_name} component to the %{target_component_name} component.
         imports:
           help:
             answers: |
@@ -689,7 +700,7 @@ en:
         proposals_imports:
           create:
             invalid: There was a problem importing the proposals.
-            success: "%{number} proposals successfully imported."
+            success: The import process has started. We will let you know once it has finished.
           new:
             create: Import proposals
             no_components: There are no other proposal components in this participatory space to import the proposals from.


### PR DESCRIPTION
#### :tophat: What? Why?

When importing multiple proposals from one component to another, the process can be time-consuming and may lead to server timeout errors.

To improve scalability and efficiency, I propose moving this operation to the background. Instead of handling the import synchronously, the `ImportProposals` command will enqueue a job to process the proposals asynchronously. Once the import is complete, the system will notify the user, ensuring a smoother and more reliable experience.

#### :pushpin: Related Issues

- Fixes #14154

#### Testing

1. Create 1.000 proposals in a component
2. Go to another component and import the proposals from the other component
3. See how it notifies the user the process is being done in the background
4. Wait for a minutes and see how the user will receive an email notifying the process has been completed successfully

:hearts: Thank you!
