### PR TITLE
Do not render a comment if the root commentable is deleted

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comment_card_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comment_card_cell.rb
@@ -9,6 +9,8 @@ module Decidim
       include Cell::ViewModel::Partial
 
       def show
+        return unless model.root_commentable
+
         cell card_size, model, options
       end
 

--- a/decidim-comments/spec/cells/decidim/comments/comment_card_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comment_card_cell_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Comments
+  describe CommentCardCell, type: :cell do
+    controller Decidim::Comments::CommentsController
+
+    subject { my_cell.call }
+
+    let(:my_cell) { cell("decidim/comments/comment_card", comment) }
+    let(:organization) { create(:organization) }
+    let(:participatory_process) { create(:participatory_process, organization:) }
+    let(:assembly) { create(:assembly, organization:) }
+    let(:component) { create(:component, participatory_space: participatory_process) }
+    let(:commentable) { create(:dummy_resource, component:) }
+    let(:comment) { create(:comment, commentable:) }
+    let(:created_at) { Time.current }
+
+    context "when root commentable is deleted" do
+      before do
+        commentable.destroy!
+        comment.reload
+      end
+
+      it "does not render the card" do
+        expect(subject).to have_no_css("#comment_#{comment.id}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
In some situations, rendering activity pages (such as last activities or user's activities) can break in case there are comments that have the root commentable deleted. This could happen e.g. with meetings or results.

#### Testing
- Create a result (for example)
- Add comments to it
- Look at one of the activity pages where this comment appears
- Delete the whole resource through the Rails console (since soft delete could affect this)
- See an error on the page