### PR TITLE
Fix profile user display on some resolutions

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -167,7 +167,7 @@ header {
       }
 
       &__item {
-        @apply relative;
+        @apply flex relative;
       }
 
       &__search {


### PR DESCRIPTION
#### :tophat: What? Why?
On certain dimensions, a user would not be able to access their profile or key information from the front end view. This was due to missing ```flex``` display component within mobile__item view. 

#### :pushpin: Related Issues
- Fixes #14368

#### Testing
1. Login
2. Activate the DOM in your browser.
3. Change to the mobile view and use dimensions from ```1080 x``` or less  (eg ```860x``` or < )
4. See the profile not disappear from the header.

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/f8183d21-7cda-4e37-a4b5-c8c37037cfa3)

:hearts: Thank you!
