### PR TITLE
Fix flaky initiatives creation spec

### DIFF
--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -793,6 +793,7 @@ describe "Initiative" do
           dynamically_attach_file(:initiative_documents, Decidim::Dev.asset("Exampledocument.pdf"))
           dynamically_attach_file(:initiative_photos, Decidim::Dev.asset("avatar.jpg"))
           find_button("Continue").click
+          expect(page).to have_content("Your initiative has been successfully created.")
         end
 
         it "saves the attachments" do


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed a flaky spec on this test run:
https://github.com/decidim/decidim/actions/runs/15528703017/job/43713147962?pr=14828

This should fix it.

#### :pushpin: Related Issues
- Related to #14828

#### Testing
Run this several times within `decidim-initiatives`:
```bash
$ bundle exec rspec spec/system/create_initiative_spec.rb -e "Initiative creating an initiative without validation when finish saves the attachments"
```

See the spec passing.