### PR TITLE
Fix I18n scoping in Upcoming meeting event

### DIFF
--- a/decidim-meetings/app/events/decidim/meetings/upcoming_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/upcoming_meeting_event.rb
@@ -30,7 +30,7 @@ module Decidim
       end
 
       def default_email_intro
-        I18n.t("decidim.events.meetings.upcoming_meeting.email_intro", **i18n_options)
+        I18n.t("email_intro", **i18n_options)
       end
 
       def custom_message

--- a/decidim-meetings/spec/events/decidim/meetings/upcoming_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/upcoming_meeting_event_spec.rb
@@ -17,6 +17,30 @@ describe Decidim::Meetings::UpcomingMeetingEvent do
     end
   end
 
+  describe "default_email_intro" do
+    context "when custom message is unset" do
+      it "is generated correctly" do
+        allow(subject).to receive(:custom_message).and_return(nil)
+        expect(subject.email_intro).to eq("The \"#{resource_title}\" meeting will start in less than 48h.")
+      end
+    end
+
+    context "when custom message is set" do
+      it "is generated correctly" do
+        resource.reminder_message_custom_content = { "en" => "My custom message that states \"{{meeting_title}}\" starts in {{before_hours}} hours" }
+        expect(subject.email_intro).to eq("My custom message that states \"#{resource_title}\" starts in 48 hours")
+      end
+    end
+
+    context "when custom message has a customized time interval" do
+      it "is generated correctly" do
+        resource.send_reminders_before_hours = 2
+        allow(subject).to receive(:custom_message).and_return(nil)
+        expect(subject.email_intro).to eq("The \"#{resource_title}\" meeting will start in less than 2h.")
+      end
+    end
+  end
+
   describe "resource_text" do
     it "returns the meeting description" do
       expect(subject.resource_text).to eq translated(resource.description)

--- a/decidim-meetings/spec/events/decidim/meetings/upcoming_meeting_event_spec.rb
+++ b/decidim-meetings/spec/events/decidim/meetings/upcoming_meeting_event_spec.rb
@@ -20,7 +20,7 @@ describe Decidim::Meetings::UpcomingMeetingEvent do
   describe "default_email_intro" do
     context "when custom message is unset" do
       it "is generated correctly" do
-        allow(subject).to receive(:custom_message).and_return(nil)
+        resource.reminder_message_custom_content = nil
         expect(subject.email_intro).to eq("The \"#{resource_title}\" meeting will start in less than 48h.")
       end
     end
@@ -35,7 +35,7 @@ describe Decidim::Meetings::UpcomingMeetingEvent do
     context "when custom message has a customized time interval" do
       it "is generated correctly" do
         resource.send_reminders_before_hours = 2
-        allow(subject).to receive(:custom_message).and_return(nil)
+        resource.reminder_message_custom_content = nil
         expect(subject.email_intro).to eq("The \"#{resource_title}\" meeting will start in less than 2h.")
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
While working on #13267, i have seen a spec that fails with the following error : 
```
       ActionView::Template::Error: Translation missing: en.decidim.events.meetings.upcoming_meeting.decidim.events.meetings.upcoming_meeting.email_intro
```
This PR fixes this by correctly scoping the text. 
```
en.decidim.events.meetings.upcoming_meeting.email_intro
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14470

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/2751ab1f-059d-4d93-9ead-61f121dc5555)

:hearts: Thank you!
