### PR TITLE
Allow searching for participatory processes groups

### DIFF
--- a/decidim-core/lib/decidim/searchable.rb
+++ b/decidim-core/lib/decidim/searchable.rb
@@ -31,7 +31,9 @@ module Decidim
     end
 
     def self.searchable_resources_of_type_participatory_space
-      searchable_resources.select { |r| r.constantize.reflect_on_association(:components).present? }
+      searchable_resources
+        .select { |r| r.constantize.reflect_on_association(:organization).present? }
+        .reject { |r| searchable_resources_of_type_participant.keys.include?(r) }
     end
 
     def self.searchable_resources_of_type_component

--- a/decidim-participatory_processes/app/models/decidim/participatory_process_group.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process_group.rb
@@ -3,6 +3,7 @@
 module Decidim
   class ParticipatoryProcessGroup < ApplicationRecord
     include Decidim::Resourceable
+    include Decidim::Searchable
     include Decidim::Traceable
     include Decidim::HasUploadValidations
     include Decidim::TranslatableResource
@@ -22,6 +23,14 @@ module Decidim
 
     has_one_attached :hero_image
     validates_upload :hero_image, uploader: Decidim::HeroImageUploader
+
+    searchable_fields({
+                        participatory_space: :itself,
+                        A: :title,
+                        B: :description
+                      },
+                      index_on_create: ->(_process) { true },
+                      index_on_update: ->(process) { true })
 
     # Scope to return only the promoted groups.
     #

--- a/decidim-participatory_processes/app/models/decidim/participatory_process_group.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process_group.rb
@@ -30,7 +30,7 @@ module Decidim
                         B: :description
                       },
                       index_on_create: ->(_process) { true },
-                      index_on_update: ->(process) { true })
+                      index_on_update: ->(_process) { true })
 
     # Scope to return only the promoted groups.
     #

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -50,6 +50,8 @@ module Decidim
       initializer "decidim_participatory_processes.register_icons" do
         Decidim.icons.register(name: "Decidim::ParticipatoryProcess", icon: "treasure-map-line", description: "Participatory Process", category: "activity",
                                engine: :participatory_process)
+        Decidim.icons.register(name: "Decidim::ParticipatoryProcessGroup", icon: "treasure-map-line", description: "Participatory Process Group", category: "activity",
+                               engine: :participatory_process)
         Decidim.icons.register(name: "archive-line", icon: "archive-line", category: "system", description: "", engine: :participatory_process)
         Decidim.icons.register(name: "grid-line", icon: "grid-line", category: "system", description: "", engine: :participatory_process)
         Decidim.icons.register(name: "globe-line", icon: "globe-line", category: "system", description: "", engine: :participatory_process)

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -27,6 +27,7 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
     resource.model_class_name = "Decidim::ParticipatoryProcessGroup"
     resource.card = "decidim/participatory_processes/process_group"
     resource.content_blocks_scope_name = "participatory_process_group_homepage"
+    resource.searchable = true
   end
 
   participatory_space.register_stat :followers_count, tag: :followers, priority: Decidim::StatsRegistry::LOW_PRIORITY do |spaces, _start_at, _end_at|

--- a/decidim-participatory_processes/spec/services/decidim/participatory_processes/searchable_participatory_process_group_resource_spec.rb
+++ b/decidim-participatory_processes/spec/services/decidim/participatory_processes/searchable_participatory_process_group_resource_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 module Decidim
   describe Search do
-    # We can not use the shared example "global search of participatory spaces",
+    # We cannot use the shared example "global search of participatory spaces",
     # as the Participatory Process Group is not Publicable (does not have a `published_at` column)
     let(:participatory_process_group) do
       create(

--- a/decidim-participatory_processes/spec/services/decidim/participatory_processes/searchable_participatory_process_group_resource_spec.rb
+++ b/decidim-participatory_processes/spec/services/decidim/participatory_processes/searchable_participatory_process_group_resource_spec.rb
@@ -88,7 +88,7 @@ module Decidim
             on(:ok) do |results_by_type|
               results = results_by_type[participatory_space.class.name]
               expect(results[:count]).to eq 2
-              expect(results[:results]).to match_array [participatory_space, participatory_space2]
+              expect(results[:results]).to contain_exactly(participatory_space, participatory_space2)
             end
             on(:invalid) { raise("Should not happen") }
           end

--- a/decidim-participatory_processes/spec/services/decidim/participatory_processes/searchable_participatory_process_group_resource_spec.rb
+++ b/decidim-participatory_processes/spec/services/decidim/participatory_processes/searchable_participatory_process_group_resource_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Search do
+    # We can not use the shared example "global search of participatory spaces",
+    # as the Participatory Process Group is not Publicable (does not have a `published_at` column)
+    let(:participatory_process_group) do
+      create(
+        :participatory_process_group,
+        organization:,
+        title: Decidim::Faker::Localized.name,
+        description: description1
+      )
+    end
+    let(:participatory_space) { participatory_process_group }
+    let(:participatory_process_group2) do
+      create(
+        :participatory_process_group,
+        organization:,
+        title: Decidim::Faker::Localized.name,
+        description: description2
+      )
+    end
+    let(:participatory_space2) { participatory_process_group2 }
+    let(:searchable_resource_attrs_mapper) do
+      lambda { |space, locale|
+        {
+          "content_a" => I18n.transliterate(translated(space.title, locale:)),
+          "content_d" => I18n.transliterate(translated(space.description, locale:))
+        }
+      }
+    end
+
+    include_context "when a resource is ready for global search"
+
+    describe "Indexing of participatory_spaces" do
+      context "when on create" do
+        context "when participatory_spaces are created" do
+          it "indexes a SearchableResource after ParticipatorySpace creation" do
+            searchables = Decidim::SearchableResource.where(resource_type: participatory_space.class.name, resource_id: participatory_space.id)
+            expect(searchables.first.content_a).to eq participatory_space.title["en"].to_s
+          end
+        end
+      end
+
+      context "when on update" do
+        it "updates the associated SearchableResource ParticipatorySpace update" do
+          searchable = Decidim::SearchableResource.find_by(resource_type: participatory_space.class.name, resource_id: participatory_space.id)
+          created_at = searchable.created_at
+          updated_title = { "en" => "Brand new title", "machine_translations" => {} }
+          participatory_space.update(title: updated_title)
+
+          participatory_space.save!
+          searchable.reload
+
+          organization.available_locales.each do |locale|
+            searchable = Decidim::SearchableResource.find_by(resource_type: participatory_space.class.name, resource_id: participatory_space.id, locale:)
+            expect(searchable.content_a).to eq updated_title[locale.to_s].to_s
+            expect(searchable.updated_at).to be > created_at
+          end
+        end
+      end
+
+      context "when on destroy" do
+        it "destroys the associated SearchableResource after ParticipatorySpace destroy" do
+          participatory_space.destroy
+
+          searchables = Decidim::SearchableResource.where(resource_type: participatory_space.class.name, resource_id: participatory_space.id)
+
+          expect(searchables.any?).to be false
+        end
+      end
+    end
+
+    describe "Search" do
+      # trick to force creating participatory_space2 declared in users of this shared_examples
+      let!(:spaces) { [participatory_space, participatory_space2] }
+      let(:description2) do
+        msg = "Chewie, I will be waiting for your signal. Take care, you two. May the Force be with you. Ow!"
+        { ca: "CA:#{msg}", en: "EN:#{msg}", es: "ES:#{msg}" }
+      end
+
+      context "when searching by ParticipatorySpace resource_type" do
+        it "returns ParticipatorySpace results" do
+          Decidim::Search.call("Ow", organization, resource_type: participatory_space.class.name) do
+            on(:ok) do |results_by_type|
+              results = results_by_type[participatory_space.class.name]
+              expect(results[:count]).to eq 2
+              expect(results[:results]).to match_array [participatory_space, participatory_space2]
+            end
+            on(:invalid) { raise("Should not happen") }
+          end
+        end
+
+        it "allows searching by prefix characters" do
+          Decidim::Search.call("wait", organization, resource_type: participatory_space.class.name) do
+            on(:ok) do |results_by_type|
+              results = results_by_type[participatory_space.class.name]
+              expect(results[:count]).to eq 1
+              expect(results[:results]).to eq [participatory_space2]
+            end
+            on(:invalid) { raise("Should not happen") }
+          end
+        end
+      end
+    end
+
+    private
+
+    def expect_searchable_resource_to_correspond_to_participatory_space(searchable, space, locale)
+      attrs = searchable.attributes.clone
+      attrs.delete("id")
+      attrs.delete("created_at")
+      attrs.delete("updated_at")
+      expect(attrs).to eq(expected_searchable_resource_attrs(space, locale))
+    end
+
+    def expected_searchable_resource_attrs(space, locale)
+      {
+        "locale" => locale,
+        "decidim_organization_id" => space.organization.id,
+        "decidim_participatory_space_id" => space.id,
+        "decidim_participatory_space_type" => space.class.name,
+        "decidim_scope_id" => space.respond_to?(:decidim_scope_id) ? space.decidim_scope_id : nil,
+        "resource_id" => space.id,
+        "resource_type" => space.class.name
+      }.merge(searchable_resource_attrs_mapper.call(space, locale))
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR allows searching by the participatory processes groups in the general search. 

#### :pushpin: Related Issues
 
- Fixes #9773 

#### Testing

1. Go to /processes
2. Copy the title of a process group
3. Search for it in the general search

### :camera: Screenshots

![Screenshot of a process group in the search](https://github.com/user-attachments/assets/e258733f-9619-46d1-b01c-e82db612ac02)

:hearts: Thank you!
