### PR TITLE
Fix result timeline entry description formatting

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/results/_timeline.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/results/_timeline.html.erb
@@ -18,7 +18,7 @@
 
               <% if translated_attribute(timeline_entry.description).present? %>
                 <div class="timeline__description__description">
-                  <%= decidim_escape_translated(timeline_entry.description) %>
+                  <%= decidim_sanitize_editor_admin(translated_attribute(timeline_entry.description)) %>
                 </div>
               <% end %>
             </div>

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -331,6 +331,25 @@ describe "Explore results", versioning: true, type: :system do
       end
     end
 
+    context "with timeline entries" do
+      let!(:timeline_entry) { create(:timeline_entry, description: description, result: result) }
+      let(:description) do
+        generate_localized_title(:timeline_entry_description).transform_values { |v| "<p>#{v}</p>" }
+      end
+
+      before do
+        # Revisit the path to load updated results
+        visit path
+
+        expect(page).to have_text("PROJECT EVOLUTION")
+        page.scroll_to(find(".section-heading", text: "PROJECT EVOLUTION"))
+      end
+
+      it "displays the timeline entry description correctly" do
+        expect(page).not_to have_content("&lt;p&gt")
+      end
+    end
+
     context "when filtering" do
       before do
         create(:result, component: component, scope: scope)


### PR DESCRIPTION
#### :tophat: What? Why?
The result entry timeline description is written in HTML and using `decidim_escape_translated` here causes the HTML to be escaped.

Works in 0.27.5, broken in 0.27.6. The formatting has been broken by #12547.

The fix is only applied to 0.27 version because this is refactored in 0.28+ and the bug is caused by a functionality breaking security fix.

#### :pushpin: Related Issues
- Related to #12547

#### Testing
- Create a result timeline entry
- Go to the result page to see the timeline entry
- See that the description is formatted correctly

### :camera: Screenshots
Before:
![Invalid formatting before](https://github.com/user-attachments/assets/b78cd672-b82d-406e-a700-e4357067cdc4)

After:
![Correct formatting after](https://github.com/user-attachments/assets/5afd8e36-228f-49e8-9630-00b44b9ab405)
