### PR TITLE
Backport 'Fix missing image label in attachment' to v0.28

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -4,6 +4,10 @@ en:
     attributes:
       account:
         delete_reason: Reason to delete your account
+      attachment:
+        documents: Documents
+        image: Image
+        photos: Photos
       common:
         created_at: Created at
       conversation:


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #14532 to v0.28

:hearts: Thank you!