### PR TITLE
Change secondary buttons to transparent in admin panel

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/admin/results/bulk_actions/_dropdown.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/bulk_actions/_dropdown.html.erb
@@ -1,7 +1,7 @@
 <div id="js-bulk-actions-wrapper">
   <button
     id="js-bulk-actions-button"
-    class="button button__sm button__secondary hide"
+    class="button button__sm button__transparent-secondary hide"
     type="button"
     data-toggle="js-bulk-actions-dropdown"
     data-action-button>

--- a/decidim-accountability/app/views/decidim/accountability/admin/shared/_subnav.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/shared/_subnav.html.erb
@@ -1,1 +1,1 @@
-<%= link_to t(".statuses"), statuses_path, class: "button button__sm button__secondary" %>
+<%= link_to t(".statuses"), statuses_path, class: "button button__sm button__transparent-secondary" %>

--- a/decidim-admin/app/views/decidim/admin/exports/_dropdown.html.erb
+++ b/decidim-admin/app/views/decidim/admin/exports/_dropdown.html.erb
@@ -1,4 +1,4 @@
-<span class="exports button button__sm button__secondary" data-toggle="<%= dropdown_id(filters) %>">
+<span class="exports button button__sm button__transparent-secondary" data-toggle="<%= dropdown_id(filters) %>">
   <% if filters.present? %>
     <%= t("actions.export-selection", scope: "decidim.admin") %>
   <% else %>

--- a/decidim-admin/app/views/decidim/admin/imports/_dropdown.html.erb
+++ b/decidim-admin/app/views/decidim/admin/imports/_dropdown.html.erb
@@ -1,4 +1,4 @@
-<span class="imports button button__sm button__secondary" data-toggle="import-dropdown">
+<span class="imports button button__sm button__transparent-secondary" data-toggle="import-dropdown">
   <%= t "actions.import", scope: "decidim.admin" %>
   <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
 </span>

--- a/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
@@ -4,9 +4,9 @@
     <h1 class="item_show__header-title">
       <%= t(".title") %>
       <% if allowed_to? :create, :space_private_user %>
-        <%= link_to t(".publish_all"), publish_all_participatory_space_private_users_path(current_participatory_space), class: "button button__sm button__secondary publish-all", method: :post %>
-        <%= link_to t(".unpublish_all"), unpublish_all_participatory_space_private_users_path(current_participatory_space), class: "button button__sm button__secondary unpublish-all", method: :post %>
-        <%= link_to t(".import_via_csv"), new_participatory_space_private_users_csv_imports_path, class: "button button__sm button__secondary import" %>
+        <%= link_to t(".publish_all"), publish_all_participatory_space_private_users_path(current_participatory_space), class: "button button__sm button__transparent-secondary publish-all", method: :post %>
+        <%= link_to t(".unpublish_all"), unpublish_all_participatory_space_private_users_path(current_participatory_space), class: "button button__sm button__transparent-secondary unpublish-all", method: :post %>
+        <%= link_to t(".import_via_csv"), new_participatory_space_private_users_csv_imports_path, class: "button button__sm button__transparent-secondary import" %>
         <%= link_to t("actions.participatory_space_private_user.new", scope: "decidim.admin"), url_for(action: :new), class: "button button__sm button__secondary new" %>
       <% end %>
     </h1>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -1099,7 +1099,7 @@ en:
           title: Edit topic
           update: Update topic
         new:
-          create: Create topic
+          create: New topic
           title: New topic
         update:
           error: There was a problem updating this topic.
@@ -1123,7 +1123,7 @@ en:
         index:
           last_notable_change: Last notable change
         new:
-          create: Create page
+          create: New page
           title: New page
         topic:
           empty: There are no pages under this topic.

--- a/decidim-admin/spec/system/admin_manages_more_locales_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_more_locales_spec.rb
@@ -18,7 +18,7 @@ describe "Admin language selector" do
     login_as admin, scope: :user
     visit decidim_admin.root_path
     click_on "Pages"
-    click_on "Create page"
+    click_on "New page"
   end
 
   after do

--- a/decidim-admin/spec/system/static_pages_spec.rb
+++ b/decidim-admin/spec/system/static_pages_spec.rb
@@ -59,7 +59,7 @@ describe "Content pages" do
       end
 
       it "can create topics" do
-        click_on "Create topic"
+        click_on "New topic"
 
         within ".new_static_page_topic" do
           fill_in_i18n(
@@ -158,14 +158,14 @@ describe "Content pages" do
 
     context "when displaying the page form" do
       before do
-        click_on "Create page"
+        click_on "New page"
       end
 
       it_behaves_like "having a rich text editor", "new_static_page", "full"
     end
 
     it "can create new pages" do
-      click_on "Create page"
+      click_on "New page"
 
       within ".new_static_page" do
         fill_in :static_page_slug, with: "welcome"

--- a/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/budgets/index.html.erb
@@ -7,7 +7,7 @@
         <%= export_dropdown %>
       <% end %>
       <% if allowed_to? :remind, :order %>
-        <%= link_to t("actions.send_voting_reminders", scope: "decidim.budgets"), admin_reminders_path(current_component, name: "orders"), class: "button button__sm button__secondary" %>
+        <%= link_to t("actions.send_voting_reminders", scope: "decidim.budgets"), admin_reminders_path(current_component, name: "orders"), class: "button button__sm button__transparent-secondary" %>
       <% end %>
       <div id="js-other-actions-wrapper">
         <%= link_to t("actions.new_budget", scope: "decidim.budgets"), new_budget_path, class: "button button__sm button__secondary" if allowed_to? :create, :budget %>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/bulk_actions/_dropdown.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/bulk_actions/_dropdown.html.erb
@@ -1,7 +1,7 @@
 <div id="js-bulk-actions-wrapper">
   <button
     id="js-bulk-actions-button"
-    class="button button__sm button__secondary"
+    class="button button__sm button__transparent-secondary"
     type="button"
     data-toggle="js-bulk-actions-dropdown">
     <%= t("decidim.budgets.admin.projects.index.actions") %>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_registrations/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_registrations/index.html.erb
@@ -4,7 +4,7 @@
     <h1 class="item_show__header-title">
       <%= t(".registrations") %>
       <% if allowed_to? :export_conference_registrations, :conference, conference: conference %>
-        <span class="exports button button__sm button__secondary button--title" data-toggle="export-dropdown">
+        <span class="exports button button__sm button__transparent-secondary button--title" data-toggle="export-dropdown">
           <%= t "actions.export", scope: "decidim.admin" %>
           <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
         </span>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_questions_form.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_questions_form.html.erb
@@ -1,7 +1,7 @@
 <div class="questionnaire-questions form__wrapper">
   <div class="row column text-center my-4">
-    <button type="button" class="button button__sm button__secondary collapse-all"><%= t(".collapse") %></button>
-    <button type="button" class="button button__sm button__secondary expand-all"><%= t(".expand") %></button>
+    <button type="button" class="button button__sm button__transparent-secondary collapse-all"><%= t(".collapse") %></button>
+    <button type="button" class="button button__sm button__transparent-secondary expand-all"><%= t(".expand") %></button>
   </div>
 
   <% if questionnaire.questions_editable? %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit_questions.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/edit_questions.html.erb
@@ -11,9 +11,9 @@
 
       <% unless template? questionnaire.questionnaire_for %>
         <% if questionnaire.questions_editable? %>
-          <button class="button button__sm button__secondary add-question"><%= t(".add_question") %></button>
-          <button class="button button__sm button__secondary add-separator"><%= t(".add_separator") %></button>
-          <button class="button button__sm button__secondary add-title-and-description"><%= t(".add_title_and_description") %></button>
+          <button class="button button__sm button__transparent-secondary add-question"><%= t(".add_question") %></button>
+          <button class="button button__sm button__transparent-secondary add-separator"><%= t(".add_separator") %></button>
+          <button class="button button__sm button__transparent-secondary add-title-and-description"><%= t(".add_title_and_description") %></button>
         <% end %>
         <% if allowed_to? :preview, :questionnaire %>
           <%= link_to t("preview", scope: "decidim.forms.admin.questionnaires.form"), public_url, class: "button button__sm button__transparent-secondary", target: :_blank, data: { "external-link": false } %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
@@ -1,4 +1,4 @@
-<span class="exports button button__sm button__secondary" data-toggle="<%= dropdown_id(collection_ids) %>">
+<span class="exports button button__sm button__transparent-secondary" data-toggle="<%= dropdown_id(collection_ids) %>">
   <% if collection_ids.present? %>
     <%= t("actions.export-selection", scope: "decidim.admin") %>
   <% else %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_bulk-actions.html.erb
@@ -24,10 +24,6 @@
       <% end %>
     <% end %>
   <% end %>
-
-  <% if allowed_to? :create, :proposal %>
-    <%= link_to t("actions.new", scope: "decidim.proposals"), new_proposal_path, class: "button button__sm button__secondary" %>
-  <% end %>
 </div>
 
 <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/merge" %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
@@ -1,7 +1,7 @@
 <div id="js-bulk-actions-wrapper">
   <button
     id="js-bulk-actions-button"
-    class="button button__sm button__secondary"
+    class="button button__sm button__transparent-secondary"
     type="button"
     data-toggle="js-bulk-actions-dropdown">
     <%= t("decidim.proposals.admin.proposals.index.actions") %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -8,7 +8,11 @@
       </div>
       <div class="flex items-center gap-x-4">
         <%= render partial: "bulk-actions" %>
-        <%= link_to t(".statuses"), proposal_states_path, class: "button button__sm button__secondary" %>
+        <%= link_to t(".statuses"), proposal_states_path, class: "button button__sm button__transparent-secondary" %>
+
+        <% if allowed_to? :create, :proposal %>
+          <%= link_to t("actions.new", scope: "decidim.proposals"), new_proposal_path, class: "button button__sm button__secondary" %>
+        <% end %>
         <%= render partial: "decidim/admin/components/resource_action" %>
       </div>
     </h1>

--- a/decidim-surveys/app/views/decidim/surveys/admin/questions/surveys/edit.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/questions/surveys/edit.html.erb
@@ -16,9 +16,9 @@
       <h1 class="item_show__header-title">
         <%= t(".title") %>
           <% if questionnaire.questions_editable? %>
-            <button class="button button__sm button__secondary add-question"><%= t("add_question", scope: "decidim.forms.admin.questionnaires.edit_questions") %></button>
-            <button class="button button__sm button__secondary add-separator"><%= t("add_separator", scope: "decidim.forms.admin.questionnaires.edit_questions") %></button>
-            <button class="button button__sm button__secondary add-title-and-description"><%= t("add_title_and_description", scope: "decidim.forms.admin.questionnaires.edit_questions") %></button>
+            <button class="button button__sm button__transparent-secondary add-question"><%= t("add_question", scope: "decidim.forms.admin.questionnaires.edit_questions") %></button>
+            <button class="button button__sm button__transparent-secondary add-separator"><%= t("add_separator", scope: "decidim.forms.admin.questionnaires.edit_questions") %></button>
+            <button class="button button__sm button__transparent-secondary add-title-and-description"><%= t("add_title_and_description", scope: "decidim.forms.admin.questionnaires.edit_questions") %></button>
           <% end %>
           <% if allowed_to? :preview, :questionnaire %>
             <%= link_to t("preview", scope: "decidim.forms.admin.questionnaires.form"), public_url, class: "button button__sm button__transparent-secondary", target: :_blank, data: { "external-link": false } %>


### PR DESCRIPTION
#### :tophat: What? Why?

This PR changes the buttons in the admin to use most of the cases the transparent version, so the "New XXX" and "Configure" are more visible too. 

#### Testing

1. Log in as admin
2. Navigate in the admin panel 

### :camera: Screenshots

#### Before

![Proposal admin page](https://github.com/user-attachments/assets/2a7d5d59-eee3-40fa-9f0f-9ff1d33ac50d)

#### After

![Proposal admin page](https://github.com/user-attachments/assets/f1e2c148-9abe-4595-85ae-ac8bc3bedfb8)

:hearts: Thank you!
