### PR TITLE
Assign expected ports for parallel tests

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -70,14 +70,6 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
-      redis:
-        image: redis
-        ports: ["6379:6379"]
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -33,7 +33,7 @@ end
 # Expected values: "", "2", "3", etc. (see parallel_tests documentation)
 parallel_run_idx = ENV.fetch("TEST_ENV_NUMBER", "").to_i
 parallel_run_idx -= 1 if parallel_run_idx.positive?
-1.step do |num|
+Capybara.server_port = 1.step do |num|
   port = 4999 + num + (100 * parallel_run_idx)
   next if port == 5432 # Reserved for PostgreSQL
   next if port == 6379 # Reserved for Redis
@@ -43,10 +43,8 @@ parallel_run_idx -= 1 if parallel_run_idx.positive?
     Socket.tcp("127.0.0.1", port, connect_timeout: 5).close
     warn "Port #{port} is already in use, trying another one."
   rescue Errno::ECONNREFUSED
-    break
+    break port
   end
-ensure
-  Capybara.server_port = port
 end
 
 Capybara.register_driver :headless_chrome do |app|

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -30,24 +30,19 @@ module Decidim
   end
 end
 
-1.step do
-  port = rand(5000..6999)
+# Expected values: "", "2", "3", etc. (see parallel_tests documentation)
+parallel_run_idx = ENV.fetch("TEST_ENV_NUMBER", "").to_i
+parallel_run_idx -= 1 if parallel_run_idx.positive?
+1.step do |num|
+  port = 4999 + num + (100 * parallel_run_idx)
+  next if port == 5432 # Reserved for PostgreSQL
   next if port == 6379 # Reserved for Redis
 
+  # Make sure the port is not reserved by any other application.
   begin
-    redis = Redis.new
-    reserved_ports = (redis.get("decidim_test_capybara_reserved_ports") || "").split(",").map(&:to_i)
-    unless reserved_ports.include?(port)
-      reserved_ports << port
-      if ParallelTests.last_process?
-        redis.del("decidim_test_capybara_reserved_ports")
-      else
-        redis.set("decidim_test_capybara_reserved_ports", reserved_ports.sort.join(","))
-      end
-      break
-    end
-  rescue Redis::CannotConnectError
-    # Redis is not available
+    Socket.tcp("127.0.0.1", port, connect_timeout: 5).close
+    warn "Port #{port} is already in use, trying another one."
+  rescue Errno::ECONNREFUSED
     break
   end
 ensure


### PR DESCRIPTION
#### :tophat: What? Why?
It seems that the parallel tests are often failing due to reserved ports. This has been tried to be fixed in the past unsuccessfully, see. e.g. #12705, #9661.

The problem is that the servers are started at seemingly random times, which is why the random port assignment is not the best strategy in case it happens at the time when the port is not yet reserved (i.e. the port is determined for the server in another thread but the server has not yet started). Instead, we can use [`TEST_ENV_NUMBER` provided by `parallel_tests`](https://github.com/grosser/parallel_tests/blob/f4c855ab225750d4f04766c0b1f5e4542d8d6352/lib/parallel_tests/test/runner.rb#L91) to separate the different processes from each other.

This also reverts the changes from #12705 as that is not needed with this strategy.

#### :pushpin: Related Issues
- Related to
  * #12705
  * #9661

#### Testing
No easy way to test as the old strategy assigns ports randomly. Just see if this improves the consistency of parallel test runs.

Yet, it should not be too uncommon scenario since the currently assigned range of ports is 5000-6999 (- 2 reserved ports within that range), so in theory this could happen once every 1997 runs, i.e. 0.05% of the test runs. Perform 1997 separate test runs and it should occur once. There are 26 sets of tests which potentially start Capybara. For testing commits/PRs, the probability is therefore higher as there are more concurrent chances for the same event. Could be less if the Redis strategy really worked but apparently it does not work persistently.