### PR TITLE
Add missing URL for resources in GraphQL API

### DIFF
--- a/decidim-accountability/spec/types/integration_schema_spec.rb
+++ b/decidim-accountability/spec/types/integration_schema_spec.rb
@@ -155,6 +155,7 @@ describe "Decidim::Api::QueryType" do
           }
         ]
       },
+      "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
       "weight" => 0
     }
   end

--- a/decidim-api/lib/decidim/api/test/component_context.rb
+++ b/decidim-api/lib/decidim/api/test/component_context.rb
@@ -22,6 +22,7 @@ shared_context "with a graphql decidim component" do
           name {
             translation(locale: "#{locale}")
           }
+          url
           weight
           __typename
           ...fooComponent

--- a/decidim-blogs/spec/types/integration_schema_spec.rb
+++ b/decidim-blogs/spec/types/integration_schema_spec.rb
@@ -123,6 +123,7 @@ describe "Decidim::Api::QueryType" do
           "startCursor" => "MQ"
         }
       },
+      "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
       "weight" => 0
     }
   end

--- a/decidim-budgets/spec/types/integration_schema_spec.rb
+++ b/decidim-budgets/spec/types/integration_schema_spec.rb
@@ -118,6 +118,7 @@ describe "Decidim::Api::QueryType" do
           }
         ]
       },
+      "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
       "weight" => 0
     }
   end

--- a/decidim-comments/lib/decidim/api/comment_type.rb
+++ b/decidim-comments/lib/decidim/api/comment_type.rb
@@ -22,6 +22,7 @@ module Decidim
       field :sgid, GraphQL::Types::String, "The Comment's signed global id", null: false
       field :up_voted, GraphQL::Types::Boolean, "Check if the current user has upvoted the comment", null: false
       field :up_votes, GraphQL::Types::Int, "The number of comment's upVotes", null: false, method: :up_votes_count
+      field :url, GraphQL::Types::String, "The URL for this meeting", null: false, method: :reported_content_url
       field :user_allowed_to_comment, GraphQL::Types::Boolean, "Check if the current user can comment", null: false
 
       def sgid

--- a/decidim-comments/spec/types/comment_type_spec.rb
+++ b/decidim-comments/spec/types/comment_type_spec.rb
@@ -237,6 +237,14 @@ module Decidim
           expect(response).to include("alreadyReported" => true)
         end
       end
+
+      describe "url" do
+        let(:query) { "{ url }" }
+
+        it "returns all the required fields" do
+          expect(response["url"]).to eq(model.reported_content_url)
+        end
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/api/interfaces/component_interface.rb
+++ b/decidim-core/lib/decidim/api/interfaces/component_interface.rb
@@ -14,6 +14,12 @@ module Decidim
 
       field :participatory_space, ParticipatorySpaceType, "The participatory space in which this component belongs to.", null: false
 
+      field :url, String, "The URL of this component.", null: false
+
+      def url
+        Decidim::EngineRouter.main_proxy(object).root_url
+      end
+
       def self.resolve_type(obj, _ctx)
         obj.manifest.query_type.constantize
       end

--- a/decidim-core/spec/types/component_type_spec.rb
+++ b/decidim-core/spec/types/component_type_spec.rb
@@ -17,6 +17,14 @@ module Decidim
           expect(response["name"]["translation"]).to eq(model.name["en"])
         end
       end
+
+      describe "url" do
+        let(:query) { "{ url }" }
+
+        it "returns all the required fields" do
+          expect(response["url"]).to eq(Decidim::EngineRouter.main_proxy(model).root_url)
+        end
+      end
     end
   end
 end

--- a/decidim-debates/spec/types/integration_schema_spec.rb
+++ b/decidim-debates/spec/types/integration_schema_spec.rb
@@ -123,6 +123,7 @@ describe "Decidim::Api::QueryType" do
           }
         ]
       },
+      "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
       "weight" => 0
     }
   end

--- a/decidim-initiatives/lib/decidim/api/initiative_type.rb
+++ b/decidim-initiatives/lib/decidim/api/initiative_type.rb
@@ -34,6 +34,11 @@ module Decidim
       field :signature_type, GraphQL::Types::String, "Signature type of the initiative", null: true
       field :slug, GraphQL::Types::String, "The slug of the initiative", null: false
       field :state, GraphQL::Types::String, "Current status of the initiative", null: true
+      field :url, GraphQL::Types::String, "The URL of this initiative", null: true
+
+      def url
+        Decidim::EngineRouter.main_proxy(object).initiative_url(object)
+      end
     end
   end
 end

--- a/decidim-initiatives/spec/types/initiative_type_spec.rb
+++ b/decidim-initiatives/spec/types/initiative_type_spec.rb
@@ -66,6 +66,14 @@ module Decidim
         end
       end
 
+      describe "url" do
+        let(:query) { "{ url }" }
+
+        it "returns all the required fields" do
+          expect(response["url"]).to eq(Decidim::EngineRouter.main_proxy(model).initiative_url(model))
+        end
+      end
+
       describe "description" do
         let(:query) { '{ description { translation(locale: "en")}}' }
 

--- a/decidim-initiatives/spec/types/integration_schema_spec.rb
+++ b/decidim-initiatives/spec/types/integration_schema_spec.rb
@@ -41,8 +41,8 @@ describe "Decidim::Api::QueryType" do
       "state" => initiative.state,
       "title" => { "translation" => initiative.title[locale] },
       "type" => initiative.class.name,
-      "updatedAt" => initiative.updated_at.to_time.iso8601
-
+      "updatedAt" => initiative.updated_at.to_time.iso8601,
+      "url" => Decidim::EngineRouter.main_proxy(initiative).initiative_url(initiative)
     }
   end
   let(:initiative_type_data) do
@@ -126,6 +126,7 @@ describe "Decidim::Api::QueryType" do
         }
         type
         updatedAt
+        url
       }
     )
   end
@@ -229,6 +230,7 @@ describe "Decidim::Api::QueryType" do
         }
         type
         updatedAt
+        url
       }
     )
     end

--- a/decidim-meetings/lib/decidim/api/meeting_type.rb
+++ b/decidim-meetings/lib/decidim/api/meeting_type.rb
@@ -42,9 +42,14 @@ module Decidim
       field :title, Decidim::Core::TranslatedFieldType, "The title of this meeting.", null: false
       field :transparent, GraphQL::Types::Boolean, "For private meetings, information is public if transparent", null: false
       field :type_of_meeting, GraphQL::Types::String, "The type of the meeting (online or in-person)", null: false
+      field :url, GraphQL::Types::String, "The URL for this meeting", null: false
       field :video_url, GraphQL::Types::String, "URL for the video of the session, if any", null: true
       field :withdrawn, GraphQL::Types::Boolean, "Whether this meeting has been withdrawn or not", method: :withdrawn?, null: true
       field :withdrawn_at, Decidim::Core::DateTimeType, description: "The date and time this meeting was withdrawn", null: true
+
+      def url
+        Decidim::ResourceLocatorPresenter.new(object).url
+      end
 
       def registration_form
         object.questionnaire if object.registration_form_enabled?

--- a/decidim-meetings/spec/types/integration_schema_spec.rb
+++ b/decidim-meetings/spec/types/integration_schema_spec.rb
@@ -82,6 +82,7 @@ describe "Decidim::Api::QueryType" do
           transparent
           type
           updatedAt
+          url
           userAllowedToComment
         }
       }
@@ -145,6 +146,7 @@ describe "Decidim::Api::QueryType" do
       "transparent" => meeting.transparent?,
       "type" => "Decidim::Meetings::Meeting",
       "updatedAt" => meeting.updated_at.to_time.iso8601,
+      "url" => Decidim::ResourceLocatorPresenter.new(meeting).url,
       "userAllowedToComment" => meeting.user_allowed_to_comment?(current_user)
     }
   end
@@ -265,6 +267,7 @@ describe "Decidim::Api::QueryType" do
               transparent
               type
               updatedAt
+              url
               userAllowedToComment
             }
           }

--- a/decidim-meetings/spec/types/integration_schema_spec.rb
+++ b/decidim-meetings/spec/types/integration_schema_spec.rb
@@ -163,6 +163,7 @@ describe "Decidim::Api::QueryType" do
           }
         ]
       },
+      "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
       "weight" => 0
     }
   end

--- a/decidim-meetings/spec/types/meeting_type_spec.rb
+++ b/decidim-meetings/spec/types/meeting_type_spec.rb
@@ -69,6 +69,14 @@ module Decidim
         end
       end
 
+      describe "url" do
+        let(:query) { "{ url }" }
+
+        it "returns all the required fields" do
+          expect(response["url"]).to eq(Decidim::ResourceLocatorPresenter.new(model).url)
+        end
+      end
+
       describe "isWithdrawn" do
         let(:query) { "{ isWithdrawn }" }
 

--- a/decidim-pages/lib/decidim/api/page_type.rb
+++ b/decidim-pages/lib/decidim/api/page_type.rb
@@ -10,6 +10,11 @@ module Decidim
       field :body, Decidim::Core::TranslatedFieldType, "The body of this page.", null: true
       field :id, GraphQL::Types::ID, "The id of the page", null: false
       field :title, Decidim::Core::TranslatedFieldType, "The title of this page (same as the component name).", null: false
+      field :url, GraphQL::Types::String, "The URL for this page", null: false
+
+      def url
+        Decidim::ResourceLocatorPresenter.new(object).url
+      end
     end
   end
 end

--- a/decidim-pages/spec/types/integration_schema_spec.rb
+++ b/decidim-pages/spec/types/integration_schema_spec.rb
@@ -51,6 +51,7 @@ describe "Decidim::Api::QueryType" do
           }
         ]
       },
+      "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
       "weight" => 0
     }
   end

--- a/decidim-pages/spec/types/integration_schema_spec.rb
+++ b/decidim-pages/spec/types/integration_schema_spec.rb
@@ -18,6 +18,7 @@ describe "Decidim::Api::QueryType" do
             translation(locale:"#{locale}")
           }
           updatedAt
+          url
         }
       }
 )
@@ -33,7 +34,8 @@ describe "Decidim::Api::QueryType" do
       "createdAt" => page.created_at.to_time.iso8601,
       "id" => page.id.to_s,
       "title" => { "translation" => page.title[locale] },
-      "updatedAt" => page.updated_at.to_time.iso8601
+      "updatedAt" => page.updated_at.to_time.iso8601,
+      "url" => Decidim::ResourceLocatorPresenter.new(page).url
     }
   end
 
@@ -69,6 +71,7 @@ describe "Decidim::Api::QueryType" do
                 translation(locale:"#{locale}")
               }
               updatedAt
+              url
             }
           }
         }

--- a/decidim-pages/spec/types/page_type_spec.rb
+++ b/decidim-pages/spec/types/page_type_spec.rb
@@ -49,6 +49,14 @@ module Decidim
           expect(response["updatedAt"]).to eq(model.updated_at.to_time.iso8601)
         end
       end
+
+      describe "url" do
+        let(:query) { "{ url }" }
+
+        it "returns all the required fields" do
+          expect(response["url"]).to eq(Decidim::ResourceLocatorPresenter.new(model).url)
+        end
+      end
     end
   end
 end

--- a/decidim-participatory_processes/lib/decidim/api/participatory_process_type.rb
+++ b/decidim-participatory_processes/lib/decidim/api/participatory_process_type.rb
@@ -37,6 +37,11 @@ module Decidim
       field :steps, [Decidim::ParticipatoryProcesses::ParticipatoryProcessStepType, { null: true }], "All the steps of this process.", null: false
       field :subtitle, Decidim::Core::TranslatedFieldType, "The subtitle of this participatory process.", null: true
       field :target, Decidim::Core::TranslatedFieldType, "Who participates in this participatory process.", null: true
+      field :url, GraphQL::Types::String, "The URL of this participatory process.", null: true
+
+      def url
+        Decidim::EngineRouter.main_proxy(object).participatory_process_url(object)
+      end
 
       def hero_image
         object.attached_uploader(:hero_image).url

--- a/decidim-participatory_processes/spec/types/integration_schema_spec.rb
+++ b/decidim-participatory_processes/spec/types/integration_schema_spec.rb
@@ -141,6 +141,7 @@ describe "Decidim::Api::QueryType" do
           }
         type
         updatedAt
+        url
       }
     )
   end
@@ -182,7 +183,8 @@ describe "Decidim::Api::QueryType" do
       "target" => { "translation" => participatory_process.target[locale] },
       "title" => { "translation" => participatory_process.title[locale] },
       "type" => "Decidim::ParticipatoryProcess",
-      "updatedAt" => participatory_process.updated_at.to_time.iso8601
+      "updatedAt" => participatory_process.updated_at.to_time.iso8601,
+      "url" => Decidim::EngineRouter.main_proxy(participatory_process).participatory_process_url(participatory_process)
     }
   end
   let(:query) do

--- a/decidim-participatory_processes/spec/types/participatory_process_type_spec.rb
+++ b/decidim-participatory_processes/spec/types/participatory_process_type_spec.rb
@@ -62,6 +62,14 @@ module Decidim
         end
       end
 
+      describe "url" do
+        let(:query) { "{ url }" }
+
+        it "returns all the required fields" do
+          expect(response["url"]).to eq(Decidim::EngineRouter.main_proxy(model).participatory_process_url(model))
+        end
+      end
+
       describe "publishedAt" do
         let(:query) { "{ publishedAt }" }
 

--- a/decidim-proposals/lib/decidim/api/proposal_type.rb
+++ b/decidim-proposals/lib/decidim/api/proposal_type.rb
@@ -35,6 +35,12 @@ module Decidim
       field :withdrawn, GraphQL::Types::Boolean, "Whether this proposal has been withdrawn or not", method: :withdrawn?, null: true
       field :withdrawn_at, Decidim::Core::DateTimeType, description: "The date and time this proposal was withdrawn", null: true
 
+      field :url, GraphQL::Types::String, "The URL for this proposal", null: false
+
+      def url
+        Decidim::ResourceLocatorPresenter.new(object).url
+      end
+
       def coordinates
         [object.latitude, object.longitude]
       end

--- a/decidim-proposals/spec/types/integration_schema_spec.rb
+++ b/decidim-proposals/spec/types/integration_schema_spec.rb
@@ -82,6 +82,7 @@ describe "Decidim::Api::QueryType" do
           totalCommentsCount
           type
           updatedAt
+          url
           userAllowedToComment
           versions {
             id
@@ -159,6 +160,7 @@ describe "Decidim::Api::QueryType" do
       "totalCommentsCount" => proposal.comments_count,
       "type" => "Decidim::Proposals::Proposal",
       "updatedAt" => proposal.updated_at.to_time.iso8601,
+      "url" => Decidim::ResourceLocatorPresenter.new(proposal).url,
       "userAllowedToComment" => proposal.user_allowed_to_comment?(current_user),
       "versions" => [],
       "versionsCount" => 0,
@@ -282,6 +284,7 @@ describe "Decidim::Api::QueryType" do
               totalCommentsCount
               type
               updatedAt
+              url
               userAllowedToComment
               versions {
                 id

--- a/decidim-proposals/spec/types/integration_schema_spec.rb
+++ b/decidim-proposals/spec/types/integration_schema_spec.rb
@@ -182,6 +182,7 @@ describe "Decidim::Api::QueryType" do
           }
         ]
       },
+      "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
       "weight" => 0
     }
   end

--- a/decidim-proposals/spec/types/proposal_type_spec.rb
+++ b/decidim-proposals/spec/types/proposal_type_spec.rb
@@ -71,6 +71,14 @@ module Decidim
         end
       end
 
+      describe "url" do
+        let(:query) { "{ url }" }
+
+        it "returns all the required fields" do
+          expect(response["url"]).to eq(Decidim::ResourceLocatorPresenter.new(model).url)
+        end
+      end
+
       context "when is answered" do
         before do
           model.answer = { en: "Some answer" }

--- a/decidim-sortitions/lib/decidim/api/sortition_type.rb
+++ b/decidim-sortitions/lib/decidim/api/sortition_type.rb
@@ -22,7 +22,12 @@ module Decidim
       field :selected_proposals, [GraphQL::Types::Int, { null: true }], "The selected proposals for this sortition", null: true
       field :target_items, GraphQL::Types::Int, "The target items for this sortition", null: true
       field :title, Decidim::Core::TranslatedFieldType, "The title for this sortition", null: true
+      field :url, GraphQL::Types::String, "The URL for this sortition", null: false
       field :witnesses, Decidim::Core::TranslatedFieldType, "The witnesses for this sortition", null: true
+
+      def url
+        Decidim::ResourceLocatorPresenter.new(object).url
+      end
 
       def self.authorized?(object, context)
         context[:sortition] = object

--- a/decidim-sortitions/spec/types/integration_schema_spec.rb
+++ b/decidim-sortitions/spec/types/integration_schema_spec.rb
@@ -33,6 +33,7 @@ describe "Decidim::Api::QueryType" do
           totalCommentsCount
           type
           updatedAt
+          url
           userAllowedToComment
           witnesses { translation(locale: "#{locale}") }
         }
@@ -71,6 +72,7 @@ describe "Decidim::Api::QueryType" do
       "totalCommentsCount" => sortition.comments_count,
       "type" => "Decidim::Sortitions::Sortition",
       "updatedAt" => sortition.updated_at.to_time.iso8601,
+      "url" => Decidim::ResourceLocatorPresenter.new(sortition).url,
       "userAllowedToComment" => sortition.user_allowed_to_comment?(current_user),
       "witnesses" => { "translation" => sortition.witnesses[locale] }
     }
@@ -141,6 +143,7 @@ describe "Decidim::Api::QueryType" do
                 totalCommentsCount
                 type
                 updatedAt
+                url
                 userAllowedToComment
                 witnesses { translation(locale: "#{locale}") }
               }

--- a/decidim-sortitions/spec/types/integration_schema_spec.rb
+++ b/decidim-sortitions/spec/types/integration_schema_spec.rb
@@ -90,6 +90,7 @@ describe "Decidim::Api::QueryType" do
           }
         ]
       },
+      "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
       "weight" => 0
     }
   end

--- a/decidim-sortitions/spec/types/sortition_type_spec.rb
+++ b/decidim-sortitions/spec/types/sortition_type_spec.rb
@@ -101,6 +101,14 @@ module Decidim
         end
       end
 
+      describe "url" do
+        let(:query) { "{ url }" }
+
+        it "returns all the required fields" do
+          expect(response["url"]).to eq(Decidim::ResourceLocatorPresenter.new(model).url)
+        end
+      end
+
       describe "candidateProposals" do
         let(:query) { "{ candidateProposals }" }
 

--- a/decidim-surveys/lib/decidim/api/survey_type.rb
+++ b/decidim-surveys/lib/decidim/api/survey_type.rb
@@ -9,6 +9,11 @@ module Decidim
 
       field :id, GraphQL::Types::ID, "The internal ID for this survey", null: false
       field :questionnaire, Decidim::Forms::QuestionnaireType, "The questionnaire for this survey", null: true
+      field :url, GraphQL::Types::String, "The URL for this survey", null: false
+
+      def url
+        Decidim::ResourceLocatorPresenter.new(object).url
+      end
 
       def self.authorized?(object, context)
         context[:survey] = object

--- a/decidim-surveys/spec/types/integration_schema_spec.rb
+++ b/decidim-surveys/spec/types/integration_schema_spec.rb
@@ -107,6 +107,7 @@ describe "Decidim::Api::QueryType" do
           }
         ]
       },
+      "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
       "weight" => 0
     }
   end

--- a/decidim-surveys/spec/types/integration_schema_spec.rb
+++ b/decidim-surveys/spec/types/integration_schema_spec.rb
@@ -44,6 +44,7 @@ describe "Decidim::Api::QueryType" do
             updatedAt
           }
           updatedAt
+          url
         }
       }
 )
@@ -89,7 +90,8 @@ describe "Decidim::Api::QueryType" do
         "tos" => { "translation" => survey.questionnaire.tos[locale] },
         "updatedAt" => survey.questionnaire.updated_at.to_time.iso8601
       },
-      "updatedAt" => survey.updated_at.to_time.iso8601
+      "updatedAt" => survey.updated_at.to_time.iso8601,
+      "url" => Decidim::ResourceLocatorPresenter.new(survey).url
     }
   end
 
@@ -152,6 +154,7 @@ describe "Decidim::Api::QueryType" do
                 updatedAt
               }
               updatedAt
+              url
             }
           }
         }

--- a/decidim-surveys/spec/types/survey_type_spec.rb
+++ b/decidim-surveys/spec/types/survey_type_spec.rb
@@ -33,6 +33,14 @@ module Decidim
         end
       end
 
+      describe "url" do
+        let(:query) { "{ url }" }
+
+        it "returns all the required fields" do
+          expect(response["url"]).to eq(Decidim::ResourceLocatorPresenter.new(model).url)
+        end
+      end
+
       describe "questionnaire" do
         let(:query) { "{ questionnaire { id }} " }
 


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR we are adding the url method which is missing from certain resources. I am adding it as a fix, as I would need it rather sooner for a Commission development.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13986

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
