### PR TITLE
Add more configurations on proposals with seeds

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -17,7 +17,7 @@ module Decidim
 
         Decidim::Proposals.create_default_states!(component, admin_user)
 
-        5.times do |n|
+        (5..30).to_a.sample.times do |n|
           proposal = create_proposal!(component:)
 
           if proposal.state.nil? && component.settings.amendments_enabled?

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -50,7 +50,12 @@ module Decidim
 
       def create_component!
         step_settings = if participatory_space.allows_steps?
-                          { participatory_space.active_step.id => { votes_enabled: true, votes_blocked: false, creation_enabled: true } }
+                          { participatory_space.active_step.id => {
+                            votes_enabled: true,
+                            votes_blocked: [false, true].sample,
+                            votes_hidden: [false, true].sample,
+                            creation_enabled: true
+                          } }
                         else
                           {}
                         end
@@ -61,7 +66,10 @@ module Decidim
           published_at: Time.current,
           participatory_space:,
           settings: {
-            vote_limit: 0,
+            minimum_votes_per_user: (0..2).to_a.sample,
+            vote_limit: (0..5).to_a.sample,
+            threshold_per_proposal: [0, (10..100).to_a.sample].sample,
+            can_accumulate_votes_beyond_threshold: [true, false].sample,
             attachments_allowed: [true, false].sample,
             amendments_enabled: participatory_space.id.odd?,
             collaborative_drafts_enabled: true,


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds more configurations to the possible seeds in proposals, so we could have detected bugs like #14221, that are frontend issues, and as such are really difficult to catch in an automated way. 

Basically the settings that I listed at https://github.com/decidim/decidim/pull/14221#pullrequestreview-2669439683 
 
#### Testing

1. Run bin/rails db:drop db:create db:schema:load db:seed 
2. Navigate to the different proposals components 

### :camera: Screenshots

![Example of a proposal configuration](https://github.com/user-attachments/assets/c1f797a8-9031-4612-aeb5-f88d84560871)

![Example of another proposal configuration](https://github.com/user-attachments/assets/23547a0c-15c9-4a81-95c6-53d232f1bddf)

:hearts: Thank you!
