### PR TITLE
Fix alignment of sorting options on projects

### DIFF
--- a/decidim-budgets/app/packs/stylesheets/budgets.scss
+++ b/decidim-budgets/app/packs/stylesheets/budgets.scss
@@ -134,7 +134,7 @@
   }
 
   &__list--header {
-    @apply flex items-center -ml-2 md:ml-0;
+    @apply flex items-center justify-between -ml-2 md:ml-0;
   }
 
   &-list {


### PR DESCRIPTION
#### :tophat: What? Why?
Sorting options for projects were misaligned to the left when more than one project was available under the Budgets component. The header was missing the flex box option ```justify-content: space-between``` to separate these sorting options to either side of the container.

#### :pushpin: Related Issues
- Fixes #14356 

#### Testing
1. Navigate to a participatory budgeting component in the frontend.  
2. Locate the sorting options for the list of projects.  
3. Observe that the options appear on the correct side (to the right).  

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/d339e084-1902-4cc1-b310-1b93a98e601c)

:hearts: Thank you!
