### PR TITLE
Trigger login event on omniauth login

### DIFF
--- a/docs/modules/customize/pages/oauth.adoc
+++ b/docs/modules/customize/pages/oauth.adoc
@@ -30,4 +30,16 @@ ActiveSupport::Notifications.subscribe "decidim.user.omniauth_registration" do |
 end
 ----
 
+Note that, if the user is already registered, the `CreateOmniauthRegistration` command will not trigger the "decidim.user.omniauth_registration" event byt instead it will trigger the "decidim.user.omniauth_login" event, which has the same payload as the registration event.
+
+For instance, to retrigger the `IdCatMobilVerificationJob` after a user logs in via omniauth, you can subscribe to the "decidim.user.omniauth_login" event as follows:
+
+[source,ruby]
+----
+ActiveSupport::Notifications.subscribe "decidim.user.omniauth_login" do |name, started, finished, unique_id, data|
+  puts "the data: #{data.inspect}"
+  IdCatMobilVerificationJob.perform_later(data[:raw_data])
+end
+----
+
 It is a good practice to delegate the required implementation to a Job to bring a fastest response to the user, also it will avoid that crashes in this code to propagate to the registration process.

--- a/docs/modules/customize/pages/oauth.adoc
+++ b/docs/modules/customize/pages/oauth.adoc
@@ -30,7 +30,7 @@ ActiveSupport::Notifications.subscribe "decidim.user.omniauth_registration" do |
 end
 ----
 
-Note that, if the user is already registered, the `CreateOmniauthRegistration` command will not trigger the "decidim.user.omniauth_registration" event byt instead it will trigger the "decidim.user.omniauth_login" event, which has the same payload as the registration event.
+Note that, if the user is already registered, the `CreateOmniauthRegistration` command will not trigger the "decidim.user.omniauth_registration" event by instead it will trigger the "decidim.user.omniauth_login" event, which has the same payload as the registration event.
 
 For instance, to retrigger the `IdCatMobilVerificationJob` after a user logs in via omniauth, you can subscribe to the "decidim.user.omniauth_login" event as follows:
 


### PR DESCRIPTION
#### :tophat: What? Why?

I increasingly see that we need to deal with automatic user processing after an Omniauth Login (for instance to renew/cancel a verification). 
However, current Decidim only triggers the event `decidim.user.omniauth_registration` when there is no identity created yet. This means that subsequents logins won't generate any events.

This adds the event `decidim.user.omniauth_login` when user logs in using omniauth. This will allow implementators to have more control and avoid hacks to implement post-login user processing.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
