### PR TITLE
Fix digest emails to use organization timezone

### DIFF
--- a/decidim-core/app/presenters/decidim/notification_to_mailer_presenter.rb
+++ b/decidim-core/app/presenters/decidim/notification_to_mailer_presenter.rb
@@ -19,10 +19,11 @@ module Decidim
     delegate :safe_resource_text, to: :event
 
     def date_time
+      created_at_in_time_zone = created_at.in_time_zone(resource.organization.time_zone)
       if frequency == :daily
-        created_at.strftime("%H:%M")
+        I18n.l(created_at_in_time_zone, format: :time_of_day)
       else
-        I18n.l(created_at, format: :decidim_short)
+        I18n.l(created_at_in_time_zone, format: :decidim_short)
       end
     end
 

--- a/decidim-core/spec/presenters/decidim/notification_to_mailer_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/notification_to_mailer_presenter_spec.rb
@@ -18,11 +18,45 @@ module Decidim
       end
     end
 
+    context "with a daily frequency in different timezone" do
+      let(:notification) do
+        create(:notification, created_at: creating_date) do |notification|
+          org = notification.resource.organization
+          org.time_zone = "Asia/Tokyo"
+          org.save!
+        end
+      end
+
+      describe "#date_time" do
+        it "returns the hour formated" do
+          allow(subject).to receive(:frequency).and_return(:daily)
+          expect(subject.date_time).to eq("06:00")
+        end
+      end
+    end
+
     context "with a weekly frequency" do
       describe "#date_time" do
         it "returns the date formated" do
           allow(subject).to receive(:frequency).and_return(:weekly)
           expect(subject.date_time).to eq("01/09/2021 21:00")
+        end
+      end
+    end
+
+    context "with a weekly frequency in different timezone" do
+      let(:notification) do
+        create(:notification, created_at: creating_date) do |notification|
+          org = notification.resource.organization
+          org.time_zone = "Asia/Tokyo"
+          org.save!
+        end
+      end
+
+      describe "#date_time" do
+        it "returns the hour formated" do
+          allow(subject).to receive(:frequency).and_return(:weekly)
+          expect(subject.date_time).to eq("02/09/2021 06:00")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

In the digest emails sent by Decidim, timestamps are shown. However, they currently do not use the organization's configured time zone. As a result, the timestamps can appear confusing or incorrect to recipients.

This pull request fixes the issue by making the timestamps respect the organization's time zone setting.

#### Testing

This pull request adds RSpec tests for the new behavior.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

:hearts: Thank you!
