### PR TITLE
Fix accessibility in extra_data content_block cell in process show page

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_extra_data/extra_data.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_extra_data/extra_data.erb
@@ -2,10 +2,10 @@
   <div class="participatory-space__metadata-item">
     <div class="participatory-space__metadata-item-title">
       <%= icon item[:icon] %>
-      <span><%= item[:title] %></span>
+      <h2><%= item[:title] %></h2>
     </div>
     <% if item[:text].present? %>
-      <%= content_tag :span, item[:text] %>
+      <%= content_tag :p, item[:text] %>
     <% elsif item[:partial].present? %>
       <%= render item[:partial] %>
     <% end %>


### PR DESCRIPTION
🎩 What? Why?
This PR updates tthe extra_data cell in participatory_process content_block participatory_space_extra_data, replacing:
- a span by an h2 for a title
- a span by a p for a text

📌 Related to
These changes address accessibility concerns highlighted during the city of Lyon rgaa audit (page 31 of the audit, paragraphs 8.9 and 9.1), and align with WCAG standards:

https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships

#### Testing

1. As an admin, go to a participatory process
2. Go to Phases tab, and add phases to it
3. Go to Landing page tab, and add Phase & Duration block in the active blocks.
4. Go to the participatory process show page
5. Navigate in the page with Voice Over and ear that the title and text of the phases are correctly identified

### :camera: Screenshots
<img width="796" alt="426116071-6f938975-89de-47b4-900f-68917866f164" src="https://github.com/user-attachments/assets/1ae4320b-0474-4f90-b80a-1332a2e0322b" />


:hearts: Thank you!
