### PR TITLE
Fix meeting overriding customized frame-src security policy

### DIFF
--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -81,7 +81,12 @@ module Decidim
 
       initializer "decidim_meetings.content_security_handlers" do |_app|
         Decidim.configure do |config|
-          config.content_security_policies_extra.deep_merge!({ "frame-src" => %w(player.twitch.tv meet.jit.si) })
+          if config.content_security_policies_extra["frame-src"].respond_to?(:<<)
+            config.content_security_policies_extra["frame-src"] << "player.twitch.tv"
+            config.content_security_policies_extra["frame-src"] << "meet.jit.si"
+          else
+            config.content_security_policies_extra["frame-src"] = %w(player.twitch.tv meet.jit.si)
+          end
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

The meetings module add some opinionated services (I think this should be done in an initializer via default values in ENV vars btw).

They way it is implemented now, if you have an initializer such as:

```ruby
Decidim.configure do |config|
  config.content_security_policies_extra = {
    "frame-src" => ["https://anothercoolservice.org"]
  }
end
```

It gets removed due `deep_merge` overriding the key. So you cannot use the iframe.

This affects 0.28 onwards.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
