### PR TITLE
Disable rspec's profile examples in CI

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/spec_helper.rb
@@ -24,7 +24,7 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
   config.example_status_persistence_file_path = ".rspec-failures"
   config.filter_run_when_matching :focus
-  config.profile_examples = 10
+  config.profile_examples = 10 unless ENV.fetch("CI", false)
   config.default_formatter = "doc" if config.files_to_run.one?
 
   # If you are not using ActiveRecord, or you'd prefer not to run each of your


### PR DESCRIPTION
#### :tophat: What? Why?

Having the last 10 slow examples in the CI is too noisy, so this PR changes this behavior so it's only show locally and not in the CI 

#### :pushpin: Related Issues 

- Introduced on #9931

#### Testing

Running a spec with the CI env var should not show the slow 10 examples
Running a spec without the CI env var should show these 10 examples
 
:hearts: Thank you!
