### PR TITLE
Fix budget index card width

### DIFF
--- a/decidim-budgets/app/cells/decidim/budgets/budgets_list/show.erb
+++ b/decidim-budgets/app/cells/decidim/budgets/budgets_list/show.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% if budgets.where.not(id: voted.map(&:id)).exists? %>
-  <div id="budgets" class="card__list-list !space-y-5">
+  <div id="budgets" class="card__list-list !space-y-5 w-full">
     <%= main_list %>
   </div>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
Index of Budgets listed within Decidim did not take the full length of the page. This has been adjusted now by adding ```w-full``` to the budget list cell.

#### :pushpin: Related Issues

- Related to #?
- Fixes #?

#### Testing
1. Use a Decidim application
2. Find a Budget component (within processes for example)
3. Click the component 
4. See the list of Budgets taking up more width in the list

### :camera: Screenshots
BEFORE:
![image](https://github.com/user-attachments/assets/84754f84-d8bc-45bc-ade5-ccc234b8f600)


AFTER: 
![image](https://github.com/user-attachments/assets/b6f07456-281c-4513-8504-48c336b577be)


:hearts: Thank you!
