### PR TITLE
Fix admin pipeline with `welcome_notification_body` spec error

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
@@ -62,6 +62,7 @@ module TranslationHelpers
   # localized_values - a Hash where the keys are the locales IDs and the values
   #   are the values that will be entered in the form field.
   def fill_in_i18n_editor(field, tab_selector, localized_values)
+    clear_i18n_editor field, tab_selector, localized_values.keys
     fill_in_i18n_fields(field, tab_selector, localized_values) do |locator, value|
       fill_in_editor locator, with: value
     end


### PR DESCRIPTION
#### :tophat: What? Why?
We have noticed that the admin pipeline is failing with some error related to the field not being updated properly. This PR fixes that. 

The error was caused by the admin form being already filled in, which caused the added value to be added as a plain div ( no actual text) within the editor. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots

![image](https://github.com/user-attachments/assets/95c4d0b1-00c2-472e-81f5-0d01afd12f10)

:hearts: Thank you!
