### PR TITLE
Update supported versions in Security policy with v0.27 deprecation message

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,12 +10,11 @@ is the last version with the old design. This marks 18 months since the release
 of v0.28, giving ample time for organizations to upgrade to newer versions that
 include the latest design and features.
 
-
 | Version  | Supported          |
 | -------- | ------------------ |
 | 0.30.x   | :white_check_mark: |
 | 0.29.x   | :white_check_mark: |
-| 0.28.x   | :x: |
+| 0.28.x   | :x:                |
 | 0.27.x   | :white_check_mark: |
 | \<= 0.26 | :x:                |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,20 @@
 
 ## Supported Versions
 
-Until we have the version 1.0 we support only the last three minor versions with
+Until we have the version 1.0 we support only the last two minor versions with
 security updates.
+
+Exceptionally, we are also extending support for v0.27 until October 2025, as it
+is the last version with the old design. This marks 18 months since the release
+of v0.28, giving ample time for organizations to upgrade to newer versions that
+include the latest design and features.
+
 
 | Version  | Supported          |
 | -------- | ------------------ |
+| 0.30.x   | :white_check_mark: |
 | 0.29.x   | :white_check_mark: |
-| 0.28.x   | :white_check_mark: |
+| 0.28.x   | :x: |
 | 0.27.x   | :white_check_mark: |
 | \<= 0.26 | :x:                |
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR updates the security policy with the exception of v0.27. 

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/releases/tag/v0.30.0 
 
 

:hearts: Thank you!
