### PR TITLE
Fix missing image label in attachment

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
         delete_reason: Reason to delete your account
       attachment:
         documents: Documents
+        image: Image
         photos: Photos
       common:
         created_at: Created at


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing #13267, @andreslucena requested  a missing string to be extracted for back porting. This PR does that.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13267

#### Testing
- Pipeline is green

:hearts: Thank you!
