### PR TITLE
Removed "Decidim::DestroyAccount" left behind user data

### DIFF
--- a/decidim-core/app/commands/decidim/destroy_account.rb
+++ b/decidim-core/app/commands/decidim/destroy_account.rb
@@ -19,6 +19,8 @@ module Decidim
         destroy_user_account!
         destroy_user_identities
         destroy_follows
+        destroy_user_authorizations
+        destroy_user_versions
         destroy_participatory_space_private_user
         delegate_destroy_to_participatory_spaces
       end
@@ -49,6 +51,14 @@ module Decidim
 
     def destroy_user_identities
       current_user.identities.destroy_all
+    end
+
+    def destroy_user_versions
+      current_user.versions.destroy_all
+    end
+
+    def destroy_user_authorizations
+      Decidim::Authorization.where(decidim_user_id: current_user.id).destroy_all
     end
 
     def destroy_follows


### PR DESCRIPTION
#### :tophat: What? Why?
 I have added two methods, `destroy_user_authorizations` and `destroy_user_versions`, that are called on the DestroyAccount command. These two methods will search and destroy all the versions and authorizations related to the deleted user.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/decidim/decidim/issues/10608

#### Testing
1. Create an account.
2. Go to _My Account -> Authorizations_ and set one or more verification methods. 
    _*Available authorizations can be set from the system admin panel_
3. Go to _My Account -> Delete my account_, and delete the account. 
4. Check the `Decidim::Authorization`  table and observe that there is no data associated with the deleted user. 
5. Check the user version and observe that there is no data associated with the deleted user. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

:hearts: Thank you!
