### PR TITLE
Hide empty announcement block when no text is present

### DIFF
--- a/decidim-core/app/views/decidim/shared/_component_announcement.html.erb
+++ b/decidim-core/app/views/decidim/shared/_component_announcement.html.erb
@@ -1,5 +1,5 @@
 <% announcement = translated_attribute(current_settings.announcement).presence || translated_attribute(component_settings.announcement).presence %>
-<% if announcement %>
+<% if strip_tags(announcement).present? %>
   <section class="layout-main__section">
     <%= cell("decidim/announcement", announcement, local_assigns.merge(callout_class: "editor-content")) %>
   </section>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes a bug where the **announcement block** was still being displayed even when no actual content was present.

Until version 0.28, announcements were only shown when there was real text. However, due to HTML tags being saved (e.g., `<p></p>`) when the textarea had been filled and then emptied, the frontend would still render the block.

Now we strip HTML tags and whitespace from the announcement content to make sure it's truly empty before rendering it.

#### :pushpin: Related Issues
- Related to [#?](https://3.basecamp.com/4186608/buckets/11242950/todos/8504985236)

#### Testing
1. Go to the back office (BO) and edit any component that has no announcement.
2. Add announcement text → save → check that it appears on the public page.
3. Go back to BO and delete the text → save again.
4. Confirm that the announcement block no longer appears on the public page.

:hearts: Thank you!
