### PR TITLE
Fix edit comment modal cell displaying old cached values

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/edit_comment_modal_form_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/edit_comment_modal_form_cell.rb
@@ -11,7 +11,7 @@ module Decidim
       def cache_hash
         hash = []
         hash.push(I18n.locale)
-        hash.push(model.id)
+        hash.push(model.cache_key_with_version)
         hash.push(current_user.try(:id))
         hash.join(Decidim.cache_key_separator)
       end


### PR DESCRIPTION
#### :tophat: What? Why?
After editing a comment and opening the edit modal again, it will display the old value (even after refresh).
Changed the cache hash of `edit_comment_modal_cell` to use `model.cache_key_with_version` instead of `model.id`

#### :pushpin: Related Issues
- Fixes #14280

#### Testing

1. Go to dev app folder 
2. Run rails dev:cache (output should be: Development mode is now being cached.)
3. start server
4. Access a proposal/meeting
5. Add a comment (e.g. Comment1)
6. Edit the comment (e.g. Comment12)
7. Click on edit again and the value will be Comment1 (wrong)
8. Apply patch
9. Repeat 7 and value should be Comment12

:hearts: Thank you!
