### PR TITLE
Fix `NoMethodError` when uploading a file with bullet enabled

### DIFF
--- a/decidim-core/app/forms/decidim/upload_validation_form.rb
+++ b/decidim-core/app/forms/decidim/upload_validation_form.rb
@@ -79,7 +79,7 @@ module Decidim
     class AttachmentContextProxy
       attr_reader :organization, :attachment_context
 
-      delegate :id, :_read_attribute, to: :organization
+      delegate :id, :_read_attribute, :read_attribute, to: :organization
 
       def initialize(organization, attachment_context)
         @organization = organization


### PR DESCRIPTION
While reviewing #14807, i have noticed the upload is not working, as the uploader fails with `NoMethodError (undefined method `read_attribute' for an instance of Decidim::UploadValidationForm::AttachmentContextProxy)`. This PR fixes it.

This seems to be an error caused by latest version of Rails combined with Bullet. 

<details>
<summary>Stacktrace</summary>

```
00:34:36 web.1         | bullet (8.0.8) lib/bullet/ext/object.rb:29:in `bullet_join_potential_composite_primary_key'
00:34:36 web.1         | bullet (8.0.8) lib/bullet/ext/object.rb:22:in `bullet_primary_key_value'
00:34:36 web.1         | bullet (8.0.8) lib/bullet/detector/n_plus_one_query.rb:46:in `block in add_possible_objects'
00:34:36 web.1         | bullet (8.0.8) lib/bullet/detector/n_plus_one_query.rb:42:in `map'
00:34:36 web.1         | bullet (8.0.8) lib/bullet/detector/n_plus_one_query.rb:42:in `add_possible_objects'
00:34:36 web.1         | bullet (8.0.8) lib/bullet/active_record72.rb:271:in `reader'
00:34:36 web.1         | activerecord (7.2.2.1) lib/active_record/associations/builder/association.rb:104:in `attached_to'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/app/models/decidim/attachment.rb:31:in `organization'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/lib/decidim/has_upload_validations.rb:62:in `maximum_upload_size'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/lib/decidim/has_upload_validations.rb:11:in `block in validates_upload'
00:34:36 web.1         | file_validators (3.0.0) lib/file_validators/validators/file_size_validator.rb:64:in `check_errors'
00:34:36 web.1         | file_validators (3.0.0) lib/file_validators/validators/file_size_validator.rb:27:in `block in validate_each'
00:34:36 web.1         | file_validators (3.0.0) lib/file_validators/validators/file_size_validator.rb:26:in `each'
00:34:36 web.1         | file_validators (3.0.0) lib/file_validators/validators/file_size_validator.rb:26:in `validate_each'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/app/validators/passthru_validator.rb:45:in `block in validate_each'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/app/validators/passthru_validator.rb:39:in `each'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/app/validators/passthru_validator.rb:39:in `validate_each'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/app/forms/decidim/upload_validation_form.rb:44:in `file_validators'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:362:in `block in make_lambda'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:179:in `block in call'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:668:in `block (2 levels) in default_terminator'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:667:in `catch'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:667:in `block in default_terminator'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:180:in `call'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:559:in `block in invoke_before'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:559:in `each'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:559:in `invoke_before'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:109:in `run_callbacks'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:913:in `_run_validate_callbacks'
00:34:36 web.1         | activemodel (7.2.2.1) lib/active_model/validations.rb:441:in `run_validations!'
00:34:36 web.1         | activemodel (7.2.2.1) lib/active_model/validations.rb:366:in `valid?'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/lib/decidim/attribute_object/form.rb:157:in `valid?'
00:34:36 web.1         | activemodel (7.2.2.1) lib/active_model/validations.rb:403:in `invalid?'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/app/commands/decidim/validate_upload.rb:10:in `call'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/lib/decidim/command.rb:19:in `call'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/app/controllers/decidim/upload_validations_controller.rb:15:in `create'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_controller/metal/basic_implicit_render.rb:8:in `send_action'
00:34:36 web.1         | actionpack (7.2.2.1) lib/abstract_controller/base.rb:226:in `process_action'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_controller/metal/rendering.rb:193:in `process_action'
00:34:36 web.1         | actionpack (7.2.2.1) lib/abstract_controller/callbacks.rb:261:in `block in process_action'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:121:in `block in run_callbacks'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/core_ext/time/zones.rb:65:in `use_zone'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb:21:in `use_organization_time_zone'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:130:in `block in run_callbacks'
00:34:36 web.1         | i18n (1.14.7) lib/i18n.rb:353:in `with_locale'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/app/controllers/concerns/decidim/locale_switcher.rb:24:in `switch_locale'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:130:in `block in run_callbacks'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:141:in `run_callbacks'
00:34:36 web.1         | actionpack (7.2.2.1) lib/abstract_controller/callbacks.rb:260:in `process_action'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_controller/metal/rescue.rb:27:in `process_action'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_controller/metal/instrumentation.rb:77:in `block in process_action'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/notifications.rb:210:in `block in instrument'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/notifications/instrumenter.rb:58:in `instrument'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/notifications.rb:210:in `instrument'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_controller/metal/instrumentation.rb:76:in `process_action'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_controller/metal/params_wrapper.rb:259:in `process_action'
00:34:36 web.1         | activerecord (7.2.2.1) lib/active_record/railties/controller_runtime.rb:39:in `process_action'
00:34:36 web.1         | actionpack (7.2.2.1) lib/abstract_controller/base.rb:163:in `process'
00:34:36 web.1         | actionview (7.2.2.1) lib/action_view/rendering.rb:40:in `process'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_controller/metal.rb:252:in `dispatch'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_controller/metal.rb:335:in `dispatch'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:50:in `serve'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:53:in `block in serve'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `each'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `find_routes'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:34:in `serve'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:896:in `call'
00:34:36 web.1         | railties (7.2.2.1) lib/rails/engine.rb:535:in `call'
00:34:36 web.1         | railties (7.2.2.1) lib/rails/railtie.rb:226:in `public_send'
00:34:36 web.1         | railties (7.2.2.1) lib/rails/railtie.rb:226:in `method_missing'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/routing/mapper.rb:33:in `block in <class:Constraints>'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/routing/mapper.rb:62:in `serve'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:53:in `block in serve'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `each'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `find_routes'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:34:in `serve'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:896:in `call'
00:34:36 web.1         | batch-loader (2.0.5) lib/batch_loader/middleware.rb:11:in `call'
00:34:36 web.1         | bullet (8.0.8) lib/bullet/rack.rb:21:in `call'
00:34:36 web.1         | omniauth (2.1.3) lib/omniauth/strategy.rb:202:in `call!'
00:34:36 web.1         | omniauth (2.1.3) lib/omniauth/strategy.rb:169:in `call'
00:34:36 web.1         | omniauth (2.1.3) lib/omniauth/strategy.rb:202:in `call!'
00:34:36 web.1         | omniauth (2.1.3) lib/omniauth/strategy.rb:169:in `call'
00:34:36 web.1         | omniauth (2.1.3) lib/omniauth/strategy.rb:202:in `call!'
00:34:36 web.1         | omniauth (2.1.3) lib/omniauth/strategy.rb:169:in `call'
00:34:36 web.1         | omniauth (2.1.3) lib/omniauth/strategy.rb:202:in `call!'
00:34:36 web.1         | omniauth (2.1.3) lib/omniauth/strategy.rb:169:in `call'
00:34:36 web.1         | omniauth (2.1.3) lib/omniauth/builder.rb:44:in `call'
00:34:36 web.1         | warden (1.2.9) lib/warden/manager.rb:36:in `block in call'
00:34:36 web.1         | warden (1.2.9) lib/warden/manager.rb:34:in `catch'
00:34:36 web.1         | warden (1.2.9) lib/warden/manager.rb:34:in `call'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/lib/decidim/middleware/strip_x_forwarded_host.rb:12:in `call'
00:34:36 web.1         | /home/alecslupu/Sites/decidim/develop/decidim-core/lib/decidim/middleware/current_organization.rb:22:in `call'
00:34:36 web.1         | rack (2.2.16) lib/rack/tempfile_reaper.rb:15:in `call'
00:34:36 web.1         | rack (2.2.16) lib/rack/etag.rb:27:in `call'
00:34:36 web.1         | rack (2.2.16) lib/rack/conditional_get.rb:40:in `call'
00:34:36 web.1         | rack (2.2.16) lib/rack/head.rb:12:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/http/content_security_policy.rb:38:in `call'
00:34:36 web.1         | rack (2.2.16) lib/rack/session/abstract/id.rb:266:in `context'
00:34:36 web.1         | rack (2.2.16) lib/rack/session/abstract/id.rb:260:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/cookies.rb:704:in `call'
00:34:36 web.1         | activerecord (7.2.2.1) lib/active_record/migration.rb:674:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/callbacks.rb:101:in `run_callbacks'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:30:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
00:34:36 web.1         | web-console (4.2.1) lib/web_console/middleware.rb:132:in `call_app'
00:34:36 web.1         | web-console (4.2.1) lib/web_console/middleware.rb:28:in `block in call'
00:34:36 web.1         | web-console (4.2.1) lib/web_console/middleware.rb:17:in `catch'
00:34:36 web.1         | web-console (4.2.1) lib/web_console/middleware.rb:17:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
00:34:36 web.1         | railties (7.2.2.1) lib/rails/rack/logger.rb:41:in `call_app'
00:34:36 web.1         | railties (7.2.2.1) lib/rails/rack/logger.rb:29:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
00:34:36 web.1         | request_store (1.7.0) lib/request_store/middleware.rb:19:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/request_id.rb:33:in `call'
00:34:36 web.1         | rack (2.2.16) lib/rack/method_override.rb:24:in `call'
00:34:36 web.1         | activesupport (7.2.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:61:in `block in call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:26:in `collect_events'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:60:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/static.rb:27:in `call'
00:34:36 web.1         | rack (2.2.16) lib/rack/sendfile.rb:110:in `call'
00:34:36 web.1         | actionpack (7.2.2.1) lib/action_dispatch/middleware/host_authorization.rb:143:in `call'
00:34:36 web.1         | rack-mini-profiler (3.3.1) lib/mini_profiler.rb:334:in `call'
00:34:36 web.1         | shakapacker (7.1.0) lib/shakapacker/dev_server_proxy.rb:25:in `perform_request'
00:34:36 web.1         | rack-proxy (0.7.7) lib/rack/proxy.rb:87:in `call'
00:34:36 web.1         | rack-cors (1.1.1) lib/rack/cors.rb:100:in `call'
00:34:36 web.1         | railties (7.2.2.1) lib/rails/engine.rb:535:in `call'
00:34:36 web.1         | puma (6.5.0) lib/puma/configuration.rb:279:in `call'
00:34:36 web.1         | puma (6.5.0) lib/puma/request.rb:99:in `block in handle_request'
00:34:36 web.1         | puma (6.5.0) lib/puma/thread_pool.rb:389:in `with_force_shutdown'
00:34:36 web.1         | puma (6.5.0) lib/puma/request.rb:98:in `handle_request'
00:34:36 web.1         | puma (6.5.0) lib/puma/server.rb:468:in `process_client'
00:34:36 web.1         | puma (6.5.0) lib/puma/server.rb:249:in `block in run'
00:34:36 web.1         | puma (6.5.0) lib/puma/thread_pool.rb:166:in `block in spawn_thread'

```

</details>


#### :tophat: What? Why?
*Please describe your pull request.*

#### Testing
1. login as admin, 
2. visit an admin proposal component and configure attachments (Allow attachments)
3. Visit Frontent, and create a proposal draft
4. Add Attachments 
5. See the error 
6. Apply patch
7. Repeat 3,4 
8. See the error is not there.


:hearts: Thank you!
