### PR TITLE
Hide remaining slots counter after user registers for meetings

### DIFF
--- a/decidim-meetings/app/cells/decidim/meetings/join_meeting_button/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/join_meeting_button/show.erb
@@ -31,5 +31,5 @@
   ) %>
 <% end %>
 <% if shows_remaining_slots? %>
-  <%= render :remaining_slots %>
+  <%= render :remaining_slots unless participant_registered_for_meeting? %>
 <% end %>

--- a/decidim-meetings/app/cells/decidim/meetings/join_meeting_button_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/join_meeting_button_cell.rb
@@ -36,6 +36,10 @@ module Decidim
         options[:show_remaining_slots] && model.available_slots.positive?
       end
 
+      def participant_registered_for_meeting?
+        registration.present?
+      end
+
       def i18n_join_text
         return I18n.t("join", scope: "decidim.meetings.meetings.show") if model.has_available_slots?
 

--- a/decidim-meetings/spec/system/meeting_registrations_spec.rb
+++ b/decidim-meetings/spec/system/meeting_registrations_spec.rb
@@ -188,7 +188,7 @@ describe "Meeting registrations" do
           end
 
           expect(page).to have_css(".button", text: "Cancel your registration")
-          expect(page).to have_text("19 slots remaining")
+          expect(page).to have_no_text("19 slots remaining")
           find("#dropdown-trigger-resource-#{meeting.id}").click
 
           expect(page).to have_text("Stop following")
@@ -210,7 +210,7 @@ describe "Meeting registrations" do
 
           expect(page).to have_content("successfully")
 
-          expect(page).to have_text("19 slots remaining")
+          expect(page).to have_no_text("19 slots remaining")
           find("#dropdown-trigger-resource-#{meeting.id}").click
           expect(page).to have_text("Stop following")
           expect(page).to have_text("Participants")
@@ -238,7 +238,7 @@ describe "Meeting registrations" do
           end
 
           expect(page).to have_css(".button", text: "Cancel your registration")
-          expect(page).to have_text("19 slots remaining")
+          expect(page).to have_no_text("19 slots remaining")
           find("#dropdown-trigger-resource-#{meeting.id}").click
           expect(page).to have_text("Stop following")
         end


### PR DESCRIPTION
#### :tophat: What? Why?
I have added a condition that checks the current user registration status before rendering the remaining slots block.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/decidim/decidim/issues/14514

#### Testing
 1. Create a meeting with a limited number of slots.
 2. As a participant, register for the meeting.
 3. See that the number of available slots are *NOT* visible after registration.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

:hearts: Thank you!
