### PR TITLE
Backport 'Fix copy blocks when duplicating assemblies or spaces' to v0.29

### DIFF
--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/copy_assembly.rb
@@ -31,6 +31,7 @@ module Decidim
               copy_assembly_attachments
               copy_assembly_categories if @form.copy_categories?
               copy_assembly_components if @form.copy_components?
+              copy_landing_page_blocks if @form.copy_landing_page_blocks?
             end
           end
 
@@ -94,6 +95,38 @@ module Decidim
               weight: component.weight
             )
             component.manifest.run_hooks(:copy, new_component:, old_component: component)
+          end
+        end
+
+        def copy_landing_page_blocks
+          blocks = Decidim::ContentBlock.where(scoped_resource_id: @assembly.id, scope_name: "assembly_homepage", organization: @assembly.organization)
+          return if blocks.blank?
+
+          blocks.each do |block|
+            new_block = Decidim::ContentBlock.create!(
+              organization: @copied_assembly.organization,
+              scope_name: "assembly_homepage",
+              scoped_resource_id: @copied_assembly.id,
+              manifest_name: block.manifest_name,
+              settings: block.settings,
+              weight: block.weight,
+              published_at: block.published_at.present? ? @copied_assembly.created_at : nil # determine if block is active/inactive
+            )
+            copy_block_attachments(block, new_block) if block.attachments.present?
+          end
+        end
+
+        def copy_block_attachments(block, new_block)
+          block.attachments.map(&:name).each do |name|
+            original_image = block.images_container.send(name).blob
+            next if original_image.blank?
+
+            new_block.images_container.send("#{name}=", ActiveStorage::Blob.create_and_upload!(
+                                                          io: StringIO.new(original_image.download),
+                                                          filename: "image.png",
+                                                          content_type: block.images_container.background_image.blob.content_type
+                                                        ))
+            new_block.save!
           end
         end
       end

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_copy_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_copy_form.rb
@@ -16,6 +16,7 @@ module Decidim
         attribute :slug, String
         attribute :copy_categories, Boolean
         attribute :copy_components, Boolean
+        attribute :copy_landing_page_blocks, Boolean
 
         validates :slug, presence: true, format: { with: Decidim::Assembly.slug_format }
         validates :title, translatable_presence: true

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_copies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_copies/_form.html.erb
@@ -21,6 +21,9 @@
             <div class="columns">
               <%= form.check_box :copy_components %>
             </div>
+            <div class="columns">
+              <%= form.check_box :copy_landing_page_blocks %>
+            </div>
           </div>
         </div>
       </div>

--- a/decidim-assemblies/spec/commands/copy_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/copy_assembly_spec.rb
@@ -11,6 +11,7 @@ module Decidim::Assemblies
     let(:scope) { create(:scope, organization:) }
     let(:errors) { double.as_null_object }
     let!(:assembly) { create(:assembly) }
+    let!(:content_block) { create(:content_block, manifest_name: :hero, organization: assembly.organization, scope_name: :assembly_homepage, scoped_resource_id: assembly.id) }
     let!(:component) { create(:component, manifest_name: :dummy, participatory_space: assembly) }
     let(:form) do
       instance_double(
@@ -19,7 +20,8 @@ module Decidim::Assemblies
         title: { en: "title" },
         slug: "copied-slug",
         copy_categories?: copy_categories,
-        copy_components?: copy_components
+        copy_components?: copy_components,
+        copy_landing_page_blocks?: copy_landing_page_blocks
       )
     end
     let!(:category) do
@@ -32,6 +34,7 @@ module Decidim::Assemblies
     let(:invalid) { false }
     let(:copy_categories) { false }
     let(:copy_components) { false }
+    let(:copy_landing_page_blocks) { false }
 
     context "when the form is not valid" do
       let(:invalid) { true }
@@ -117,6 +120,40 @@ module Decidim::Assemblies
         expect(last_component.settings.attributes["dummy_global_translatable_text"]).to include(component.settings.attributes["dummy_global_translatable_text"])
         expect(last_component.step_settings.keys).to eq(component.step_settings.keys)
         expect(last_component.step_settings.values).to eq(component.step_settings.values)
+      end
+    end
+
+    context "when copy_landing_page_blocks exists" do
+      let(:copy_landing_page_blocks) { true }
+      let(:original_image) do
+        Rack::Test::UploadedFile.new(
+          Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
+          "image/jpeg"
+        )
+      end
+
+      before do
+        content_block.images_container.background_image.purge
+        content_block.images_container.background_image = original_image
+        content_block.save
+        content_block.reload
+      end
+
+      it "duplicates an assembly and the content_block with its attachments" do
+        expect { subject.call }.to change(Decidim::ContentBlock, :count).by(1)
+
+        old_block = Decidim::ContentBlock.unscoped.first
+        new_block = Decidim::ContentBlock.unscoped.last
+        last_assembly = Decidim::Assembly.last
+
+        expect(new_block.scope_name).to eq(old_block.scope_name)
+        expect(new_block.manifest_name).to eq(old_block.manifest_name)
+        # published_at is set in content_block factory
+        expect(new_block.published_at).not_to be_nil
+        expect(new_block.scoped_resource_id).to eq(last_assembly.id)
+        expect(new_block.attachments.length).to eq(1)
+        expect(new_block.attachments.first.name).to eq("background_image")
+        expect(new_block.images_container.attached_uploader(:background_image).url).not_to be_nil
       end
     end
 

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
@@ -32,6 +32,7 @@ module Decidim
               copy_participatory_process_steps if @form.copy_steps?
               copy_participatory_process_categories if @form.copy_categories?
               copy_participatory_process_components if @form.copy_components?
+              copy_landing_page_blocks if @form.copy_landing_page_blocks?
             end
           end
 
@@ -127,6 +128,39 @@ module Decidim
         def map_step_settings(step_settings)
           step_settings.each_with_object({}) do |(step_id, settings), acc|
             acc.update(@steps_relationship[step_id.to_s] => settings)
+          end
+        end
+
+        def copy_landing_page_blocks
+          blocks = Decidim::ContentBlock.where(scoped_resource_id: @participatory_process.id, scope_name: "participatory_process_homepage",
+                                               organization: @participatory_process.organization)
+          return if blocks.blank?
+
+          blocks.each do |block|
+            new_block = Decidim::ContentBlock.create!(
+              organization: @copied_process.organization,
+              scope_name: "participatory_process_homepage",
+              scoped_resource_id: @copied_process.id,
+              manifest_name: block.manifest_name,
+              settings: block.settings,
+              weight: block.weight,
+              published_at: block.published_at.present? ? @copied_process.created_at : nil # determine if block is active/inactive
+            )
+            copy_block_attachments(block, new_block) if block.attachments.present?
+          end
+        end
+
+        def copy_block_attachments(block, new_block)
+          block.attachments.map(&:name).each do |name|
+            original_image = block.images_container.send(name).blob
+            next if original_image.blank?
+
+            new_block.images_container.send("#{name}=", ActiveStorage::Blob.create_and_upload!(
+                                                          io: StringIO.new(original_image.download),
+                                                          filename: "image.png",
+                                                          content_type: block.images_container.background_image.blob.content_type
+                                                        ))
+            new_block.save!
           end
         end
       end

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_copy_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_copy_form.rb
@@ -17,6 +17,7 @@ module Decidim
         attribute :copy_steps, Boolean
         attribute :copy_categories, Boolean
         attribute :copy_components, Boolean
+        attribute :copy_landing_page_blocks, Boolean
 
         validates :slug, presence: true, format: { with: Decidim::ParticipatoryProcess.slug_format }
         validates :title, translatable_presence: true

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_copies/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_copies/_form.html.erb
@@ -25,6 +25,10 @@
               <div class="columns">
                 <%= form.check_box :copy_components %>
               </div>
+
+              <div class="columns">
+                <%= form.check_box :copy_landing_page_blocks %>
+              </div>
             </div>
           </div>
         </div>

--- a/decidim-participatory_processes/spec/commands/copy_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/copy_participatory_process_spec.rb
@@ -12,6 +12,7 @@ module Decidim::ParticipatoryProcesses
     let(:scope) { create(:scope, organization:) }
     let(:errors) { double.as_null_object }
     let!(:participatory_process) { create(:participatory_process, :with_steps) }
+    let!(:content_block) { create(:content_block, manifest_name: :hero, organization: participatory_process.organization, scope_name: :participatory_process_homepage, scoped_resource_id: participatory_process.id) }
     let!(:component) { create(:component, manifest_name: :dummy, participatory_space: participatory_process) }
     let(:form) do
       instance_double(
@@ -22,6 +23,7 @@ module Decidim::ParticipatoryProcesses
         copy_steps?: copy_steps,
         copy_categories?: copy_categories,
         copy_components?: copy_components,
+        copy_landing_page_blocks?: copy_landing_page_blocks,
         current_user:
       )
     end
@@ -36,6 +38,7 @@ module Decidim::ParticipatoryProcesses
     let(:copy_steps) { false }
     let(:copy_categories) { false }
     let(:copy_components) { false }
+    let(:copy_landing_page_blocks) { false }
 
     context "when the form is not valid" do
       let(:invalid) { true }
@@ -151,6 +154,40 @@ module Decidim::ParticipatoryProcesses
         expect(last_component.settings.attributes["dummy_global_translatable_text"]).to include(component.settings.attributes["dummy_global_translatable_text"])
         expect(last_component.step_settings.keys).not_to eq(component.step_settings.keys)
         expect(last_component.step_settings.values).not_to eq(component.step_settings.values)
+      end
+    end
+
+    context "when copy_landing_page_blocks exists" do
+      let(:copy_landing_page_blocks) { true }
+      let(:original_image) do
+        Rack::Test::UploadedFile.new(
+          Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
+          "image/jpeg"
+        )
+      end
+
+      before do
+        content_block.images_container.background_image.purge
+        content_block.images_container.background_image = original_image
+        content_block.save
+        content_block.reload
+      end
+
+      it "duplicates a participatory_process and the content_block with its attachments" do
+        expect { subject.call }.to change(Decidim::ContentBlock, :count).by(1)
+
+        old_block = Decidim::ContentBlock.unscoped.first
+        new_block = Decidim::ContentBlock.unscoped.last
+        last_process = Decidim::ParticipatoryProcess.last
+
+        expect(new_block.scope_name).to eq(old_block.scope_name)
+        expect(new_block.manifest_name).to eq(old_block.manifest_name)
+        # published_at is set in content_block factory
+        expect(new_block.published_at).not_to be_nil
+        expect(new_block.scoped_resource_id).to eq(last_process.id)
+        expect(new_block.attachments.length).to eq(1)
+        expect(new_block.attachments.first.name).to eq("background_image")
+        expect(new_block.images_container.attached_uploader(:background_image).url).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #14521 to v0.29

:hearts: Thank you!