### PR TITLE
Backport 'Prevent importing withdrawn or moderated proposals to another component' to v0.29

### DIFF
--- a/decidim-proposals/app/jobs/decidim/proposals/admin/import_proposals_job.rb
+++ b/decidim-proposals/app/jobs/decidim/proposals/admin/import_proposals_job.rb
@@ -30,7 +30,7 @@ module Decidim
         private
 
         def proposals
-          proposals = Decidim::Proposals::Proposal.where(component: origin_component)
+          proposals = Decidim::Proposals::Proposal.not_hidden.not_withdrawn.where(component: origin_component)
           proposals = proposals.where(scope: proposal_scopes) unless proposal_scopes.empty?
 
           if @form["states"].include?("not_answered")


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #14777 to v0.29

:hearts: Thank you!