### PR TITLE
Add well known file needed from https://decidim.org/funding.json

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://decidim.org/funding.json


### PR DESCRIPTION
#### :tophat: What? Why?

We want to apply to a funding FLOSS fund, and for this we're implementing a funding.json at decidim.org: https://decidim.org/funding.json 

For validating that this repository is owned by us, we need to add this file, as it is mentioned in our funding.json. 

I already applied these files to the other places needed:

- https://docs.decidim.org/en/develop/develop/admin/_assets/.well-known/funding-manifest-urls
- https://github.com/decidim/documentation/blob/develop/.well-known/funding-manifest-urls

#### :pushpin: Related Links
 
- Related to https://floss.fund
 
#### Testing

Nothing, as it is just a flat file 

:hearts: Thank you!
