### PR TITLE
Implement dropdown menu for other actions in spaces

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/index.html.erb
@@ -9,52 +9,76 @@
     </h1>
   </div>
   <%= admin_filter_selector %>
-  <div class="table-scroll">
+  <div class="table-stacked">
     <table class="table-list">
       <thead>
         <tr>
-          <th><%= sort_link(query, :name,t("models.assembly_user_role.fields.name", scope: "decidim.admin"), default_order: :desc) %></th>
+          <th><%= sort_link(query, :name, t("models.assembly_user_role.fields.name", scope: "decidim.admin"), default_order: :desc) %></th>
           <th><%= sort_link(query, :email, t("models.assembly_user_role.fields.email", scope: "decidim.admin"), default_order: :desc) %></th>
           <th><%= sort_link(query, :last_sign_in_at, t("models.user.fields.last_sign_in_at", scope: "decidim.admin"), default_order: :desc) %></th>
           <th><%= sort_link(query, :invitation_accepted_at, t("models.user.fields.invitation_accepted_at", scope: "decidim.admin"), default_order: :desc) %></th>
           <th><%= sort_link(query, :role, t("models.assembly_user_role.fields.role", scope: "decidim.admin"), default_order: :desc) %></th>
-          <th></th>
+          <th><%= t("models.assembly_user_role.fields.actions", scope: "decidim.admin") %></th>
         </tr>
       </thead>
       <tbody>
         <% filtered_collection.each do |role| %>
           <tr>
-            <td>
+            <td data-label="<%= t("models.assembly_user_role.fields.name", scope: "decidim.admin") %>">
               <%= role.user.name %><br>
             </td>
-            <td>
+            <td data-label="<%= t("models.assembly_user_role.fields.email", scope: "decidim.admin") %>">
               <%= role.user.email %><br>
             </td>
-            <td>
+            <td data-label="<%= t("models.user.fields.last_sign_in_at", scope: "decidim.admin") %>">
               <% if role.user.invitation_sent_at %>
                 <%= l role.user.invitation_sent_at, format: :short %>
               <% end %>
             </td>
-            <td>
+            <td data-label="<%= t("models.user.fields.invitation_accepted_at", scope: "decidim.admin") %>">
               <% if role.user.invitation_accepted_at %>
                 <%= l role.user.invitation_accepted_at, format: :short %>
               <% end %>
             </td>
-            <td>
+            <td data-label="<%= t("models.user.fields.role", scope: "decidim.admin") %>">
               <%= t("#{role.role}", scope: "decidim.admin.models.assembly_user_role.roles") %><br>
             </td>
-            <td class="table-list__actions">
-              <% if allowed_to?(:invite, :assembly_user_role, user_role: role) && role.user.invited_to_sign_up? %>
-                <%= icon_link_to "refresh-line", resend_invitation_assembly_user_role_path(current_assembly, role), t("actions.resend_invitation", scope: "decidim.admin"), class: "resend-invitation", method: :post %>
-              <% end %>
+            <td class="table-list__actions" data-label="<%= t("models.assembly_user_role.fields.actions", scope: "decidim.admin") %>">
+              <button type="button" data-component="dropdown" data-target="actions-assembly-user-role-<%= role.id %>" aria-label="<%= t('decidim.admin.actions.actions_label', resource: role.user.name) %>">
+                <%= icon "more-fill", class: "text-secondary" %>
+              </button>
 
-              <% if allowed_to? :update, :assembly_user_role, user_role: role %>
-                <%= icon_link_to "pencil-line", edit_assembly_user_role_path(current_assembly, role), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
-              <% end %>
+              <div class="inline-block relative">
+                <ul id="actions-assembly-user-role-<%= role.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                  <% if allowed_to?(:invite, :assembly_user_role, user_role: role) && role.user.invited_to_sign_up? %>
+                    <li class="dropdown__item">
+                      <%= link_to resend_invitation_assembly_user_role_path(current_assembly, role), method: :post, class: "dropdown__button resend-invitation" do %>
+                        <%= icon "refresh-line" %> <%= t("actions.resend_invitation", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
 
-              <% if allowed_to? :destroy, :assembly_user_role, user_role: role %>
-                <%= icon_link_to "delete-bin-line", assembly_user_role_path(current_assembly, role), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
-              <% end %>
+                  <hr>
+
+                  <% if allowed_to? :update, :assembly_user_role, user_role: role %>
+                    <li class="dropdown__item">
+                      <%= link_to edit_assembly_user_role_path(current_assembly, role), class: "dropdown__button" do %>
+                        <%= icon "pencil-line" %> <%= t("actions.edit", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+
+                  <hr>
+
+                  <% if allowed_to? :destroy, :assembly_user_role, user_role: role %>
+                    <li class="dropdown__item">
+                      <%= link_to assembly_user_role_path(current_assembly, role), method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, class: "dropdown__button dropdown__button--danger" do %>
+                        <%= icon "delete-bin-line" %> <%= t("actions.destroy", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -194,6 +194,7 @@ en:
             vice_president: Vice president
         assembly_user_role:
           fields:
+            actions: Actions
             email: Email
             name: Name
             role: Role

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_registrations/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_registrations/index.html.erb
@@ -24,7 +24,7 @@
       <% end %>
     </h1>
   </div>
-  <div class="table-scroll">
+  <div class="table-stacked">
     <table class="table-list">
       <thead>
         <tr>
@@ -32,29 +32,39 @@
           <th><%= t("models.conference_registration.fields.email", scope: "decidim.conferences") %></th>
           <th><%= t("models.conference_registration.fields.registration_type", scope: "decidim.conferences") %></th>
           <th><%= t("models.conference_registration.fields.state", scope: "decidim.conferences") %></th>
-          <th></th>
+          <th><%= t("models.conference_registration.fields.actions", scope: "decidim.conferences") %></th>
         </tr>
       </thead>
       <tbody>
         <% @conference_registrations.each do |registration| %>
           <tr data-id="<%= registration.id %>">
-            <td>
+            <td data-label="<%= t("models.conference_registration.fields.name", scope: "decidim.conferences") %>">
               <%= registration.user.name %>
             </td>
-            <td>
+            <td data-label="<%= t("models.conference_registration.fields.email", scope: "decidim.conferences") %>">
               <%= registration.user.email %>
             </td>
-            <td>
+            <td data-label="<%= t("models.conference_registration.fields.registration_type", scope: "decidim.conferences") %>">
               <%= translated_attribute(registration.registration_type.title) %>
             </td>
-            <td>
+            <td data-label="<%= t("models.conference_registration.fields.state", scope: "decidim.conferences") %>">
               <%= t("models.conference_registration.fields.states.#{registration.confirmed? ? "confirmed" : "pending"}", scope: "decidim.conferences") %>
             </td>
-            <td>
-              <% if allowed_to?(:confirm, :conference_registration, conference_registration: registration) %>
-                <% if !registration.confirmed? %>
-                  <%= icon_link_to "check-line", confirm_conference_conference_registration_path(current_conference, registration), t("actions.confirm", scope: "decidim.admin"), class: "action-icon--publish", method: :post %>
-                <% end %>
+            <td data-label="<%= t("models.conference_registration.fields.actions", scope: "decidim.conferences") %>">
+              <% if allowed_to?(:confirm, :conference_registration, conference_registration: registration) && !registration.confirmed? %>
+                <button type="button" data-component="dropdown" data-target="actions-conference-registration-<%= registration.id %>" aria-label="<%= t('decidim.admin.actions.actions_label', resource: t('models.conference_registration.name', scope: 'decidim.admin')) %>">
+                  <%= icon "more-fill", class: "text-secondary" %>
+                </button>
+
+                <div class="inline-block relative">
+                  <ul id="actions-conference-registration-<%= registration.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                    <li class="dropdown__item">
+                      <%= link_to confirm_conference_conference_registration_path(current_conference, registration), method: :post, class: "dropdown__button action-icon--publish" do %>
+                        <%= icon "check-line" %> <%= t("actions.confirm", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  </ul>
+                </div>
               <% end %>
             </td>
           </tr>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
@@ -25,48 +25,77 @@
     </div>
   </div>
 
-  <div class="table-scroll">
+  <div class="table-stacked">
     <table class="table-list">
       <thead>
         <tr>
           <th><%= t("models.conference_speaker.fields.full_name", scope: "decidim.admin") %></th>
           <th><%= t("models.conference_speaker.fields.position", scope: "decidim.admin") %></th>
           <th><%= t("models.conference_speaker.fields.affiliation", scope: "decidim.admin") %></th>
-
-          <th></th>
+          <th><%= t("models.conference_speaker.fields.actions", scope: "decidim.admin") %></th>
         </tr>
       </thead>
       <tbody>
         <% @conference_speakers.each do |speaker| %>
           <% speaker_presenter = Decidim::Admin::ConferenceSpeakerPresenter.new(speaker) %>
           <tr>
-            <td>
+            <td data-label="<%= t("models.conference_speaker.fields.full_name", scope: "decidim.admin") %>">
               <%= speaker_presenter.name %>
             </td>
-            <td>
+            <td data-label="<%= t("models.conference_speaker.fields.position", scope: "decidim.admin") %>">
               <%= translated_attribute(speaker.position) %>
             </td>
-            <td>
+            <td data-label="<%= t("models.conference_speaker.fields.affiliation", scope: "decidim.admin") %>">
               <%= translated_attribute(speaker.affiliation) %>
             </td>
-            <td class="table-list__actions">
-              <% if allowed_to? :update, :conference_speaker, speaker: speaker %>
-                <%= icon_link_to "pencil-line", edit_conference_speaker_path(current_conference, speaker), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
-              <% end %>
+            <td class="table-list__actions" data-label="<%= t("models.conference_speaker.fields.actions", scope: "decidim.admin") %>">
+              <button type="button" data-component="dropdown" data-target="actions-conference-speaker-<%= speaker.id %>" aria-label="<%= t('decidim.admin.actions.actions_label', resource: speaker_presenter.name) %>">
+                <%= icon "more-fill" %>
+              </button>
 
-              <% if allowed_to? :update, :conference_speaker, speaker: speaker %>
-                <% if speaker.published? %>
-                  <%= icon_link_to "close-circle-line", unpublish_conference_speaker_path(current_conference, speaker.id), t("actions.unpublish", scope: "decidim.admin"), method: :put, class: "action-icon--unpublish" %>
-                <% else %>
-                  <%= icon_link_to "check-line", publish_conference_speaker_path(current_conference, speaker.id), t("actions.publish", scope: "decidim.admin"), method: :put, class: "action-icon--publish" %>
-                <% end %>
-              <% else %>
-                <span class="action-space icon"></span>
-              <% end %>
+              <div class="inline-block relative">
+                <ul id="actions-conference-speaker-<%= speaker.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                  <% if allowed_to? :update, :conference_speaker, speaker: speaker %>
+                    <li class="dropdown__item">
+                      <%= link_to edit_conference_speaker_path(current_conference, speaker), class: "dropdown__button" do %>
+                        <%= icon "pencil-line" %>
+                        <%= t("actions.edit", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
 
-              <% if allowed_to? :destroy, :conference_speaker, speaker: speaker %>
-                <%= icon_link_to "delete-bin-line", conference_speaker_path(current_conference, speaker), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
-              <% end %>
+                  <hr>
+
+                  <% if allowed_to? :update, :conference_speaker, speaker: speaker %>
+                    <% if speaker.published? %>
+                      <li class="dropdown__item">
+                        <%= link_to unpublish_conference_speaker_path(current_conference, speaker.id), method: :put, class: "dropdown__button" do %>
+                          <%= icon "close-circle-line" %>
+                          <%= t("actions.unpublish", scope: "decidim.admin") %>
+                        <% end %>
+                      </li>
+                    <% else %>
+                      <li class="dropdown__item">
+                        <%= link_to publish_conference_speaker_path(current_conference, speaker.id), method: :put, class: "dropdown__button" do %>
+                          <%= icon "check-line" %>
+                          <%= t("actions.publish", scope: "decidim.admin") %>
+                        <% end %>
+                      </li>
+                    <% end %>
+                  <% end %>
+
+                  <hr>
+
+                  <% if allowed_to? :destroy, :conference_speaker, speaker: speaker %>
+                    <li class="dropdown__item">
+                      <%= link_to conference_speaker_path(current_conference, speaker), method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, class: "dropdown__button" do %>
+                        <%= icon "delete-bin-line" %>
+                        <%= t("actions.destroy", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/index.html.erb
@@ -9,7 +9,7 @@
     </h1>
   </div>
   <%= admin_filter_selector %>
-  <div class="table-scroll">
+  <div class="table-stacked">
     <table class="stack table-list">
       <thead>
         <tr>
@@ -18,43 +18,66 @@
           <th><%= sort_link(query, :last_sign_in_at, t("models.user.fields.last_sign_in_at", scope: "decidim.admin"), default_order: :desc) %></th>
           <th><%= sort_link(query, :invitation_accepted_at, t("models.user.fields.invitation_accepted_at", scope: "decidim.admin"), default_order: :desc) %></th>
           <th><%= sort_link(query, :role, t("models.conference_user_role.fields.role", scope: "decidim.admin"), default_order: :desc) %></th>
-          <th></th>
+          <th><%= t("models.conference_user_role.fields.actions", scope: "decidim.admin") %></th>
         </tr>
       </thead>
       <tbody>
         <% filtered_collection.each do |role| %>
           <tr>
-            <td>
+            <td data-label="<%= t("models.conference_user_role.fields.actions", scope: "decidim.admin") %>">
               <%= role.user.name %><br>
             </td>
-            <td>
+            <td data-label="<%= t("models.conference_user_role.fields.email", scope: "decidim.admin") %>">
               <%= role.user.email %><br>
             </td>
-            <td>
+            <td data-label="<%= t("models.user.fields.last_sign_in_at", scope: "decidim.admin") %>">
               <% if role.user.invitation_sent_at %>
                 <%= l role.user.invitation_sent_at, format: :short %>
               <% end %>
             </td>
-            <td>
+            <td data-label="<%= t("models.user.fields.invitation_accepted_at", scope: "decidim.admin") %>">
               <% if role.user.invitation_accepted_at %>
                 <%= l role.user.invitation_accepted_at, format: :short %>
               <% end %>
             </td>
-            <td>
+            <td data-label="<%= t("models.conference_user_role.fields.role", scope: "decidim.admin") %>">
               <%= t("#{role.role}", scope: "decidim.admin.models.conference_user_role.roles") %><br>
             </td>
-            <td class="table-list__actions">
-              <% if allowed_to?(:invite, :conference_user_role, user_role: role) && role.user.invited_to_sign_up? %>
-                <%= icon_link_to "refresh-line", resend_invitation_conference_user_role_path(current_conference, role), t("actions.resend_invitation", scope: "decidim.admin"), class: "resend-invitation", method: :post %>
-              <% end %>
+            <td class="table-list__actions" data-label="<%= t("models.conference_user_role.fields.actions", scope: "decidim.admin") %>">
+              <button type="button" data-component="dropdown" data-target="actions-conference-user-role-<%= role.id %>" aria-label="<%= t('decidim.admin.actions.actions_label', resource: role.user.name) %>">
+                <%= icon "more-fill", class: "text-secondary" %>
+              </button>
 
-              <% if allowed_to? :update, :conference_user_role, user_role: role %>
-                <%= icon_link_to "pencil-line", edit_conference_user_role_path(current_conference, role), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
-              <% end %>
+              <div class="inline-block relative">
+                <ul id="actions-conference-user-role-<%= role.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                  <% if allowed_to?(:invite, :conference_user_role, user_role: role) && role.user.invited_to_sign_up? %>
+                    <li class="dropdown__item">
+                      <%= link_to resend_invitation_conference_user_role_path(current_conference, role), method: :post, class: "dropdown__button" do %>
+                        <%= icon "refresh-line" %>
+                        <%= t("actions.resend_invitation", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
 
-              <% if allowed_to? :destroy, :conference_user_role, user_role: role %>
-                <%= icon_link_to "delete-bin-line", conference_user_role_path(current_conference, role), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
-              <% end %>
+                  <% if allowed_to? :update, :conference_user_role, user_role: role %>
+                    <li class="dropdown__item">
+                      <%= link_to edit_conference_user_role_path(current_conference, role), class: "dropdown__button" do %>
+                        <%= icon "pencil-line" %>
+                        <%= t("actions.edit", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+
+                  <% if allowed_to? :destroy, :conference_user_role, user_role: role %>
+                    <li class="dropdown__item">
+                      <%= link_to conference_user_role_path(current_conference, role), method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, class: "dropdown__button dropdown__button--danger" do %>
+                        <%= icon "delete-bin-line" %>
+                        <%= t("actions.destroy", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/decidim-conferences/app/views/decidim/conferences/admin/media_links/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/media_links/index.html.erb
@@ -8,37 +8,56 @@
       <% end %>
     </h1>
   </div>
-  <div class="table-scroll">
+  <div class="table-stacked">
     <table class="table-list">
       <thead>
         <tr>
           <th><%= t("models.media_link.fields.title", scope: "decidim.admin") %></th>
           <th><%= t("models.media_link.fields.link", scope: "decidim.admin") %></th>
           <th><%= t("models.media_link.fields.date", scope: "decidim.admin") %></th>
-
-          <th></th>
+          <th><%= t("models.media_link.fields.actions", scope: "decidim.admin") %></th>
         </tr>
       </thead>
       <tbody>
         <% @media_links.each do |media_link| %>
           <tr>
-            <td>
+            <td data-label="<%= t("models.media_link.fields.title", scope: "decidim.admin") %>">
               <%= translated_attribute(media_link.title) %>
             </td>
-            <td>
+            <td data-label="<%= t("models.media_link.fields.link", scope: "decidim.admin") %>">
               <%= media_link.link %>
             </td>
-            <td>
+            <td data-label="<%= t("models.media_link.fields.date", scope: "decidim.admin") %>">
               <%= l(media_link.date, format: :decidim_short ) %>
             </td>
-            <td class="table-list__actions">
-              <% if allowed_to? :update, :media_link, media_link: media_link %>
-                <%= icon_link_to "pencil-line", edit_conference_media_link_path(current_conference, media_link), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
-              <% end %>
+            <td class="table-list__actions" data-label="<%= t("models.media_link.fields.actions", scope: "decidim.admin") %>">
+              <button type="button" data-component="dropdown" data-target="actions-media-link-<%= media_link.id %>" aria-label="<%= t('decidim.admin.actions.actions_label', resource: translated_attribute(media_link.title)) %>">
+                <%= icon "more-fill", class: "text-secondary" %>
+              </button>
 
-              <% if allowed_to? :destroy, :media_link, media_link: media_link %>
-                <%= icon_link_to "delete-bin-line", conference_media_link_path(current_conference, media_link), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
-              <% end %>
+              <div class="inline-block relative">
+                <ul id="actions-media-link-<%= media_link.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                  <% if allowed_to? :update, :media_link, media_link: media_link %>
+                    <li class="dropdown__item">
+                      <%= link_to edit_conference_media_link_path(current_conference, media_link), class: "dropdown__button" do %>
+                        <%= icon "pencil-line" %>
+                        <%= t("actions.edit", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+
+                  <hr>
+
+                  <% if allowed_to? :destroy, :media_link, media_link: media_link %>
+                    <li class="dropdown__item">
+                      <%= link_to conference_media_link_path(current_conference, media_link), method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, class: "dropdown__button dropdown__button--danger" do %>
+                        <%= icon "delete-bin-line" %>
+                        <%= t("actions.destroy", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/decidim-conferences/app/views/decidim/conferences/admin/partners/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/partners/index.html.erb
@@ -8,7 +8,7 @@
       <% end %>
     </h1>
   </div>
-  <div class="table-scroll">
+  <div class="table-stacked">
     <table class="table-list">
       <thead>
         <tr>
@@ -16,37 +16,56 @@
           <th><%= t("models.partner.fields.partner_type", scope: "decidim.admin") %></th>
           <th><%= t("models.partner.fields.link", scope: "decidim.admin") %></th>
           <th><%= t("models.partner.fields.logo", scope: "decidim.admin") %></th>
-
-          <th></th>
+          <th><%= t("models.partner.fields.actions", scope: "decidim.admin") %></th>
         </tr>
       </thead>
       <tbody>
         <% @partners.each do |partner| %>
           <tr>
-            <td>
+            <td data-label="<%= t("models.partner.fields.name", scope: "decidim.admin") %>">
               <%= partner.name %>
             </td>
-            <td>
+            <td data-label="<%= t("models.partner.fields.partner_type", scope: "decidim.admin") %>">
               <%= t("#{partner.partner_type}", scope: "decidim.admin.models.partner.types") %>
             </td>
-            <td>
+            <td data-label="<%= t("models.partner.fields.link", scope: "decidim.admin") %>">
               <% if partner.link.presence %>
                 <%= link_to partner.link, partner.link, target: "_blank" %>
               <% end %>
             </td>
-            <td>
+            <td data-label="<%= t("models.partner.fields.logo", scope: "decidim.admin") %>">
               <% if partner.logo.attached? %>
                 <%= image_tag(partner.attached_uploader(:logo).variant_url(:thumb)) %>
               <% end %>
             </td>
-            <td class="table-list__actions">
-              <% if allowed_to? :update, :partner, partner: partner %>
-                <%= icon_link_to "pencil-line", edit_conference_partner_path(current_conference, partner), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
-              <% end %>
+            <td class="table-list__actions" data-label="<%= t("models.partner.fields.actions", scope: "decidim.admin") %>">
+              <button type="button" data-component="dropdown" data-target="actions-partner-<%= partner.id %>" aria-label="<%= t('decidim.admin.actions.actions_label', resource: partner.name || t('models.partner.name', scope: 'decidim.admin')) %>">
+                <%= icon "more-fill", class: "text-secondary" %>
+              </button>
 
-              <% if allowed_to? :destroy, :partner, partner: partner %>
-                <%= icon_link_to "delete-bin-line", conference_partner_path(current_conference, partner), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
-              <% end %>
+              <div class="inline-block relative">
+                <ul id="actions-partner-<%= partner.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                  <% if allowed_to? :update, :partner, partner: partner %>
+                    <li class="dropdown__item">
+                      <%= link_to edit_conference_partner_path(current_conference, partner), class: "dropdown__button" do %>
+                        <%= icon "pencil-line" %>
+                        <%= t("actions.edit", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+
+                  <hr>
+
+                  <% if allowed_to? :destroy, :partner, partner: partner %>
+                    <li class="dropdown__item">
+                      <%= link_to conference_partner_path(current_conference, partner), method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, class: "dropdown__button dropdown__button--danger" do %>
+                        <%= icon "delete-bin-line" %>
+                        <%= t("actions.destroy", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/decidim-conferences/app/views/decidim/conferences/admin/registration_types/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/registration_types/index.html.erb
@@ -8,7 +8,7 @@
       <% end %>
     </h1>
   </div>
-  <div class="table-scroll">
+  <div class="table-stacked">
     <table class="table-list">
       <thead>
         <tr>
@@ -17,42 +17,76 @@
           <th><%= t("models.registration_type.fields.weight", scope: "decidim.admin") %></th>
           <th><%= t("models.registration_type.fields.conference_meetings", scope: "decidim.admin") %></th>
           <th><%= t("models.registration_type.fields.registrations_count", scope: "decidim.admin") %></th>
-          <th></th>
+          <th><%= t("models.registration_type.fields.actions", scope: "decidim.admin") %></th>
         </tr>
       </thead>
       <tbody>
         <% @registration_types.each do |registration_type| %>
           <tr>
-            <td>
+            <td data-label="<%= t("models.registration_type.fields.title", scope: "decidim.admin") %>">
               <%= translated_attribute(registration_type.title) %>
             </td>
-            <td>
+            <td data-label="<%= t("models.registration_type.fields.price", scope: "decidim.admin") %>">
               <%= registration_type.price %>
             </td>
-            <td>
+            <td data-label="<%= t("models.registration_type.fields.weight", scope: "decidim.admin") %>">
               <%= registration_type.weight %>
             </td>
-            <td>
+            <td data-label="<%= t("models.registration_type.fields.conference_meetings", scope: "decidim.admin") %>">
               <%= registration_type.conference_meeting_registration_types.count %>
             </td>
-            <td>
+            <td data-label="<%= t("models.registration_type.fields.registrations_count", scope: "decidim.admin") %>">
               <%= registration_type.conference_registrations.count %>
             </td>
-            <td class="table-list__actions">
-              <% if allowed_to?(:update, :registration_type, registration_type: registration_type) && !registration_type.conference_registrations.any? %>
-                <%= icon_link_to "pencil-line", edit_conference_registration_type_path(current_conference, registration_type), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
-              <% end %>
 
-              <% if allowed_to?(:update, :registration_type, registration_type: registration_type) %>
-                <% if registration_type.published? %>
-                  <%= icon_link_to "close-circle-line", conference_registration_type_publish_path(current_conference, registration_type), t("actions.unpublish", scope: "decidim.admin"), class: "action-icon--unpublish", method: :delete %>
-                <% else %>
-                  <%= icon_link_to "check-line", conference_registration_type_publish_path(current_conference, registration_type), t("actions.publish", scope: "decidim.admin"), class: "action-icon--publish", method: :post %>
-                <% end %>
-              <% end %>
-              <% if allowed_to?(:destroy, :registration_type, registration_type: registration_type) && !registration_type.conference_registrations.any? %>
-                <%= icon_link_to "delete-bin-line", conference_registration_type_path(current_conference, registration_type), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
-              <% end %>
+            <td class="table-list__actions" data-label="<%= t("models.registration_type.fields.actions", scope: "decidim.admin") %>">
+              <button type="button" data-component="dropdown" data-target="actions-conference-registration-type-<%= registration_type.id %>" aria-label="<%= t('decidim.admin.actions.actions_label', resource: translated_attribute(registration_type.title)) %>">
+                <%= icon "more-fill", class: "text-secondary" %>
+              </button>
+
+              <div class="inline-block relative">
+                <ul id="actions-conference-registration-type-<%= registration_type.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                  <% if allowed_to?(:update, :registration_type, registration_type: registration_type) && !registration_type.conference_registrations.any? %>
+                    <li class="dropdown__item">
+                      <%= link_to edit_conference_registration_type_path(current_conference, registration_type), class: "dropdown__button" do %>
+                        <%= icon "pencil-line" %>
+                        <%= t("actions.edit", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+
+                  <hr>
+
+                  <% if allowed_to?(:update, :registration_type, registration_type: registration_type) %>
+                    <% if registration_type.published? %>
+                      <li class="dropdown__item">
+                        <%= link_to conference_registration_type_publish_path(current_conference, registration_type), method: :delete, class: "dropdown__button" do %>
+                          <%= icon "close-circle-line" %>
+                          <%= t("actions.unpublish", scope: "decidim.admin") %>
+                        <% end %>
+                      </li>
+                    <% else %>
+                      <li class="dropdown__item">
+                        <%= link_to conference_registration_type_publish_path(current_conference, registration_type), method: :post, class: "dropdown__button" do %>
+                          <%= icon "check-line" %>
+                          <%= t("actions.publish", scope: "decidim.admin") %>
+                        <% end %>
+                      </li>
+                    <% end %>
+                  <% end %>
+
+                  <hr>
+
+                  <% if allowed_to?(:destroy, :registration_type, registration_type: registration_type) && !registration_type.conference_registrations.any? %>
+                    <li class="dropdown__item">
+                      <%= link_to conference_registration_type_path(current_conference, registration_type), method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, class: "dropdown__button" do %>
+                        <%= icon "delete-bin-line" %>
+                        <%= t("actions.destroy", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
             </td>
           </tr>
         <% end %>
@@ -60,4 +94,5 @@
     </table>
   </div>
 </div>
+
 <%= decidim_paginate @registration_types %>

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -225,12 +225,14 @@ en:
             title: Title
         conference_speaker:
           fields:
+            actions: Actions
             affiliation: Affiliation
             full_name: Full name
             position: Position
           name: Conference Speaker
         conference_user_role:
           fields:
+            actions: Actions
             email: Email
             name: Name
             role: Role
@@ -242,12 +244,14 @@ en:
             moderator: Moderator
         media_link:
           fields:
+            actions: Actions
             date: Date
             link: Link
             title: Title
           name: Media link
         partner:
           fields:
+            actions: Actions
             link: Link
             logo: Logo
             name: Name
@@ -258,6 +262,7 @@ en:
             main_promotor: Main promotor
         registration_type:
           fields:
+            actions: Actions
             conference_meetings: Conference meetings
             price: Price
             registrations_count: Registrations count
@@ -517,6 +522,7 @@ en:
             sent: Sent
         conference_registration:
           fields:
+            actions: Actions
             email: Email
             name: Name
             registration_type: Registration type

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/committee_requests/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/committee_requests/index.html.erb
@@ -20,12 +20,12 @@
   </div>
 </div>
 
-<div class="table-scroll mt-4">
+<div class="table-stacked mt-4">
   <table class="table-list">
     <thead>
     <tr>
       <th><%= t "user", scope: "activemodel.attributes.initiatives_committee_member" %></th>
-      <th></th>
+      <th><%= t "actions", scope: "decidim.admin.models.initiatives_committee_member.fields" %></th>
     </tr>
     </thead>
     <tbody>
@@ -38,17 +38,35 @@
 
       <% current_initiative.committee_members.each do |request| %>
         <tr data-id="<%= request.id %>">
-          <td>
+          <td data-label="<%= t "user", scope: "activemodel.attributes.initiatives_committee_member" %>">
             <%= link_to request.user.name, "mailto:#{request.user.email}" %>
           </td>
-          <td class="table-list__actions">
-            <% if allowed_to? :approve, :initiative_committee_member, request: request %>
-              <%= icon_link_to "check-line", approve_initiative_committee_request_path(current_initiative, request), t(".approve"), class: "action-icon--check" %>
-            <% end %>
 
-            <% if allowed_to? :revoke, :initiative_committee_member, request: request %>
-              <%= icon_link_to "delete-bin-line", revoke_initiative_committee_request_path(current_initiative, request), t(".revoke"), class: "action-icon--remove", method: :delete, data: { confirm: t(".confirm_revoke") } %>
-            <% end %>
+          <td class="table-list__actions" data-label="<%= t "actions", scope: "decidim.admin.models.initiatives_committee_member.fields" %>">
+            <button type="button" data-component="dropdown" data-target="actions-initiative-committee-request-<%= request.id %>" aria-label="<%= t('decidim.admin.actions.actions_label', resource: request.user.name) %>">
+              <%= icon "more-fill", class: "text-secondary" %>
+            </button>
+
+            <div class="inline-block relative">
+              <ul id="actions-initiative-committee-request-<%= request.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                <% if allowed_to? :approve, :initiative_committee_member, request: request %>
+                  <li class="dropdown__item">
+                    <%= link_to approve_initiative_committee_request_path(current_initiative, request), class: "dropdown__button" do %> <%= icon "check-line" %>
+                      <%= t(".approve") %>
+                    <% end %>
+                  </li>
+                <% end %>
+
+                <% if allowed_to? :revoke, :initiative_committee_member, request: request %>
+                  <li class="dropdown__item">
+                    <%= link_to revoke_initiative_committee_request_path(current_initiative, request), method: :delete, data: { confirm: t(".confirm_revoke") }, class: "dropdown__button" do %>
+                      <%= icon "delete-bin-line" %>
+                      <%= t(".revoke") %>
+                    <% end %>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
           </td>
         </tr>
       <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_initiative_type_scopes.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_initiative_type_scopes.html.erb
@@ -13,7 +13,7 @@
     </h2>
   </div>
   <div id="panel-<%= t("initiatives_types.initiative_type_scopes.title", scope: "decidim.initiatives.admin") %>" class="card-section">
-    <div class="table-scroll">
+    <div class="table-stacked">
       <table class="table-list">
         <thead>
         <tr>
@@ -21,19 +21,35 @@
           <th class="text-right">
             <%= t("models.initiatives_type_scope.fields.supports_required", scope: "decidim.admin") %>
           </th>
-          <th></th>
+          <th><%= t("models.initiatives_type_scope.fields.actions", scope: "decidim.admin") %></th>
         </tr>
         </thead>
         <tbody>
         <% initiative_type.scopes.each do |s| %>
           <tr>
-            <td><%= translated_attribute(s.scope_name) %></td>
-            <td class="text-right"><%= s.supports_required %></td>
-            <td class="table-list__actions">
-              <%= icon_link_to "pencil-line",
-                               decidim_admin_initiatives.edit_initiatives_type_initiatives_type_scope_path(initiative_type, s),
-                               t("actions.configure", scope: "decidim.admin"),
-                               class: "action-icon--new" if allowed_to? :edit, :initiative_type_scope, initiative_type_scope: s %>
+            <td data-label="<%= t("models.initiatives_type_scope.fields.scope", scope: "decidim.admin") %>">
+              <%= translated_attribute(s.scope_name) %>
+            </td>
+            <td class="text-right" data-label="<%= t("models.initiatives_type_scope.fields.supports_required", scope: "decidim.admin") %>">
+              <%= s.supports_required %>
+            </td>
+            <td class="table-list__actions" data-label="<%= t("models.initiatives_type_scope.fields.actions", scope: "decidim.admin") %>">
+              <% if allowed_to? :edit, :initiative_type_scope, initiative_type_scope: s %>
+                <button type="button" data-component="dropdown" data-target="actions-initiative-type-scope-<%= s.id %>" aria-label="<%= t('decidim.admin.actions.actions_label', resource: s.scope_name) %>">
+                  <%= icon "more-fill", class: "text-secondary" %>
+                </button>
+
+                <div class="inline-block relative">
+                  <ul id="actions-initiative-type-scope-<%= s.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                    <li class="dropdown__item">
+                      <%= link_to decidim_admin_initiatives.edit_initiatives_type_initiatives_type_scope_path(initiative_type, s), class: "dropdown__button" do %>
+                        <%= icon "pencil-line" %>
+                        <%= t("actions.configure", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  </ul>
+                </div>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -125,8 +125,12 @@ en:
             state: Status
             supports_count: Signatures
             title: Initiatives
+        initiatives_committee_member:
+          fields:
+            actions: Actions
         initiatives_type_scope:
           fields:
+            actions: Actions
             scope: Scope
             supports_required: Signatures required
           name: Initiative type scope

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/index.html.erb
@@ -9,20 +9,20 @@
     </h1>
   </div>
   <% if current_participatory_process.steps.any? %>
-    <div class="table-scroll">
+    <div class="table-stacked">
       <table class="table-list">
         <thead>
           <tr>
             <th><%= t("models.participatory_process_step.fields.title", scope: "decidim.admin") %></th>
             <th><%= t("models.participatory_process_step.fields.start_date", scope: "decidim.admin") %></th>
             <th><%= t("models.participatory_process_step.fields.end_date", scope: "decidim.admin") %></th>
-            <th></th>
+            <th><%= t("models.participatory_process_step.fields.actions", scope: "decidim.admin") %></th>
           </tr>
         </thead>
         <tbody class="sortable" data-sort-url="<%= ordering_participatory_process_steps_path(current_participatory_process) %>">
           <% current_participatory_process.steps.each do |step| %>
             <tr data-id="<%= step.id %>">
-              <td>
+              <td data-label="<%= t("models.participatory_process_step.fields.title", scope: "decidim.admin") %>">
                 <div class="flex items-center gap-x-2">
                   <%= icon "drag-move-2-line" %>
                   <% if step.active? %>
@@ -31,34 +31,50 @@
                   <%= link_to translated_attribute(step.title), edit_participatory_process_step_path(current_participatory_process, step) %><br>
                 </div>
               </td>
-              <td>
+              <td data-label="<%= t("models.participatory_process_step.fields.start_date", scope: "decidim.admin") %>">
                 <% if step.start_date %>
                   <%= l step.start_date, format: :long %>
                 <% end %>
               </td>
-              <td>
+              <td data-label="<%= t("models.participatory_process_step.fields.end_date", scope: "decidim.admin") %>">
                 <% if step.end_date %>
                   <%= l step.end_date, format: :long %>
                 <% end %>
               </td>
-              <td class="table-list__actions">
-                <% if allowed_to? :update, :process_step, process_step: step %>
-                  <%= icon_link_to "pencil-line", edit_participatory_process_step_path(current_participatory_process, step), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
-                <% else %>
-                  <span class="action-space icon"></span>
-                <% end %>
+              <td class="table-list__actions" data-label="<%= t("models.participatory_process_step.fields.actions", scope: "decidim.admin") %>">
+                <button type="button" data-component="dropdown" data-target="actions-process-step-<%= step.id %>" aria-label="<%= t('decidim.admin.actions.actions_label', resource: translated_attribute(step.title)) %>">
+                  <%= icon "more-fill", class: "text-secondary" %>
+                </button>
 
-                <% if allowed_to?(:activate, :process_step, process_step: step) && !step.active? %>
-                  <%= icon_link_to "check-line", participatory_process_step_activate_path(current_participatory_process, step), t("actions.activate", scope: "decidim.admin"), class: "action-icon--activate", method: :post %>
-                <% else %>
-                  <span class="action-space icon"></span>
-                <% end %>
+                <div class="inline-block relative">
+                  <ul id="actions-process-step-<%= step.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                    <% if allowed_to? :update, :process_step, process_step: step %>
+                      <li class="dropdown__item">
+                        <%= link_to edit_participatory_process_step_path(current_participatory_process, step), class: "dropdown__button" do %>
+                          <%= icon "pencil-line" %> <%= t("actions.edit", scope: "decidim.admin") %>
+                        <% end %>
+                      </li>
+                    <% end %>
 
-                <% if allowed_to? :destroy, :process_step, process_step: step %>
-                  <%= icon_link_to "delete-bin-line", participatory_process_step_path(current_participatory_process, step), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
-                <% else %>
-                  <span class="action-space icon"></span>
-                <% end %>
+                    <% if allowed_to?(:activate, :process_step, process_step: step) && !step.active? %>
+                      <li class="dropdown__item">
+                        <%= link_to participatory_process_step_activate_path(current_participatory_process, step), method: :post, class: "dropdown__button" do %>
+                          <%= icon "check-line" %> <%= t("actions.activate", scope: "decidim.admin") %>
+                        <% end %>
+                      </li>
+                    <% end %>
+
+                    <hr>
+
+                    <% if allowed_to? :destroy, :process_step, process_step: step %>
+                      <li class="dropdown__item">
+                        <%= link_to participatory_process_step_path(current_participatory_process, step), method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, class: "dropdown__button dropdown__button--danger" do %>
+                          <%= icon "delete-bin-line" %> <%= t("actions.destroy", scope: "decidim.admin") %>
+                        <% end %>
+                      </li>
+                    <% end %>
+                  </ul>
+                </div>
               </td>
             </tr>
           <% end %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/index.html.erb
@@ -10,58 +10,72 @@
     </h1>
   </div>
   <%= admin_filter_selector %>
-  <div class="table-scroll">
+  <div class="table-stacked">
     <table class="stack table-list">
       <thead>
         <tr>
-          <th><%= sort_link(query, :name,t("models.participatory_process_user_role.fields.name", scope: "decidim.admin"), default_order: :desc) %></th>
+          <th><%= sort_link(query, :name, t("models.participatory_process_user_role.fields.name", scope: "decidim.admin"), default_order: :desc) %></th>
           <th><%= sort_link(query, :email, t("models.participatory_process_user_role.fields.email", scope: "decidim.admin"), default_order: :desc) %></th>
           <th><%= sort_link(query, :last_sign_in_at, t("models.user.fields.last_sign_in_at", scope: "decidim.admin"), default_order: :desc) %></th>
           <th><%= sort_link(query, :invitation_accepted_at, t("models.user.fields.invitation_accepted_at", scope: "decidim.admin"), default_order: :desc) %></th>
           <th><%= sort_link(query, :role, t("models.participatory_process_user_role.fields.role", scope: "decidim.admin"), default_order: :desc) %></th>
-          <th></th>
+          <th><%= t("models.participatory_process_user_role.fields.actions", scope: "decidim.admin") %></th>
         </tr>
       </thead>
       <tbody>
         <% filtered_collection.each do |role| %>
           <tr>
-            <td>
+            <td data-label="<%= t("models.participatory_process_user_role.fields.name", scope: "decidim.admin") %>">
               <%= role.user.name %><br>
             </td>
-            <td>
+            <td data-label="<%= t("models.participatory_process_user_role.fields.email", scope: "decidim.admin") %>">
               <%= role.user.email %><br>
             </td>
-            <td>
+            <td data-label="<%= t("models.user.fields.last_sign_in_at", scope: "decidim.admin") %>">
               <% if role.user.invitation_sent_at %>
                 <%= l role.user.invitation_sent_at, format: :short %>
               <% end %>
             </td>
-            <td>
+            <td data-label="<%= t("models.user.fields.invitation_accepted_at", scope: "decidim.admin") %>">
               <% if role.user.invitation_accepted_at %>
                 <%= l role.user.invitation_accepted_at, format: :short %>
               <% end %>
             </td>
-            <td>
+            <td data-label="<%= t("models.participatory_process_user_role.fields.role", scope: "decidim.admin") %>">
               <%= t("#{role.role}", scope: "decidim.admin.models.participatory_process_user_role.roles") %><br>
             </td>
-            <td class="table-list__actions">
-              <% if allowed_to? :update, :process_user_role, user_role: role %>
-                <%= icon_link_to "pencil-line", edit_participatory_process_user_role_path(current_participatory_process, role), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
-              <% else %>
-                <span class="action-space icon"></span>
-              <% end %>
+            <td class="table-list__actions" data-label="<%= t("models.participatory_process_user_role.fields.actions", scope: "decidim.admin") %>">
+              <button type="button" data-component="dropdown" data-target="actions-user-role-<%= role.id %>" aria-label="<%= t('decidim.admin.actions.actions_label', resource: role.user.name) %>">
+                <%= icon "more-fill", class: "text-secondary" %>
+              </button>
 
-              <% if allowed_to?(:invite, :process_user_role, user_role: role) && role.user.invited_to_sign_up? %>
-                <%= icon_link_to "refresh-line", resend_invitation_participatory_process_user_role_path(current_participatory_process, role), t("actions.resend_invitation", scope: "decidim.admin"), class: "resend-invitation", method: :post %>
-              <% else %>
-                <span class="action-space icon"></span>
-              <% end %>
+              <div class="inline-block relative">
+                <ul id="actions-user-role-<%= role.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                  <% if allowed_to? :update, :process_user_role, user_role: role %>
+                    <li class="dropdown__item">
+                      <%= link_to edit_participatory_process_user_role_path(current_participatory_process, role), class: "dropdown__button" do %>
+                        <%= icon "pencil-line" %> <%= t("actions.edit", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
 
-              <% if allowed_to? :destroy, :process_user_role, user_role: role %>
-                <%= icon_link_to "delete-bin-line", participatory_process_user_role_path(current_participatory_process, role), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
-              <% else %>
-                <span class="action-space icon"></span>
-              <% end %>
+                  <% if allowed_to?(:invite, :process_user_role, user_role: role) && role.user.invited_to_sign_up? %>
+                    <li class="dropdown__item">
+                      <%= link_to resend_invitation_participatory_process_user_role_path(current_participatory_process, role), method: :post, class: "dropdown__button resend-invitation" do %>
+                        <%= icon "refresh-line" %> <%= t("actions.resend_invitation", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+
+                  <% if allowed_to? :destroy, :process_user_role, user_role: role %>
+                    <li class="dropdown__item">
+                      <%= link_to participatory_process_user_role_path(current_participatory_process, role), method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, class: "dropdown__button dropdown__button--danger" do %>
+                        <%= icon "delete-bin-line" %> <%= t("actions.destroy", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -140,12 +140,14 @@ en:
           name: Process group
         participatory_process_step:
           fields:
+            actions: Actions
             end_date: End date
             start_date: Start date
             title: Title
           name: Participatory process phase
         participatory_process_user_role:
           fields:
+            actions: Actions
             email: Email
             name: Name
             role: Role


### PR DESCRIPTION
#### :tophat: What? Why?

This PR moves the actions for the admin tables to a meatball menu, so it is easier to understand what each actions does. It's a follow-up from #14805, this time doing the other tables from the spaces sections in the admin panel. 

#### :pushpin: Related Issues
 
- Related to #14713
- Related to #14805
- Related to #14651

#### Testing

1. Sign in as admin
2. Navigate in the dashboard and see the actions for the resources

:hearts: Thank you!
