### PR TITLE
Fix Aitools documentation

### DIFF
--- a/docs/modules/services/pages/aitools.adoc
+++ b/docs/modules/services/pages/aitools.adoc
@@ -146,7 +146,7 @@ bin/rails decidim:ai:spam:load_application_dataset[/path/to/file.csv]
 In some cases, like an upgrade, you may want to train your model using your existing data, so you can use:
 
 ```bash
-bin/rails decidim:ai:spam:train_using_database
+bin/rails decidim:ai:spam:train_application_database
 ```
 
 === Reset the model
@@ -154,7 +154,7 @@ bin/rails decidim:ai:spam:train_using_database
 If the trained model becomes corrupt, you could use the below command to reinitialize the model. Once you do this, you would need to train the model again. using any of the above commands.
 
 ```bash
-bin/rails decidim:ai:spam:reset_model
+bin/rails decidim:ai:spam:reset
 ```
 
 == Sidekiq


### PR DESCRIPTION
#### :tophat: What? Why?
While installing the module for an application, i have noticed the tasks specified in the docs are different from the ones already existing in the application, This fixes that. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. In a terminal run `./bin/rails --tasks | grep 'decidim:ai'`
2. See the tasks presented in [docs](https://docs.decidim.org/en/develop/services/aitools) are different than the one app returns 
3. Apply patch 
4. See the tasks returned by app are the same with the ones in documentation

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
