### PR TITLE
Fix CSS details (mostly alignments and gaps)

### DIFF
--- a/decidim-comments/app/packs/stylesheets/comments.scss
+++ b/decidim-comments/app/packs/stylesheets/comments.scss
@@ -466,7 +466,7 @@
 }
 
 .publish-comment-button {
-  @apply md:relative fixed inset-x-0 bottom-0 z-30 md:z-0 flex flex-row items-center md:items-end md:justify-end font-semibold justify-around bg-white md:bg-transparent gap-4 md:gap-0 p-4 md:p-0 shadow-inner md:shadow-none first:[&>*]:grow md:first:[&>*]:grow-0 h-14 md:h-fit first:[&>button]:py-3;
+  @apply ml-auto md:relative fixed inset-x-0 bottom-0 z-30 md:z-0 flex flex-row items-center md:items-end md:justify-end font-semibold justify-around bg-white md:bg-transparent gap-4 md:gap-0 p-4 md:p-0 shadow-inner md:shadow-none first:[&>*]:grow md:first:[&>*]:grow-0 h-14 md:h-fit first:[&>button]:py-3;
 }
 
 .fullscreen {

--- a/decidim-core/app/packs/stylesheets/decidim/_content_blocks.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_content_blocks.scss
@@ -30,7 +30,7 @@
   }
 
   &__span {
-    @apply text-gray-2 font-semibold uppercase;
+    @apply mb-4 text-gray-2 font-semibold uppercase;
   }
 
   & ~ & {

--- a/decidim-core/app/packs/stylesheets/decidim/_modal_authorization.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_modal_authorization.scss
@@ -15,7 +15,7 @@
     }
 
     &-container {
-      @apply mt-8 space-y-8;
+      @apply m-8 space-y-8;
     }
   }
 }

--- a/decidim-core/app/packs/stylesheets/decidim/_profile.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_profile.scss
@@ -45,7 +45,7 @@
 
   &__actions {
     &-main {
-      @apply w-fit mx-auto gap-x-4 gap-y-6 md:gap-4;
+      @apply grid w-fit mx-auto gap-x-4 gap-y-6 md:gap-4;
 
       &__dropdown {
         @apply divide-y divide-gray-3 z-20 w-64;

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -4,7 +4,7 @@
   <%= render "decidim/devise/shared/links" %>
 <% end %>
 
-<%= render(layout: "layouts/decidim/shared/layout_center", locals: { columns: 8 }) do %>
+<%= render(layout: "layouts/decidim/shared/layout_center") do %>
   <div class="flex justify-center">
     <h1 class="title-decorator my-12"><%= t("decidim.devise.registrations.new.sign_up") %></h1>
   </div>

--- a/decidim-core/app/views/decidim/devise/sessions/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <% add_decidim_page_title(t("devise.sessions.new.log_in")) %>
 
-<%= render(layout: "layouts/decidim/shared/layout_center", locals: { columns: 8 }) do %>
+<%= render(layout: "layouts/decidim/shared/layout_center") do %>
 
   <div class="flex justify-center">
     <h1 class="title-decorator my-12"><%= t("devise.sessions.new.log_in") %></h1>

--- a/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -5,7 +5,7 @@
       <% link_classes = "login__omniauth-button login__omniauth-button--#{normalize_provider_name(provider)}" %>
       <%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: link_classes, method: :post, title: t("devise.shared.links.log_in_with_provider", provider: normalize_provider_name(provider).titleize) do %>
         <%= oauth_icon provider %>
-        <span><%= t("devise.shared.links.log_in_with_provider", provider: normalize_provider_name(provider).titleize) %></span>
+        <span class="sr-only"><%= t("devise.shared.links.log_in_with_provider", provider: normalize_provider_name(provider).titleize) %></span>
       <% end %>
     <% end %>
   </div>

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_list.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_list.scss
@@ -40,7 +40,7 @@
 
   &__block {
     &-map {
-      @apply aspect-[2/1] md:aspect-[4/1] rounded overflow-hidden [&>*]:h-full;
+      @apply mb-4 aspect-[2/1] md:aspect-[4/1] rounded overflow-hidden [&>*]:h-full;
     }
 
     &-list {


### PR DESCRIPTION
## :tophat: What? Why?

This PR fixes multiple details with the CSS. 

These were detected in Metadecidim's staging with v0.30.0.rc2, so there are some of these fixes that are relevant to v0.30 only, but others that should be backported to v0.29. I'm doing only one PR to not hammer the CI, we can check out each particular issue if it's reproducible on those versions when backporting. 

## Issues

#### Publish comment button disposition

##### To reproduce

1. Log in
2. Go to a proposal page
3. Scroll to the Publish comment section

##### Before

![Screenshot of the bug](https://github.com/user-attachments/assets/8f12abb9-0584-47b2-a3b2-283ab291bd05)

##### After

![Screenshot of the fix](https://github.com/user-attachments/assets/aa1c5f74-8b14-4e07-9d20-e6674147fdda)

----

#### Missing gap in the content block subtitle

##### To reproduce

1. Log in 
2. Go to an admin's process page
3. Add the Post content block
5. Go to the public page

##### Before

![Screenshot of the bug](https://github.com/user-attachments/assets/34a6a4a4-68cb-4578-b7b4-a111b1822195)

##### After

![Screenshot of the fix](https://github.com/user-attachments/assets/1f5e5e7e-5c95-4e10-81b1-2a6df42aabf3)

---

#### Missing gap in the meetings' map content block 

##### To reproduce

1. Log in 
2. Go to an admin's process page
3. Add the "Upcoming meetings" content block
5. Go to the public page

##### Before
 
![Screenshot of the bug](https://github.com/user-attachments/assets/f4b238ce-9bc5-40b7-8a75-9d5a9230c518)

##### After

![Screenshot of the fix](https://github.com/user-attachments/assets/f6a81afd-d3da-4677-aeb9-e9c16fef62a3)

----

#### Fix the "Create an account" layout page

##### To reproduce

0. Enable social logins in `config/secrets.yml`
1. Without a log in, go to http://localhost:3000/users/sign_up 

##### Before
 
![Screenshot of the bug](https://github.com/user-attachments/assets/664d9a4d-4c79-4216-b1d6-74d3630285fd)

##### After
 
![Screenshot of the fix](https://github.com/user-attachments/assets/f2ed6b2c-db62-4b5b-8b98-ea3018f5347f)
 
----

#### Fix the "Log in" layout page

##### To reproduce

0. Enable social logins in `config/secrets.yml`
1. Without a log in, go to http://localhost:3000/users/sign_in

##### Before

![Screenshot of the bug](https://github.com/user-attachments/assets/5afb5755-a293-4956-908d-4be9ff227827)

##### After
 
![Screenshot of the fix](https://github.com/user-attachments/assets/c1dc17cd-8e94-417c-b242-1f3cb5879350)
 
----

#### Fix the "Authorization required" page in surveys

##### To reproduce

1. Log in as admin
2. Go to a components' list admin page
3. Add a permission to the surveys' component
4. Go to the public page
5. Click in a survey
6. See the "Authorization required" page

##### Before

![Screenshot of the bug](https://github.com/user-attachments/assets/849b1d58-1488-4e01-8430-6a9953ab5226)

##### After

![Screenshot of the fix](https://github.com/user-attachments/assets/049ac809-8ca6-4eea-b20d-0fc9b128aea6)

----

#### Missing gap in the Profiles' page

##### To reproduce

1. Log in as a participant
2. Go to the "My public profile" page of this participant

##### Before

![Screenshot of the bug](https://github.com/user-attachments/assets/812f84e9-c149-4f72-87c9-717be4e34388)

##### After

![Screenshot of the fix](https://github.com/user-attachments/assets/8f70dc3e-ec78-4200-869c-c19ee7f99723)

:hearts: Thank you!
