### PR TITLE
Backport 'Fix nickname casing task and add validation in account edit form' to v0.29

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -584,6 +584,8 @@ newusermanager
 newwindow
 nicknamizable
 nicknamize
+nicknamenicknamenick
+nicknamenicknamenickname
 nie
 nikola
 nlevel

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -21,7 +21,10 @@ module Decidim
 
     validates :name, presence: true, format: { with: Decidim::User::REGEXP_NAME }
     validates :email, presence: true, "valid_email_2/email": { disposable: true }
-    validates :nickname, presence: true, format: { with: Decidim::UserBaseEntity::REGEXP_NAME }
+    validates :nickname,
+              presence: true,
+              format: { with: Decidim::User::REGEXP_NICKNAME, message: :format },
+              length: { maximum: Decidim::User.nickname_max_length }
 
     validates :nickname, length: { maximum: Decidim::User.nickname_max_length, allow_blank: true }
     validates :password, password: { name: :name, email: :email, username: :nickname }, if: -> { password.present? }

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -33,6 +33,12 @@ en:
         personal_url: Personal URL
         remove_avatar: Remove avatar
         tos_agreement: Terms of service agreement
+    errors:
+      models:
+        user:
+          attributes:
+            nickname:
+              format: The nickname must be lowercase and contain no spaces
     models:
       decidim/attachment_created_event: Attachment
       decidim/component_published_event: Active component

--- a/decidim-core/lib/tasks/upgrade/decidim_fix_nickname_uniqueness.rake
+++ b/decidim-core/lib/tasks/upgrade/decidim_fix_nickname_uniqueness.rake
@@ -7,7 +7,7 @@ namespace :decidim do
       logger.info("Fixing user nicknames case...")
 
       has_changed = []
-      Decidim::User.not_deleted.find_each do |user|
+      Decidim::UserBaseEntity.not_deleted.find_each do |user|
         user.nickname.downcase!
 
         begin
@@ -15,11 +15,11 @@ namespace :decidim do
             user.save!
             has_changed << user.id
           end
-        rescue ActiveRecord::RecordInvalid
+        rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
           update_user_nickname(user, Decidim::UserBaseEntity.nicknamize(user.nickname, organization: user.organization))
           has_changed << user.id
         rescue ActiveRecord::RecordInvalid # rubocop:disable Lint/DuplicateRescueException
-          logger.warn("User ID (#{similar_user.id}) : #{e}")
+          logger.warn("User ID (#{user.id}) : #{e}")
         end
       end
       logger.info("Process terminated, #{has_changed.count} users nickname have been updated.")

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -86,6 +86,59 @@ describe "Account" do
       end
     end
 
+    describe "when updating the user's nickname" do
+      it "changes the user's nickname - 'nickname'" do
+        within "form.edit_user" do
+          fill_in "Nickname", with: "nickname"
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("Your account was successfully updated.")
+        expect(page).to have_field("user[nickname]", with: "nickname", type: "text")
+      end
+
+      it "respects the maxlength attribute with a really long word - 'nicknamenicknamenickname'" do
+        within "form.edit_user" do
+          fill_in "Nickname", with: "nicknamenicknamenickname"
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("Your account was successfully updated.")
+        expect(page).to have_field("user[nickname]", with: "nicknamenicknamenick", type: "text")
+      end
+
+      it "shows error when word has a capital letter - 'nickName'" do
+        within "form.edit_user" do
+          fill_in "Nickname", with: "nickName"
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("There was a problem updating your account.")
+        expect(page).to have_content("The nickname must be lowercase and contain no spaces")
+        expect(page).to have_field("user[nickname]", with: "nickName", type: "text")
+      end
+
+      it "shows error when word starts with a capital letter - 'Nickname'" do
+        within "form.edit_user" do
+          fill_in "Nickname", with: "Nickname"
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("There was a problem updating your account.")
+        expect(page).to have_field("user[nickname]", with: "Nickname", type: "text")
+      end
+
+      it "shows error when string has a space - 'nick name'" do
+        within "form.edit_user" do
+          fill_in "Nickname", with: "nick name"
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("There was a problem updating your account.")
+        expect(page).to have_field("user[nickname]", with: "nick name", type: "text")
+      end
+    end
+
     describe "when update password" do
       let!(:encrypted_password) { user.encrypted_password }
       let(:new_password) { "decidim1234567890" }


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #14405 to v0.29

:hearts: Thank you!