### PR TITLE
Fix proposal deprecation warning for state alias

### DIFF
--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -242,9 +242,6 @@ module Decidim
         proposal_state&.token || "not_answered"
       end
 
-      # This is only used to define the setter, as the getter will be overridden below.
-      alias_attribute :internal_state, :state
-
       # Public: Returns the internal state of the proposal.
       #
       # Returns Boolean.


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes a rails 7.1 deprecation warning required for rails 7.2 upgrade.

```
DEPRECATION WARNING: Decidim::Proposals::Proposal model aliases `state`, but `state` is not an attribute. Starting in Rails 7.2, alias_attribute with non-attribute targets will raise. Use `alias_method :internal_state, :state` or define the method manually. (called from block (2 levels) in <top (required)> at /home/runner/work/decidim/decidim/decidim-proposals/spec/system/comments_spec.rb:8)
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13267 
- Related to #14784 

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![image](https://github.com/user-attachments/assets/08efb74f-8847-418d-9e4e-723e281ff79a)

:hearts: Thank you!
