### PR TITLE
Fix wcag keyboard modal cookie settings

### DIFF
--- a/decidim-core/app/views/layouts/decidim/footer/_main_legal.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_legal.html.erb
@@ -3,6 +3,6 @@
     <%= link_to t("layouts.decidim.footer.terms_of_service"), decidim.page_path("terms-of-service") %>
   </li>
   <li>
-    <button data-dialog-open="dc-modal" class="underline"><%= t("layouts.decidim.footer.data_consent_settings") %></button>
+    <a href="#" role="button" data-dialog-open="dc-modal"><%= t("layouts.decidim.footer.data_consent_settings") %></a>
   </li>
 </ul>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_legal.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_legal.html.erb
@@ -3,6 +3,6 @@
     <%= link_to t("layouts.decidim.footer.terms_of_service"), decidim.page_path("terms-of-service") %>
   </li>
   <li>
-    <a href="#" data-dialog-open="dc-modal"><%= t("layouts.decidim.footer.data_consent_settings") %></a>
+    <button data-dialog-open="dc-modal" class="underline"><%= t("layouts.decidim.footer.data_consent_settings") %></button>
   </li>
 </ul>


### PR DESCRIPTION
#### :tophat: What? 
Updated the cookie settings modal trigger in the footer by adding `role="button"` to the `<a>` tag.

#### :tophat: Why?
Insure the `<a> tag` behave like a button for an interactive action that opens a modal, expected by assistive technologies:
- Enhances accessibility by natively supporting keyboard interactions like `TAB + ENTER` and `TAB + SPACE`

#### :pushpin: Related Issues
- WCAG Criterion: [4.1.2 - Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
- WCAG Criterion: [2.1.1 - Keyboard Accessibility](https://www.w3.org/WAI/WCAG21/Understanding/keyboard)
- [Decidim Issue ](https://github.com/decidim/decidim/issues/13721)

#### :clipboard:  Steps to Test
1. Navigate to any page with the footer.
2. Focus on the "Data Consent Settings" button using TAB:
- With VoiceOver (macOS) or NVDA (Windows) activated verify that the modal opens correctly when you : Press SPACE or ENTER to open the modal.
- Inspect and verify that the `<a>` tag as `role="button" ` 

#### :clipboard: Subtasks
- [x] Added role="button" to the <a> tag.
- [x] Confirmed keyboard interactions (SPACE/ENTER) work as expected.

### :camera: Screenshots (optional)

### Additional Context
This update improves compliance with WCAG accessibility standards and enhances the user experience for those navigating via keyboard or assistive technologies.

:hearts: Thank you!
