### PR TITLE
Fix details and minor details 

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_login.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_login.scss
@@ -32,6 +32,10 @@ $google_background_hover: #dcdcdc; // 30% opacity
 
       &--developer {
         @apply flex;
+
+        svg {
+          @apply fill-current;
+        }
       }
 
       &--facebook {

--- a/decidim-forms/app/cells/decidim/forms/step_navigation_cell.rb
+++ b/decidim-forms/app/cells/decidim/forms/step_navigation_cell.rb
@@ -45,6 +45,8 @@ module Decidim
       end
 
       def confirm_data
+        return {} if allow_editing_answers? && current_user
+
         {
           data: {
             confirm:,
@@ -55,10 +57,9 @@ module Decidim
       end
 
       def confirm
-        return t("decidim.forms.step_navigation.show.are_you_sure_no_edit") unless allow_editing_answers?
         return t("decidim.forms.step_navigation.show.are_you_sure_edit_guest") unless current_user
 
-        t("decidim.forms.step_navigation.show.are_you_sure_edit")
+        t("decidim.forms.step_navigation.show.are_you_sure_no_edit")
       end
     end
   end

--- a/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire_answers.rb
+++ b/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire_answers.rb
@@ -29,7 +29,7 @@ module Decidim
 
               @query = paginate(collection)
               @participants = participants(@query)
-              @total = participants_query.count_participants
+              @total = questionnaire.count_participants
 
               render template: "decidim/forms/admin/questionnaires/answers/index"
             end

--- a/decidim-forms/app/models/decidim/forms/questionnaire.rb
+++ b/decidim-forms/app/models/decidim/forms/questionnaire.rb
@@ -39,6 +39,10 @@ module Decidim
         Decidim::Forms::AdminLog::QuestionnairePresenter
       end
 
+      def count_participants
+        Decidim::Forms::QuestionnaireParticipants.new(self).count_participants
+      end
+
       private
 
       # salt is used to generate secure hash in anonymous answers

--- a/decidim-forms/config/locales/en.yml
+++ b/decidim-forms/config/locales/en.yml
@@ -218,7 +218,6 @@ en:
           tos_agreement: By participating you accept its Terms of Service
       step_navigation:
         show:
-          are_you_sure_edit: You will be able to edit your answers. Are you sure?
           are_you_sure_edit_guest: If you want to be able to edit your answers afterwards, then you need to log in or create an account.
           are_you_sure_no_edit: This action cannot be undone and you will not be able to edit your answers. Are you sure?
           back: Back

--- a/decidim-forms/spec/models/decidim/forms/questionnaire_spec.rb
+++ b/decidim-forms/spec/models/decidim/forms/questionnaire_spec.rb
@@ -34,6 +34,17 @@ module Decidim
         expect(questionnaire.questionnaire_for).to eq(questionable)
       end
 
+      describe "#count_participants" do
+        it "returns the unique participants number" do
+          user1 = create(:user, organization: questionable.organization)
+          create(:answer, questionnaire: subject, user: user1)
+          create(:answer, questionnaire: subject, user: user1)
+          create(:answer, questionnaire: subject, user: create(:user, organization: questionable.organization))
+
+          expect(subject.reload.count_participants).to eq(2)
+        end
+      end
+
       describe "#questions_editable?" do
         it "returns false when questionnaire has already answers" do
           create(:answer, questionnaire:)

--- a/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/main_data/content.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_process_groups/content_blocks/main_data/content.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 decorator"><%= title_text %></h2>
+<h2 class="h2 decorator mb-4"><%= title_text %></h2>
 
 <div class="editor-content content-block__description">
   <%= description_text %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -886,7 +886,7 @@ en:
           success: Co-author invitation successfully canceled.
         create:
           error: There was a problem inviting the co-author.
-          success: "%{author_name} successfully invited as a co-author."
+          success: "%{author_name} has been successfully invited as a co-author."
         destroy:
           error: There was a problem declining the invitation.
           success: The invitation has been declined.

--- a/decidim-proposals/spec/system/proposal_comment_actions_spec.rb
+++ b/decidim-proposals/spec/system/proposal_comment_actions_spec.rb
@@ -41,7 +41,7 @@ describe "Interact with commenters" do
           end
         end
 
-        expect(page).to have_content("successfully invited as a co-author")
+        expect(page).to have_content("has been successfully invited as a co-author")
 
         within "#comment_#{comment.id}" do
           find("#dropdown-trigger-toggle-context-menu-#{comment.id}").click

--- a/decidim-surveys/app/controllers/decidim/surveys/admin/answers_controller.rb
+++ b/decidim-surveys/app/controllers/decidim/surveys/admin/answers_controller.rb
@@ -12,7 +12,7 @@ module Decidim
 
           @query = paginate(collection)
           @participants = participants(@query)
-          @total = participants_query.count_participants
+          @total = questionnaire.count_participants
           @survey = questionnaire_for
 
           render template: "decidim/surveys/admin/answers/index"

--- a/decidim-surveys/app/views/decidim/surveys/admin/answers/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/answers/index.html.erb
@@ -29,7 +29,7 @@
       <thead>
         <tr>
           <th>#</th>
-          <th><%= first_table_th(@participants.first) %></th>
+          <th class="!text-left"><%= first_table_th(@participants.first) %></th>
           <th><%= t("user_status", scope: "decidim.forms.user_answers_serializer") %></th>
           <th><%= t("ip_hash", scope: "decidim.forms.user_answers_serializer") %></th>
           <th><%= t("completion", scope: "decidim.forms.user_answers_serializer") %></th>
@@ -41,7 +41,7 @@
         <% @participants.each_with_index do |participant, idx| %>
           <tr>
             <td><%= idx + 1 + page_offset %></td>
-            <td>
+            <td class="!text-left">
               <% if allowed_to? :show, :questionnaire_answers %>
                 <%= link_to first_table_td(participant), questionnaire_participant_answers_url(participant.session_token) %>
               <% else %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/publish_answers/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/publish_answers/index.html.erb
@@ -20,6 +20,7 @@
     <ol class="list-decimal list-inside">
       <% @survey.questionnaire.questions.each do |question| %>
         <% next if question.question_type == "separator" %>
+        <% next if question.question_type == "title_and_description" %>
 
         <li class="<%= "text-gray" unless question_answer_is_publicable(question.question_type) %> mb-6">
           <div class="inline">

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
@@ -23,7 +23,7 @@
           <tr>
             <td><%= decidim_sanitize_translated(survey.title) %></td>
             <td><%= survey.questionnaire.questions.size %></td>
-            <td><%= survey.questionnaire.answers.size %></td>
+            <td><%= survey.questionnaire.count_participants %></td>
             <td><%= survey.open? ? t("models.survey.status.open", scope: "decidim.surveys") : t("models.survey.status.closed", scope: "decidim.surveys") %></td>
             <td class="table-list__actions">
                 <%= icon_link_to "pencil-line", edit_survey_path(survey), t("actions.edit", scope: "decidim.surveys"), class: "action-icon--edit" %>

--- a/decidim-surveys/spec/shared/editable_survey_answer_examples.rb
+++ b/decidim-surveys/spec/shared/editable_survey_answer_examples.rb
@@ -70,7 +70,7 @@ shared_examples "editable survey answers" do
     end
 
     check "questionnaire_tos_agreement"
-    accept_confirm { click_on "Submit" }
+    click_on "Submit"
   end
 
   it "restricts the change of an answer when editing is disabled" do
@@ -129,7 +129,7 @@ shared_examples "editable survey answers" do
     drag_and_drop(first: answer_options.second, second: answer_options.last, last: answer_options.first)
 
     check "questionnaire_tos_agreement"
-    accept_confirm { click_on "Submit" }
+    click_on "Submit"
 
     expect(page).to have_content("Edit your answers")
     click_on "Edit your answers"


### PR DESCRIPTION
## :tophat: What? Why?

This PR fixes multiple details, mainly with the CSS but also some other minor bugfixes.

These were detected in Metadecidim's staging with v0.30.0.rc2, so there are some of these fixes that are relevant to v0.30 only, but others that should be backported to v0.29. I'm doing only one PR to not hammer the CI, we can check out each particular issue if it's reproducible on those versions when backporting.

## :pushpin: Related Issues
 
- Related to #14228
 
## Issues

### Fix color for developers' OAuth icon

#### To reproduce

1. Log out if you are logged in 
2. Go to http://localhost:3000/users/sign_in 

##### Before

![Screenshot of the bug](https://github.com/user-attachments/assets/766fdd4b-4757-4635-ae80-02784f157fe5)

##### After

![Screenshot of the fix](https://github.com/user-attachments/assets/0ca819bc-ee24-4a66-aeb7-c521ecba13a0)

-----

### Fix copy for co-author announcement

#### To reproduce

1. Log in as one user (for instance, admin@example.org)
2. Go to a proposals component with creation enabled (`Participants can create proposals` setting) 
3. Create a proposal
4. On another browser, log in as another user (for instance user@example.org) 
5. Publish a comment
6. Go to the other browser
7. Find this comment, click on the three dots menu (aka meatballs menu), click on "Mark as co-author", click on "OK" button
8. See the text of the announcement

##### Before

![Screenshot of the bug](https://github.com/user-attachments/assets/59365ef4-ce60-47d7-b84d-5f9635b72d75)

##### After

![Screenshot of the fix](https://github.com/user-attachments/assets/5187ab61-72fe-4714-affd-b3caa98a6c14)

-----

### Fix bad answers counting in surveys' admin table

#### To reproduce

1. Log in
2. Go to a surveys component in the admin panel
3. Go to a survey without answers. Enable answers
10. Answer it
11. See the number of answers (it should be 1, it is not)

##### Before

![Screenshot of the bug](https://github.com/user-attachments/assets/be4c6110-03f6-4e92-bc36-0e3632686cb6)

##### After

![Screenshot of the fix](https://github.com/user-attachments/assets/7650349e-4e8e-411d-9d05-4205a2d5ec4a)

-----

### Align answer's participant name to the left in the admin's answers table

#### To reproduce

1. Log in
2. Go to a proposal page
3. Scroll to the Publish comment section

##### Before

![Screenshot of the bug](https://github.com/user-attachments/assets/ea388954-0a51-44c0-a01d-9a258863090d)

##### After

![Screenshot of the fix](https://github.com/user-attachments/assets/f473d3b4-257d-4ef3-b437-87f8fefffc72)

-----

### Do not show confirmation when a participant can edit their surveys' answers

#### To reproduce

1. Log in
2. Go to a surveys component in the admin panel
3. Go to a survey without answers. Enable answers and enable edition of the answers
4. Answer it
5. See that you have a modal telling you that you can change your answers (do not make much sense)

(As it is a not showing thing, I can't provide an screenshot)

-----

### Do not show Titles in questions to publish answers

#### To reproduce

1. Log in
2. Go to a surveys component in the admin panel
3. Go to a survey without answers. Enable answers
4. Add a question of type "Title and description"
5. Answer the survey
12. Disable answers
13. Go to the Responses tab
14. Click on "Publish answers" button
15. See that you can publish the "Title and description" question (that doesn't have any answer - ?)

##### Before

![Screenshot of the bug](https://github.com/user-attachments/assets/6d2083fa-e00f-496c-919d-e2d9932fdf1b)

##### After

![Screenshot of the fix](https://github.com/user-attachments/assets/638d4471-6f92-420c-b1c0-48d2ef345719)

-----

### Add some margin in the participatory process group main data content block

#### To reproduce

1. Go to a participatory group page like http://localhost:3000/processes_groups/1 

##### Before

![Screenshot of the bug](https://github.com/user-attachments/assets/f3a685be-6317-4e4f-b1b4-45e538733383)

##### After

![Screenshot of the fix](https://github.com/user-attachments/assets/eac58156-9485-4ba9-b6cb-ad4a21d43770)

-----

:hearts: Thank you!
