### PR TITLE
Fix visibility of resources in QR Code controller

### DIFF
--- a/decidim-core/app/controllers/decidim/qr_controller.rb
+++ b/decidim-core/app/controllers/decidim/qr_controller.rb
@@ -3,13 +3,12 @@
 require "rqrcode"
 
 module Decidim
-  class InvalidUrlError < StandardError; end
-
   class QrController < Decidim::ApplicationController
     include Decidim::OrganizationHelper
     include Decidim::QrCodeHelper
 
     helper_method :resource, :qr_code, :qr_code_image
+    before_action :validate_resource
 
     layout false
 
@@ -31,6 +30,12 @@ module Decidim
     end
 
     private
+
+    def validate_resource
+      raise ActiveRecord::RecordNotFound if resource.blank?
+      raise ActiveRecord::RecordNotFound if resource.respond_to?(:hidden?) && resource.hidden?
+      raise ActiveRecord::RecordNotFound if resource.respond_to?(:published?) && !resource.published?
+    end
 
     def processed_params
       return {} if resource.is_a?(Decidim::Participable)

--- a/decidim-core/app/controllers/decidim/qr_controller.rb
+++ b/decidim-core/app/controllers/decidim/qr_controller.rb
@@ -34,7 +34,7 @@ module Decidim
     def validate_resource
       raise ActiveRecord::RecordNotFound if resource.blank?
       raise ActiveRecord::RecordNotFound if resource.respond_to?(:hidden?) && resource.hidden?
-      raise ActiveRecord::RecordNotFound if resource.respond_to?(:published?) && !resource.published?
+      raise ActiveRecord::RecordNotFound if resource.is_a?(Decidim::Publicable) && !resource.published?
     end
 
     def processed_params

--- a/decidim-core/lib/decidim/core/test/shared_examples/social_share_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/social_share_examples.rb
@@ -51,6 +51,12 @@ shared_examples "a social share via QR code" do
   let(:parameterized_title) { CGI.escapeHTML(title) }
   let!(:card_image) { nil }
 
+  context "when the url is malformed" do
+    it_behaves_like "a 404 page" do
+      let(:target_path) { decidim.qr_path(resource: "Missing") }
+    end
+  end
+
   it "has the QR code" do
     visit_resource
     click_on "Share"

--- a/decidim-debates/spec/system/debates_social_share_spec.rb
+++ b/decidim-debates/spec/system/debates_social_share_spec.rb
@@ -32,7 +32,19 @@ describe "Social shares" do
 
   it_behaves_like "a social share meta tag", "description_image.jpg"
   it_behaves_like "a social share widget"
-  it_behaves_like "a social share via QR code"
+  it_behaves_like "a social share via QR code" do
+    context "when the resource is moderated" do
+      let(:debate) { create(:debate, component:, description:) }
+
+      before do
+        create(:moderation, reportable: debate, hidden_at: 1.day.ago)
+      end
+
+      it_behaves_like "a 404 page" do
+        let(:target_path) { decidim.qr_path(resource: debate.to_sgid.to_s) }
+      end
+    end
+  end
 
   context "when no description images" do
     let(:description_image_path) { "" }

--- a/decidim-meetings/spec/system/meetings_social_share_spec.rb
+++ b/decidim-meetings/spec/system/meetings_social_share_spec.rb
@@ -39,6 +39,26 @@ describe "Social shares" do
   it_behaves_like "a social share widget"
   it_behaves_like "a social share via QR code" do
     let(:card_image) { "city3.jpeg" }
+
+    context "when the resource is not published" do
+      let(:meeting) { create(:meeting, component:, description:) }
+
+      it_behaves_like "a 404 page" do
+        let(:target_path) { decidim.qr_path(resource: meeting.to_sgid.to_s) }
+      end
+    end
+
+    context "when the resource is moderated" do
+      let(:meeting) { create(:meeting, :published, component:, description:) }
+
+      before do
+        create(:moderation, reportable: meeting, hidden_at: 1.day.ago)
+      end
+
+      it_behaves_like "a 404 page" do
+        let(:target_path) { decidim.qr_path(resource: meeting.to_sgid.to_s) }
+      end
+    end
   end
 
   context "when no attachment images" do

--- a/decidim-proposals/spec/system/proposals_social_share_spec.rb
+++ b/decidim-proposals/spec/system/proposals_social_share_spec.rb
@@ -36,6 +36,26 @@ describe "Social shares" do
   it_behaves_like "a social share widget"
   it_behaves_like "a social share via QR code" do
     let(:card_image) { "city3.jpeg" }
+
+    context "when the resource is not published" do
+      let(:proposal) { create(:proposal, :unpublished, component:, body:) }
+
+      it_behaves_like "a 404 page" do
+        let(:target_path) { decidim.qr_path(resource: proposal.to_sgid.to_s) }
+      end
+    end
+
+    context "when the resource is moderated" do
+      let(:proposal) { create(:proposal, :published, component:, body:) }
+
+      before do
+        create(:moderation, reportable: proposal, hidden_at: 1.day.ago)
+      end
+
+      it_behaves_like "a 404 page" do
+        let(:target_path) { decidim.qr_path(resource: proposal.to_sgid.to_s) }
+      end
+    end
   end
 
   context "when no attachment images" do


### PR DESCRIPTION
#### :tophat: What? Why?
While working on #14493, @andreslucena noticed that QR code controller is able to display the moderated resources, thing that we do not want. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14493

#### Testing
1. Visit a participatory space
2. Identify a propsal, navigate to it 
3. Click on report and follow the report steps
4. Click on share, then QR. 
5. Click Print 
6. On a new tab, visit the admin / moderation section
7. Hide the propsal 
8. Visit the QR print page and refresh
9. See the proposal is still visible 
10. Apply patch 
11. See QR is not available anymore

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
