### PR TITLE
QR share modal image

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_modal_share.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_modal_share.scss
@@ -24,7 +24,7 @@
 
         &:first-child {
           img {
-            @apply inline-block;
+            @apply block;
           }
 
           h2 {

--- a/decidim-core/app/packs/stylesheets/decidim/_modal_share.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_modal_share.scss
@@ -24,7 +24,7 @@
 
         &:first-child {
           img {
-            @apply h-32;
+            @apply inline-block;
           }
 
           h2 {


### PR DESCRIPTION
#### :tophat: What? Why?
```block``` applied to element influencing the ```img``` selector in the ```.qr-modal``` class, to allow any image to take 100% width available to the element. This will also allow any image to stay centered within the modal container.

#### :pushpin: Related Issues
- Fixes #14435 

#### Testing
1. Login and head to the Admin panel
2. Go to Settings
3. Head to Appearance
4. Add a large image to (like the one used in www.nightly.decidim.org).
5. Save/update
6. Go back to Homepage and find a Process with Proposals active
7. Click on a Proposal and click 'Share QR'
8. See the image not stretched with the title displayed properly.  

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/35075635-519a-47c1-9f63-bb7812c21bce)

:hearts: Thank you!
