### PR TITLE
Improve the map specs in order to avoid random failures

### DIFF
--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -14,7 +14,7 @@ shared_examples "manage projects" do
       expect(page).to have_content("Proposals")
     end
 
-    context "when geocoding is enabled", :serves_geocoding_autocomplete do
+    context "when geocoding is enabled" do
       let(:address) { "Some address" }
       let(:latitude) { 40.1234 }
       let(:longitude) { 2.1234 }

--- a/decidim-core/lib/decidim/core/test/shared_examples/map_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/map_examples.rb
@@ -203,8 +203,8 @@ shared_examples "a record with front-end geocoding address field" do |geocoded_m
     # geocoding should be bypassed in this situation which is why these match
     # what was returned by the front-end geocoding. These values are returned by
     # the dummy test geocoding API defined at
-    # `decidim-dev/lib/decidim/dev/test/rspec_support/geocoder.rb`. Search for
-    # `:serves_geocoding_autocomplete`.
+    # `decidim-dev/lib/decidim/dev/test/map_server.rb`. Search for
+    # `serve_autocomplete`.
     expect(page).to have_content("successfully")
     final = if geocoded_record
               geocoded_model.find(geocoded_record.id)

--- a/decidim-core/spec/lib/geocodable_spec.rb
+++ b/decidim-core/spec/lib/geocodable_spec.rb
@@ -7,7 +7,7 @@ module Decidim
   # will not get broken by the Geocoder gem's updates. The reason for the
   # customization is to pass the record in question for the geocoding searches
   # in order to correctly initialize the geocoding utility.
-  describe Geocodable do
+  describe Geocodable, configures_map: true do
     subject do
       record_class.new(
         organization:,
@@ -30,8 +30,6 @@ module Decidim
     let(:longitude) { 2.1234 }
 
     before do
-      Decidim::Map.reset_utility_configuration!
-      GeocoderHelpers.configure_maps
       stub_geocoding(address, [latitude, longitude])
     end
 

--- a/decidim-core/spec/lib/map/autocomplete_spec.rb
+++ b/decidim-core/spec/lib/map/autocomplete_spec.rb
@@ -6,12 +6,7 @@ require "decidim/core/test/shared_examples/form_builder_examples"
 
 module Decidim
   module Map
-    describe Autocomplete do
-      before do
-        Decidim::Map.reset_utility_configuration!
-        GeocoderHelpers.configure_maps
-      end
-
+    describe Autocomplete, configures_map: true do
       include_context "with map utility" do
         subject { utility }
       end

--- a/decidim-core/spec/lib/map/provider/static_map/here_spec.rb
+++ b/decidim-core/spec/lib/map/provider/static_map/here_spec.rb
@@ -10,14 +10,52 @@ module Decidim
           let(:latitude) { 60.149790 }
           let(:longitude) { 24.887430 }
           let(:api_key) { "key1234" }
+          let(:url) { "https://image.maps.hereapi.com/mia/v3/base/mc/overlay" }
 
           include_context "with map utility" do
             subject { utility }
 
-            let(:config) { { api_key: } }
+            let(:config) { { api_key:, url: } }
+          end
+
+          describe "#url" do
+            it "returns the URL in correct format" do
+              size = Decidim::Map::StaticMap::DEFAULT_SIZE
+              params = {
+                apiKey: api_key,
+                overlay: "point:#{latitude},#{longitude};icon=cp;size=large|#{latitude},#{longitude};style=circle;width=50m;color=%231B9D2C60"
+              }
+              expect(subject.url(latitude:, longitude:)).to eq(
+                "#{url}:radius=90/#{size}x#{size}/png8?#{URI.encode_www_form(params)}"
+              )
+            end
+
+            context "with legacy URL" do
+              let(:url) { "https://image.maps.ls.hereapi.com/mia/1.6/mapview" }
+
+              it "returns the legacy style URL" do
+                allow(ActiveSupport::Deprecation).to receive(:warn)
+
+                params = {
+                  c: "#{latitude}, #{longitude}",
+                  z: Decidim::Map::StaticMap::DEFAULT_ZOOM,
+                  w: Decidim::Map::StaticMap::DEFAULT_SIZE,
+                  h: Decidim::Map::StaticMap::DEFAULT_SIZE,
+                  f: 1,
+                  apiKey: api_key
+                }
+                expect(subject.url(latitude:, longitude:)).to eq(
+                  "#{url}?#{URI.encode_www_form(params)}"
+                )
+              end
+            end
           end
 
           describe "#url_params" do
+            before do
+              allow(ActiveSupport::Deprecation).to receive(:warn)
+            end
+
             it "returns the default params" do
               expect(
                 subject.url_params(

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_attachments_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_attachments_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Admin manages meetings attachments", serves_map: true do
+describe "Admin manages meetings attachments" do
   let(:manifest_name) { "meetings" }
   let!(:meeting) { create(:meeting, scope:, component: current_component) }
 

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_copy_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_copy_spec.rb
@@ -71,14 +71,14 @@ describe "Admin copies meetings" do
     end
   end
 
-  context "when hybrid", serves_geocoding_autocomplete: true, serves_map: true do
+  context "when hybrid" do
     let(:type_of_meeting) { :hybrid }
 
     before do
       stub_geocoding(address, [latitude, longitude])
     end
 
-    it "creates a new hybrid meeting", :serves_geocoding_autocomplete, :slow do
+    it "creates a new hybrid meeting", :slow do
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
         click_on "Duplicate"
       end
@@ -132,14 +132,14 @@ describe "Admin copies meetings" do
     end
   end
 
-  context "when in person", serves_geocoding_autocomplete: true, serves_map: true do
+  context "when in person" do
     let(:type_of_meeting) { :in_person }
 
     before do
       stub_geocoding(address, [latitude, longitude])
     end
 
-    it "creates a new In person meeting", :serves_geocoding_autocomplete, :slow do
+    it "creates a new In person meeting", :slow do
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
         click_on "Duplicate"
       end

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_other_features_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_other_features_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Admin manages meetings other features", serves_geocoding_autocomplete: true, serves_map: true do
+describe "Admin manages meetings other features" do
   let(:manifest_name) { "meetings" }
   let!(:meeting) { create(:meeting, :published, scope:, services: [], component: current_component) }
 

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "decidim/dev/test/rspec_support/tom_select"
 
-describe "Admin manages meetings", serves_geocoding_autocomplete: true, serves_map: true do
+describe "Admin manages meetings" do
   let(:manifest_name) { "meetings" }
   let!(:meeting) { create(:meeting, :published, services: [], component: current_component) }
   let(:address) { "Some address" }
@@ -168,7 +168,7 @@ describe "Admin manages meetings", serves_geocoding_autocomplete: true, serves_m
     end
   end
 
-  it "updates a meeting", :serves_geocoding_autocomplete do
+  it "updates a meeting" do
     within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
       click_on "Edit"
     end
@@ -225,7 +225,7 @@ describe "Admin manages meetings", serves_geocoding_autocomplete: true, serves_m
     expect(meeting.reload.registrations_enabled).to be false
   end
 
-  it "adds a few services to the meeting", :serves_geocoding_autocomplete do
+  it "adds a few services to the meeting" do
     within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
       click_on "Edit"
     end
@@ -286,7 +286,7 @@ describe "Admin manages meetings", serves_geocoding_autocomplete: true, serves_m
     expect(page).to have_current_path(meeting_path)
   end
 
-  it "creates a new meeting", :serves_geocoding_autocomplete do
+  it "creates a new meeting" do
     click_on "New meeting"
 
     fill_in_i18n(:meeting_title, "#meeting-title-tabs", **attributes[:title].except("machine_translations"))
@@ -363,7 +363,7 @@ describe "Admin manages meetings", serves_geocoding_autocomplete: true, serves_m
     end
   end
 
-  context "when using the front-end geocoder", :serves_geocoding_autocomplete do
+  context "when using the front-end geocoder" do
     it_behaves_like(
       "a record with front-end geocoding address field",
       Decidim::Meetings::Meeting,

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -33,7 +33,7 @@ describe "User creates meeting" do
     switch_to_host(organization.host)
   end
 
-  context "when creating a new meeting", :serves_geocoding_autocomplete do
+  context "when creating a new meeting" do
     let(:user) { create(:user, :confirmed, organization:) }
 
     context "when the user is not logged in" do

--- a/decidim-meetings/spec/system/user_edit_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_edit_meeting_spec.rb
@@ -58,7 +58,7 @@ describe "User edit meeting" do
       expect(page).to have_content(decidim_sanitize_translated(taxonomy.name))
     end
 
-    context "when using the front-end geocoder", :serves_geocoding_autocomplete do
+    context "when using the front-end geocoder" do
       it_behaves_like(
         "a record with front-end geocoding address field",
         Decidim::Meetings::Meeting,

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -135,7 +135,7 @@ shared_examples "manage proposals" do
             end
           end
 
-          context "when geocoding is enabled", :serves_geocoding_autocomplete do
+          context "when geocoding is enabled" do
             before do
               current_component.update!(settings: { geocoding_enabled: true, taxonomy_filters: [taxonomy_filter.id] })
             end

--- a/decidim-proposals/spec/system/collaborative_drafts_fields_spec.rb
+++ b/decidim-proposals/spec/system/collaborative_drafts_fields_spec.rb
@@ -114,7 +114,7 @@ describe "Collaborative drafts" do
           end
         end
 
-        context "when geocoding is enabled", :serves_geocoding_autocomplete do
+        context "when geocoding is enabled" do
           let!(:component) do
             create(:proposal_component,
                    :with_creation_enabled,

--- a/decidim-proposals/spec/system/device_location_spec.rb
+++ b/decidim-proposals/spec/system/device_location_spec.rb
@@ -42,7 +42,7 @@ describe "User location button" do
     end
   end
 
-  describe "when public", :serves_geocoding_autocomplete do
+  describe "when public" do
     before do
       visit_component
       click_link_or_button "New proposal"
@@ -51,7 +51,7 @@ describe "User location button" do
     it_behaves_like "uses device location"
   end
 
-  context "when admin", :serves_geocoding_autocomplete do
+  context "when admin" do
     before do
       visit manage_component_path(component)
       click_link_or_button "New proposal"

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -205,7 +205,7 @@ describe "Edit proposals" do
         stub_geocoding(new_address, [latitude, longitude])
       end
 
-      it "can be updated with address", :serves_geocoding_autocomplete do
+      it "can be updated with address" do
         visit_component
 
         click_on translated(proposal.title)

--- a/decidim-proposals/spec/system/proposals_fields_spec.rb
+++ b/decidim-proposals/spec/system/proposals_fields_spec.rb
@@ -93,7 +93,7 @@ describe "Proposals" do
           end
         end
 
-        context "when geocoding is enabled", :serves_geocoding_autocomplete do
+        context "when geocoding is enabled" do
           let!(:component) do
             create(:proposal_component,
                    :with_creation_enabled,


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed in another PR (#14403) that the map specs are randomly failing.

This attempts to fix this and also adds other improvements to the map specs:

- Revert map configurations after each test with the `:configures_map` context
  * This was attempted at #13901 but the source of the problem is different. The map configurations need to be cleared **after** the spec that modifies them, otherwise following specs will have incorrect configurations causing unexpected results with random test order. The `:configures_map` context has to be added to all specs that modify the default map configurations during tests.
- Remove the `:serves_geocoding_autocomplete` context as this is not used correctly
  * Instead, clear the stubbed response(s) automatically in case `stub_geocoding` is called within the test
- Removes the `:serves_map` context as this is not even defined anymore and not necessary anymore (it was removed at #12707)
- Add specs for `Decidim::Map::Provider::StaticMap#url` as this was changed at #14180

#### :pushpin: Related Issues
- Related to
  * #13901
  * #12707
  * #14180
  * #14403 (where the failure was noticed)

#### Testing
Run the map specs multiple times and expect them to pass and not to display any deprecation warnings:
```
$ cd decidim-core
$ for i in {1..10}; do bundle exec rspec spec/lib/map_spec.rb spec/lib/map/ || break ; done
```