### PR TITLE
Disable webpack live reload

### DIFF
--- a/decidim-core/lib/decidim/webpacker/shakapacker.yml
+++ b/decidim-core/lib/decidim/webpacker/shakapacker.yml
@@ -62,6 +62,8 @@ development:
       #  port: 8080
     # Should we use gzip compression?
     compress: true
+    # Disable live reloading for faster development experience
+    live_reload: false
     # Note that apps that do not check the host are vulnerable to DNS rebinding attacks
     allowed_hosts: "all"
     pretty: true


### PR DESCRIPTION
#### :tophat: What? Why?
Developers are constantly complaining about the painstakingly slow development speeds with Tailbloat.

One of the reason is the constant reloading that may happen simultaneously in multiple tabs.

Therefore, the sensible default would be to disable live reloading for the development server.

This does not fix the extremely slow development speeds with Tailbloat but it improves the current situation.

#### Testing
- Run the webpack development server
- Run the server
- Load the site
- Make a change in a view file
- See that the page is not reloaded