### PR TITLE
Withdrawn proposals/meetings displayed in the last activity feed

### DIFF
--- a/decidim-core/spec/queries/decidim/last_activity_spec.rb
+++ b/decidim-core/spec/queries/decidim/last_activity_spec.rb
@@ -10,8 +10,13 @@ describe Decidim::LastActivity do
 
   let(:commentable) { create(:dummy_resource, component:) }
   let(:comment) { create(:comment, commentable:) }
+  let!(:proposal_component) { create(:proposal_component) }
+  let!(:withdrawn_proposal) { create(:proposal, :withdrawn, component: proposal_component) }
   let!(:action_log) do
     create(:action_log, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: comment, organization:)
+  end
+  let!(:action_log_for_withdrawn_proposal) do
+    create(:action_log, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: withdrawn_proposal, organization:)
   end
 
   let(:component) do
@@ -33,6 +38,7 @@ describe Decidim::LastActivity do
     allow(Decidim::ActionLog).to receive(:public_resource_types).and_return(
       %w(
         Decidim::Comments::Comment
+        Decidim::Proposals::Proposal
         Decidim::Dev::DummyResource
       )
     )
@@ -44,6 +50,7 @@ describe Decidim::LastActivity do
   describe "#query" do
     it "returns the activities" do
       expect(subject.count).to eq(3)
+      expect(subject).not_to include(action_log_for_withdrawn_proposal)
     end
   end
 end

--- a/decidim-core/spec/queries/decidim/participatory_space_last_activity_spec.rb
+++ b/decidim-core/spec/queries/decidim/participatory_space_last_activity_spec.rb
@@ -11,8 +11,17 @@ describe Decidim::ParticipatorySpaceLastActivity do
 
   let(:commentable) { create(:dummy_resource, component:) }
   let(:comment) { create(:comment, commentable:) }
+  let!(:proposal_component) { create(:proposal_component) }
+  let!(:withdrawn_proposal) { create(:proposal, :withdrawn, component: proposal_component) }
+  let!(:proposal) { create(:proposal, :published, component: proposal_component) }
   let!(:action_log) do
     create(:action_log, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: comment, organization:, participatory_space:)
+  end
+  let!(:action_log_for_withdrawn_proposal) do
+    create(:action_log, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: withdrawn_proposal, organization:, participatory_space:)
+  end
+  let!(:action_log_for_proposal) do
+    create(:action_log, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: proposal, organization:, participatory_space:)
   end
   let(:component) do
     create(:component, :published, participatory_space:)
@@ -32,6 +41,7 @@ describe Decidim::ParticipatorySpaceLastActivity do
     allow(Decidim::ActionLog).to receive(:public_resource_types).and_return(
       %w(
         Decidim::Comments::Comment
+        Decidim::Proposals::Proposal
         Decidim::Dev::DummyResource
       )
     )
@@ -42,8 +52,10 @@ describe Decidim::ParticipatorySpaceLastActivity do
 
   describe "#query" do
     it "returns the activities" do
-      expect(subject.count).to eq(2)
+      expect(subject.count).to eq(3)
       expect(subject).not_to include(another_action_log)
+      expect(subject).not_to include(action_log_for_withdrawn_proposal)
+      expect(subject).to include(action_log_for_proposal)
       expect(subject).to include(action_log)
     end
   end

--- a/decidim-core/spec/system/last_activity_spec.rb
+++ b/decidim-core/spec/system/last_activity_spec.rb
@@ -4,6 +4,9 @@ require "spec_helper"
 
 describe "Last activity" do
   let(:organization) { create(:organization) }
+  let!(:proposal_component) { create(:proposal_component) }
+  let!(:withdrawn_proposal) { create(:proposal, :withdrawn, component: proposal_component) }
+  let!(:proposal) { create(:proposal, :published, component: proposal_component) }
   let(:commentable) { create(:dummy_resource, component:) }
   let(:comment) { create(:comment, commentable:) }
   let!(:action_log) do
@@ -13,6 +16,12 @@ describe "Last activity" do
            participatory_space: comment.participatory_space,
            resource: comment,
            organization:)
+  end
+  let!(:action_log_for_withdrawn_proposal) do
+    create(:action_log, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: withdrawn_proposal, organization:, participatory_space: comment.participatory_space,)
+  end
+  let!(:action_log_for_proposal) do
+    create(:action_log, created_at: 1.day.ago, action: "create", visibility: "public-only", resource: proposal, organization:, participatory_space: comment.participatory_space,)
   end
   let!(:another_action_log) do
     create(:action_log,
@@ -44,6 +53,7 @@ describe "Last activity" do
     allow(Decidim::ActionLog).to receive(:public_resource_types).and_return(
       %w(
         Decidim::Comments::Comment
+        Decidim::Proposals::Proposal
         Decidim::Dev::DummyResource
       )
     )
@@ -62,13 +72,15 @@ describe "Last activity" do
 
     it "displays the activities at the home page" do
       within "#last_activity" do
-        expect(page).to have_css("[data-activity]", count: 3)
+        expect(page).to have_css("[data-activity]", count: 4)
       end
     end
 
     it "shows activities long comment shorten text" do
       expect(page).to have_content(long_body_comment[0..79])
       expect(page).to have_no_content(another_comment.translated_body)
+      expect(page).to have_no_content(withdrawn_proposal.title)
+
     end
 
     context "when there is a deleted comment" do
@@ -89,10 +101,12 @@ describe "Last activity" do
       end
 
       it "shows all activities" do
-        expect(page).to have_css("[data-activity]", count: 3)
+        expect(page).to have_css("[data-activity]", count: 4)
         expect(page).to have_content(translated(resource.title))
         expect(page).to have_content(translated(comment.commentable.title))
         expect(page).to have_content(translated(another_comment.commentable.title))
+        expect(page).to have_content(translated(proposal.title))
+        expect(page).to have_no_content(translated(withdrawn_proposal.title))
       end
 
       it "shows the activities in correct order" do
@@ -164,7 +178,7 @@ describe "Last activity" do
         end
 
         it "works without an empty pagination" do
-          expect(page).to have_css("[data-activity]", count: 3)
+          expect(page).to have_css("[data-activity]", count: 4)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
I have added a new method, `filter_withdrawn,` which filters the results of the last activity query in order to except the withdrawn resources.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/decidim/decidim/issues/8201

#### Testing
1. Create a new proposal/meeting.
2. Go to the 'Last activity' page.
3. Observe the log with the proposal/meeting creation.
4. Withdraw the created proposal/meeting.
5. Go to the 'Last activity' page and observe that the proposal/meeting creation log is not displayed anymore.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

:hearts: Thank you!
