### PR TITLE
Fix an UI error in budgeting in the progress bar

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/projects/_order_progress_summary_content.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_order_progress_summary_content.html.erb
@@ -26,7 +26,7 @@
         <div class="budget-summary__progressbar--meter bg-success" style="width: <%= current_order_budget_percent %>%"> </div>
       </div>
       <div class="budget-summary__progressbar-marks">
-        <span class="budget-summary__progressbar-legend" style="width: <%= current_order_budget_percent_minimum %>%;">
+        <span class="budget-summary__progressbar-legend">
           <strong id="order-total-budget<%= "-responsive" if responsive %>" class="budget-summary__progressbar-legend-strong">
             <%= render partial: "decidim/budgets/projects/order_total_budget" %>
           </strong>


### PR DESCRIPTION
#### :tophat: What? Why?

There's an extra style definition of "width" that should not be there.
Affecting 0.28 onwards.

Usually it does not affect all browsers all the time but it safer to remove this unnecessary styling

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
Before:
![image](https://github.com/user-attachments/assets/b7e2982a-33fb-425c-903d-8d4e7b94307e)

After:
![image](https://github.com/user-attachments/assets/ab72b76b-1f1e-4feb-9bed-8c97d56fc9d5)

:hearts: Thank you!
