### PR TITLE
Force api authentication with configuration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -91,6 +91,6 @@ result = 1 + 1 if before
 result = 1 + 1 if after
 ```
 
-### 5.2. Add force_api_authentication configuration options.
+### 5.2. Add force_api_authentication configuration options
 
 There are times that we need to let only authenticated users to use the API. This configuration option filters out unauthenticated users from accessing the api endpoint. You need to add `DECIDIM_API_FORCE_API_AUTHENTICATION` to your environment variables if you want to enable this feature.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -91,6 +91,6 @@ result = 1 + 1 if before
 result = 1 + 1 if after
 ```
 
-### 5.2 Add force_api_authentication configuration options.
+### 5.2. Add force_api_authentication configuration options.
 
 There are times that we need to let only authenticated users to use the API. This configuration option filters out unauthenticated users from accessing the api endpoint. You need to add `DECIDIM_API_FORCE_API_AUTHENTICATION` to your environment variables if you want to enable this feature.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -86,9 +86,11 @@ If you have used code as such:
 result = 1 + 1 if before
 ```
 
-You need to change it to:
-
 ```ruby
 # Explain the usage of the API as it is in the new version
 result = 1 + 1 if after
-        ```
+```
+
+### 5.2 Add force_api_authentication configuration options.
+
+There are times that we need to let only authenticated users to use the API. This configuration option filters out unauthenticated users from accessing the api endpoint. You need to add `DECIDIM_API_FORCE_API_AUTHENTICATION` to your environment variables if you want to enable this feature.

--- a/decidim-api/app/controllers/decidim/api/application_controller.rb
+++ b/decidim-api/app/controllers/decidim/api/application_controller.rb
@@ -24,7 +24,8 @@ module Decidim
       def permission_scope
         :public
       end
-    private
+
+      private
 
       def ensure_api_authenticated!
         return unless Decidim::Api.force_api_authentication

--- a/decidim-api/app/controllers/decidim/api/application_controller.rb
+++ b/decidim-api/app/controllers/decidim/api/application_controller.rb
@@ -5,6 +5,8 @@ module Decidim
     # Base controller for `decidim-api`. All other controllers inherit from this.
     class ApplicationController < ::DecidimController
       skip_before_action :verify_authenticity_token
+      before_action :ensure_api_authenticated!
+
       include NeedsOrganization
       include UseOrganizationTimeZone
       include NeedsPermission
@@ -21,6 +23,23 @@ module Decidim
 
       def permission_scope
         :public
+      end
+    private
+
+      def ensure_api_authenticated!
+        return unless Decidim::Api.force_api_authentication
+        return if user_signed_in?
+
+        respond_to do |format|
+          format.html do
+            flash[:warning] = t("actions.login_before_access", scope: "decidim.core")
+            store_location_for(:user, request.path)
+            redirect_to decidim.new_user_session_path
+          end
+          format.json do
+            render json: { error: "Access denied" }, status: :unauthorized
+          end
+        end
       end
     end
   end

--- a/decidim-api/lib/decidim/api.rb
+++ b/decidim-api/lib/decidim/api.rb
@@ -42,5 +42,11 @@ module Decidim
       @orphan_types ||= []
       @orphan_types += [type]
     end
+
+    # Public Setting that can make the API authentication necessary in order to
+    # access it.
+    config_accessor :force_api_authentication do
+      false
+    end
   end
 end

--- a/decidim-api/lib/decidim/api.rb
+++ b/decidim-api/lib/decidim/api.rb
@@ -28,6 +28,12 @@ module Decidim
       %w(1 true yes).include?(ENV.fetch("DECIDIM_API_DISCLOSE_SYSTEM_VERSION", nil))
     end
 
+    # Public Setting that can make the API authentication necessary in order to
+    # access it.
+    config_accessor :force_api_authentication do
+      %w(1 true yes).include?(ENV.fetch("DECIDIM_API_FORCE_API_AUTHENTICATION", nil))
+    end
+
     # This declares all the types an interface or union can resolve to. This needs
     # to be done in order to be able to have them found. This is a shortcoming of
     # graphql-ruby and the way it deals with loading types, in combination with
@@ -41,12 +47,6 @@ module Decidim
     def self.add_orphan_type(type)
       @orphan_types ||= []
       @orphan_types += [type]
-    end
-
-    # Public Setting that can make the API authentication necessary in order to
-    # access it.
-    config_accessor :force_api_authentication do
-      false
     end
   end
 end

--- a/decidim-api/spec/controllers/queries_controller_spec.rb
+++ b/decidim-api/spec/controllers/queries_controller_spec.rb
@@ -34,6 +34,17 @@ module Decidim
         parsed_response = JSON.parse(response.body)["data"]
         expect(parsed_response["__schema"]["queryType"]["name"]).to eq("Query")
       end
+
+      context "with force sign in enabled" do
+        before do
+          allow(::Decidim::Api).to receive(:force_api_authentication).and_return(true)
+        end
+
+        it "returns 403 when credentials are invalid" do
+          post :create, params: { query: "{ __schema { queryType { name } } }" }
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
     end
   end
 end

--- a/decidim-api/spec/system/graphiql_spec.rb
+++ b/decidim-api/spec/system/graphiql_spec.rb
@@ -37,4 +37,16 @@ describe "GraphiQL" do
       expect(page).to have_content("\"id\": \"#{participatory_process.id}\"")
     end
   end
+
+  context "with force_api_authentication enabled" do
+    before do
+      allow(Decidim::Api).to receive(:force_api_authentication).and_return(true)
+      visit decidim_api.graphiql_path
+    end
+
+    it "forces the user to log in" do
+      expect(page).to have_current_path("/users/sign_in")
+      expect(page).to have_content("Please, log in with your account before access")
+    end
+  end
 end

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -413,6 +413,8 @@ if Decidim.module_installed? :api
     config.schema_max_per_page = Rails.application.secrets.dig(:decidim, :api, :schema_max_per_page).presence || 50
     config.schema_max_complexity = Rails.application.secrets.dig(:decidim, :api, :schema_max_complexity).presence || 5000
     config.schema_max_depth = Rails.application.secrets.dig(:decidim, :api, :schema_max_depth).presence || 15
+    config.disclose_system_version = %w(1 true yes).include?(ENV.fetch("DECIDIM_API_DISCLOSE_SYSTEM_VERSION", nil))
+    config.force_api_authentication = %w(1 true yes).include?(ENV.fetch("DECIDIM_API_FORCE_API_AUTHENTICATION", nil))
   end
 end
 

--- a/docs/modules/configure/pages/environment_variables.adoc
+++ b/docs/modules/configure/pages/environment_variables.adoc
@@ -623,6 +623,11 @@ Additional context: This has been revealed as an issue during a security audit o
 |15
 |No
 
+|DECIDIM_API_FORCE_API_AUTHENTICATION
+|Enable authentication for using api through setting Api configuration option. This is used to filter out unauthorized users from using api endpoint.
+|false
+|No
+
 |*DECIDIM_SERVICE_WORKER_ENABLED*
 |Enable/Disable the service worker. This is used to enable offline support and to deliver push notifications. In development it is recommended to be disabled because its aggressive cache configuration might cause some issues when submitting forms.
 |false


### PR DESCRIPTION
#### :tophat: What? Why?
There are times that we need to let only authenticated users to use the API. This PR makes this feature available. By default, force_api_authentication is disabled, so that the api works normally as it was before. Once enable this configuration, the users will be redirected to sign_in before using the api.

#### :pushpin: Related Issues
This PR is partly related to https://github.com/decidim/decidim/issues/13254. 

#### Testing
1. set the following to true in 
```
config_accessor :force_api_authentication do
  true
end
``` 
2. re-run the server
3. go to the /api 
4. You will be redirected to sign_in page

:hearts: Thank you!
