### PR TITLE
Do not show a CSP warning during admin edits organization spec

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -150,9 +150,8 @@ describe "Admin manages organization" do
       end
 
       context "when the admin terms of service content has an image with an alt tag" do
-        let(:another_organization) { create(:organization) }
-        let(:image) { create(:attachment, attached_to: another_organization) }
-        let(:image_url) { image.attached_uploader(:file).url }
+        let(:image) { create(:attachment, :with_image) }
+        let(:image_url) { image.attached_uploader(:file).url(host: organization_host) }
         let(:organization_host) { "example.lvh.me" }
         let(:organization) do
           create(
@@ -177,9 +176,9 @@ describe "Admin manages organization" do
                 <button type="button" aria-label="Resize image (bottom left corner)" data-image-resizer-control="bottom-left"></button>
                 <button type="button" aria-label="Resize image (bottom right corner)" data-image-resizer-control="bottom-right"></button>
                 <div data-image-resizer-dimensions="">
-                  <span data-image-resizer-dimension="width" data-image-resizer-dimension-value=""></span>
+                  <span data-image-resizer-dimension="width" data-image-resizer-dimension-value="512"></span>
                   ×
-                  <span data-image-resizer-dimension="height" data-image-resizer-dimension-value=""></span></div>
+                  <span data-image-resizer-dimension="height" data-image-resizer-dimension-value="342"></span></div>
                 <div class="editor-content-image" data-image=""><img src="#{image_url}" alt="foo bar"></div>
               </div>
             </div>
@@ -194,8 +193,6 @@ describe "Admin manages organization" do
       end
 
       context "when the admin terms of service content has an br tags" do
-        let(:another_organization) { create(:organization) }
-        let(:image) { create(:attachment, attached_to: another_organization) }
         let(:organization) do
           create(
             :organization,
@@ -276,8 +273,6 @@ describe "Admin manages organization" do
       end
 
       context "when adding br tags to terms of service content" do
-        let(:another_organization) { create(:organization) }
-        let(:image) { create(:attachment, attached_to: another_organization) }
         let(:organization) do
           create(
             :organization,
@@ -337,8 +332,6 @@ describe "Admin manages organization" do
       end
 
       context "when modifying list using rich text editor" do
-        let(:another_organization) { create(:organization) }
-        let(:image) { create(:attachment, attached_to: another_organization) }
         let(:organization) do
           create(
             :organization,


### PR DESCRIPTION
#### :tophat: What? Why?
During admin edits organization spec, there was the following CSP warning displayed in the console:

```
Admin manages organization
  edit
    when using the rich text editor
      when the admin terms of service content has an image with an alt tag
2025-03-27 18:34:46 +0200 SEVERE: http://example.lvh.me:5000/admin/organization/edit - Refused to load the image 'http://1.lvh.me:5000/rails/active_storage/disk/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDVG9JYTJWNVNTSWhhWGd5TVdONU1HeGhNRGszTjNaNWR6WTNlRE4wYldVNE1HVnhPQVk2QmtWVU9oQmthWE53YjNOcGRHbHZia2tpUFdsdWJHbHVaVHNnWm1sc1pXNWhiV1U5SW1OcGRIa3VhbkJsWnlJN0lHWnBiR1Z1WVcxbEtqMVZWRVl0T0NjblkybDBlUzVxY0dWbkJqc0dWRG9SWTI5dWRHVnVkRjkwZVhCbFNTSVBhVzFoWjJVdmFuQmxad1k3QmxRNkVYTmxjblpwWTJWZmJtRnRaVG9KZEdWemRBPT0iLCJleHAiOiIyMDI1LTAzLTI4VDE2OjM0OjQzLjk2NFoiLCJwdXIiOiJibG9iX2tleSJ9fQ==--a0516e69bd20b6a744112341523b2560f85b868a/city.jpeg' because it violates the following Content Security Policy directive: "img-src 'self' *.hereapi.com data: example.lvh.me https://via.placeholder.com http://maps.lvh.me:5000 localhost:* example.lvh.me:*".
```

This PR fixes the issue.

The reason why the image is created in another organization is because otherwise there would be an endless loop during the test initialization (create organization -> create admin terms content -> create image within the organization -> create organization -> ...).

Also noticed that the `:image` is set in other contexts where it is needed. Removed those.

#### :pushpin: Related Issues
- Related to #6920

#### Testing

Run the following spec:

```
$ cd decidim-admin
$ bundle exec rspec spec/system/admin_manages_organization_spec.rb -e "when the admin terms of service content has an image with an alt tag"
```

Expect not to see any CSP warnings in the console.