### PR TITLE
Fix wcag process titles hierarchy

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_extra_data/extra_data.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_extra_data/extra_data.erb
@@ -1,9 +1,9 @@
 <% extra_data_items.each do |item| %>
   <div class="participatory-space__metadata-item">
-    <div class="participatory-space__metadata-item-title">
+    <h3 class="participatory-space__metadata-item-title">
       <%= icon item[:icon] %>
-      <span><%= item[:title] %></span>
-    </div>
+      <%= item[:title] %>
+    </h3>
     <% if item[:text].present? %>
       <%= content_tag :span, item[:text] %>
     <% elsif item[:partial].present? %>


### PR DESCRIPTION
🎩 What?
This change improves accessibility on the Process Show Page by correcting the heading structure:

Replaced a <div> and <span> used visually as section titles with a semantic <h3> element.
This ensures that assistive technologies correctly identify these elements as headings, improving navigation and readability.
It aligns with:

WCAG 1.3.1 – Info and Relationships: headings are now programmatically conveyed, not just visually styled.
WCAG 2.4.6 – Headings and Labels: headings describe page structure and sections in a clear, accessible way.

🎯 Why?
This issue comes from an accessibility audit funded by the City of Lyon, targeting compliance with RGAA (page 62 of the audit, paragraph 9.1 presence de titre de hiérarchies simulé)

Improvements:

Ensures proper heading hierarchy for assistive technologies.
Allows screen readers to recognize section titles correctly.
Enhances keyboard navigation and WCAG compliance.
📌 Related
WCAG Criterion: [1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships)
WCAG Criterion: [2.4.6 - Headings and Labels](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels)

✅ Steps to Test

Navigate to any Process page.
Confirm that the element previously styled as a title (class: participatory-space__metadata-item-title) is now a <h3>.
Activate a screen reader (VoiceOver on macOS / NVDA on Windows).
Navigate through the page headings:
Verify that the new h3 is announced properly as a heading.

### :camera: Screenshots
<img width="1368" alt="417212400-d7eab8d0-d430-42c9-8095-e3c89a524c6b" src="https://github.com/user-attachments/assets/0375762d-bfab-4c65-87c2-fedd4b8f756e" />


:hearts: Thank you!
