### PR TITLE
Fix searches filtering results when not are commentable

### DIFF
--- a/decidim-core/app/commands/decidim/search.rb
+++ b/decidim-core/app/commands/decidim/search.rb
@@ -37,6 +37,12 @@ module Decidim
                     klass.order_by_id_list(result_ids.take(HIGHLIGHTED_RESULTS_COUNT))
                   end
 
+        uncommentable_resources = uncommentable_resources(results) if results.present?
+        if uncommentable_resources.present?
+          results = results - uncommentable_resources
+          results_count = results_count - uncommentable_resources.count
+        end
+
         results_by_type.update(class_name => {
                                  count: results_count,
                                  results:
@@ -88,6 +94,16 @@ module Decidim
       query = query.order("datetime DESC")
       query = query.global_search(I18n.transliterate(term)) if term.present?
       query
+    end
+
+    def uncommentable_resources(results)
+      results.where(id: results.select { |obj| related_uncommentable_resources?(obj) }.map(&:id))
+    end
+
+    private
+
+    def related_uncommentable_resources?(object)
+      object.respond_to?(:commentable) && !object.commentable.commentable?
     end
   end
 end

--- a/decidim-core/app/commands/decidim/search.rb
+++ b/decidim-core/app/commands/decidim/search.rb
@@ -39,8 +39,8 @@ module Decidim
 
         uncommentable_resources = uncommentable_resources(results) if results.present?
         if uncommentable_resources.present?
-          results = results - uncommentable_resources
-          results_count = results_count - uncommentable_resources.count
+          results -= uncommentable_resources
+          results_count -= uncommentable_resources.count
         end
 
         results_by_type.update(class_name => {
@@ -99,8 +99,6 @@ module Decidim
     def uncommentable_resources(results)
       results.where(id: results.select { |obj| related_uncommentable_resources?(obj) }.map(&:id))
     end
-
-    private
 
     def related_uncommentable_resources?(object)
       object.respond_to?(:commentable) && !object.commentable.commentable?

--- a/decidim-core/lib/decidim/core/test/shared_examples/uncommentable_component_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/uncommentable_component_examples.rb
@@ -20,7 +20,7 @@ shared_examples "an uncommentable component" do
   end
 
   describe "when search a comment in the global search" do
-    let(:comment) { create :comment }
+    let(:comment) { create(:comment) }
 
     it "does not displays the comment" do
       component.update!(settings: { comments_enabled: false })

--- a/decidim-core/lib/decidim/core/test/shared_examples/uncommentable_component_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/uncommentable_component_examples.rb
@@ -8,7 +8,7 @@ shared_examples "an uncommentable component" do
            manifest:,
            participatory_space:)
   end
-  let!(:comment) { create(:comment, commentable: resources.first ) }
+  let!(:comment) { create(:comment, commentable: resources.first) }
 
   it "does not displays comments count" do
     component.update!(settings: { comments_enabled: false })

--- a/decidim-core/lib/decidim/core/test/shared_examples/uncommentable_component_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/uncommentable_component_examples.rb
@@ -8,6 +8,7 @@ shared_examples "an uncommentable component" do
            manifest:,
            participatory_space:)
   end
+  let!(:comment) { create(:comment, commentable: resources.first ) }
 
   it "does not displays comments count" do
     component.update!(settings: { comments_enabled: false })
@@ -20,9 +21,18 @@ shared_examples "an uncommentable component" do
   end
 
   describe "when search a comment in the global search" do
-    let(:comment) { create(:comment) }
+    it "does displays the comments" do
+      visit decidim.root_path
 
-    it "does not displays the comment" do
+      within ".main-bar__search" do
+        fill_in "term", with: comment.body["en"]
+        find("input#input-search").native.send_keys :enter
+      end
+
+      expect(page).to have_content("1 Results for the search")
+    end
+
+    it "does not displays the comment when comments are disable" do
       component.update!(settings: { comments_enabled: false })
       visit decidim.root_path
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/uncommentable_component_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/uncommentable_component_examples.rb
@@ -18,4 +18,20 @@ shared_examples "an uncommentable component" do
       expect(page).to have_no_link(resource_locator(resource).path)
     end
   end
+
+  describe "when search a comment in the global search" do
+    let(:comment) { create :comment }
+
+    it "does not displays the comment" do
+      component.update!(settings: { comments_enabled: false })
+      visit decidim.root_path
+
+      within ".main-bar__search" do
+        fill_in "term", with: comment.body["en"]
+        find("input#input-search").native.send_keys :enter
+      end
+
+      expect(page).to have_content("0 Results for the search")
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
In searches, when you have a proposal with comments and then you disable the comments, there is an error, and global search does not work.

![Screenshot from 2025-03-10 14-16-04](https://github.com/user-attachments/assets/63e1282c-a7c7-42f4-a91e-eb76044e63be)


In this PR, uncommentable (with the comments disabled) resources are excluded from search results.

#### Testing
1. Go to any proposal and do a comment
2. Disable the comments
3. Try to search for the comment in the global search
4. The comment does not appear (the count neither)

### :camera: Screenshots

#### With comments enable in the proposal
![Screenshot from 2025-03-18 15-40-35](https://github.com/user-attachments/assets/178bca05-41b6-4769-9c21-c306813945b9)
![Screenshot from 2025-03-18 15-41-21](https://github.com/user-attachments/assets/5770c3ea-4917-49a9-aef5-36a432814fc9)

#### With comments disabled in the proposal
![Screenshot from 2025-03-18 16-12-15](https://github.com/user-attachments/assets/f2ec67ea-db4d-46f6-afa7-2da14ba1004c)


:hearts: Thank you!
