### PR TITLE
Fix accordion in Open Data page

### DIFF
--- a/decidim-core/app/views/decidim/open_data/index.html.erb
+++ b/decidim-core/app/views/decidim/open_data/index.html.erb
@@ -17,7 +17,7 @@
       <%= t("description", scope: "decidim.open_data.index", organization_name: current_organization_name) %>
       </p>
 
-      <%= render layout: "decidim/application/accordion_section", locals: { panel_id: "explanation", title: t("title", scope: "decidim.open_data.index.explanation") } do %>
+      <%= render layout: "decidim/application/accordion_section", locals: { panel_id: "explanation", title: t("title", scope: "decidim.open_data.index.explanation"), open_accordion: true } do %>
         <p> <%= t("body_1", scope: "decidim.open_data.index.explanation", organization_name: current_organization_name) %> </p>
         <p> <%= t("body_2", scope: "decidim.open_data.index.explanation") %> </p>
       <% end %>

--- a/decidim-core/spec/system/download_open_data_files_spec.rb
+++ b/decidim-core/spec/system/download_open_data_files_spec.rb
@@ -30,8 +30,6 @@ describe "Download Open Data files", download: true do
 
     expect(page).to have_content("Here, you will find data files that are regularly generated from various deliberative and governance processes within")
     expect(page).to have_content("Download results in CSV format")
-
-    click_on("What are these files?")
     expect(page).to have_content("These files are in CSV (Comma-Separated Values) format, which is a widely-used file format")
 
     click_on("How to open and work with these files")


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes the accordion in the open data page, so the first element is open.

This is what was designed initially, with the idea to "show" to visitors how the accordion works.  

#### Testing

Go to http://localhost:3000/open-data 

### :camera: Screenshots

![image](https://github.com/user-attachments/assets/f82dbd87-4179-47f4-a9bf-ee5eb082a14e)


:hearts: Thank you!
