### PR TITLE
Date localization documentation

### DIFF
--- a/docs/modules/customize/pages/index.adoc
+++ b/docs/modules/customize/pages/index.adoc
@@ -29,4 +29,4 @@ Inside of your application you can customize it in different ways:
 * xref:customize:texts.adoc[Texts]
 * xref:customize:users_registration_mode.adoc[User registration mode]
 * xref:customize:views.adoc[Views]
-
+* xref:customize:localization.adoc[localization]

--- a/docs/modules/customize/pages/localization.adoc
+++ b/docs/modules/customize/pages/localization.adoc
@@ -1,0 +1,31 @@
+= Changing the Date Format
+
+By default, the date format in Decidim follows the *day-month-year (d-m-y)* order. If users wish to customize this format according to their localization preferences, they can do so by modifying the relevant i18n key.
+
+== How to Change the Date Format
+
+The date format is defined in the `decidim-core/config/locales/en.yml` file. The specific key that controls this format is:
+
+[source,yaml]
+----
+help:
+  date_format: 'Format: dd/mm/yyyy'
+order: d-m-y
+----
+
+=== Steps to Customize
+
+1. Open the `decidim-core/config/locales/en.yml` file.
+2. Locate the `help.date_format` and `order` keys.
+3. Modify the format as needed. For example, to switch to a *month-day-year (m-d-y)* format:
+
+[source,yaml]
+----
+help:
+  date_format: 'Format: mm/dd/yyyy'
+order: m-d-y
+----
+
+4. Save the changes to apply the new format.
+
+This ensures that users see date values formatted in a way that aligns with their localization preferences.


### PR DESCRIPTION
#### :tophat: What? Why?
Localization documentation page was required to detail how users can find i18n keys relevant to their localization with regards to the formatting of date within the date_picker in forms, for example: ```d-m-y``` or ```m-d-y```. 

#### :pushpin: Related Issues
- Related to #14312 
- Related to #14321 

#### Testing

### :camera: Screenshots

:hearts: Thank you!
