### PR TITLE
Fix linked proposals

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_linked_proposals.html.erb
@@ -1,3 +1,3 @@
 <% resources.each do |proposal| %>
-  <%= cell "decidim/proposals/proposal_l", proposal, url_extra_params: { included_in: resource.to_gid } %>
+  <%= cell "decidim/proposals/proposal_l", proposal, url_extra_params: { included_in: resource.to_gid }, hide_voting: true %>
 <% end %>

--- a/decidim-proposals/spec/system/proposal_show_spec.rb
+++ b/decidim-proposals/spec/system/proposal_show_spec.rb
@@ -81,5 +81,33 @@ describe "Show a Proposal" do
         end
       end
     end
+
+    context "when proposal author is a meeting" do
+      let(:address) { "Somewhere over the rainbow" }
+      let(:latitude) { 40.1234 }
+      let(:longitude) { 2.1234 }
+      let!(:author) { create(:user, :deleted, organization: component.organization) }
+      let!(:proposal) { create(:proposal, component:, users: [author]) }
+      let(:meeting_component) { create(:meeting_component, participatory_space: participatory_process) }
+      let!(:meeting) { create(:meeting, :published, component: meeting_component, address:, latitude:, longitude:) }
+
+      it "shows the meeting link" do
+        stub_geocoding_coordinates([latitude, longitude])
+        proposal.link_resources(meeting, "proposals_from_meeting")
+        visit resource_locator(meeting).path
+        expect(page).to have_content(translated(proposal.title))
+      end
+
+      context "when the proposal component has votes enabled" do
+        let(:component) { create(:proposal_component, :with_votes_enabled, participatory_space: participatory_process) }
+
+        it "shows the meeting link" do
+          stub_geocoding_coordinates([latitude, longitude])
+          proposal.link_resources(meeting, "proposals_from_meeting")
+          visit resource_locator(meeting).path
+          expect(page).to have_content(translated(proposal.title))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Today @mllocs let me know that linked proposals to meetings are actually raising an error. This is the same error i got while trying to implement the proposal voting in the 0.29 branch.

This was not caught before because it was not added in the meetings, and in the budgets (where i've encountered the issue) we have the history implementation. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13883

#### Testing
1. Take the spec added to this PR 
2. Run it against develop 
3. See it crashes 
4. Also see this pipeline is green

:hearts: Thank you!
