### PR TITLE
Change content blocks (layout) pages titles

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/organization_homepage_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_homepage_controller.rb
@@ -33,6 +33,10 @@ module Decidim
       def resource_content_block_cell
         "decidim/admin/homepage_content_block"
       end
+
+      def content_blocks_title
+        t("decidim.admin.menu.homepage")
+      end
     end
   end
 end

--- a/decidim-admin/app/views/decidim/admin/shared/landing_page/_content_blocks.html.erb
+++ b/decidim-admin/app/views/decidim/admin/shared/landing_page/_content_blocks.html.erb
@@ -1,4 +1,4 @@
-<% add_decidim_page_title(t("edit_landing_page", scope: "decidim.admin.titles")) %>
+<% add_decidim_page_title(content_blocks_title) %>
 
 <div class="card edit_content_blocks">
   <div class="item_show__header">

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -579,7 +579,7 @@ en:
         content: Reported content
         external_domain_allowlist: Allowed external domains
         help_sections: Help sections
-        homepage: Homepage
+        homepage: Homepage layout
         impersonations: Impersonations
         insights: Insights
         manage: Manage

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -1219,7 +1219,6 @@ en:
         authorization_workflows: Verification methods
         dashboard: Dashboard
         edit_external_domains: Allowed list of external domains
-        edit_landing_page: Page contents
         impersonatable_users: Manageable participants
         impersonations: Participants management
         menu: Menu

--- a/decidim-admin/lib/decidim/admin/menu.rb
+++ b/decidim-admin/lib/decidim/admin/menu.rb
@@ -159,7 +159,7 @@ module Decidim
                         I18n.t("menu.homepage", scope: "decidim.admin"),
                         decidim_admin.edit_organization_homepage_path,
                         position: 1.2,
-                        icon_name: "home-gear-line",
+                        icon_name: "layout-masonry-line",
                         if: allowed_to?(:update, :organization, organization: current_organization),
                         active: [%w(
                           decidim/admin/organization_homepage

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_landing_page_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_landing_page_controller.rb
@@ -31,6 +31,10 @@ module Decidim
         def resource_content_block_cell
           "decidim/assemblies/content_block"
         end
+
+        def content_blocks_title
+          t("decidim.admin.menu.assemblies_submenu.landing_page")
+        end
       end
     end
   end

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -171,7 +171,7 @@ en:
           attachments: Attachments
           components: Components
           info: About this assembly
-          landing_page: Landing page
+          landing_page: Landing page layout
           moderations: Moderations
           private_users: Members
           see_assembly: See assembly

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_group_landing_page_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_group_landing_page_controller.rb
@@ -43,6 +43,10 @@ module Decidim
 
         alias participatory_process_group scoped_resource
 
+        def content_blocks_title
+          t("decidim.admin.menu.participatory_process_groups_submenu.landing_page")
+        end
+
         private
 
         def collection

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_landing_page_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_landing_page_controller.rb
@@ -31,6 +31,10 @@ module Decidim
         def resource_content_block_cell
           "decidim/participatory_processes/content_block"
         end
+
+        def content_blocks_title
+          t("decidim.admin.menu.participatory_processes_submenu.landing_page")
+        end
       end
     end
   end

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -111,7 +111,7 @@ en:
         participatory_process_groups: Process groups
         participatory_process_groups_submenu:
           info: Info
-          landing_page: Landing page
+          landing_page: Landing page layout
         participatory_processes: Processes
         participatory_processes_submenu:
           attachment_collections: Folders
@@ -119,7 +119,7 @@ en:
           attachments: Attachments
           components: Components
           info: About this process
-          landing_page: Landing page
+          landing_page: Landing page layout
           moderations: Moderations
           private_users: Members
           process_admins: Process admins


### PR DESCRIPTION
#### :tophat: What? Why?

This PR is the last touch from #14721:

- renames the content block pages for spaces (from "Landing page" to "Landing page layout")  
- renames the content block page for the homepage (from "Homepage" to "Homepage layout")  
- changes the icon in the homepage to be consistent with the landing page icons
- adds the page title in these pages (before it was just "Page contents") 

#### :pushpin: Related Issues

- Fixes #14766 
- Fixes #14721 

#### Testing

Everything should be green
Check acceptance criteries from #14766  

### :camera: Screenshots

![image](https://github.com/user-attachments/assets/e409812e-ca7e-4528-bd3b-00daf133dd8b)


:hearts: Thank you!
