### PR TITLE
Restructure admin settings form

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -5,7 +5,7 @@ module Decidim
     # A command with all the business logic for updating the current
     # organization.
     class UpdateOrganization < Decidim::Commands::UpdateResource
-      fetch_form_attributes :name, :default_locale, :reference_prefix, :time_zone, :twitter_handler,
+      fetch_form_attributes :name, :description, :default_locale, :reference_prefix, :time_zone, :twitter_handler,
                             :facebook_handler, :instagram_handler, :youtube_handler, :github_handler, :badges_enabled,
                             :comments_max_length, :enable_machine_translations, :admin_terms_of_service_body,
                             :rich_text_editor_in_public_views, :enable_participatory_space_filters

--- a/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization_appearance.rb
@@ -7,7 +7,7 @@ module Decidim
     class UpdateOrganizationAppearance < Decidim::Commands::UpdateResource
       fetch_file_attributes :logo, :highlighted_content_banner_image, :favicon, :official_img_footer
 
-      fetch_form_attributes :cta_button_path, :cta_button_text, :description, :official_url,
+      fetch_form_attributes :cta_button_path, :cta_button_text, :official_url,
                             :highlighted_content_banner_enabled, :highlighted_content_banner_action_url,
                             :highlighted_content_banner_title, :highlighted_content_banner_short_description,
                             :highlighted_content_banner_action_title,

--- a/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_appearance_form.rb
@@ -32,7 +32,6 @@ module Decidim
       attribute :tertiary_color, String
 
       translatable_attribute :cta_button_text, String
-      translatable_attribute :description, Decidim::Attributes::RichText
       translatable_attribute :highlighted_content_banner_title, String
       translatable_attribute :highlighted_content_banner_short_description, Decidim::Attributes::RichText
       translatable_attribute :highlighted_content_banner_action_title, String

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -11,6 +11,7 @@ module Decidim
       mimic :organization
 
       translatable_attribute :name, String
+      translatable_attribute :description, Decidim::Attributes::RichText
       attribute :reference_prefix, String
       attribute :time_zone, String
       attribute :twitter_handler, String

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -14,6 +14,10 @@
       </div>
 
       <div class="row column">
+        <%= form.translated :editor, :description, aria: { label: :description } %>
+      </div>
+
+      <div class="row column">
         <%= form.collection_select :default_locale, localized_locales(current_organization.available_locales), :id, :name %>
       </div>
 

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -1,11 +1,110 @@
 <div class="form__wrapper">
-  <div class="card pt-4">
-    <div class="card-section">
+  <div class="card" data-component="accordion" id="accordion-basic_configuration">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-basic_configuration" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title" id="basic_configuration">
+          <%= t(".basic_configuration") %>
+        </h2>
+      </button>
+    </div>
+    <div id="panel-basic_configuration" class="card-section">
       <div class="row column">
-        <div class="columns">
-          <%= form.translated :text_field, :name %>
+        <%= form.translated :text_field, :name %>
+      </div>
+
+      <div class="row column">
+        <%= form.collection_select :default_locale, localized_locales(current_organization.available_locales), :id, :name %>
+      </div>
+
+      <div class="row column">
+        <%= form.time_zone_select :time_zone %>
+      </div>
+
+      <div class="row column">
+        <%= form.text_field :reference_prefix %>
+      </div>
+    </div>
+  </div>
+
+  <div class="card" data-component="accordion" id="accordion-welcome_notification">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-welcome_notification" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title" id="welcome_notification">
+          <%= t(".welcome_notification") %>
+        </h2>
+      </button>
+    </div>
+    <div id="panel-welcome_notification" class="card-section">
+      <div class="row column" id="welcome-notification-details">
+        <%= form.check_box :send_welcome_notification %>
+        <div class="send-welcome-notification-details">
+          <%= form.check_box :customize_welcome_notification %>
+
+          <div class="customize-welcome-notification-details">
+            <%= form.translated :text_field, :welcome_notification_subject, aria: { label: :welcome_notification_subject } %>
+            <%= form.translated :editor, :welcome_notification_body, aria: { label: :welcome_notification_body } %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card" data-component="accordion" id="accordion-admin_terms_of_service">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-admin_terms_of_service" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title" id="admin_terms_of_service">
+          <%= t(".admin_terms_of_service") %>
+        </h2>
+      </button>
+    </div>
+    <div id="panel-admin_terms_of_service" class="card-section">
+      <div class="row column">
+        <%= form.translated :editor, :admin_terms_of_service_body, aria: { label: :admin_terms_of_service_body } %>
+      </div>
+    </div>
+  </div>
+
+  <div class="card" data-component="accordion" id="accordion-extra_features">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-extra_features" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title" id="extra_features">
+          <%= t(".extra_features") %>
+        </h2>
+      </button>
+    </div>
+    <div id="panel-extra_features" class="card-section">
+      <div class="row column">
+        <%= form.check_box :badges_enabled %>
+      </div>
+
+      <div class="row column">
+        <%= form.check_box :enable_participatory_space_filters %>
+      </div>
+
+      <% if Decidim.config.enable_machine_translations %>
+        <div class="row column">
+          <%= form.check_box :enable_machine_translations %>
         </div>
 
+        <div class="row column">
+          <%= form.label :machine_translation_display_priority, t("activemodel.attributes.organization.machine_translation_display_priority") %>
+            <%= form.collection_radio_buttons :machine_translation_display_priority, form.object.machine_translation_priorities, :first, :last %>
+        </div>
+      <% end %>
+
+      <div class="row column">
+        <%= form.check_box :rich_text_editor_in_public_views, help_text: t(".rich_text_editor_in_public_views_help") %>
+      </div>
+
+      <div class="row column">
+        <%= form.text_field :comments_max_length %>
+      </div>
+
+      <div class="row column">
         <div class="columns">
           <div class="label--tabs">
             <label for="organization_social_handlers">
@@ -31,61 +130,6 @@
             <% end %>
           </div>
         </div>
-      </div>
-
-      <div class="row column">
-        <%= form.collection_select :default_locale, localized_locales(current_organization.available_locales), :id, :name %>
-      </div>
-
-      <div class="row column">
-        <%= form.time_zone_select :time_zone %>
-      </div>
-
-      <div class="row column">
-        <%= form.text_field :reference_prefix %>
-      </div>
-
-      <div class="row column">
-        <%= form.check_box :badges_enabled %>
-      </div>
-
-      <div class="row column">
-        <%= form.check_box :enable_participatory_space_filters %>
-      </div>
-
-      <% if Decidim.config.enable_machine_translations %>
-        <div class="row column">
-          <%= form.check_box :enable_machine_translations %>
-        </div>
-
-        <div class="row column">
-          <%= form.label :machine_translation_display_priority, t("activemodel.attributes.organization.machine_translation_display_priority") %>
-            <%= form.collection_radio_buttons :machine_translation_display_priority, form.object.machine_translation_priorities, :first, :last %>
-        </div>
-      <% end %>
-
-      <div class="row column">
-        <%= form.text_field :comments_max_length %>
-      </div>
-
-      <div class="row column">
-        <%= form.check_box :rich_text_editor_in_public_views, help_text: t(".rich_text_editor_in_public_views_help") %>
-      </div>
-
-      <div class="row column" id="welcome-notification-details">
-        <%= form.check_box :send_welcome_notification %>
-        <div class="send-welcome-notification-details">
-          <%= form.check_box :customize_welcome_notification %>
-
-          <div class="customize-welcome-notification-details">
-            <%= form.translated :text_field, :welcome_notification_subject, aria: { label: :welcome_notification_subject } %>
-            <%= form.translated :editor, :welcome_notification_body, aria: { label: :welcome_notification_body } %>
-          </div>
-        </div>
-      </div>
-
-      <div class="row column">
-        <%= form.translated :editor, :admin_terms_of_service_body, aria: { label: :admin_terms_of_service_body } %>
       </div>
     </div>
   </div>

--- a/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization_appearance/_form.html.erb
@@ -9,9 +9,6 @@
       </button>
     </div>
     <div id="panel-homepage_appearance_title" class="card-section">
-      <div class="row column">
-        <%= form.translated :editor, :description, aria: { label: :description } %>
-      </div>
 
     <div class="row">
       <div class="columns slug">

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -879,6 +879,9 @@ en:
           title: Edit organization
           update: Update
         form:
+          admin_terms_of_service: Admin terms of service
+          basic_configuration: Basic configuration
+          extra_features: Extra features
           facebook: Facebook
           github: GitHub
           instagram: Instagram
@@ -887,6 +890,7 @@ en:
           twitter: X
           url: URL
           youtube: YouTube
+          welcome_notification: Welcome notification
         update:
           error: There was a problem updating this organization.
           success: Organization updated successfully.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -889,8 +889,8 @@ en:
           social_handlers: Social
           twitter: X
           url: URL
-          youtube: YouTube
           welcome_notification: Welcome notification
+          youtube: YouTube
         update:
           error: There was a problem updating this organization.
           success: Organization updated successfully.

--- a/decidim-admin/spec/commands/decidim/admin/update_organization_appearance_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_organization_appearance_spec.rb
@@ -10,9 +10,6 @@ module Decidim::Admin
       let(:params) do
         {
           organization: {
-            description_en: "My description",
-            description_es: "Mi descripción",
-            description_ca: "La meva descripció",
             enable_omnipresent_banner: false,
             header_snippets: '<script>alert("Hello");</script>',
             favicon: upload_test_file(Decidim::Dev.test_file("icon.png", "image/png"))

--- a/decidim-admin/spec/commands/decidim/admin/update_organization_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_organization_spec.rb
@@ -11,6 +11,7 @@ module Decidim::Admin
         {
           organization: {
             name: { en: "My super organization" },
+            description: { en: "My super description" },
             reference_prefix: "MSO",
             time_zone: "Hawaii",
             default_locale: "en",
@@ -74,6 +75,7 @@ module Decidim::Admin
           organization.reload
 
           expect(translated(organization.name)).to eq("My super organization")
+          expect(translated(organization.description)).to eq("My super description")
           expect(organization.rich_text_editor_in_public_views).to be(true)
           expect(organization.enable_machine_translations).to be(true)
         end

--- a/decidim-admin/spec/forms/base_organization_form_spec.rb
+++ b/decidim-admin/spec/forms/base_organization_form_spec.rb
@@ -12,6 +12,13 @@ module Decidim
       end
 
       let(:name) { { ca: "", en: "My super organization", es: "" } }
+      let(:description) do
+        {
+          en: "Description, awesome description",
+          es: "Descripción",
+          ca: "Descripció"
+        }
+      end
       let(:reference_prefix) { "MSO" }
       let(:time_zone) { "UTC" }
       let(:twitter_handler) { "My twitter awesome handler" }
@@ -35,6 +42,9 @@ module Decidim
         {
           "organization" => {
             "name" => name,
+            "description_en" => description[:en],
+            "description_es" => description[:es],
+            "description_ca" => description[:ca],
             "reference_prefix" => reference_prefix,
             "time_zone" => time_zone,
             "default_locale" => default_locale,

--- a/decidim-admin/spec/forms/organization_appearance_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_appearance_form_spec.rb
@@ -12,13 +12,6 @@ module Decidim
       end
 
       let(:header_snippets) { "<my-html />" }
-      let(:description) do
-        {
-          en: "Description, awesome description",
-          es: "Descripción",
-          ca: "Descripció"
-        }
-      end
       let(:organization) { create(:organization) }
       let(:cta_button_path) { nil }
       let(:highlighted_content_banner_enabled) { false }
@@ -39,9 +32,6 @@ module Decidim
       let(:attributes) do
         {
           "organization" => {
-            "description_en" => description[:en],
-            "description_es" => description[:es],
-            "description_ca" => description[:ca],
             "show_statics" => false,
             "cta_button_path" => cta_button_path,
             "header_snippets" => header_snippets,

--- a/decidim-admin/spec/system/admin_manages_organization_appearance_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_appearance_spec.rb
@@ -59,12 +59,6 @@ describe "Admin manages organization" do
     it "updates the values from the form" do
       visit decidim_admin.edit_organization_appearance_path
 
-      fill_in_i18n_editor :organization_description,
-                          "#organization-description-tabs",
-                          en: "My own super description",
-                          es: "Mi gran descripción",
-                          ca: "La meva gran descripció"
-
       fill_in "Official organization URL", with: "http://www.example.com"
 
       dynamically_attach_file(:organization_logo, Decidim::Dev.asset("city2.jpeg"))

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -20,6 +20,12 @@ describe "Admin manages organization" do
 
       fill_in_i18n :organization_name, "#organization-name-tabs", **attributes[:name].except("machine_translations")
 
+      fill_in_i18n_editor :organization_description,
+                    "#organization-description-tabs",
+                    en: "My own super description",
+                    es: "Mi gran descripción",
+                    ca: "La meva gran descripció"
+
       %w(X Facebook Instagram YouTube GitHub).each do |network|
         within "#organization_social_handlers" do
           click_on network

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -96,22 +96,22 @@ describe "Admin manages organization" do
         end
 
         it "deletes paragraph changes pressing backspace" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys "ef", [:enter], "gh", [:backspace], [:backspace], [:backspace], [:backspace]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys "ef", [:enter], "gh", [:backspace], [:backspace], [:backspace], [:backspace]
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq("<p>e</p>".gsub("\n", ""))
         end
 
         it "deletes linebreaks when pressing backspace" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys "a", [:left], [:enter], [:shift, :enter], [:backspace], [:backspace]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys "a", [:left], [:enter], [:shift, :enter], [:backspace], [:backspace]
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq("<p>a</p>".gsub("\n", ""))
         end
 
         it "creates and deletes linebreaks with enter, shift+enter and backspace" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys "acd", [:left], [:left]
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter], [:shift, :enter], [:shift, :enter], "b", [:left], [:backspace], [:backspace], [:backspace]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys "acd", [:left], [:left]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter], [:shift, :enter], [:shift, :enter], "b", [:left], [:backspace], [:backspace], [:backspace]
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq("<p>abcd</p>".gsub("\n", ""))
@@ -234,16 +234,16 @@ describe "Admin manages organization" do
         end
 
         it "creates single br tag" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys([:left, :left, :left, :left, :left])
-          find('div[contenteditable="true"].ProseMirror').native.send_keys([:shift, :enter])
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys([:left, :left, :left, :left, :left])
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys([:shift, :enter])
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq('<p>foo<br><br><a target="_blank" href="https://www.decidim.org">link</a></p>')
         end
 
         it "does not create br tag inside a tag" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys([:left, :left, :left, :left])
-          find('div[contenteditable="true"].ProseMirror').native.send_keys([:shift, :enter])
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys([:left, :left, :left, :left])
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys([:shift, :enter])
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq('<p>foo<br><br><a target="_blank" href="https://www.decidim.org">link</a></p>')
@@ -269,7 +269,7 @@ describe "Admin manages organization" do
         end
 
         it "is still editable" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys(Array.new(15) { :backspace }, "bar baz")
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys(Array.new(15) { :backspace }, "bar baz")
           click_on "Update"
           expect(page).to have_content("Organization updated successfully")
           expect(find(
@@ -294,16 +294,16 @@ describe "Admin manages organization" do
         end
 
         it "renders new br tags inside the editor" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter], "Here shift+enter makes line change:", [:shift, :enter], "instead of new paragraph!"
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter], "Here shift+enter makes line change:", [:shift, :enter], "instead of new paragraph!"
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq("#{terms_content}<p>Here shift+enter makes line change:<br>instead of new paragraph!</p>".gsub("\n", ""))
         end
 
         it "makes smartbreak (<br>) when pressing line break button" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter], "foo"
-          find("button[data-editor-type='hardBreak']").click
-          find('div[contenteditable="true"].ProseMirror').native.send_keys "bar"
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter], "foo"
+          find("#organization_admin_terms_of_service_body_en button[data-editor-type='hardBreak']").click
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys "bar"
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq("#{terms_content}<p>foo<br>bar</p>".gsub("\n", ""))
@@ -311,7 +311,7 @@ describe "Admin manages organization" do
 
         describe "editor history" do
           it "has undo" do
-            find('div[contenteditable="true"].ProseMirror').native.send_keys(
+            find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys(
               "foo",
               [:shift, :enter],
               "bar",
@@ -329,7 +329,7 @@ describe "Admin manages organization" do
           end
 
           it "has redo" do
-            find('div[contenteditable="true"].ProseMirror').native.send_keys [:shift, :enter], "X", [:control, "z"], [:control, :shift, "z"]
+            find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:shift, :enter], "X", [:control, "z"], [:control, :shift, "z"]
             expect(find(
               "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
             )["innerHTML"]).to eq("<p>Paragraph</p><p>Some<br>text<br>here</p><p>Another paragraph<br>X</p>".gsub("\n", ""))
@@ -358,67 +358,67 @@ describe "Admin manages organization" do
         end
 
         it "renders new list item" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter], "List item 4"
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter], "List item 4"
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq("<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item 3</p></li><li><p>List item 4</p></li></ul>".gsub("\n", ""))
         end
 
         it "ends the list when pressing enter twice and starts new paragraph" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :enter], "Another paragraph"
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :enter], "Another paragraph"
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq("#{terms_content}<p>Another paragraph</p>".gsub("\n", ""))
         end
 
         it "deletes empty list item when pressing backspace and starts new paragraph" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :backspace, :enter], "Another paragraph"
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :backspace, :enter], "Another paragraph"
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq("#{terms_content}<p>Another paragraph</p>".gsub("\n", ""))
         end
 
         it "deletes linebreaks (and smartbreaks) using the backspace" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :enter, :enter, :backspace, :backspace, :backspace, :backspace]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :enter, :enter, :backspace, :backspace, :backspace, :backspace]
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq(terms_content.to_s.gsub("\n", ""))
         end
 
         it "keeps right cursor position when using the backspace" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter, "bc", :left, :left]
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :backspace, :backspace, "a"]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter, "bc", :left, :left]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :backspace, :backspace, "a"]
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq("<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item 3</p></li><li><p>abc</p></li></ul>".to_s.gsub("\n", ""))
         end
 
         it "keeps right format when using the backspace" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :backspace, "abc", :left, :left, :left, :backspace]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :backspace, "abc", :left, :left, :left, :backspace]
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq("<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item 3abc</p></li></ul>".to_s.gsub("\n", ""))
         end
 
         it "keeps right cursor position when using backspace after empty list item" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter, "bcd", :left, :left, :left]
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :enter, :enter, :backspace, :backspace, :backspace, :backspace, :backspace, :backspace, "a"]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter, "bcd", :left, :left, :left]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :enter, :enter, :backspace, :backspace, :backspace, :backspace, :backspace, :backspace, "a"]
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq("<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item 3</p></li><li><p>abcd</p></li></ul>".to_s.gsub("\n", ""))
         end
 
         it "keeps right cursor position when using backspace after list item with text" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter, "acd", :left, :left]
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :backspace, :backspace, :enter, :enter, :backspace, :backspace, :backspace, :backspace, "b"]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter, "acd", :left, :left]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :backspace, :backspace, :enter, :enter, :backspace, :backspace, :backspace, :backspace, "b"]
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq("<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item 3</p></li><li><p>abcd</p></li></ul>".to_s.gsub("\n", ""))
         end
 
         it "does not delete characters below when pressing backspace" do
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:up, :up, :up, :home, "a", :backspace]
-          find('div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :enter, :enter, :backspace, :backspace, :backspace]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:up, :up, :up, :home, "a", :backspace]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys [:enter, :enter, :enter, :backspace, :backspace, :backspace]
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
           )["innerHTML"]).to eq(terms_content.to_s.gsub("\n", ""))
@@ -484,7 +484,7 @@ describe "Admin manages organization" do
 
         it "parses the pasted content correctly with the strong element" do
           # Focus the editor before sending the paste event
-          find('div[contenteditable="true"].ProseMirror').native.send_keys "a", [:backspace]
+          find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys "a", [:backspace]
 
           page.execute_script(
             <<~JS
@@ -507,7 +507,7 @@ describe "Admin manages organization" do
         let(:organization) { create(:organization, admin_terms_of_service_body: {}) }
 
         it "saves the content correctly with the video" do
-          within ".editor" do
+          within "#organization_admin_terms_of_service_body_en.editor" do
             within ".editor .editor-toolbar" do
               find("button[data-editor-type='videoEmbed']").click
             end

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -21,10 +21,10 @@ describe "Admin manages organization" do
       fill_in_i18n :organization_name, "#organization-name-tabs", **attributes[:name].except("machine_translations")
 
       fill_in_i18n_editor :organization_description,
-                    "#organization-description-tabs",
-                    en: "My own super description",
-                    es: "Mi gran descripción",
-                    ca: "La meva gran descripció"
+                          "#organization-description-tabs",
+                          en: "My own super description",
+                          es: "Mi gran descripción",
+                          ca: "La meva gran descripció"
 
       %w(X Facebook Instagram YouTube GitHub).each do |network|
         within "#organization_social_handlers" do


### PR DESCRIPTION
#### :tophat: What? Why?

This PR restructure the admin settings form so it is easy to work with

#### :pushpin: Related Issues
 
- Fixes #14722 

#### Testing

1. Sign in as admin
2. Go to http://localhost:3000/admin/organization/edit

### :camera: Screenshots

#### Before 

![image](https://github.com/user-attachments/assets/9511ca28-b6ae-447a-a1ef-675dfa9b0680)


#### After

![image](https://github.com/user-attachments/assets/41ab5fa6-02ee-419e-bf37-1e3d1d71ac87)

:hearts: Thank you!
