### PR TITLE
Re enable the localized specs

### DIFF
--- a/decidim-core/spec/mailers/reported_mailer_spec.rb
+++ b/decidim-core/spec/mailers/reported_mailer_spec.rb
@@ -135,8 +135,7 @@ module Decidim
       let(:default_body) { "has been hidden" }
       let(:locale) { nil }
 
-      # Temporary disabled as we are missing the translations for new actions
-      # include_examples "localised email"
+      include_examples "localised email"
 
       it "includes the participatory space name" do
         expect(email_body(mail)).to include(decidim_escape_translated(moderation.participatory_space.title))


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #14588 we have separated  the automated and manual moderation emails in 2 separated emails . Because we did not had the translations for Catalan, we have disabled the specs, leaving some actions as described in this [comment](https://github.com/decidim/decidim/pull/14588#discussion_r2068224256).

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related: #14588

#### Testing
-  Green pipeline 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
