### PR TITLE
Documentation update for ```ruby``` version in develop

### DIFF
--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -4,7 +4,7 @@ In order to develop on decidim, you will need:
 
 * *Git* 2.34+
 * *PostgreSQL* 14.5+
-* *Ruby* 3.1.1
+* *Ruby* 3.3.0
 * *NodeJS* 18.17.x
 * *Npm* 9.6.x
 * *ImageMagick*
@@ -33,8 +33,8 @@ echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 source ~/.bashrc
 git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
-rbenv install 3.1.1
-rbenv global 3.1.1
+rbenv install 3.3.0
+rbenv global 3.3.0
 ----
 
 == 2. Installing PostgreSQL


### PR DESCRIPTION
#### :tophat: What? Why?
The documentation is out of date since the release of v0.30. This PR updates the documentation for the ```ruby``` version in develop to ```3.3.0```.

#### :pushpin: Related Issues
- Related to #14199

#### Testing

### :camera: Screenshots

:hearts: Thank you!
