### PR TITLE
fix: Reporting user for multi tenant

### DIFF
--- a/decidim-ai/app/jobs/decidim/ai/spam_detection/generic_spam_analyzer_job.rb
+++ b/decidim-ai/app/jobs/decidim/ai/spam_detection/generic_spam_analyzer_job.rb
@@ -29,7 +29,7 @@ module Decidim
         end
 
         def reporting_user
-          @reporting_user ||= Decidim::User.find_by!(email: Decidim::Ai::SpamDetection.reporting_user_email)
+          @reporting_user ||= Decidim::User.find_by!(email: Decidim::Ai::SpamDetection.reporting_user_email, organization: @author.organization)
         end
       end
     end

--- a/decidim-ai/spec/jobs/decidim/ai/spam_detection/generic_spam_analyzer_job_spec.rb
+++ b/decidim-ai/spec/jobs/decidim/ai/spam_detection/generic_spam_analyzer_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Ai::SpamDetection::GenericSpamAnalyzerJob do
+  subject { described_class }
+
+  let!(:organization_one) { create(:organization) }
+  let!(:organization_two) { create(:organization) }
+  let!(:user_one) { create(:user, email: reporting_user_email, organization: organization_one) }
+  let!(:user_two) { create(:user, email: reporting_user_email, organization: organization_two) }
+  let(:reporting_user_email) { "reporting@example.org" }
+
+  describe "queue" do
+    it "is queued to spam_analysis" do
+      expect(subject.queue_name).to eq "spam_analysis"
+    end
+  end
+
+  describe "#reporting_user" do
+    before do
+      allow(Decidim::Ai::SpamDetection).to receive(:reporting_user_email).and_return(reporting_user_email)
+    end
+
+    it "finds the user by email" do
+      obj = subject.new
+      obj.instance_variable_set(:@author, user_two)
+      expect(obj.send(:reporting_user)).to eq user_two
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

Reporting user must be on the same organization than the reported content. 

See [Moderation's validations](https://github.com/decidim/decidim/blob/b21a958322d2a1308444d4264dac12a42979bad7/decidim-core/app/models/decidim/report.rb#L32)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #14854 

#### Testing
*Describe the best way to test or validate your PR.*


    Create two Decidim Organization
    Create Reporting user bundle exec rake decidim:ai:spam:create_reporting_user (Will create a user for each existing organization)
    Create a spam content on the second organization
    See missing report in the backoffice



:hearts: Thank you!
