### PR TITLE
Fix error in announcement field when has a link with an attachment

### DIFF
--- a/decidim-core/lib/decidim/translatable_attributes.rb
+++ b/decidim-core/lib/decidim/translatable_attributes.rb
@@ -62,7 +62,7 @@ module Decidim
             final = super(value)
             return unless final # Do not set the `nil` values for the parent hash
 
-            final = value_type.serialize(final) if value_type
+            final = value_type.serialize(final) if value_type && !final.include?('/rails/active_storage/')
 
             public_send("#{name}=", field.merge(locale => final))
           end

--- a/decidim-core/lib/decidim/translatable_attributes.rb
+++ b/decidim-core/lib/decidim/translatable_attributes.rb
@@ -129,7 +129,7 @@ module Decidim
     end
 
     def attachment?(value)
-      value.is_a?(String) && value.include?("/rails/active_storage/")
+      value.is_a?(String) && value.include?(ActiveStorage.routes_prefix)
     end
   end
 end

--- a/decidim-core/lib/decidim/translatable_attributes.rb
+++ b/decidim-core/lib/decidim/translatable_attributes.rb
@@ -62,7 +62,7 @@ module Decidim
             final = super(value)
             return unless final # Do not set the `nil` values for the parent hash
 
-            final = value_type.serialize(final) if value_type && !final.include?('/rails/active_storage/')
+            final = value_type.serialize(final) if value_type && !attachment?(final)
 
             public_send("#{name}=", field.merge(locale => final))
           end
@@ -126,6 +126,10 @@ module Decidim
     def default_locale?(locale)
       locale.to_s == try(:default_locale).to_s ||
         locale.to_s == try(:current_organization).try(:default_locale).to_s
+    end
+
+    def attachment?(value)
+      value.is_a?(String) && value.include?("/rails/active_storage/")
     end
   end
 end

--- a/decidim-core/spec/lib/translatable_attributes_spec.rb
+++ b/decidim-core/spec/lib/translatable_attributes_spec.rb
@@ -65,6 +65,16 @@ module Decidim
           expect(model.name_pt__BR).to eq("Hello")
         end
       end
+
+      context "when values are serialized" do
+        it "does not serialize the value if is an attachment" do
+          allow(model).to receive(:name).and_return("https://example.com/rails/active_storage/blobs/redirect/some_value")
+
+          expect(model.name_en).to eq("https://example.com/rails/active_storage/blobs/redirect/some_value")
+          expect(model.name_ca).to eq("https://example.com/rails/active_storage/blobs/redirect/some_value")
+          expect(model.name_pt__BR).to eq("https://example.com/rails/active_storage/blobs/redirect/some_value")
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/lib/translatable_attributes_spec.rb
+++ b/decidim-core/spec/lib/translatable_attributes_spec.rb
@@ -68,11 +68,11 @@ module Decidim
 
       context "when values are serialized" do
         it "does not serialize the value if is an attachment" do
-          allow(model).to receive(:name).and_return("https://example.com/rails/active_storage/blobs/redirect/some_value")
+          allow(model).to receive(:name).and_return("https://example.com#{ActiveStorage.routes_prefix}/blobs/redirect/some_value")
 
-          expect(model.name_en).to eq("https://example.com/rails/active_storage/blobs/redirect/some_value")
-          expect(model.name_ca).to eq("https://example.com/rails/active_storage/blobs/redirect/some_value")
-          expect(model.name_pt__BR).to eq("https://example.com/rails/active_storage/blobs/redirect/some_value")
+          expect(model.name_en).to eq("https://example.com#{ActiveStorage.routes_prefix}/blobs/redirect/some_value")
+          expect(model.name_ca).to eq("https://example.com#{ActiveStorage.routes_prefix}/blobs/redirect/some_value")
+          expect(model.name_pt__BR).to eq("https://example.com#{ActiveStorage.routes_prefix}/blobs/redirect/some_value")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
There is an error with embedding a link from an attached document in the “Announcement” field, the link cannot be opened.

In this PR, if the field is an active storage link don't serialize rich text when there is an active storage link.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/issues/14229

#### Testing

1. Attach a document in your organization (e.g. to “Related Documents”).
2. Copy the link of the attached document
3. Embed the link in an “Announcement” field.
4. Go to the public view and try to click on the link.
5. The link is clickable

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/550d2bf3-413f-4404-9d8d-1619651c2506)


:hearts: Thank you!
