### PR TITLE
Fix author's name display in posts in participatory process show page

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_cards.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_cards.scss
@@ -163,7 +163,7 @@
   /* shared styles */
   &__highlight-metadata,
   &__grid-metadata {
-    @apply mt-auto flex items-center justify-between flex-wrap overflow-x-hidden text-sm text-gray-2 [&>*]:flex [&>*]:items-center [&>*]:gap-1 first:[&>*]:flex-none;
+    @apply mt-auto items-center justify-between flex-wrap inline-block [word-break:break-word] text-sm text-gray-2 [&>*]:flex [&>*]:items-center [&>*]:gap-1 first:[&>*]:flex-none;
 
     svg {
       @apply flex-none text-gray fill-current;

--- a/decidim-core/app/packs/stylesheets/decidim/_cards.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_cards.scss
@@ -163,7 +163,7 @@
   /* shared styles */
   &__highlight-metadata,
   &__grid-metadata {
-    @apply mt-auto items-center justify-between flex-wrap inline-block [word-break:break-word] text-sm text-gray-2 [&>*]:flex [&>*]:items-center [&>*]:gap-1 first:[&>*]:flex-none;
+    @apply mt-auto flex items-center justify-between flex-wrap w-full text-sm text-gray-2 [&>*]:flex [&>*]:items-center [&>*]:gap-1 first:[&>*]:w-4/5;
 
     svg {
       @apply flex-none text-gray fill-current;

--- a/decidim-core/app/packs/stylesheets/decidim/_cards.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_cards.scss
@@ -163,7 +163,7 @@
   /* shared styles */
   &__highlight-metadata,
   &__grid-metadata {
-    @apply mt-auto flex items-center justify-between flex-wrap text-sm text-gray-2 [&>*]:flex [&>*]:items-center [&>*]:gap-1 first:[&>*]:flex-none;
+    @apply mt-auto flex items-center justify-between flex-wrap overflow-x-hidden text-sm text-gray-2 [&>*]:flex [&>*]:items-center [&>*]:gap-1 first:[&>*]:flex-none;
 
     svg {
       @apply flex-none text-gray fill-current;


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the author's name display in grid cards on participatory process show page when the name is long (more than 35 characters). The overflowing text will go back to the line to keep it all (no information lost for accessibility).

#### :pushpin: Related Issues

- Related https://github.com/decidim/decidim/issues/14524

#### Testing

1. As an admin, update your account's name so that it is very long (more than 35 characters)
2. In the back office, go to a participatory process with a blog component and create a new post
3. In the landing page of the participatory process, ensure that the Posts(blog) block is active
4. In the front, go to the participatory process show page
5. Decrease the size of screen (or go in the dev tools to the responsive mode), and see that the overflowing of the author name in the grid card is hidden

:hearts: Thank you!
