### PR TITLE
Related processes to process group help text

### DIFF
--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/_form.html.erb
@@ -20,8 +20,8 @@
       <div class="row column">
         <% if processes_for_select %>
           <%= form.select :participatory_process_ids, processes_for_select, {}, { multiple: true, class: "chosen-select" } %>
-          <%= form.label :participatory_process_ids, t("decidim.participatory_process_groups.related_processes.help") %>
         <% end %>
+        <%= form.label :participatory_process_ids, t("decidim.participatory_process_groups.related_processes.help") %>
       </div>
 
       <div class="row column">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/_form.html.erb
@@ -20,6 +20,7 @@
       <div class="row column">
         <% if processes_for_select %>
           <%= form.select :participatory_process_ids, processes_for_select, {}, { multiple: true, class: "chosen-select" } %>
+          <%= form.label :participatory_process_ids, t("decidim.participatory_process_groups.related_processes.help") %>
         <% end %>
       </div>
 

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -377,6 +377,8 @@ en:
           updated_at: The last date this space was updated
           url: The URL of the space
     participatory_process_groups:
+      related_processes:
+        help: All the selected processes will be assigned to this group, including the ones that are already assigned to other groups.
       content_blocks:
         extra_data:
           developer_group: Promoted by

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -377,8 +377,6 @@ en:
           updated_at: The last date this space was updated
           url: The URL of the space
     participatory_process_groups:
-      related_processes:
-        help: All the selected processes will be assigned to this group, including the ones that are already assigned to other groups.
       content_blocks:
         extra_data:
           developer_group: Promoted by
@@ -406,6 +404,8 @@ en:
           participatory_processes:
             one: 1 process
             other: "%{count} processes"
+      related_processes:
+        help: All the selected processes will be assigned to this group, including the ones that are already assigned to other groups.
       show:
         title: Participatory process groups
     participatory_process_steps:


### PR DESCRIPTION
#### :tophat: What? Why?
It was concluded in #14417 that the functionality of selecting related processes while editing process groups, while working correctly, can misleading in terms of its functionality. 

Help text has now been added to clear up what will happen when you select a process to been assigned to the process group you're editing.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/14417

#### Testing
1. Login
2. Go admin panel and find processes
3. Click on process groups
4. Click one to edit 
5. See the help under the ```form.select``` for related processes.

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/4afe716e-aaec-4450-bcce-15b07b3fab67)

:hearts: Thank you!
