### PR TITLE
Bump @rails/activestorage npm package from v7.0 to v7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4613,9 +4613,10 @@
       }
     },
     "node_modules/@rails/activestorage": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@rails/activestorage/-/activestorage-7.1.3.tgz",
-      "integrity": "sha512-B+RFYAU8vdTPFg0IJcRp2ey0Qw9hpcUOqHHcWqftDJ76ZMBi9+m/UUeMJlNsSd0l9eD+1HLlFSo1X//cY4yiDw==",
+      "version": "7.2.201",
+      "resolved": "https://registry.npmjs.org/@rails/activestorage/-/activestorage-7.2.201.tgz",
+      "integrity": "sha512-7hCJsh2eULFwki4MhDGVLSdAABkmjQkCm9LNE2UK6Ti9uRMkhpER+PoLFLJ2QlJkahZuN62gbCnOnLczRxZSdA==",
+      "license": "MIT",
       "dependencies": {
         "spark-md5": "^3.0.1"
       }
@@ -21042,7 +21043,7 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
-        "@rails/activestorage": "^7.0.8",
+        "@rails/activestorage": "^7.2.201",
         "@tarekraafat/autocomplete.js": "10.2.7",
         "@tiptap/core": "2.1.13",
         "@tiptap/extension-blockquote": "2.1.13",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@emoji-mart/data": "^1.1.2",
-    "@rails/activestorage": "^7.0.8",
+    "@rails/activestorage": "^7.2.201",
     "@tarekraafat/autocomplete.js": "10.2.7",
     "@tiptap/core": "2.1.13",
     "@tiptap/extension-blockquote": "2.1.13",


### PR DESCRIPTION
#### :tophat: What? Why?
This PR originated from #14804, where it has been requested to upgrade 
- [ ] @rails/ujs 
- [x] @rails/activestorage

During our last maintainer meeting we decided to upgrade just the active storage. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #14804

#### Testing
1. green pipeline

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
