### PR TITLE
Add run id to screenshots folder

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: screenshots
+          name: Screenshots of run ${{ github.run_id }}
           path: ./spec/decidim_dummy_app/tmp/screenshots
           if-no-files-found: ignore
           overwrite: true


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds the github run id to screenshots folder, to make sure that screenshots of 2 failing system specs are not being overriden (Ex When Meetings Admin & Meetings System have each one a failing spec, then the last screenshot will be the one from the pipeline that take longest to succeed )

![image](https://github.com/user-attachments/assets/5e84e470-a281-4456-9d53-176090a357a5)

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14853

#### Testing
Visit any system action, and see the summary tab. 
Ex https://github.com/decidim/decidim/actions/runs/15589904267?pr=14857

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
