### PR TITLE
Fix flaky spec in announcements

### DIFF
--- a/decidim-core/lib/decidim/core/test/shared_examples/announcements_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/announcements_examples.rb
@@ -14,6 +14,8 @@ shared_examples "manage announcements" do
 
     click_on "Update"
 
+    expect(page).to have_content "The component was updated successfully"
+
     visit main_component_path(current_component)
 
     within page.find("[data-announcement]", match: :first) do
@@ -47,6 +49,8 @@ shared_examples "manage announcements" do
       )
 
       click_on "Update"
+
+      expect(page).to have_content "The component was updated successfully"
 
       visit main_component_path(current_component)
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR tries to fix a flaky spec in announcements shared example. 

For what I could see, sometimes the example expects to be in the public page but it is actually still in the admin page. My hypothesis is that there's some kind of a race condition betwwen the click in the Update button and the visit to the public page, where sometimes the Update isn't finished and it gets redirected to the admin panel. By actually checking that the update is finished it seems to work much better according to my testing.

#### :pushpin: Related Issues

- Related to https://github.com/decidim/decidim/actions/runs/15273535733/job/43026577495?pr=14713 here it failed 5 times in a row. I could also reproduce this with the Debates component

#### Testing

Run the following Fish shell oneliner (or translate it to Bash first if you want). It should pass always. To be honest I think I got another flaky at least one, related to a session close, but this is out of the scope of the current PR :)

```shell
for i in (seq 1 50) ; echo $i ; bin/rspec decidim-debates/spec/system/admin_manages_debates_spec.rb:17 || break ; end
```

### Stacktrace

This is the stacktrace of the failure:

```
Admin manages debates
  behaves like manage announcements
    customize a general announcement for the component
    when the general announcement is set
      customize an announcement for the current step and it has more priority (FAILED - 1)

Failures:

  1) Admin manages debates behaves like manage announcements when the general announcement is set customize an announcement for the current step and it has more priority
     Failure/Error: raise Capybara::ElementNotFound, "Unable to find #{query.applied_description}" if result.empty?

     Capybara::ElementNotFound:
       Unable to find css "[data-announcement]"

     [Screenshot Image]: file:///home/apereira/Work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_debates_behaves_like_manage_announcements_when_the_general_announcement_is_set_customize_an_announcement_for_the_current_step_and_it_has_more_priority_391.png

     [Screenshot HTML]: file:///home/apereira/Work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_debates_behaves_like_manage_announcements_when_the_general_announcement_is_set_customize_an_announcement_for_the_current_step_and_it_has_more_priority_391.html
``` 

### :camera: Screenshots

This is the screenshot of the failure: 
![failures_r_spec_example_groups_admin_manages_debates_behaves_like_manage_announcements_when_the_general_announcement_is_set_customize_an_announcement_for_the_current_step_and_it_has_more_priority_391](https://github.com/user-attachments/assets/aae58541-05b3-40f6-80e0-f3e1a1178469)


:hearts: Thank you!
