### PR TITLE
Ignore rule 'no duplicate header' for markdown linter

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -7,3 +7,5 @@ line-length: false
 no-bare-urls: false
 
 no-inline-html: false
+
+no-duplicate-header: false


### PR DESCRIPTION
#### :tophat: What? Why?

While preparing v0.30.0.rc2, we have received an offense on the markdown linter, as it was detecting duplicated headers in the CHANGELOG.md file. This error can be ignored as we will have those duplicated headers in that file.

I already applied it in that branch but we should also have it in develop for the consistency.

![image](https://github.com/user-attachments/assets/f050d685-d817-462f-8728-c258acf37ccf)

#### :pushpin: Related Issues
 
- Related to #14205 

#### Testing

Everything should be green 

:hearts: Thank you!
