### PR TITLE
DX improvement: better error handling in decidim-sass-loader

### DIFF
--- a/packages/webpacker/src/loaders/decidim-sass-loader.js
+++ b/packages/webpacker/src/loaders/decidim-sass-loader.js
@@ -62,7 +62,10 @@ module.exports = function(content) { // eslint-disable-line no-undef
     );
   } catch (error) {
     if (error.span && typeof error.span.url !== "undefined") {
-      this.addDependency(url.fileURLToPath(error.span.url));
+      const errorUrl = typeof error.span.url === "string" ? new URL(error.span.url) : error.span.url;
+      if (errorUrl.protocol === "file:") {
+        this.addDependency(url.fileURLToPath(error.span.url));
+      }
     }
 
     callback(error);


### PR DESCRIPTION
#### :tophat: What? Why?
decidim-sass-loader will try to `addDependency` if an error is raised at compilation time. If the error occurs for an external module, the error.url is not a `file://`, silencing compilation error with another error `ERR_INVALID_URL_SCHEME`: 
``` 
ERROR in ./vendor/ruby/3.2.0/gems/decidim-core-0.29.2/app/packs/entrypoints/decidim_core.scss (./vendor/ruby/3.2.0/gems/decidim-core-0.29.2/app/packs/entrypoints/decidim_core.scss.webpack[javascript/auto]!=!./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[4].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[4].use[2]!./node_modules/@decidim/webpacker/src/loaders/decidim-sass-loader.js!./vendor/ruby/3.2.0/gems/decidim-core-0.29.2/app/packs/entrypoints/decidim_core.scss)
Module build failed (from ./node_modules/@decidim/webpacker/src/loaders/decidim-sass-loader.js):
TypeError [ERR_INVALID_URL_SCHEME]: The URL must be of scheme file
    at new NodeError (node:internal/errors:405:5)
    at Object.fileURLToPath (node:internal/url:1479:11)
    at module.exports (/home/decidim/app/node_modules/@decidim/webpacker/src/loaders/decidim-sass-loader.js:65:30)
 @ ./vendor/ruby/3.2.0/gems/decidim-core-0.29.2/app/packs/entrypoints/decidim_core.scss
 @ ./vendor/ruby/3.2.0/gems/decidim-core-0.29.2/app/packs/entrypoints/decidim_core.js 4:0-39
``` 
After the patch is applied, the error gets revealed: 
```
ERROR in ./vendor/ruby/3.2.0/gems/decidim-core-0.29.2/app/packs/entrypoints/decidim_core.scss
Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
HookWebpackError: Module build failed (from ./node_modules/@decidim/webpacker/src/loaders/decidim-sass-loader.js):
Error: Error: Can't find stylesheet to import.
  ╷
3 │ @import "stylesheets/decidim/my_module/";
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
  !decidim-style-imports[app] 3:9            @import
  stylesheets/decidim/application.scss 84:9  @import
``` 

:hearts: Thank you!
