### PR TITLE
Fix budget detail with "You voted for this" string

### DIFF
--- a/decidim-budgets/app/cells/decidim/budgets/project_voted_hint_cell.rb
+++ b/decidim-budgets/app/cells/decidim/budgets/project_voted_hint_cell.rb
@@ -9,20 +9,23 @@ module Decidim
       def show
         return unless voted_for?(model)
 
-        content_tag :span, safe_join(hint), class: css_class
+        content_tag :span, hint, class: css_class
       end
 
       private
 
       def hint
-        contents = []
-        contents << icon("check-line", role: "img", "aria-hidden": true)
-        contents << " "
-        contents << t("decidim.budgets.projects.project.you_voted")
+        content_tag :div, class: "success" do
+          contents = []
+          contents << icon("check-line", role: "img", "aria-hidden": true)
+          contents << " "
+          contents << t("decidim.budgets.projects.project.you_voted")
+          safe_join(contents)
+        end
       end
 
       def css_class
-        css = ["text-sm", "text-success"]
+        css = ["card__list-metadata"]
         css << options[:class] if options[:class]
         css.join(" ")
       end

--- a/decidim-core/app/packs/stylesheets/decidim/_cards.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_cards.scss
@@ -151,6 +151,10 @@
       }
     }
 
+    & > div.success {
+      @apply text-sm text-success;
+    }
+
     [data-author] + [data-author] {
       @apply -ml-4;
     }


### PR DESCRIPTION
#### :tophat: What? Why?
This PR just fixes a small css issue in budgets: Check in the pics "You voted for this" text

Before: 
![image](https://github.com/user-attachments/assets/b66cdbdd-8281-46a5-9253-5c58aa3891ef)

After:
![image](https://github.com/user-attachments/assets/acd3061f-82bb-4afb-91c9-d105c90901a6)


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. Go to a budget component 
2. Enable voting 
3. Vote for a project 
4. Visit the budget page 
5. See error 
6. Apply patch 
7. See error is gone

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
