### PR TITLE
Require organization in `nicknamize` method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -347,3 +347,23 @@ result = 1 + 1 if after
 ### 5.2. Add force_api_authentication configuration options
 
 There are times that we need to let only authenticated users to use the API. This configuration option filters out unauthenticated users from accessing the api endpoint. You need to add `DECIDIM_API_FORCE_API_AUTHENTICATION` to your environment variables if you want to enable this feature.
+
+### 5.3. Require organization in nicknamize method
+
+In order to avoid potential performance issues, we have changed the `nicknamize` method by requiring the organization as a parameter.
+
+If you have used code as such:
+
+```ruby
+# We were including the organization in an optional scope
+Decidim::UserBaseEntity.nicknamize(nickname, decidim_organization_id: user.decidim_organization_id)
+```
+
+You need to change it, to something like:
+
+```ruby
+# Now the organization is the required second parameter of the method
+Decidim::UserBaseEntity.nicknamize(nickname, user.decidim_organization_id)
+```
+
+You can read more about this change on PR [#14669](https://github.com/decidim/decidim/pull/14669).

--- a/decidim-admin/app/controllers/decidim/admin/impersonations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/impersonations_controller.rb
@@ -99,7 +99,7 @@ module Decidim
           managed: true,
           name: params.dig(:impersonate_user, :name)
         ) do |u|
-          u.nickname = Decidim::UserBaseEntity.nicknamize(u.name, organization: current_organization)
+          u.nickname = Decidim::UserBaseEntity.nicknamize(u.name, current_organization.id)
           u.admin = false
           u.tos_agreement = true
         end

--- a/decidim-conferences/app/commands/decidim/conferences/admin/invite_user_to_join_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/invite_user_to_join_conference.rb
@@ -79,7 +79,7 @@ module Decidim
             end
           else
             user.name = form.name
-            user.nickname = UserBaseEntity.nicknamize(user.name, organization: user.organization)
+            user.nickname = UserBaseEntity.nicknamize(user.name, user.decidim_organization_id)
             invite_user_to_sign_up
             create_invitation!
           end

--- a/decidim-core/app/commands/decidim/invite_user.rb
+++ b/decidim-core/app/commands/decidim/invite_user.rb
@@ -41,7 +41,7 @@ module Decidim
       @user = Decidim::User.new(
         name: form.name,
         email: form.email.downcase,
-        nickname: UserBaseEntity.nicknamize(form.name, organization: form.organization),
+        nickname: UserBaseEntity.nicknamize(form.name, form.organization.id),
         organization: form.organization,
         admin: form.role == "admin",
         roles: form.role == "admin" ? [] : [form.role].compact

--- a/decidim-core/app/forms/decidim/ephemeral_user_form.rb
+++ b/decidim-core/app/forms/decidim/ephemeral_user_form.rb
@@ -17,7 +17,7 @@ module Decidim
     end
 
     def nickname
-      super || User.nicknamize(name)
+      super || User.nicknamize(name, organization.id)
     end
   end
 end

--- a/decidim-core/app/forms/decidim/omniauth_registration_form.rb
+++ b/decidim-core/app/forms/decidim/omniauth_registration_form.rb
@@ -26,7 +26,7 @@ module Decidim
     end
 
     def normalized_nickname
-      UserBaseEntity.nicknamize(nickname || name, organization: current_organization)
+      UserBaseEntity.nicknamize(nickname || name, current_organization.id)
     end
 
     def newsletter_at

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -37,7 +37,7 @@ module Decidim
     end
 
     def generate_nickname(name, organization)
-      Decidim::UserBaseEntity.nicknamize(name, organization:)
+      Decidim::UserBaseEntity.nicknamize(name, organization.id)
     end
 
     def valid_users

--- a/decidim-core/db/migrate/20171212103803_create_unique_nicknames.rb
+++ b/decidim-core/db/migrate/20171212103803_create_unique_nicknames.rb
@@ -11,7 +11,7 @@ class CreateUniqueNicknames < ActiveRecord::Migration[5.1]
     add_column :decidim_users, :nickname, :string, limit: 20
 
     User.where.not(name: nil).find_each do |user|
-      user.update!(nickname: UserBaseEntity.nicknamize(user.name, decidim_organization_id: user.decidim_organization_id))
+      user.update!(nickname: UserBaseEntity.nicknamize(user.name, user.decidim_organization_id))
     end
 
     add_index :decidim_users,

--- a/decidim-core/db/migrate/20180221101934_fix_nickname_index.rb
+++ b/decidim-core/db/migrate/20180221101934_fix_nickname_index.rb
@@ -11,7 +11,7 @@ class FixNicknameIndex < ActiveRecord::Migration[5.1]
     User.where(nickname: nil)
         .where(deleted_at: nil)
         .where(managed: false)
-        .find_each { |u| u.update(nickname: UserBaseEntity.nicknamize(u.name, decidim_organization_id: u.decidim_organization_id)) }
+        .find_each { |u| u.update(nickname: UserBaseEntity.nicknamize(u.name, u.decidim_organization_id)) }
 
     # rubocop:disable Rails/SkipsModelValidations
     User.where(nickname: nil).update_all("nickname = ''")

--- a/decidim-core/db/migrate/20180706104107_add_nickname_to_managed_users.rb
+++ b/decidim-core/db/migrate/20180706104107_add_nickname_to_managed_users.rb
@@ -7,7 +7,7 @@ class AddNicknameToManagedUsers < ActiveRecord::Migration[5.2]
 
   def up
     User.where(managed: true, nickname: nil).includes(:organization).find_each do |user|
-      user.nickname = UserBaseEntity.nicknamize(user.name, organization: user.organization)
+      user.nickname = UserBaseEntity.nicknamize(user.name, user.decidim_organization_id)
       user.save
     end
   end

--- a/decidim-core/db/migrate/20181001124950_move_users_groups_to_users_table.rb
+++ b/decidim-core/db/migrate/20181001124950_move_users_groups_to_users_table.rb
@@ -64,7 +64,7 @@ class MoveUsersGroupsToUsersTable < ActiveRecord::Migration[5.2]
         verified_at: old_user_group.verified_at
       }
       new_attributes = clean_attributes.merge(
-        nickname: UserBaseEntity.nicknamize(clean_attributes["name"]),
+        nickname: UserBaseEntity.nicknamize(clean_attributes["name"], old_user_group.decidim_organization_id),
         extended_data:
       )
       new_user_group = NewUserGroup.create!(new_attributes)

--- a/decidim-core/db/migrate/20190412131728_fix_user_names.rb
+++ b/decidim-core/db/migrate/20190412131728_fix_user_names.rb
@@ -23,7 +23,7 @@ class FixUserNames < ActiveRecord::Migration[5.2]
 
         entity.name = entity.name.delete(characters_to_remove).strip
         sanitized_nickname = entity.nickname.delete(characters_to_remove).strip
-        entity.nickname = UserBaseEntity.nicknamize(sanitized_nickname, organization: entity.organization)
+        entity.nickname = UserBaseEntity.nicknamize(sanitized_nickname, entity.decidim_organization_id)
         entity.save(validate: false)
       end
     end

--- a/decidim-core/lib/decidim/nicknamizable.rb
+++ b/decidim-core/lib/decidim/nicknamizable.rb
@@ -27,19 +27,16 @@ module Decidim
       # * Disambiguates it so it is unique.
       #
       # name - the String to nicknamize
-      # scope - a Hash with extra values to scope the nickname to
+      # organization_id - the organization id we are using as scope for the uniqueness
       #
       # Example to nicknamize a user name, scoped to the organization:
       #
-      #    nicknamize(user_name, organization: current_organization)
+      #    nicknamize(user_name, organization_id)
       #
-      def nicknamize(name, scope = {})
+      def nicknamize(name, organization_id)
         return unless name
 
-        disambiguate(
-          name.parameterize(separator: "_")[nickname_length_range],
-          scope
-        )
+        disambiguate(name.parameterize(separator: "_")[nickname_length_range], organization_id)
       end
 
       private
@@ -48,11 +45,11 @@ module Decidim
         (0...nickname_max_length)
       end
 
-      def disambiguate(name, scope)
+      def disambiguate(name, organization_id)
         candidate = name
 
         2.step do |n|
-          return candidate if Decidim::UserBaseEntity.where(nickname: candidate.downcase).where(scope).empty?
+          return candidate if Decidim::UserBaseEntity.where(nickname: candidate.downcase).where(decidim_organization_id: organization_id).empty?
 
           candidate = numbered_variation_of(name, n)
         end

--- a/decidim-core/lib/tasks/upgrade/decidim_fix_nickname_uniqueness.rake
+++ b/decidim-core/lib/tasks/upgrade/decidim_fix_nickname_uniqueness.rake
@@ -16,7 +16,7 @@ namespace :decidim do
             has_changed << user.id
           end
         rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
-          update_user_nickname(user, Decidim::UserBaseEntity.nicknamize(user.nickname, organization: user.organization))
+          update_user_nickname(user, Decidim::UserBaseEntity.nicknamize(user.nickname, user.decidim_organization_id))
           has_changed << user.id
         rescue ActiveRecord::RecordInvalid # rubocop:disable Lint/DuplicateRescueException
           logger.warn("User ID (#{user.id}) : #{e}")

--- a/decidim-core/spec/lib/nicknamizable_spec.rb
+++ b/decidim-core/spec/lib/nicknamizable_spec.rb
@@ -49,21 +49,21 @@ module Decidim
 
       shared_examples "resolves existing conflicts" do |factory|
         it "resolves conflicts with current nicknames" do
-          create(factory, nickname: "ana_pastor")
+          create(factory, nickname: "ana_pastor", organization:)
 
           expect(subject.nicknamize("ana_pastor", organization.id)).to eq("ana_pastor_2")
         end
 
         it "resolves conflicts with long current nicknames" do
-          create(factory, nickname: "felipe_rocks_so_much")
+          create(factory, nickname: "felipe_rocks_so_much", organization:)
 
           expect(subject.nicknamize("Felipe Rocks So Much", organization.id)).to eq("felipe_rocks_so_mu_2")
         end
 
         it "resolves conflicts with other existing nicknames" do
-          create(factory, nickname: "existing")
-          create(factory, nickname: "existing_1")
-          create(factory, nickname: "existing_2")
+          create(factory, nickname: "existing", organization:)
+          create(factory, nickname: "existing_1", organization:)
+          create(factory, nickname: "existing_2", organization:)
 
           expect(subject.nicknamize("existing", organization.id)).to eq("existing_3")
         end

--- a/decidim-core/spec/lib/nicknamizable_spec.rb
+++ b/decidim-core/spec/lib/nicknamizable_spec.rb
@@ -25,7 +25,7 @@ module Decidim
           another_user = create(:user, nickname: "ana_pastor")
           another_org_id = another_user.decidim_organization_id
 
-          expect(subject.nicknamize("ana_pastor",another_org_id + 1)).to eq("ana_pastor")
+          expect(subject.nicknamize("ana_pastor", another_org_id + 1)).to eq("ana_pastor")
         end
       end
 

--- a/decidim-core/spec/lib/nicknamizable_spec.rb
+++ b/decidim-core/spec/lib/nicknamizable_spec.rb
@@ -18,29 +18,31 @@ module Decidim
     end
 
     describe "#nicknamize" do
+      let(:organization) { create(:organization) }
+
       context "when a scope is provided" do
         it "resolves conflicts with nicknames outside the scope" do
           another_user = create(:user, nickname: "ana_pastor")
           another_org_id = another_user.decidim_organization_id
 
-          expect(subject.nicknamize("ana_pastor", decidim_organization_id: another_org_id + 1)).to eq("ana_pastor")
+          expect(subject.nicknamize("ana_pastor",another_org_id + 1)).to eq("ana_pastor")
         end
       end
 
       it "copies non-duplicated usernames following slugization rules" do
-        expect(subject.nicknamize("peter")).to eq("peter")
+        expect(subject.nicknamize("peter", organization.id)).to eq("peter")
       end
 
       it "converts everything to lowercase" do
-        expect(subject.nicknamize("PETER")).to eq("peter")
+        expect(subject.nicknamize("PETER", organization.id)).to eq("peter")
       end
 
       it "slugizes non-duplicated usernames" do
-        expect(subject.nicknamize("Rodríguez San Pedro")).to eq("rodriguez_san_pedro")
+        expect(subject.nicknamize("Rodríguez San Pedro", organization.id)).to eq("rodriguez_san_pedro")
       end
 
       it "trims very long usernames" do
-        nickname = subject.nicknamize("Felipe Juan Froilan de todos los Santos")
+        nickname = subject.nicknamize("Felipe Juan Froilan de todos los Santos", organization.id)
         expect(nickname).to eq("felipe_juan_froilan_")
         expect(nickname.length).to eq(20)
       end
@@ -49,13 +51,13 @@ module Decidim
         it "resolves conflicts with current nicknames" do
           create(factory, nickname: "ana_pastor")
 
-          expect(subject.nicknamize("ana_pastor")).to eq("ana_pastor_2")
+          expect(subject.nicknamize("ana_pastor", organization.id)).to eq("ana_pastor_2")
         end
 
         it "resolves conflicts with long current nicknames" do
           create(factory, nickname: "felipe_rocks_so_much")
 
-          expect(subject.nicknamize("Felipe Rocks So Much")).to eq("felipe_rocks_so_mu_2")
+          expect(subject.nicknamize("Felipe Rocks So Much", organization.id)).to eq("felipe_rocks_so_mu_2")
         end
 
         it "resolves conflicts with other existing nicknames" do
@@ -63,7 +65,7 @@ module Decidim
           create(factory, nickname: "existing_1")
           create(factory, nickname: "existing_2")
 
-          expect(subject.nicknamize("existing")).to eq("existing_3")
+          expect(subject.nicknamize("existing", organization.id)).to eq("existing_3")
         end
       end
 

--- a/decidim-dev/app/presenters/decidim/dev/official_author_presenter.rb
+++ b/decidim-dev/app/presenters/decidim/dev/official_author_presenter.rb
@@ -8,7 +8,7 @@ module Decidim
       end
 
       def nickname
-        Decidim::UserBaseEntity.nicknamize(name)
+        ""
       end
 
       def deleted?

--- a/decidim-dev/app/presenters/decidim/dev/official_author_presenter.rb
+++ b/decidim-dev/app/presenters/decidim/dev/official_author_presenter.rb
@@ -8,7 +8,7 @@ module Decidim
       end
 
       def nickname
-        ""
+        "decidim_dev_official"
       end
 
       def deleted?

--- a/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
@@ -79,7 +79,7 @@ module Decidim
             end
           else
             user.name = form.name
-            user.nickname = User.nicknamize(user.name, organization: user.organization)
+            user.nickname = User.nicknamize(user.name, user.decidim_organization_id)
             invite_user_to_sign_up
             create_invitation!
           end


### PR DESCRIPTION
#### :tophat: What? Why?

Previously, the `nicknamize` method accepted a custom scope, which could lead to performance issues. This was due to the fact that the users table has a composite index on nickname and organization id, and queries that didn't include organization id might not use the index efficiently (especially problematic on large datasets).

This PR makes the organization id a required parameter in the `nicknamize` method and removes support for passing a custom scope. This ensures that queries consistently leverage the composite index and avoids potential performance bottlenecks.

Additionally, I fixed an issue in `Decidim::EphemeralUserForm`, where the organization was not being included in the scope passed to the `nicknamize` method.

#### Testing

Just try to create a new user as usual and nothing should change, as this is an internal fix.

:hearts: Thank you!
