### PR TITLE
Fix enum deprecation warnings as result of Rails 7.2 upgrade 

### DIFF
--- a/decidim-collaborative_texts/app/models/decidim/collaborative_texts/suggestion.rb
+++ b/decidim-collaborative_texts/app/models/decidim/collaborative_texts/suggestion.rb
@@ -11,7 +11,7 @@ module Decidim
 
       after_save :update_document_counters
 
-      enum status: [:pending, :accepted, :rejected]
+      enum :status, [:pending, :accepted, :rejected]
       belongs_to :document_version, class_name: "Decidim::CollaborativeTexts::Version", counter_cache: true, inverse_of: :suggestions
       has_one :document, class_name: "Decidim::CollaborativeTexts::Document", through: :document_version
 

--- a/decidim-core/app/models/decidim/amendment.rb
+++ b/decidim-core/app/models/decidim/amendment.rb
@@ -10,7 +10,7 @@ module Decidim
 
     validates :state, presence: true, inclusion: { in: STATES.keys.map(&:to_s) }
 
-    enum state: STATES, _default: "draft"
+    enum :state, STATES, default: "draft"
 
     # Reports the mapped resource type for authorization transfers.
     #

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -41,7 +41,7 @@ module Decidim
     #  enabled: Users registration and sign in are enabled (default value).
     #  existing: Users cannot be registered in the system. Only existing users can sign in.
     #  disable: Users cannot register or sign in.
-    enum users_registration_mode: [:enabled, :existing, :disabled], _prefix: true
+    enum :users_registration_mode, [:enabled, :existing, :disabled], prefix: true
 
     validates :host, uniqueness: true
     validates :reference_prefix, presence: true

--- a/decidim-core/app/models/decidim/reminder_record.rb
+++ b/decidim-core/app/models/decidim/reminder_record.rb
@@ -7,6 +7,6 @@ module Decidim
     belongs_to :reminder, foreign_key: "decidim_reminder_id", class_name: "Decidim::Reminder"
     belongs_to :remindable, foreign_type: "remindable_type", polymorphic: true, optional: true
 
-    enum state: STATES
+    enum :state, STATES
   end
 end

--- a/decidim-elections/app/models/decidim/elections/election.rb
+++ b/decidim-elections/app/models/decidim/elections/election.rb
@@ -26,7 +26,7 @@ module Decidim
 
       validates :title, presence: true
 
-      enum results_availability: RESULTS_AVAILABILITY_OPTIONS.index_with(&:to_s), _prefix: "results"
+      enum :results_availability, RESULTS_AVAILABILITY_OPTIONS.index_with(&:to_s), prefix: "results"
 
       searchable_fields(
         A: :title,

--- a/decidim-forms/app/models/decidim/forms/display_condition.rb
+++ b/decidim-forms/app/models/decidim/forms/display_condition.rb
@@ -10,7 +10,7 @@ module Decidim
     # if the selected response option is ("equal") or is not ("not_equal") a given one, or whether
     # the text value of the response matches a string ("match").
     class DisplayCondition < Forms::ApplicationRecord
-      enum condition_type: [:responded, :not_responded, :equal, :not_equal, :match], _prefix: true
+      enum :condition_type, [:responded, :not_responded, :equal, :not_equal, :match], prefix: true
 
       # Question which will be displayed or hidden
       belongs_to :question,

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -66,8 +66,8 @@ module Decidim
              dependent: :destroy,
              as: :participatory_space
 
-    enum signature_type: [:online, :offline, :any], _suffix: true
-    enum state: [:created, :validating, :discarded, :open, :rejected, :accepted]
+    enum :signature_type, [:online, :offline, :any], suffix: true
+    enum :state, [:created, :validating, :discarded, :open, :rejected, :accepted]
 
     validates :title, :description, :state, :signature_type, presence: true
     validates :hashtag,

--- a/decidim-initiatives/app/models/decidim/initiatives_committee_member.rb
+++ b/decidim-initiatives/app/models/decidim/initiatives_committee_member.rb
@@ -12,7 +12,7 @@ module Decidim
                foreign_key: "decidim_users_id",
                class_name: "Decidim::User"
 
-    enum state: [:requested, :rejected, :accepted]
+    enum :state, [:requested, :rejected, :accepted]
 
     validates :state, presence: true
     validates :user, uniqueness: { scope: :initiative }

--- a/decidim-initiatives/app/models/decidim/initiatives_type.rb
+++ b/decidim-initiatives/app/models/decidim/initiatives_type.rb
@@ -24,7 +24,7 @@ module Decidim
              through: :scopes,
              class_name: "Decidim::Initiative"
 
-    enum signature_type: [:online, :offline, :any], _suffix: true
+    enum :signature_type, [:online, :offline, :any], suffix: true
 
     validates :title, :description, :signature_type, presence: true
 

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -51,10 +51,10 @@ module Decidim
       has_many :meeting_links, dependent: :destroy, class_name: "Decidim::Meetings::MeetingLink", foreign_key: "decidim_meeting_id"
       has_many :components, through: :meeting_links, class_name: "Decidim::Component", foreign_key: "decidim_component_id"
 
-      enum iframe_access_level: [:all, :signed_in, :registered], _prefix: true
-      enum iframe_embed_type: [:none, :embed_in_meeting_page, :open_in_live_event_page, :open_in_new_tab], _prefix: true
-      enum type_of_meeting: TYPE_OF_MEETING
-      enum registration_type: REGISTRATION_TYPES, _scopes: false
+      enum :iframe_access_level, [:all, :signed_in, :registered], prefix: true
+      enum :iframe_embed_type, [:none, :embed_in_meeting_page, :open_in_live_event_page, :open_in_new_tab], prefix: true
+      enum :type_of_meeting, TYPE_OF_MEETING
+      enum :registration_type, REGISTRATION_TYPES, scopes: false
 
       component_manifest_name "meetings"
 

--- a/decidim-meetings/app/models/decidim/meetings/question.rb
+++ b/decidim-meetings/app/models/decidim/meetings/question.rb
@@ -9,7 +9,7 @@ module Decidim
       QUESTION_TYPES = %w(single_option multiple_option).freeze
 
       translatable_fields :body
-      enum status: { unpublished: 0, published: 1, closed: 2 }
+      enum :status, { unpublished: 0, published: 1, closed: 2 }
 
       belongs_to :questionnaire, class_name: "Decidim::Meetings::Questionnaire", foreign_key: "decidim_questionnaire_id"
 

--- a/decidim-meetings/app/models/decidim/meetings/registration.rb
+++ b/decidim-meetings/app/models/decidim/meetings/registration.rb
@@ -15,7 +15,7 @@ module Decidim
 
       before_validation :generate_code, on: :create
 
-      enum status: { registered: "registered", waiting_list: "waiting_list" }
+      enum :status, { registered: "registered", waiting_list: "waiting_list" }
 
       scope :on_waiting_list, -> { waiting_list.order(:created_at) }
       scope :public_participant, -> { where(public_participation: true) }

--- a/decidim-proposals/app/models/decidim/proposals/collaborative_draft.rb
+++ b/decidim-proposals/app/models/decidim/proposals/collaborative_draft.rb
@@ -34,7 +34,7 @@ module Decidim
 
       STATES = { open: 0, published: 10, withdrawn: -1 }.freeze
 
-      enum state: STATES, _default: "open"
+      enum :state, STATES, default: "open"
       scope :except_withdrawn, -> { not_withdrawn.or(where(state: nil)) }
 
       scope_search_multi :with_any_state, [:open, :published, :withdrawn]

--- a/decidim-proposals/db/migrate/20240110203500_add_withdrawn_at_field_to_proposals.rb
+++ b/decidim-proposals/db/migrate/20240110203500_add_withdrawn_at_field_to_proposals.rb
@@ -4,7 +4,7 @@ class AddWithdrawnAtFieldToProposals < ActiveRecord::Migration[6.1]
   class CustomProposal < Decidim::Proposals::ApplicationRecord
     self.table_name = "decidim_proposals_proposals"
     STATES = { not_answered: 0, evaluating: 10, accepted: 20, rejected: -10, withdrawn: -20 }.freeze
-    enum state: STATES, _default: "not_answered"
+    enum :state, STATES, default: "not_answered"
   end
 
   def up

--- a/decidim-proposals/db/migrate/20240110203504_create_default_proposal_states.rb
+++ b/decidim-proposals/db/migrate/20240110203504_create_default_proposal_states.rb
@@ -10,7 +10,7 @@ class CreateDefaultProposalStates < ActiveRecord::Migration[6.1]
 
     self.table_name = :decidim_proposals_proposals
     STATES = { not_answered: 0, evaluating: 10, accepted: 20, rejected: -10 }.freeze
-    enum old_state: STATES, _default: "not_answered"
+    enum :old_state, STATES, default: "not_answered"
   end
 
   def up


### PR DESCRIPTION
#### :tophat: What? Why?
When we have merged #14784 we left behind some of the deprecation warnings regarding the change in enum API. This PR fixes it.  

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14784

#### Testing
1. Green pipeline 
2. Navigate to job action log and look for any deprecation warnings 
3. There should be none

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
