### PR TITLE
Backport 'Register user without avatar on omniauth registration if avatar_url is unreachable' to v0.28

### DIFF
--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -67,18 +67,22 @@ module Decidim
         @user.nickname = form.normalized_nickname
         @user.newsletter_notifications_at = nil
         @user.password = SecureRandom.hex
-        if form.avatar_url.present?
-          url = URI.parse(form.avatar_url)
-          filename = File.basename(url.path)
-          file = url.open
-          @user.avatar.attach(io: file, filename:)
-        end
+        attach_avatar(form.avatar_url) if form.avatar_url.present?
         @user.skip_confirmation! if verified_email
         @user.tos_agreement = "1"
         @user.save!
 
         @user.after_confirmation if verified_email
       end
+    end
+
+    def attach_avatar(avatar_url)
+      url = URI.parse(avatar_url)
+      filename = File.basename(url.path)
+      file = url.open
+      @user.avatar.attach(io: file, filename:)
+    rescue OpenURI::HTTPError, Errno::ECONNREFUSED
+      # Do not attach the avatar, as it fails to fetch it.
     end
 
     def create_identity

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -85,6 +85,48 @@ module Decidim
             expect(user.valid_password?("decidim123456789")).to be(true)
           end
 
+          it "download and attach the avatar" do
+            stub_request(:get, "http://www.example.com/foo.jpg").to_return(
+              status: 200,
+              body: File.read("spec/assets/avatar.jpg"), headers: { "Content-Type" => "image/jpeg" }
+            )
+            expect { command.call }.to broadcast(:ok)
+            user = User.find_by(email: form.email)
+            expect(user.avatar).to be_attached
+            expect(user.avatar.attachment.filename.to_s).to eq("foo.jpg")
+            expect(user.avatar.attachment.blob.byte_size).to eq(File.open("spec/assets/avatar.jpg").size)
+          end
+
+          context "when avatar URL fetching fails" do
+            it "with a 404 HTTP code, it saves the user without avatar" do
+              stub_request(:get, "http://www.example.com/foo.jpg").to_return(status: 404)
+              expect { command.call }.to broadcast(:ok)
+              user = User.find_by(email: form.email)
+              expect(user.avatar).not_to be_attached
+            end
+
+            it "with a 502 HTTP code, it saves the user without avatar" do
+              stub_request(:get, "http://www.example.com/foo.jpg").to_return(status: 502)
+              expect { command.call }.to broadcast(:ok)
+              user = User.find_by(email: form.email)
+              expect(user.avatar).not_to be_attached
+            end
+
+            it "with a 500 HTTP code, it saves the user without avatar" do
+              stub_request(:get, "http://www.example.com/foo.jpg").to_return(status: 500)
+              expect { command.call }.to broadcast(:ok)
+              user = User.find_by(email: form.email)
+              expect(user.avatar).not_to be_attached
+            end
+
+            it "with a 401 HTTP code, it saves the user without avatar" do
+              stub_request(:get, "http://www.example.com/foo.jpg").to_return(status: 401)
+              expect { command.call }.to broadcast(:ok)
+              user = User.find_by(email: form.email)
+              expect(user.avatar).not_to be_attached
+            end
+          end
+
           # NOTE: This is important so that the users who are only
           # authenticating using omniauth will not need to update their
           # passwords.


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #14135 to v0.28

:hearts: Thank you!