### PR TITLE
Fix opinion buttons on comments for accessibility

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comment_form/opinion.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment_form/opinion.erb
@@ -1,5 +1,5 @@
 <div>
-  <span class="comment__opinion-label"><%= t("decidim.components.add_comment_form.opinion.label") %></span>
+  <p class="comment__opinion-label"><%= t("decidim.components.add_comment_form.opinion.label") %></p>
   <div data-opinion-toggle class="comment__opinion-container">
     <button type="button" aria-pressed="false" data-toggle-ok="true" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.positive_selected") %>">
       <span><%= t("decidim.components.comment.alignment.in_favor") %></span>

--- a/decidim-comments/app/cells/decidim/comments/comment_form/opinion.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment_form/opinion.erb
@@ -1,11 +1,11 @@
 <div>
-  <p class="comment__opinion-label"><%= t("decidim.components.add_comment_form.opinion.label") %></p>
+  <p id="opinion" class="comment__opinion-label"><%= t("decidim.components.add_comment_form.opinion.label") %></p>
   <div data-opinion-toggle class="comment__opinion-container">
-    <button type="button" aria-pressed="false" data-toggle-ok="true" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.positive_selected") %>">
+    <button type="button" aria-pressed="false" aria-describedby="opinion" data-toggle-ok="true" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.positive_selected") %>">
       <span><%= t("decidim.components.comment.alignment.in_favor") %></span>
       <%= icon "thumb-up-line" %>
     </button>
-    <button type="button" aria-pressed="false" data-toggle-ko="true" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.negative_selected") %>">
+    <button type="button" aria-pressed="false" aria-describedby="opinion" data-toggle-ko="true" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.negative_selected") %>">
       <span><%= t("decidim.components.comment.alignment.against") %></span>
       <%= icon "thumb-down-line" %>
     </button>

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -377,6 +377,7 @@ export default class CommentsComponent {
 
     $opinionButtons.removeClass("is-active").attr("aria-pressed", "false");
     $btn.addClass("is-active").attr("aria-pressed", "true");
+    $btn.css("fontWeight","bold");
 
     if ($btn.data("toggleOk")) {
       $alignment.val(1);

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -377,7 +377,7 @@ export default class CommentsComponent {
 
     $opinionButtons.removeClass("is-active").attr("aria-pressed", "false");
     $btn.addClass("is-active").attr("aria-pressed", "true");
-    $btn.css("fontWeight","bold");
+    $btn.css("fontWeight", "bold");
 
     if ($btn.data("toggleOk")) {
       $alignment.val(1);


### PR DESCRIPTION
#### :tophat: What? Why?
This PR renders more accessible the opinion buttons on comments, by
- adding a bold style to the selected button (criterias 1.3.1 and 1.41 from WCAG)
- adding a aria-describedby on the buttons (criterias 2.5.3 and 4.1.2 from WCAG)

This also changes a meaningless span tag for a p tag, for the text associated to the buttons (criteria 1.3.1 from WCAG).

Those changes were raised in the audit of Angers city (page 90). In the audit on 0.29 version of decidim, the problem was identified in Proposals, but it is still present on Debates for the actual version of decidim.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/issues/14780

#### Testing
As a logged in user, go to the show page of a debate that has comments_layout set to "two-columns"
In the new comment to add, click on one of the buttons 'in favor" or "against".
See that the selected button is bold.
Open your inspector and check that the changes described in what? paragraph above are applied

### :camera: Screenshots
<img width="862" alt="449148028-fdffcbb3-f63d-4b29-8865-e9ad8d27751e" src="https://github.com/user-attachments/assets/b1512d0d-a604-4845-85f1-c1652b1f12f4" />


:hearts: Thank you!
