### PR TITLE
Meetings permission refactor

### DIFF
--- a/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/permissions.rb
@@ -15,46 +15,20 @@ module Decidim
 
         return permission_action unless user
 
-        case permission_action.subject
-        when :response
-          case permission_action.action
-          when :create
-            toggle_allow(can_respond_question?)
-          end
-        when :question
-          case permission_action.action
-          when :update
-            toggle_allow(can_update_question?)
-          end
-        when :meeting
-          case permission_action.action
-          when :join
-            toggle_allow(can_join_meeting?)
-          when :leave
-            toggle_allow(can_leave_meeting?)
-          when :decline_invitation
-            toggle_allow(can_decline_invitation?)
-          when :create
-            toggle_allow(can_create_meetings?)
-          when :update
-            toggle_allow(can_update_meeting?)
-          when :withdraw
-            toggle_allow(can_withdraw_meeting?)
-          when :close
-            toggle_allow(can_close_meeting?)
-          when :register
-            toggle_allow(can_register_invitation_meeting?)
-          when :reply_poll
-            toggle_allow(can_reply_poll?)
-          end
-        when :poll
-          case permission_action.action
-          when :update
-            toggle_allow(can_update_poll?)
-          end
-        else
-          return permission_action
-        end
+        return permission_action if permission_action.subject
+
+        allow! if subject == :response && action == :create && can_respond_question?
+        allow! if subject == :question && action == :update && can_update_question?
+        allow! if subject == :meeting && action == :join && can_join_meeting?
+        allow! if subject == :meeting && action == :leave && can_leave_meeting?
+        allow! if subject == :meeting && action == :decline_invitation && can_decline_invitation?
+        allow! if subject == :meeting && action == :create && can_create_meetings?
+        allow! if subject == :meeting && action == :update && can_update_meeting?
+        allow! if subject == :meeting && action == :withdraw && can_withdraw_meeting?
+        allow! if subject == :meeting && action == :close && can_close_meeting?
+        allow! if subject == :meeting && action == :register && can_register_invitation_meeting?
+        allow! if subject == :meeting && action == :reply_poll && can_reply_poll?
+        allow! if subject == :poll && action == :update && can_update_poll?
 
         permission_action
       end


### PR DESCRIPTION
#### :tophat: What? Why?
While looking for a solution for https://github.com/decidim/decidim/issues/13720, I noticed the permission logic for administrators in meetings was long overdue a refactor. This will be the case for other modules.   

#### :pushpin: Related Issues
- Related to #13720 

#### Testing
Run `decidim-meetings/spec/permissions/decidim/meetings/permissions_spec.rb` pipeline should be green. 

1. Create a process admin as a admin for a process
2. Log out as a admin and login as the process admin (use letter_opener if you're a Decidim collaborator to complete the TOS)
3. Head to the process you've been assigned to.
4. perform an action such as 'Create a meeting'
5. See you've created the new meeting without any change from before

### :camera: Screenshots

:hearts: Thank you!
