### PR TITLE
Use better URI regexp to detect host part of blobs and prevent errors

### DIFF
--- a/decidim-core/lib/decidim/content_parsers/blob_parser.rb
+++ b/decidim-core/lib/decidim/content_parsers/blob_parser.rb
@@ -20,19 +20,19 @@ module Decidim
       # https://github.com/rails/rails/blob/a7e379896552ce43b822385c03c37f2bd47739d3/activestorage/config/routes.rb#L5-L14
       BLOB_REGEX = %r{
         # Group 1: Host part
-        (
+        (?<host_part>
           # Group 2: Domain and subpath part
-          https?://((?!/rails).)+
+          #{URI::DEFAULT_PARSER.make_regexp}
         )?
         /rails/active_storage
         # Group 3: Blob path, representation path or disk service path
-        /(blobs/redirect|blobs/proxy|blobs|representations/redirect|representations/proxy|representations|disk)
+        /(?<type_part>blobs/redirect|blobs/proxy|blobs|representations/redirect|representations/proxy|representations|disk)
         # Group 4: Signed ID for blobs or encoded key for disk service
-        /([^/]+)
+        /(?<key_part>[^/]+)
         # Group 5: Variation part (only for representations)
         (
           # Group 6: Variation key for representations
-          /([\w.=-]+)
+          /(?<variation_part>[\w.=-]+)
         )?
         # Group 7: Filename
         /([\w.=-]+)
@@ -46,8 +46,10 @@ module Decidim
 
       def replace_blobs(text)
         text.gsub(BLOB_REGEX) do |match|
-          type_part = Regexp.last_match(3)
-          key_part = Regexp.last_match(4)
+          named_captures = Regexp.last_match.named_captures
+
+          type_part = named_captures["type_part"]
+          key_part = named_captures["key_part"]
 
           variation_key = nil
           blob =
@@ -59,7 +61,7 @@ module Decidim
               # Representation or blob
               if type_part.start_with?("representations")
                 # Representation
-                variation_part = Regexp.last_match(6)
+                variation_part = named_captures["variation_part"]
                 variation_key = generate_variation_key(variation_part)
               end
 

--- a/decidim-core/lib/decidim/content_parsers/blob_parser.rb
+++ b/decidim-core/lib/decidim/content_parsers/blob_parser.rb
@@ -22,7 +22,7 @@ module Decidim
         # Group 1: Host part
         (?<host_part>
           # Group 2: Domain and subpath part
-          #{URI::DEFAULT_PARSER.make_regexp}
+          #{URI::DEFAULT_PARSER.make_regexp(%w(https http))}
         )?
         /rails/active_storage
         # Group 3: Blob path, representation path or disk service path

--- a/decidim-core/spec/content_parsers/decidim/blob_parser_spec.rb
+++ b/decidim-core/spec/content_parsers/decidim/blob_parser_spec.rb
@@ -72,6 +72,26 @@ module Decidim
       it "creates rewrites the URLs correctly" do
         expect(subject).to eq(parsed_content)
       end
+
+      context "when content is preceded by a link with an URL" do
+        let(:parser) { described_class.new(content_with_url, context) }
+        let(:content_with_url) do
+          <<~HTML.squish
+            <p><a href='https://example.org/document.pdf'>Link to document</a></p>
+            #{content}
+          HTML
+        end
+        let(:parsed_content_with_url) do
+          <<~HTML.squish
+            <p><a href='https://example.org/document.pdf'>Link to document</a></p>
+            #{parsed_content}
+          HTML
+        end
+
+        it "rewrites the URLs correctly" do
+          expect(subject).to eq(parsed_content_with_url)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes a bug produced when a user uses rich text editor and attaches a file after a link and includes a test

To reproduce the bug:
1. As admin edit the description of a participatory process
2. At the end of the description add a new line with a URL (ex. https://example.org/document.pdf)
3. Save the changes. The description should include the previous link
4. Edit again and at the end of the description add a new line and attach an image
5. Save the changes. The link will be scrambled with the image reference and the link text and URL will be removed. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing

Follow the steps of the description. The link and the image should be present.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
