### PR TITLE
Fix specs for multiple_file_field_include_hidden

### DIFF
--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
@@ -42,7 +42,7 @@ export default class UploadModal {
 
     this.emptyItems = this.modal.querySelector("[data-dropzone-no-items]");
     this.uploadItems = this.modal.querySelector("[data-dropzone-items]");
-    this.input = this.dropZone.querySelector("input");
+    this.input = this.dropZone.querySelector("input[type=file]");
     this.items = []
 
     this.attachmentCounter = 0;


### PR DESCRIPTION
#### :tophat: What? Why?

It seems that adding photos in the admin proposal interface does not work because i creates and additional input called "add_photos" that is wrongly detected by the upload modal.

Note that this is not a backport because this fix has been made in this PR for develop https://github.com/decidim/decidim/pull/14735

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*


![imatge](https://github.com/user-attachments/assets/f1f2da73-5fad-4c59-a81a-b6ac2e863562)


:hearts: Thank you!
