### PR TITLE
Fix report modals to improve accessibility

### DIFF
--- a/decidim-core/app/cells/decidim/report_button/flag_modal.erb
+++ b/decidim-core/app/cells/decidim/report_button/flag_modal.erb
@@ -13,7 +13,7 @@
               [:offensive, t("decidim.shared.flag_modal.offensive")],
               [:does_not_belong, t("decidim.shared.flag_modal.does_not_belong", organization_name: current_organization_name)]
             ], :first, :last do |builder|
-              builder.label(for: nil, class: "form__wrapper-checkbox-label") { builder.radio_button(id: nil) + builder.text }
+              builder.label(for: "#{builder.value.to_s}-#{modal_id}", class: "form__wrapper-checkbox-label") { builder.radio_button(id: "#{builder.value.to_s}-#{modal_id}") + builder.text }
             end %>
           </fieldset>
 

--- a/decidim-core/app/cells/decidim/report_button/flag_modal.erb
+++ b/decidim-core/app/cells/decidim/report_button/flag_modal.erb
@@ -6,16 +6,18 @@
       <div>
         <div class="form__wrapper flag-modal__form">
           <p id="dialog-desc-<%= modal_id %>" class="flag-modal__form-description"><%= t("decidim.shared.flag_modal.description") %></p>
-          <p class="flag-modal__form-reason"><%= t("decidim.shared.flag_modal.reason") %>:</p>
-          <%= f.collection_radio_buttons :reason, [
-            [:spam, t("decidim.shared.flag_modal.spam")],
-            [:offensive, t("decidim.shared.flag_modal.offensive")],
-            [:does_not_belong, t("decidim.shared.flag_modal.does_not_belong", organization_name: current_organization_name)]
-          ], :first, :last do |builder|
-            builder.label(for: nil, class: "form__wrapper-checkbox-label") { builder.radio_button(id: nil) + builder.text }
-          end %>
+          <fieldset class="mt-6">
+            <legend class="flag-modal__form-reason"><%= t("decidim.shared.flag_modal.reason") %>:</legend>
+            <%= f.collection_radio_buttons :reason, [
+              [:spam, t("decidim.shared.flag_modal.spam")],
+              [:offensive, t("decidim.shared.flag_modal.offensive")],
+              [:does_not_belong, t("decidim.shared.flag_modal.does_not_belong", organization_name: current_organization_name)]
+            ], :first, :last do |builder|
+              builder.label(for: nil, class: "form__wrapper-checkbox-label") { builder.radio_button(id: nil) + builder.text }
+            end %>
+          </fieldset>
 
-          <%= f.text_area :details, rows: 4, label_options: { class: "flag-modal__form-textarea-label", for: nil }, id: nil %>
+          <%= f.text_area :details, rows: 4, label_options: { class: "flag-modal__form-textarea-label", for: "additional-comments-#{modal_id}" }, id: "additional-comments-#{modal_id}" %>
 
           <% if frontend_administrable? %>
             <%= f.check_box :hide,

--- a/decidim-core/app/cells/decidim/report_user_button/flag_modal.erb
+++ b/decidim-core/app/cells/decidim/report_user_button/flag_modal.erb
@@ -13,7 +13,7 @@
               [:offensive, t("decidim.shared.flag_user_modal.offensive")],
               [:does_not_belong, t("decidim.shared.flag_user_modal.does_not_belong", organization_name: current_organization_name)]
             ], :first, :last do |builder|
-              builder.label(for: nil, class: "form__wrapper-checkbox-label") { builder.radio_button(id: nil) + builder.text }
+              builder.label(for: "#{builder.value.to_s}-#{modal_id}", class: "form__wrapper-checkbox-label") { builder.radio_button(id: "#{builder.value.to_s}-#{modal_id}") + builder.text }
             end %>
           </fieldset>
           <%= f.text_area :details, rows: 4, label_options: { class: "flag-modal__form-textarea-label", for: "additional-comments-#{modal_id}" }, id: "additional-comments-#{modal_id}" %>

--- a/decidim-core/app/cells/decidim/report_user_button/flag_modal.erb
+++ b/decidim-core/app/cells/decidim/report_user_button/flag_modal.erb
@@ -6,16 +6,17 @@
       <div>
         <div class="form__wrapper flag-modal__form">
           <p class="flag-modal__form-description"><%= t("decidim.shared.flag_user_modal.description") %></p>
-          <p class="flag-modal__form-reason"><%= t("decidim.shared.flag_modal.reason") %>:</p>
-          <%= f.collection_radio_buttons :reason, [
-            [:spam, t("decidim.shared.flag_user_modal.spam")],
-            [:offensive, t("decidim.shared.flag_user_modal.offensive")],
-            [:does_not_belong, t("decidim.shared.flag_user_modal.does_not_belong", organization_name: current_organization_name)]
-          ], :first, :last do |builder|
-            builder.label(for: nil, class: "form__wrapper-checkbox-label") { builder.radio_button(id: nil) + builder.text }
-          end %>
-
-          <%= f.text_area :details, rows: 4, label_options: { class: "flag-modal__form-textarea-label", for: nil }, id: nil %>
+          <fieldset class="mt-6">
+            <legend class="flag-modal__form-reason"><%= t("decidim.shared.flag_modal.reason") %>:</legend>
+            <%= f.collection_radio_buttons :reason, [
+              [:spam, t("decidim.shared.flag_user_modal.spam")],
+              [:offensive, t("decidim.shared.flag_user_modal.offensive")],
+              [:does_not_belong, t("decidim.shared.flag_user_modal.does_not_belong", organization_name: current_organization_name)]
+            ], :first, :last do |builder|
+              builder.label(for: nil, class: "form__wrapper-checkbox-label") { builder.radio_button(id: nil) + builder.text }
+            end %>
+          </fieldset>
+          <%= f.text_area :details, rows: 4, label_options: { class: "flag-modal__form-textarea-label", for: "additional-comments-#{modal_id}" }, id: "additional-comments-#{modal_id}" %>
 
           <% if frontend_administrable? %>
             <%= f.check_box :block,


### PR DESCRIPTION
#### :tophat: What? Why?
This PR updates flag modals to improve accessibility, by adding:
- a `fieldset` and `legend` on radio buttons
- a value to the `for` and `id` attributes on radio buttons
- a value to the `for` and `id` attributes of the textarea

This PR is issued from the audit of Angers city (page 92 and 93), and corresponds to criterias 1.3.1 and 3.3.2 from WCAG

#### Testing
As a logged in user, go to a process, and then to proposals
Find a proposal with comments and report one comment
Right Click + "Inspect", and see in the html that the changes above are effective.

### :camera: Screenshots
<img width="973" alt="450655874-c70aa543-7091-4c8b-a480-e77ba7ce504b" src="https://github.com/user-attachments/assets/ecea2a8c-8f24-44ff-a577-362792f2b63c" />


:hearts: Thank you!
