### PR TITLE
Fix questionnaires javascript on Rails 7.1

### DIFF
--- a/decidim-admin/app/packs/src/decidim/admin/dynamic_fields.component.js
+++ b/decidim-admin/app/packs/src/decidim/admin/dynamic_fields.component.js
@@ -34,9 +34,12 @@ class DynamicFieldsComponent {
     }
 
     $.fn.template = function(placeholder, value) {
+      // Clean up the template HTML to ensure it only contains elements.
+      const $template = $(this).filter((_idx, el) => el.nodeType === Node.ELEMENT_NODE);
+
       // See the comment below in the `_addField()` method regarding the
       // `<template>` tag support in IE11.
-      const $subtemplate = $(this).find("template, .decidim-template");
+      const $subtemplate = $template.find("template, .decidim-template");
 
       if ($subtemplate.length > 0) {
         $subtemplate.html((index, oldHtml) => $(oldHtml).template(placeholder, value)[0].outerHTML);
@@ -44,7 +47,7 @@ class DynamicFieldsComponent {
 
       // Handle those subtemplates that are mapped with the `data-template`
       // attribute. This is also because of the IE11 support.
-      const $subtemplateParents = $(this).find("[data-template]");
+      const $subtemplateParents = $template.find("[data-template]");
 
       if ($subtemplateParents.length > 0) {
         $subtemplateParents.each((_i, elem) => {
@@ -64,15 +67,15 @@ class DynamicFieldsComponent {
         });
       }
 
-      $(this).replaceAttribute("id", placeholder, value);
-      $(this).replaceAttribute("name", placeholder, value);
-      $(this).replaceAttribute("data-tabs-content", placeholder, value);
-      $(this).replaceAttribute("for", placeholder, value);
-      $(this).replaceAttribute("tabs_id", placeholder, value);
-      $(this).replaceAttribute("href", placeholder, value);
-      $(this).replaceAttribute("value", placeholder, value);
+      $template.replaceAttribute("id", placeholder, value);
+      $template.replaceAttribute("name", placeholder, value);
+      $template.replaceAttribute("data-tabs-content", placeholder, value);
+      $template.replaceAttribute("for", placeholder, value);
+      $template.replaceAttribute("tabs_id", placeholder, value);
+      $template.replaceAttribute("href", placeholder, value);
+      $template.replaceAttribute("value", placeholder, value);
 
-      return this;
+      return $template;
     }
   }
 
@@ -147,9 +150,7 @@ class DynamicFieldsComponent {
       // as they are submitted with them.
       $template = $wrapper.children(`template, ${templateClass}`);
     }
-
     const $newField = $($template.html()).template(this.placeholderId, this._getUID());
-
     $newField.find("ul.tabs").attr("data-tabs", true);
 
     const $lastQuestion = $container.find(this.fieldSelector).last()


### PR DESCRIPTION
#### :tophat: What? Why?

The upgrade to Rails 7.1 introduces different defaults that affects the questionnaires javascript when creating dynamic fields.

The problem is that this Javascript (see `decidim-admin/app/packs/src/decidim/admin/dynamic_fields.component.js` and `decidim-admin/app/packs/src/decidim/admin/forms.js`) only looks at the first node on the rendered HTML. This is a problem on Rails 7.1 as, by default,  it has enabled "annotated rendered views", which adds HTML comments in each rendered partial (which is good as it facilitates the identification of templates).

This PR solves the problem by modifying the JQuery plugin `template` defined in the file `dynamic_fields.component.js`, ensuring only nodes of type ELEMENT are present.

However, this change should be considered provisional (or a hack), as the real problem is that this javascript does not solve the task in a robust way (and it's pretty cryptic). I suggest, when JQuery is remove, this should be completely refactored.


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing

In development mode, try to add a question to a questionnaire, open the javascript console. Errors will appear.

### :camera: Screenshots

![Screenshot from 2025-06-12 10-40-07](https://github.com/user-attachments/assets/ca1f06b1-409d-437a-9461-9481a4a94c02)

:hearts: Thank you!
