### PR TITLE
Fix warning for 'user-follow-line' icon

### DIFF
--- a/decidim-conferences/lib/decidim/conferences/engine.rb
+++ b/decidim-conferences/lib/decidim/conferences/engine.rb
@@ -62,7 +62,6 @@ module Decidim
 
         Decidim.icons.register(name: "film-line", icon: "film-line", category: "system", description: "", engine: :conferences)
         Decidim.icons.register(name: "ticket-line", icon: "ticket-line", category: "system", description: "", engine: :conferences)
-        Decidim.icons.register(name: "user-follow-line", icon: "user-follow-line", category: "system", description: "", engine: :conferences)
         Decidim.icons.register(name: "link-m", icon: "link-m", category: "system", description: "", engine: :conferences)
       end
 

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -119,6 +119,7 @@ module Decidim
         Decidim.icons.register(name: "close-circle-line", icon: "close-circle-line", category: "system", description: "", engine: :core)
         Decidim.icons.register(name: "contacts-line", icon: "contacts-line", category: "system", description: "", engine: :core)
         Decidim.icons.register(name: "user-settings-line", icon: "user-settings-line", category: "system", description: "", engine: :core)
+        Decidim.icons.register(name: "user-follow-line", icon: "user-follow-line", category: "system", description: "", engine: :core)
         Decidim.icons.register(name: "user-star-line", icon: "user-star-line", category: "system", description: "", engine: :core)
         Decidim.icons.register(name: "user-add-line", icon: "user-add-line", category: "system", description: "", engine: :core)
         Decidim.icons.register(name: "share-forward-line", icon: "share-forward-line", category: "system", description: "", engine: :core)

--- a/decidim-meetings/lib/decidim/meetings/engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/engine.rb
@@ -73,7 +73,6 @@ module Decidim
         Decidim.icons.register(name: "bill-line", icon: "bill-line", category: "system", description: "", engine: :meetings)
         Decidim.icons.register(name: "add-box-line", icon: "add-box-line", category: "system", description: "", engine: :meetings)
         Decidim.icons.register(name: "calendar-close-line", icon: "calendar-close-line", category: "system", description: "", engine: :meetings)
-        Decidim.icons.register(name: "user-follow-line", icon: "user-follow-line", category: "system", description: "", engine: :meetings)
       end
 
       initializer "decidim_meetings.content_processors" do |_app|


### PR DESCRIPTION
#### :tophat: What? Why?

There's a warning when running some specs. This PR fixes it.  

#### Testing

```
$ bin/rspec decidim-admin/spec/system/admin_manages_organization_spec.rb
DEPRECATION WARNING: user-follow-line already registered. {"name"=>"user-follow-line", "icon"=>"user-follow-line", "description"=>"", "category"=>"system", "engine"=>:meetings} (called from block in <class:Engine> at /home/apereira/Work/decidim/decidim/decidim-conferences/lib/decidim/conferences/engine.rb:65)

(...)
```

:hearts: Thank you!
