### PR TITLE
Fix warnings for documentation project

### DIFF
--- a/docs/modules/configure/pages/initializer.adoc
+++ b/docs/modules/configure/pages/initializer.adoc
@@ -113,7 +113,7 @@ Allows to make geographical mapping in some components, like Proposals or Meetin
 
 == Custom resource reference
 
-Custom resource reference generator method. See the See xref:admin:system.adoc[System panel docs] for more information.
+Custom resource reference generator method. See the See xref:configure:system.adoc[System panel docs] for more information.
 
 [source,ruby]
 ....

--- a/docs/modules/customize/pages/localization.adoc
+++ b/docs/modules/customize/pages/localization.adoc
@@ -28,8 +28,8 @@ The following keys are relevant to time and date format:
 
 If you need to change the format to comply with the United States of America standard, you must do the following:
 
-1. Create or update the file `config/locales/en.yml` in your generated application.
-2. Add the following snippet:
+. Create or update the file `config/locales/en.yml` in your generated application.
+. Add the following snippet:
 ```yaml
 en:
   date:
@@ -45,7 +45,7 @@ en:
       order: m-d-y
       separator: "/"
 ```
-3. Restart your application server.
+. Restart your application server.
 
 Note that in the case of the `order` value, currently it only supports two values:
 
@@ -54,4 +54,4 @@ Note that in the case of the `order` value, currently it only supports two value
 
 == Currency unit
 
-If you are using the xref:admin:components/budgets.adoc[Budget] component or the xref:components/proposals/answers.adoc[Proposals' answers with costs] feature, you may want to change the `DECIDIM_CURRENCY_UNIT` environment variable to a currency other than the default Euro (€). Read more about how to customize xref:configure:environment_variables.adoc[Environment Variables].
+If you are using the xref:admin:components/budgets.adoc[Budget] component or the xref:admin:components/proposals/answers.adoc[Proposals' answers with costs] feature, you may want to change the `DECIDIM_CURRENCY_UNIT` environment variable to a currency other than the default Euro (€). Read more about how to customize xref:configure:environment_variables.adoc[Environment Variables].

--- a/docs/modules/develop/pages/endorsable.adoc
+++ b/docs/modules/develop/pages/endorsable.adoc
@@ -23,6 +23,7 @@ For performance, an endorsable has a counter cache of endorsements.
 |#counter cache column |       +--------------------+   +-------------+
 |-endorsements_counter |       |-author: a user     |<--+Decidim::User|
 +----------------------+       +--------------------+   +-------------+
+----
 
 Thus, each endorsable must have the endorsements counter cache column.
 This is an example migration to add the endorsements counter cache column to a resource:
@@ -74,22 +75,22 @@ To render this button, `decidim-core` offers the `decidim/endorsement_buttons` c
 
 [source,ruby]
 ----
-cell("decidim/endorsement_buttons", resource)
+  cell("decidim/endorsement_buttons", resource)
 ----
 
 This cell will render the endorsement buttons depending on whether user endorsed the resource or not. The endorsements are labeled as *Likes*.
 
 [source,ruby]
 ----
-# By default the `show` method is invoked as usual
-# Renders `render_endorsements_count` and `render_endorsements_button` in a block.
-#
-# It takes into account:
-# - if endorsements are enabled
-# - if users are logged in
-# - if users require verification
- #
-cell("decidim/endorsement_buttons", resource)
+  # By default the `show` method is invoked as usual
+  # Renders `render_endorsements_count` and `render_endorsements_button` in a block.
+  #
+  # It takes into account:
+  # - if endorsements are enabled
+  # - if users are logged in
+  # - if users require verification
+  #
+  cell("decidim/endorsement_buttons", resource)
 ----
 
 === The list of endorsers
@@ -98,8 +99,9 @@ The `Decidim::EndorsersListCell` renders the list of endorsers of a resource. It
 
 [source,ruby]
 ----
-# to render the list of endorsers, the cell requires the endorsable resource, and the current user
-cell "decidim/endorsers_list", resource
-# or using the helper
-endorsers_list_cell(resource)
+  # to render the list of endorsers, the cell requires the endorsable resource, and the current user
+  cell "decidim/endorsers_list", resource
+  # or using the helper
+  endorsers_list_cell(resource)
 ----
+

--- a/docs/modules/install/pages/empty-database.adoc
+++ b/docs/modules/install/pages/empty-database.adoc
@@ -31,4 +31,4 @@ At the development environment, you have https://github.com/ryanb/letter_opener[
 
 == Extra notes
 
-Decidim is a https://en.wikipedia.org/wiki/Multitenancy[multitenant] application that allows you to host multiple different Decidim-based websites within the same system. Organizations are isolated from each other and users in those organizations cannot see any data from other organizations. Therefore, creating the organization is a key part of the process when setting up Decidim. To learn more about the system panel and organizations, refer to the xref:admin:system.adoc[System] panel documentation.
+Decidim is a https://en.wikipedia.org/wiki/Multitenancy[multitenant] application that allows you to host multiple different Decidim-based websites within the same system. Organizations are isolated from each other and users in those organizations cannot see any data from other organizations. Therefore, creating the organization is a key part of the process when setting up Decidim. To learn more about the system panel and organizations, refer to the xref:configure:system.adoc[System] panel documentation.

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -184,7 +184,7 @@ Note that the system panel admin user you created earlier is also separated from
 * *System admin* - Manages the organizations on the same platform, does not necessarily have to be involved in any organization
 * *Organization admin* - Administers a single organization, i.e. manages its content, sets up processes, adds components, manages user accounts, etc.
 
-You can read the xref:admin:system.adoc[System panel] documentation for more info on what are organizations and how they work.
+You can read the xref:configure:system.adoc[System panel] documentation for more info on what are organizations and how they work.
 
 == Checklist
 


### PR DESCRIPTION
#### :tophat: What? Why?

The build process of the documentation repository has lots of warnings and errors (mostly missing pages because of renames/moves). This PR fixes these warnings in `develop`. After this is merged, I'll manually backport this to the other versions to fix the errors there.

For instance: 

```
[10:39:35.134] ERROR (asciidoctor): target of xref not found: admin:scopes.adoc
    file: docs/en/modules/admin/pages/components.adoc
    source: https://github.com/decidim/documentation (branch: develop | start path: docs/en)
[10:39:36.092] ERROR (asciidoctor): target of xref not found: admin:scopes.adoc
    file: docs/en/modules/admin/pages/components/accountability.adoc
    source: https://github.com/decidim/documentation (branch: develop | start path: docs/en)
[10:39:36.335] WARN (asciidoctor): section title out of sequence: expected level 2, got level 3
    file: docs/en/modules/admin/pages/components/skeleton.adoc:132
    source: https://github.com/decidim/documentation (branch: develop | start path: docs/en)
[10:39:36.339] ERROR (asciidoctor): target of image not found: components/skeleton/component_skeleton.png
    file: docs/en/modules/admin/pages/components/skeleton.adoc
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/decidim/documentation/actions/runs/14793619146/job/41535859145  

#### Testing

What I do locally is:

1. Apply this patch in your local copy of `decidim/documentation` (adapt it to your decidim local copy)
```diff
diff --git a/antora-playbook.yml b/antora-playbook.yml
index ef0a5c9..52a9c84 100644
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -12,7 +12,7 @@ content:
       start_path: docs/en
       branches: [release/0.30-stable, release/0.29-stable, release/0.28-stable, release/0.27-stable, develop]
       edit_url: "https://github.com/decidim/documentation/edit/{refname}/{path}"
-    - url: https://github.com/decidim/decidim
+    - url: /home/apereira/Work/decidim/decidim
       start_path: docs
       branches: [release/0.30-stable, release/0.29-stable, release/0.28-stable, release/0.27-stable, develop]
 ui:
```
2. Add a commit `git commit -a -m "REMOVE: work locally"` - this is necessary because the build process changes this file and uses git
3. Run `npm run build`
4. See the output before and after this commit. You shouldn't see any error in develop 

Mind that there are some errors still, but those belong to other release branches, like

```
[16:27:36.034] ERROR (asciidoctor): target of xref not found: admin:system.adoc
    file: docs/modules/install/pages/empty-database.adoc
    source: /home/apereira/Work/decidim/decidim/.git (branch: release/0.30-stable | start path: docs)
[16:27:36.086] ERROR (asciidoctor): target of xref not found: admin:system.adoc
    file: docs/modules/install/pages/index.adoc
    source: /home/apereira/Work/decidim/decidim/.git (branch: release/0.30-stable | start path: docs)
```

### :camera: Screenshots

![image](https://github.com/user-attachments/assets/db2d7e54-fded-47d3-956e-245d5a7296b2)

:hearts: Thank you!
