### PR TITLE
Allow admin users to see proposal votes on private spaces

### DIFF
--- a/decidim-proposals/app/cells/decidim/proposals/proposal_vote/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_vote/show.erb
@@ -1,4 +1,4 @@
-<% if !current_settings.votes_hidden? && current_component.participatory_space.can_participate?(current_user) %>
+<% if !current_settings.votes_hidden? && (current_component.participatory_space.can_participate?(current_user) || current_user.admin?) %>
   <% if component_settings.participatory_texts_enabled? && from_proposals_list %>
     <%= render partial: "decidim/proposals/proposals/participatory_texts/proposal_votes_count", locals: { proposal: resource, from_proposals_list: true } %>
   <% else %>


### PR DESCRIPTION
#### :tophat: What? Why?
Allow admin users to see proposal votes in the listing page on proposal components from private spaces.

#### :pushpin: Related Issues
- Fixes #14523

#### Testing
1. Log in as an admin.
2. Configure a proposal component to display votes.
3. Make the space of the proposal component private.
4. View the proposal component’s public view and see the votes.

:hearts: Thank you!
