### PR TITLE
Fix pipeline after Crowdin update in `organization_spec.rb`

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -152,6 +152,8 @@ commentvotes
 conferenceinvites
 conferenceregistrations
 confirmada
+confirmado
+confirmat
 Consolas
 constantized
 contingut
@@ -615,6 +617,7 @@ nodistro
 nodoc
 nok
 nomargin
+nombre
 nominatim
 noopen
 nopadding
@@ -765,6 +768,8 @@ reddit
 refactorings
 regexes
 regexps
+registrado
+registrat
 reivindicate
 relogin
 remindable
@@ -990,6 +995,7 @@ uploaders
 upvoted
 upvotes
 upvoting
+usuarias
 usecase
 usename
 usergroup
@@ -1018,6 +1024,7 @@ vkontakte
 vml
 vnd
 voner
+vostre
 votar
 votings
 VPAGQ

--- a/decidim-core/spec/types/organization_spec.rb
+++ b/decidim-core/spec/types/organization_spec.rb
@@ -48,8 +48,8 @@ describe "Decidim::Api::QueryType" do
                  "description" => {
                    "translations" => [
                      { "locale" => "en", "text" => "The total number of users who have signed up and confirmed their account via email." },
-                     { "locale" => "ca", "text" => "The total number of users who have signed up and confirmed their account via email." },
-                     { "locale" => "es", "text" => "The total number of users who have signed up and confirmed their account via email." }
+                     { "locale" => "ca", "text" => "El nombre total d'usuàries que s'han registrat i confirmat el vostre compte per correu electrònic." },
+                     { "locale" => "es", "text" => "El número total de usuarias que se han registrado y confirmado su cuenta por correo electrónico." }
                    ]
                  }
                }])


### PR DESCRIPTION
#### :tophat: What? Why?
After i have merged the Crowdin, i have noticed a broken pipeline caused by missing translations. This PR fixes that. 

:hearts: Thank you!
