### PR TITLE
Evenly distrbuted content blocks

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_content_blocks.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_content_blocks.scss
@@ -27,6 +27,10 @@
         @apply block;
       }
     }
+
+    > h3:not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+      @apply mb-[-0.4rem] pt-4 pb-2;
+    }
   }
 
   &__span {

--- a/decidim-core/app/packs/stylesheets/decidim/_content_blocks.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_content_blocks.scss
@@ -28,7 +28,7 @@
       }
     }
 
-    > h3:not(:where([class~="not-prose"] *)) {
+    > h3:not([class~="not-prose"]) {
       @apply mb-[-0.4rem] pt-4 pb-2;
     }
   }

--- a/decidim-core/app/packs/stylesheets/decidim/_content_blocks.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_content_blocks.scss
@@ -28,7 +28,7 @@
       }
     }
 
-    > h3:not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+    > h3:not(:where([class~="not-prose"] *)) {
       @apply mb-[-0.4rem] pt-4 pb-2;
     }
   }


### PR DESCRIPTION
#### :tophat: What? Why?
Current content blocks configuration unevenly distributed the title and description in the about section of the Assembiles module. This PR fixes this by a configuration only affecting the `h3` title and description.

#### :pushpin: Related Issues
- Fixes #14408

#### Testing
1. Use a Decidim application.
2. Head to Assemblies.
3. Scroll down and see `h3` title and description distributed properly.

### :camera: Screenshots
<img width="1131" alt="Screenshot 2025-04-02 at 16 04 50" src="https://github.com/user-attachments/assets/c466537a-2fec-43a6-8e14-21db97131771" />

:hearts: Thank you!
