### PR TITLE
Fix ruby version specified in documentation for manual installation

### DIFF
--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -4,7 +4,7 @@ In order to develop on decidim, you will need:
 
 * *Git* 2.34+
 * *PostgreSQL* 14.5+
-* *Ruby* 3.1.1
+* *Ruby* 3.2.2
 * *NodeJS* 18.17.x
 * *Npm* 9.6.x
 * *ImageMagick*
@@ -33,8 +33,8 @@ echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 source ~/.bashrc
 git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
-rbenv install 3.1.1
-rbenv global 3.1.1
+rbenv install 3.2.2
+rbenv global 3.2.2
 ----
 
 == 2. Installing PostgreSQL


### PR DESCRIPTION
Correct ruby version in 0.29 instructions

#### :tophat: What? Why?
The instructions for installing 0.29.X are inconsistent with their ruby versions.
A user needs `3.2.2` and the instructions show `3.1.1` still

### :camera: Screenshots
<img width="277" alt="image" src="https://github.com/user-attachments/assets/7d8ced7f-d832-46a0-b7b7-41d637760aa6" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/848d1a9a-0c71-4dbf-9c57-f40cdbbb66e9" />


:hearts: Thank you!
