### PR TITLE
Fix submit on button on forms with taxonomies

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -233,6 +233,7 @@ module Decidim
           content_tag(:button,
                       t("#{name}_add", scope: i18n_scope),
                       class: "button button__xs button__transparent-secondary js-add-taxonomy-filter",
+                      type: "button",
                       data: {
                         url: decidim_admin.taxonomy_filters_selector_index_path(component_id: @component.id)
                       })


### PR DESCRIPTION
#### :tophat: What? Why?

While working in the admin, I found a mini bug related with #12996.

When you submit a form with the `enter` key, it opens the taxonomies drawer instead of submitting the form. This is because the type of button isn't defined and the browser tries to be clever and infer that this is the action that we want to do. 

This PR fixes it. 

#### :pushpin: Related Issues
 
- Related to #12996 

#### Testing

1. Sign in as admin
2. Go to a form with this button. I detected this in the proposals component's configuration admin page.
3. Go to an input text
4. Press enter
5. (Before) see that the taxonomies drawer opens
6. (After) see that the form is submitted (as you'd expect)

### :camera: Screenshots

![Screenshot of the bug](https://github.com/user-attachments/assets/5d8ac55e-8392-4ce5-8c5e-4b707184e96f)

:hearts: Thank you!
