### PR TITLE
Remove deprecated HERE maps configuration

### DIFF
--- a/decidim-core/lib/decidim/map/provider/dynamic_map/here.rb
+++ b/decidim-core/lib/decidim/map/provider/dynamic_map/here.rb
@@ -13,25 +13,6 @@ module Decidim
             base_config = configuration.fetch(:tile_layer, {})
 
             api_key = configuration[:api_key]
-            if api_key.is_a?(Array)
-              # Support for legacy style configurations
-              ActiveSupport::Deprecation.warn(
-                <<~DEPRECATION.strip
-                  Please use a single api_key configuration for HERE maps.
-
-                  For further information, see:
-                  https://developer.here.com/documentation/maps/3.1.16.1/dev_guide/topics/migration.html
-
-                  Also make sure your Decidim.maps configurations are using the
-                  up to date format.
-                DEPRECATION
-              )
-
-              return base_config.merge(
-                app_id: api_key[0],
-                app_code: api_key[1]
-              )
-            end
 
             base_config.merge(api_key:, language: language_code)
           end

--- a/decidim-core/lib/decidim/map/provider/static_map/here.rb
+++ b/decidim-core/lib/decidim/map/provider/static_map/here.rb
@@ -16,7 +16,7 @@ module Decidim
               f: 1
             }
 
-             params[:apiKey] = configuration[:api_key]
+            params[:apiKey] = configuration[:api_key]
 
             params
           end

--- a/decidim-core/lib/decidim/map/provider/static_map/here.rb
+++ b/decidim-core/lib/decidim/map/provider/static_map/here.rb
@@ -16,15 +16,7 @@ module Decidim
               f: 1
             }
 
-            api_key = configuration[:api_key]
-            if api_key.is_a?(Array)
-              # Legacy way of configuring the API credentials
-              params[:app_id] = api_key[0]
-              params[:app_code] = api_key[1]
-            else
-              # The new way of configuring the API key
-              params[:apiKey] = api_key
-            end
+            configuration[:api_key]
 
             params
           end

--- a/decidim-core/lib/decidim/map/provider/static_map/here.rb
+++ b/decidim-core/lib/decidim/map/provider/static_map/here.rb
@@ -16,7 +16,7 @@ module Decidim
               f: 1
             }
 
-            configuration[:api_key]
+             params[:apiKey] = configuration[:api_key]
 
             params
           end

--- a/decidim-core/spec/lib/map/provider/dynamic_map/here_spec.rb
+++ b/decidim-core/spec/lib/map/provider/dynamic_map/here_spec.rb
@@ -69,7 +69,7 @@ module Decidim
             context "with legacy style API key configuration" do
               let(:config) do
                 {
-                  api_key: %w(appid123 secret456),
+                  api_key: "appid123secret456",
                   tile_layer: { foo: "bar" }
                 }
               end

--- a/decidim-core/spec/lib/map/provider/dynamic_map/here_spec.rb
+++ b/decidim-core/spec/lib/map/provider/dynamic_map/here_spec.rb
@@ -79,7 +79,7 @@ module Decidim
                 expect(subject.builder_options).to eq(
                   marker_color: "#e02d2d",
                   tile_layer: {
-                    api_key: %w(appid123 secret456),
+                    api_key: "appid123secret456",
                     foo: "bar",
                     language: "en"
                   }

--- a/decidim-core/spec/lib/map/provider/dynamic_map/here_spec.rb
+++ b/decidim-core/spec/lib/map/provider/dynamic_map/here_spec.rb
@@ -75,13 +75,13 @@ module Decidim
               end
 
               it "returns the correct builder options" do
-                expect(ActiveSupport::Deprecation).to receive(:warn)
+                allow(ActiveSupport::Deprecation).to receive(:warn)
                 expect(subject.builder_options).to eq(
                   marker_color: "#e02d2d",
                   tile_layer: {
-                    app_id: "appid123",
-                    app_code: "secret456",
-                    foo: "bar"
+                    api_key: %w(appid123 secret456),
+                    foo: "bar",
+                    language: "en"
                   }
                 )
               end

--- a/decidim-core/spec/lib/map/provider/static_map/here_spec.rb
+++ b/decidim-core/spec/lib/map/provider/static_map/here_spec.rb
@@ -68,8 +68,7 @@ module Decidim
                     longitude:
                   )
                 ).to eq(
-                  app_id: "appid123",
-                  app_code: "secret456",
+                  apiKey: %w(appid123 secret456),
                   c: "#{latitude}, #{longitude}",
                   z: Decidim::Map::StaticMap::DEFAULT_ZOOM,
                   w: Decidim::Map::StaticMap::DEFAULT_SIZE,

--- a/decidim-core/spec/lib/map/provider/static_map/here_spec.rb
+++ b/decidim-core/spec/lib/map/provider/static_map/here_spec.rb
@@ -68,7 +68,7 @@ module Decidim
                     longitude:
                   )
                 ).to eq(
-                  apiKey: %w(appid123 secret456),
+                  apiKey: "appid123secret456",
                   c: "#{latitude}, #{longitude}",
                   z: Decidim::Map::StaticMap::DEFAULT_ZOOM,
                   w: Decidim::Map::StaticMap::DEFAULT_SIZE,

--- a/decidim-core/spec/lib/map/provider/static_map/here_spec.rb
+++ b/decidim-core/spec/lib/map/provider/static_map/here_spec.rb
@@ -59,7 +59,7 @@ module Decidim
             end
 
             context "with legacy style API key configuration" do
-              let(:api_key) { %w(appid123 secret456) }
+              let(:api_key) { "appid123secret456" }
 
               it "returns the default params" do
                 expect(


### PR DESCRIPTION
#### :tophat: What? Why?
While merging #14164, HERE map configuration within Decidim is now unused due to the deprecation of V1 & V2. This change removes the unnecessary code.

#### :pushpin: Related Issues
- Related to #14164

#### Testing
Visit pages: ```decidim-core/lib/decidim/map/provider/static_map/here.rb``` & ```decidim-core/lib/decidim/map/provider/dynamic_map/here.rb```. See deprecated code removed

### :camera: Screenshots

:hearts: Thank you!
