### PR TITLE
Hidden resource report translation

### DIFF
--- a/decidim-core/app/controllers/decidim/reports_controller.rb
+++ b/decidim-core/app/controllers/decidim/reports_controller.rb
@@ -2,6 +2,7 @@
 
 module Decidim
   # Exposes the report resource so users can report a reportable.
+  # Unless the reportable is marked as hideable, the resource notice will change accordingly.
   class ReportsController < Decidim::ApplicationController
     include FormFactory
     include NeedsPermission

--- a/decidim-core/app/controllers/decidim/reports_controller.rb
+++ b/decidim-core/app/controllers/decidim/reports_controller.rb
@@ -15,7 +15,11 @@ module Decidim
 
       CreateReport.call(@form, reportable) do
         on(:ok) do
-          flash[:notice] = I18n.t("decidim.reports.create.success")
+          flash[:notice] = if hideable?
+                             I18n.t("decidim.reports.hide.success")
+                           else
+                             I18n.t("decidim.reports.create.success")
+                           end
           redirect_to reportable.reload.reported_content_url
         end
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1569,11 +1569,11 @@ en:
         see_report: See report
         subject: A resource has been reported
     reports:
-      hide:
-        success: This resource has been hidden.
       create:
         error: There was a problem creating the report. Please, try it again.
         success: The report has been created successfully and it will be reviewed by an admin.
+      hide:
+        success: This resource has been hidden.
       parent_hidden:
         report_details: The parent resource was hidden
     resource:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1571,7 +1571,7 @@ en:
     reports:
       create:
         error: There was a problem creating the report. Please, try it again.
-        success: The report has been created successfully and it will be reviewed by an admin.
+        success: This resource has been hidden.
       parent_hidden:
         report_details: The parent resource was hidden
     resource:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1569,9 +1569,11 @@ en:
         see_report: See report
         subject: A resource has been reported
     reports:
+      hide:
+        success: This resource has been hidden.
       create:
         error: There was a problem creating the report. Please, try it again.
-        success: This resource has been hidden.
+        success: The report has been created successfully and it will be reviewed by an admin.
       parent_hidden:
         report_details: The parent resource was hidden
     resource:


### PR DESCRIPTION
#### :tophat: What? Why?
Hidden reports on the front end of Decidim applications use the wrong translation for the flash call out when a resource is successfully hidden. This PR updates the translation.

#### :pushpin: Related Issues
- Fixes #14559 

#### Testing
1. Sign in as admin
2. Search for an user generated resource
3. Click in "Report" and in  "Hide this content" checkbox. 
4. Click in the "Hide" button 
5. See the callout updated correctly.

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/68da651c-0858-4928-ae98-25199b08c20e)

:hearts: Thank you!
