### PR TITLE
fix wcag by replace div > span with h3

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_extra_data/extra_data.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_extra_data/extra_data.erb
@@ -1,9 +1,9 @@
 <% extra_data_items.each do |item| %>
   <div class="participatory-space__metadata-item">
-    <div class="participatory-space__metadata-item-title">
+    <h3 class="participatory-space__metadata-item-title">
       <%= icon item[:icon] %>
-      <span><%= item[:title] %></span>
-    </div>
+      <%= item[:title] %>
+    </h3>
     <% if item[:text].present? %>
       <%= content_tag :span, item[:text] %>
     <% elsif item[:partial].present? %>


### PR DESCRIPTION
🎩 What?
Updated the heading structure on the Process Show Page by replacing a <div> and <span> used as titles with a proper <h3> element.

🎯 Why?
- Ensures proper heading hierarchy for assistive technologies.
- Allows screen readers to recognize section titles correctly.
- Enhances keyboard navigation and WCAG compliance.

📌 Related Issues
WCAG Criterion: [1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
WCAG Criterion: [2.4.6 - Headings and Labels](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels)
Grist [Diagnostique Decidim] (https://grist.simone-de-beauvoir.indiehosters.net/o/team-osp/7Mwbi3TEFVCs/Suivi-de-laccessibilite-en-029/p/6#a1.s14.r19.c55)

✅ Steps to Test
1. Navigate to a Process.
3. Ensure that <h3> elements replace the previous <div> and <span> participatory-space__metadata-item-title.
5. Test with a screen reader: Use VoiceOver (macOS) / NVDA (Windows):
- Verify that the headings 3 are correctly announced.

### :camera: Screenshots
<img width="1368" alt="Capture d’écran 2025-02-26 à 16 10 25" src="https://github.com/user-attachments/assets/d7eab8d0-d430-42c9-8095-e3c89a524c6b" />

🔍 Additional Context
This issue originates from an accessibility audit funded by the city of Lyon, targeting compliance with RGAA and corresponding WCAG standards. The changes ensure clearer navigation and improved usability for assistive technologies.

:hearts: Thank you!
