### PR TITLE
Document additional scheduled tasks

### DIFF
--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -133,16 +133,6 @@ For production environments, you can configure these tasks with `crontab -e`. Fo
 
 Additional cron jobs may be available depending on the modules you've installed.
 
-==== AI module
-
-If you have installed the `decidim-ai` module, you may want to add to your crontab the following
-
-[source,console]
-----
-# Train model using application database
-0 2 * * * cd /home/user/decidim_application && RAILS_ENV=production bundle exec rake decidim:ai:spam:train_application_database
-----
-
 ==== Initiatives module
 
 If you have installed the `decidim-initiatives` module, you may want to add to your crontab the following
@@ -155,7 +145,7 @@ If you have installed the `decidim-initiatives` module, you may want to add to y
 # Checks validating initiatives and moves all without changes for a configured time to discarded state
 0 7 * * * cd /home/user/decidim_application && RAILS_ENV=production bundle exec rake decidim_initiatives:check_validating
 
-#Notifies progress on published initiatives
+# Notifies progress on published initiatives
 0 8 * * * cd /home/user/decidim_application && RAILS_ENV=production bundle exec rake decidim_initiatives:notify_progress
 ----
 

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -131,7 +131,7 @@ For production environments, you can configure these tasks with `crontab -e`. Fo
 
 === Scheduled tasks from modules
 
-Additional cron jobs may be available depending on the modules you've installed.
+Additional cron jobs may be available depending on the modules you have installed.
 
 ==== Initiatives module
 

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -129,6 +129,36 @@ For production environments, you can configure these tasks with `crontab -e`. Fo
 */15 * * * * cd /home/user/decidim_application && RAILS_ENV=production bundle exec rake decidim_participatory_processes:change_active_step
 ----
 
+=== Scheduled tasks from modules
+
+Additional cron jobs may be available depending on the modules you've installed.
+
+==== AI module
+
+If you have installed the `decidim-ai` module, you may want to add to your crontab the following
+
+[source,console]
+----
+# Train model using application database
+0 2 * * * cd /home/user/decidim_application && RAILS_ENV=production bundle exec rake decidim:ai:spam:train_application_database
+----
+
+==== Initiatives module
+
+If you have installed the `decidim-initiatives` module, you may want to add to your crontab the following
+
+[source,console]
+----
+# Checks published initiatives and moves to accepted/rejected state depending on the votes collected when the signing period has finished
+30 7 * * * cd /home/user/decidim_application && RAILS_ENV=production bundle exec rake decidim_initiatives:check_published
+
+# Checks validating initiatives and moves all without changes for a configured time to discarded state
+0 7 * * * cd /home/user/decidim_application && RAILS_ENV=production bundle exec rake decidim_initiatives:check_validating
+
+#Notifies progress on published initiatives
+0 8 * * * cd /home/user/decidim_application && RAILS_ENV=production bundle exec rake decidim_initiatives:notify_progress
+----
+
 === Further configuration
 
 We also have other guides on how to configure some extra mandatory components:


### PR DESCRIPTION
#### :tophat: What? Why?
While working on an internal project, i noticed there are some crons missing. Investigating further i noticed that the list of cron jobs available in documentation may be incomplete. After checking with @fblupi i realized my hunch is correct. 

This PR documents additional tasks. 

#### Testing
1. Navigate to the [Scheduled task](https://docs.decidim.org/en/develop/install/index.html#_scheduled_tasks) documentation page
2. See the initiatives and ai modules are missing 
3. Build locally the documentation 
4. See on the same page we have a new section `Scheduled tasks from modules`

:hearts: Thank you!
