### PR TITLE
Backport 'Fix missing image label in attachment' to v0.30

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
         delete_reason: Reason to delete your account
       attachment:
         documents: Documents
+        image: Image
         photos: Photos
       common:
         created_at: Created at


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #14532 to v0.30

:hearts: Thank you!