### PR TITLE
Renamed Projects entires to Milestones in accountability

### DIFF
--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -52,9 +52,9 @@ en:
         import_csv: Import results from CSV file
         new_result: New result
         new_status: New status
-        new_timeline_entry: New timeline entry
+        new_timeline_entry: New milestone
         preview: Preview
-        timeline_entries: Project evolution
+        timeline_entries: Milestones
         title: Actions
         view_deleted_results: View deleted results
       admin:
@@ -195,7 +195,7 @@ en:
             title: Edit entry
             update: Update entry
           index:
-            title: Project timeline entries
+            title: Milestones entries
           new:
             create: Create entry
             title: New entry


### PR DESCRIPTION
#### :tophat: What? Why?
Confusing terminology, "Projects" used to describe new entries in Accountability were not up to date with widely used Project Management terminology. "Project Evolution", including the index title and new entries have been changed to "Milestones".

#### :pushpin: Related Issues
- Fixes #14697 

#### Testing
1. Login as a Admin
2. Head go to the admin panel and go to Assemblies
3. Click the Accountability component
4. Hover over the actions to see the i18n translation changed to "Milestones"
5. Click on "Milestones" and see the title change to "Milestones entires" and "New Milestone". 

### :camera: Screenshots
"Milestone" action
![Screenshot from 2025-05-20 11-13-01](https://github.com/user-attachments/assets/f5d1b1bd-5378-47ac-8706-80210d8d4a9d)


Newly named "Milestone" index 
![image](https://github.com/user-attachments/assets/77577e72-eece-4a42-9ef6-829990e875af)

:hearts: Thank you!
