### PR TITLE
Make the form borders and spacings consistents

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_forms.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_forms.scss
@@ -16,7 +16,7 @@
     input[type="week"],
     select,
     textarea {
-      @apply mt-0;
+      @apply mt-2;
     }
 
     & label:not(&-checkbox-label),

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_forms.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_forms.scss
@@ -24,10 +24,6 @@
       @apply text-sm;
     }
 
-    .help-text {
-      @apply mt-1;
-    }
-
     .row .columns,
     .row.column {
       @apply mb-4;

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_item_edit.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_item_edit.scss
@@ -3,7 +3,7 @@
 
   &-form {
     .card {
-      @apply rounded bg-white border-neutral-200 border-2 fill-secondary;
+      @apply rounded bg-white border-neutral-200 border fill-secondary;
     }
 
     .card-section {

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_item_edit.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_item_edit.scss
@@ -42,10 +42,6 @@
       @apply font-semibold text-md text-left inline-block text-secondary;
     }
 
-    .label--tabs {
-      @apply mb-2;
-    }
-
     label {
       @apply text-gray-2 text-sm;
     }

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_item_edit.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_item_edit.scss
@@ -71,6 +71,12 @@
       .editor-container .editor-input .ProseMirror {
         @apply bg-background-2;
       }
+
+      &.edit_content_block {
+        .tabs-content {
+          @apply mb-2;
+        }
+      }
     }
   }
 

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_item_edit.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_item_edit.scss
@@ -3,7 +3,7 @@
 
   &-form {
     .card {
-      @apply rounded bg-white border-background border fill-secondary;
+      @apply rounded bg-white border-neutral-200 border-2 fill-secondary;
     }
 
     .card-section {
@@ -30,7 +30,7 @@
       }
 
       &[aria-expanded="true"] {
-        @apply border-solid border-b border-gray w-full rounded-none;
+        @apply border-solid border-b border-neutral-200 w-full rounded-none;
 
         svg {
           @apply rotate-90 transition-transform;

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_item_edit.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_item_edit.scss
@@ -71,12 +71,6 @@
       .editor-container .editor-input .ProseMirror {
         @apply bg-background-2;
       }
-
-      &.edit_content_block {
-        .tabs-content {
-          @apply mb-2;
-        }
-      }
     }
   }
 
@@ -106,10 +100,6 @@
         @apply bg-white text-secondary;
       }
     }
-  }
-
-  .label--tabs {
-    @apply mb-2;
   }
 }
 

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_item_show.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_item_show.scss
@@ -3,7 +3,7 @@
 }
 
 .item_show__header {
-  @apply flex items-center pb-4 border-b-2 border-neutral-200 mb-4 gap-x-2;
+  @apply flex items-center pb-4 border-b border-neutral-200 mb-4 gap-x-2;
 
   > svg {
     @apply w-4 h-4;

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_item_show.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_item_show.scss
@@ -3,7 +3,7 @@
 }
 
 .item_show__header {
-  @apply flex items-center pb-4 border-b border-gray mb-4 gap-x-2;
+  @apply flex items-center pb-4 border-b-2 border-neutral-200 mb-4 gap-x-2;
 
   > svg {
     @apply w-4 h-4;

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_tabs.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_tabs.scss
@@ -51,6 +51,10 @@
   }
 }
 
+.tabs-panel .help-text {
+  @apply mt-1;
+}
+
 .tabs-panel[aria-hidden="true"] {
   @apply hidden;
 }

--- a/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
@@ -8,11 +8,7 @@
 
 <div class="item__edit-form">
   <%= decidim_form_for(@form, html: { class: "form-defaults form edit_organization" }, url: organization_path) do |f| %>
-    <div class="card">
-      <div class="card-section">
-        <%= render partial: "form", object: f %>
-      </div>
-    </div>
+    <%= render partial: "form", object: f %>
     <div class="item__edit-sticky">
       <div class="item__edit-sticky-container">
         <%= f.submit t(".update"), class: "button button__sm button__secondary" %>

--- a/decidim-admin/app/views/decidim/admin/shared/landing_page_content_blocks/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/shared/landing_page_content_blocks/edit.html.erb
@@ -8,11 +8,9 @@
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { class: "form-defaults form edit_content_block" }, url: resource_landing_page_content_block_path) do |form| %>
       <div class="form__wrapper">
-        <div class="card py-4">
+        <div class="card pt-4">
           <div class="card-section">
-            <div class="row column">
-              <%= cell content_block.settings_form_cell, form, content_block: %>
-            </div>
+            <%= cell content_block.settings_form_cell, form, content_block: %>
           </div>
         </div>
       </div>

--- a/decidim-admin/lib/decidim/admin/form_builder.rb
+++ b/decidim-admin/lib/decidim/admin/form_builder.rb
@@ -67,7 +67,7 @@ module Decidim
           name,
           {
             toolbar: :full,
-            lines: 25
+            lines: 8
           }.merge(options)
         )
       end

--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
@@ -1,3 +1,5 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.number_field :max_results, label: %>
+  <div class="row column">
+    <%= settings_fields.number_field :max_results, label: %>
+  </div>
 <% end %>

--- a/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
@@ -1,3 +1,5 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.number_field :max_results, label: %>
+  <div class="row column">
+    <%= settings_fields.number_field :max_results, label: %>
+  </div>
 <% end %>

--- a/decidim-core/app/cells/decidim/content_blocks/hero_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/hero_settings_form/show.erb
@@ -1,7 +1,11 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.translated :text_field, :welcome_text, label: t(".welcome_text") %>
+  <div class="row column">
+    <%= settings_fields.translated :text_field, :welcome_text, label: t(".welcome_text") %>
+  </div>
 <% end %>
 
 <% form.fields_for :images, form.object.images do |images_fields| %>
-  <%= images_fields.upload :background_image, label: t(".background_image") %>
+  <div class="row column">
+    <%= images_fields.upload :background_image, label: t(".background_image"), button_class: "button button__sm button__transparent-secondary" %>
+  </div>
 <% end %>

--- a/decidim-core/app/cells/decidim/content_blocks/highlighted_elements_for_component_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/highlighted_elements_for_component_settings_form/show.erb
@@ -1,4 +1,11 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select(:order, order_options, prompt: "", label:) if include_order_setting? %>
-  <%= settings_fields.select :component_id, component_options, prompt: "", label: component_label %>
+  <% if include_order_setting? %>
+    <div class="row column">
+      <%= settings_fields.select(:order, order_options, prompt: "", label:) %>
+    </div>
+  <% end %>
+
+  <div class="row column">
+    <%= settings_fields.select :component_id, component_options, prompt: "", label: component_label %>
+  </div>
 <% end %>

--- a/decidim-core/app/cells/decidim/content_blocks/html_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/html_settings_form/show.erb
@@ -1,3 +1,5 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.translated :text_area, :html_content, label: %>
+  <div class="row column">
+    <%= settings_fields.translated :text_area, :html_content, label: %>
+  </div>
 <% end %>

--- a/decidim-core/app/cells/decidim/content_blocks/last_activity_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/last_activity_settings_form/show.erb
@@ -1,3 +1,5 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.number_field :max_last_activity_users, label: %>
+  <div class="row column">
+    <%= settings_fields.number_field :max_last_activity_users, label: %>
+  </div>
 <% end %>

--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_hero_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_hero_settings_form/show.erb
@@ -1,8 +1,15 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.translated :text_field, :button_text, label: t("decidim.content_blocks.cta_settings_form.button_text") %>
-  <%= settings_fields.translated :text_field, :button_url, label: t("decidim.content_blocks.cta_settings_form.button_url") %>
+  <div class="row column">
+    <%= settings_fields.translated :text_field, :button_text, label: t("decidim.content_blocks.cta_settings_form.button_text") %>
+  </div>
+
+  <div class="row column">
+    <%= settings_fields.translated :text_field, :button_url, label: t("decidim.content_blocks.cta_settings_form.button_url") %>
+  </div>
 <% end %>
 
 <% form.fields_for :images, form.object.images do |images_fields| %>
-  <%= images_fields.upload :background_image, label: t("decidim.content_blocks.cta_settings_form.background_image") %>
+  <div class="row column">
+    <%= images_fields.upload :background_image, label: t("decidim.content_blocks.cta_settings_form.background_image"), button_class: "button button__sm button__transparent-secondary" %>
+  </div>
 <% end %>

--- a/decidim-core/app/packs/stylesheets/decidim/_datepicker.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_datepicker.scss
@@ -174,10 +174,6 @@
     @apply flex-1 text-center;
   }
 
-  &__help-text-container {
-    @apply w-full h-10 relative;
-  }
-
   &__help-date {
     @apply w-1/2 relative inline-block;
   }

--- a/decidim-core/app/packs/stylesheets/decidim/_forms.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_forms.scss
@@ -79,7 +79,7 @@
 }
 
 .form__wrapper {
-  @apply flex flex-col pt-10 pb-4 gap-10 last:pb-0;
+  @apply flex flex-col pt-10 pb-4 gap-5 last:pb-0;
 
   &-block {
     @apply py-10 last:pb-0 border-background flex flex-col gap-4 [&_p]:text-gray-2;
@@ -96,10 +96,6 @@
   & label:not(&-checkbox-label),
   &-block label:not(&-checkbox-label) {
     @apply font-semibold text-lg;
-  }
-
-  .help-text {
-    @apply mt-4;
   }
 
   input[type="date"],

--- a/decidim-core/app/packs/stylesheets/decidim/_forms.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_forms.scss
@@ -23,7 +23,7 @@
   select,
   textarea {
     &:not(.reset-defaults) {
-      @apply inline-block px-4 py-2 border border-gray outline outline-1 outline-transparent rounded bg-background-2 text-black font-normal placeholder:text-gray focus:outline-2 focus:outline-secondary disabled:bg-background-3 disabled:text-gray-2 disabled:cursor-not-allowed;
+      @apply inline-block px-4 py-2 border border-neutral-200 outline outline-1 outline-transparent rounded bg-background-2 text-black font-normal placeholder:text-gray focus:outline-2 focus:outline-secondary disabled:bg-background-3 disabled:text-gray-2 disabled:cursor-not-allowed;
 
       &.sm {
         @apply px-1 py-0.5 text-sm;

--- a/decidim-core/app/packs/stylesheets/decidim/_modal_update.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_modal_update.scss
@@ -117,7 +117,7 @@
   }
 
   &__files {
-    @apply mt-1 space-y-4;
+    @apply mt-2 space-y-4;
 
     /* It does not use regular class names, because it could come from javascript also. Avoid binds among css and js */
     > * {

--- a/decidim-core/app/packs/stylesheets/decidim/_modal_update.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_modal_update.scss
@@ -119,10 +119,6 @@
   &__files {
     @apply mt-1 space-y-4;
 
-    &-container {
-      @apply space-y-10 [&_label]:block [&_label]:mb-4;
-    }
-
     /* It does not use regular class names, because it could come from javascript also. Avoid binds among css and js */
     > * {
       @apply flex flex-col gap-2;

--- a/decidim-core/app/packs/stylesheets/decidim/editor.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/editor.scss
@@ -17,7 +17,7 @@
 }
 
 .editor-container {
-  @apply editor-props editor-suggestions-props flex flex-col border border-neutral-200 rounded;
+  @apply editor-props editor-suggestions-props flex flex-col border border-neutral-200 rounded mt-2;
 
   &.editor-disabled {
     .editor-input .ProseMirror {

--- a/decidim-core/app/packs/stylesheets/decidim/editor.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/editor.scss
@@ -1,6 +1,5 @@
 .editor-props {
   --editor-active-color: #487bda;
-  --editor-border-color: #e5e5e5;
   --editor-disabled-color: #eee;
   --editor-bubble-border-color: #ccc;
   --editor-bubble-shadow-color: #333;

--- a/decidim-core/app/packs/stylesheets/decidim/editor.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/editor.scss
@@ -1,6 +1,6 @@
 .editor-props {
   --editor-active-color: #487bda;
-  --editor-border-color: #ccc;
+  --editor-border-color: #e5e5e5;
   --editor-disabled-color: #eee;
   --editor-bubble-border-color: #ccc;
   --editor-bubble-shadow-color: #333;
@@ -16,12 +16,8 @@
   @apply outline outline-4 outline-[var(--editor-active-color)];
 }
 
-.editor-border {
-  @apply border-solid border-[#ccc];
-}
-
 .editor-container {
-  @apply editor-props editor-suggestions-props flex flex-col mt-4 border editor-border;
+  @apply editor-props editor-suggestions-props flex flex-col border border-neutral-200 rounded;
 
   &.editor-disabled {
     .editor-input .ProseMirror {
@@ -30,7 +26,7 @@
   }
 
   .editor-toolbar {
-    @apply py-1.5 px-2.5 border-0 border-b editor-border;
+    @apply py-1.5 px-2.5 border-b border-b-neutral-200;
 
     .editor-toolbar-group {
       @apply inline-block mx-2.5;

--- a/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_settings_form/show.erb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_settings_form/show.erb
@@ -1,4 +1,9 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.number_field :max_results, label: max_results_label %>
-  <%= settings_fields.select :order, order_select, prompt: "", label: order_label %>
+  <div class="row column">
+    <%= settings_fields.number_field :max_results, label: max_results_label %>
+  </div>
+
+  <div class="row column">
+    <%= settings_fields.select :order, order_select, prompt: "", label: order_label %>
+  </div>
 <% end %>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
@@ -1,3 +1,5 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.number_field :max_results, label: %>
+  <div class="row column">
+    <%= settings_fields.number_field :max_results, label: %>
+  </div>
 <% end %>


### PR DESCRIPTION
## :tophat: What? Why?

Based on the latest mockups from the Admin panel, this PR introduces some mini fixes: 

1. Fix the borders to use always the same style (color, width and radius/round)
2. Fix the modal button margin
3. Lower the number of lines in the WYSIWYG editor 
4. Fix the spaces (margins and paddins) between the different elements of the forms (labels, inputs, help texts, tabs, etc) 

I'm applying these changes in all the forms globally, some apply directly to the admin and also in the participants view. We should do a thorough review in both views, with different forms and resolutions. 

## :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/issues/14273 

## Testing

Everything should look good, specially to @julietapasetti and @carolromero 😄 

## :camera: Screenshots 

### Before

![Process edit form detail 1 (before the changes)](https://github.com/user-attachments/assets/58615fbe-6c2b-472d-bb6b-bb9f84e31027)
![Process edit form detail 2 (before the changes)](https://github.com/user-attachments/assets/e7507e91-8984-4020-a65c-6e5fba9c1e2c)

### After

![Process edit form detail 1 (after the changes)](https://github.com/user-attachments/assets/5f48cb6b-3d69-40be-bd28-2b6179dc38aa)
![Process edit form detail 2 (after the changes)](https://github.com/user-attachments/assets/968a3a7b-cf06-4558-aa0e-9f8c21fee8fa)

:hearts: Thank you!
