### PR TITLE
Fix image missing error

### DIFF
--- a/decidim-core/app/resolvers/decidim/meta_image_url_resolver.rb
+++ b/decidim-core/app/resolvers/decidim/meta_image_url_resolver.rb
@@ -25,6 +25,7 @@ module Decidim
     # @return [String, nil] - The resolved image blob or nil if no image is found.
     def resolve
       return unless blob
+      return unless blob.service.exist?(blob.key)
 
       resized_variant = blob.variant(resize_to_limit: [1200, 630]).processed
       Rails.application.routes.url_helpers.rails_representation_url(resized_variant, only_path: true)

--- a/decidim-core/spec/services/decidim/meta_image_url_resolver_spec.rb
+++ b/decidim-core/spec/services/decidim/meta_image_url_resolver_spec.rb
@@ -53,6 +53,18 @@ describe Decidim::MetaImageUrlResolver do
     it { is_expected.to end_with("/icon.png") }
   end
 
+  context "when there is no image attached" do
+    let(:hero_image) { nil }
+    let(:banner_image) { nil }
+    let(:resource) { nil }
+
+    before do
+      FileUtils.rm(Rails.root.glob("tmp/storage/**/**/#{content_block.images_container.background_image.blob.key}"))
+    end
+
+    it { is_expected.to be_nil }
+  end
+
   context "when avatar image" do
     let(:avatar) { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
     let(:resource) { user }


### PR DESCRIPTION
#### :tophat: What? Why?
While upgrading, i have stumbled upon a bug where an error is raised if there is no image attached.

<details>
<summary>Stacktrace</summary>

16:21:48 web.1          | ActionView::Template::Error (ActiveStorage::FileNotFoundError):
16:21:48 web.1          |     1: <% add_decidim_meta_tags(
16:21:48 web.1          |     2:     description: strip_tags(translated_attribute(current_organization.description)),
16:21:48 web.1          |     3:     title: current_organization_name,
16:21:48 web.1          |     4:     url: request.original_url,
16:21:48 web.1          |   
16:21:48 web.1          | activestorage (7.0.8.7) lib/active_storage/service/disk_service.rb:150:in `rescue in stream'
16:21:48 web.1          | activestorage (7.0.8.7) lib/active_storage/service/disk_service.rb:143:in `stream'
16:21:48 web.1          | activestorage (7.0.8.7) lib/active_storage/service/disk_service.rb:29:in `block in download'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `block in instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications/instrumenter.rb:24:in `instrument'
16:21:48 web.1          | sentry-rails (5.19.0) lib/sentry/rails/tracing.rb:54:in `instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `instrument'
16:21:48 web.1          | activestorage (7.0.8.7) lib/active_storage/service.rb:163:in `instrument'
16:21:48 web.1          | activestorage (7.0.8.7) lib/active_storage/service/disk_service.rb:28:in `download'
16:21:48 web.1          | activestorage (7.0.8.7) lib/active_storage/downloader.rb:32:in `download'
16:21:48 web.1          | activestorage (7.0.8.7) lib/active_storage/downloader.rb:13:in `block in open'
16:21:48 web.1          | activestorage (7.0.8.7) lib/active_storage/downloader.rb:24:in `open_tempfile'
16:21:48 web.1          | activestorage (7.0.8.7) lib/active_storage/downloader.rb:12:in `open'
16:21:48 web.1          | activestorage (7.0.8.7) lib/active_storage/service.rb:90:in `open'
16:21:48 web.1          | activestorage (7.0.8.7) app/models/active_storage/blob.rb:301:in `open'
16:21:48 web.1          | activestorage (7.0.8.7) app/models/active_storage/variant_with_record.rb:34:in `transform_blob'
16:21:48 web.1          | activestorage (7.0.8.7) app/models/active_storage/variant_with_record.rb:19:in `process'
16:21:48 web.1          | activestorage (7.0.8.7) app/models/active_storage/variant_with_record.rb:14:in `processed'
16:21:48 web.1          | decidim-core (0.30.0.rc1) app/resolvers/decidim/meta_image_url_resolver.rb:29:in `resolve'
16:21:48 web.1          | decidim-core (0.30.0.rc1) app/helpers/decidim/meta_tags_helper.rb:137:in `resolve_meta_image_url'
16:21:48 web.1          | decidim-core (0.30.0.rc1) app/helpers/decidim/meta_tags_helper.rb:19:in `add_decidim_meta_tags'
16:21:48 web.1          | decidim-core (0.30.0.rc1) app/views/layouts/decidim/_meta_tags_config.html.erb:1
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/base.rb:244:in `public_send'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/base.rb:244:in `_run'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/template.rb:157:in `block in render'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `block in instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications/instrumenter.rb:24:in `instrument'
16:21:48 web.1          | sentry-rails (5.19.0) lib/sentry/rails/tracing.rb:54:in `instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `instrument'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/template.rb:361:in `instrument_render_template'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/template.rb:155:in `render'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/partial_renderer.rb:251:in `block in render_partial_template'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `block in instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications/instrumenter.rb:24:in `instrument'
16:21:48 web.1          | sentry-rails (5.19.0) lib/sentry/rails/tracing.rb:54:in `instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `instrument'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/partial_renderer.rb:246:in `render_partial_template'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/partial_renderer.rb:237:in `render'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/renderer.rb:81:in `render_partial_to_object'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/renderer.rb:27:in `render_to_object'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/renderer.rb:22:in `render'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/helpers/rendering_helper.rb:37:in `block in render'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/base.rb:270:in `in_rendering_context'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/helpers/rendering_helper.rb:33:in `render'
16:21:48 web.1          | decidim-core (0.30.0.rc1) app/views/layouts/decidim/_application.html.erb:1
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/base.rb:244:in `public_send'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/base.rb:244:in `_run'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/template.rb:157:in `block in render'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `block in instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications/instrumenter.rb:24:in `instrument'
16:21:48 web.1          | sentry-rails (5.19.0) lib/sentry/rails/tracing.rb:54:in `instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `instrument'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/template.rb:361:in `instrument_render_template'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/template.rb:155:in `render'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/partial_renderer.rb:251:in `block in render_partial_template'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `block in instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications/instrumenter.rb:24:in `instrument'
16:21:48 web.1          | sentry-rails (5.19.0) lib/sentry/rails/tracing.rb:54:in `instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `instrument'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/partial_renderer.rb:246:in `render_partial_template'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/partial_renderer.rb:237:in `render'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/renderer.rb:81:in `render_partial_to_object'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/renderer.rb:53:in `render_partial'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/helpers/rendering_helper.rb:44:in `render'
16:21:48 web.1          | decidim-core (0.30.0.rc1) app/views/layouts/decidim/application.html.erb:1
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/base.rb:244:in `public_send'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/base.rb:244:in `_run'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/template.rb:157:in `block in render'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `block in instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications/instrumenter.rb:24:in `instrument'
16:21:48 web.1          | sentry-rails (5.19.0) lib/sentry/rails/tracing.rb:54:in `instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `instrument'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/template.rb:361:in `instrument_render_template'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/template.rb:155:in `render'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/template_renderer.rb:76:in `block in render_with_layout'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `block in instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications/instrumenter.rb:24:in `instrument'
16:21:48 web.1          | sentry-rails (5.19.0) lib/sentry/rails/tracing.rb:54:in `instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `instrument'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/template_renderer.rb:74:in `render_with_layout'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/template_renderer.rb:59:in `render_template'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/template_renderer.rb:11:in `render'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/renderer.rb:61:in `render_template_to_object'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/renderer/renderer.rb:29:in `render_to_object'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/rendering.rb:117:in `block in _render_template'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/base.rb:270:in `in_rendering_context'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/rendering.rb:116:in `_render_template'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/streaming.rb:216:in `_render_template'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/rendering.rb:103:in `render_to_body'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/rendering.rb:158:in `render_to_body'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/renderers.rb:141:in `render_to_body'
16:21:48 web.1          | actionpack (7.0.8.7) lib/abstract_controller/rendering.rb:27:in `render'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/rendering.rb:139:in `render'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/instrumentation.rb:22:in `block (2 levels) in render'
16:21:48 web.1          | /home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/benchmark.rb:313:in `realtime'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/core_ext/benchmark.rb:14:in `ms'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/instrumentation.rb:22:in `block in render'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/instrumentation.rb:91:in `cleanup_view_runtime'
16:21:48 web.1          | activerecord (7.0.8.7) lib/active_record/railties/controller_runtime.rb:34:in `cleanup_view_runtime'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/instrumentation.rb:21:in `render'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/implicit_render.rb:35:in `default_render'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/basic_implicit_render.rb:7:in `send_action'
16:21:48 web.1          | actionpack (7.0.8.7) lib/abstract_controller/base.rb:215:in `process_action'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/rendering.rb:165:in `process_action'
16:21:48 web.1          | actionpack (7.0.8.7) lib/abstract_controller/callbacks.rb:234:in `block in process_action'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/callbacks.rb:118:in `block in run_callbacks'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/core_ext/time/zones.rb:65:in `use_zone'
16:21:48 web.1          | decidim-core (0.30.0.rc1) app/controllers/concerns/decidim/use_organization_time_zone.rb:21:in `use_organization_time_zone'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/callbacks.rb:127:in `block in run_callbacks'
16:21:48 web.1          | i18n (1.14.7) lib/i18n.rb:353:in `with_locale'
16:21:48 web.1          | decidim-core (0.30.0.rc1) app/controllers/concerns/decidim/locale_switcher.rb:24:in `switch_locale'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/callbacks.rb:127:in `block in run_callbacks'
16:21:48 web.1          | sentry-rails (5.19.0) lib/sentry/rails/controller_transaction.rb:19:in `block in sentry_around_action'
16:21:48 web.1          | sentry-ruby (5.19.0) lib/sentry/hub.rb:109:in `block in with_child_span'
16:21:48 web.1          | sentry-ruby (5.19.0) lib/sentry/span.rb:226:in `with_child_span'
16:21:48 web.1          | sentry-ruby (5.19.0) lib/sentry/hub.rb:107:in `with_child_span'
16:21:48 web.1          | sentry-ruby (5.19.0) lib/sentry-ruby.rb:498:in `with_child_span'
16:21:48 web.1          | sentry-rails (5.19.0) lib/sentry/rails/controller_transaction.rb:16:in `sentry_around_action'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/callbacks.rb:127:in `block in run_callbacks'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/callbacks.rb:138:in `run_callbacks'
16:21:48 web.1          | actionpack (7.0.8.7) lib/abstract_controller/callbacks.rb:233:in `process_action'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/rescue.rb:23:in `process_action'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/instrumentation.rb:67:in `block in process_action'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `block in instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications/instrumenter.rb:24:in `instrument'
16:21:48 web.1          | sentry-rails (5.19.0) lib/sentry/rails/tracing.rb:54:in `instrument'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/notifications.rb:206:in `instrument'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/instrumentation.rb:66:in `process_action'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal/params_wrapper.rb:259:in `process_action'
16:21:48 web.1          | activerecord (7.0.8.7) lib/active_record/railties/controller_runtime.rb:27:in `process_action'
16:21:48 web.1          | actionpack (7.0.8.7) lib/abstract_controller/base.rb:151:in `process'
16:21:48 web.1          | actionview (7.0.8.7) lib/action_view/rendering.rb:39:in `process'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal.rb:188:in `dispatch'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_controller/metal.rb:251:in `dispatch'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/routing/route_set.rb:49:in `dispatch'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/routing/route_set.rb:32:in `serve'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/journey/router.rb:50:in `block in serve'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/journey/router.rb:32:in `each'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/journey/router.rb:32:in `serve'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/routing/route_set.rb:852:in `call'
16:21:48 web.1          | railties (7.0.8.7) lib/rails/engine.rb:530:in `call'
16:21:48 web.1          | railties (7.0.8.7) lib/rails/railtie.rb:226:in `public_send'
16:21:48 web.1          | railties (7.0.8.7) lib/rails/railtie.rb:226:in `method_missing'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/routing/mapper.rb:19:in `block in <class:Constraints>'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/routing/mapper.rb:48:in `serve'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/journey/router.rb:50:in `block in serve'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/journey/router.rb:32:in `each'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/journey/router.rb:32:in `serve'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/routing/route_set.rb:852:in `call'
16:21:48 web.1          | omniauth (2.1.2) lib/omniauth/strategy.rb:202:in `call!'
16:21:48 web.1          | omniauth (2.1.2) lib/omniauth/strategy.rb:169:in `call'
16:21:48 web.1          | omniauth (2.1.2) lib/omniauth/builder.rb:44:in `call'
16:21:48 web.1          | batch-loader (2.0.5) lib/batch_loader/middleware.rb:11:in `call'
16:21:48 web.1          | omniauth (2.1.2) lib/omniauth/strategy.rb:202:in `call!'
16:21:48 web.1          | omniauth (2.1.2) lib/omniauth/strategy.rb:169:in `call'
16:21:48 web.1          | omniauth (2.1.2) lib/omniauth/builder.rb:44:in `call'
16:21:48 web.1          | warden (1.2.9) lib/warden/manager.rb:36:in `block in call'
16:21:48 web.1          | warden (1.2.9) lib/warden/manager.rb:34:in `catch'
16:21:48 web.1          | warden (1.2.9) lib/warden/manager.rb:34:in `call'
16:21:48 web.1          | decidim-core (0.30.0.rc1) lib/decidim/middleware/strip_x_forwarded_host.rb:12:in `call'
16:21:48 web.1          | decidim-core (0.30.0.rc1) lib/decidim/middleware/current_organization.rb:22:in `call'
16:21:48 web.1          | rack (2.2.11) lib/rack/tempfile_reaper.rb:15:in `call'
16:21:48 web.1          | rack (2.2.11) lib/rack/etag.rb:27:in `call'
16:21:48 web.1          | rack (2.2.11) lib/rack/conditional_get.rb:27:in `call'
16:21:48 web.1          | rack (2.2.11) lib/rack/head.rb:12:in `call'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/http/content_security_policy.rb:39:in `call'
16:21:48 web.1          | rack (2.2.11) lib/rack/session/abstract/id.rb:266:in `context'
16:21:48 web.1          | rack (2.2.11) lib/rack/session/abstract/id.rb:260:in `call'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/middleware/cookies.rb:704:in `call'
16:21:48 web.1          | activerecord (7.0.8.7) lib/active_record/migration.rb:638:in `call'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/middleware/callbacks.rb:27:in `block in call'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/callbacks.rb:99:in `run_callbacks'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/middleware/callbacks.rb:26:in `call'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/middleware/executor.rb:14:in `call'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/middleware/actionable_exceptions.rb:17:in `call'
16:21:48 web.1          | sentry-rails (5.19.0) lib/sentry/rails/rescued_exception_interceptor.rb:12:in `call'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/middleware/debug_exceptions.rb:28:in `call'
16:21:48 web.1          | web-console (4.2.1) lib/web_console/middleware.rb:132:in `call_app'
16:21:48 web.1          | web-console (4.2.1) lib/web_console/middleware.rb:28:in `block in call'
16:21:48 web.1          | web-console (4.2.1) lib/web_console/middleware.rb:17:in `catch'
16:21:48 web.1          | web-console (4.2.1) lib/web_console/middleware.rb:17:in `call'
16:21:48 web.1          | sentry-ruby (5.19.0) lib/sentry/rack/capture_exceptions.rb:30:in `block (2 levels) in call'
16:21:48 web.1          | sentry-ruby (5.19.0) lib/sentry/hub.rb:258:in `with_session_tracking'
16:21:48 web.1          | sentry-ruby (5.19.0) lib/sentry-ruby.rb:411:in `with_session_tracking'
16:21:48 web.1          | sentry-ruby (5.19.0) lib/sentry/rack/capture_exceptions.rb:21:in `block in call'
16:21:48 web.1          | sentry-ruby (5.19.0) lib/sentry/hub.rb:59:in `with_scope'
16:21:48 web.1          | sentry-ruby (5.19.0) lib/sentry-ruby.rb:391:in `with_scope'
16:21:48 web.1          | sentry-ruby (5.19.0) lib/sentry/rack/capture_exceptions.rb:20:in `call'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/middleware/show_exceptions.rb:29:in `call'
16:21:48 web.1          | railties (7.0.8.7) lib/rails/rack/logger.rb:40:in `call_app'
16:21:48 web.1          | railties (7.0.8.7) lib/rails/rack/logger.rb:25:in `block in call'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/tagged_logging.rb:99:in `block in tagged'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/tagged_logging.rb:37:in `tagged'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/tagged_logging.rb:99:in `tagged'
16:21:48 web.1          | railties (7.0.8.7) lib/rails/rack/logger.rb:25:in `call'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/middleware/remote_ip.rb:93:in `call'
16:21:48 web.1          | request_store (1.7.0) lib/request_store/middleware.rb:19:in `call'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/middleware/request_id.rb:26:in `call'
16:21:48 web.1          | rack (2.2.11) lib/rack/method_override.rb:24:in `call'
16:21:48 web.1          | activesupport (7.0.8.7) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/middleware/executor.rb:14:in `call'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/middleware/static.rb:23:in `call'
16:21:48 web.1          | rack (2.2.11) lib/rack/sendfile.rb:110:in `call'
16:21:48 web.1          | actionpack (7.0.8.7) lib/action_dispatch/middleware/host_authorization.rb:131:in `call'
16:21:48 web.1          | shakapacker (7.1.0) lib/shakapacker/dev_server_proxy.rb:25:in `perform_request'
16:21:48 web.1          | rack-proxy (0.7.7) lib/rack/proxy.rb:87:in `call'
16:21:48 web.1          | rack-cors (1.1.1) lib/rack/cors.rb:100:in `call'
16:21:48 web.1          | railties (7.0.8.7) lib/rails/engine.rb:530:in `call'
16:21:48 web.1          | puma (6.5.0) lib/puma/configuration.rb:279:in `call'
16:21:48 web.1          | puma (6.5.0) lib/puma/request.rb:99:in `block in handle_request'
16:21:48 web.1          | puma (6.5.0) lib/puma/thread_pool.rb:389:in `with_force_shutdown'
16:21:48 web.1          | puma (6.5.0) lib/puma/request.rb:98:in `handle_request'
16:21:48 web.1          | puma (6.5.0) lib/puma/server.rb:468:in `process_client'
16:21:48 web.1          | puma (6.5.0) lib/puma/server.rb:249:in `block in run'
16:21:48 web.1          | puma (6.5.0) lib/puma/thread_pool.rb:166:in `block in spawn_thread'


</details>

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing

1. On your local machine, rename your `tmp/storage` folder. 
2. Visit the search page 
3. See the error 
4. Apply patch 
5. See there is no error 
6. Move back your storage folder


### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
