### PR TITLE
Fix Comment cell to not show reply button when depth eq MAX_DEPTH

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comment_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comment_cell.rb
@@ -125,6 +125,7 @@ module Decidim
 
       def can_reply?
         return false if two_columns_layout?
+        return false if model.depth >= Comment::MAX_DEPTH
         return true if current_participatory_space && user_has_any_role?(current_user, current_participatory_space)
 
         user_signed_in? && accepts_new_comments? &&

--- a/decidim-comments/spec/cells/decidim/comments/comment_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comment_cell_spec.rb
@@ -310,6 +310,16 @@ module Decidim::Comments
         allow(commentable).to receive(:accepts_new_comments?).and_return(true)
       end
 
+      context "when depth is equal to MAX_DEPTH" do
+        before do
+          allow(comment).to receive(:depth).and_return(Comment::MAX_DEPTH)
+        end
+
+        it "returns false" do
+          expect(my_cell.send(:can_reply?)).to be false
+        end
+      end
+
       context "when two columns layout is enabled" do
         before do
           allow(commentable).to receive(:two_columns_layout?).and_return(true)


### PR DESCRIPTION
#### :tophat: What? Why?
Reply button is available on comments at MAX_DEPTH and the reply will fail because of the depth validation on the comment model.

#### :pushpin: Related Issues
- Fixes #14033

#### Testing
1. Sign in as a admin
2. Go to a proposal page
3. Reply to a comments
4. Reply to the previous reply
5. Reply to the last reply 
6. Should not see reply button

:hearts: Thank you!
