### PR TITLE
Use defined token if present in generate_token method

### DIFF
--- a/decidim-proposals/app/models/decidim/proposals/proposal_state.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal_state.rb
@@ -38,7 +38,7 @@ module Decidim
       protected
 
       def generate_token
-        self.token = ensure_unique_token(translated_attribute(title).parameterize(separator: "_"))
+        self.token = ensure_unique_token(token.presence || translated_attribute(title).parameterize(separator: "_"))
       end
 
       def ensure_unique_token(token)

--- a/decidim-proposals/spec/system/admin/admin_manages_proposal_states_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_manages_proposal_states_spec.rb
@@ -110,12 +110,12 @@ describe "Admin manages proposals states" do
       {
         title: { "en" => "Editable state" },
         announcement_title: { "en" => "Editable announcement title" },
-        token: "editable",
+        token: "editable_state",
         bg_color: "#EBF9FF",
         text_color: "#0851A6"
       }
     end
-    let!(:state) { create(:proposal_state, component: current_component, **state_params) }
+    let!(:proposal_state) { create(:proposal_state, component: current_component, **state_params) }
     let(:attributes) { attributes_for(:proposal_state) }
 
     before do
@@ -127,7 +127,7 @@ describe "Admin manages proposals states" do
     end
 
     it "updates a proposal state" do
-      within "tr", text: translated(state.title) do
+      within "tr", text: translated(proposal_state.title) do
         click_on "Edit"
       end
 
@@ -159,7 +159,7 @@ describe "Admin manages proposals states" do
     end
 
     it "updates the label and announcement previews" do
-      within "tr", text: translated(state.title) do
+      within "tr", text: translated(proposal_state.title) do
         click_on "Edit"
       end
 


### PR DESCRIPTION
This PR fixes a bug that prevents the correct creation of default proposal states with a correct token when the default locale of the organization is not `:en`. The method to create the default proposal states provides a value for token but it is ignored by the generate_token callback.

This bug affects to the migration from 0.28 to 0.29 defined in `decidim-proposals/db/migrate/20240110203504_create_default_proposal_states.rb`

This fix has been applied in #13057 since 0.30 revision

#### :tophat: What? Why?
*Please describe your pull request.*

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
