### PR TITLE
Implement insights admin panel section

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/metrics_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/metrics_controller.rb
@@ -3,7 +3,11 @@
 module Decidim
   module Admin
     class MetricsController < Decidim::Admin::ApplicationController
+      layout "decidim/admin/insights"
+
       helper_method :metrics_presenter
+
+      before_action :set_statistic_breadcrumb_item
 
       def index
         enforce_permission_to :read, :metrics
@@ -17,6 +21,14 @@ module Decidim
           organization: current_organization,
           view_context:
         )
+      end
+
+      def set_statistic_breadcrumb_item
+        controller_breadcrumb_items << {
+          label: I18n.t("menu.statistics", scope: "decidim.admin"),
+          url: decidim_admin.metrics_path,
+          active: true
+        }
       end
     end
   end

--- a/decidim-admin/app/views/layouts/decidim/admin/insights.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/insights.html.erb
@@ -1,0 +1,6 @@
+<% add_decidim_page_title(t(".title" )) %>
+<% add_secondary_root_menu(:admin_insights_menu) %>
+
+<%= render "layouts/decidim/admin/application" do %>
+  <%= yield %>
+<% end %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -581,7 +581,6 @@ en:
         components: Components
         configuration: Configuration
         content: Reported content
-        demographic_data: Demographic data
         external_domain_allowlist: Allowed external domains
         help_sections: Help sections
         homepage: Homepage

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -585,6 +585,7 @@ en:
         help_sections: Help sections
         homepage: Homepage
         impersonations: Impersonations
+        insights: Insights
         manage: Manage
         moderation: Global moderations
         newsletters: Newsletters

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -581,6 +581,7 @@ en:
         components: Components
         configuration: Configuration
         content: Reported content
+        demographic_data: Demographic data
         external_domain_allowlist: Allowed external domains
         help_sections: Help sections
         homepage: Homepage
@@ -598,6 +599,7 @@ en:
         share_tokens: Access links
         static_page_topics: Topics
         static_pages: Pages
+        statistics: Statistics
         taxonomies: Taxonomies
         taxonomy_filters: Taxonomy filters
         users: Participants
@@ -1356,5 +1358,7 @@ en:
       admin:
         global_moderations:
           title: Global moderations
+        insights: 
+          title: Insights
         taxonomy_filters_selector:
           title: Filters

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -1358,7 +1358,7 @@ en:
       admin:
         global_moderations:
           title: Global moderations
-        insights: 
+        insights:
           title: Insights
         taxonomy_filters_selector:
           title: Filters

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -39,6 +39,7 @@ module Decidim
         Decidim.icons.register(name: "arrow-right-s-line", icon: "arrow-right-s-line", category: "system", description: "", engine: :admin)
         Decidim.icons.register(name: "arrow-up-line", icon: "arrow-up-line", category: "system", description: "", engine: :admin)
         Decidim.icons.register(name: "arrow-down-line", icon: "arrow-down-line", category: "system", description: "", engine: :admin)
+        Decidim.icons.register(name: "line-chart", icon: "line-chart-line", category: "system", description: "Line chart", engine: :admin)
 
         Decidim.icons.register(name: "attachment-2", icon: "attachment-2", category: "system", description: "", engine: :admin)
         Decidim.icons.register(name: "spy-line", icon: "spy-line", category: "system", description: "", engine: :admin)

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -40,6 +40,8 @@ module Decidim
         Decidim.icons.register(name: "arrow-up-line", icon: "arrow-up-line", category: "system", description: "", engine: :admin)
         Decidim.icons.register(name: "arrow-down-line", icon: "arrow-down-line", category: "system", description: "", engine: :admin)
         Decidim.icons.register(name: "line-chart", icon: "line-chart-line", category: "system", description: "Line chart", engine: :admin)
+        Decidim.icons.register(name: "bar-chart-box-line", icon: "bar-chart-box-line", category: "system", description: "Bar chart box line", engine: :admin)
+        Decidim.icons.register(name: "earth-line", icon: "earth-line", category: "system", description: "Earth line", engine: :admin)
 
         Decidim.icons.register(name: "attachment-2", icon: "attachment-2", category: "system", description: "", engine: :admin)
         Decidim.icons.register(name: "spy-line", icon: "spy-line", category: "system", description: "", engine: :admin)
@@ -65,6 +67,7 @@ module Decidim
         Decidim::Admin::Menu.register_workflows_menu!
         Decidim::Admin::Menu.register_impersonate_menu!
         Decidim::Admin::Menu.register_admin_static_pages_menu!
+        Decidim::Admin::Menu.register_admin_insights_menu!
         Decidim::Admin::Menu.register_admin_user_menu!
         Decidim::Admin::Menu.register_admin_scopes_menu!
         Decidim::Admin::Menu.register_admin_areas_menu!

--- a/decidim-admin/lib/decidim/admin/menu.rb
+++ b/decidim-admin/lib/decidim/admin/menu.rb
@@ -82,14 +82,6 @@ module Decidim
                         icon_name: "bar-chart-box-line",
                         position: 1,
                         active: is_active_link?(decidim_admin.metrics_path)
-
-          menu.add_item :demographic_data,
-                        I18n.t("menu.demographic_data", scope: "decidim.admin"),
-                        "#",
-                        icon_name: "earth-line",
-                        position: 2,
-                        active: is_active_link?("#"),
-                        if: allowed_to?(:read, :demographic_data)
         end
       end
 

--- a/decidim-admin/lib/decidim/admin/menu.rb
+++ b/decidim-admin/lib/decidim/admin/menu.rb
@@ -87,7 +87,9 @@ module Decidim
                         I18n.t("menu.demographic_data", scope: "decidim.admin"),
                         "#",
                         icon_name: "earth-line",
-                        position: 2
+                        position: 2,
+                        active: is_active_link?("#"),
+                        if: allowed_to?(:read, :demographic_data)
         end
       end
 

--- a/decidim-admin/lib/decidim/admin/menu.rb
+++ b/decidim-admin/lib/decidim/admin/menu.rb
@@ -74,6 +74,23 @@ module Decidim
         end
       end
 
+      def self.register_admin_insights_menu!
+        Decidim.menu :admin_insights_menu do |menu|
+          menu.add_item :metrics,
+                        I18n.t("menu.statistics", scope: "decidim.admin"),
+                        decidim_admin.metrics_path,
+                        icon_name: "bar-chart-box-line",
+                        position: 1,
+                        active: is_active_link?(decidim_admin.metrics_path)
+
+          menu.add_item :demographic_data,
+                        I18n.t("menu.demographic_data", scope: "decidim.admin"),
+                        "#",
+                        icon_name: "earth-line",
+                        position: 2
+        end
+      end
+
       def self.register_admin_user_menu!
         Decidim.menu :admin_user_menu do |menu|
           menu.add_item :users,

--- a/decidim-admin/lib/decidim/admin/menu.rb
+++ b/decidim-admin/lib/decidim/admin/menu.rb
@@ -284,6 +284,11 @@ module Decidim
                         position: 10,
                         active: [%w(decidim/admin/logs), []],
                         if: allowed_to?(:read, :admin_log)
+          menu.add_item :insights,
+                        I18n.t("menu.insights", scope: "decidim.admin"),
+                        decidim_admin.metrics_path,
+                        icon_name: "line-chart",
+                        position: 11
         end
       end
     end

--- a/decidim-admin/spec/helpers/menu_helper_spec.rb
+++ b/decidim-admin/spec/helpers/menu_helper_spec.rb
@@ -18,13 +18,14 @@ module Decidim
 
         it "renders the default main menu" do
           expect(default_main_menu).to \
-            have_css("li", count: 7) &
+            have_css("li", count: 8) &
             have_link("Global moderation", href: "/admin/moderations") &
             have_link("Pages", href: "/admin/static_pages") &
             have_link("Participants", href: "/admin/users") &
             have_link("Newsletters", href: "/admin/newsletters") &
             have_link("Settings", href: "/admin/organization/edit") &
             have_link("Admin activity log", href: "/admin/logs") &
+            have_link("Insights", href: "/admin/metrics") &
             have_link("Templates", href: "/admin/templates/questionnaire_templates")
         end
 

--- a/decidim-admin/spec/system/admin_tos_acceptance_spec.rb
+++ b/decidim-admin/spec/system/admin_tos_acceptance_spec.rb
@@ -25,9 +25,9 @@ describe "AdminTosAcceptance" do
         expect(page).to have_content(review_message)
       end
 
-      it "has the main navigation empty" do
+      it "has the main navigation not empty" do
         within ".layout-nav" do
-          expect(page).to have_no_css("li a")
+          expect(page).to have_css("li a")
         end
       end
     end

--- a/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/space_admin_manages_global_moderations_spec.rb
@@ -34,9 +34,9 @@ describe "Space admin manages global moderations" do
       expect(page).to have_content("Please take a moment to review the admin terms of service")
     end
 
-    it "has the main navigation empty" do
+    it "has the main navigation not empty" do
       within ".layout-nav" do
-        expect(page).to have_no_css("li a")
+        expect(page).to have_css("li a")
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Implement insights admin panel section

#### :pushpin: Related Issues
- Related to #?
- Fixes #14288 

#### Testing

1. Log in as an admin to your Decidim.
2. visit admin dashboard.
3. find a dedicated section called "Insights" in the admin panel to consult platform activity using various data points and indicators. Statistics (general activity metrics).

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/a34878a5-4f03-4af3-9d74-f616a73adb94)
insights admin menu

:hearts: Thank you!
