### PR TITLE
Prevent the error generating the diff for non-translatable fields in old version records

### DIFF
--- a/decidim-core/app/services/decidim/base_diff_renderer.rb
+++ b/decidim-core/app/services/decidim/base_diff_renderer.rb
@@ -41,6 +41,8 @@ module Decidim
     end
 
     def parse_i18n_changeset(attribute, values, type, diff)
+      return diff unless values.last.is_a?(Hash)
+
       (values.last.keys - ["machine_translations"]).each do |locale, _value|
         first_value = values.first.try(:[], locale)
         last_value = values.last.try(:[], locale)

--- a/decidim-proposals/spec/services/decidim/proposals/diff_renderer_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/diff_renderer_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe DiffRenderer do
+      subject { described_class.new(version).diff }
+
+      let(:proposal) { create(:proposal) }
+      let(:version) { PaperTrail::Version.create(item: proposal, event: "update", object_changes: { title: [title, other_title] }) }
+
+      context "with title as string" do
+        let(:title) { generate(:title) }
+        let(:other_title) { generate(:title) }
+
+        it "renders an empty diff" do
+          expect(subject).to be_empty
+        end
+      end
+
+      context "with title as translatable string" do
+        let(:title) { generate_localized_title(:proposal_title, skip_injection: true) }
+        let(:other_title) { generate_localized_title(:proposal_title, skip_injection: true) }
+
+        it "renders the diff successfully" do
+          expect(subject.dig(:title_en, :old_value)).to eq(title[:en])
+          expect(subject.dig(:title_en, :new_value)).to eq(other_title[:en])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Prevent the error generating the diff for non-translatable fields in old version records by returning the diff directly instead of processing by treating the values as objects.

This solution will prevent the error, but we won't be able to deserialize the older titles, as PaperTrail deserializes the values by checking the attribute type in the model. If the attribute is a Hash (as the translatable fields) it will expect a Hash and will always return nil when we send a string as a parameter for the deserialization. This nil value was the responsible of the error we had, as we were treating it as an object.

#### :pushpin: Related Issues
- Fixes #14346

#### Testing
Access a page of a proposal with old versions with non-translatable title

:hearts: Thank you!
