### PR TITLE
Fix text in calendar share modal

### DIFF
--- a/decidim-core/app/views/decidim/shared/_results_per_page.html.erb
+++ b/decidim-core/app/views/decidim/shared/_results_per_page.html.erb
@@ -1,7 +1,7 @@
 <% menu_id = "#{SecureRandom.uuid}_results_per_page_menu" %>
 <div class="flex items-center gap-1">
   <%= icon "list-check-2", class: "w-4 h-4 text-gray fill-current" %>
-  <span class="text-gray-2"><%= t("decidim.shared.results_per_page.label") %></span>
+  <p class="text-gray-2"><%= t("decidim.shared.results_per_page.label") %></p>
 
   <details class="relative">
       <summary id="<%= menu_id %>-control" class="flex items-center cursor-pointer text-secondary font-semibold" aria-controls="<%= menu_id %>" aria-haspopup="menu" title="<%= t("decidim.shared.results_per_page.title") %>">

--- a/decidim-meetings/app/views/decidim/meetings/_calendar_modal.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/_calendar_modal.html.erb
@@ -9,8 +9,8 @@
   <div class="space-y-8">
     <h3 id="dialog-title-calendarShare" class="h3"><%= t(".calendar_url") %></h3>
 
-    <div id="dialog-desc-calendarShare" class="meeting-list__modal-text"><%= t(".copy_calendar_url_description") %></div>
-    <div class="meeting-list__modal-text"><%= t(".copy_calendar_url_explanation") %></div>
+    <p id="dialog-desc-calendarShare" class="meeting-list__modal-text"><%= t(".copy_calendar_url_description") %></p>
+    <p class="meeting-list__modal-text"><%= t(".copy_calendar_url_explanation") %></p>
 
     <div class="meeting-list__modal-input">
       <input id="urlCalendarUrl" type="text" title="<%= t(".calendar_url") %>" value="<%= "#{path}" %>" readonly>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR improves accessibility on meeting's index page by replacing meeningless span and div with p (on "Result per page" and inside the calendar share modal).

#### :pushpin: Related Issues
These changes address accessibility concerns highlighted during the city of Lyon RGAA Audit (page 66 of the audit, paragraph 24.2), and align with WCAG 2.1 standards:
🔗 WCAG References:
[1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html): Ensures information and relationships are perceivable for assistive technologies.

#### Testing

1. In Front Office, go to a meetings index page
2. Ensure you have more than 25 meetings on the page
3. Enable VoiceOver (or any screen reader)
4. Navigate through the page and see that the "Result per page" is identified as text information
5. Click on Export Calendar.
6. In the modal, ensure that the informations are identified as text information


:hearts: Thank you!
