### PR TITLE
Fix attachment folder in Blogs when attachment disabled

### DIFF
--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/_actions.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/_actions.html.erb
@@ -5,8 +5,8 @@
 <% else %>
   <% if allowed_to? :update, :blogpost, blogpost: post %>
     <%= icon_link_to "pencil-line", edit_post_path(post), t("actions.edit", scope: "decidim.blogs"), class: "action-icon--edit" %>
-    <%= icon_link_to "folder-line", post_attachment_collections_path(post), t("actions.attachment_collections", scope: "decidim.meetings"), class: "action-icon--attachment_collections" %>
     <% if component_settings.attachments_allowed? %>
+      <%= icon_link_to "folder-line", post_attachment_collections_path(post), t("actions.attachment_collections", scope: "decidim.meetings"), class: "action-icon--attachment_collections" %>
       <%= icon_link_to "attachment-line", post_attachments_path(post), t("actions.attachments", scope: "decidim.meetings"), class: "action-icon--attachments" %>
     <% end %>
   <% end %>

--- a/decidim-blogs/spec/system/admin_manages_posts_attachment_collections_spec.rb
+++ b/decidim-blogs/spec/system/admin_manages_posts_attachment_collections_spec.rb
@@ -7,6 +7,11 @@ describe "Admin manages posts attachment collections" do
   let(:manifest_name) { "blogs" }
   let!(:post) { create(:post, component: current_component, title: { en: "Post title 1" }, author: user) }
 
+  before do
+    component_settings = current_component["settings"]["global"].merge!(attachments_allowed: true)
+    current_component.update!(settings: component_settings)
+  end
+
   include_context "when managing a component as an admin"
 
   it_behaves_like "manage posts attachment collections"


### PR DESCRIPTION
#### :tophat: What? Why?

When Blog component has the "Allow attachments" setting disabled, it still show the Folder icon. This PR fixes it.

#### :pushpin: Related Issues
 
- Related to #14085 
 
#### Testing

. Sign in as admin
. Go to the configuration of a Blogs component
. Disable the "Allow attachments" setting
. Go to the Manage page 
. (Before the patch) See that you have the Folder icon
. (After the patch) See that you don't have the Folder icon

### :camera: Screenshots

#### Before

![image](https://github.com/user-attachments/assets/2aae401e-629b-4e8d-b6ab-1671a5b01c23)

#### After

![image](https://github.com/user-attachments/assets/aa6c02ee-3c03-40ef-a2b6-4b79e1b9b298)

:hearts: Thank you!
