### PR TITLE
Generate a random nickname to ephemeral users

### DIFF
--- a/decidim-core/app/forms/decidim/ephemeral_user_form.rb
+++ b/decidim-core/app/forms/decidim/ephemeral_user_form.rb
@@ -17,7 +17,7 @@ module Decidim
     end
 
     def nickname
-      super || User.nicknamize(name, organization.id)
+      super || User.nicknamize("#{name}_#{SecureRandom.alphanumeric(8)}", organization.id)
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Previously, we used `visitant` as the prefix for all ephemeral users. However, since we rely on the `nicknamize` method to ensure nickname uniqueness, this led to performance issues: each time a new ephemeral user was created, the system performed up to `n` checks (where `n` is the number of existing ephemeral users) to find an available nickname (e.g., `visitant`, `visitant_2`, `visitant_3`, …, `visitant_9000`).

With this change, we append 8 random alphanumeric characters to the `visitant` prefix. This significantly reduces the number of nickname collision checks, preventing performance degradation as the number of ephemeral users increases.

:hearts: Thank you!
