### PR TITLE
Add attachments button in proposals

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -63,7 +63,7 @@
                               label: t("decidim.proposals.proposals.edit.add_attachments"),
                               button_label: t("decidim.proposals.proposals.edit.add_attachments"),
                               button_edit_label: t("decidim.proposals.proposals.edit.edit_attachments"),
-                              button_class: "button button__lg button__transparent-secondary mt-2 md:w-auto w-full",
+                              button_class: "button button__sm button__transparent-secondary mt-2 md:w-auto w-full",
                               help_i18n_scope: "decidim.forms.file_help.file",
                               help_text: t("attachment_legend", scope: "decidim.proposals.proposals.edit") %>
         </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -63,7 +63,7 @@
                               label: t("decidim.proposals.proposals.edit.add_attachments"),
                               button_label: t("decidim.proposals.proposals.edit.add_attachments"),
                               button_edit_label: t("decidim.proposals.proposals.edit.edit_attachments"),
-                              button_class: "button button__lg button__transparent-secondary w-full",
+                              button_class: "button button__lg button__transparent-secondary mt-2 md:w-auto w-full",
                               help_i18n_scope: "decidim.forms.file_help.file",
                               help_text: t("attachment_legend", scope: "decidim.proposals.proposals.edit") %>
         </div>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the "Add Attachments" button responsiveness within proposals on desktop by adding `md:w-auto` and a little margin on top. We've also changed it size from `button__lg` to `button__sm` to resemble more consistency throughout the admin panel. 

#### :pushpin: Related Issues
- Fixes #14662

#### Testing
1. Login.
2. Go to a process and make sure the process has proposals component configured.
3. Click Proposals 
4. Click create a new proposal
5. In the form scroll down to see the "Add attachment" button configured for desktop use

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/6a3cf778-d8e2-463a-857e-c343b957625d)

![image](https://github.com/user-attachments/assets/e1054134-aac9-47fb-a172-5513f67cee7a)


:hearts: Thank you!
