### PR TITLE
Fix bug with checking a data-toggler check_box

### DIFF
--- a/decidim-core/app/packs/src/decidim/toggle.js
+++ b/decidim-core/app/packs/src/decidim/toggle.js
@@ -27,7 +27,6 @@ export default function createToggle(component) {
       const node = document.getElementById(id)
 
       if (node) {
-        node.hidden = !node.hidden
         node.setAttribute("aria-expanded", !node.hidden);
       }
     });


### PR DESCRIPTION
#### :tophat: What? Why?

While working on #14736, I found a bug with the data-toggler when using it with a check_box when it isn't checked. This PR fixes this bug. 

I thought this was a browser dependant issue, but I could reproduce this both with Firefox and with Google Chrome.
 
#### Testing

1. Sign in as admin
2. Go to a meeting edit form
3. Leave the "Send a reminder for this meeting" unchecked and Update this form
4. Go back to the same form 
5. Check "Send a reminder for this meeting" checkbox
6. (Before this patch) See that the other fields aren't shown 
6. (After this patch) See that the fields are shown 

### :camera: Screenshots

Screenshot of the bug: 

![image](https://github.com/user-attachments/assets/f7827a7d-ad72-42b2-aa2a-e32b6ea9ebcd)

:hearts: Thank you!
